### PR TITLE
[opt](parquet-reader) Opt parquet fixed length decimal type reading.

### DIFF
--- a/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
+++ b/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
@@ -103,14 +103,29 @@ Status FixLengthPlainDecoder<PhysicalType>::_decode_string(MutableColumnPtr& dor
     while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
-            std::vector<StringRef> string_values;
-            string_values.reserve(run_length);
-            for (size_t i = 0; i < run_length; ++i) {
-                char* buf_start = _data->data + _offset;
-                string_values.emplace_back(buf_start, _type_length);
-                _offset += _type_length;
+            auto* column_string = assert_cast<ColumnString*>(doris_column.get());
+            auto& chars = column_string->get_chars();
+            auto& offsets = column_string->get_offsets();
+            size_t bytes_size = chars.size();
+
+            // copy chars
+            size_t data_size = run_length * _type_length;
+            size_t old_size = chars.size();
+            chars.resize(old_size + data_size);
+            memcpy(chars.data() + old_size, _data->data, data_size);
+
+            // copy offsets
+            offsets.resize(offsets.size() + run_length);
+            auto* offsets_data = offsets.data() + offsets.size() - run_length;
+
+            int i = 0;
+            for (; i < run_length; i++) {
+                bytes_size += _type_length;
+                *(offsets_data++) = bytes_size;
             }
-            doris_column->insert_many_strings(&string_values[0], run_length);
+
+            //doris_column->insert_many_strings_fixed_length<_type_length>(&string_values[0], run_length);
+            _offset += data_size;
             break;
         }
         case ColumnSelectVector::NULL_DATA: {

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -29,6 +29,7 @@
 
 #include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader_writer_fwd.h"
+#include "parquet_column_convert.h"
 #include "vec/columns/columns_number.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exec/format/parquet/parquet_common.h"
@@ -183,6 +184,7 @@ private:
     std::unique_ptr<ColumnChunkReader> _chunk_reader;
     std::vector<level_t> _rep_levels;
     std::vector<level_t> _def_levels;
+    std::unique_ptr<ParquetConvert::ColumnConvert> _converter = nullptr;
 
     Status _skip_values(size_t num_values);
     Status _read_values(size_t num_values, ColumnPtr& doris_column, DataTypePtr& type,

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -266,10 +266,8 @@ static Status get_column_values(io::FileReaderSPtr file_reader, tparquet::Column
     }
     if (need_convert) {
         std::unique_ptr<ParquetConvert::ColumnConvert> converter;
-        ParquetConvert::ConvertParams convert_params;
-        convert_params.init(field_schema, &ctz);
         RETURN_IF_ERROR(ParquetConvert::get_converter(parquet_physical_type, show_type, data_type,
-                                                      &converter, &convert_params));
+                                                      &converter, field_schema, &ctz));
         auto x = doris_column->assume_mutable();
         RETURN_IF_ERROR(converter->convert(src_column, x));
     }


### PR DESCRIPTION
## Proposed changes

[opt] (parquet-reader) Opt parquet fixed length decimal type reading. 


```
select count(l_quantity) from lineitem;
```

For tpch-500-parquet(one node): 5.81 s -> 2.70 s



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

