### PR TITLE
[fix](memory) Fix LRUCacheType::NUMBER charge

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -356,8 +356,12 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     e->deleter = deleter;
     e->charge = charge;
     e->key_length = key.size();
-    e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : 1);
+    // if LRUCacheType::NUMBER, charge not add handle_size,
+    // because charge at this time is no longer the memory size, but an independent weight.
+    e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : charge);
     DCHECK(_type == LRUCacheType::SIZE || bytes != -1) << " _type " << _type;
+    // if LRUCacheType::NUMBER and bytes equals 0, such as some caches cannot accurately track memory size.
+    // cache mem tracker value divided by handle_size(106) will get the number of cache entries.
     e->bytes = (_type == LRUCacheType::SIZE ? handle_size + charge : handle_size + bytes);
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -357,7 +357,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     e->charge = charge;
     e->key_length = key.size();
     // if LRUCacheType::NUMBER, charge not add handle_size,
-    // because charge at this time is no longer the memory size, but an independent weight.
+    // because charge at this time is no longer the memory size, but an weight.
     e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : charge);
     DCHECK(_type == LRUCacheType::SIZE || bytes != -1) << " _type " << _type;
     // if LRUCacheType::NUMBER and bytes equals 0, such as some caches cannot accurately track memory size.

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -670,7 +670,7 @@ void ShardedLRUCache::update_cache_metrics() const {
 Cache::Handle* DummyLRUCache::insert(const CacheKey& key, void* value, size_t charge,
                                      void (*deleter)(const CacheKey& key, void* value),
                                      CachePriority priority, size_t bytes) {
-    size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
+    size_t handle_size = sizeof(LRUHandle);
     auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
     e->value = value;
     e->deleter = deleter;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -55,8 +55,8 @@ class Cache;
 class LRUCachePolicy;
 
 enum LRUCacheType {
-    SIZE,  // The capacity of cache is based on the size of cache entry.
-    NUMBER // The capacity of cache is based on the number of cache entry.
+    SIZE, // The capacity of cache is based on the memory size of cache entry, memory size = handle size + charge.
+    NUMBER // The capacity of cache is based on the number of cache entry, number = charge, the weight of an entry.
 };
 
 static constexpr LRUCacheType DEFAULT_LRU_CACHE_TYPE = LRUCacheType::SIZE;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -626,7 +626,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_user_function_cache);
 
-    // cache_manager must be destoried after _inverted_index_query_cache
+    // cache_manager must be destoried after all cache.
     // https://github.com/apache/doris/issues/24082#issuecomment-1712544039
     SAFE_DELETE(_cache_manager);
 


### PR DESCRIPTION
## Proposed changes

if LRUCacheType::NUMBER, charge not add handle_size, because charge at this time is no longer the memory size, but an independent weight.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

