### PR TITLE
[Cleanup](Nereids): delete useless `ddlSql` to avoid wrong usage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaObject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaObject.java
@@ -26,14 +26,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public class MetaObject implements Writable {
+public abstract class MetaObject implements Writable {
 
     @SerializedName(value = "signature")
     protected long signature;
     @SerializedName(value = "lastCheckTime")
     protected long lastCheckTime; // last check consistency time
 
-    public MetaObject() {
+    protected MetaObject() {
         signature = -1L;
         lastCheckTime = -1L;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -21,7 +21,6 @@ import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.analysis.AggregateInfo;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.ColumnDef;
-import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DataSortInfo;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotDescriptor;
@@ -1264,11 +1263,6 @@ public class OlapTable extends Table {
         return dataSize;
     }
 
-    @Override
-    public CreateTableStmt toCreateTableStmt(String dbName) {
-        throw new RuntimeException("Don't support anymore");
-    }
-
     // Get the md5 of signature string of this table with specified partitions.
     // This method is used to determine whether the tables have the same schema.
     // Contains:
@@ -2396,7 +2390,7 @@ public class OlapTable extends Table {
                 && getEnableUniqueKeyMergeOnWrite());
     }
 
-    public void initAutoIncrentGenerator(long dbId) {
+    public void initAutoIncrementGenerator(long dbId) {
         for (Column column : fullSchema) {
             if (column.isAutoInc()) {
                 autoIncrementGenerator = new AutoIncrementGenerator(dbId, id, column.getUniqueId());
@@ -2498,9 +2492,7 @@ public class OlapTable extends Table {
     public List<Tablet> getAllTablets() throws AnalysisException {
         List<Tablet> tablets = Lists.newArrayList();
         for (Partition partition : getPartitions()) {
-            for (Tablet tablet : partition.getBaseIndex().getTablets()) {
-                tablets.add(tablet);
-            }
+            tablets.addAll(partition.getBaseIndex().getTablets());
         }
         return tablets;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -18,7 +18,6 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.alter.AlterCancelException;
-import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.catalog.constraint.Constraint;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -116,8 +115,6 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
     // table(view)'s comment
     @SerializedName(value = "comment")
     protected String comment = "";
-    // sql for creating this table, default is "";
-    protected String ddlSql = "";
 
     @SerializedName(value = "constraints")
     private HashMap<String, Constraint> constraintsMap = new HashMap<>();
@@ -353,10 +350,6 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
         return fullSchema;
     }
 
-    public String getDdlSql() {
-        return ddlSql;
-    }
-
     // should override in subclass if necessary
     public List<Column> getBaseSchema() {
         return getBaseSchema(Util.showHiddenColumns());
@@ -548,10 +541,6 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
 
     public void setId(long id) {
         this.id = id;
-    }
-
-    public CreateTableStmt toCreateTableStmt(String dbName) {
-        throw new NotImplementedException("toCreateTableStmt not implemented");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -147,11 +147,6 @@ public class View extends Table {
         return inlineViewDef;
     }
 
-    @Override
-    public String getDdlSql() {
-        return inlineViewDef;
-    }
-
     /**
      * Initializes the originalViewDef, inlineViewDef, and queryStmt members
      * by parsing the expanded view definition SQL-string.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2445,7 +2445,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         }
 
         olapTable.initSchemaColumnUniqueId();
-        olapTable.initAutoIncrentGenerator(db.getId());
+        olapTable.initAutoIncrementGenerator(db.getId());
         olapTable.rebuildFullSchema();
 
         // analyze version info

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -222,7 +222,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
             case MATERIALIZED_VIEW:
                 return makeOlapScan(table, unboundRelation, tableQualifier);
             case VIEW:
-                Plan viewPlan = parseAndAnalyzeView(((View) table).getDdlSql(), cascadesContext);
+                Plan viewPlan = parseAndAnalyzeView(((View) table).getInlineViewDef(), cascadesContext);
                 return new LogicalSubQueryAlias<>(tableQualifier, viewPlan);
             case HMS_EXTERNAL_TABLE:
                 if (Config.enable_query_hive_views && ((HMSExternalTable) table).isView()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
@@ -133,11 +133,6 @@ public class CreateViewTest {
         Assert.assertEquals(1, view4.getFullSchema().size());
         Assert.assertNotNull(view4.getColumn("s1"));
 
-        View view5 = (View) db.getTableOrDdlException("view5");
-        Assert.assertTrue(view5.getDdlSql().contains("hour"));
-        Assert.assertTrue(view5.getDdlSql().contains("now"));
-        Assert.assertTrue(view5.getDdlSql().contains("curdate"));
-
         View view6 = (View) db.getTableOrDdlException("view6");
         Assert.assertEquals(4, view6.getFullSchema().size());
         Assert.assertNotNull(view6.getColumn("k1"));


### PR DESCRIPTION
## Proposed changes

`ddlSql` is useless and some code use `getDdlSql()` wrong, so delete those code

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

