### PR TITLE
Revert "[fix](read) remove logic of estimating count of rows to read in segment iterator to avoid wrong result of unique key  (#29109) (#29110)"

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2385,8 +2385,10 @@ void SegmentIterator::_update_max_row(const vectorized::Block* block) {
     _estimate_row_size = false;
     auto avg_row_size = block->bytes() / block->rows();
 
-    int block_row_max = config::doris_scan_block_max_mb / avg_row_size;
-    _opts.block_row_max = std::min(block_row_max, _opts.block_row_max);
+    if (avg_row_size > 0) {
+        int block_row_max = config::doris_scan_block_max_mb / avg_row_size;
+        _opts.block_row_max = std::min(std::max(1, block_row_max), _opts.block_row_max);
+    }
 }
 
 Status SegmentIterator::current_block_row_locations(std::vector<RowLocation>* block_row_locations) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -251,6 +251,8 @@ private:
 
     void _convert_dict_code_for_predicate_if_necessary_impl(ColumnPredicate* predicate);
 
+    void _update_max_row(const vectorized::Block* block);
+
     bool _check_apply_by_bitmap_index(ColumnPredicate* pred);
     bool _check_apply_by_inverted_index(ColumnPredicate* pred, bool pred_in_compound = false);
 
@@ -383,6 +385,9 @@ private:
     // the actual init process is delayed to the first call to next_batch()
     bool _lazy_inited;
     bool _inited;
+    bool _estimate_row_size;
+    // Read up to 100 rows at a time while waiting for the estimated row size.
+    int _wait_times_estimate_row_size;
 
     StorageReadOptions _opts;
     // make a copy of `_opts.column_predicates` in order to make local changes


### PR DESCRIPTION
## Proposed changes

This reverts commit 74b5ef0980e18cd3d0132199db4962955f08a8e7.

And fix bug: when avg_row_size > config::doris_scan_block_max_mb,
_opts.block_row_max will be set to 0, which will cause early EOF.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

