### PR TITLE
[fix](move-memtable) fix use-after-free in LoadStreamReplyHandler

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -136,17 +136,11 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
           _tablet_schema_for_index(stub._tablet_schema_for_index),
           _enable_unique_mow_for_index(stub._enable_unique_mow_for_index) {};
 
-LoadStreamStub::~LoadStreamStub() = default;
-
-Status LoadStreamStub::close_stream() {
+LoadStreamStub::~LoadStreamStub() {
     if (_is_init.load() && !_is_closed.load()) {
-        LOG(INFO) << "closing stream, " << *this;
         auto ret = brpc::StreamClose(_stream_id);
-        if (ret != 0) {
-            return Status::InternalError("StreamClose failed, err={}", ret);
-        }
+        LOG(INFO) << *this << " is deconstructed, close " << (ret == 0 ? "success" : "failed");
     }
-    return Status::OK();
 }
 
 // open_load_stream

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -28,30 +28,34 @@
 
 namespace doris {
 
-int LoadStreamStub::LoadStreamReplyHandler::on_received_messages(brpc::StreamId id,
-                                                                 butil::IOBuf* const messages[],
-                                                                 size_t size) {
+int LoadStreamReplyHandler::on_received_messages(brpc::StreamId id, butil::IOBuf* const messages[],
+                                                 size_t size) {
+    auto stub = _stub.lock();
+    if (!stub) {
+        LOG(WARNING) << "stub is not exist when on_received_messages, " << *this;
+        return 0;
+    }
     for (size_t i = 0; i < size; i++) {
         butil::IOBufAsZeroCopyInputStream wrapper(*messages[i]);
         PLoadStreamResponse response;
         response.ParseFromZeroCopyStream(&wrapper);
 
         if (response.eos()) {
-            _is_eos.store(true);
+            stub->_is_eos.store(true);
         }
 
         Status st = Status::create(response.status());
 
         std::stringstream ss;
-        ss << "on_received_messages, load_id=" << _load_id << ", backend_id=" << _dst_id;
+        ss << "on_received_messages, " << *this << ", stream_id=" << id;
         if (response.success_tablet_ids_size() > 0) {
             ss << ", success tablet ids:";
             for (auto tablet_id : response.success_tablet_ids()) {
                 ss << " " << tablet_id;
             }
-            std::lock_guard<bthread::Mutex> lock(_success_tablets_mutex);
+            std::lock_guard<bthread::Mutex> lock(stub->_success_tablets_mutex);
             for (auto tablet_id : response.success_tablet_ids()) {
-                _success_tablets.push_back(tablet_id);
+                stub->_success_tablets.push_back(tablet_id);
             }
         }
         if (response.failed_tablets_size() > 0) {
@@ -60,11 +64,24 @@ int LoadStreamStub::LoadStreamReplyHandler::on_received_messages(brpc::StreamId 
                 Status st = Status::create(pb.status());
                 ss << " " << pb.id() << ":" << st;
             }
-            std::lock_guard<bthread::Mutex> lock(_failed_tablets_mutex);
+            std::lock_guard<bthread::Mutex> lock(stub->_failed_tablets_mutex);
             for (auto pb : response.failed_tablets()) {
                 Status st = Status::create(pb.status());
-                _failed_tablets.emplace(pb.id(), st);
+                stub->_failed_tablets.emplace(pb.id(), st);
             }
+        }
+        if (response.tablet_schemas_size() > 0) {
+            ss << ", tablet schema num: " << response.tablet_schemas_size();
+            std::lock_guard<bthread::Mutex> lock(stub->_schema_mutex);
+            for (const auto& schema : response.tablet_schemas()) {
+                auto tablet_schema = std::make_unique<TabletSchema>();
+                tablet_schema->init_from_pb(schema.tablet_schema());
+                stub->_tablet_schema_for_index->emplace(schema.index_id(),
+                                                        std::move(tablet_schema));
+                stub->_enable_unique_mow_for_index->emplace(
+                        schema.index_id(), schema.enable_unique_key_merge_on_write());
+            }
+            stub->_schema_cv.notify_all();
         }
         ss << ", status: " << st;
         LOG(INFO) << ss.str();
@@ -83,21 +100,26 @@ int LoadStreamStub::LoadStreamReplyHandler::on_received_messages(brpc::StreamId 
                              << status;
             }
         }
-
-        if (response.tablet_schemas_size() > 0) {
-            std::vector<PTabletSchemaWithIndex> schemas(response.tablet_schemas().begin(),
-                                                        response.tablet_schemas().end());
-            _stub->add_schema(schemas);
-        }
     }
     return 0;
 }
 
-void LoadStreamStub::LoadStreamReplyHandler::on_closed(brpc::StreamId id) {
-    LOG(INFO) << "on_closed, load_id=" << _load_id << ", stream_id=" << id;
-    std::lock_guard<bthread::Mutex> lock(_mutex);
-    _is_closed.store(true);
-    _close_cv.notify_all();
+void LoadStreamReplyHandler::on_closed(brpc::StreamId id) {
+    Defer defer {[this]() { delete this; }};
+    LOG(INFO) << "on_closed, " << *this << ", stream_id=" << id;
+    auto stub = _stub.lock();
+    if (!stub) {
+        LOG(WARNING) << "stub is not exist when on_closed, " << *this;
+        return;
+    }
+    std::lock_guard<bthread::Mutex> lock(stub->_close_mutex);
+    stub->_is_closed.store(true);
+    stub->_close_cv.notify_all();
+}
+
+inline std::ostream& operator<<(std::ostream& ostr, const LoadStreamReplyHandler& handler) {
+    ostr << "LoadStreamReplyHandler load_id=" << UniqueId(handler._load_id) << ", dst_id=" << handler._dst_id;
+    return ostr;
 }
 
 LoadStreamStub::LoadStreamStub(PUniqueId load_id, int64_t src_id, int num_use)
@@ -117,9 +139,8 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
 LoadStreamStub::~LoadStreamStub() = default;
 
 Status LoadStreamStub::close_stream() {
-    if (_is_init.load() && !_handler.is_closed()) {
-        LOG(INFO) << "closing stream, load_id=" << print_id(_load_id) << ", src_id=" << _src_id
-                  << ", dst_id=" << _dst_id << ", stream_id=" << _stream_id;
+    if (_is_init.load() && !_is_closed.load()) {
+        LOG(INFO) << "closing stream, " << *this;
         auto ret = brpc::StreamClose(_stream_id);
         if (ret != 0) {
             return Status::InternalError("StreamClose failed, err={}", ret);
@@ -129,24 +150,23 @@ Status LoadStreamStub::close_stream() {
 }
 
 // open_load_stream
-Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
+Status LoadStreamStub::open(std::shared_ptr<LoadStreamStub> self,
+                            BrpcClientCache<PBackendService_Stub>* client_cache,
                             const NodeInfo& node_info, int64_t txn_id,
                             const OlapTableSchemaParam& schema,
                             const std::vector<PTabletID>& tablets_for_schema, int total_streams,
                             bool enable_profile) {
-    std::unique_lock<bthread::Mutex> lock(_mutex);
+    std::unique_lock<bthread::Mutex> lock(_open_mutex);
     if (_is_init.load()) {
         return Status::OK();
     }
     _dst_id = node_info.id;
-    _handler.set_dst_id(_dst_id);
-    _handler.set_load_id(_load_id);
     std::string host_port = get_host_port(node_info.host, node_info.brpc_port);
     brpc::StreamOptions opt;
     opt.max_buf_size = config::load_stream_max_buf_size;
     opt.idle_timeout_ms = config::load_stream_idle_timeout_ms;
     opt.messages_in_batch = config::load_stream_messages_in_batch;
-    opt.handler = &_handler;
+    opt.handler = new LoadStreamReplyHandler(_load_id, _dst_id, self);
     brpc::Controller cntl;
     if (int ret = StreamCreate(&_stream_id, cntl, &opt)) {
         return Status::Error<true>(ret, "Failed to create stream");
@@ -178,8 +198,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
         return Status::InternalError("Failed to connect to backend {}: {}", _dst_id,
                                      cntl.ErrorText());
     }
-    LOG(INFO) << "open load stream " << _stream_id << " load_id=" << print_id(_load_id)
-              << " for backend " << _dst_id << " (" << host_port << ")";
+    LOG(INFO) << "open load stream to " << host_port << ", " << *this;
     _is_init.store(true);
     return Status::OK();
 }
@@ -263,18 +282,6 @@ Status LoadStreamStub::get_schema(const std::vector<PTabletID>& tablets) {
     return _encode_and_send(header);
 }
 
-void LoadStreamStub::add_schema(const std::vector<PTabletSchemaWithIndex>& schemas) {
-    std::lock_guard<bthread::Mutex> lock(_mutex);
-    for (const auto& schema : schemas) {
-        auto tablet_schema = std::make_unique<TabletSchema>();
-        tablet_schema->init_from_pb(schema.tablet_schema());
-        _tablet_schema_for_index->emplace(schema.index_id(), std::move(tablet_schema));
-        _enable_unique_mow_for_index->emplace(schema.index_id(),
-                                              schema.enable_unique_key_merge_on_write());
-    }
-    _schema_cv.notify_all();
-}
-
 Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, int64_t tablet_id,
                                        int64_t timeout_ms) {
     if (_tablet_schema_for_index->contains(index_id)) {
@@ -297,6 +304,36 @@ Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, i
         return Status::TimedOut("timeout to get tablet schema for index {}", index_id);
     }
     return Status::OK();
+}
+
+Status LoadStreamStub::close_wait(int64_t timeout_ms) {
+        DBUG_EXECUTE_IF("LoadStreamStub::close_wait.long_wait", {
+            while (true) {
+            };
+        });
+        if (!_is_init.load() || _is_closed.load()) {
+            return Status::OK();
+        }
+        if (timeout_ms <= 0) {
+            timeout_ms = config::close_load_stream_timeout_ms;
+        }
+        DCHECK(timeout_ms > 0) << "timeout_ms should be greator than 0";
+        std::unique_lock<bthread::Mutex> lock(_close_mutex);
+        if (_is_closed.load()) {
+            return Status::OK();
+        }
+        int ret = _close_cv.wait_for(lock, timeout_ms * 1000);
+        if (ret != 0) {
+            return Status::InternalError(
+                    "stream close_wait timeout, error={}, load_id={}, dst_id={}, stream_id={}", ret,
+                    print_id(_load_id), _dst_id, _stream_id);
+        }
+        if (!_is_eos.load()) {
+            return Status::InternalError(
+                    "stream closed without eos, load_id={}, dst_id={}, stream_id={}",
+                    print_id(_load_id), _dst_id, _stream_id);
+        }
+        return Status::OK();
 }
 
 Status LoadStreamStub::_encode_and_send(PStreamHeader& header, std::span<const Slice> data) {
@@ -357,6 +394,12 @@ Status LoadStreamStub::_send_with_retry(butil::IOBuf& buf) {
             return Status::InternalError("StreamWrite failed, err={}", ret);
         }
     }
+}
+
+inline std::ostream& operator<<(std::ostream& ostr, const LoadStreamStub& stub) {
+    ostr << "LoadStreamStub load_id=" << print_id(stub._load_id) << ", src_id=" << stub._src_id
+         << ", dst_id=" << stub._dst_id << ", stream_id=" << stub._stream_id;
+    return ostr;
 }
 
 } // namespace doris

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -148,10 +148,6 @@ public:
     // GET_SCHEMA
     Status get_schema(const std::vector<PTabletID>& tablets);
 
-    // close stream, usually close is initiated by the remote.
-    // in case of remote failure, we should be able to close stream locally.
-    Status close_stream();
-
     // wait remote to close stream,
     // remote will close stream when it receives CLOSE_LOAD
     // if timeout_ms <= 0, will fallback to config::close_load_stream_timeout_ms

--- a/be/src/vec/sink/load_stream_stub_pool.cpp
+++ b/be/src/vec/sink/load_stream_stub_pool.cpp
@@ -31,24 +31,6 @@ void LoadStreams::release(Status status) {
     DBUG_EXECUTE_IF("LoadStreams.release.keeping_streams", { num_use = 1; });
     if (num_use == 0) {
         LOG(INFO) << "releasing streams, load_id=" << _load_id << ", dst_id=" << _dst_id;
-        for (auto& stream : _streams) {
-            auto st = stream->close_stream();
-            DBUG_EXECUTE_IF("LoadStreams.release.close_stream_failed",
-                            { st = Status::InternalError("stream close failed"); });
-            if (!st.ok()) {
-                LOG(WARNING) << "close stream failed " << st;
-            }
-        }
-        if (status.ok()) {
-            for (auto& stream : _streams) {
-                auto st = stream->close_wait();
-                DBUG_EXECUTE_IF("LoadStreams.release.close_wait_failed",
-                                { st = Status::InternalError("stream close wait timeout"); });
-                if (!st.ok()) {
-                    LOG(WARNING) << "close wait failed " << st;
-                }
-            }
-        }
         _pool->erase(_load_id, _dst_id);
     } else {
         LOG(INFO) << "keeping streams, load_id=" << _load_id << ", dst_id=" << _dst_id

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -278,14 +278,14 @@ Status VTabletWriterV2::_open_streams_to_backend(int64_t dst_id, LoadStreams& st
     // get tablet schema from each backend only in the 1st stream
     for (auto& stream : streams.streams() | std::ranges::views::take(1)) {
         const std::vector<PTabletID>& tablets_for_schema = _indexes_from_node[node_info->id];
-        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(), *node_info,
-                                     _txn_id, *_schema, tablets_for_schema, _total_streams,
-                                     _state->enable_profile()));
+        RETURN_IF_ERROR(stream->open(stream, _state->exec_env()->brpc_internal_client_cache(),
+                                     *node_info, _txn_id, *_schema, tablets_for_schema,
+                                     _total_streams, _state->enable_profile()));
     }
     // for the rest streams, open without getting tablet schema
     for (auto& stream : streams.streams() | std::ranges::views::drop(1)) {
-        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(), *node_info,
-                                     _txn_id, *_schema, {}, _total_streams,
+        RETURN_IF_ERROR(stream->open(stream, _state->exec_env()->brpc_internal_client_cache(),
+                                     *node_info, _txn_id, *_schema, {}, _total_streams,
                                      _state->enable_profile()));
     }
     return Status::OK();

--- a/regression-test/suites/fault_injection_p0/test_load_stream_stub_failure_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_load_stream_stub_failure_injection.groovy
@@ -89,10 +89,6 @@ suite("test_stream_stub_fault_injection", "nonConcurrent") {
     load_with_injection("LoadStreamStub._send_with_retry.stream_write_failed", "StreamWrite failed, err=32")
     // LoadStreams keeping stream when release
     load_with_injection("LoadStreams.release.keeping_streams", "")
-    // LoadStreams close stream failed
-    load_with_injection("LoadStreams.release.close_stream_failed", "")
-    // LoadStreams close wait failed
-    load_with_injection("LoadStreams.release.close_wait_failed", "")
 
     sql """ DROP TABLE IF EXISTS `baseall` """
     sql """ DROP TABLE IF EXISTS `test` """


### PR DESCRIPTION
## Proposed changes

Brpc Stream Handler should not be freed before stream close.

This PR changes LoadStreamReplyHandler to free itself in on_closed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

