### PR TITLE
[fix](regression-test) result is not stable for test_show_statistic_proc

### DIFF
--- a/regression-test/suites/show_p0/test_show_statistic_proc.groovy
+++ b/regression-test/suites/show_p0/test_show_statistic_proc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_statistic_proc", "show") {
+suite("test_show_statistic_proc", "nonConcurrent") {
 
     sql """drop user if exists test_show_statistic_proc_user1"""
 
@@ -29,8 +29,8 @@ suite("test_show_statistic_proc", "show") {
         sql """ show proc '/statistic' """
     }
     def result2 = connect(user = 'test_show_statistic_proc_user1', password = '12345', url = context.config.jdbcUrl) {
-            sql """ show databases """
-        }
+        sql """ show databases """
+    }
     assertEquals(result1.size(), result2.size())
     assertEquals(result1[result1.size() - 1][1].toInteger(), result2.size() - 1)
     def containsTargetDb = false


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If there are databases create or drop, between result1 and result2, then this case will failed.
make this case `nonConcurrent` to fix. (**Master and Branch-2.0** both have this problem)

```
    def result1 = connect(user = 'test_show_statistic_proc_user1', password = '12345', url = context.config.jdbcUrl) {
        sql """ show proc '/statistic' """
    }
    def result2 = connect(user = 'test_show_statistic_proc_user1', password = '12345', url = context.config.jdbcUrl) {
        sql """ show databases """
    }
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

