### PR TITLE
[Fix](Nereids) fix fe ut failed cause of getting statement context

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -2773,6 +2773,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
             }
             if (distributeHint.distributeType != DistributeType.NONE
+                    && ConnectContext.get().getStatementContext() != null
                     && !ConnectContext.get().getStatementContext().getHints().contains(distributeHint)) {
                 ConnectContext.get().getStatementContext().addHint(distributeHint);
             }


### PR DESCRIPTION
## Proposed changes

Problem:
    fe ut failed cause of null pointer error
Cause:
    fe ut getting statement context from connection context failed
Resolved:
    add null pointer judgement

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

