### PR TITLE
[fix](publish-version) set failed when meet error tablet in publish version

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -284,6 +284,8 @@ Status EnginePublishVersionTask::execute() {
                 LOG(WARNING) << "publish version failed on transaction, not found tablet. "
                              << "transaction_id=" << transaction_id << ", tablet_id=" << tablet_id
                              << ", version=" << par_ver_info.version;
+                res = Status::Error<PUSH_TABLE_NOT_EXIST>(
+                        "can't get tablet when publish version. tablet_id={}", tablet_id);
             } else {
                 // check if the version exist, if not exist, then set publish failed
                 if (_error_tablet_ids->find(tablet_id) == _error_tablet_ids->end()) {
@@ -302,6 +304,8 @@ Status EnginePublishVersionTask::execute() {
                                     << ", tablet_id=" << tablet_id << ", tablet_state="
                                     << tablet_state_name(tablet->tablet_state())
                                     << ", version=" << par_ver_info.version;
+                            res = Status::Error<PUBLISH_VERSION_NOT_CONTINUOUS>(
+                                    "check version exist failed, tablet id {}", tablet_id);
                         }
                     }
                 }


### PR DESCRIPTION
## Proposed changes
```
finish to publish version on transaction.transaction_id=26611, cost(us): 422, error_tablet_size=41, res=[OK]
```

There exist error tablet when publish version but res is OK, which cause publish do not retry and publish daemon thread in fe will loop long time for save error tablet.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

