### PR TITLE
[fix](auditloader) support audit table millisecond and fix stmt truncated by '\r'

### DIFF
--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -55,7 +55,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     private final static Logger LOG = LogManager.getLogger(AuditLoaderPlugin.class);
 
     private static final ThreadLocal<SimpleDateFormat> dateFormatContainer = ThreadLocal.withInitial(
-            () -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+            () -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"));
 
     private StringBuilder auditLogBuffer = new StringBuilder();
     private StringBuilder slowLogBuffer = new StringBuilder();
@@ -179,7 +179,9 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
         logBuffer.append(event.peakMemoryBytes).append("\t");
         // trim the query to avoid too long
         // use `getBytes().length` to get real byte length
-        String stmt = truncateByBytes(event.stmt).replace("\n", " ").replace("\t", " ");
+        String stmt = truncateByBytes(event.stmt).replace("\n", " ")
+                                                    .replace("\t", " ")
+                                                    .replace("\r", " ");
         LOG.debug("receive audit event with stmt: {}", stmt);
         logBuffer.append(stmt).append("\n");
     }
@@ -338,7 +340,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
 
     public static String longToTimeString(long timeStamp) {
         if (timeStamp <= 0L) {
-            return "1900-01-01 00:00:00";
+            return "1900-01-01 00:00:00.000";
         }
         return dateFormatContainer.get().format(new Date(timeStamp));
     }


### PR DESCRIPTION


## Proposed changes

cherry pick #29479

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

