### PR TITLE
[Opt](parquet-reader) Opt `ColumnSelectVector::set_run_length_null_map()` in parquet reader.

### DIFF
--- a/be/src/vec/exec/format/parquet/parquet_common.cpp
+++ b/be/src/vec/exec/format/parquet/parquet_common.cpp
@@ -97,11 +97,17 @@ void ColumnSelectVector::set_run_length_null_map(const std::vector<uint16_t>& ru
             NullMap& map_data_column = *null_map;
             auto null_map_index = map_data_column.size();
             map_data_column.resize(null_map_index + num_read);
-            for (size_t i = 0; i < num_values; ++i) {
-                if (_data_map[i] == CONTENT) {
-                    map_data_column[null_map_index++] = (UInt8) false;
-                } else if (_data_map[i] == NULL_DATA) {
-                    map_data_column[null_map_index++] = (UInt8) true;
+            if (_num_nulls == 0) {
+                memset(map_data_column.data() + null_map_index, 0, num_read);
+            } else if (_num_nulls == num_values) {
+                memset(map_data_column.data() + null_map_index, 1, num_read);
+            } else {
+                for (size_t i = 0; i < num_values; ++i) {
+                    if (_data_map[i] == CONTENT) {
+                        map_data_column[null_map_index++] = (UInt8) false;
+                    } else if (_data_map[i] == NULL_DATA) {
+                        map_data_column[null_map_index++] = (UInt8) true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

[Opt] (parquet-reader) Opt `ColumnSelectVector::set_run_length_null_map()` in parquet reader.

### Test Result:
tpch500，2 node:
```
select count(l_orderkey), count(l_extendedprice), count(l_discount), count(l_shipdate) from lineitem 
where l_shipdate > '1995-03-15';
```
9 s to 7.9 s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

