### PR TITLE
[refactor](tabletwriter) make tablet writer's rpc callback safe, could exit any time

### DIFF
--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -1105,7 +1105,7 @@ std::string LRUFileCache::dump_structure_unlocked(const Key& key, std::lock_guar
 }
 
 void LRUFileCache::run_background_operation() {
-    int64_t interval_time_seconds = 20;
+    int64_t interval_time_seconds = 3;
     while (!_close) {
         std::this_thread::sleep_for(std::chrono::seconds(interval_time_seconds));
         // report

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -1105,7 +1105,7 @@ std::string LRUFileCache::dump_structure_unlocked(const Key& key, std::lock_guar
 }
 
 void LRUFileCache::run_background_operation() {
-    int64_t interval_time_seconds = 3;
+    int64_t interval_time_seconds = 20;
     while (!_close) {
         std::this_thread::sleep_for(std::chrono::seconds(interval_time_seconds));
         // report

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -558,10 +558,13 @@ public:
     auto& pipeline_id_to_profile() { return _pipeline_id_to_profile; }
 
     void set_task_execution_context(std::shared_ptr<TaskExecutionContext> context) {
+        _task_execution_context_inited = true;
         _task_execution_context = context;
     }
 
     std::weak_ptr<TaskExecutionContext> get_task_execution_context() {
+        CHECK(_task_execution_context_inited)
+                << "_task_execution_context_inited == false, the ctx is not inited";
         return _task_execution_context;
     }
 
@@ -572,6 +575,10 @@ private:
 
     std::shared_ptr<MemTrackerLimiter> _query_mem_tracker;
 
+    // Could not find a better way to record if the weak ptr is inited, use a bool to record
+    // it. In some unit test cases, the runtime state's task ctx is not inited, then the test
+    // hang, it is very hard to debug.
+    bool _task_execution_context_inited = false;
     // Hold execution context for other threads
     std::weak_ptr<TaskExecutionContext> _task_execution_context;
 

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -392,6 +392,9 @@ protected:
     bool _is_closed = false;
 
     RuntimeState* _state = nullptr;
+    // A context lock for callbacks, the callback has to lock the ctx, to avoid
+    // the object is deleted during callback is running.
+    std::weak_ptr<TaskExecutionContext> _task_exec_ctx;
     // rows number received per tablet, tablet_id -> rows_num
     std::vector<std::pair<int64_t, int64_t>> _tablets_received_rows;
     // rows number filtered per tablet, tablet_id -> filtered_rows_num

--- a/be/test/vec/exec/vtablet_sink_test.cpp
+++ b/be/test/vec/exec/vtablet_sink_test.cpp
@@ -526,6 +526,8 @@ TEST_F(VOlapTableSinkTest, convert) {
     query_options.batch_size = 1024;
     query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
+    std::shared_ptr<TaskExecutionContext> task_ctx_lock = std::make_shared<TaskExecutionContext>();
+    state.set_task_execution_context(task_ctx_lock);
     state.init_mem_trackers(TUniqueId());
 
     ObjectPool obj_pool;
@@ -656,6 +658,8 @@ TEST_F(VOlapTableSinkTest, add_block_failed) {
     query_options.batch_size = 1;
     query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
+    std::shared_ptr<TaskExecutionContext> task_ctx_lock = std::make_shared<TaskExecutionContext>();
+    state.set_task_execution_context(task_ctx_lock);
     state.init_mem_trackers(TUniqueId());
 
     TDescriptorTable tdesc_tbl;
@@ -770,6 +774,8 @@ TEST_F(VOlapTableSinkTest, decimal) {
     query_options.batch_size = 1;
     query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
+    std::shared_ptr<TaskExecutionContext> task_ctx_lock = std::make_shared<TaskExecutionContext>();
+    state.set_task_execution_context(task_ctx_lock);
     state.init_mem_trackers(TUniqueId());
 
     ObjectPool obj_pool;

--- a/be/test/vec/exec/vtablet_sink_test.cpp
+++ b/be/test/vec/exec/vtablet_sink_test.cpp
@@ -404,6 +404,9 @@ public:
         query_options.batch_size = 1;
         query_options.be_exec_version = be_exec_version;
         RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
+        std::shared_ptr<TaskExecutionContext> task_ctx_lock =
+                std::make_shared<TaskExecutionContext>();
+        state.set_task_execution_context(task_ctx_lock);
         state.init_mem_trackers(TUniqueId());
 
         ObjectPool obj_pool;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

