### PR TITLE
[fix](move-memtable) check eos when close stream

### DIFF
--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -135,7 +135,7 @@ private:
 
     void _report_result(StreamId stream, const Status& status,
                         const std::vector<int64_t>& success_tablet_ids,
-                        const FailedTablets& failed_tablets);
+                        const FailedTablets& failed_tablets, bool eos);
     void _report_schema(StreamId stream, const PStreamHeader& hdr);
 
     // report failure for one message
@@ -144,7 +144,7 @@ private:
         if (header.has_tablet_id()) {
             failed_tablets.emplace_back(header.tablet_id(), status);
         }
-        _report_result(stream, status, {}, failed_tablets);
+        _report_result(stream, status, {}, failed_tablets, false);
     }
 
 private:

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -36,6 +36,10 @@ int LoadStreamStub::LoadStreamReplyHandler::on_received_messages(brpc::StreamId 
         PLoadStreamResponse response;
         response.ParseFromZeroCopyStream(&wrapper);
 
+        if (response.eos()) {
+            _is_eos.store(true);
+        }
+
         Status st = Status::create(response.status());
 
         std::stringstream ss;

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -63,6 +63,7 @@
 #include "util/debug_points.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
+#include "util/uid_util.h"
 #include "vec/columns/column.h"
 #include "vec/common/allocator.h"
 #include "vec/core/block.h"
@@ -110,12 +111,12 @@ private:
             int ret = _close_cv.wait_for(lock, timeout_ms * 1000);
             if (ret != 0) {
                 return Status::InternalError(
-                        "stream close_wait timeout, load_id={}, be_id={}, error={}", _load_id,
-                        _dst_id, ret);
+                        "stream close_wait timeout, load_id={}, be_id={}, error={}",
+                        print_id(_load_id), _dst_id, ret);
             }
             if (!_is_eos.load()) {
                 return Status::InternalError("stream closed without eos, load_id={} be_id={}",
-                                             _load_id, _dst_id);
+                                             print_id(_load_id), _dst_id);
             }
             return Status::OK();
         };

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -63,7 +63,6 @@
 #include "util/debug_points.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
-#include "util/uid_util.h"
 #include "vec/columns/column.h"
 #include "vec/common/allocator.h"
 #include "vec/core/block.h"

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -99,7 +99,7 @@ private:
         void on_closed(brpc::StreamId id) override;
 
         bool is_closed() { return _is_closed.load(); }
-        
+
         bool is_eos() { return _is_eos.load(); }
 
         Status close_wait(int64_t timeout_ms) {
@@ -112,11 +112,11 @@ private:
             if (ret != 0) {
                 return Status::InternalError(
                         "stream close_wait timeout, load_id={}, be_id={}, error={}",
-                        print_id(_load_id), _dst_id, ret);
+                        _load_id.to_string(), _dst_id, ret);
             }
             if (!_is_eos.load()) {
                 return Status::InternalError("stream closed without eos, load_id={} be_id={}",
-                                             print_id(_load_id), _dst_id);
+                                             _load_id.to_string(), _dst_id);
             }
             return Status::OK();
         };

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -98,6 +98,8 @@ private:
         void on_closed(brpc::StreamId id) override;
 
         bool is_closed() { return _is_closed.load(); }
+        
+        bool is_eos() { return _is_eos.load(); }
 
         Status close_wait(int64_t timeout_ms) {
             DCHECK(timeout_ms > 0) << "timeout_ms should be greator than 0";
@@ -106,7 +108,16 @@ private:
                 return Status::OK();
             }
             int ret = _close_cv.wait_for(lock, timeout_ms * 1000);
-            return ret == 0 ? Status::OK() : Status::Error<true>(ret, "stream close_wait timeout");
+            if (ret != 0) {
+                return Status::InternalError(
+                        "stream close_wait timeout, load_id={}, be_id={}, error={}", _load_id,
+                        _dst_id, ret);
+            }
+            if (!_is_eos.load()) {
+                return Status::InternalError("stream closed without eos, load_id={} be_id={}",
+                                             _load_id, _dst_id);
+            }
+            return Status::OK();
         };
 
         std::vector<int64_t> success_tablets() {
@@ -126,6 +137,7 @@ private:
         UniqueId _load_id;    // for logging
         int64_t _dst_id = -1; // for logging
         std::atomic<bool> _is_closed;
+        std::atomic<bool> _is_eos;
         bthread::Mutex _mutex;
         bthread::ConditionVariable _close_cv;
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -778,6 +778,7 @@ message PLoadStreamResponse {
     repeated PFailedTablet failed_tablets = 3;
     optional bytes load_stream_profile = 4;
     repeated PTabletSchemaWithIndex tablet_schemas = 5;
+    optional bool eos = 6;
 }
 
 message PStreamHeader {


### PR DESCRIPTION
## Proposed changes

LoadStream will set a eos flag on last report status message.
LoadStreamStub should check whether this flag is exist after closing stream.

If eos is missing, there might be tablets missing.
In this case stub should report an error.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

