### PR TITLE
[Fix](core) Fix initializing the WalManager could prevent the BE from starting

### DIFF
--- a/be/src/olap/wal/wal_manager.cpp
+++ b/be/src/olap/wal/wal_manager.cpp
@@ -352,8 +352,10 @@ Status WalManager::add_recover_wal(int64_t db_id, int64_t table_id, int64_t wal_
     }
     table_ptr->add_wal(wal_id, wal);
 #ifndef BE_TEST
-    RETURN_IF_ERROR(update_wal_dir_limit(_get_base_wal_path(wal)));
-    RETURN_IF_ERROR(update_wal_dir_used(_get_base_wal_path(wal)));
+    WARN_IF_ERROR(update_wal_dir_limit(_get_base_wal_path(wal)),
+                  "Failed to update wal dir limit while add recover wal!");
+    WARN_IF_ERROR(update_wal_dir_used(_get_base_wal_path(wal)),
+                  "Failed to update wal dir used while add recove wal!");
 #endif
     return Status::OK();
 }

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -257,7 +257,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _storage_engine = new StorageEngine(options);
     auto st = _storage_engine->open();
     if (!st.ok()) {
-        LOG(ERROR) << "Lail to open StorageEngine, res=" << st;
+        LOG(ERROR) << "Fail to open StorageEngine, res=" << st;
         return st;
     }
     _storage_engine->set_heartbeat_flags(this->heartbeat_flags());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

The PR fixed an issue where initializing the WalManager could prevent the BE from starting.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

