### PR TITLE
[enhance](FS) Improve FS error code

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -79,6 +79,7 @@ namespace ErrorCode {
     E(FILE_ALREADY_EXIST, -122, true);                       \
     E(BAD_CAST, -123, true);                                 \
     E(ARITHMETIC_OVERFLOW_ERRROR, -124, false);              \
+    E(PERMISSION_DENIED, -125, false);                       \
     E(CALL_SEQUENCE_ERROR, -202, true);                      \
     E(BUFFER_OVERFLOW, -204, true);                          \
     E(CONFIG_ERROR, -205, true);                             \

--- a/be/src/io/fs/broker_file_system.cpp
+++ b/be/src/io/fs/broker_file_system.cpp
@@ -337,10 +337,6 @@ Status BrokerFileSystem::rename_impl(const Path& orig_name, const Path& new_name
     return Status::OK();
 }
 
-Status BrokerFileSystem::rename_dir_impl(const Path& orig_name, const Path& new_name) {
-    return rename_impl(orig_name, new_name);
-}
-
 Status BrokerFileSystem::upload_impl(const Path& local_file, const Path& remote_file) {
     // 1. open local file for read
     FileSystemSPtr local_fs = global_local_filesystem();
@@ -388,21 +384,6 @@ Status BrokerFileSystem::batch_upload_impl(const std::vector<Path>& local_files,
     return Status::OK();
 }
 
-Status BrokerFileSystem::direct_upload_impl(const Path& remote_file, const std::string& content) {
-    FileWriterPtr broker_writer = nullptr;
-    RETURN_IF_ERROR(create_file_impl(remote_file, &broker_writer, nullptr));
-    RETURN_IF_ERROR(broker_writer->append({content}));
-    return broker_writer->close();
-}
-
-Status BrokerFileSystem::upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                                   const std::string& checksum) {
-    std::string temp = remote_file.string() + ".part";
-    std::string final_file = remote_file.string() + "." + checksum;
-    RETURN_IF_ERROR(upload_impl(local_file, temp));
-    return rename_impl(temp, final_file);
-}
-
 Status BrokerFileSystem::download_impl(const Path& remote_file, const Path& local_file) {
     // 1. open remote file for read
     FileReaderSPtr broker_reader = nullptr;
@@ -422,7 +403,6 @@ Status BrokerFileSystem::download_impl(const Path& remote_file, const Path& loca
     VLOG(2) << "read remote file: " << remote_file << " to local: " << local_file;
     constexpr size_t buf_sz = 1024 * 1024;
     std::unique_ptr<uint8_t[]> read_buf(new uint8_t[buf_sz]);
-    size_t write_offset = 0;
     size_t cur_offset = 0;
     while (true) {
         size_t read_len = 0;
@@ -433,34 +413,9 @@ Status BrokerFileSystem::download_impl(const Path& remote_file, const Path& loca
             break;
         }
 
-        RETURN_IF_ERROR(local_writer->write_at(write_offset, {read_buf.get(), read_len}));
-        write_offset += read_len;
+        RETURN_IF_ERROR(local_writer->append({read_buf.get(), read_len}));
     } // file_handler should be closed before calculating checksum
 
-    return Status::OK();
-}
-
-Status BrokerFileSystem::direct_download_impl(const Path& remote_file, std::string* content) {
-    // 1. open remote file for read
-    FileReaderSPtr broker_reader = nullptr;
-    RETURN_IF_ERROR(open_file_internal(remote_file, &broker_reader, FileReaderOptions::DEFAULT));
-
-    constexpr size_t buf_sz = 1024 * 1024;
-    std::unique_ptr<char[]> read_buf(new char[buf_sz]);
-    size_t write_offset = 0;
-    size_t cur_offset = 0;
-    while (true) {
-        size_t read_len = 0;
-        Slice file_slice(read_buf.get(), buf_sz);
-        RETURN_IF_ERROR(broker_reader->read_at(cur_offset, file_slice, &read_len));
-        cur_offset += read_len;
-        if (read_len == 0) {
-            break;
-        }
-
-        content->insert(write_offset, read_buf.get(), read_len);
-        write_offset += read_len;
-    }
     return Status::OK();
 }
 

--- a/be/src/io/fs/broker_file_system.h
+++ b/be/src/io/fs/broker_file_system.h
@@ -63,16 +63,11 @@ protected:
     Status list_impl(const Path& dir, bool only_file, std::vector<FileInfo>* files,
                      bool* exists) override;
     Status rename_impl(const Path& orig_name, const Path& new_name) override;
-    Status rename_dir_impl(const Path& orig_name, const Path& new_name) override;
 
     Status upload_impl(const Path& local_file, const Path& remote_file) override;
     Status batch_upload_impl(const std::vector<Path>& local_files,
                              const std::vector<Path>& remote_files) override;
-    Status direct_upload_impl(const Path& remote_file, const std::string& content) override;
-    Status upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                     const std::string& checksum) override;
     Status download_impl(const Path& remote_file, const Path& local_file) override;
-    Status direct_download_impl(const Path& remote_file, std::string* content) override;
 
 private:
     BrokerFileSystem(const TNetworkAddress& broker_addr,

--- a/be/src/io/fs/broker_file_writer.cpp
+++ b/be/src/io/fs/broker_file_writer.cpp
@@ -127,11 +127,6 @@ Status BrokerFileWriter::close() {
     return Status::OK();
 }
 
-Status BrokerFileWriter::abort() {
-    // TODO: should remove file
-    return Status::OK();
-}
-
 Status BrokerFileWriter::appendv(const Slice* data, size_t data_cnt) {
     DCHECK(!_closed);
     if (!_opened) {

--- a/be/src/io/fs/broker_file_writer.h
+++ b/be/src/io/fs/broker_file_writer.h
@@ -46,12 +46,8 @@ public:
     virtual ~BrokerFileWriter();
 
     Status close() override;
-    Status abort() override;
     Status appendv(const Slice* data, size_t data_cnt) override;
     Status finalize() override;
-    Status write_at(size_t offset, const Slice& data) override {
-        return Status::NotSupported("not support");
-    }
 
 private:
     Status _open();

--- a/be/src/io/fs/err_utils.cpp
+++ b/be/src/io/fs/err_utils.cpp
@@ -18,15 +18,19 @@
 #include "io/fs/err_utils.h"
 
 // IWYU pragma: no_include <bthread/errno.h>
+#include <aws/s3/S3Errors.h>
 #include <errno.h> // IWYU pragma: keep
 #include <fmt/format.h>
 #include <string.h>
 
 #include <sstream>
 
+#include "common/status.h"
 #include "io/fs/hdfs.h"
 
 namespace doris {
+using namespace ErrorCode;
+
 namespace io {
 
 std::string errno_to_str() {
@@ -71,6 +75,56 @@ std::string glob_err_to_str(int code) {
         break;
     }
     return fmt::format("({}), {}", code, msg);
+}
+
+Status localfs_error(const std::error_code& ec, std::string_view msg) {
+    if (ec == std::errc::io_error) {
+        return Status::Error<IO_ERROR, false>(msg);
+    } else if (ec == std::errc::no_such_file_or_directory) {
+        return Status::Error<NOT_FOUND, false>(msg);
+    } else if (ec == std::errc::file_exists) {
+        return Status::Error<ALREADY_EXIST, false>(msg);
+    } else if (ec == std::errc::no_space_on_device) {
+        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(msg);
+    } else if (ec == std::errc::permission_denied) {
+        return Status::Error<PERMISSION_DENIED, false>(msg);
+    } else {
+        return Status::Error<doris::INTERNAL_ERROR, false>("{}: {}", msg, ec.message());
+    }
+}
+
+Status localfs_error(int posix_errno, std::string_view msg) {
+    switch (posix_errno) {
+    case EIO:
+        return Status::Error<IO_ERROR, false>(msg);
+    case ENOENT:
+        return Status::Error<NOT_FOUND, false>(msg);
+    case EEXIST:
+        return Status::Error<ALREADY_EXIST, false>(msg);
+    case ENOSPC:
+        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(msg);
+    case EACCES:
+        return Status::Error<PERMISSION_DENIED, false>(msg);
+    default:
+        return Status::Error<doris::INTERNAL_ERROR, false>("{}: {}", msg,
+                                                           std::strerror(posix_errno));
+    }
+}
+
+Status s3fs_error(const Aws::S3::S3Error& err, std::string_view msg) {
+    using namespace Aws::Http;
+    switch (err.GetResponseCode()) {
+    case HttpResponseCode::NOT_FOUND:
+        return Status::Error<NOT_FOUND, false>("{}: {} {}", msg, err.GetExceptionName(),
+                                               err.GetMessage());
+    case HttpResponseCode::FORBIDDEN:
+        return Status::Error<PERMISSION_DENIED, false>("{}: {} {}", msg, err.GetExceptionName(),
+                                                       err.GetMessage());
+    default:
+        return Status::Error<doris::INTERNAL_ERROR, false>("{}: {} {} code={}", msg,
+                                                           err.GetExceptionName(), err.GetMessage(),
+                                                           err.GetResponseCode());
+    }
 }
 
 } // namespace io

--- a/be/src/io/fs/err_utils.h
+++ b/be/src/io/fs/err_utils.h
@@ -20,6 +20,12 @@
 #include <string>
 #include <system_error>
 
+#include "common/status.h"
+
+namespace Aws::S3 {
+class S3Error;
+} // namespace Aws::S3
+
 namespace doris {
 namespace io {
 
@@ -27,6 +33,10 @@ std::string errno_to_str();
 std::string errcode_to_str(const std::error_code& ec);
 std::string hdfs_error();
 std::string glob_err_to_str(int code);
+
+Status localfs_error(const std::error_code& ec, std::string_view msg);
+Status localfs_error(int posix_errno, std::string_view msg);
+Status s3fs_error(const Aws::S3::S3Error& err, std::string_view msg);
 
 } // namespace io
 } // namespace doris

--- a/be/src/io/fs/file_system.cpp
+++ b/be/src/io/fs/file_system.cpp
@@ -80,11 +80,5 @@ Status FileSystem::rename(const Path& orig_name, const Path& new_name) {
     FILESYSTEM_M(rename_impl(orig_path, new_path));
 }
 
-Status FileSystem::rename_dir(const Path& orig_name, const Path& new_name) {
-    auto orig_path = absolute_path(orig_name);
-    auto new_path = absolute_path(new_name);
-    FILESYSTEM_M(rename_dir_impl(orig_path, new_path));
-}
-
 } // namespace io
 } // namespace doris

--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -80,7 +80,6 @@ public:
     Status file_size(const Path& file, int64_t* file_size) const;
     Status list(const Path& dir, bool only_file, std::vector<FileInfo>* files, bool* exists);
     Status rename(const Path& orig_name, const Path& new_name);
-    Status rename_dir(const Path& orig_name, const Path& new_name);
 
     std::shared_ptr<FileSystem> getSPtr() { return shared_from_this(); }
 
@@ -145,9 +144,6 @@ protected:
 
     /// rename file from orig_name to new_name
     virtual Status rename_impl(const Path& orig_name, const Path& new_name) = 0;
-
-    /// rename dir from orig_name to new_name
-    virtual Status rename_dir_impl(const Path& orig_name, const Path& new_name) = 0;
 
     virtual Path absolute_path(const Path& path) const {
         if (path.is_absolute()) {

--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -49,14 +49,9 @@ public:
     // Normal close. Wait for all data to persist before returning.
     virtual Status close() = 0;
 
-    // Abnormal close and remove this file.
-    virtual Status abort() = 0;
-
     Status append(const Slice& data) { return appendv(&data, 1); }
 
     virtual Status appendv(const Slice* data, size_t data_cnt) = 0;
-
-    virtual Status write_at(size_t offset, const Slice& data) = 0;
 
     // Call this method when there is no more data to write.
     // FIXME(cyx): Does not seem to be an appropriate interface for file system?

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -306,10 +306,6 @@ Status HdfsFileSystem::rename_impl(const Path& orig_name, const Path& new_name) 
     return Status::OK();
 }
 
-Status HdfsFileSystem::rename_dir_impl(const Path& orig_name, const Path& new_name) {
-    return rename_impl(orig_name, new_name);
-}
-
 Status HdfsFileSystem::upload_impl(const Path& local_file, const Path& remote_file) {
     // 1. open local file for read
     FileSystemSPtr local_fs = global_local_filesystem();
@@ -351,21 +347,6 @@ Status HdfsFileSystem::batch_upload_impl(const std::vector<Path>& local_files,
     return Status::OK();
 }
 
-Status HdfsFileSystem::direct_upload_impl(const Path& remote_file, const std::string& content) {
-    FileWriterPtr hdfs_writer = nullptr;
-    RETURN_IF_ERROR(create_file(remote_file, &hdfs_writer));
-    RETURN_IF_ERROR(hdfs_writer->append({content}));
-    return Status::OK();
-}
-
-Status HdfsFileSystem::upload_with_checksum_impl(const Path& local, const Path& remote_file,
-                                                 const std::string& checksum) {
-    std::string temp = remote_file.string() + ".part";
-    std::string final_file = remote_file.string() + "." + checksum;
-    RETURN_IF_ERROR(upload_impl(local, temp));
-    return rename_impl(temp, final_file);
-}
-
 Status HdfsFileSystem::download_impl(const Path& remote_file, const Path& local_file) {
     // 1. open remote file for read
     FileReaderSPtr hdfs_reader = nullptr;
@@ -385,7 +366,6 @@ Status HdfsFileSystem::download_impl(const Path& remote_file, const Path& local_
     LOG(INFO) << "read remote file: " << remote_file << " to local: " << local_file;
     constexpr size_t buf_sz = 1024 * 1024;
     std::unique_ptr<char[]> read_buf(new char[buf_sz]);
-    size_t write_offset = 0;
     size_t cur_offset = 0;
     while (true) {
         size_t read_len = 0;
@@ -396,34 +376,9 @@ Status HdfsFileSystem::download_impl(const Path& remote_file, const Path& local_
             break;
         }
 
-        RETURN_IF_ERROR(local_writer->write_at(write_offset, {read_buf.get(), read_len}));
-        write_offset += read_len;
+        RETURN_IF_ERROR(local_writer->append({read_buf.get(), read_len}));
     }
 
-    return Status::OK();
-}
-
-Status HdfsFileSystem::direct_download_impl(const Path& remote_file, std::string* content) {
-    // 1. open remote file for read
-    FileReaderSPtr hdfs_reader = nullptr;
-    RETURN_IF_ERROR(open_file_internal(remote_file, &hdfs_reader, FileReaderOptions::DEFAULT));
-
-    constexpr size_t buf_sz = 1024 * 1024;
-    std::unique_ptr<char[]> read_buf(new char[buf_sz]);
-    size_t write_offset = 0;
-    size_t cur_offset = 0;
-    while (true) {
-        size_t read_len = 0;
-        Slice file_slice(read_buf.get(), buf_sz);
-        RETURN_IF_ERROR(hdfs_reader->read_at(cur_offset, file_slice, &read_len));
-        cur_offset += read_len;
-        if (read_len == 0) {
-            break;
-        }
-
-        content->insert(write_offset, read_buf.get(), read_len);
-        write_offset += read_len;
-    }
     return Status::OK();
 }
 

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -134,16 +134,11 @@ protected:
     Status list_impl(const Path& dir, bool only_file, std::vector<FileInfo>* files,
                      bool* exists) override;
     Status rename_impl(const Path& orig_name, const Path& new_name) override;
-    Status rename_dir_impl(const Path& orig_name, const Path& new_name) override;
 
     Status upload_impl(const Path& local_file, const Path& remote_file) override;
     Status batch_upload_impl(const std::vector<Path>& local_files,
                              const std::vector<Path>& remote_files) override;
-    Status direct_upload_impl(const Path& remote_file, const std::string& content) override;
-    Status upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                     const std::string& checksum) override;
     Status download_impl(const Path& remote_file, const Path& local_file) override;
-    Status direct_download_impl(const Path& remote_file, std::string* content) override;
 
 private:
     Status delete_internal(const Path& path, int is_recursive);

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -67,11 +67,6 @@ Status HdfsFileWriter::close() {
     return Status::OK();
 }
 
-Status HdfsFileWriter::abort() {
-    // TODO: should delete remote file
-    return Status::OK();
-}
-
 Status HdfsFileWriter::appendv(const Slice* data, size_t data_cnt) {
     DCHECK(!_closed);
     if (!_opened) {

--- a/be/src/io/fs/hdfs_file_writer.h
+++ b/be/src/io/fs/hdfs_file_writer.h
@@ -37,12 +37,8 @@ public:
     ~HdfsFileWriter();
 
     Status close() override;
-    Status abort() override;
     Status appendv(const Slice* data, size_t data_cnt) override;
     Status finalize() override;
-    Status write_at(size_t offset, const Slice& data) override {
-        return Status::NotSupported("not support");
-    }
 
 private:
     Status _open();

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -68,7 +68,7 @@ Status LocalFileSystem::create_file_impl(const Path& file, FileWriterPtr* writer
         }
     });
     if (-1 == fd) {
-        return Status::IOError("failed to open {}: {}", file.native(), errno_to_str());
+        return localfs_error(errno, fmt::format("failed to create file {}", file.native()));
     }
     bool sync_data = opts != nullptr ? opts->sync_file_data : true;
     *writer = std::make_unique<LocalFileWriter>(
@@ -85,7 +85,7 @@ Status LocalFileSystem::open_file_impl(const Path& file, FileReaderSPtr* reader,
     int fd = -1;
     RETRY_ON_EINTR(fd, open(file.c_str(), O_RDONLY));
     if (fd < 0) {
-        return Status::IOError("failed to open {}: {}", file.native(), errno_to_str());
+        return localfs_error(errno, fmt::format("failed to open {}", file.native()));
     }
     *reader = std::make_shared<LocalFileReader>(
             file, fsize, fd, std::static_pointer_cast<LocalFileSystem>(shared_from_this()));
@@ -97,13 +97,13 @@ Status LocalFileSystem::create_directory_impl(const Path& dir, bool failed_if_ex
         bool exists = true;
         RETURN_IF_ERROR(exists_impl(dir, &exists));
         if (exists) {
-            return Status::IOError("failed to create {}, already exists", dir.native());
+            return Status::AlreadyExist("failed to create {}, already exists", dir.native());
         }
     }
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
     if (ec) {
-        return Status::IOError("failed to create {}: {}", dir.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to create {}", dir.native()));
     }
     return Status::OK();
 }
@@ -115,12 +115,12 @@ Status LocalFileSystem::delete_file_impl(const Path& file) {
         return Status::OK();
     }
     if (!std::filesystem::is_regular_file(file)) {
-        return Status::IOError("failed to delete {}, not a file", file.native());
+        return Status::InternalError("failed to delete {}, not a file", file.native());
     }
     std::error_code ec;
     std::filesystem::remove(file, ec);
     if (ec) {
-        return Status::IOError("failed to delete {}: {}", file.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to delete {}", file.native()));
     }
     return Status::OK();
 }
@@ -132,12 +132,12 @@ Status LocalFileSystem::delete_directory_impl(const Path& dir) {
         return Status::OK();
     }
     if (!std::filesystem::is_directory(dir)) {
-        return Status::IOError("failed to delete {}, not a directory", dir.native());
+        return Status::InternalError("failed to delete {}, not a directory", dir.native());
     }
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
     if (ec) {
-        return Status::IOError("failed to delete {}: {}", dir.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to delete {}", dir.native()));
     }
     return Status::OK();
 }
@@ -168,7 +168,7 @@ Status LocalFileSystem::exists_impl(const Path& path, bool* res) const {
     std::error_code ec;
     *res = std::filesystem::exists(path, ec);
     if (ec) {
-        return Status::IOError("failed to check exists {}: {}", path.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to check exists {}", path.native()));
     }
     return Status::OK();
 }
@@ -177,7 +177,7 @@ Status LocalFileSystem::file_size_impl(const Path& file, int64_t* file_size) con
     std::error_code ec;
     *file_size = std::filesystem::file_size(file, ec);
     if (ec) {
-        return Status::IOError("failed to get file size {}: {}", file.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to get file size {}", file.native()));
     }
     return Status::OK();
 }
@@ -196,7 +196,8 @@ Status LocalFileSystem::directory_size(const Path& dir_path, size_t* dir_size) {
         }
         return Status::OK();
     }
-    return Status::IOError("faile to get dir size {}", dir_path.native());
+    // TODO(plat1ko): Use error code according to std::error_code
+    return Status::InternalError("faile to get dir size {}", dir_path.native());
 }
 
 Status LocalFileSystem::list_impl(const Path& dir, bool only_file, std::vector<FileInfo>* files,
@@ -225,7 +226,7 @@ Status LocalFileSystem::list_impl(const Path& dir, bool only_file, std::vector<F
         files->push_back(std::move(file_info));
     }
     if (ec) {
-        return Status::IOError<false>("failed to list {}: {}", dir.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to list {}", dir.native()));
     }
     return Status::OK();
 }
@@ -234,14 +235,10 @@ Status LocalFileSystem::rename_impl(const Path& orig_name, const Path& new_name)
     std::error_code ec;
     std::filesystem::rename(orig_name, new_name, ec);
     if (ec) {
-        return Status::IOError("failed to rename {} to {}: {}", orig_name.native(),
-                               new_name.native(), errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to rename {} to {}", orig_name.native(),
+                                             new_name.native()));
     }
     return Status::OK();
-}
-
-Status LocalFileSystem::rename_dir_impl(const Path& orig_name, const Path& new_name) {
-    return rename_impl(orig_name, new_name);
 }
 
 Status LocalFileSystem::link_file(const Path& src, const Path& dest) {
@@ -252,8 +249,8 @@ Status LocalFileSystem::link_file(const Path& src, const Path& dest) {
 
 Status LocalFileSystem::link_file_impl(const Path& src, const Path& dest) {
     if (::link(src.c_str(), dest.c_str()) != 0) {
-        return Status::IOError("failed to create hard link from {} to {}: {}", src.native(),
-                               dest.native(), errno_to_str());
+        return localfs_error(errno, fmt::format("failed to create hard link from {} to {}",
+                                                src.native(), dest.native()));
     }
     return Status::OK();
 }
@@ -262,8 +259,7 @@ Status LocalFileSystem::canonicalize(const Path& path, std::string* real_path) {
     std::error_code ec;
     Path res = std::filesystem::canonical(path, ec);
     if (ec) {
-        return Status::IOError("failed to canonicalize path {}: {}", path.native(),
-                               errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to canonicalize {}", path.native()));
     }
     *real_path = res.string();
     return Status::OK();
@@ -274,10 +270,7 @@ Status LocalFileSystem::is_directory(const Path& path, bool* res) {
     std::error_code ec;
     *res = std::filesystem::is_directory(tmp_path, ec);
     if (ec) {
-        LOG(WARNING) << fmt::format("failed to check is dir {}: {}", tmp_path.native(),
-                                    errcode_to_str(ec));
-        return Status::IOError("failed to check is dir {}: {}", tmp_path.native(),
-                               errcode_to_str(ec));
+        return localfs_error(ec, fmt::format("failed to canonicalize {}", path.native()));
     }
     return Status::OK();
 }
@@ -290,15 +283,15 @@ Status LocalFileSystem::md5sum(const Path& file, std::string* md5sum) {
 Status LocalFileSystem::md5sum_impl(const Path& file, std::string* md5sum) {
     int fd = open(file.c_str(), O_RDONLY);
     if (fd < 0) {
-        return Status::IOError("failed to open file for md5sum {}: {}", file.native(),
-                               errno_to_str());
+        return localfs_error(errno,
+                             fmt::format("failed to open file for md5sum {}", file.native()));
     }
 
     struct stat statbuf;
     if (fstat(fd, &statbuf) < 0) {
         std::string err = errno_to_str();
         close(fd);
-        return Status::InternalError("failed to stat file {}: {}", file.native(), err);
+        return localfs_error(errno, fmt::format("failed to stat file {}", file.native()));
     }
     size_t file_len = statbuf.st_size;
     CONSUME_THREAD_MEM_TRACKER(file_len);
@@ -338,37 +331,6 @@ Status LocalFileSystem::iterate_directory_impl(
     return Status::OK();
 }
 
-Status LocalFileSystem::mtime(const Path& file, time_t* m_time) {
-    auto path = absolute_path(file);
-    FILESYSTEM_M(mtime_impl(path, m_time));
-}
-
-Status LocalFileSystem::mtime_impl(const Path& file, time_t* m_time) {
-    int fd = open(file.c_str(), O_RDONLY);
-    if (fd < 0) {
-        return Status::IOError("failed to get mtime for file {}: {}", file.native(),
-                               errno_to_str());
-    }
-
-    Defer defer {[&]() { close(fd); }};
-    struct stat statbuf;
-    if (fstat(fd, &statbuf) < 0) {
-        return Status::IOError("failed to stat file {}: {}", file.native(), errno_to_str());
-    }
-    *m_time = statbuf.st_mtime;
-    return Status::OK();
-}
-
-Status LocalFileSystem::delete_and_create_directory(const Path& dir) {
-    auto path = absolute_path(dir);
-    FILESYSTEM_M(delete_and_create_directory_impl(path));
-}
-
-Status LocalFileSystem::delete_and_create_directory_impl(const Path& dir) {
-    RETURN_IF_ERROR(delete_directory_impl(dir));
-    return create_directory_impl(dir);
-}
-
 Status LocalFileSystem::get_space_info(const Path& dir, size_t* capacity, size_t* available) {
     auto path = absolute_path(dir);
     FILESYSTEM_M(get_space_info_impl(path, capacity, available));
@@ -378,26 +340,26 @@ Status LocalFileSystem::get_space_info_impl(const Path& path, size_t* capacity, 
     std::error_code ec;
     std::filesystem::space_info info = std::filesystem::space(path, ec);
     if (ec) {
-        return Status::IOError("failed to get available space for path {}: {}", path.native(),
-                               errcode_to_str(ec));
+        return localfs_error(
+                ec, fmt::format("failed to get available space for path {}", path.native()));
     }
     *capacity = info.capacity;
     *available = info.available;
     return Status::OK();
 }
 
-Status LocalFileSystem::copy_dirs(const Path& src, const Path& dest) {
+Status LocalFileSystem::copy_path(const Path& src, const Path& dest) {
     auto src_path = absolute_path(src);
     auto dest_path = absolute_path(dest);
-    FILESYSTEM_M(copy_dirs_impl(src_path, dest_path));
+    FILESYSTEM_M(copy_path_impl(src_path, dest_path));
 }
 
-Status LocalFileSystem::copy_dirs_impl(const Path& src, const Path& dest) {
+Status LocalFileSystem::copy_path_impl(const Path& src, const Path& dest) {
     std::error_code ec;
     std::filesystem::copy(src, dest, std::filesystem::copy_options::recursive, ec);
     if (ec) {
-        return Status::IOError("failed to copy from {} to {}: {}", src.native(), dest.native(),
-                               errcode_to_str(ec));
+        return localfs_error(
+                ec, fmt::format("failed to copy from {} to {}", src.native(), dest.native()));
     }
     return Status::OK();
 }
@@ -431,20 +393,6 @@ bool LocalFileSystem::contain_path(const Path& parent_, const Path& sub_) {
         }
     }
     return true;
-}
-
-Status LocalFileSystem::read_file_to_string(const Path& file, std::string* content) {
-    FileReaderSPtr file_reader;
-    RETURN_IF_ERROR(open_file(file, &file_reader));
-    size_t file_size = file_reader->size();
-    content->resize(file_size);
-    size_t bytes_read = 0;
-    RETURN_IF_ERROR(file_reader->read_at(0, {*content}, &bytes_read));
-    if (bytes_read != file_size) {
-        return Status::IOError("failed to read file {} to string. bytes read: {}, file size: {}",
-                               file.native(), bytes_read, file_size);
-    }
-    return file_reader->close();
 }
 
 static std::shared_ptr<LocalFileSystem> local_fs = io::LocalFileSystem::create("");
@@ -491,7 +439,7 @@ Status LocalFileSystem::_glob(const std::string& pattern, std::vector<std::strin
     int rc = glob(pattern.c_str(), GLOB_TILDE, NULL, &glob_result);
     if (rc != 0) {
         globfree(&glob_result);
-        return Status::IOError("failed to glob {}: {}", pattern, glob_err_to_str(rc));
+        return Status::InternalError("failed to glob {}: {}", pattern, glob_err_to_str(rc));
     }
 
     for (size_t i = 0; i < glob_result.gl_pathc; ++i) {

--- a/be/src/io/fs/local_file_system.h
+++ b/be/src/io/fs/local_file_system.h
@@ -54,21 +54,14 @@ public:
     // iterate the given dir and execute cb on each entry
     Status iterate_directory(const std::string& dir,
                              const std::function<bool(const FileInfo&)>& cb);
-    // Return the mtime of given file
-    Status mtime(const Path& file, time_t* m_time);
-    // remove dir if eixsts and create a new one
-    Status delete_and_create_directory(const Path& dir);
     // return disk available space where the given path is.
     Status get_space_info(const Path& path, size_t* capacity, size_t* available);
-    // copy src dir to dest dir, recursivly
-    Status copy_dirs(const Path& src, const Path& dest);
+    // Copy src path to dest path. If `src` is a directory, this method will call recursively for each directory entry.
+    Status copy_path(const Path& src, const Path& dest);
     // return true if parent path contain sub path
     static bool contain_path(const Path& parent, const Path& sub);
     // delete dir or file
     Status delete_directory_or_file(const Path& path);
-
-    // read local file and save content to "content"
-    Status read_file_to_string(const Path& file, std::string* content);
 
     Status canonicalize_local_file(const std::string& dir, const std::string& file_path,
                                    std::string* full_path);
@@ -88,22 +81,19 @@ protected:
     Status create_directory_impl(const Path& dir, bool failed_if_exists = false) override;
     Status delete_file_impl(const Path& file) override;
     Status delete_directory_impl(const Path& dir) override;
+    Status delete_directory_or_file_impl(const Path& path);
     Status batch_delete_impl(const std::vector<Path>& files) override;
     Status exists_impl(const Path& path, bool* res) const override;
     Status file_size_impl(const Path& file, int64_t* file_size) const override;
     Status list_impl(const Path& dir, bool only_file, std::vector<FileInfo>* files,
                      bool* exists) override;
     Status rename_impl(const Path& orig_name, const Path& new_name) override;
-    Status rename_dir_impl(const Path& orig_name, const Path& new_name) override;
     Status link_file_impl(const Path& src, const Path& dest);
     Status md5sum_impl(const Path& file, std::string* md5sum);
     Status iterate_directory_impl(const std::string& dir,
                                   const std::function<bool(const FileInfo&)>& cb);
-    Status mtime_impl(const Path& file, time_t* m_time);
-    Status delete_and_create_directory_impl(const Path& dir);
     Status get_space_info_impl(const Path& path, size_t* capacity, size_t* available);
-    Status copy_dirs_impl(const Path& src, const Path& dest);
-    Status delete_directory_or_file_impl(const Path& path);
+    Status copy_path_impl(const Path& src, const Path& dest);
 
 private:
     // a wrapper for glob(), return file list in "res"

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -32,40 +32,42 @@
 #include <ostream>
 #include <utility>
 
+// IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"
+#include "common/sync_point.h"
 #include "gutil/macros.h"
+#include "io/fs/err_utils.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "io/fs/path.h"
-#include "util/debug_points.h"
 #include "util/doris_metrics.h"
 
 namespace doris {
-namespace detail {
+namespace io {
+namespace {
 
 Status sync_dir(const io::Path& dirname) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("sync_dir", Status::IOError(""));
     int fd;
     RETRY_ON_EINTR(fd, ::open(dirname.c_str(), O_DIRECTORY | O_RDONLY));
     if (-1 == fd) {
-        return Status::IOError("cannot open {}: {}", dirname.native(), std::strerror(errno));
+        return localfs_error(errno, fmt::format("failed to open {}", dirname.native()));
     }
+    Defer defer {[fd] { ::close(fd); }};
 #ifdef __APPLE__
     if (fcntl(fd, F_FULLFSYNC) < 0) {
-        return Status::IOError("cannot sync {}: {}", dirname.native(), std::strerror(errno));
+        return localfs_error(errno, fmt::format("failed to sync {}", dirname.native()));
     }
 #else
     if (0 != ::fdatasync(fd)) {
-        return Status::IOError("cannot fdatasync {}: {}", dirname.native(), std::strerror(errno));
+        return localfs_error(errno, fmt::format("failed to sync {}", dirname.native()));
     }
 #endif
-    ::close(fd);
     return Status::OK();
 }
 
-} // namespace detail
-
-namespace io {
+} // namespace
 
 LocalFileWriter::LocalFileWriter(Path path, int fd, FileSystemSPtr fs, bool sync_data)
         : FileWriter(std::move(path), fs), _fd(fd), _sync_data(sync_data) {
@@ -78,23 +80,33 @@ LocalFileWriter::LocalFileWriter(Path path, int fd)
         : LocalFileWriter(path, fd, global_local_filesystem()) {}
 
 LocalFileWriter::~LocalFileWriter() {
-    if (_opened) {
-        static_cast<void>(close());
+    if (!_closed) {
+        _abort();
     }
-    CHECK(!_opened || _closed) << "open: " << _opened << ", closed: " << _closed;
+    DorisMetrics::instance()->local_file_open_writing->increment(-1);
+    DorisMetrics::instance()->file_created_total->increment(1);
+    DorisMetrics::instance()->local_bytes_written_total->increment(_bytes_appended);
 }
 
 Status LocalFileWriter::close() {
     return _close(_sync_data);
 }
 
-Status LocalFileWriter::abort() {
-    RETURN_IF_ERROR(_close(false));
-    return io::global_local_filesystem()->delete_file(_path);
+void LocalFileWriter::_abort() {
+    auto st = _close(false);
+    if (!st.ok()) [[unlikely]] {
+        LOG(WARNING) << "close file failed when abort file writer: " << st;
+    }
+    st = io::global_local_filesystem()->delete_file(_path);
+    if (!st.ok()) [[unlikely]] {
+        LOG(WARNING) << "delete file failed when abort file writer: " << st;
+    }
 }
 
 Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
-    DCHECK(!_closed);
+    if (_closed) [[unlikely]] {
+        return Status::InternalError("append to closed file: ", _path.native());
+    }
     _dirty = true;
 
     // Convert the results into the iovec vector to request
@@ -113,9 +125,11 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
         // Never request more than IOV_MAX in one request.
         size_t iov_count = std::min(data_cnt - completed_iov, static_cast<size_t>(IOV_MAX));
         ssize_t res;
-        RETRY_ON_EINTR(res, ::writev(_fd, iov + completed_iov, iov_count));
+        RETRY_ON_EINTR(res,
+                       SYNC_POINT_HOOK_RETURN_VALUE(::writev(_fd, iov + completed_iov, iov_count),
+                                                    "LocalFileWriter::writev", _fd));
         if (UNLIKELY(res < 0)) {
-            return Status::IOError("cannot write to {}: {}", _path.native(), std::strerror(errno));
+            return localfs_error(errno, fmt::format("failed to write {}", _path.native()));
         }
 
         if (LIKELY(res == n_left)) {
@@ -145,33 +159,16 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
     return Status::OK();
 }
 
-Status LocalFileWriter::write_at(size_t offset, const Slice& data) {
-    DCHECK(!_closed);
-    _dirty = true;
-
-    size_t bytes_req = data.size;
-    char* from = data.data;
-
-    while (bytes_req != 0) {
-        auto res = ::pwrite(_fd, from, bytes_req, offset);
-        if (-1 == res && errno != EINTR) {
-            return Status::IOError("cannot write to {}: {}", _path.native(), std::strerror(errno));
-        }
-        if (res > 0) {
-            from += res;
-            bytes_req -= res;
-        }
-    }
-    return Status::OK();
-}
-
 Status LocalFileWriter::finalize() {
-    DCHECK(!_closed);
+    if (_closed) [[unlikely]] {
+        return Status::InternalError("finalize closed file: ", _path.native());
+    }
+
     if (_dirty) {
 #if defined(__linux__)
         int flags = SYNC_FILE_RANGE_WRITE;
         if (sync_file_range(_fd, 0, 0, flags) < 0) {
-            return Status::IOError("cannot sync {}: {}", _path.native(), std::strerror(errno));
+            return localfs_error(errno, fmt::format("failed to finalize {}", _path.native()));
         }
 #endif
     }
@@ -182,33 +179,32 @@ Status LocalFileWriter::_close(bool sync) {
     if (_closed) {
         return Status::OK();
     }
-    _closed = true;
-    if (sync && _dirty) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileWriter::close", Status::IOError("inject io error"));
+    if (sync) {
+        if (_dirty) {
 #ifdef __APPLE__
-        if (fcntl(_fd, F_FULLFSYNC) < 0) {
-            return Status::IOError("cannot sync {}: {}", _path.native(), std::strerror(errno));
-        }
+            if (fcntl(_fd, F_FULLFSYNC) < 0) [[unlikely]] {
+                return localfs_error(errno, fmt::format("failed to sync {}", _path.native()));
+            }
 #else
-        if (0 != ::fdatasync(_fd)) {
-            return Status::IOError("cannot fdatasync {}: {}", _path.native(), std::strerror(errno));
-        }
+            if (0 != ::fdatasync(_fd)) [[unlikely]] {
+                return localfs_error(errno, fmt::format("failed to sync {}", _path.native()));
+            }
 #endif
-        RETURN_IF_ERROR(detail::sync_dir(_path.parent_path()));
-        _dirty = false;
+            _dirty = false;
+        }
+        RETURN_IF_ERROR(sync_dir(_path.parent_path()));
     }
 
-    DorisMetrics::instance()->local_file_open_writing->increment(-1);
-    DorisMetrics::instance()->file_created_total->increment(1);
-    DorisMetrics::instance()->local_bytes_written_total->increment(_bytes_appended);
-
     if (0 != ::close(_fd)) {
-        return Status::IOError("cannot close {}: {}", _path.native(), std::strerror(errno));
+        return localfs_error(errno, fmt::format("failed to close {}", _path.native()));
     }
 
     DBUG_EXECUTE_IF("LocalFileWriter.close.failed", {
         return Status::IOError("cannot close {}: {}", _path.native(), std::strerror(errno));
     });
 
+    _closed = true;
     return Status::OK();
 }
 

--- a/be/src/io/fs/local_file_writer.h
+++ b/be/src/io/fs/local_file_writer.h
@@ -35,12 +35,11 @@ public:
     ~LocalFileWriter() override;
 
     Status close() override;
-    Status abort() override;
     Status appendv(const Slice* data, size_t data_cnt) override;
-    Status write_at(size_t offset, const Slice& data) override;
     Status finalize() override;
 
 private:
+    void _abort();
     Status _close(bool sync);
 
 private:

--- a/be/src/io/fs/remote_file_system.cpp
+++ b/be/src/io/fs/remote_file_system.cpp
@@ -43,25 +43,9 @@ Status RemoteFileSystem::batch_upload(const std::vector<Path>& local_files,
     FILESYSTEM_M(batch_upload_impl(local_files, remote_paths));
 }
 
-Status RemoteFileSystem::direct_upload(const Path& remote_file, const std::string& content) {
-    auto remote_path = absolute_path(remote_file);
-    FILESYSTEM_M(direct_upload_impl(remote_path, content));
-}
-
-Status RemoteFileSystem::upload_with_checksum(const Path& local_file, const Path& remote,
-                                              const std::string& checksum) {
-    auto remote_path = absolute_path(remote);
-    FILESYSTEM_M(upload_with_checksum_impl(local_file, remote_path, checksum));
-}
-
 Status RemoteFileSystem::download(const Path& remote_file, const Path& local) {
     auto remote_path = absolute_path(remote_file);
     FILESYSTEM_M(download_impl(remote_path, local));
-}
-
-Status RemoteFileSystem::direct_download(const Path& remote_file, std::string* content) {
-    auto remote_path = absolute_path(remote_file);
-    FILESYSTEM_M(direct_download_impl(remote_path, content));
 }
 
 Status RemoteFileSystem::connect() {

--- a/be/src/io/fs/remote_file_system.h
+++ b/be/src/io/fs/remote_file_system.h
@@ -40,11 +40,7 @@ public:
     Status upload(const Path& local_file, const Path& dest_file);
     Status batch_upload(const std::vector<Path>& local_files,
                         const std::vector<Path>& remote_files);
-    Status direct_upload(const Path& remote_file, const std::string& content);
-    Status upload_with_checksum(const Path& local_file, const Path& remote,
-                                const std::string& checksum);
     Status download(const Path& remote_file, const Path& local);
-    Status direct_download(const Path& remote_file, std::string* content);
 
     Status connect();
 
@@ -64,20 +60,9 @@ protected:
     virtual Status batch_upload_impl(const std::vector<Path>& local_files,
                                      const std::vector<Path>& remote_files) = 0;
 
-    /// save the content in "content" directly to remote file
-    virtual Status direct_upload_impl(const Path& remote_file, const std::string& content) = 0;
-
-    /// upload local_file to remote_file,
-    /// and the final remote file name is "remote_file.checksum"
-    virtual Status upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                             const std::string& checksum) = 0;
-
     /// download remote_file to local_file
     /// local_file should be an absolute path on local filesystem.
     virtual Status download_impl(const Path& remote_file, const Path& local_file) = 0;
-
-    /// save of content of remote_file directly into "content"
-    virtual Status direct_download_impl(const Path& remote_file, std::string* content) = 0;
 
     // The derived class should implement this method.
     // if file_size < 0, the file size should be fetched from file system

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -65,6 +65,7 @@
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "io/fs/err_utils.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/remote_file_system.h"
@@ -77,9 +78,9 @@ namespace doris {
 namespace io {
 
 #ifndef CHECK_S3_CLIENT
-#define CHECK_S3_CLIENT(client)                         \
-    if (!client) {                                      \
-        return Status::IOError("init s3 client error"); \
+#define CHECK_S3_CLIENT(client)                               \
+    if (!client) {                                            \
+        return Status::InternalError("init s3 client error"); \
     }
 #endif
 
@@ -94,6 +95,10 @@ namespace io {
     std::string key;       \
     RETURN_IF_ERROR(get_key(path, &key));
 #endif
+
+std::string S3FileSystem::full_path(std::string_view key) const {
+    return fmt::format("{}/{}/{}", _s3_conf.endpoint, _s3_conf.bucket, key);
+}
 
 Status S3FileSystem::create(S3Conf s3_conf, std::string id, std::shared_ptr<S3FileSystem>* fs) {
     (*fs).reset(new S3FileSystem(std::move(s3_conf), std::move(id)));
@@ -113,6 +118,7 @@ S3FileSystem::S3FileSystem(S3Conf&& s3_conf, std::string&& id)
             _s3_conf.prefix.pop_back();
         }
     }
+    // TODO(plat1ko): AwsTransferManager will be deprecated
     _executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
             _id.c_str(), config::s3_transfer_executor_pool_size);
 }
@@ -123,7 +129,7 @@ Status S3FileSystem::connect_impl() {
     std::lock_guard lock(_client_mu);
     _client = S3ClientFactory::instance().create(_s3_conf);
     if (!_client) {
-        return Status::IOError("failed to init s3 client with {}", _s3_conf.to_string());
+        return Status::InternalError("failed to init s3 client with {}", _s3_conf.to_string());
     }
     return Status::OK();
 }
@@ -166,7 +172,7 @@ Status S3FileSystem::delete_file_impl(const Path& file) {
         outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
         return Status::OK();
     }
-    return Status::IOError("failed to delete file {}: {}", file.native(), error_msg(key, outcome));
+    return s3fs_error(outcome.GetError(), fmt::format("failed to delete file {}", full_path(key)));
 }
 
 Status S3FileSystem::delete_directory_impl(const Path& dir) {
@@ -187,8 +193,9 @@ Status S3FileSystem::delete_directory_impl(const Path& dir) {
         auto outcome = client->ListObjectsV2(request);
         s3_bvar::s3_list_total << 1;
         if (!outcome.IsSuccess()) {
-            return Status::IOError("failed to list objects when delete dir {}: {}", dir.native(),
-                                   error_msg(prefix, outcome));
+            return s3fs_error(
+                    outcome.GetError(),
+                    fmt::format("failed to list objects when delete dir {}", full_path(prefix)));
         }
         const auto& result = outcome.GetResult();
         Aws::Vector<Aws::S3::Model::ObjectIdentifier> objects;
@@ -203,13 +210,13 @@ Status S3FileSystem::delete_directory_impl(const Path& dir) {
             auto delete_outcome = client->DeleteObjects(delete_request);
             s3_bvar::s3_delete_total << 1;
             if (!delete_outcome.IsSuccess()) {
-                return Status::IOError("failed to delete dir {}: {}", dir.native(),
-                                       error_msg(prefix, delete_outcome));
+                return s3fs_error(delete_outcome.GetError(),
+                                  fmt::format("failed to delete dir {}", full_path(prefix)));
             }
             if (!delete_outcome.GetResult().GetErrors().empty()) {
                 const auto& e = delete_outcome.GetResult().GetErrors().front();
-                return Status::IOError("fail to delete object: {}",
-                                       error_msg(e.GetKey(), e.GetMessage()));
+                return Status::InternalError("failed to delete object {}: {}",
+                                             full_path(e.GetKey()), e.GetMessage());
             }
         }
         is_trucated = result.GetIsTruncated();
@@ -245,15 +252,16 @@ Status S3FileSystem::batch_delete_impl(const std::vector<Path>& remote_files) {
         auto delete_outcome = client->DeleteObjects(delete_request);
         s3_bvar::s3_delete_total << 1;
         if (UNLIKELY(!delete_outcome.IsSuccess())) {
-            return Status::IOError(
-                    "failed to delete objects: {}",
-                    error_msg(delete_request.GetDelete().GetObjects().front().GetKey(),
-                              delete_outcome));
+            return s3fs_error(
+                    delete_outcome.GetError(),
+                    fmt::format(
+                            "failed to delete objects {}",
+                            full_path(delete_request.GetDelete().GetObjects().front().GetKey())));
         }
         if (UNLIKELY(!delete_outcome.GetResult().GetErrors().empty())) {
             const auto& e = delete_outcome.GetResult().GetErrors().front();
-            return Status::IOError("failed to delete objects: {}",
-                                   error_msg(e.GetKey(), delete_outcome));
+            return Status::InternalError("failed to delete object {}: {}", full_path(e.GetKey()),
+                                         e.GetMessage());
         }
     } while (path_iter != remote_files.end());
 
@@ -275,8 +283,8 @@ Status S3FileSystem::exists_impl(const Path& path, bool* res) const {
     } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
         *res = false;
     } else {
-        return Status::IOError("failed to check exists {}: {}", path.native(),
-                               error_msg(key, outcome));
+        return s3fs_error(outcome.GetError(),
+                          fmt::format("failed to check exists {}", full_path(key)));
     }
     return Status::OK();
 }
@@ -293,9 +301,8 @@ Status S3FileSystem::file_size_impl(const Path& file, int64_t* file_size) const 
     s3_bvar::s3_head_total << 1;
     if (outcome.IsSuccess()) {
         *file_size = outcome.GetResult().GetContentLength();
-    } else {
-        return Status::IOError("failed to get file size {}, {}", file.native(),
-                               error_msg(key, outcome));
+        return s3fs_error(outcome.GetError(),
+                          fmt::format("failed to get file size {}", full_path(key)));
     }
     return Status::OK();
 }
@@ -319,8 +326,8 @@ Status S3FileSystem::list_impl(const Path& dir, bool only_file, std::vector<File
         auto outcome = client->ListObjectsV2(request);
         s3_bvar::s3_list_total << 1;
         if (!outcome.IsSuccess()) {
-            return Status::IOError("failed to list {}: {}", dir.native(),
-                                   error_msg(prefix, outcome));
+            return s3fs_error(outcome.GetError(),
+                              fmt::format("failed to list {}", full_path(prefix)));
         }
         for (const auto& obj : outcome.GetResult().GetContents()) {
             std::string key = obj.GetKey();
@@ -341,13 +348,7 @@ Status S3FileSystem::list_impl(const Path& dir, bool only_file, std::vector<File
 }
 
 Status S3FileSystem::rename_impl(const Path& orig_name, const Path& new_name) {
-    RETURN_IF_ERROR(copy(orig_name, new_name));
-    return delete_file_impl(orig_name);
-}
-
-Status S3FileSystem::rename_dir_impl(const Path& orig_name, const Path& new_name) {
-    RETURN_IF_ERROR(copy_dir(orig_name, new_name));
-    return delete_directory_impl(orig_name);
+    return Status::NotSupported("S3FileSystem::rename_impl");
 }
 
 Status S3FileSystem::upload_impl(const Path& local_file, const Path& remote_file) {
@@ -368,8 +369,8 @@ Status S3FileSystem::upload_impl(const Path& local_file, const Path& remote_file
     auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now() - start);
 
     if (handle->GetStatus() != Aws::Transfer::TransferStatus::COMPLETED) {
-        return Status::IOError("failed to upload {}: {}", remote_file.native(),
-                               error_msg(key, handle->GetLastError().GetMessage()));
+        return s3fs_error(handle->GetLastError(), fmt::format("failed to upload {} to {}",
+                                                              local_file.native(), full_path(key)));
     }
 
     auto file_size = std::filesystem::file_size(local_file);
@@ -410,42 +411,11 @@ Status S3FileSystem::batch_upload_impl(const std::vector<Path>& local_files,
         handle->WaitUntilFinished();
         if (handle->GetStatus() != Aws::Transfer::TransferStatus::COMPLETED) {
             // TODO(cyx): Maybe we can cancel remaining handles.
-            return Status::IOError(
-                    "failed to upload: {}",
-                    error_msg(handle->GetKey(), handle->GetLastError().GetMessage()));
+            return s3fs_error(handle->GetLastError(),
+                              fmt::format("failed to upload to {}", full_path(handle->GetKey())));
         }
     }
     return Status::OK();
-}
-
-Status S3FileSystem::direct_upload_impl(const Path& remote_file, const std::string& content) {
-    CHECK_S3_CLIENT(_client);
-    Aws::S3::Model::PutObjectRequest request;
-    GET_KEY(key, remote_file);
-    request.WithBucket(_s3_conf.bucket).WithKey(key);
-    const std::shared_ptr<Aws::IOStream> input_data =
-            Aws::MakeShared<Aws::StringStream>("upload_directly");
-    *input_data << content.c_str();
-    if (input_data->good()) {
-        request.SetBody(input_data);
-    }
-    if (!input_data->good()) {
-        return Status::IOError("failed to direct upload {}: failed to read from string",
-                               remote_file.native());
-    }
-    Aws::S3::Model::PutObjectOutcome response = _client->PutObject(request);
-    s3_bvar::s3_put_total << 1;
-    if (response.IsSuccess()) {
-        return Status::OK();
-    } else {
-        return Status::IOError("failed to direct upload {}: {}", remote_file.native(),
-                               error_msg(key, response));
-    }
-}
-
-Status S3FileSystem::upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                               const std::string& checksum) {
-    return upload_impl(local_file, remote_file.string() + "." + checksum);
 }
 
 Status S3FileSystem::download_impl(const Path& remote_file, const Path& local_file) {
@@ -467,61 +437,7 @@ Status S3FileSystem::download_impl(const Path& remote_file, const Path& local_fi
                                    remote_file.native(), local_file.native());
         }
     } else {
-        return Status::IOError("failed to download {}: {}", remote_file.native(),
-                               error_msg(key, response));
-    }
-    return Status::OK();
-}
-
-Status S3FileSystem::direct_download_impl(const Path& remote, std::string* content) {
-    CHECK_S3_CLIENT(_client);
-    Aws::S3::Model::GetObjectRequest request;
-    GET_KEY(key, remote);
-    request.WithBucket(_s3_conf.bucket).WithKey(key);
-    Aws::S3::Model::GetObjectOutcome response = _client->GetObject(request);
-    s3_bvar::s3_get_total << 1;
-    if (response.IsSuccess()) {
-        std::stringstream ss;
-        ss << response.GetResult().GetBody().rdbuf();
-        *content = ss.str();
-    } else {
-        return Status::IOError("failed to direct download {}: {}", remote.native(),
-                               error_msg(key, response));
-    }
-    return Status::OK();
-}
-
-Status S3FileSystem::copy(const Path& src, const Path& dst) {
-    CHECK_S3_CLIENT(_client);
-    Aws::S3::Model::CopyObjectRequest request;
-    GET_KEY(src_key, src);
-    GET_KEY(dst_key, dst);
-    request.WithCopySource(_s3_conf.bucket + "/" + src_key)
-            .WithKey(dst_key)
-            .WithBucket(_s3_conf.bucket);
-    Aws::S3::Model::CopyObjectOutcome response = _client->CopyObject(request);
-    s3_bvar::s3_copy_object_total << 1;
-    if (response.IsSuccess()) {
-        return Status::OK();
-    } else {
-        return Status::IOError("failed to copy from {} to {}: {}", src.native(), dst.native(),
-                               error_msg(src_key, response));
-    }
-}
-
-Status S3FileSystem::copy_dir(const Path& src, const Path& dst) {
-    std::vector<FileInfo> files;
-    bool exists = false;
-    RETURN_IF_ERROR(list_impl(src, true, &files, &exists));
-    if (!exists) {
-        return Status::IOError("path not found: {}", src.native());
-    }
-    if (files.empty()) {
-        LOG(WARNING) << "Nothing need to copy: " << src << " -> " << dst;
-        return Status::OK();
-    }
-    for (auto& file : files) {
-        RETURN_IF_ERROR(copy(src / file.file_name, dst / file.file_name));
+        return localfs_error(errno, fmt::format("failed to write file {}", local_file.native()));
     }
     return Status::OK();
 }
@@ -530,19 +446,6 @@ Status S3FileSystem::get_key(const Path& path, std::string* key) const {
     CHECK_S3_PATH(uri, path);
     *key = uri.get_key();
     return Status::OK();
-}
-
-template <typename AwsOutcome>
-std::string S3FileSystem::error_msg(const std::string& key, const AwsOutcome& outcome) const {
-    return fmt::format("(endpoint: {}, bucket: {}, key:{}, {}), {}, error code {}",
-                       _s3_conf.endpoint, _s3_conf.bucket, key,
-                       outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(),
-                       outcome.GetError().GetResponseCode());
-}
-
-std::string S3FileSystem::error_msg(const std::string& key, const std::string& err) const {
-    return fmt::format("(endpoint: {}, bucket: {}, key:{}), {}", _s3_conf.endpoint, _s3_conf.bucket,
-                       key, err);
 }
 
 } // namespace io

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -82,16 +82,11 @@ protected:
     Status list_impl(const Path& dir, bool only_file, std::vector<FileInfo>* files,
                      bool* exists) override;
     Status rename_impl(const Path& orig_name, const Path& new_name) override;
-    Status rename_dir_impl(const Path& orig_name, const Path& new_name) override;
 
     Status upload_impl(const Path& local_file, const Path& remote_file) override;
     Status batch_upload_impl(const std::vector<Path>& local_files,
                              const std::vector<Path>& remote_files) override;
-    Status direct_upload_impl(const Path& remote_file, const std::string& content) override;
-    Status upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                     const std::string& checksum) override;
     Status download_impl(const Path& remote_file, const Path& local_file) override;
-    Status direct_download_impl(const Path& remote_file, std::string* content) override;
 
     Path absolute_path(const Path& path) const override {
         if (path.string().find("://") != std::string::npos) {
@@ -108,13 +103,9 @@ protected:
 private:
     S3FileSystem(S3Conf&& s3_conf, std::string&& id);
 
-    template <typename AwsOutcome>
-    std::string error_msg(const std::string& key, const AwsOutcome& outcome) const;
-    std::string error_msg(const std::string& key, const std::string& err) const;
-    /// copy file from src to dst
-    Status copy(const Path& src, const Path& dst);
-    /// copy dir from src to dst
-    Status copy_dir(const Path& src, const Path& dst);
+    // Full path for error message, format: endpoint/bucket/key
+    std::string full_path(std::string_view key) const;
+
     Status get_key(const Path& path, std::string* key) const;
 
 private:

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -48,14 +48,11 @@ public:
 
     Status close() override;
 
-    Status abort() override;
     Status appendv(const Slice* data, size_t data_cnt) override;
     Status finalize() override;
-    Status write_at(size_t offset, const Slice& data) override {
-        return Status::NotSupported("not support");
-    }
 
 private:
+    Status _abort();
     void _wait_until_finish(std::string_view task_name);
     Status _complete();
     Status _create_multi_upload_request();

--- a/be/src/io/fs/stream_sink_file_writer.h
+++ b/be/src/io/fs/stream_sink_file_writer.h
@@ -47,14 +47,6 @@ public:
 
     Status close() override;
 
-    Status abort() override {
-        return Status::NotSupported("StreamSinkFileWriter::abort() is not supported");
-    }
-
-    Status write_at(size_t offset, const Slice& data) override {
-        return Status::NotSupported("StreamSinkFileWriter::write_at() is not supported");
-    }
-
 private:
     template <bool eos>
     Status _flush();

--- a/be/src/olap/file_header.h
+++ b/be/src/olap/file_header.h
@@ -139,13 +139,11 @@ Status FileHeader<MessageType, ExtraType>::serialize() {
     // write to file
     io::FileWriterPtr file_writer;
     RETURN_IF_ERROR(io::global_local_filesystem()->create_file(_file_path, &file_writer));
-    RETURN_IF_ERROR(file_writer->write_at(
-            0, {(const uint8_t*)&_fixed_file_header, _fixed_file_header_size}));
-    RETURN_IF_ERROR(file_writer->write_at(
-            _fixed_file_header_size,
+    RETURN_IF_ERROR(
+            file_writer->append({(const uint8_t*)&_fixed_file_header, _fixed_file_header_size}));
+    RETURN_IF_ERROR(file_writer->append(
             {(const uint8_t*)&_extra_fixed_header, sizeof(_extra_fixed_header)}));
-    RETURN_IF_ERROR(file_writer->write_at(_fixed_file_header_size + sizeof(_extra_fixed_header),
-                                          {_proto_string}));
+    RETURN_IF_ERROR(file_writer->append({_proto_string}));
     return file_writer->close();
 }
 

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -297,7 +297,7 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
             return Status::Error<FILE_ALREADY_EXIST>("file already exist: {}", dst_path);
         }
         auto src_path = segment_file_path(i);
-        RETURN_IF_ERROR(io::global_local_filesystem()->copy_dirs(src_path, dst_path));
+        RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(src_path, dst_path));
         for (auto& column : _schema->columns()) {
             // if (column.has_inverted_index()) {
             const TabletIndex* index_meta = _schema->get_inverted_index(column);
@@ -308,7 +308,7 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
                 std::string inverted_index_dst_file_path =
                         InvertedIndexDescriptor::get_index_file_name(
                                 dst_path, index_meta->index_id(), index_meta->get_index_suffix());
-                RETURN_IF_ERROR(io::global_local_filesystem()->copy_dirs(
+                RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(
                         inverted_index_src_file_path, inverted_index_dst_file_path));
                 LOG(INFO) << "success to copy file. from=" << inverted_index_src_file_path << ", "
                           << "to=" << inverted_index_dst_file_path;

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
@@ -672,8 +672,7 @@ void DorisCompoundDirectory::renameFile(const char* from, const char* to) {
     if (exists) {
         LOG_AND_THROW_IF_ERROR(fs->delete_directory(nu), fmt::format("Delete {} IO error", nu))
     }
-    LOG_AND_THROW_IF_ERROR(fs->rename_dir(old, nu),
-                           fmt::format("Rename {} to {} IO error", old, nu))
+    LOG_AND_THROW_IF_ERROR(fs->rename(old, nu), fmt::format("Rename {} to {} IO error", old, nu))
 }
 
 lucene::store::IndexOutput* DorisCompoundDirectory::createOutput(const char* name) {

--- a/be/src/runtime/block_spill_manager.cpp
+++ b/be/src/runtime/block_spill_manager.cpp
@@ -53,7 +53,7 @@ Status BlockSpillManager::init() {
         } else {
             auto suffix = ToStringFromUnixMillis(UnixMillis());
             auto gc_dir = fmt::format("{}/{}/{}", path.path, BLOCK_SPILL_GC_DIR, suffix);
-            RETURN_IF_ERROR(io::global_local_filesystem()->rename_dir(dir, gc_dir));
+            RETURN_IF_ERROR(io::global_local_filesystem()->rename(dir, gc_dir));
             RETURN_IF_ERROR(io::global_local_filesystem()->create_directory(dir));
         }
     }

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -203,7 +203,7 @@ Status SnapshotLoader::upload(const std::map<std::string, std::string>& src_to_d
             // upload
             std::string remote_path = dest_path + '/' + local_file;
             std::string local_path = src_path + '/' + local_file;
-            RETURN_IF_ERROR(upload_with_checksum(*_remote_fs, local_path, local_path, md5sum));
+            RETURN_IF_ERROR(upload_with_checksum(*_remote_fs, local_path, remote_path, md5sum));
         } // end for each tablet's local files
 
         tablet_files->emplace(tablet_id, local_files_with_checksum);

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -60,6 +60,29 @@
 #include "util/thrift_rpc_helper.h"
 
 namespace doris {
+namespace {
+
+Status upload_with_checksum(io::RemoteFileSystem& fs, std::string_view local_path,
+                            std::string_view remote_path, std::string_view checksum) {
+    auto full_remote_path = fmt::format("{}.{}", remote_path, checksum);
+    switch (fs.type()) {
+    case io::FileSystemType::HDFS:
+    case io::FileSystemType::BROKER: {
+        std::string temp = fmt::format("{}.part", remote_path);
+        RETURN_IF_ERROR(fs.upload(local_path, temp));
+        RETURN_IF_ERROR(fs.rename(temp, full_remote_path));
+        break;
+    }
+    case io::FileSystemType::S3:
+        RETURN_IF_ERROR(fs.upload(local_path, full_remote_path));
+        break;
+    default:
+        LOG(FATAL) << "unknown fs type: " << static_cast<int>(fs.type());
+    }
+    return Status::OK();
+}
+
+} // namespace
 
 SnapshotLoader::SnapshotLoader(ExecEnv* env, int64_t job_id, int64_t task_id)
         : _env(env),
@@ -178,10 +201,9 @@ Status SnapshotLoader::upload(const std::map<std::string, std::string>& src_to_d
             }
 
             // upload
-            std::string full_remote_file = dest_path + "/" + local_file;
-            std::string full_local_file = src_path + "/" + local_file;
-            RETURN_IF_ERROR(
-                    _remote_fs->upload_with_checksum(full_local_file, full_remote_file, md5sum));
+            std::string remote_path = dest_path + '/' + local_file;
+            std::string local_path = src_path + '/' + local_file;
+            RETURN_IF_ERROR(upload_with_checksum(*_remote_fs, local_path, local_path, md5sum));
         } // end for each tablet's local files
 
         tablet_files->emplace(tablet_id, local_files_with_checksum);

--- a/be/src/util/os_util.cpp
+++ b/be/src/util/os_util.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,6 @@
 using std::string;
 using std::vector;
 using strings::Split;
-using strings::Substitute;
 
 namespace doris {
 

--- a/be/test/io/fs/local_file_system_test.cpp
+++ b/be/test/io/fs/local_file_system_test.cpp
@@ -17,16 +17,20 @@
 
 #include "io/fs/local_file_system.h"
 
+#include <asm-generic/errno-base.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include <filesystem>
 #include <vector>
 
 #include "common/status.h"
+#include "common/sync_point.h"
 #include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_writer.h"
@@ -34,502 +38,73 @@
 
 namespace doris {
 
+static constexpr std::string_view test_dir = "ut_dir/local_fs_test";
+
 class LocalFileSystemTest : public testing::Test {
 public:
-    virtual void SetUp() {
-        EXPECT_TRUE(
-                io::global_local_filesystem()->delete_and_create_directory(_s_test_data_path).ok());
+    void SetUp() override {
+        Status st;
+        st = io::global_local_filesystem()->delete_directory(test_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(test_dir);
+        ASSERT_TRUE(st.ok()) << st;
     }
 
-    Status save_string_file(const std::filesystem::path& filename, const std::string& content) {
-        io::FileWriterPtr file_writer;
-        RETURN_IF_ERROR(io::global_local_filesystem()->create_file(filename, &file_writer));
-        RETURN_IF_ERROR(file_writer->append(content));
-        return file_writer->close();
+    void TearDown() override {
+        Status st;
+        st = io::global_local_filesystem()->delete_directory(test_dir);
+        EXPECT_TRUE(st.ok()) << st;
     }
-
-    bool check_exists(const std::string& file) {
-        bool exists = true;
-        EXPECT_TRUE(io::global_local_filesystem()->exists(file, &exists).ok());
-        return exists;
-    }
-
-    bool is_dir(const std::string& path) {
-        bool is_dir = true;
-        EXPECT_TRUE(io::global_local_filesystem()->is_directory(path, &is_dir).ok());
-        return is_dir;
-    }
-
-    Status list_dirs_files(const std::string& path, std::vector<std::string>* dirs,
-                           std::vector<std::string>* files) {
-        bool only_file = true;
-        if (dirs != nullptr) {
-            only_file = false;
-        }
-        std::vector<io::FileInfo> file_infos;
-        bool exists = true;
-        RETURN_IF_ERROR(io::global_local_filesystem()->list(path, only_file, &file_infos, &exists));
-        for (auto& file_info : file_infos) {
-            if (file_info.is_file && files != nullptr) {
-                files->push_back(file_info.file_name);
-            }
-            if (!file_info.is_file && dirs != nullptr) {
-                dirs->push_back(file_info.file_name);
-            }
-        }
-        return Status::OK();
-    }
-
-    Status delete_file_paths(const std::vector<std::string>& ps) {
-        for (auto& p : ps) {
-            bool exists = true;
-            RETURN_IF_ERROR(io::global_local_filesystem()->exists(p, &exists));
-            if (!exists) {
-                continue;
-            }
-            RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory_or_file(p));
-        }
-        return Status::OK();
-    }
-
-    // delete the mock cgroup folder
-    virtual void TearDown() {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_s_test_data_path).ok());
-    }
-
-    static std::string _s_test_data_path;
 };
 
-std::string LocalFileSystemTest::_s_test_data_path = "./file_utils_testxxxx123";
-
-TEST_F(LocalFileSystemTest, TestRemove) {
-    // remove_all
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-    EXPECT_FALSE(check_exists("./file_test"));
-
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/123/456/789").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/abc/def/zxc").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/abc/123").ok());
-
-    static_cast<void>(save_string_file("./file_test/s1", "123"));
-    static_cast<void>(save_string_file("./file_test/123/s2", "123"));
-
-    EXPECT_TRUE(check_exists("./file_test"));
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-    EXPECT_FALSE(check_exists("./file_test"));
-
-    // remove
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/abc/123").ok());
-    static_cast<void>(save_string_file("./file_test/abc/123/s2", "123"));
-
-    EXPECT_TRUE(check_exists("./file_test/abc/123/s2"));
-    EXPECT_TRUE(io::global_local_filesystem()->delete_file("./file_test/abc/123/s2").ok());
-    EXPECT_FALSE(check_exists("./file_test/abc/123/s2"));
-
-    EXPECT_TRUE(check_exists("./file_test/abc/123"));
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test/abc/123").ok());
-    EXPECT_FALSE(check_exists("./file_test/abc/123"));
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-    EXPECT_FALSE(check_exists("./file_test"));
-
-    // remove paths
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/123/456/789").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/abc/def/zxc").ok());
-    static_cast<void>(save_string_file("./file_test/s1", "123"));
-    static_cast<void>(save_string_file("./file_test/s2", "123"));
-
-    std::vector<std::string> ps;
-    ps.push_back("./file_test/123/456/789");
-    ps.push_back("./file_test/123/456");
-    ps.push_back("./file_test/123");
-
-    EXPECT_TRUE(check_exists("./file_test/123"));
-    EXPECT_TRUE(delete_file_paths(ps).ok());
-    EXPECT_FALSE(check_exists("./file_test/123"));
-
-    ps.clear();
-    ps.push_back("./file_test/s1");
-    ps.push_back("./file_test/abc/def");
-
-    EXPECT_TRUE(delete_file_paths(ps).ok());
-    EXPECT_FALSE(check_exists("./file_test/s1"));
-    EXPECT_FALSE(check_exists("./file_test/abc/def/"));
-
-    ps.clear();
-    ps.push_back("./file_test/abc/def/zxc");
-    ps.push_back("./file_test/s2");
-    ps.push_back("./file_test/abc/def");
-    ps.push_back("./file_test/abc");
-
-    EXPECT_TRUE(delete_file_paths(ps).ok());
-    EXPECT_FALSE(check_exists("./file_test/s2"));
-    EXPECT_FALSE(check_exists("./file_test/abc"));
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
+bool check_exist(const std::string& path) {
+    bool res = false;
+    auto st = io::global_local_filesystem()->exists(path, &res);
+    EXPECT_TRUE(st.ok()) << st;
+    return res;
 }
 
-TEST_F(LocalFileSystemTest, TestCreateDir) {
-    // normal
-    std::string path = "./file_test/123/456/789";
-    static_cast<void>(io::global_local_filesystem()->delete_directory("./file_test"));
-    EXPECT_FALSE(check_exists(path));
-
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-
-    EXPECT_TRUE(check_exists(path));
-    EXPECT_TRUE(is_dir("./file_test"));
-    EXPECT_TRUE(is_dir("./file_test/123"));
-    EXPECT_TRUE(is_dir("./file_test/123/456"));
-    EXPECT_TRUE(is_dir("./file_test/123/456/789"));
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-
-    // normal
-    path = "./file_test/123/456/789/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-    EXPECT_FALSE(check_exists(path));
-
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-
-    EXPECT_TRUE(check_exists(path));
-    EXPECT_TRUE(is_dir("./file_test"));
-    EXPECT_TRUE(is_dir("./file_test/123"));
-    EXPECT_TRUE(is_dir("./file_test/123/456"));
-    EXPECT_TRUE(is_dir("./file_test/123/456/789"));
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-
-    // absolute path;
-    std::string real_path;
-    EXPECT_TRUE(io::global_local_filesystem()->canonicalize(".", &real_path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()
-                        ->create_directory(real_path + "/file_test/absolute/path/123/asdf")
-                        .ok());
-    EXPECT_TRUE(is_dir("./file_test/absolute/path/123/asdf"));
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("./file_test").ok());
-
-    char filename[] = "temp-XXXXXX";
-    // Setup a temporary directory with one subdir
-    std::string dir_name = mkdtemp(filename);
-    io::Path dir {dir_name};
-    io::Path subdir1 = dir / "path1";
-    io::Path subdir2 = dir / "path2";
-    io::Path subdir3 = dir / "a" / "longer" / "path";
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir1).ok());
-    // Test error cases by removing write permissions on root dir to prevent
-    // creation/deletion of subdirs
-    chmod(dir.string().c_str(), 0);
-    if (getuid() == 0) { // User root
-        EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir1).ok());
-        EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir2).ok());
-    } else { // User other
-        EXPECT_FALSE(io::global_local_filesystem()->create_directory(subdir1).ok());
-        EXPECT_FALSE(io::global_local_filesystem()->create_directory(subdir2).ok());
-    }
-    // Test success cases by adding write permissions back
-    chmod(dir.string().c_str(), S_IRWXU);
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(subdir1).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(subdir2).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir1).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir2).ok());
-    // Check that directories were created
-    bool is_dir = false;
-    EXPECT_TRUE(io::global_local_filesystem()->is_directory(subdir1, &is_dir).ok());
-    EXPECT_TRUE(is_dir);
-    EXPECT_TRUE(io::global_local_filesystem()->is_directory(subdir2, &is_dir).ok());
-    EXPECT_TRUE(is_dir);
-    EXPECT_FALSE(io::global_local_filesystem()->is_directory(subdir3, &is_dir).ok());
-    // Check that nested directories can be created
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(subdir3).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->is_directory(subdir3, &is_dir).ok());
-    EXPECT_TRUE(is_dir);
-    // Cleanup
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(dir).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestContainPath) {
-    {
-        std::string parent("/a/b");
-        std::string sub("/a/b/c");
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-
-    {
-        std::string parent("/a/b/");
-        std::string sub("/a/b/c/");
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-
-    {
-        std::string parent("/a///./././/./././b/"); // "/a/b/."
-        std::string sub("/a/b/../././b/c/");        // "/a/b/c/"
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-
-    {
-        // relative path
-        std::string parent("a/b/"); // "a/b/"
-        std::string sub("a/b/c/");  // "a/b/c/"
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-    {
-        // relative path
-        std::string parent("a////./././b/"); // "a/b/"
-        std::string sub("a/b/../././b/c/");  // "a/b/c/"
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-    {
-        // absolute path and relative path
-        std::string parent("/a////./././b/"); // "/a/b/"
-        std::string sub("a/b/../././b/c/");   // "a/b/c/"
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(parent, sub));
-        EXPECT_FALSE(io::global_local_filesystem()->contain_path(sub, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(parent, parent));
-        EXPECT_TRUE(io::global_local_filesystem()->contain_path(sub, sub));
-    }
-}
-
-TEST_F(LocalFileSystemTest, TestRename) {
-    std::string path = "./file_rename/";
-    std::string new_path = "./file_rename2/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->rename_dir(path, new_path).ok());
-
-    static_cast<void>(save_string_file("./file_rename2/f1", "just test1"));
-    EXPECT_TRUE(
-            io::global_local_filesystem()->rename("./file_rename2/f1", "./file_rename2/f2").ok());
-
-    std::vector<std::string> dirs;
-    std::vector<std::string> files;
-    EXPECT_TRUE(list_dirs_files(new_path, &dirs, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(1, files.size());
-    EXPECT_EQ("f2", files[0]);
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(new_path).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestLink) {
-    std::string path = "./file_link/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-
-    // link file
-    static_cast<void>(save_string_file("./file_link/f2", "just test2"));
-    EXPECT_TRUE(
-            io::global_local_filesystem()->link_file("./file_link/f2", "./file_link/f2-1").ok());
-    std::vector<std::string> dirs;
-    std::vector<std::string> files;
-    EXPECT_TRUE(list_dirs_files("./file_link/", &dirs, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(2, files.size());
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory("file_link2").ok());
-}
-
-TEST_F(LocalFileSystemTest, TestMD5) {
-    std::string path = "./file_md5/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-
-    // link fir
-    static_cast<void>(save_string_file("./file_md5/f1", "just test1"));
-    std::string md5;
-    EXPECT_TRUE(io::global_local_filesystem()->md5sum("./file_md5/f1", &md5).ok());
-    EXPECT_EQ("56947c63232fef1c65e4c3f4d1c69a9c", md5);
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestCopyAndBatchDelete) {
-    std::string path = "./file_copy/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_copy/1").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_copy/2").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_copy/3").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_copy/4").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_copy/5").ok());
-
-    static_cast<void>(save_string_file("./file_copy/f1", "just test1"));
-    static_cast<void>(save_string_file("./file_copy/f2", "just test2"));
-    static_cast<void>(save_string_file("./file_copy/f3", "just test3"));
-    static_cast<void>(save_string_file("./file_copy/1/f4", "just test3"));
-    static_cast<void>(save_string_file("./file_copy/2/f5", "just test3"));
-
-    // copy
-    std::string dest_path = "./file_copy_dest/";
-    EXPECT_TRUE(io::global_local_filesystem()->copy_dirs(path, dest_path).ok());
-
-    std::vector<std::string> dirs;
-    std::vector<std::string> files;
-    EXPECT_TRUE(list_dirs_files("./file_copy_dest", &dirs, &files).ok());
-    EXPECT_EQ(5, dirs.size());
-    EXPECT_EQ(3, files.size());
-
-    dirs.clear();
-    files.clear();
-    EXPECT_TRUE(list_dirs_files("./file_copy_dest/1/", &dirs, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(1, files.size());
-
-    dirs.clear();
-    files.clear();
-    EXPECT_TRUE(list_dirs_files("./file_copy_dest/2/", &dirs, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(1, files.size());
-
-    // batch delete
-    std::vector<io::Path> delete_files;
-    delete_files.emplace_back("./file_copy/f3");
-    delete_files.emplace_back("./file_copy/1/f4");
-    delete_files.emplace_back("./file_copy/2/f5");
-    EXPECT_TRUE(io::global_local_filesystem()->batch_delete(delete_files).ok());
-
-    dirs.clear();
-    files.clear();
-    EXPECT_TRUE(list_dirs_files("./file_copy/1/", &dirs, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(0, files.size());
-
-    dirs.clear();
-    files.clear();
-    EXPECT_TRUE(list_dirs_files("./file_copy/", &dirs, &files).ok());
-    EXPECT_EQ(5, dirs.size());
-    EXPECT_EQ(2, files.size());
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(dest_path).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestIterate) {
-    std::string path = "./file_iterate/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory(path).ok());
-
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_iterate/d1").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_iterate/d2").ok());
-    static_cast<void>(save_string_file("./file_iterate/f1", "just test1"));
-    static_cast<void>(save_string_file("./file_iterate/f2", "just test2"));
-    static_cast<void>(save_string_file("./file_iterate/f3", "just test3"));
-    static_cast<void>(save_string_file("./file_iterate/d1/f4", "just test4"));
-    static_cast<void>(save_string_file("./file_iterate/d2/f5", "just test5"));
-
-    int64_t file_count = 0;
-    int64_t dir_count = 0;
-    auto cb = [&](const io::FileInfo& file) -> bool {
-        if (file.is_file) {
-            if (file.file_name != "f1") {
-                file_count++;
-            }
-        } else {
-            dir_count++;
-        }
-        return true;
-    };
-
-    auto cb2 = [&](const io::FileInfo& file) -> bool { return false; };
-
-    EXPECT_TRUE(io::global_local_filesystem()->iterate_directory("./file_iterate/", cb).ok());
-    EXPECT_EQ(2, file_count);
-    EXPECT_EQ(2, dir_count);
-
-    file_count = 0;
-    dir_count = 0;
-    EXPECT_TRUE(io::global_local_filesystem()->iterate_directory("./file_iterate/", cb2).ok());
-    EXPECT_EQ(0, file_count);
-    EXPECT_EQ(0, dir_count);
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestListDirsFiles) {
-    std::string path = "./file_test/";
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/1").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/2").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/3").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/4").ok());
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./file_test/5").ok());
-
-    std::vector<std::string> dirs;
-    std::vector<std::string> files;
-
-    EXPECT_TRUE(list_dirs_files("./file_test", &dirs, &files).ok());
-    EXPECT_EQ(5, dirs.size());
-    EXPECT_EQ(0, files.size());
-
-    dirs.clear();
-    files.clear();
-
-    EXPECT_TRUE(list_dirs_files("./file_test", &dirs, nullptr).ok());
-    EXPECT_EQ(5, dirs.size());
-    EXPECT_EQ(0, files.size());
-
-    static_cast<void>(save_string_file("./file_test/f1", "just test"));
-    static_cast<void>(save_string_file("./file_test/f2", "just test"));
-    static_cast<void>(save_string_file("./file_test/f3", "just test"));
-
-    dirs.clear();
-    files.clear();
-
-    EXPECT_TRUE(list_dirs_files("./file_test", &dirs, &files).ok());
-    EXPECT_EQ(5, dirs.size());
-    EXPECT_EQ(3, files.size());
-
-    dirs.clear();
-    files.clear();
-
-    EXPECT_TRUE(list_dirs_files("./file_test", nullptr, &files).ok());
-    EXPECT_EQ(0, dirs.size());
-    EXPECT_EQ(3, files.size());
-
-    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(path).ok());
-}
-
-TEST_F(LocalFileSystemTest, TestRandomAccess) {
-    std::string fname = "./ut_dir/local_filesystem/random_access";
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./ut_dir/local_filesystem/").ok());
+Status save_string_file(const std::string& path, const std::string& content) {
     io::FileWriterPtr file_writer;
-    EXPECT_TRUE(io::global_local_filesystem()->create_file(fname, &file_writer).ok());
+    RETURN_IF_ERROR(io::global_local_filesystem()->create_file(path, &file_writer));
+    RETURN_IF_ERROR(file_writer->append(content));
+    return file_writer->close();
+}
+
+TEST_F(LocalFileSystemTest, WriteRead) {
+    auto fname = fmt::format("{}/abc", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
     Slice field1("123456789");
-    EXPECT_TRUE(file_writer->append(field1).ok());
+    st = file_writer->append(field1);
+    ASSERT_TRUE(st.ok()) << st;
 
     std::string buf;
     for (int i = 0; i < 100; ++i) {
         buf.push_back((char)i);
     }
-    EXPECT_TRUE(file_writer->append(buf).ok());
+    st = file_writer->append(buf);
+    ASSERT_TRUE(st.ok()) << st;
     Slice abc("abc");
     Slice bcd("bcd");
     Slice slices[2] {abc, bcd};
-    EXPECT_TRUE(file_writer->appendv(slices, 2).ok());
-    EXPECT_TRUE(file_writer->close().ok());
+    st = file_writer->appendv(slices, 2);
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->finalize();
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 115);
 
-    int64_t size;
-    EXPECT_TRUE(io::global_local_filesystem()->file_size(fname, &size).ok());
-    EXPECT_EQ(115, size);
+    int64_t fsize;
+    st = io::global_local_filesystem()->file_size(fname, &fsize);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(115, fsize);
     {
         io::FileReaderSPtr file_reader;
-        EXPECT_TRUE(io::global_local_filesystem()->open_file(fname, &file_reader).ok());
+        st = io::global_local_filesystem()->open_file(fname, &file_reader);
+        ASSERT_TRUE(st.ok()) << st;
 
         char mem[1024];
         Slice slice1(mem, 9);
@@ -537,78 +112,267 @@ TEST_F(LocalFileSystemTest, TestRandomAccess) {
         Slice slice3(mem + 9 + 100, 3);
         Slice slice4(mem + 9 + 100 + 3, 3);
         size_t bytes_read = 0;
-        EXPECT_TRUE(file_reader->read_at(0, slice1, &bytes_read).ok());
-        EXPECT_STREQ("123456789", std::string(slice1.data, slice1.size).c_str());
-        EXPECT_EQ(9, bytes_read);
+        st = file_reader->read_at(0, slice1, &bytes_read);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(9, bytes_read);
+        EXPECT_EQ(std::string_view(slice1.data, slice1.size), "123456789");
+        st = file_reader->read_at(9, slice2, &bytes_read);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(100, bytes_read);
+        for (int i = 0; i < 100; ++i) {
+            EXPECT_EQ((int)slice2.data[i], i);
+        }
 
-        EXPECT_TRUE(file_reader->read_at(9, slice2, &bytes_read).ok());
-        EXPECT_EQ(100, bytes_read);
+        st = file_reader->read_at(109, slice3, &bytes_read);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(3, bytes_read);
+        EXPECT_EQ(std::string_view(slice3.data, slice3.size), "abc");
+        st = file_reader->read_at(112, slice4, &bytes_read);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(3, bytes_read);
+        EXPECT_EQ(std::string_view(slice4.data, slice4.size), "bcd");
 
-        EXPECT_TRUE(file_reader->read_at(109, slice3, &bytes_read).ok());
-        EXPECT_STREQ("abc", std::string(slice3.data, slice3.size).c_str());
-        EXPECT_EQ(3, bytes_read);
-
-        EXPECT_TRUE(file_reader->read_at(112, slice4, &bytes_read).ok());
-        EXPECT_STREQ("bcd", std::string(slice4.data, slice4.size).c_str());
-        EXPECT_EQ(3, bytes_read);
-
-        EXPECT_TRUE(file_reader->close().ok());
+        st = file_reader->close();
+        ASSERT_TRUE(st.ok()) << st;
     }
 }
 
-TEST_F(LocalFileSystemTest, TestRandomWrite) {
-    std::string fname = "./ut_dir/env_posix/random_rw";
-    EXPECT_TRUE(io::global_local_filesystem()->create_directory("./ut_dir/env_posix").ok());
+TEST_F(LocalFileSystemTest, Exist) {
+    auto fname = fmt::format("{}/abc", test_dir);
+    ASSERT_FALSE(check_exist(fname));
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->finalize();
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_TRUE(check_exist(fname));
+}
+
+TEST_F(LocalFileSystemTest, List) {
+    io::FileWriterPtr file_writer;
+    auto fname = fmt::format("{}/abc", test_dir);
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->finalize();
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_TRUE(check_exist(fname));
+    std::vector<io::FileInfo> files;
+    bool exists;
+    st = io::global_local_filesystem()->list(fname, false, &files, &exists);
+    ASSERT_FALSE(st.ok()) << st; // Not a dir, can not list
+
+    auto dname = fmt::format("{}/dir/dir1/dir2", test_dir);
+    st = io::global_local_filesystem()->create_directory(dname);
+    ASSERT_TRUE(st.ok()) << st;
+    files.clear();
+    st = io::global_local_filesystem()->list(dname, false, &files, &exists);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_TRUE(files.empty());
+    for (int i = 0; i < 10; ++i) {
+        st = save_string_file(fmt::format("{}/{}", dname, i), "abc");
+        ASSERT_TRUE(st.ok()) << st;
+    }
+    files.clear();
+    st = io::global_local_filesystem()->list(dname, false, &files, &exists);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(files.size(), 10);
+    std::sort(files.begin(), files.end(),
+              [](auto&& file1, auto&& file2) { return file1.file_name < file2.file_name; });
+    for (int i = 0; i < 10; ++i) {
+        ASSERT_EQ(std::to_string(i), files[i].file_name);
+    }
+}
+
+TEST_F(LocalFileSystemTest, Delete) {
+    io::FileWriterPtr file_writer;
+    auto fname = fmt::format("{}/abc", test_dir);
+    auto st = save_string_file(fname, "abc");
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_TRUE(check_exist(fname));
+    st = io::global_local_filesystem()->delete_directory(fname);
+    ASSERT_FALSE(st.ok()) << st;
+    st = io::global_local_filesystem()->delete_file(fname);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_FALSE(check_exist(fname));
+    st = io::global_local_filesystem()->delete_file(fname);
+    ASSERT_TRUE(st.ok()) << st; // Delete non-existed file is ok
+
+    auto dname = fmt::format("{}/dir/dir1/dir2", test_dir);
+    st = io::global_local_filesystem()->create_directory(dname);
+    ASSERT_TRUE(st.ok()) << st;
+    for (int i = 0; i < 10; ++i) {
+        st = save_string_file(fmt::format("{}/{}", dname, i), "abc");
+        ASSERT_TRUE(st.ok()) << st;
+    }
+    st = io::global_local_filesystem()->delete_file(dname);
+    ASSERT_FALSE(st.ok()) << st;
+    st = io::global_local_filesystem()->delete_directory(dname);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_FALSE(check_exist(dname));
+    st = io::global_local_filesystem()->delete_directory(dname);
+    ASSERT_TRUE(st.ok()) << st;                                     // Delete non-existed dir is ok
+    ASSERT_TRUE(check_exist(fmt::format("{}/dir/dir1", test_dir))); // Parent should exist
+}
+
+TEST_F(LocalFileSystemTest, AbnormalFileWriter) {
+    auto fname = fmt::format("{}/abc", test_dir);
+    {
+        io::FileWriterPtr file_writer;
+        auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+        ASSERT_TRUE(st.ok()) << st;
+        st = file_writer->append("abc");
+        ASSERT_TRUE(st.ok()) << st;
+        // ~LocalFileWriter
+    }
+    ASSERT_FALSE(check_exist(fname));
+    io::FileReaderSPtr file_reader;
+    auto st = io::global_local_filesystem()->open_file(fname, &file_reader);
+    ASSERT_FALSE(st.ok()) << st; // Cannot open non-existed file
 
     io::FileWriterPtr file_writer;
-    EXPECT_TRUE(io::global_local_filesystem()->create_file(fname, &file_writer).ok());
+    st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->append("abc");
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+    st = file_writer->append("abc");
+    ASSERT_FALSE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 3);
+    st = io::global_local_filesystem()->open_file(fname, &file_reader);
+    ASSERT_TRUE(st.ok()) << st;
+    char buf[1024];
+    size_t bytes_read;
+    st = file_reader->read_at(0, {buf, 3}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 3);
+    EXPECT_EQ(std::string_view(buf, 3), "abc");
+    st = file_reader->read_at(3, {buf + 3, 1}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 0);
+}
 
-    // write data
-    Slice field1("123456789");
-    EXPECT_TRUE(file_writer->write_at(0, field1).ok());
-    std::string buf;
-    for (int i = 0; i < 100; ++i) {
-        buf.push_back((char)i);
-    }
-    EXPECT_TRUE(file_writer->write_at(9, buf).ok());
-    Slice abc("abc");
-    Slice bcd("bcd");
-    Slice slices[2] {abc, bcd};
-    EXPECT_TRUE(file_writer->write_at(0, slices[0]).ok());
-    EXPECT_TRUE(file_writer->write_at(3, slices[1]).ok());
-    EXPECT_TRUE(file_writer->close().ok());
+TEST_F(LocalFileSystemTest, AbnormalWriteRead) {
+    auto sp = SyncPoint::get_instance();
+    Defer defer {[sp] {
+        sp->clear_call_back("LocalFileWriter::writev");
+        sp->clear_call_back("LocalFileReader::pread");
+    }};
+    sp->enable_processing();
 
-    int64_t size = 0;
-    EXPECT_TRUE(io::global_local_filesystem()->file_size(fname, &size).ok());
-    EXPECT_EQ(109, size);
-    {
-        io::FileReaderSPtr file_reader;
-        EXPECT_TRUE(io::global_local_filesystem()->open_file(fname, &file_reader).ok());
+    // Test EIO
+    auto fname = fmt::format("{}/abc", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+    sp->set_call_back("LocalFileWriter::writev", [](auto&& args) {
+        auto* ret = try_any_cast_ret<ssize_t>(args);
+        ret->first = -1;
+        ret->second = true;
+        errno = EIO;
+    });
+    st = file_writer->append("abc");
+    ASSERT_FALSE(st.ok()) << st;
 
-        char mem[1024];
-        Slice slice1(mem, 3);
-        Slice slice2(mem + 3, 3);
-        Slice slice3(mem + 6, 3);
+    // Test EINTR
+    int retry = 2;
+    sp->set_call_back("LocalFileWriter::writev", [&retry](auto&& args) {
+        if (retry-- > 0) {
+            auto* ret = try_any_cast_ret<ssize_t>(args);
+            ret->first = -1;
+            ret->second = true;
+            errno = EINTR;
+        } else {
+            auto* ret = try_any_cast_ret<ssize_t>(args);
+            ret->second = false;
+        }
+    });
+    st = file_writer->append("abc");
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 3);
 
-        size_t bytes_read = 0;
-        EXPECT_TRUE(file_reader->read_at(0, slice1, &bytes_read).ok());
-        EXPECT_STREQ("abc", std::string(slice1.data, slice1.size).c_str());
-        EXPECT_EQ(3, bytes_read);
+    // Test partial write
+    std::vector<Slice> content {"defg", "hijklmn", "opqrstu", "vwxyz"};
+    std::vector<std::vector<iovec>> partial_content {
+            {{content[0].data, 4}, {content[1].data, 2}},
+            {{content[1].data + 2, 5}},
+            {{content[2].data, 4}},
+            {{content[2].data + 4, 3}, {content[3].data, 5}}};
+    size_t idx = 0;
+    sp->set_call_back("LocalFileWriter::writev", [&partial_content, &idx](auto&& args) {
+        // Mock partial write
+        auto fd = try_any_cast<int>(args[0]);
+        auto* ret = try_any_cast_ret<ssize_t>(args);
+        ret->first = ::writev(fd, partial_content[idx].data(), partial_content[idx].size());
+        ret->second = true;
+        ++idx;
+    });
+    st = file_writer->appendv(content.data(), content.size());
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 26);
 
-        EXPECT_TRUE(file_reader->read_at(3, slice2, &bytes_read).ok());
-        EXPECT_STREQ("bcd", std::string(slice2.data, slice2.size).c_str());
-        EXPECT_EQ(3, bytes_read);
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
 
-        EXPECT_TRUE(file_reader->read_at(6, slice3, &bytes_read).ok());
-        EXPECT_STREQ("789", std::string(slice3.data, slice3.size).c_str());
-        EXPECT_EQ(3, bytes_read);
+    io::FileReaderSPtr file_reader;
+    st = io::global_local_filesystem()->open_file(fname, &file_reader);
+    ASSERT_TRUE(st.ok()) << st;
+    char buf[1024];
+    size_t bytes_read = 0;
+    st = file_reader->read_at(0, {buf, 26}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 26);
+    EXPECT_EQ(std::string_view(buf, 26), "abcdefghijklmnopqrstuvwxyz");
 
-        Slice slice4(mem, 100);
-        EXPECT_TRUE(file_reader->read_at(9, slice4, &bytes_read).ok());
-        EXPECT_EQ(100, bytes_read);
+    // Test EIO
+    sp->set_call_back("LocalFileReader::pread", [](auto&& args) {
+        auto* ret = try_any_cast_ret<ssize_t>(args);
+        ret->first = -1;
+        ret->second = true;
+        errno = EIO;
+    });
+    st = file_reader->read_at(0, {buf, 26}, &bytes_read);
+    ASSERT_FALSE(st.ok()) << st;
 
-        EXPECT_TRUE(file_reader->close().ok());
-    }
+    // Test EINTR
+    retry = 2;
+    sp->set_call_back("LocalFileReader::pread", [&retry](auto&& args) {
+        if (retry-- > 0) {
+            auto* ret = try_any_cast_ret<ssize_t>(args);
+            ret->first = -1;
+            ret->second = true;
+            errno = EINTR;
+        } else {
+            auto* ret = try_any_cast_ret<ssize_t>(args);
+            ret->second = false;
+        }
+    });
+    memset(buf, 0, sizeof(buf));
+    st = file_reader->read_at(0, {buf, 26}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 26);
+    EXPECT_EQ(std::string_view(buf, 26), "abcdefghijklmnopqrstuvwxyz");
+
+    // Test partial read
+    size_t offset = 0;
+    sp->set_call_back("LocalFileReader::pread", [&offset](auto&& args) {
+        // Mock partial read
+        auto fd = try_any_cast<int>(args[0]);
+        auto* buf = try_any_cast<char*>(args[1]);
+        auto* ret = try_any_cast_ret<ssize_t>(args);
+        ret->first = ::pread(fd, buf, 5, offset);
+        ret->second = true;
+        offset += ret->first;
+    });
+    memset(buf, 0, sizeof(buf));
+    st = file_reader->read_at(0, {buf, 26}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 26);
+    EXPECT_EQ(std::string_view(buf, 26), "abcdefghijklmnopqrstuvwxyz");
 }
 
 TEST_F(LocalFileSystemTest, TestGlob) {
@@ -624,9 +388,12 @@ TEST_F(LocalFileSystemTest, TestGlob) {
                         ->create_directory("./be/ut_build_ASAN/test/file_path/3")
                         .ok());
 
-    static_cast<void>(save_string_file("./be/ut_build_ASAN/test/file_path/1/f1.txt", "just test"));
-    static_cast<void>(save_string_file("./be/ut_build_ASAN/test/file_path/1/f2.txt", "just test"));
-    static_cast<void>(save_string_file("./be/ut_build_ASAN/test/file_path/f3.txt", "just test"));
+    auto st = save_string_file("./be/ut_build_ASAN/test/file_path/1/f1.txt", "just test");
+    ASSERT_TRUE(st.ok()) << st;
+    st = save_string_file("./be/ut_build_ASAN/test/file_path/1/f2.txt", "just test");
+    ASSERT_TRUE(st.ok()) << st;
+    st = save_string_file("./be/ut_build_ASAN/test/file_path/f3.txt", "just test");
+    ASSERT_TRUE(st.ok()) << st;
 
     std::vector<io::FileInfo> files;
     EXPECT_FALSE(io::global_local_filesystem()->safe_glob("./../*.txt", &files).ok());

--- a/be/test/olap/bitmap_filter_column_predicate_test.cpp
+++ b/be/test/olap/bitmap_filter_column_predicate_test.cpp
@@ -47,7 +47,10 @@ public:
 
     const std::string kTestDir = "./ut_dir/bitmap_filter_column_predicate_test";
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -71,7 +71,10 @@ static TabletColumn create_int_sequence_value(int32_t id, bool is_nullable = tru
 class DeleteBitmapCalculatorTest : public testing::Test {
 public:
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kSegmentDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kSegmentDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kSegmentDir);
+        ASSERT_TRUE(st.ok()) << st;
         doris::EngineOptions options;
         k_engine = new StorageEngine(options);
         ExecEnv::GetInstance()->set_storage_engine(k_engine);

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -65,9 +65,10 @@ static void set_up() {
     char buffer[MAX_PATH_LEN];
     EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
     config::storage_root_path = string(buffer) + "/data_test";
-    EXPECT_TRUE(io::global_local_filesystem()
-                        ->delete_and_create_directory(config::storage_root_path)
-                        .ok());
+    auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
     EXPECT_TRUE(io::global_local_filesystem()
                         ->delete_directory(string(getenv("DORIS_HOME")) + "/" + UNUSED_PREFIX)
                         .ok());
@@ -286,9 +287,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = string(buffer) + "/data_delete_condition";
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         // 1. Prepare for query split key.
         // create base tablet
@@ -493,9 +495,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = string(buffer) + "/data_delete_condition";
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         // 1. Prepare for query split key.
         // create base tablet
@@ -868,9 +871,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = string(buffer) + "/data_delete_condition";
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         // 1. Prepare for query split key.
         // create base tablet

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -74,8 +74,10 @@ static void set_up() {
     char buffer[MAX_PATH_LEN];
     EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
     config::storage_root_path = std::string(buffer) + "/data_test";
-    static_cast<void>(
-            io::global_local_filesystem()->delete_and_create_directory(config::storage_root_path));
+    auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
     std::vector<StorePath> paths;
     paths.emplace_back(config::storage_root_path, -1);
 

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -69,8 +69,14 @@ static void set_up() {
     path2 = std::string(buffer) + "/data_test_2";
     config::storage_root_path = path1 + ";" + path2;
     config::min_file_descriptor_number = 1000;
-    EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(path1).ok());
-    EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(path2).ok());
+    auto st = io::global_local_filesystem()->delete_directory(path1);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->create_directory(path1);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->delete_directory(path2);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->create_directory(path2);
+    ASSERT_TRUE(st.ok()) << st;
     std::vector<StorePath> paths;
     paths.emplace_back(path1, -1);
     paths.emplace_back(path2, -1);

--- a/be/test/olap/memtable_flush_executor_test.cpp
+++ b/be/test/olap/memtable_flush_executor_test.cpp
@@ -47,9 +47,11 @@ void set_up() {
     char buffer[1024];
     getcwd(buffer, 1024);
     config::storage_root_path = std::string(buffer) + "/flush_test";
-    EXPECT_TRUE(io::global_local_filesystem()
-                        ->delete_and_create_directory(config::storage_root_path)
-                        .ok());
+    auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
+    st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+    ASSERT_TRUE(st.ok()) << st;
+
     std::vector<StorePath> paths;
     paths.emplace_back(config::storage_root_path, -1);
 

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -81,15 +81,17 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = std::string(buffer) + "/data_test";
-        static_cast<void>(io::global_local_filesystem()->delete_and_create_directory(
-                config::storage_root_path));
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
         std::vector<StorePath> paths;
         paths.emplace_back(config::storage_root_path, -1);
 
         doris::EngineOptions options;
         options.store_paths = paths;
         _engine = std::make_unique<StorageEngine>(options);
-        Status st = _engine->open();
+        st = _engine->open();
         EXPECT_TRUE(st.ok()) << st.to_string();
 
         ExecEnv* exec_env = doris::ExecEnv::GetInstance();

--- a/be/test/olap/olap_meta_test.cpp
+++ b/be/test/olap/olap_meta_test.cpp
@@ -39,8 +39,10 @@ class OlapMetaTest : public testing::Test {
 public:
     virtual void SetUp() {
         _root_path = "./ut_dir/olap_meta_test";
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(_root_path).ok());
-
+        auto st = io::global_local_filesystem()->delete_directory(_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_root_path);
+        ASSERT_TRUE(st.ok()) << st;
         _meta = new OlapMeta(_root_path);
         Status s = _meta->init();
         EXPECT_EQ(Status::OK(), s);

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -82,7 +82,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         absolute_dir = std::string(buffer) + kTestDir;
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(absolute_dir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(absolute_dir + "/tablet_path")
                             .ok());

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -41,7 +41,10 @@ using namespace ErrorCode;
 class PrimaryKeyIndexTest : public testing::Test {
 public:
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -94,9 +94,10 @@ public:
         config::storage_root_path = std::string(buffer) + "/" + kTestDir;
         config::min_file_descriptor_number = 1000;
 
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         std::vector<StorePath> paths {{config::storage_root_path, -1}};
 

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -73,7 +73,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         absolute_dir = std::string(buffer) + kTestDir;
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(absolute_dir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(absolute_dir + "/tablet_path")
                             .ok());

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -91,9 +91,10 @@ public:
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = std::string(buffer) + "/data_test";
 
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         std::vector<StorePath> paths;
         paths.emplace_back(config::storage_root_path, -1);

--- a/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
@@ -50,7 +50,10 @@ public:
     const std::string kTestDir = "./ut_dir/bitmap_index_test";
 
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
@@ -48,7 +48,10 @@ const std::string dname = "./ut_dir/bloom_filter_index_reader_writer_test";
 class BloomFilterIndexReaderWriterTest : public testing::Test {
 public:
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(dname).ok());
+        auto st = io::global_local_filesystem()->delete_directory(dname);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(dname);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(dname).ok());

--- a/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
@@ -53,7 +53,10 @@ public:
 protected:
     void SetUp() override {
         config::disable_storage_page_cache = true;
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(TEST_DIR).ok());
+        auto st = io::global_local_filesystem()->delete_directory(TEST_DIR);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(TEST_DIR);
+        ASSERT_TRUE(st.ok()) << st;
     }
 
     void TearDown() override {

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -47,7 +47,10 @@ public:
     const std::string kTestDir = "./ut_dir/invertedInvertedIndexSearcherCache::instance()_test";
 
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
@@ -37,7 +37,10 @@ public:
     const std::string kTestDir = "./ut_dir/ordinal_page_index_test";
 
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
@@ -40,7 +40,10 @@ public:
     const std::string kTestDir = "./ut_dir/zone_map_index_test";
 
     void SetUp() override {
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(kTestDir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
     }
     void TearDown() override {
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -66,9 +66,10 @@ public:
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = std::string(buffer) + "/data_test";
 
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         std::vector<StorePath> paths;
         paths.emplace_back(config::storage_root_path, -1);

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -39,8 +39,10 @@ class StorageEngineTest : public testing::Test {
 public:
     virtual void SetUp() {
         _engine_data_path = "./be/test/olap/test_data/converter_test_data/tmp";
-        EXPECT_TRUE(
-                io::global_local_filesystem()->delete_and_create_directory(_engine_data_path).ok());
+        auto st = io::global_local_filesystem()->delete_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(
                 io::global_local_filesystem()->create_directory(_engine_data_path + "/meta").ok());
         _data_dir.reset(new DataDir(_engine_data_path, 100000000));

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -101,14 +101,8 @@ public:
 
     Status close() override { return _local_file_writer->close(); }
 
-    Status abort() override { return _local_file_writer->abort(); }
-
     Status appendv(const Slice* data, size_t data_cnt) override {
         return _local_file_writer->appendv(data, data_cnt);
-    }
-
-    Status write_at(size_t offset, const Slice& data) override {
-        return _local_file_writer->write_at(offset, data);
     }
 
     Status finalize() override { return _local_file_writer->finalize(); }
@@ -181,20 +175,7 @@ protected:
         return Status::OK();
     }
 
-    Status direct_upload_impl(const Path& remote_file, const std::string& content) override {
-        return Status::OK();
-    }
-
-    Status upload_with_checksum_impl(const Path& local_file, const Path& remote_file,
-                                     const std::string& checksum) override {
-        return Status::OK();
-    }
-
     Status download_impl(const Path& remote_file, const Path& local_file) override {
-        return Status::OK();
-    }
-
-    Status direct_download_impl(const Path& remote_file, std::string* content) override {
         return Status::OK();
     }
 
@@ -207,10 +188,6 @@ protected:
     Status connect_impl() override { return Status::OK(); }
 
     Status rename_impl(const Path& orig_name, const Path& new_name) override {
-        return Status::OK();
-    }
-
-    Status rename_dir_impl(const Path& orig_name, const Path& new_name) override {
         return Status::OK();
     }
 
@@ -237,9 +214,10 @@ public:
         config::storage_root_path = std::string(buffer) + "/" + kTestDir;
         config::min_file_descriptor_number = 1000;
 
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(get_remote_path(remote_tablet_path(kTabletId)))
                             .ok());
@@ -249,7 +227,7 @@ public:
         EngineOptions options;
         options.store_paths = paths;
         k_engine = std::make_unique<StorageEngine>(options);
-        auto st = k_engine->open();
+        st = k_engine->open();
         EXPECT_TRUE(st.ok()) << st.to_string();
         ExecEnv* exec_env = doris::ExecEnv::GetInstance();
         exec_env->set_memtable_memory_limiter(new MemTableMemoryLimiter());

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -55,8 +55,10 @@ class TabletMgrTest : public testing::Test {
 public:
     virtual void SetUp() {
         _engine_data_path = "./be/test/olap/test_data/converter_test_data/tmp";
-        EXPECT_TRUE(
-                io::global_local_filesystem()->delete_and_create_directory(_engine_data_path).ok());
+        auto st = io::global_local_filesystem()->delete_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(
                 io::global_local_filesystem()->create_directory(_engine_data_path + "/meta").ok());
 

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -79,7 +79,10 @@ public:
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         absolute_dir = std::string(buffer) + kTestDir;
 
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(absolute_dir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(absolute_dir + "/tablet_path")
                             .ok());

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -584,9 +584,10 @@ public:
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         config::storage_root_path = std::string(buffer) + "/data_test";
 
-        EXPECT_TRUE(io::global_local_filesystem()
-                            ->delete_and_create_directory(config::storage_root_path)
-                            .ok());
+        auto st = io::global_local_filesystem()->delete_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(config::storage_root_path);
+        ASSERT_TRUE(st.ok()) << st;
 
         std::vector<StorePath> paths;
         paths.emplace_back(config::storage_root_path, -1);

--- a/be/test/vec/core/block_spill_test.cpp
+++ b/be/test/vec/core/block_spill_test.cpp
@@ -75,8 +75,10 @@ public:
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         test_data_dir = std::string(buffer) + "/" + TMP_DATA_DIR;
         std::cout << "test data dir: " << test_data_dir << "\n";
-        static_cast<void>(
-                io::global_local_filesystem()->delete_and_create_directory(test_data_dir));
+        auto st = io::global_local_filesystem()->delete_directory(test_data_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(test_data_dir);
+        ASSERT_TRUE(st.ok()) << st;
 
         std::vector<StorePath> paths;
         paths.emplace_back(test_data_dir, -1);

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -84,8 +84,10 @@ protected:
         char buffer[MAX_PATH_LEN];
         EXPECT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
         absolute_dir = std::string(buffer) + kTestDir;
-
-        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(absolute_dir).ok());
+        auto st = io::global_local_filesystem()->delete_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(absolute_dir);
+        ASSERT_TRUE(st.ok()) << st;
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(absolute_dir + "/tablet_path")
                             .ok());

--- a/regression-test/suites/export_p0/test_outfile_exception.groovy
+++ b/regression-test/suites/export_p0/test_outfile_exception.groovy
@@ -84,7 +84,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -103,7 +103,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -122,7 +122,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -141,7 +141,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -160,6 +160,6 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 }

--- a/regression-test/suites/nereids_p0/outfile/test_outfile_exception.groovy
+++ b/regression-test/suites/nereids_p0/outfile/test_outfile_exception.groovy
@@ -85,7 +85,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -104,7 +104,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -123,7 +123,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -142,7 +142,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 
 
@@ -161,6 +161,6 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "NoSuchBucket"
     }
 }


### PR DESCRIPTION
## Proposed changes

Normalize (local & S3) FS error code:

| std::errc | Posix errno | Aws HttpResponseCode | Doris ErrorCode |
| ------- | ------- | ------- | ------- |
| io_error | EIO | \ | IO_ERROR |
| file_exists | EEXIST | \ | ALREADY_EXIST |
| no_such_file_or_directory | ENOENT | NOT_FOUND | NOT_FOUND |
| no_space_on_device | ENOSPC | \ | DISK_REACH_CAPACITY_LIMIT |
| permission_denied | EACCES | FORBIDDEN | PERMISSION_DENIED |
| others | others | others | INTERNAL_ERROR |

Remove some useless FS functions.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

