### PR TITLE
[Enhancement](array) reserve nested column to improve read array column

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1161,6 +1161,8 @@ DEFINE_mInt64(local_exchange_buffer_mem_limit, "134217728");
 // Default 300s, if its value <= 0, then log is disabled
 DEFINE_mInt64(enable_debug_log_timeout_secs, "0");
 
+DEFINE_mBool(enable_read_columns_batch_range, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1236,6 +1236,8 @@ DECLARE_mInt64(enable_debug_log_timeout_secs);
 
 DECLARE_mBool(enable_column_type_check);
 
+DECLARE_mBool(enable_read_columns_batch_range);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -294,6 +294,9 @@ public:
         return Status::NotSupported("read_by_rowids not implement");
     }
 
+    virtual Status read_by_ranges(const ordinal_t* ordinals, const size_t* counts,
+                                  size_t num_ranges, vectorized::MutableColumnPtr& dst);
+
     virtual ordinal_t get_current_ordinal() const = 0;
 
     virtual Status get_row_ranges_by_zone_map(
@@ -523,6 +526,9 @@ public:
     Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
+                          vectorized::MutableColumnPtr& dst) override;
+
+    Status read_by_ranges(const ordinal_t* ordinals, const size_t* counts, size_t num_ranges,
                           vectorized::MutableColumnPtr& dst) override;
 
     Status seek_to_first() override {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -216,8 +216,14 @@ private:
     // for vectorization implementation
     [[nodiscard]] Status _read_columns(const std::vector<ColumnId>& column_ids,
                                        vectorized::MutableColumns& column_block, size_t nrows);
+    [[nodiscard]] Status _read_columns_by_ranges(const std::vector<ColumnId>& column_ids,
+                                                 vectorized::MutableColumns& column_block,
+                                                 const ordinal_t* ordinals, const size_t* counts,
+                                                 size_t num_ranges);
     [[nodiscard]] Status _read_columns_by_index(uint32_t nrows_read_limit, uint32_t& nrows_read,
                                                 bool set_block_rowid);
+    [[nodiscard]] Status _read_columns_by_index_batch(uint32_t nrows_read_limit,
+                                                      uint32_t& nrows_read, bool set_block_rowid);
     void _replace_version_col(size_t num_rows);
     void _init_current_block(vectorized::Block* block,
                              std::vector<vectorized::MutableColumnPtr>& non_pred_vector);


### PR DESCRIPTION
## Proposed changes

The old way reading array column one range by one range can not reserve nested column and may cause nested column resize many times. Add an option to read column by range batch.  But this change makes the block seek metric lost. No idea how to solve this problem.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

