### PR TITLE
[fix](planner)strip trailing zeros for decimal literal if the precision larger than max decimal precision in doris

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -126,6 +126,17 @@ public class DecimalLiteral extends LiteralExpr {
         this.value = value;
         int precision = getBigDecimalPrecision(this.value);
         int scale = getBigDecimalScale(this.value);
+        int maxPrecision = ScalarType.MAX_DECIMAL128_PRECISION;
+        int integerPart = precision - scale;
+        if (precision > maxPrecision) {
+            BigDecimal stripedValue = value.stripTrailingZeros();
+            int stripedPrecision = getBigDecimalPrecision(stripedValue);
+            if (stripedPrecision <= maxPrecision) {
+                this.value = stripedValue.setScale(maxPrecision - integerPart);
+                precision = getBigDecimalPrecision(this.value);
+                scale = getBigDecimalScale(this.value);
+            }
+        }
         if (enforceV3) {
             type = ScalarType.createDecimalV3Type(precision, scale);
         } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralTest.java
@@ -82,5 +82,12 @@ public class DecimalLiteralTest {
         scale = ((ScalarType) literal.getType()).getScalarScale();
         Assert.assertEquals(3, precision);
         Assert.assertEquals(3, scale);
+
+        decimal = new BigDecimal("197323961.520000000000000000000000000000");
+        literal = new DecimalLiteral(decimal);
+        precision = ((ScalarType) literal.getType()).getScalarPrecision();
+        scale = ((ScalarType) literal.getType()).getScalarScale();
+        Assert.assertEquals(38, precision);
+        Assert.assertEquals(29, scale);
     }
 }


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/29737

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

