### PR TITLE
[improvement](broker-load) Improve broker building process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ fe_plugins/output
 fe_plugins/**/.factorypath
 
 fs_brokers/apache_hdfs_broker/src/main/resources/
-fs_brokers/apache_hdfs_broker/src/main/thrift/
 
 # regression-test
 regression-test/framework/dependency-reduced-pom.xml

--- a/fs_brokers/apache_hdfs_broker/build.sh
+++ b/fs_brokers/apache_hdfs_broker/build.sh
@@ -28,7 +28,6 @@ export BROKER_HOME="${ROOT}"
 
 # prepare thrift
 mkdir -p "${BROKER_HOME}/src/main/resources/thrift"
-mkdir -p "${BROKER_HOME}/src/main/thrift"
 
 cp "${BROKER_HOME}/../../gensrc/thrift/PaloBrokerService.thrift" "${BROKER_HOME}/src/main/resources/thrift"/
 

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -73,6 +73,7 @@ under the License.
         <netty.version>4.1.65.Final</netty.version>
         <gcs.version>hadoop2-2.2.15</gcs.version>
         <doris.hive.catalog.shade.version>1.0.1</doris.hive.catalog.shade.version>
+        <skip.plugin>false</skip.plugin>
     </properties>
     <profiles>
         <!-- for custom internal repository -->
@@ -381,7 +382,6 @@ under the License.
                             <arguments>
                                 <argument>-p</argument>
                                 <argument>${basedir}/src/main/resources/thrift</argument>
-                                <argument>${basedir}/src/main/thrift</argument>
                             </arguments>
                             <skip>${skip.plugin}</skip>
                         </configuration>
@@ -409,11 +409,9 @@ under the License.
                 <artifactId>maven-thrift-plugin</artifactId>
                 <version>0.1.11</version>
                 <configuration>
-                    <thriftExecutable>${env.DORIS_THIRDPARTY}/installed/bin/thrift</thriftExecutable>
+                    <thriftExecutable>${doris.home}/thirdparty/installed/bin/thrift</thriftExecutable>
                     <thriftSourceRoot>${basedir}/src/main/resources/thrift/</thriftSourceRoot>
-                    <outputDirectory>${basedir}/src/main/thrift/</outputDirectory>
                     <generator>java:fullcamel</generator>
-                    <skip>${skip.plugin}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Proposed changes

Currently the property `outputDirectory` in plugin `maven-thrift-plugin` is not conventional, users need to mark this directory as `Generated Sources Root` manually, this may confuse some new users. This pull request uses the preferred way as below:
- Thrift files are generated into `target/generated-sources` automatically when compiled, then the generated source files can be loaded automatically when reload the maven project.

