### PR TITLE
(feature)[pipelineX]Make operator_id negative in pipelineX.

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -502,7 +502,7 @@ Status PipelineXFragmentContext::_build_pipeline_tasks(
             runtime_state->set_desc_tbl(_desc_tbl);
             runtime_state->set_per_fragment_instance_idx(local_params.sender_id);
             runtime_state->set_num_per_fragment_instances(request.num_senders);
-            runtime_state->resize_op_id_to_local_state(max_operator_id(), max_sink_operator_id());
+            runtime_state->resize_op_id_to_local_state(max_operator_id());
             runtime_state->set_load_stream_per_node(request.load_stream_per_node);
             runtime_state->set_total_load_streams(request.total_load_streams);
             runtime_state->set_num_local_sink(request.num_local_sink);

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
@@ -109,11 +109,11 @@ public:
         return _runtime_filter_mgr_map[fragment_instance_id].get();
     }
 
-    [[nodiscard]] int next_operator_id() { return _operator_id++; }
+    [[nodiscard]] int next_operator_id() { return _operator_id--; }
 
     [[nodiscard]] int max_operator_id() const { return _operator_id; }
 
-    [[nodiscard]] int next_sink_operator_id() { return _sink_operator_id++; }
+    [[nodiscard]] int next_sink_operator_id() { return _sink_operator_id--; }
 
     [[nodiscard]] int max_sink_operator_id() const { return _sink_operator_id; }
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -469,22 +469,25 @@ int64_t RuntimeState::get_load_mem_limit() {
     }
 }
 
-void RuntimeState::resize_op_id_to_local_state(int operator_size, int sink_size) {
-    _op_id_to_local_state.resize(operator_size);
+void RuntimeState::resize_op_id_to_local_state(int operator_size) {
+    _op_id_to_local_state.resize(-operator_size);
 }
 
 void RuntimeState::emplace_local_state(
         int id, std::unique_ptr<doris::pipeline::PipelineXLocalStateBase> state) {
+    id = -id;
     DCHECK(id < _op_id_to_local_state.size());
     DCHECK(!_op_id_to_local_state[id]);
     _op_id_to_local_state[id] = std::move(state);
 }
 
 doris::pipeline::PipelineXLocalStateBase* RuntimeState::get_local_state(int id) {
+    id = -id;
     return _op_id_to_local_state[id].get();
 }
 
 Result<RuntimeState::LocalState*> RuntimeState::get_local_state_result(int id) {
+    id = -id;
     if (id >= _op_id_to_local_state.size()) {
         return ResultError(Status::InternalError("get_local_state out of range size:{} , id:{}",
                                                  _op_id_to_local_state.size(), id));

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -553,7 +553,7 @@ public:
 
     Result<SinkLocalState*> get_sink_local_state_result(int id);
 
-    void resize_op_id_to_local_state(int operator_size, int sink_size);
+    void resize_op_id_to_local_state(int operator_size);
 
     auto& pipeline_id_to_profile() { return _pipeline_id_to_profile; }
 


### PR DESCRIPTION
## Proposed changes

"operator_id" should be invisible, but the local shuffle is a planned operator in the BE (Backend), without a plan node ID. We use it in profiles and other places, and there might be duplicates. Therefore, we switch it to a negative number here to distinguish it as a plan node ID.

before
```
                  Pipeline  :  2(instance_num=8):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (PASSTHROUGH)  (id=4):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  6.64ms,  max  7.853ms,  min  2.949ms
                            -  InputRows:  sum  12.077321M  (12077321),  avg  1.509665M  (1509665),  max  1.51194M  (1511940),  min  1.507361M  (1507361)
                            -  OpenTime:  avg  1.929us,  max  4.69us,  min  1.2us
                            -  WaitForDependency[LocalExchangeSinkDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                          OLAP_SCAN_OPERATOR  (id=370.  table  name  =  lineorder):

```
now
```
         Pipeline  :  2(instance_num=8):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (PASSTHROUGH)  (id=-4):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  2.347ms,  max  5.184ms,  min  1.757ms
                            -  InputRows:  sum  12.077321M  (12077321),  avg  1.509665M  (1509665),  max  1.51194M  (1511940),  min  1.507361M  (1507361)
                            -  OpenTime:  avg  1.253us,  max  2.85us,  min  1.10us
                            -  WaitForDependency[LocalExchangeSinkDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                          OLAP_SCAN_OPERATOR  (id=370.  table  name  =  lineorder):
                                -  PlanInfo
```

This is a temporary solution; in reality, the runtime state is at the pipeline task level. We don't need a fragment-level ID (as you can see in 'get sink state,' the ID passed is not used, as each task has only one sink).

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

