### PR TITLE
[fix](statistics)Fix analyze empty external NPE bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
@@ -81,7 +81,7 @@ public class ColStatsData {
 
     public ColStatsData(ResultRow row) {
         this.statsId = new StatsId(row);
-        this.count = (long) Double.parseDouble(row.get(7));
+        this.count = (long) Double.parseDouble(row.getWithDefault(7, "0"));
         this.ndv = (long) Double.parseDouble(row.getWithDefault(8, "0"));
         this.nullCount = (long) Double.parseDouble(row.getWithDefault(9, "0"));
         this.minLit = row.get(10);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class ColStatsDataTest {
+    @Test
+    public void testConstructNotNull() {
+        List<String> values = Lists.newArrayList();
+        values.add("id");
+        values.add("10000");
+        values.add("20000");
+        values.add("30000");
+        values.add("0");
+        values.add("col");
+        values.add(null);
+        values.add("100");
+        values.add("200");
+        values.add("300");
+        values.add("min");
+        values.add("max");
+        values.add("400");
+        values.add("500");
+        ResultRow row = new ResultRow(values);
+        ColStatsData data = new ColStatsData(row);
+        Assertions.assertEquals("id", data.statsId.id);
+        Assertions.assertEquals(10000, data.statsId.catalogId);
+        Assertions.assertEquals(20000, data.statsId.dbId);
+        Assertions.assertEquals(30000, data.statsId.tblId);
+        Assertions.assertEquals(0, data.statsId.idxId);
+        Assertions.assertEquals("col", data.statsId.colId);
+        Assertions.assertEquals(null, data.statsId.partId);
+        Assertions.assertEquals(100, data.count);
+        Assertions.assertEquals(200, data.ndv);
+        Assertions.assertEquals(300, data.nullCount);
+        Assertions.assertEquals("min", data.minLit);
+        Assertions.assertEquals("max", data.maxLit);
+        Assertions.assertEquals(400, data.dataSizeInBytes);
+        Assertions.assertEquals("500", data.updateTime);
+    }
+
+    @Test
+    public void testConstructNull() {
+        List<String> values = Lists.newArrayList();
+        values.add("id");
+        values.add("10000");
+        values.add("20000");
+        values.add("30000");
+        values.add("0");
+        values.add("col");
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        values.add(null);
+        ResultRow row = new ResultRow(values);
+        ColStatsData data = new ColStatsData(row);
+        Assertions.assertEquals("id", data.statsId.id);
+        Assertions.assertEquals(10000, data.statsId.catalogId);
+        Assertions.assertEquals(20000, data.statsId.dbId);
+        Assertions.assertEquals(30000, data.statsId.tblId);
+        Assertions.assertEquals(0, data.statsId.idxId);
+        Assertions.assertEquals("col", data.statsId.colId);
+        Assertions.assertEquals(null, data.statsId.partId);
+        Assertions.assertEquals(0, data.count);
+        Assertions.assertEquals(0, data.ndv);
+        Assertions.assertEquals(0, data.nullCount);
+        Assertions.assertEquals(null, data.minLit);
+        Assertions.assertEquals(null, data.maxLit);
+        Assertions.assertEquals(0, data.dataSizeInBytes);
+        Assertions.assertEquals(null, data.updateTime);
+    }
+}

--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic_auto.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic_auto.groovy
@@ -48,8 +48,8 @@ suite("test_hive_statistic_auto", "p2,external,hive,external_remote,external_rem
             assertEquals(result[0][3], "0.0")
             assertEquals(result[0][4], "400.0")
             assertEquals(result[0][5], "4.0")
-            assertEquals(result[0][6], "1")
-            assertEquals(result[0][7], "50")
+            assertEquals(result[0][6], "N/A")
+            assertEquals(result[0][7], "N/A")
 
             result = sql """show column stats `statistics` (lo_orderkey)"""
             if (result.size <= 0) {
@@ -62,8 +62,8 @@ suite("test_hive_statistic_auto", "p2,external,hive,external_remote,external_rem
             assertEquals(result[0][3], "0.0")
             assertEquals(result[0][4], "400.0")
             assertEquals(result[0][5], "4.0")
-            assertEquals(result[0][6], "1")
-            assertEquals(result[0][7], "98")
+            assertEquals(result[0][6], "N/A")
+            assertEquals(result[0][7], "N/A")
 
             result = sql """show column stats `statistics` (lo_linenumber)"""
             if (result.size <= 0) {
@@ -76,8 +76,8 @@ suite("test_hive_statistic_auto", "p2,external,hive,external_remote,external_rem
             assertEquals(result[0][3], "0.0")
             assertEquals(result[0][4], "400.0")
             assertEquals(result[0][5], "4.0")
-            assertEquals(result[0][6], "1")
-            assertEquals(result[0][7], "7")
+            assertEquals(result[0][6], "N/A")
+            assertEquals(result[0][7], "N/A")
         }
 
         sql """drop catalog ${catalog_name}"""


### PR DESCRIPTION
Sample analyzing for empty external table may return null value for count ndv and null count, we need to handle this case to avoid NPE.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

