### PR TITLE
[refactor_close](VTabletWriter) plan_fragment_executor should call DataSink::try_close before close

### DIFF
--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -538,10 +538,10 @@ Status AsyncWriterSink<Writer, Parent>::close(RuntimeState* state, Status exec_s
     // if the init failed, the _writer may be nullptr. so here need check
     if (_writer) {
         // if (_writer->need_normal_close()) {
-            if (exec_status.ok() && !state->is_cancelled()) {
-                RETURN_IF_ERROR(_writer->commit_trans());
-            }
-            RETURN_IF_ERROR(_writer->close(exec_status));
+        if (exec_status.ok() && !state->is_cancelled()) {
+            RETURN_IF_ERROR(_writer->commit_trans());
+        }
+        RETURN_IF_ERROR(_writer->close(exec_status));
         // } else {
         //     RETURN_IF_ERROR(_writer->get_writer_status());
         // }

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -354,6 +354,8 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
             std::lock_guard<std::mutex> l(_status_lock);
             status = _status;
         }
+        status = _sink->try_close(runtime_state(), status);
+        RETURN_IF_ERROR(status);
         status = _sink->close(runtime_state(), status);
         RETURN_IF_ERROR(status);
     }

--- a/be/src/runtime/result_writer.h
+++ b/be/src/runtime/result_writer.h
@@ -39,7 +39,7 @@ public:
     virtual Status init(RuntimeState* state) = 0;
 
     // WIP: should be renamed to flush/finish or something like this
-    virtual Status try_close(RuntimeState * state) = 0;
+    virtual Status try_close(RuntimeState* state) = 0;
 
     virtual Status close(Status s = Status::OK()) = 0;
 

--- a/be/src/vec/sink/async_writer_sink.h
+++ b/be/src/vec/sink/async_writer_sink.h
@@ -110,9 +110,9 @@ public:
     }
 
     Status try_close(RuntimeState* state, Status exec_status) override {
-        if (state->is_cancelled() || !exec_status.ok()) {
-            return _writer->try_close(state);
-        }
+        // if (state->is_cancelled() || !exec_status.ok()) {
+        return _writer->try_close(state);
+        // }
         return Status::OK();
     }
 

--- a/be/src/vec/sink/varrow_flight_result_writer.h
+++ b/be/src/vec/sink/varrow_flight_result_writer.h
@@ -47,9 +47,7 @@ public:
 
     bool can_sink() override;
 
-    Status try_close(RuntimeState*) override {
-        return Status::OK();
-    }
+    Status try_close(RuntimeState*) override { return Status::OK(); }
 
     Status close(Status) override;
 

--- a/be/src/vec/sink/vmysql_result_writer.h
+++ b/be/src/vec/sink/vmysql_result_writer.h
@@ -51,9 +51,7 @@ public:
 
     bool can_sink() override;
 
-    Status try_close(RuntimeState * state) override {
-        return Status::OK();
-    };
+    Status try_close(RuntimeState* state) override { return Status::OK(); };
 
     Status close(Status status) override;
 


### PR DESCRIPTION
1. fix
VTabletWriter::close called  VTabletWriter::try_close before refactor
now VTabletWriter::close is called by be/src/runtime/plan_fragment_executor.cpp
2. some formatting