### PR TITLE
[fix](Nereids) topn runtime filter only support simplest case (#29312)

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopNRuntimeFilterTest.java
@@ -20,8 +20,10 @@ package org.apache.doris.nereids.postprocess;
 import org.apache.doris.nereids.datasets.ssb.SSBTestBase;
 import org.apache.doris.nereids.processor.post.PlanPostProcessors;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDeferMaterializeTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import org.junit.jupiter.api.Assertions;
@@ -41,7 +43,7 @@ public class TopNRuntimeFilterTest extends SSBTestBase {
                 .implement();
         PhysicalPlan plan = checker.getPhysicalPlan();
         plan = new PlanPostProcessors(checker.getCascadesContext()).process(plan);
-        Assertions.assertTrue(plan.children().get(0).child(0) instanceof PhysicalDeferMaterializeTopN);
+        Assertions.assertInstanceOf(PhysicalDeferMaterializeTopN.class, plan.children().get(0).child(0));
         PhysicalDeferMaterializeTopN<? extends Plan> localTopN
                 = (PhysicalDeferMaterializeTopN<? extends Plan>) plan.child(0).child(0);
         Assertions.assertTrue(localTopN.getPhysicalTopN().isEnableRuntimeFilter());
@@ -56,9 +58,25 @@ public class TopNRuntimeFilterTest extends SSBTestBase {
                 .implement();
         PhysicalPlan plan = checker.getPhysicalPlan();
         plan = new PlanPostProcessors(checker.getCascadesContext()).process(plan);
-        Assertions.assertTrue(plan.children().get(0).child(0) instanceof PhysicalDeferMaterializeTopN);
+        Assertions.assertInstanceOf(PhysicalDeferMaterializeTopN.class, plan.children().get(0).child(0));
         PhysicalDeferMaterializeTopN<? extends Plan> localTopN
                 = (PhysicalDeferMaterializeTopN<? extends Plan>) plan.child(0).child(0);
         Assertions.assertFalse(localTopN.getPhysicalTopN().isEnableRuntimeFilter());
+    }
+
+    @Test
+    public void testNotUseTopNRfForComplexCase() {
+        String sql = "select * from (select 1) tl join (select * from customer order by c_custkey limit 5) tb";
+        PlanChecker checker = PlanChecker.from(connectContext).analyze(sql)
+                .rewrite()
+                .implement();
+        PhysicalPlan plan = checker.getPhysicalPlan();
+        plan = new PlanPostProcessors(checker.getCascadesContext()).process(plan);
+        Assertions.assertInstanceOf(PhysicalTopN.class, plan.child(0).child(0).child(1).child(0));
+        Assertions.assertEquals(SortPhase.LOCAL_SORT, ((PhysicalTopN<? extends Plan>) plan
+                .child(0).child(0).child(1).child(0)).getSortPhase());
+        PhysicalTopN<? extends Plan> localTopN = (PhysicalTopN<? extends Plan>) plan
+                .child(0).child(0).child(1).child(0);
+        Assertions.assertFalse(localTopN.isEnableRuntimeFilter());
     }
 }


### PR DESCRIPTION
pick from master
PR: #29312
commit: cdf2bb24a4f8443d302e8c7b78b54d84f2ce4d5a

only support simple case: select ... from tbl [where ...] order by ... limit ...

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

