### PR TITLE
[refactor](Nereids): refactor PredicatePropagation & support to infer Equal Condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFK.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFK.java
@@ -36,7 +36,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
 import org.apache.doris.nereids.trees.plans.visitor.CustomRewriter;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
-import org.apache.doris.nereids.util.ImmutableEquivalenceSet;
+import org.apache.doris.nereids.util.ImmutableEqualSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -145,7 +145,7 @@ public class EliminateJoinByFK extends DefaultPlanRewriter<JobContext> implement
             return project;
         }
 
-        private @Nullable Map<Slot, Slot> mapPrimaryToForeign(ImmutableEquivalenceSet<Slot> equivalenceSet,
+        private @Nullable Map<Slot, Slot> mapPrimaryToForeign(ImmutableEqualSet<Slot> equivalenceSet,
                 Set<Slot> foreignKeys) {
             ImmutableMap.Builder<Slot, Slot> builder = new ImmutableMap.Builder<>();
             for (Slot foreignSlot : foreignKeys) {
@@ -164,7 +164,7 @@ public class EliminateJoinByFK extends DefaultPlanRewriter<JobContext> implement
         // 4. if foreign key is null, add a isNotNull predicate for null-reject join condition
         private Plan eliminateJoin(LogicalProject<LogicalJoin<?, ?>> project, ForeignKeyContext context) {
             LogicalJoin<?, ?> join = project.child();
-            ImmutableEquivalenceSet<Slot> equalSet = join.getEqualSlots();
+            ImmutableEqualSet<Slot> equalSet = join.getEqualSlots();
             Set<Slot> leftSlots = Sets.intersection(join.left().getOutputSet(), equalSet.getAllItemSet());
             Set<Slot> rightSlots = Sets.intersection(join.right().getOutputSet(), equalSet.getAllItemSet());
             if (context.isForeignKey(leftSlots) && context.isPrimaryKey(rightSlots)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -38,7 +38,7 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Join;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
-import org.apache.doris.nereids.util.ImmutableEquivalenceSet;
+import org.apache.doris.nereids.util.ImmutableEqualSet;
 import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.nereids.util.Utils;
 
@@ -467,12 +467,12 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     /**
      * get Equal slot from join
      */
-    public ImmutableEquivalenceSet<Slot> getEqualSlots() {
+    public ImmutableEqualSet<Slot> getEqualSlots() {
         // TODO: Use fd in the future
         if (!joinType.isInnerJoin() && !joinType.isSemiJoin()) {
-            return ImmutableEquivalenceSet.of();
+            return ImmutableEqualSet.empty();
         }
-        ImmutableEquivalenceSet.Builder<Slot> builder = new ImmutableEquivalenceSet.Builder<>();
+        ImmutableEqualSet.Builder<Slot> builder = new ImmutableEqualSet.Builder<>();
         hashJoinConjuncts.stream()
                 .filter(e -> e instanceof EqualPredicate
                         && e.child(0) instanceof Slot

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.nereids.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,6 +47,9 @@ public class ImmutableEqualSet<T> {
         private final Map<T, T> parent = new HashMap<>();
         private final Map<T, Integer> size = new HashMap<>();
 
+        /**
+         * Add a equal pair
+         */
         public void addEqualPair(T a, T b) {
             T root1 = findRoot(a);
             T root2 = findRoot(b);
@@ -85,6 +90,21 @@ public class ImmutableEqualSet<T> {
         return root.keySet().stream()
                 .filter(t -> root.get(t).equals(ra) && !t.equals(a))
                 .collect(ImmutableSet.toImmutableSet());
+    }
+
+    /**
+     * Calculate all equal set
+     */
+    public List<Set<T>> calEqualSetList() {
+        return root.values()
+                .stream()
+                .distinct()
+                .map(a -> {
+                    T ra = root.get(a);
+                    return root.keySet().stream()
+                            .filter(t -> root.get(t).equals(ra))
+                            .collect(ImmutableSet.toImmutableSet());
+                }).collect(ImmutableList.toImmutableList());
     }
 
     public Set<T> getAllItemSet() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
@@ -25,56 +25,60 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * EquivalenceSet
+ * A class representing an immutable set of elements with equivalence relations.
  */
-public class ImmutableEquivalenceSet<T> {
-    final Map<T, T> root;
+public class ImmutableEqualSet<T> {
+    private final Map<T, T> root;
 
-    ImmutableEquivalenceSet(Map<T, T> root) {
+    ImmutableEqualSet(Map<T, T> root) {
         this.root = ImmutableMap.copyOf(root);
     }
 
-    public static <T> ImmutableEquivalenceSet<T> of() {
-        return new ImmutableEquivalenceSet<>(ImmutableMap.of());
+    public static <T> ImmutableEqualSet<T> empty() {
+        return new ImmutableEqualSet<>(ImmutableMap.of());
     }
 
     /**
-     * Builder of ImmutableEquivalenceSet
+     * Builder for ImmutableEqualSet.
      */
     public static class Builder<T> {
-        final Map<T, T> parent = new HashMap<>();
+        private final Map<T, T> parent = new HashMap<>();
+        private final Map<T, Integer> size = new HashMap<>();
 
         public void addEqualPair(T a, T b) {
-            parent.computeIfAbsent(b, v -> v);
-            parent.computeIfAbsent(a, v -> v);
-            union(a, b);
-        }
-
-        private void union(T a, T b) {
             T root1 = findRoot(a);
             T root2 = findRoot(b);
 
             if (root1 != root2) {
-                parent.put(b, root1);
-                findRoot(b);
+                // merge by size
+                if (size.get(root1) < size.get(root2)) {
+                    parent.put(root1, root2);
+                    size.put(root2, size.get(root2) + size.get(root1));
+                } else {
+                    parent.put(root2, root1);
+                    size.put(root1, size.get(root1) + size.get(root2));
+                }
             }
         }
 
         private T findRoot(T a) {
+            parent.putIfAbsent(a, a); // Ensure that the element is added
+            size.putIfAbsent(a, 1); // Initialize size to 1
+
             if (!parent.get(a).equals(a)) {
-                parent.put(a, findRoot(parent.get(a)));
+                parent.put(a, findRoot(parent.get(a))); // Path compression
             }
             return parent.get(a);
         }
 
-        public ImmutableEquivalenceSet<T> build() {
+        public ImmutableEqualSet<T> build() {
             parent.keySet().forEach(this::findRoot);
-            return new ImmutableEquivalenceSet<>(parent);
+            return new ImmutableEqualSet<>(parent);
         }
     }
 
     /**
-     * cal equal set for a except self
+     * Calculate equal set for a except self
      */
     public Set<T> calEqualSet(T a) {
         T ra = root.get(a);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PredicatePropagationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PredicatePropagationTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -34,6 +35,7 @@ import java.util.Set;
 class PredicatePropagationTest {
     private final SlotReference a = new SlotReference("a", SmallIntType.INSTANCE);
     private final SlotReference b = new SlotReference("b", BigIntType.INSTANCE);
+    private final SlotReference c = new SlotReference("c", BigIntType.INSTANCE);
 
     @Test
     void equal() {
@@ -45,6 +47,20 @@ class PredicatePropagationTest {
     @Test
     void in() {
         Set<Expression> exprs = ImmutableSet.of(new EqualTo(a, b), new InPredicate(a, ImmutableList.of(Literal.of(1))));
+        Set<Expression> inferExprs = PredicatePropagation.infer(exprs);
+        System.out.println(inferExprs);
+    }
+
+    @Test
+    void inferSlotEqual() {
+        Set<Expression> exprs = ImmutableSet.of(new EqualTo(a, b), new EqualTo(a, c));
+        Set<Expression> inferExprs = PredicatePropagation.infer(exprs);
+        System.out.println(inferExprs);
+    }
+
+    @Test
+    void inferComplex0() {
+        Set<Expression> exprs = ImmutableSet.of(new EqualTo(a, b), new EqualTo(a, c), new GreaterThan(a, Literal.of(1)));
         Set<Expression> inferExprs = PredicatePropagation.infer(exprs);
         System.out.println(inferExprs);
     }

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------PhysicalOlapScan[t2]
 --------PhysicalDistribute[DistributionSpecHash]
-----------NestedLoopJoin[CROSS_JOIN](t4.c4 = t3.c3)(t3.c3 = t4.c4)
+----------NestedLoopJoin[CROSS_JOIN]
 ------------PhysicalOlapScan[t3]
 ------------PhysicalDistribute[DistributionSpecReplicated]
 --------------PhysicalOlapScan[t4]

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------PhysicalOlapScan[t2]
 --------PhysicalDistribute[DistributionSpecHash]
-----------NestedLoopJoin[CROSS_JOIN]
+----------NestedLoopJoin[CROSS_JOIN](t3.c3 = t4.c4)
 ------------PhysicalOlapScan[t3]
 ------------PhysicalDistribute[DistributionSpecReplicated]
 --------------PhysicalOlapScan[t4]


### PR DESCRIPTION
## Proposed changes

Support infer Equal Condition like `a = b and b = c` -> `a = c` (avoid to infer `c = a`)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

