### PR TITLE
[fix](array) fix reserve nested column when filter array column

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -694,22 +694,22 @@ ColumnPtr ColumnArray::filter_generic(const Filter& filt, ssize_t result_size_hi
 
     if (size == 0) return ColumnArray::create(data);
 
+    ssize_t nested_result_size_hint = 0;
     Filter nested_filt(get_offsets().back());
     for (size_t i = 0; i < size; ++i) {
-        if (filt[i])
-            memset(&nested_filt[offset_at(i)], 1, size_at(i));
-        else
-            memset(&nested_filt[offset_at(i)], 0, size_at(i));
+        auto arr_size = size_at(i);
+        if (filt[i]) {
+            memset(&nested_filt[offset_at(i)], 1, arr_size);
+            nested_result_size_hint += arr_size;
+        } else {
+            memset(&nested_filt[offset_at(i)], 0, arr_size);
+        }
     }
 
     auto res = ColumnArray::create(data->clone_empty());
 
-    ssize_t nested_result_size_hint = 0;
     if (result_size_hint < 0)
         nested_result_size_hint = result_size_hint;
-    else if (result_size_hint && result_size_hint < 1000000000 &&
-             data->size() < 1000000000) /// Avoid overflow.
-        nested_result_size_hint = result_size_hint * data->size() / size;
 
     res->data = data->filter(nested_filt, nested_result_size_hint);
 

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -708,8 +708,9 @@ ColumnPtr ColumnArray::filter_generic(const Filter& filt, ssize_t result_size_hi
 
     auto res = ColumnArray::create(data->clone_empty());
 
-    if (result_size_hint < 0)
+    if (result_size_hint < 0) {
         nested_result_size_hint = result_size_hint;
+    }
 
     res->data = data->filter(nested_filt, nested_result_size_hint);
 

--- a/be/test/vec/core/column_array_test.cpp
+++ b/be/test/vec/core/column_array_test.cpp
@@ -234,4 +234,35 @@ TEST(ColumnArrayTest, StringArrayReplicateTest) {
     check_array_data<std::string>(*res1, {"abc", "d", "abc", "d", "ef", "", "", ""});
 }
 
+TEST(ColumnArrayTest, IntArrayFilterTest) {
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
+    auto data_column = ColumnVector<int32_t>::create();
+    // init column array with [[1,2,3],[],[4],[5,6]]
+    std::vector<ColumnArray::Offset64> offs = {0, 3, 3, 4, 6};
+    std::vector<int32_t> vals = {1, 2, 3, 4, 5, 6};
+    for (size_t i = 1; i < offs.size(); ++i) {
+        off_column->insert_data((const char*)(&offs[i]), 0);
+    }
+    for (auto& v : vals) {
+        data_column->insert_data((const char*)(&v), 0);
+    }
+    ColumnArray array_column(std::move(data_column), std::move(off_column));
+
+    // return array column: [[1,2,3]];
+    IColumn::Filter filter(array_column.size(), 0);
+    filter[0] = 1;
+    // test hint
+    {
+        auto res1 = array_column.filter(filter, 1);
+        check_array_offsets(*res1, {3});
+        check_array_data<int32_t>(*res1, {1, 2, 3});
+    }
+    // test no hint
+    {
+        auto res1 = array_column.filter(filter, -1);
+        check_array_offsets(*res1, {3});
+        check_array_data<int32_t>(*res1, {1, 2, 3});
+    }
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes


As the ResultOffsetsBuilder in columns_common.cpp add offset by push_back_without_reserve, if the reserve capacity is smaller, it will cause coredump.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

