### PR TITLE
Revert "[fix](read) remove logic of estimating count of rows to read in segment iterator to avoid wrong result of unique key. (#29109)"

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2539,7 +2539,7 @@ void SegmentIterator::_update_max_row(const vectorized::Block* block) {
     auto avg_row_size = block->bytes() / block->rows();
     if (avg_row_size > 0) {
         int block_row_max = config::doris_scan_block_max_mb / avg_row_size;
-        _opts.block_row_max = std::min(block_row_max, _opts.block_row_max);
+        _opts.block_row_max = std::min(std::max(1, block_row_max), _opts.block_row_max);
     }
 }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -263,6 +263,8 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
           _lazy_materialization_read(false),
           _lazy_inited(false),
           _inited(false),
+          _estimate_row_size(true),
+          _wait_times_estimate_row_size(10),
           _pool(new ObjectPool) {}
 
 Status SegmentIterator::init(const StorageReadOptions& opts) {
@@ -2184,6 +2186,13 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
 
     _current_batch_rows_read = 0;
     uint32_t nrows_read_limit = _opts.block_row_max;
+    if (_wait_times_estimate_row_size > 0) {
+        // first time, read 100 rows to estimate average row size, to avoid oom caused by a single batch being too large.
+        // If no valid data is read for the first time, block_row_max is read each time thereafter.
+        // Avoid low performance when valid data cannot be read all the time
+        nrows_read_limit = std::min(nrows_read_limit, (uint32_t)100);
+        _wait_times_estimate_row_size--;
+    }
     RETURN_IF_ERROR(_read_columns_by_index(
             nrows_read_limit, _current_batch_rows_read,
             _lazy_materialization_read || _opts.record_rowids || _is_need_expr_eval));
@@ -2330,6 +2339,9 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             // shrink char_type suffix zero data
             block->shrink_char_type_column_suffix_zero(_char_type_idx);
 
+            if (UNLIKELY(_estimate_row_size) && block->rows() > 0) {
+                _update_max_row(block);
+            }
             return Status::OK();
         }
         // step4: read non_predicate column
@@ -2364,6 +2376,10 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         }
     }
 #endif
+
+    if (UNLIKELY(_estimate_row_size) && block->rows() > 0) {
+        _update_max_row(block);
+    }
 
     // reverse block row order
     if (_opts.read_orderby_key_reverse) {
@@ -2515,6 +2531,15 @@ void SegmentIterator::_convert_dict_code_for_predicate_if_necessary_impl(
         col_ptr->convert_dict_codes_if_necessary();
     } else if (PredicateTypeTraits::is_bloom_filter(predicate->type())) {
         col_ptr->initialize_hash_values_for_runtime_filter();
+    }
+}
+
+void SegmentIterator::_update_max_row(const vectorized::Block* block) {
+    _estimate_row_size = false;
+    auto avg_row_size = block->bytes() / block->rows();
+    if (avg_row_size > 0) {
+        int block_row_max = config::doris_scan_block_max_mb / avg_row_size;
+        _opts.block_row_max = std::min(block_row_max, _opts.block_row_max);
     }
 }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -286,6 +286,8 @@ private:
 
     void _convert_dict_code_for_predicate_if_necessary_impl(ColumnPredicate* predicate);
 
+    void _update_max_row(const vectorized::Block* block);
+
     bool _check_apply_by_bitmap_index(ColumnPredicate* pred);
     bool _check_apply_by_inverted_index(ColumnPredicate* pred, bool pred_in_compound = false);
 
@@ -440,6 +442,9 @@ private:
     // the actual init process is delayed to the first call to next_batch()
     bool _lazy_inited;
     bool _inited;
+    bool _estimate_row_size;
+    // Read up to 100 rows at a time while waiting for the estimated row size.
+    int _wait_times_estimate_row_size;
 
     StorageReadOptions _opts;
     // make a copy of `_opts.column_predicates` in order to make local changes


### PR DESCRIPTION
## Proposed changes

This reverts commit 3e5c8d9949fb3ee92470a97e08b0c3c8a2400679.

And fix bug: when avg_row_size > config::doris_scan_block_max_mb,
_opts.block_row_max will be set to 0, which will cause early EOF.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

