### PR TITLE
[fix](delete) fix incorrect tablet schema of delete predicate rowset

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -299,7 +299,8 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
                 int schemaHash = targetTbl.getSchemaHashByIndexId(indexId);
 
                 List<TColumn> columnsDesc = Lists.newArrayList();
-                for (Column column : targetTbl.getSchemaByIndexId(indexId)) {
+                // using to update schema of the rowset, so full columns should be included
+                for (Column column : targetTbl.getSchemaByIndexId(indexId, true)) {
                     columnsDesc.add(column.toThrift());
                 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The tablet schema of delete predicate rowset  information missing hidden columns. If using it may cause be coredump.
After just completing the schema change, delete predicate operate will trigger the case.

<!--Describe your changes.-->
SIGSEGV unknown detail explain (@0x0) received by PID 2120948 (TID 2122716 OR 0x7f8e6592b700) from PID 0; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/code/doris/be/src/common/signal_handler.h:417
1# 0x00007F920555E0C0 in /lib/x86_64-linux-gnu/libc.so.6
2# doris::segment_v2::SegmentIterator::_init_return_column_iterators() at /root/code/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1237
3# doris::segment_v2::SegmentIterator::init_iterators() at /root/code/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:357
4# doris::segment_v2::SegmentIterator::_init_impl(doris::StorageReadOptions const&) at /root/code/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:330
5# doris::segment_v2::SegmentIterator::init(doris::StorageReadOptions const&) at /root/code/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:272
6# doris::segment_v2::Segment::new_iterator(std::shared_ptr<doris::Schema const>, doris::StorageReadOptions const&, std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> >*) in /root/correctness-test/doris-2.0/be/lib/doris_be
7# doris::BetaRowsetReader::get_segment_iterators(doris::RowsetReaderContext*, std::vector<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> >, std::allocator<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> > > >*, bool) at /root/code/doris/be/src/olap/rowset/beta_rowset_reader.cpp:245
8# doris::vectorized::VerticalBlockReader::_get_segment_iterators(doris::TabletReader::ReaderParams const&, std::vector<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> >, std::allocator<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> > > >, std::vector<bool, std::allocator<bool> >, std::vector<doris::RowsetId, std::allocator<doris::RowsetId> >*) in /root/correctness-test/doris-2.0/be/lib/doris_be
9# doris::vectorized::VerticalBlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) at /root/code/doris/be/src/vec/olap/vertical_block_reader.cpp:117
10# doris::vectorized::VerticalBlockReader::init(doris::TabletReader::ReaderParams const&) at /root/code/doris/be/src/vec/olap/vertical_block_reader.cpp:216
11# doris::Merger::vertical_compact_one_group(std::shared_ptr<doris::Tablet>, doris::ReaderType, std::shared_ptr<doris::TabletSchema>, bool, std::vector<unsigned int, std::allocator<unsigned int> > const&, doris::vectorized::RowSourcesBuffer*, std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, doris::Merger::Statistics*, std::vector<unsigned int, std::allocator<unsigned int> >) in /root/correctness-test/doris-2.0/be/lib/doris_be
12# doris::Merger::vertical_merge_rowsets(std::shared_ptr<doris::Tablet>, doris::ReaderType, std::shared_ptr<doris::TabletSchema>, std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, doris::Merger::Statistics*) at /root/code/doris/be/src/olap/merger.cpp:369
13# doris::Compaction::do_compaction_impl(long) at /root/code/doris/be/src/olap/compaction.cpp:350
14# doris::Compaction::do_compaction(long) at /root/code/doris/be/src/olap/compaction.cpp:125
15# doris::BaseCompaction::execute_compact_impl() at /root/code/doris/be/src/olap/base_compaction.cpp:87
16# doris::Compaction::execute_compact() at /root/code/doris/be/src/olap/compaction.cpp:107


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

