### PR TITLE
[fix](proc)Merge fix for long-running queries into 1.2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
@@ -60,9 +60,9 @@ public class CurrentQueryStatementsProcNode implements ProcNodeInterface {
 
         // sort according to ExecTime
         sortedRowData.sort((l1, l2) -> {
-            final int execTime1 = Integer.parseInt(l1.get(EXEC_TIME_INDEX));
-            final int execTime2 = Integer.parseInt(l2.get(EXEC_TIME_INDEX));
-            return execTime2 - execTime1;
+            final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
+            final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
+            return Long.compare(execTime2, execTime1);
         });
         result.setRows(sortedRowData);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
@@ -91,9 +91,9 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
         }
         // sort according to ExecTime
         sortedRowData.sort((l1, l2) -> {
-            final int execTime1 = Integer.parseInt(l1.get(EXEC_TIME_INDEX));
-            final int execTime2 = Integer.parseInt(l2.get(EXEC_TIME_INDEX));
-            return execTime2 - execTime1;
+            final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
+            final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
+            return  Long.compare(execTime2, execTime1);
         });
         result.setRows(sortedRowData);
         return result;


### PR DESCRIPTION
## Proposed changes

Port #21400 fix from 2.0 to 1.2
Addresses NumberFormatException in '/current_queries'
Occurs when ExecTime exceeds MAX_INT
Replaces 'Integer.parseInt' with proper long type handling

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

