### PR TITLE
[fix](rowset-reader) direct mode shouldn't use merge iterator (#29678)

### DIFF
--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -214,7 +214,7 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params) {
             // unique keys with merge on write, no need to merge sort keys in rowset
             need_ordered_result = false;
         }
-        if (_aggregation) {
+        if (_aggregation || _direct_mode) {
             // compute engine will aggregate rows with the same key,
             // it's ok for rowset to return unordered result
             need_ordered_result = false;


### PR DESCRIPTION
## Proposed changes

pick from #29678 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

