### PR TITLE
[Fix](Variant) fix heap use after free when updating tablet schema

### DIFF
--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -93,15 +93,15 @@ Status SegmentFlusher::_expand_variant_to_subcolumns(vectorized::Block& block,
     if (_context->partial_update_info && _context->partial_update_info->is_partial_update) {
         // check columns that used to do partial updates should not include variant
         for (int i : _context->partial_update_info->update_cids) {
-            const auto& col = _context->tablet_schema->columns()[i];
+            const auto& col = _context->original_tablet_schema->columns()[i];
             if (!col.is_key() && col.name() != DELETE_SIGN) {
                 return Status::InvalidArgument(
                         "Not implement partial update for variant only support delete currently");
             }
         }
     } else {
-        for (int i = 0; i < _context->tablet_schema->columns().size(); ++i) {
-            if (_context->tablet_schema->columns()[i].is_variant_type()) {
+        for (int i = 0; i < _context->original_tablet_schema->columns().size(); ++i) {
+            if (_context->original_tablet_schema->columns()[i].is_variant_type()) {
                 variant_column_pos.push_back(i);
             }
         }
@@ -155,7 +155,8 @@ Status SegmentFlusher::_expand_variant_to_subcolumns(vectorized::Block& block,
         bool is_nullable = column_ref->is_nullable();
         const vectorized::ColumnObject& object_column = assert_cast<vectorized::ColumnObject&>(
                 remove_nullable(column_ref)->assume_mutable_ref());
-        const TabletColumn& parent_column = _context->tablet_schema->columns()[variant_pos];
+        const TabletColumn& parent_column =
+                _context->original_tablet_schema->columns()[variant_pos];
         CHECK(object_column.is_finalized());
         std::shared_ptr<vectorized::ColumnObject::Subcolumns::Node> root;
         for (auto& entry : object_column.get_subcolumns()) {


### PR DESCRIPTION
`_context->tablet_schema` maybe updated so use `_context->original_tablet_schema` instead

```
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:417
 1# 0x00007FF796C000A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007FF796BF902C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007FF79B633090 in /lib/x86_64-linux-gnu/libc.so.6
 5# memcpy at /home/zcp/repo_center/doris_master/doris/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:219
 6# doris::SegmentFlusher::_expand_variant_to_subcolumns(doris::vectorized::Block&, std::shared_ptr&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_creator.cpp:167
 7# doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_creator.cpp:67
 8# doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_creator.cpp:485
 9# doris::BaseBetaRowsetWriter::flush_memtable(doris::vectorized::Block*, int, long*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/beta_rowset_writer.cpp:484
10# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_flush_executor.cpp:126
11# doris::FlushToken::_flush_memtable(doris::MemTable*, int, long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_flush_executor.cpp:157
12# doris::MemtableFlushTask::run() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_flush_executor.cpp:60
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

