### PR TITLE
[feature](iceberg) iceberg table support equality delete

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -126,6 +126,10 @@ public:
     // set the delete rows in current parquet file
     void set_delete_rows(const std::vector<int64_t>* delete_rows) { _delete_rows = delete_rows; }
 
+    void set_equality_delete_ids(const Block& equality_delete_ids) {
+        _equality_delete_ids = equality_delete_ids;
+    }
+
     int64_t size() const { return _file_reader->size(); }
 
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
@@ -149,6 +153,12 @@ public:
     std::vector<tparquet::KeyValue> get_metadata_key_values();
     void set_table_to_file_col_map(std::unordered_map<std::string, std::string>& map) {
         _table_col_to_file_col = map;
+    }
+    void set_file_col_to_col_id_map(std::unordered_map<std::string, uint32_t>& map) {
+        _file_col_to_col_id = map;
+    }
+    void set_file_col_to_slot_id_map(std::unordered_map<std::string, int>& map) {
+        _file_col_to_slot_id = map;
     }
 
 private:
@@ -237,11 +247,16 @@ private:
     int32_t _total_groups; // num of groups(stripes) of a parquet(orc) file
     // table column name to file column name map. For iceberg schema evolution.
     std::unordered_map<std::string, std::string> _table_col_to_file_col;
+    // file column name to col_id and slot_id
+    std::unordered_map<std::string, uint32_t> _file_col_to_col_id;
+    std::unordered_map<std::string, int> _file_col_to_slot_id;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range = nullptr;
     std::vector<std::string> _read_columns;
     RowRange _whole_range = RowRange(0, 0);
     const std::vector<int64_t>* _delete_rows = nullptr;
     int64_t _delete_rows_index = 0;
+    // block save for equality delete info
+    Block _equality_delete_ids;
 
     // Used for column lazy read.
     RowGroupReader::LazyReadContext _lazy_read_ctx;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -141,6 +141,9 @@ public class Column implements Writable, GsonPostProcessable {
 
     private boolean isCompoundKey = false;
 
+    @SerializedName(value = "isIdentifierKey")
+    private boolean isIdentifierKey = false;
+
     @SerializedName(value = "hasOnUpdateDefaultValue")
     private boolean hasOnUpdateDefaultValue = false;
 
@@ -295,6 +298,7 @@ public class Column implements Writable, GsonPostProcessable {
         this.hasOnUpdateDefaultValue = column.hasOnUpdateDefaultValue;
         this.onUpdateDefaultValueExprDef = column.onUpdateDefaultValueExprDef;
         this.clusterKeyId = column.getClusterKeyId();
+        this.isIdentifierKey = column.isIdentifierKey();
     }
 
     public void createChildrenColumn(Type type, Column column) {
@@ -1155,6 +1159,14 @@ public class Column implements Writable, GsonPostProcessable {
 
     public void setCompoundKey(boolean compoundKey) {
         isCompoundKey = compoundKey;
+    }
+
+    public boolean isIdentifierKey() {
+        return isIdentifierKey;
+    }
+
+    public void setIdentifierKey(boolean identifierKey) {
+        isIdentifierKey = identifierKey;
     }
 
     public boolean hasDefaultValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -151,6 +151,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                 deleteFileDesc.setPath(splitDeletePath.toString());
                 if (filter instanceof IcebergDeleteFileFilter.PositionDelete) {
                     fileDesc.setContent(FileContent.POSITION_DELETES.id());
+                    deleteFileDesc.setContent(FileContent.POSITION_DELETES.id());
                     IcebergDeleteFileFilter.PositionDelete positionDelete =
                             (IcebergDeleteFileFilter.PositionDelete) filter;
                     OptionalLong lowerBound = positionDelete.getPositionLowerBound();
@@ -163,6 +164,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                     }
                 } else {
                     fileDesc.setContent(FileContent.EQUALITY_DELETES.id());
+                    deleteFileDesc.setContent(FileContent.EQUALITY_DELETES.id());
                     IcebergDeleteFileFilter.EqualityDelete equalityDelete =
                             (IcebergDeleteFileFilter.EqualityDelete) filter;
                     deleteFileDesc.setFieldIds(equalityDelete.getFieldIds());
@@ -325,7 +327,9 @@ public class IcebergScanNode extends FileQueryScanNode {
                         positionLowerBound.orElse(-1L), positionUpperBound.orElse(-1L)));
             } else if (delete.content() == FileContent.EQUALITY_DELETES) {
                 // todo: filters.add(IcebergDeleteFileFilter.createEqualityDelete(delete.path().toString(),
-                throw new IllegalStateException("Don't support equality delete file");
+                // throw new IllegalStateException("Don't support equality delete file");
+                filters.add(IcebergDeleteFileFilter.createEqualityDelete(delete.path().toString(),
+                        delete.equalityFieldIds()));
             } else {
                 throw new IllegalStateException("Unknown delete content: " + delete.content());
             }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -287,7 +287,8 @@ struct TIcebergDeleteFileDesc {
     1: optional string path;
     2: optional i64 position_lower_bound;
     3: optional i64 position_upper_bound;
-    4: optional list<i32> field_ids;
+    4: optional i32 content;
+    5: optional list<i32> field_ids;
 }
 
 struct TIcebergFileDesc {


### PR DESCRIPTION
Support iceberg v2 feature:
support iceberg v2 table with equality delete file; three part to modify:
1. FE add identify columns that use for filter the data in equality delete files
2. PlanNodes.thrift add comment in TIcebergDeleteFileDesc to set the delete file type
3. BE iceberg_reader and parquet_reader to read data in equality delete file and do equality delete filter

iceberg v2
https://iceberg.apache.org/spec/#appendix-e-format-version-changes
