### PR TITLE
[improvement](statistics)Do not collect min max for agg table value columns while doing sample analyze

### DIFF
--- a/regression-test/suites/statistics/analyze_stats.groovy
+++ b/regression-test/suites/statistics/analyze_stats.groovy
@@ -2612,6 +2612,30 @@ PARTITION `p599` VALUES IN (599)
    partition_result = sql """show table stats partition_test"""
    assertEquals(partition_result[0][6], "false")
 
+   // Test sample agg table value column
+   sql """
+     CREATE TABLE `agg_table_test` (
+      `id` BIGINT NOT NULL,
+      `name` VARCHAR(10) REPLACE NULL
+     ) ENGINE=OLAP
+     AGGREGATE KEY(`id`)
+     COMMENT 'OLAP'
+     DISTRIBUTED BY HASH(`id`) BUCKETS 32
+     PROPERTIES (
+      "replication_num" = "1"
+     );
+   """
+   sql """insert into agg_table_test values (1,'name1'), (2, 'name2')"""
+   Thread.sleep(1000 * 90)
+   sql """analyze table agg_table_test with sample rows 100 with sync"""
+   def agg_result = sql """show column stats agg_table_test (name)"""
+   assertEquals(agg_result[0][6], "N/A")
+   assertEquals(agg_result[0][7], "N/A")
+   agg_result = sql """show column stats agg_table_test (id)"""
+   assertEquals(agg_result[0][6], "1")
+   assertEquals(agg_result[0][7], "2")
+   sql """DROP DATABASE IF EXISTS AggTableTest"""
+
    // Test trigger type.
    sql """DROP DATABASE IF EXISTS trigger"""
    sql """CREATE DATABASE IF NOT EXISTS trigger"""
@@ -2650,5 +2674,4 @@ PARTITION `p599` VALUES IN (599)
        assertEquals(result[1][10], "MANUAL")
    }
    sql """DROP DATABASE IF EXISTS trigger"""
-
 }


### PR DESCRIPTION
While doing sample analyze for agg table value columns, skip collecting min/max value, because these columns couldn't use zonemap, we don't want to scan the whole table while sampling.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

