### PR TITLE
[Fix](Job)Fixed the problem of not deleting JOB during DROP JOB metadata playback

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -2623,9 +2623,9 @@ pause_job_stmt ::=
     ;
 
 stop_job_stmt ::=
-    KW_DROP KW_JOB opt_wild_where
+    KW_DROP KW_JOB opt_if_exists:ifExists opt_wild_where 
     {:
-      RESULT = new AlterJobStatusStmt(parser.where,org.apache.doris.job.common.JobStatus.STOPPED);
+      RESULT = new AlterJobStatusStmt(parser.where,true,ifExists);
     :}
     ;    
 resume_job_stmt ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterJobStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterJobStatusStmt.java
@@ -36,9 +36,21 @@ public class AlterJobStatusStmt extends DdlStmt {
     @Getter
     private JobStatus jobStatus;
 
+    @Getter
+    private boolean isDrop = false;
+
+    @Getter
+    private boolean ifExists;
+
     public AlterJobStatusStmt(Expr whereClause, JobStatus jobStatus) {
         this.expr = whereClause;
         this.jobStatus = jobStatus;
+    }
+
+    public AlterJobStatusStmt(Expr whereClause, boolean isDrop, boolean ifExists) {
+        this.expr = whereClause;
+        this.isDrop = isDrop;
+        this.ifExists = ifExists;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -258,7 +258,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         if (newJobStatus.equals(JobStatus.FINISHED)) {
             this.finishTimeMs = System.currentTimeMillis();
         }
-        if (JobStatus.PAUSED.equals(newJobStatus)) {
+        if (JobStatus.PAUSED.equals(newJobStatus) || JobStatus.STOPPED.equals(newJobStatus)) {
             cancelAllTasks();
         }
         jobStatus = newJobStatus;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -279,8 +279,8 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         Env.getCurrentEnv().getEditLog().logCreateJob(this);
     }
 
-    public void logFinalOperation() {
-        Env.getCurrentEnv().getEditLog().logEndJob(this);
+    public void logDeleteOperation() {
+        Env.getCurrentEnv().getEditLog().logDeleteJob(this);
     }
 
     public void logUpdateOperation() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -673,7 +673,7 @@ public class EditLog {
                 }
                 case OperationType.OP_DELETE_SCHEDULER_JOB: {
                     AbstractJob job = (AbstractJob) journal.getData();
-                    Env.getCurrentEnv().getJobManager().replayEndJob(job);
+                    Env.getCurrentEnv().getJobManager().replayDeleteJob(job);
                     break;
                 }
                 /*case OperationType.OP_CREATE_SCHEDULER_TASK: {
@@ -1625,7 +1625,7 @@ public class EditLog {
         logEdit(OperationType.OP_UPDATE_SCHEDULER_JOB, job);
     }
 
-    public void logEndJob(AbstractJob job) {
+    public void logDeleteJob(AbstractJob job) {
         logEdit(OperationType.OP_DELETE_SCHEDULER_JOB, job);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -197,6 +197,12 @@ public class DdlExecutor {
         } else if (ddlStmt instanceof AlterJobStatusStmt) {
             AlterJobStatusStmt stmt = (AlterJobStatusStmt) ddlStmt;
             try {
+                // drop job
+                if (stmt.isDrop()) {
+                    env.getJobManager().unregisterJob(stmt.getJobName(), stmt.isIfExists());
+                    return;
+                }
+                // alter job status
                 env.getJobManager().alterJobStatus(stmt.getJobName(), stmt.getJobStatus());
             } catch (Exception e) {
                 throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
@@ -32,11 +32,11 @@ public class JobExecutionConfigurationTest {
         configuration.setExecuteType(JobExecuteType.ONE_TIME);
 
         TimerDefinition timerDefinition = new TimerDefinition();
-        timerDefinition.setStartTimeMs(System.currentTimeMillis() + 1000); // Start time set to 1 second in the future
+        timerDefinition.setStartTimeMs(1000L); // Start time set to 1 second in the future
         configuration.setTimerDefinition(timerDefinition);
 
         List<Long> delayTimes = configuration.getTriggerDelayTimes(
-                System.currentTimeMillis(), System.currentTimeMillis(), System.currentTimeMillis() + 5000);
+                0L, 0L,  5000L);
 
         Assertions.assertEquals(1, delayTimes.size());
         Assertions.assertEquals(1, delayTimes.get(0).longValue());

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -26,32 +26,32 @@ suite("test_base_insert_job") {
     def jobMixedName = "Insert_recovery_Test_base_insert_job"
     sql """drop table if exists `${tableName}` force"""
     sql """
-        DROP JOB where jobname =  '${jobName}'
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
     """
     sql """
-       DROP JOB where jobname =  'JOB'
+       DROP JOB IF EXISTS where jobname =  'JOB'
     """
     sql """
-       DROP JOB where jobname =  'DO'
+       DROP JOB IF EXISTS where jobname =  'DO'
     """
     sql """
-       DROP JOB where jobname =  'AT'
+       DROP JOB IF EXISTS where jobname =  'AT'
     """
     sql """
-       DROP JOB where jobname =  'SCHEDULE'
+       DROP JOB IF EXISTS where jobname =  'SCHEDULE'
     """
     sql """
-       DROP JOB where jobname =  'STARTS'
+       DROP JOB IF EXISTS where jobname =  'STARTS'
     """
     sql """
-       DROP JOB where jobname =  'ENDS'
+       DROP JOB IF EXISTS where jobname =  'ENDS'
     """
     sql """
-        DROP JOB where jobname =  '${jobMixedName}'
+        DROP JOB IF EXISTS where jobname =  '${jobMixedName}'
     """
 
     sql """
-        DROP JOB where jobname =  '${jobName}'
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
     """
 
     sql """
@@ -82,10 +82,10 @@ suite("test_base_insert_job") {
     assert mixedNameJobs.size() == 1 && mixedNameJobs.get(0).get(0) == jobMixedName
     assert mixedNameJobs.get(0).get(1) == ''
     sql """
-        DROP JOB where jobname =  '${jobName}'
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
     """
     sql """
-        DROP JOB where jobname =  '${jobMixedName}'
+        DROP JOB IF EXISTS where jobname =  '${jobMixedName}'
     """
 
     sql """drop table if exists `${tableName}` force """
@@ -145,7 +145,7 @@ suite("test_base_insert_job") {
     //assert comment
     assert oncejob.get(0).get(1) == "test for test&68686781jbjbhj//ncsa"
     sql """
-        DROP JOB where jobname =  '${jobName}'
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
     """
 
     sql """


### PR DESCRIPTION
### Description
When we perform the DROP operation, the task is deleted from the memory, but when we restart, the metadata is played back and no remove operation is performed.


## Proposed changes
Keep the STOP state and implement the DROP interface separately. When Dropping, first change the job to the STOP state (some tasks in the queue still hold job object references. When these tasks start to execute, you need to check the job status to determine whether it is needed. execute) and then delete it.

- Fixed the problem of not deleting JOB during DROP JOB metadata playback

- DROP JOB adds IF EXISTS syntax
- Fix unstable UT as it could be affected by the current time
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

