### PR TITLE
[fix](pipelinex) coredump caused by null pointer of Dependency::_shared_state

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -53,9 +53,9 @@ public:
     ~AggSinkDependency() override = default;
 
     void set_ready() override {
-        if (_shared_state && _is_streaming_agg_state()) {
-            if (((SharedState*)Dependency::_shared_state.get())
-                        ->data_queue->has_enough_space_to_push()) {
+        std::shared_ptr<BasicSharedState> shared_state = _shared_state;
+        if (shared_state && _is_streaming_agg_state(shared_state)) {
+            if (((SharedState*)shared_state.get())->data_queue->has_enough_space_to_push()) {
                 Dependency::set_ready();
             }
         } else {
@@ -64,9 +64,9 @@ public:
     }
 
     void block() override {
-        if (_is_streaming_agg_state()) {
-            if (!((SharedState*)Dependency::_shared_state.get())
-                         ->data_queue->has_enough_space_to_push()) {
+        std::shared_ptr<BasicSharedState> shared_state = _shared_state;
+        if (_is_streaming_agg_state(shared_state)) {
+            if (!((SharedState*)shared_state.get())->data_queue->has_enough_space_to_push()) {
                 Dependency::block();
             }
         } else {
@@ -75,8 +75,8 @@ public:
     }
 
 private:
-    bool _is_streaming_agg_state() {
-        return ((SharedState*)Dependency::_shared_state.get())->data_queue != nullptr;
+    static bool _is_streaming_agg_state(const std::shared_ptr<BasicSharedState>& shared_state) {
+        return ((SharedState*)shared_state.get())->data_queue != nullptr;
     }
 };
 


### PR DESCRIPTION

## Proposed changes

```bash
#0  0x000055d8f39c8d75 in std::__uniq_ptr_impl<doris::pipeline::DataQueue, std::default_delete<doris::pipeline::DataQueue> >::_M_ptr (this=0xe8)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
#1  0x000055d8f39c8d45 in std::unique_ptr<doris::pipeline::DataQueue, std::default_delete<doris::pipeline::DataQueue> >::get (this=0xe8)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:422
#2  0x000055d8f39c66c5 in std::unique_ptr<doris::pipeline::DataQueue, std::default_delete<doris::pipeline::DataQueue> >::operator-> (this=0xe8)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:416
#3  0x000055d8f3d20a6c in doris::pipeline::AggSinkDependency::set_ready (this=0x7ff48af20510) at /root/doris/be/src/pipeline/exec/aggregation_sink_operator.h:57
#4  0x000055d8f3994cd1 in doris::pipeline::DataQueue::get_block_from_queue (this=0x7fec882fd980, output_block=0x7ff427ff0688, child_idx=0x0) at /root/doris/be/src/pipeline/exec/data_queue.cpp:124
#5  0x000055d8f3b975ac in doris::pipeline::DistinctStreamingAggSourceOperatorX::get_block (this=0x7ff497f1b8c0, state=0x7fec88311000, block=0x7ff48af8cb38, source_state=@0x7fec88315939: doris::pipeline::SourceState::DEPEND_ON_SOURCE)
    at /root/doris/be/src/pipeline/exec/distinct_streaming_aggregation_source_operator.cpp:112
#6  0x000055d8f3cd886f in doris::pipeline::OperatorXBase::get_block_after_projects (this=0x7ff497f1b8c0, state=0x7fec88311000, block=0x7fec881ae3c0, source_state=@0x7fec88315939: doris::pipeline::SourceState::DEPEND_ON_SOURCE)
    at /root/doris/be/src/pipeline/pipeline_x/operator.cpp:201
#7  0x000055d8f3daa66e in doris::pipeline::PipelineXTask::execute (this=0x7fec88315900, eos=0x7ff427ff0ec6) at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:275
#8  0x000055d8f3dbc8d6 in doris::pipeline::TaskScheduler::_do_work (this=0x7ff4f0696bf0, index=10) at /root/doris/be/src/pipeline/task_scheduler.cpp:286
#9  0x000055d8f3dc2724 in std::__invoke_impl<void, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__f=
    @0x7ff4f071bcc0: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x55d8f3dbbeb0 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __t=@0x7ff4f071bcd8: 0x7ff4f0696bf0, __args=@0x7ff4f071bcd0: 10)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#10 0x000055d8f3dc2645 in std::__invoke<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__fn=
    @0x7ff4f071bcc0: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x55d8f3dbbeb0 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __args=@0x7ff4f071bcd0: 10, __args=@0x7ff4f071bcd0: 10)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#11 0x000055d8f3dc2612 in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x7ff4f071bcc0, __args=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#12 0x000055d8f3dc25a6 in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() (this=0x7ff4f071bcc0)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#13 0x000055d8f3dc2575 in std::__invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::__invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (__f=...) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#14 0x000055d8f3dc2535 in std::__invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (__fn=...) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#15 0x000055d8f3dc231d in std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) (__functor=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#16 0x000055d8e30086e5 in std::function<void ()>::operator()() const (this=0x7ff47199d9d8) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#17 0x000055d8e45dd389 in doris::FunctionRunnable::run (this=0x7ff47199d9d0) at /root/doris/be/src/util/threadpool.cpp:48
#18 0x000055d8e45d5c86 in doris::ThreadPool::dispatch_thread (this=0x7ff4f071a800) at /root/doris/be/src/util/threadpool.cpp:543
#19 0x000055d8e45e3e19 in std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__f=@0x7ff4f07fc8c0: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55d8e45d51f0 <doris::ThreadPool::dispatch_thread()>, 
    __t=@0x7ff4f07fc8d0: 0x7ff4f071a800) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#20 0x000055d8e45e3d5d in std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__fn=@0x7ff4f07fc8c0: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55d8e45d51f0 <doris::ThreadPool::dispatch_thread()>, 
    __args=@0x7ff4f07fc8d0: 0x7ff4f071a800) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#21 0x000055d8e45e3d2d in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0x7ff4f07fc8c0, __args=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#22 0x000055d8e45e3ce6 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() (this=0x7ff4f07fc8c0) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#23 0x000055d8e45e3cb5 in std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__f=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#24 0x000055d8e45e3c75 in std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__fn=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#25 0x000055d8e45e3a6d in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (__functor=...)
    at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#26 0x000055d8e30086e5 in std::function<void ()>::operator()() const (this=0x7ff471a380f8) at /root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#27 0x000055d8e45c540f in doris::Thread::supervise_thread (arg=0x7ff471a380e0) at /root/doris/be/src/util/thread.cpp:498
#28 0x00007ff4f3fd517a in start_thread () from /lib64/libpthread.so.0
#29 0x00007ff4f486fdf3 in clone () from /lib64/libc.so.6
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

