### PR TITLE
[fix](Nereids) mark join should not eliminate join when child is empty (#29409)

### DIFF
--- a/regression-test/data/empty_relation/eliminate_empty.out
+++ b/regression-test/data/empty_relation/eliminate_empty.out
@@ -70,3 +70,8 @@ PhysicalResultSink
 
 -- !except_empty_data --
 
+-- !join_with_empty_child --
+2	8	e	v	3
+4	7		at	2
+9	3		q	0
+

--- a/regression-test/suites/empty_relation/eliminate_empty.groovy
+++ b/regression-test/suites/empty_relation/eliminate_empty.groovy
@@ -127,4 +127,56 @@ suite("eliminate_empty") {
     qt_except_empty_data """
         select r_regionkey from region where false except select n_nationkey from nation  
     """
+
+    sql """drop table if exists table_5_undef_partitions2_keys3"""
+    sql """drop table if exists table_10_undef_partitions2_keys3"""
+
+    try {
+        sql """
+            create table table_5_undef_partitions2_keys3 (
+                `col_int_undef_signed_null` int  null ,
+                `col_int_undef_signed_not_null` int  not null ,
+                `col_varchar_10__undef_signed_null` varchar(10)  null ,
+                `col_varchar_10__undef_signed_not_null` varchar(10)  not null ,
+            `pk` int
+            ) engine=olap
+            distributed by hash(pk) buckets 10
+            properties('replication_num' = '1');
+        """
+
+        sql """
+            insert into table_5_undef_partitions2_keys3(pk,col_int_undef_signed_null,col_int_undef_signed_not_null,col_varchar_10__undef_signed_null,col_varchar_10__undef_signed_not_null) values (0,9,3,"",'q'),(1,null,5,null,"ok"),(2,4,7,"","at"),(3,2,8,'e','v'),(4,null,6,'l',"really");
+        """
+
+        sql """
+            create table table_10_undef_partitions2_keys3 (
+                `col_int_undef_signed_null` int  null ,
+                `col_int_undef_signed_not_null` int  not null ,
+                `col_varchar_10__undef_signed_null` varchar(10)  null ,
+                `col_varchar_10__undef_signed_not_null` varchar(10)  not null ,
+                `pk` int
+            ) engine=olap
+            distributed by hash(pk) buckets 10
+            properties('replication_num' = '1');
+        """
+
+        sql """
+            insert into table_10_undef_partitions2_keys3(pk,col_int_undef_signed_null,col_int_undef_signed_not_null,col_varchar_10__undef_signed_null,col_varchar_10__undef_signed_not_null) values (0,null,7,'k','s'),(1,1,2,"",'l'),(2,null,7,"","look"),(3,null,5,null,'g'),(4,null,6,null,'o'),(5,4,0,'j','c'),(6,0,5,null,"so"),(7,null,3,"","something"),(8,7,0,null,""),(9,5,8,"","but");
+        """
+
+        order_qt_join_with_empty_child """
+            SELECT *
+            FROM table_5_undef_partitions2_keys3 AS t1
+            WHERE t1.`col_int_undef_signed_null` IS NOT NULL
+                OR t1.`pk` IN (
+                    SELECT `col_int_undef_signed_null`
+                    FROM table_10_undef_partitions2_keys3 AS t2
+                    LIMIT 0
+                );
+        """
+
+    } finally {
+        sql """drop table if exists table_5_undef_partitions2_keys3"""
+        sql """drop table if exists table_10_undef_partitions2_keys3"""
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

pick from master
PR #29409
commit 64696829d14e51e0781794fbb98f50df6cfe2921

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

