### PR TITLE
[fix](rowset-reader) direct mode shouldn't use merge iterator

### DIFF
--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -214,7 +214,7 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params) {
             // unique keys with merge on write, no need to merge sort keys in rowset
             need_ordered_result = false;
         }
-        if (_aggregation) {
+        if (_aggregation || _direct_mode) {
             // compute engine will aggregate rows with the same key,
             // it's ok for rowset to return unordered result
             need_ordered_result = false;

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -214,8 +214,14 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params) {
             // unique keys with merge on write, no need to merge sort keys in rowset
             need_ordered_result = false;
         }
-        if (_aggregation || _direct_mode) {
+        if (_aggregation) {
             // compute engine will aggregate rows with the same key,
+            // it's ok for rowset to return unordered result
+            need_ordered_result = false;
+        }
+
+        if (_direct_mode) {
+            // direct mode indicates that the storage layer does not need to merge,
             // it's ok for rowset to return unordered result
             need_ordered_result = false;
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

F0108 00:00:30.951457 63870 vcollect_iterator.cpp:500] Check failed: !_get_data_by_ref
*** Check failure stack trace: ***
    @     0x55abb28240ad  google::LogMessage::Fail()
    @     0x55abb28265e9  google::LogMessage::SendToLog()
    @     0x55abb2823c16  google::LogMessage::Flush()
    @     0x55abb2826c59  google::LogMessageFatal::~LogMessageFatal()
    @     0x55abb1ec5e82  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @     0x55abb1ecc6cf  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @     0x55abb1ebcee9  doris::vectorized::VCollectIterator::build_heap()
    @     0x55abb1e665ba  doris::vectorized::BlockReader::_init_collect_iter()
    @     0x55abb1e68b27  doris::vectorized::BlockReader::init()
    @     0x55aba2c6d7a0  doris::vectorized::NewOlapScanner::open()
    @     0x55aba2ce999f  doris::vectorized::ScannerScheduler::_scanner_scan()

introduced by #29242 #29545
Support unique table minmax push down to storage layer, direct_mode mode changed to true,  then VcollectIterator did not go through merge mode, and BetaRowsetReader still went through merge mode. The inconsistency between the two resulted in DCHECK failure.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

