### PR TITLE
[Opt](exec)(multi-catalog) Opt date type reading.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -577,7 +577,7 @@ Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr
     if (need_convert) {
         std::unique_ptr<ParquetConvert::ColumnConvert> converter;
         ParquetConvert::ConvertParams convert_params;
-        convert_params.init(_field_schema, _ctz, doris_column->size());
+        convert_params.init(_field_schema, _ctz);
         RETURN_IF_ERROR(ParquetConvert::get_converter(parquet_physical_type, show_type, type,
                                                       &converter, &convert_params));
         auto x = doris_column->assume_mutable();

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -2668,17 +2668,14 @@ char* DateV2Value<T>::to_string(char* to, int scale) const {
     return to + len + 1;
 }
 
-template <typename T>
-typename DateV2Value<T>::underlying_value DateV2Value<T>::to_date_int_val() const {
-    return int_val_;
-}
 // [1900-01-01, 2039-12-31]
-static std::array<DateV2Value<DateV2ValueType>, date_day_offset_dict::DICT_DAYS>
-        DATE_DAY_OFFSET_ITEMS;
-// [1900-01-01, 2039-12-31]
-static std::array<std::array<std::array<int, 31>, 12>, 140> DATE_DAY_OFFSET_DICT;
+std::array<DateV2Value<DateV2ValueType>, date_day_offset_dict::DICT_DAYS>
+        date_day_offset_dict::DATE_DAY_OFFSET_ITEMS;
 
-static bool DATE_DAY_OFFSET_ITEMS_INIT = false;
+// [1900-01-01, 2039-12-31]
+std::array<std::array<std::array<int, 31>, 12>, 140> date_day_offset_dict::DATE_DAY_OFFSET_DICT;
+
+bool date_day_offset_dict::DATE_DAY_OFFSET_ITEMS_INIT = false;
 
 date_day_offset_dict date_day_offset_dict::instance = date_day_offset_dict();
 
@@ -2716,16 +2713,6 @@ date_day_offset_dict::date_day_offset_dict() {
     }
 
     DATE_DAY_OFFSET_ITEMS_INIT = true;
-}
-
-DateV2Value<DateV2ValueType> date_day_offset_dict::operator[](int day) const {
-    int index = day + DAY_BEFORE_EPOCH;
-    if (LIKELY(index >= 0 && index < DICT_DAYS)) {
-        return DATE_DAY_OFFSET_ITEMS[index];
-    } else {
-        DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
-        return d += index;
-    }
 }
 
 int date_day_offset_dict::daynr(int year, int month, int day) const {

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -753,9 +753,11 @@ public:
     // Constructor
     DateV2Value() : date_v2_value_(0, 0, 0, 0, 0, 0, 0) {}
 
-    DateV2Value(DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(underlying_value int_val) : int_val_(int_val) {}
 
-    DateV2Value(const DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(DateV2Value<T>& other) = default;
+
+    DateV2Value(const DateV2Value<T>& other) = default;
 
     static DateV2Value create_from_olap_date(uint64_t value) {
         DateV2Value<T> date;
@@ -1132,7 +1134,7 @@ public:
                this->microsecond() == 0;
     }
 
-    underlying_value to_date_int_val() const;
+    underlying_value to_date_int_val() const { return int_val_; }
 
     bool from_date(uint32_t value);
     bool from_datetime(uint64_t value);
@@ -1528,14 +1530,6 @@ int64_t datetime_diff(const VecDateTimeValue& ts_value1, const DateV2Value<T>& t
  */
 class date_day_offset_dict {
 private:
-    static date_day_offset_dict instance;
-
-    date_day_offset_dict();
-    ~date_day_offset_dict() = default;
-    date_day_offset_dict(const date_day_offset_dict&) = default;
-    date_day_offset_dict& operator=(const date_day_offset_dict&) = default;
-
-public:
     static constexpr int DAY_BEFORE_EPOCH = 25567;                           // 1900-01-01
     static constexpr int DAY_AFTER_EPOCH = 25566;                            // 2039-12-31
     static constexpr int DICT_DAYS = DAY_BEFORE_EPOCH + 1 + DAY_AFTER_EPOCH; // 1 means 1970-01-01
@@ -1545,6 +1539,19 @@ public:
     static constexpr int DAY_OFFSET_CAL_START_POINT_DAYNR =
             719528; // 1970-01-01 (start from 0000-01-01, 0000-01-01 is day 1, returns 1)
 
+    static std::array<DateV2Value<DateV2ValueType>, DICT_DAYS> DATE_DAY_OFFSET_ITEMS;
+    static std::array<std::array<std::array<int, 31>, 12>, 140> DATE_DAY_OFFSET_DICT;
+
+    static bool DATE_DAY_OFFSET_ITEMS_INIT;
+
+    static date_day_offset_dict instance;
+
+    date_day_offset_dict();
+    ~date_day_offset_dict() = default;
+    date_day_offset_dict(const date_day_offset_dict&) = default;
+    date_day_offset_dict& operator=(const date_day_offset_dict&) = default;
+
+public:
     static bool can_speed_up_calc_daynr(int year) { return year >= START_YEAR && year <= END_YEAR; }
 
     static int get_offset_by_daynr(int daynr) { return daynr - DAY_OFFSET_CAL_START_POINT_DAYNR; }
@@ -1558,7 +1565,15 @@ public:
 
     static bool get_dict_init();
 
-    DateV2Value<DateV2ValueType> operator[](int day) const;
+    inline DateV2Value<DateV2ValueType> operator[](int day) const {
+        int index = day + DAY_BEFORE_EPOCH;
+        if (LIKELY(index >= 0 && index < DICT_DAYS)) {
+            return DATE_DAY_OFFSET_ITEMS[index];
+        } else {
+            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
+            return d += index;
+        }
+    }
 
     int daynr(int year, int month, int day) const;
 };

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -267,7 +267,7 @@ static Status get_column_values(io::FileReaderSPtr file_reader, tparquet::Column
     if (need_convert) {
         std::unique_ptr<ParquetConvert::ColumnConvert> converter;
         ParquetConvert::ConvertParams convert_params;
-        convert_params.init(field_schema, &ctz, doris_column->size());
+        convert_params.init(field_schema, &ctz);
         RETURN_IF_ERROR(ParquetConvert::get_converter(parquet_physical_type, show_type, data_type,
                                                       &converter, &convert_params));
         auto x = doris_column->assume_mutable();


### PR DESCRIPTION
## Proposed changes

[Opt] (exec) (multi-catalog) Opt date type reading. 

For tpch-500-parquet(one node): 2.32->1.57.
```
select count(l_shipdate) from lineitem;
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

