### PR TITLE
[pipelineX](fix) fix StreamingAggSource crash due to empty data block

### DIFF
--- a/be/src/pipeline/exec/streaming_aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_source_operator.cpp
@@ -83,16 +83,21 @@ Status StreamingAggSourceOperatorX::get_block(RuntimeState* state, vectorized::B
     auto& local_state = get_local_state(state);
     SCOPED_TIMER(local_state.exec_time_counter());
     if (!local_state._shared_state->data_queue->data_exhausted()) {
-        std::unique_ptr<vectorized::Block> agg_block;
+        std::unique_ptr<vectorized::Block> agg_block = nullptr;
         DCHECK(local_state._dependency->is_blocked_by() == nullptr);
         RETURN_IF_ERROR(local_state._shared_state->data_queue->get_block_from_queue(&agg_block));
 
         if (local_state._shared_state->data_queue->data_exhausted()) {
             RETURN_IF_ERROR(Base::get_block(state, block, source_state));
-        } else {
+        } else if (agg_block) {
             block->swap(*agg_block);
             agg_block->clear_column_data(row_desc().num_materialized_slots());
             local_state._shared_state->data_queue->push_free_block(std::move(agg_block));
+        } else if (local_state._shared_state->data_queue->is_all_finish()) {
+            source_state = SourceState::FINISHED;
+        } else {
+            return Status::InternalError("Something wrong in StreamingAggSource: {}",
+                                         Base::debug_string(0));
         }
     } else {
         RETURN_IF_ERROR(Base::get_block(state, block, source_state));


### PR DESCRIPTION
## Proposed changes

Aborted at 1704848211 (unix time) try "date -d @1704848211" if you are using GNU date ***
Current BE git commitID: 9e06798010 ***
SIGSEGV address not mapped to object (@0x0) received by PID 3478001 (TID 3479007 OR 0x7fd90d158700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:417
 1# 0x00007FDAD5E770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007FDAD5E7002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007FDADE1A1090 in /lib/x86_64-linux-gnu/libc.so.6
 5# std::_Vector_base<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >::_Vector_impl_data::_M_copy_data(std::_Vector_base<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >::_Vector_impl_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:111
 6# std::_Vector_base<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >::_Vector_impl_data::_M_swap_data(std::_Vector_base<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >::_Vector_impl_data&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:123
 7# std::vector<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >::swap(std::vector<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1486
 8# doris::vectorized::Block::swap(doris::vectorized::Block&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:711
 9# doris::pipeline::StreamingAggSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/streaming_aggregation_source_operator.cpp:93
10# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_x/operator.cpp:206
11# doris::pipeline::PipelineXTask::execute(bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:275
12# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:286
13# void std::_invoke_impl<void, void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>(std::_invoke_memfun_deref, void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
14# std::_invoke_result<void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>::type std::_invoke<void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>(void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
15# void std::Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>::_call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
16# void std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
17# void std::_invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>(std::_invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
19# std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
20# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
21# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48
22# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:543
23# void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
24# std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
25# void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
26# void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
27# void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
28# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
29# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
30# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
31# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:498
32# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
33# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

