### PR TITLE
[Enhancement](load) Globally limits the size of log files generated b…

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -481,6 +481,8 @@ DEFINE_Int64(load_data_reserve_hours, "4");
 DEFINE_mInt64(load_error_log_reserve_hours, "48");
 // error log size limit, default 200MB
 DEFINE_mInt64(load_error_log_limit_bytes, "209715200");
+// load Indicates the maximum number of error logs, default 500MB
+DEFINE_mInt64(load_max_error_size_bytes, "524288000");
 
 DEFINE_Int32(brpc_heavy_work_pool_threads, "-1");
 DEFINE_Int32(brpc_light_work_pool_threads, "-1");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -524,6 +524,8 @@ DECLARE_Int64(load_data_reserve_hours);
 DECLARE_mInt64(load_error_log_reserve_hours);
 // error log size limit, default 200MB
 DECLARE_mInt64(load_error_log_limit_bytes);
+// load Indicates the maximum number of error logs, default 500MB
+DECLARE_mInt64(load_max_error_size_bytes);
 
 // be brpc interface is classified into two categories: light and heavy
 // each category has diffrent thread number


### PR DESCRIPTION
…y stream load

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
1、Added the be parameter load_max_error_size_bytes, the default value is 500M, which limits the size of the error log file generated by the global stream load

2、The principle is that the sum of the size of the current error_log file plus the size of the generated error log must be smaller than the load_max_error_size_bytes parameter. If the value exceeds the maximum value, delete the oldest file before writing a new error log.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

