### PR TITLE
[Improvement](nereids) Support join derivation when mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -192,10 +192,6 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 if (rewrittenPlan == null) {
                     continue;
                 }
-                // checkout the output logical properties is the same with query
-                if (!checkOutput(queryPlan, rewrittenPlan, materializationContext)) {
-                    continue;
-                }
                 // run rbo job on mv rewritten plan
                 CascadesContext rewrittenPlanContext = CascadesContext.initContext(
                         cascadesContext.getStatementContext(), rewrittenPlan,
@@ -219,7 +215,6 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                                                     .collect(Collectors.toSet()))));
                     continue;
                 }
-                materializationContext.setSuccess(true);
                 recordIfRewritten(queryPlan, materializationContext);
                 rewriteResults.add(rewrittenPlan);
             }
@@ -587,6 +582,7 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
     }
 
     protected void recordIfRewritten(Plan plan, MaterializationContext context) {
+        context.setSuccess(true);
         if (plan.getGroupExpression().isPresent()) {
             context.addMatchedGroup(plan.getGroupExpression().get().getOwnerGroup().getGroupId());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -337,8 +337,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 // if enable join eliminate, query maybe inner join and mv maybe outer join.
                 // If the slot is at null generate side, the nullable maybe different between query and view
                 // So need to force to consistent.
-                replacedExpression = sourceExpression.nullable() ?
-                        new Nullable(replacedExpression) : new NonNullable(replacedExpression);
+                replacedExpression = sourceExpression.nullable()
+                        ? new Nullable(replacedExpression) : new NonNullable(replacedExpression);
             }
             if (sourceExpression instanceof NamedExpression) {
                 NamedExpression sourceNamedExpression = (NamedExpression) sourceExpression;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -202,6 +202,9 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                         cascadesContext.getCurrentJobContext().getRequiredProperties());
                 Rewriter.getWholeTreeRewriter(rewrittenPlanContext).execute();
                 rewrittenPlan = rewrittenPlanContext.getRewritePlan();
+                if (!checkOutput(queryPlan, rewrittenPlan, materializationContext)) {
+                    continue;
+                }
                 // check the partitions used by rewritten plan is valid or not
                 Set<Long> invalidPartitionsQueryUsed =
                         calcInvalidPartitions(rewrittenPlan, materializationContext, cascadesContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
@@ -51,7 +51,7 @@ public class Predicates {
         return predicates;
     }
 
-    public Set<? extends Expression> getPulledUpPredicates() {
+    public Set<Expression> getPulledUpPredicates() {
         return pulledUpPredicates;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
@@ -103,7 +103,7 @@ public class Predicates {
             return residualPredicate.orElse(BooleanLiteral.TRUE);
         }
 
-        public static SplitPredicate empty() {
+        public static SplitPredicate invalid() {
             return new SplitPredicate(null, null, null);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
@@ -66,8 +66,11 @@ public class PredicatesSplitter {
                 if (leftArgOnlyContainsColumnRef && rightArgOnlyContainsColumnRef) {
                     equalPredicates.add(comparisonPredicate);
                     return null;
-                } else {
+                } else if ((leftArgOnlyContainsColumnRef && rightArg instanceof Literal)
+                        || (rightArgOnlyContainsColumnRef && leftArg instanceof Literal)) {
                     rangePredicates.add(comparisonPredicate);
+                } else {
+                    residualPredicates.add(comparisonPredicate);
                 }
             } else if ((leftArgOnlyContainsColumnRef && rightArg instanceof Literal)
                     || (rightArgOnlyContainsColumnRef && leftArg instanceof Literal)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
@@ -67,7 +67,7 @@ public class PredicatesSplitter {
                     equalPredicates.add(comparisonPredicate);
                     return null;
                 } else {
-                    residualPredicates.add(comparisonPredicate);
+                    rangePredicates.add(comparisonPredicate);
                 }
             } else if ((leftArgOnlyContainsColumnRef && rightArg instanceof Literal)
                     || (rightArgOnlyContainsColumnRef && leftArg instanceof Literal)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NonNullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NonNullable.java
@@ -24,6 +24,10 @@ import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.types.DataType;
 
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
 /**
  * change nullable input col to non_nullable col
  */
@@ -39,4 +43,9 @@ public class NonNullable extends ScalarFunction implements UnaryExpression, Cust
         return FunctionSignature.ret(dataType).args(dataType);
     }
 
+    @Override
+    public Expression withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.size() == 1);
+        return new NonNullable(children.get(0));
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NonNullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NonNullable.java
@@ -45,7 +45,8 @@ public class NonNullable extends ScalarFunction implements UnaryExpression, Cust
 
     @Override
     public Expression withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() == 1);
+        Preconditions.checkArgument(children.size() == 1,
+                "the child expression of NonNullable should be only one");
         return new NonNullable(children.get(0));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Nullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Nullable.java
@@ -24,6 +24,10 @@ import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.types.DataType;
 
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
 /**
  * change non_nullable input col to nullable col
  */
@@ -39,4 +43,9 @@ public class Nullable extends ScalarFunction implements UnaryExpression, CustomS
         return FunctionSignature.ret(dataType).args(dataType);
     }
 
+    @Override
+    public Expression withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.size() == 1);
+        return new Nullable(children.get(0));
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Nullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Nullable.java
@@ -45,7 +45,8 @@ public class Nullable extends ScalarFunction implements UnaryExpression, CustomS
 
     @Override
     public Expression withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() == 1);
+        Preconditions.checkArgument(children.size() == 1,
+                "the child expression of NonNullable should be only one");
         return new Nullable(children.get(0));
     }
 }

--- a/regression-test/data/nereids_rules_p0/mv/join/inner/inner_join.out
+++ b/regression-test/data/nereids_rules_p0/mv/join/inner/inner_join.out
@@ -99,6 +99,14 @@
 6
 6
 
+-- !query1_5_before --
+6
+6
+
+-- !query1_5_after --
+6
+6
+
 -- !query2_0_before --
 4
 4
@@ -238,6 +246,20 @@
 6
 6
 6
+
+-- !query3_4_before --
+1	1
+1	1
+1	1
+1	1
+1	1
+
+-- !query3_4_after --
+1	1
+1	1
+1	1
+1	1
+1	1
 
 -- !query4_0_before --
 4

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -22,8 +22,6 @@ suite("aggregate_with_roll_up") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
-    // tmp disable to rewrite, will be removed in the future
-    sql "SET disable_nereids_rules = 'ELIMINATE_OUTER_JOIN'"
 
     sql """
     drop table if exists orders

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -22,9 +22,6 @@ suite("aggregate_without_roll_up") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
-    // tmp disable to rewrite, will be removed in the future
-    sql "SET disable_nereids_rules = 'ELIMINATE_OUTER_JOIN'"
-    sql "SET global enable_auto_analyze = false"
 
     sql """
     drop table if exists orders
@@ -173,8 +170,8 @@ suite("aggregate_without_roll_up") {
         }
     }
 
-    // single table
-    // with filter
+//    // single table
+//    // with filter
     def mv1_0 = "select o_shippriority, o_comment, " +
             "sum(o_totalprice) as sum_total, " +
             "max(o_totalprice) as max_total, " +

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -22,8 +22,6 @@ suite("inner_join") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
-    // tmp disable to rewrite, will be removed in the future
-    sql "SET disable_nereids_rules = 'ELIMINATE_OUTER_JOIN'"
 
     sql """
     drop table if exists orders
@@ -231,6 +229,21 @@ suite("inner_join") {
     order_qt_query1_4_after "${query1_4}"
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv1_4"""
 
+    def mv1_5 = """
+            select  lineitem.L_LINENUMBER, orders.O_CUSTKEY, l_partkey, o_shippriority
+            from lineitem
+            inner join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY;
+            """
+    def query1_5 = """
+            select  lineitem.L_LINENUMBER
+            from lineitem
+            inner join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY
+            and o_shippriority = l_partkey;
+            """
+    order_qt_query1_5_before "${query1_5}"
+    check_rewrite(mv1_5, query1_5, "mv1_5")
+    order_qt_query1_5_after "${query1_5}"
+    sql """ DROP MATERIALIZED VIEW IF EXISTS mv1_5"""
 
     // filter outside + left
     def mv2_0 = "select  lineitem.L_LINENUMBER, orders.O_CUSTKEY " +
@@ -348,6 +361,26 @@ suite("inner_join") {
     check_rewrite(mv3_3, query3_3, "mv3_3")
     order_qt_query3_3_after "${query3_3}"
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv3_3"""
+
+    // join derive, the mv is outer join with filter and query is inner join
+    // the predicate should be ComparisonPredicate
+    def mv3_4 = """
+            select l_linenumber, o_custkey
+            from orders
+            left join lineitem on lineitem.L_ORDERKEY = orders.O_ORDERKEY
+            where o_custkey = 1;
+            """
+    def query3_4 = """
+            select IFNULL(orders.O_CUSTKEY, 0) as custkey_not_null,
+            case when l_linenumber in (1,2,3) then l_linenumber else o_custkey end as case_when
+            from orders
+            inner join lineitem on orders.O_ORDERKEY = lineitem.L_ORDERKEY
+            where o_custkey = 1 and l_linenumber > 0;
+            """
+    order_qt_query3_4_before "${query3_4}"
+    check_rewrite(mv3_4, query3_4, "mv3_4")
+    order_qt_query3_4_after "${query3_4}"
+    sql """ DROP MATERIALIZED VIEW IF EXISTS mv3_4"""
 
 
     // filter outside + left + right

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -257,13 +257,17 @@ suite("outer_join") {
 
 
     // filter outside + right
-    def mv3_0 = "select  lineitem.L_LINENUMBER, orders.O_CUSTKEY " +
-            "from lineitem " +
-            "left join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY "
-    def query3_0 = "select lineitem.L_LINENUMBER " +
-            "from lineitem " +
-            "left join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY " +
-            "where orders.O_ORDERSTATUS = 'o'"
+    def mv3_0 = """
+            select lineitem.L_LINENUMBER, orders.O_CUSTKEY
+            from lineitem
+            left join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY;
+    """
+    def query3_0 = """
+            select lineitem.L_LINENUMBER
+            from lineitem
+            left join orders on lineitem.L_ORDERKEY = orders.O_ORDERKEY
+            where orders.O_ORDERSTATUS = 'o';
+    """
     order_qt_query3_0_before "${query3_0}"
     // use a filed not from mv, should not success
     check_not_match(mv3_0, query3_0, "mv3_0")
@@ -301,13 +305,17 @@ suite("outer_join") {
 
 
     // filter outside + left + right
-    def mv4_0 = "select l_linenumber, o_custkey, o_orderkey, o_orderstatus " +
-            "from lineitem " +
-            "left join orders on lineitem.l_orderkey = orders.o_orderkey "
-    def query4_0 = "select lineitem.l_linenumber " +
-            "from lineitem " +
-            "left join orders on lineitem.l_orderkey = orders.o_orderkey " +
-            "where o_orderstatus = 'o' AND o_orderkey = 1"
+    def mv4_0 = """
+            select l_linenumber, o_custkey, o_orderkey, o_orderstatus
+            from lineitem
+            left join orders on lineitem.l_orderkey = orders.o_orderkey;
+    """
+    def query4_0 = """
+            select lineitem.l_linenumber
+            from lineitem
+            left join orders on lineitem.l_orderkey = orders.o_orderkey
+            where o_orderstatus = 'o' AND o_orderkey = 1;
+    """
     order_qt_query4_0_before "${query4_0}"
     check_rewrite(mv4_0, query4_0, "mv4_0")
     order_qt_query4_0_after "${query4_0}"

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -22,8 +22,6 @@ suite("outer_join") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
-    // tmp disable to rewrite, will be removed in the future
-    sql "SET disable_nereids_rules = 'ELIMINATE_OUTER_JOIN'"
 
     sql """
     drop table if exists orders
@@ -364,7 +362,7 @@ suite("outer_join") {
 
     // self join test
     def mv8_0 = """
-    select 
+    select
     a.o_orderkey,
     count(distinct a.o_orderstatus) num1,
     SUM(CASE WHEN a.o_orderstatus = 'o' AND a.o_shippriority = 1 AND a.o_orderdate = '2023-12-08' AND b.o_orderdate = '2023-12-09' THEN a.o_shippriority+b.o_custkey ELSE 0 END) num2,
@@ -381,7 +379,7 @@ suite("outer_join") {
     group by a.o_orderkey;
     """
     def query8_0 = """
-    select 
+    select
     a.o_orderkey,
     SUM(CASE WHEN a.o_orderstatus = 'o' AND a.o_shippriority = 1 AND a.o_orderdate = '2023-12-08' AND b.o_orderdate = '2023-12-09' THEN a.o_shippriority+b.o_custkey ELSE 0 END) num2,
     SUM(CASE WHEN a.o_orderstatus = 'o' AND a.o_shippriority = 1 AND a.o_orderdate >= '2023-12-01' AND a.o_orderdate <= '2023-12-09' THEN a.o_shippriority+b.o_custkey ELSE 0 END) num3,

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -22,8 +22,6 @@ suite("partition_mv_rewrite") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
-    // tmp disable to rewrite, will be removed in the future
-    sql "SET disable_nereids_rules = 'ELIMINATE_OUTER_JOIN'"
 
     sql """
     drop table if exists orders


### PR DESCRIPTION
## Proposed changes

materialized view def is as following:
>            select l_linenumber, o_custkey
>           from orders
>            left join lineitem on lineitem.L_ORDERKEY = orders.O_ORDERKEY
>            where o_custkey = 1;

when query is as following, it can be rewritten by mv above
it requires that query has reject null filters on the join right input, 
current supported filter are  "=", "<", "<=", ">", ">=", "<=>" 
>            select IFNULL(orders.O_CUSTKEY, 0) as custkey_not_null,
>           case when l_linenumber in (1,2,3) then l_linenumber else o_custkey end as case_when
>            from orders
>            inner join lineitem on orders.O_ORDERKEY = lineitem.L_ORDERKEY
>            where o_custkey = 1 and l_linenumber > 0;

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

