### PR TITLE
[pipelineX](fix) Fix query cancel timeout

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -905,7 +905,6 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
         }
         {
             std::lock_guard<std::mutex> lock(query_ctx->pipeline_lock);
-            query_ctx->is_pipeline_x = true;
             query_ctx->fragment_id_to_pipeline_ctx.insert({params.fragment_id, context});
         }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -574,27 +574,29 @@ Status FragmentMgr::start_query_execution(const PExecPlanFragmentStartRequest* r
 
 void FragmentMgr::remove_pipeline_context(
         std::shared_ptr<pipeline::PipelineFragmentContext> f_context) {
-    std::lock_guard<std::mutex> lock(_lock);
-    auto query_id = f_context->get_query_id();
     auto* q_context = f_context->get_query_ctx();
-    std::vector<TUniqueId> ins_ids;
-    f_context->instance_ids(ins_ids);
-    bool all_done = q_context->countdown(ins_ids.size());
-    for (const auto& ins_id : ins_ids) {
-        {
-            std::lock_guard<std::mutex> plock(q_context->pipeline_lock);
-            if (q_context->fragment_id_to_pipeline_ctx.contains(f_context->get_fragment_id())) {
-                q_context->fragment_id_to_pipeline_ctx.erase(f_context->get_fragment_id());
-            }
+    {
+        std::lock_guard<std::mutex> lock(_lock);
+        auto query_id = f_context->get_query_id();
+        std::vector<TUniqueId> ins_ids;
+        f_context->instance_ids(ins_ids);
+        bool all_done = q_context->countdown(ins_ids.size());
+        for (const auto& ins_id : ins_ids) {
+            LOG_INFO("Removing query {} instance {}, all done? {}", print_id(query_id),
+                     print_id(ins_id), all_done);
+            _pipeline_map.erase(ins_id);
+            g_pipeline_fragment_instances_count << -1;
         }
-        LOG_INFO("Removing query {} instance {}, all done? {}", print_id(query_id),
-                 print_id(ins_id), all_done);
-        _pipeline_map.erase(ins_id);
-        g_pipeline_fragment_instances_count << -1;
+        if (all_done) {
+            LOG_INFO("Query {} finished", print_id(query_id));
+            _query_ctx_map.erase(query_id);
+        }
     }
-    if (all_done) {
-        LOG_INFO("Query {} finished", print_id(query_id));
-        _query_ctx_map.erase(query_id);
+    {
+        std::lock_guard<std::mutex> plock(q_context->pipeline_lock);
+        if (q_context->fragment_id_to_pipeline_ctx.contains(f_context->get_fragment_id())) {
+            q_context->fragment_id_to_pipeline_ctx.erase(f_context->get_fragment_id());
+        }
     }
 }
 
@@ -903,6 +905,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
         }
         {
             std::lock_guard<std::mutex> lock(query_ctx->pipeline_lock);
+            query_ctx->is_pipeline_x = true;
             query_ctx->fragment_id_to_pipeline_ctx.insert({params.fragment_id, context});
         }
 

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -79,7 +79,9 @@ void QueryContext::set_ready_to_execute(bool is_cancelled) {
     _execution_dependency->set_ready();
     {
         std::lock_guard<std::mutex> l(_start_lock);
-        _is_cancelled = is_cancelled;
+        if (!is_pipeline_x) {
+            _is_cancelled = is_cancelled;
+        }
         _ready_to_execute = true;
     }
     if (query_mem_tracker && is_cancelled) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -79,7 +79,7 @@ void QueryContext::set_ready_to_execute(bool is_cancelled) {
     _execution_dependency->set_ready();
     {
         std::lock_guard<std::mutex> l(_start_lock);
-        if (!is_pipeline_x) {
+        if (!_is_cancelled) {
             _is_cancelled = is_cancelled;
         }
         _ready_to_execute = true;

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -231,6 +231,7 @@ public:
 
     std::vector<TUniqueId> fragment_instance_ids;
     std::map<int, std::shared_ptr<pipeline::PipelineFragmentContext>> fragment_id_to_pipeline_ctx;
+    std::atomic<bool> is_pipeline_x = false;
     std::mutex pipeline_lock;
 
     // plan node id -> TFileScanRangeParams

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -231,7 +231,6 @@ public:
 
     std::vector<TUniqueId> fragment_instance_ids;
     std::map<int, std::shared_ptr<pipeline::PipelineFragmentContext>> fragment_id_to_pipeline_ctx;
-    std::atomic<bool> is_pipeline_x = false;
     std::mutex pipeline_lock;
 
     // plan node id -> TFileScanRangeParams

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -428,6 +428,7 @@ bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
         _status_error = true;
         _blocks_queue_added_cv.notify_one();
         _should_stop = true;
+        _state->get_query_ctx()->set_exec_status(_process_status);
         _set_scanner_done();
         return true;
     }


### PR DESCRIPTION
## Proposed changes

There are 2 potential reasons to cancel pipelineX query timeout.
1. Cancel fragment context first and set ready to execute will set cancel flag to false.
2. Dead lock.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

