### PR TITLE
fix violations of Sonarqube rule java:S2111

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticWindow.java
@@ -422,7 +422,7 @@ public class AnalyticWindow {
                         + "constant positive number: " + boundary.toSql());
             }
 
-            boundary.offsetValue = new BigDecimal(val);
+            boundary.offsetValue = BigDecimal.valueOf(val);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -215,7 +215,7 @@ public class FloatLiteral extends LiteralExpr {
             res.setType(targetType);
             return res;
         } else if (targetType.isDecimalV3()) {
-            DecimalLiteral res = new DecimalLiteral(new BigDecimal(value));
+            DecimalLiteral res = new DecimalLiteral(BigDecimal.valueOf(value));
             res.setType(ScalarType.createDecimalV3Type(targetType.getPrecision(),
                     ((ScalarType) targetType).decimalScale()));
             return res;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/CheckedMath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/CheckedMath.java
@@ -41,10 +41,10 @@ public class CheckedMath {
     }
 
     public static double checkedMultiply(double a, double b) {
-        BigDecimal d1 = new BigDecimal(a);
-        BigDecimal d2 = new BigDecimal(b);
+        BigDecimal d1 = BigDecimal.valueOf(a);
+        BigDecimal d2 = BigDecimal.valueOf(b);
         BigDecimal result = d1.multiply(d2);
-        if (result.compareTo(new BigDecimal(Double.MAX_VALUE)) > 0) {
+        if (result.compareTo(BigDecimal.valueOf(Double.MAX_VALUE)) > 0) {
             return Double.MAX_VALUE;
         }
         return result.doubleValue();


### PR DESCRIPTION
Hello,

This PR fixes 5 violations of Sonarqube Rule java:S2111 : ['"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111).
For more details, please see [CERT, NUM10-J.](https://wiki.sei.cmu.edu/confluence/x/kzdGBQ)

The patch was automatically generated using the ViolationFixer tool.