### PR TITLE
[fix](tablet sched) disable disk balance for single replica

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1022,6 +1022,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static boolean disable_disk_balance = false;
 
+    /**
+     * if set to true, TabletScheduler will not do disk balance for replica num = 1.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean disable_disk_balance_for_single_replica = false;
+
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1023,10 +1023,10 @@ public class Config extends ConfigBase {
     public static boolean disable_disk_balance = false;
 
     /**
-     * if set to true, TabletScheduler will not do disk balance for replica num = 1.
+     * if set to false, TabletScheduler will not do disk balance for replica num = 1.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean disable_disk_balance_for_single_replica = false;
+    public static boolean enable_disk_balance_for_single_replica = false;
 
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -211,10 +211,9 @@ public class DiskRebalancer extends Rebalancer {
                 if (alternativeTabletIds.contains(tabletId)) {
                     continue;
                 }
-                if (!Config.disable_disk_balance_for_single_replica) {
-                    if (invertedIndex.getReplicasByTabletId(tabletId).size() <= 1) {
-                        continue;
-                    }
+                if (!Config.enable_disk_balance_for_single_replica
+                        && invertedIndex.getReplicasByTabletId(tabletId).size() <= 1) {
+                    continue;
                 }
                 Replica replica = invertedIndex.getReplica(tabletId, beStat.getBeId());
                 if (replica == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -27,6 +27,7 @@ import org.apache.doris.clone.SchedException.SubCode;
 import org.apache.doris.clone.TabletSchedCtx.BalanceType;
 import org.apache.doris.clone.TabletSchedCtx.Priority;
 import org.apache.doris.clone.TabletScheduler.PathSlot;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -210,6 +210,11 @@ public class DiskRebalancer extends Rebalancer {
                 if (alternativeTabletIds.contains(tabletId)) {
                     continue;
                 }
+                if (Config.disable_disk_balance_for_single_replica) {
+                    if (invertedIndex.getReplicasByTabletId(tabletId).size() <= 1) {
+                        continue;
+                    }
+                }
                 Replica replica = invertedIndex.getReplica(tabletId, beStat.getBeId());
                 if (replica == null) {
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -210,7 +210,7 @@ public class DiskRebalancer extends Rebalancer {
                 if (alternativeTabletIds.contains(tabletId)) {
                     continue;
                 }
-                if (Config.disable_disk_balance_for_single_replica) {
+                if (!Config.disable_disk_balance_for_single_replica) {
                     if (invertedIndex.getReplicasByTabletId(tabletId).size() <= 1) {
                         continue;
                     }


### PR DESCRIPTION
BE tablet storage migrate has bug,  if publish version during storage migrate,  the tablet will miss version.

Temporary disable disk balance for single replica to avoid this problem.