### PR TITLE
[fix](move-memtable) close stream in  destructor

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -114,7 +114,12 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
           _tablet_schema_for_index(stub._tablet_schema_for_index),
           _enable_unique_mow_for_index(stub._enable_unique_mow_for_index) {};
 
-LoadStreamStub::~LoadStreamStub() = default;
+LoadStreamStub::~LoadStreamStub() {
+    Status st = close_stream();
+    if (!st.ok()) {
+        LOG(WARNING) << "stream close failed, status: " << st;
+    }
+};
 
 Status LoadStreamStub::close_stream() {
     if (_is_init.load() && !_handler.is_closed()) {


### PR DESCRIPTION
## Proposed changes
 
```
==10108==ERROR: AddressSanitizer: heap-use-after-free on address 0x616001578ab8 at pc 0x56375f9e3ccb bp 0x7fb424990cd0 sp 0x7fb424990cc8
WRITE of size 1 at 0x616001578ab8 thread T1767
    #0 0x56375f9e3cca in std::__atomic_base<bool>::store(bool, std::memory_order) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:457:2
    #1 0x56375f9e3cca in std::atomic<bool>::store(bool, std::memory_order) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/atomic:104:15
    #2 0x56375f9e3cca in doris::LoadStreamStub::LoadStreamReplyHandler::on_closed(unsigned long) /root/doris/be/src/vec/sink/load_stream_stub.cpp:99:16
    #3 0x563762915e3e in brpc::Stream::Consume(void*, bthread::TaskIterator<butil::IOBuf*>&) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x3c049e3e) (BuildId: 78bb45ef18070dd2)
    #4 0x563762919460 in bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x3c04d460) (BuildId: 78bb45ef18070dd2)
    #5 0x56376291976f in bthread::ExecutionQueueBase::_execute_tasks(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x3c04d76f) (BuildId: 78bb45ef18070dd2)
    #6 0x56376277fa64 in bthread::TaskGroup::task_runner(long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x3beb3a64) (BuildId: 78bb45ef18070dd2)
    #7 0x5637627717f0 in bthread_make_fcontext (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x3bea57f0) (BuildId: 78bb45ef18070dd2)

0x616001578ab8 is located 312 bytes inside of 544-byte region [0x616001578980,0x616001578ba0)
freed by thread T348 (FragmentMgrThre) here:
    #0 0x563738f4a80d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x1267e80d) (BuildId: 78bb45ef18070dd2)
    #1 0x56375fa00a9c in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #2 0x56375fa00a9c in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #3 0x56375fa00a9c in std::__shared_ptr<doris::LoadStreamStub, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #4 0x56375fa00a9c in void std::destroy_at<std::shared_ptr<doris::LoadStreamStub> >(std::shared_ptr<doris::LoadStreamStub>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #5 0x56375fa00a9c in void std::_Destroy<std::shared_ptr<doris::LoadStreamStub> >(std::shared_ptr<doris::LoadStreamStub>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
    #6 0x56375fa00a9c in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::LoadStreamStub>*>(std::shared_ptr<doris::LoadStreamStub>*, std::shared_ptr<doris::LoadStreamStub>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
    #7 0x56375fa00a9c in void std::_Destroy<std::shared_ptr<doris::LoadStreamStub>*>(std::shared_ptr<doris::LoadStreamStub>*, std::shared_ptr<doris::LoadStreamStub>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
    #8 0x56375fa00a9c in void std::_Destroy<std::shared_ptr<doris::LoadStreamStub>*, std::shared_ptr<doris::LoadStreamStub> >(std::shared_ptr<doris::LoadStreamStub>*, std::shared_ptr<doris::LoadStreamStub>*, std::allocator<std::shared_ptr<doris::LoadStreamStub> >&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
    #9 0x56375fa00a9c in std::vector<std::shared_ptr<doris::LoadStreamStub>, std::allocator<std::shared_ptr<doris::LoadStreamStub> > >::~vector() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
    #10 0x56375fa00a9c in doris::LoadStreams::~LoadStreams() /root/doris/be/src/vec/sink/load_stream_stub_pool.h:75:7
    #11 0x56375fa00a9c in void std::destroy_at<doris::LoadStreams>(doris::LoadStreams*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #12 0x56375fa00a9c in void std::allocator_traits<std::allocator<doris::LoadStreams> >::destroy<doris::LoadStreams>(std::allocator<doris::LoadStreams>&, doris::LoadStreams*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #13 0x56375fa00a9c in std::_Sp_counted_ptr_inplace<doris::LoadStreams, std::allocator<doris::LoadStreams>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528:2
    #14 0x56375fba26ed in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #15 0x56375fba26ed in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #16 0x56375fba26ed in std::__shared_ptr<doris::LoadStreams, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #17 0x56375fba26ed in std::pair<long const, std::shared_ptr<doris::LoadStreams> >::~pair() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterator.h:2379:12
    #18 0x56375fba26ed in void std::destroy_at<std::pair<long const, std::shared_ptr<doris::LoadStreams> > >(std::pair<long const, std::shared_ptr<doris::LoadStreams> >*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #19 0x56375fba26ed in void std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false> > >::destroy<std::pair<long const, std::shared_ptr<doris::LoadStreams> > >(std::allocator<std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false> >&, std::pair<long const, std::shared_ptr<doris::LoadStreams> >*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #20 0x56375fba26ed in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable_policy.h:1891:7
    #21 0x56375fba26ed in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<doris::LoadStreams> >, false>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable_policy.h:1913:4
    #22 0x56375fba26ed in std::_Hashtable<long, std::pair<long const, std::shared_ptr<doris::LoadStreams> >, std::allocator<std::pair<long const, std::shared_ptr<doris::LoadStreams> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::clear() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:2297:13
    #23 0x56375fba26ed in std::_Hashtable<long, std::pair<long const, std::shared_ptr<doris::LoadStreams> >, std::allocator<std::pair<long const, std::shared_ptr<doris::LoadStreams> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::~_Hashtable() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1509:7
    #24 0x56375fb85332 in std::unordered_map<long, std::shared_ptr<doris::LoadStreams>, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, std::shared_ptr<doris::LoadStreams> > > >::~unordered_map() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unordered_map.h:102:11
    #25 0x56375fb85332 in doris::vectorized::VTabletWriterV2::~VTabletWriterV2() /root/doris/be/src/vec/sink/writer/vtablet_writer_v2.cpp:65:35
    #26 0x56375fa83e7f in std::default_delete<doris::vectorized::VTabletWriterV2>::operator()(doris::vectorized::VTabletWriterV2*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #27 0x56375fa83e7f in std::unique_ptr<doris::vectorized::VTabletWriterV2, std::default_delete<doris::vectorized::VTabletWriterV2> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #28 0x56375fa83e7f in doris::vectorized::AsyncWriterSink<doris::vectorized::VTabletWriterV2, &(doris::vectorized::VOLAP_TABLE_SINK_V2.<char const at offset 0>)>::~AsyncWriterSink() /root/doris/be/src/vec/sink/async_writer_sink.h:45:7
    #29 0x56375fa7d79f in doris::vectorized::VOlapTableSinkV2::~VOlapTableSinkV2() /root/doris/be/src/vec/sink/volap_table_sink_v2.cpp:46:37
    #30 0x56375fa7d79f in doris::vectorized::VOlapTableSinkV2::~VOlapTableSinkV2() /root/doris/be/src/vec/sink/volap_table_sink_v2.cpp:46:37
    #31 0x56373b60c3f9 in std::default_delete<doris::DataSink>::operator()(doris::DataSink*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #32 0x56373b60c3f9 in std::unique_ptr<doris::DataSink, std::default_delete<doris::DataSink> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #33 0x56373b60c3f9 in doris::PlanFragmentExecutor::~PlanFragmentExecutor() /root/doris/be/src/runtime/plan_fragment_executor.cpp:112:1
    #34 0x56373b49f295 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #35 0x56373b49f295 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #36 0x56373b49f295 in std::__shared_ptr<doris::PlanFragmentExecutor, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #37 0x56373b49f295 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::~$_0() /root/doris/be/src/runtime/fragment_mgr.cpp:799:13
    #38 0x56373b49f295 in std::_Function_base::_Base_manager<doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_destroy(std::_Any_data&, std::integral_constant<bool, false>) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:174:4
    #39 0x56373b49f295 in std::_Function_base::_Base_manager<doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:200:8
    #40 0x56373b49f295 in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:283:6
    #41 0x56373bc21bb9 in std::_Function_base::~_Function_base() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:245:2
    #42 0x56373bc21bb9 in doris::FunctionRunnable::~FunctionRunnable() /root/doris/be/src/util/threadpool.cpp:44:7
    #43 0x56373bc1960b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #44 0x56373bc1960b in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #45 0x56373bc1960b in std::__shared_ptr<doris::Runnable, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #46 0x56373bc1960b in std::__shared_ptr<doris::Runnable, (__gnu_cxx::_Lock_policy)2>::reset() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1267:9
    #47 0x56373bc1960b in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:551:23
    #48 0x56373bbf7248 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #49 0x56373bbf7248 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #50 0x7fbea4a95608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

