### PR TITLE
[opt](scanner) modify max_scanners number for file scan node

### DIFF
--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -60,8 +60,11 @@ std::string FileScanLocalState::name_suffix() const {
 
 void FileScanLocalState::set_scan_ranges(RuntimeState* state,
                                          const std::vector<TScanRangeParams>& scan_ranges) {
-    int max_scanners =
-            config::doris_scanner_thread_pool_thread_num / state->query_parallel_instance_num();
+    int thread_pool_num =
+            (state->query_options().enable_file_cache && config::enable_file_cache)
+                    ? config::doris_scanner_thread_pool_thread_num
+                    : ExecEnv::GetInstance()->scanner_scheduler()->remote_thread_pool_max_size();
+    int max_scanners = thread_pool_num / state->query_parallel_instance_num();
     max_scanners = max_scanners == 0 ? 1 : max_scanners;
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {

--- a/be/src/vec/exec/scan/new_file_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_file_scan_node.cpp
@@ -60,8 +60,10 @@ Status NewFileScanNode::prepare(RuntimeState* state) {
 
 void NewFileScanNode::set_scan_ranges(RuntimeState* state,
                                       const std::vector<TScanRangeParams>& scan_ranges) {
-    int max_scanners =
-            config::doris_scanner_thread_pool_thread_num / state->query_parallel_instance_num();
+    int thread_pool_num =
+            (state->query_options().enable_file_cache && config::enable_file_cache)
+                    ? config::doris_scanner_thread_pool_thread_num
+                    : ExecEnv::GetInstance()->scanner_scheduler()->remote_thread_pool_max_size();
     max_scanners = max_scanners == 0 ? 1 : max_scanners;
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {


### PR DESCRIPTION
## Proposed changes

The max number of scanner for file scan node should match the num of thread in remote thread pool.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

