### PR TITLE
[fix](executor) Fe publish topic info tcp leak

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
@@ -117,10 +117,14 @@ public class TopicPublisherThread extends MasterDaemon {
                 LOG.warn("publish topic info to be {} error happens: , time cost={} ms",
                         be.getHost(), (System.currentTimeMillis() - beginTime), e);
             } finally {
-                if (ok) {
-                    ClientPool.backendPool.returnObject(address, client);
-                } else {
-                    ClientPool.backendPool.invalidateObject(address, client);
+                try {
+                    if (ok) {
+                        ClientPool.backendPool.returnObject(address, client);
+                    } else {
+                        ClientPool.backendPool.invalidateObject(address, client);
+                    }
+                } catch (Throwable e) {
+                    LOG.warn("recycle topic publish client failed. related backend[{}]", be.getHost(), e);
                 }
                 handler.onResponse(be);
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

After publishing topic info to be, FE did not return the thrust client correctly, resulting in a TCP connection leak.

![image](https://github.com/apache/doris/assets/24907215/8b6d280d-683a-47e6-982d-08663d2f1978)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

