### PR TITLE
[fix](move-memtable) don't fail if success tablets to one BE is less than quorum

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -140,8 +140,6 @@ private:
     Status _select_streams(int64_t tablet_id, int64_t partition_id, int64_t index_id,
                            Streams& streams);
 
-    Status _failed_reason(int64_t tablet_id);
-
     Status _close_load(const Streams& streams);
 
     Status _cancel(Status status);


### PR DESCRIPTION
## Proposed changes

Replica backends may report success of a tablet to different backends.
A single backend lacking success reports of a tablet should not fail the load.
We should let FE check the quorum instead.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

