### PR TITLE
[opt](nereids) prune runtime redundant filters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
@@ -32,8 +32,11 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalLimit;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.Statistics;
+
+import com.google.common.collect.Sets;
 
 import java.util.List;
 import java.util.Set;
@@ -57,7 +60,9 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
         if (!plan.children().isEmpty()) {
             plan.child(0).accept(this, context);
             if (context.getRuntimeFilterContext().isEffectiveSrcNode(plan.child(0))) {
-                context.getRuntimeFilterContext().addEffectiveSrcNode(plan);
+                RuntimeFilterContext.EffectiveSrcType childType = context.getRuntimeFilterContext()
+                        .getEffectiveSrcType(plan.child(0));
+                context.getRuntimeFilterContext().addEffectiveSrcNode(plan, childType);
             }
         }
         return plan;
@@ -66,13 +71,13 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
     @Override
     public PhysicalTopN visitPhysicalTopN(PhysicalTopN<? extends Plan> topN, CascadesContext context) {
         topN.child().accept(this, context);
-        context.getRuntimeFilterContext().addEffectiveSrcNode(topN);
+        context.getRuntimeFilterContext().addEffectiveSrcNode(topN, RuntimeFilterContext.EffectiveSrcType.NATIVE);
         return topN;
     }
 
     public PhysicalLimit visitPhysicalLimit(PhysicalLimit<? extends Plan> limit, CascadesContext context) {
         limit.child().accept(this, context);
-        context.getRuntimeFilterContext().addEffectiveSrcNode(limit);
+        context.getRuntimeFilterContext().addEffectiveSrcNode(limit, RuntimeFilterContext.EffectiveSrcType.NATIVE);
         return limit;
     }
 
@@ -80,11 +85,29 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
     public PhysicalHashJoin visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> join,
             CascadesContext context) {
         join.right().accept(this, context);
-        if (context.getRuntimeFilterContext().isEffectiveSrcNode(join.right())) {
-            context.getRuntimeFilterContext().addEffectiveSrcNode(join);
+        RuntimeFilterContext rfContext = context.getRuntimeFilterContext();
+        if (rfContext.isEffectiveSrcNode(join.right())) {
+            boolean enableExpand = false;
+            if (ConnectContext.get() != null) {
+                enableExpand = ConnectContext.get().getSessionVariable().expandRuntimeFilterByInnerJoin;
+            }
+            if (enableExpand && rfContext.getEffectiveSrcType(join.right())
+                    == RuntimeFilterContext.EffectiveSrcType.REF) {
+                RuntimeFilterContext.ExpandRF expand = rfContext.getExpandRfByJoin(join);
+                if (expand != null) {
+                    Set<ExprId> outputExprIdOfExpandTargets = Sets.newHashSet();
+                    outputExprIdOfExpandTargets.addAll(expand.target1.getOutputExprIds());
+                    outputExprIdOfExpandTargets.addAll(expand.target2.getOutputExprIds());
+                    rfContext.getTargetExprIdByFilterJoin(join)
+                            .stream().filter(exprId -> outputExprIdOfExpandTargets.contains(exprId))
+                            .forEach(exprId -> rfContext.removeFilter(exprId, join));
+                }
+            }
+            RuntimeFilterContext.EffectiveSrcType childType =
+                    rfContext.getEffectiveSrcType(join.right());
+            context.getRuntimeFilterContext().addEffectiveSrcNode(join, childType);
         } else {
-            RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-            List<ExprId> exprIds = ctx.getTargetExprIdByFilterJoin(join);
+            List<ExprId> exprIds = rfContext.getTargetExprIdByFilterJoin(join);
             if (exprIds != null && !exprIds.isEmpty()) {
                 boolean isEffective = false;
                 for (Expression expr : join.getEqualToConjuncts()) {
@@ -93,13 +116,21 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
                     }
                 }
                 if (!isEffective) {
-                    exprIds.stream().forEach(exprId -> context.getRuntimeFilterContext().removeFilter(exprId, join));
+                    exprIds.stream().forEach(exprId -> rfContext.removeFilter(exprId, join));
                 }
             }
         }
         join.left().accept(this, context);
-        if (context.getRuntimeFilterContext().isEffectiveSrcNode(join.left())) {
-            context.getRuntimeFilterContext().addEffectiveSrcNode(join);
+        if (rfContext.isEffectiveSrcNode(join.left())) {
+            RuntimeFilterContext.EffectiveSrcType leftType =
+                    rfContext.getEffectiveSrcType(join.left());
+            RuntimeFilterContext.EffectiveSrcType rightType =
+                    rfContext.getEffectiveSrcType(join.right());
+            if (rightType == null
+                    || (rightType == RuntimeFilterContext.EffectiveSrcType.REF
+                        && leftType == RuntimeFilterContext.EffectiveSrcType.NATIVE)) {
+                rfContext.addEffectiveSrcNode(join, leftType);
+            }
         }
         return join;
     }
@@ -122,7 +153,7 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
                 .anyMatch(slot -> isVisibleColumn(slot));
         if (visibleFilter) {
             // skip filters like: __DORIS_DELETE_SIGN__ = 0
-            context.getRuntimeFilterContext().addEffectiveSrcNode(filter);
+            context.getRuntimeFilterContext().addEffectiveSrcNode(filter, RuntimeFilterContext.EffectiveSrcType.NATIVE);
         }
         return filter;
     }
@@ -134,7 +165,7 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
         for (Slot slot : slots) {
             //if this scan node is the target of any effective RF, it is effective source
             if (!rfCtx.getTargetExprIdToFilter().get(slot.getExprId()).isEmpty()) {
-                context.getRuntimeFilterContext().addEffectiveSrcNode(scan);
+                context.getRuntimeFilterContext().addEffectiveSrcNode(scan, RuntimeFilterContext.EffectiveSrcType.REF);
                 break;
             }
         }
@@ -145,20 +176,23 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
     public PhysicalAssertNumRows visitPhysicalAssertNumRows(PhysicalAssertNumRows<? extends Plan> assertNumRows,
             CascadesContext context) {
         assertNumRows.child().accept(this, context);
-        context.getRuntimeFilterContext().addEffectiveSrcNode(assertNumRows);
+        context.getRuntimeFilterContext().addEffectiveSrcNode(assertNumRows,
+                RuntimeFilterContext.EffectiveSrcType.NATIVE);
         return assertNumRows;
     }
 
     @Override
     public PhysicalHashAggregate visitPhysicalHashAggregate(PhysicalHashAggregate<? extends Plan> aggregate,
                                                             CascadesContext context) {
+        RuntimeFilterContext ctx = context.getRuntimeFilterContext();
         aggregate.child().accept(this, context);
         // q1: A join (select x, sum(y) as z from B group by x) T on A.a = T.x
         // q2: A join (select x, sum(y) as z from B group by x) T on A.a = T.z
         // RF on q1 is not effective, but RF on q2 is. But q1 is a more generous pattern, and hence agg is not
         // regarded as an effective source. Let this RF judge by ndv.
-        if (context.getRuntimeFilterContext().isEffectiveSrcNode(aggregate.child(0))) {
-            context.getRuntimeFilterContext().addEffectiveSrcNode(aggregate);
+        if (ctx.isEffectiveSrcNode(aggregate.child(0))) {
+            RuntimeFilterContext.EffectiveSrcType childType = ctx.getEffectiveSrcType(aggregate.child());
+            ctx.addEffectiveSrcNode(aggregate, childType);
         }
         return aggregate;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
@@ -138,7 +138,6 @@ public abstract class PhysicalCatalogRelation extends PhysicalRelation implement
             getAppliedRuntimeFilters()
                     .stream().forEach(rf -> shapeBuilder.append(" RF").append(rf.getId().asInt()));
         }
-        //shapeBuilder.append("jump: ").append(getMutableState(MutableState.KEY_RF_JUMP));
         return shapeBuilder.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
@@ -138,6 +138,7 @@ public abstract class PhysicalCatalogRelation extends PhysicalRelation implement
             getAppliedRuntimeFilters()
                     .stream().forEach(rf -> shapeBuilder.append(" RF").append(rf.getId().asInt()));
         }
+        //shapeBuilder.append("jump: ").append(getMutableState(MutableState.KEY_RF_JUMP));
         return shapeBuilder.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -271,7 +271,6 @@ public class PhysicalHashJoin<
             builder.append(" build RFs:").append(runtimeFilters.stream()
                     .map(rf -> rf.shapeInfo()).collect(Collectors.joining(";")));
         }
-        builder.append(" jump: ").append(getMutableState(MutableState.KEY_RF_JUMP));
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -207,17 +207,31 @@ public class PhysicalHashJoin<
                 "join child node is null");
 
         Set<Expression> probExprList = Sets.newHashSet(probeExpr);
+        Pair<PhysicalRelation, Slot> pair = ctx.getAliasTransferMap().get(probeExpr);
+        PhysicalRelation target1 = (pair == null) ? null : pair.first;
+        PhysicalRelation target2 = null;
+        pair = ctx.getAliasTransferMap().get(srcExpr);
+        PhysicalRelation srcNode = (pair == null) ? null : pair.first;
         if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().expandRuntimeFilterByInnerJoin) {
             if (!this.equals(builderNode) && this.getJoinType() == JoinType.INNER_JOIN) {
                 for (Expression expr : this.getHashJoinConjuncts()) {
                     EqualPredicate equalTo = (EqualPredicate) expr;
                     if (probeExpr.equals(equalTo.left())) {
                         probExprList.add(equalTo.right());
+                        pair = ctx.getAliasTransferMap().get(equalTo.right());
+                        target2 = (pair == null) ? null : pair.first;
                     } else if (probeExpr.equals(equalTo.right())) {
                         probExprList.add(equalTo.left());
+                        pair = ctx.getAliasTransferMap().get(equalTo.left());
+                        target2 = (pair == null) ? null : pair.first;
+                    }
+                    if (target2 != null) {
+                        ctx.getExpandedRF().add(
+                            new RuntimeFilterContext.ExpandRF(this, srcNode, target1, target2, equalTo));
                     }
                 }
                 probExprList.remove(srcExpr);
+
             }
         }
         for (Expression prob : probExprList) {
@@ -257,7 +271,7 @@ public class PhysicalHashJoin<
             builder.append(" build RFs:").append(runtimeFilters.stream()
                     .map(rf -> rf.shapeInfo()).collect(Collectors.joining(";")));
         }
-        // builder.append("jump: ").append(getMutableState(MutableState.KEY_RF_JUMP));
+        builder.append(" jump: ").append(getMutableState(MutableState.KEY_RF_JUMP));
         return builder.toString();
     }
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query17.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query17.out
@@ -21,9 +21,9 @@ PhysicalResultSink
 ------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[ss_customer_sk,sr_customer_sk];RF4 cs_item_sk->[ss_item_sk,sr_item_sk]
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5
+----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
 --------------------------------------------PhysicalProject
 ----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
 --------------------------------------PhysicalDistribute[DistributionSpecHash]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query25.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query25.out
@@ -20,9 +20,9 @@ PhysicalResultSink
 ----------------------------------hashJoin[INNER_JOIN] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[ss_customer_sk,sr_customer_sk];RF4 cs_item_sk->[ss_item_sk,sr_item_sk]
 ------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
 ------------------------------------------PhysicalProject
 --------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
 ------------------------------------PhysicalDistribute[DistributionSpecHash]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query29.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query29.out
@@ -19,9 +19,9 @@ PhysicalResultSink
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[ss_customer_sk,sr_customer_sk];RF4 cs_item_sk->[ss_item_sk,sr_item_sk]
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
+--------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 ----------------------------------PhysicalDistribute[DistributionSpecHash]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query64.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query64.out
@@ -23,7 +23,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF9 sr_item_sk->[ss_item_sk,i_item_sk];RF10 sr_ticket_number->[ss_ticket_number]
+----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF8 i_item_sk->[ss_item_sk]
 --------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 --------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF8 RF9 RF10 RF17 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF8 RF17 RF19
 --------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query65.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query65.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF4 ss_store_sk->[s_store_sk,ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
+--------------hashJoin[INNER_JOIN] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=()
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashJoin[INNER_JOIN] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=()
 --------------------hashAgg[GLOBAL]
@@ -16,7 +16,7 @@ PhysicalResultSink
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF3 RF4
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF4
 ------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------PhysicalProject
 ----------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query72.out
@@ -21,9 +21,9 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF1 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)) build RFs:RF0 cs_item_sk->[inv_item_sk]
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity))
 --------------------------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF3
+----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF3
 --------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------hashJoin[LEFT_OUTER_JOIN] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 ------------------------------------------------hashJoin[LEFT_OUTER_JOIN] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/nostats_rf_prune/q5.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/nostats_rf_prune/q5.out
@@ -12,7 +12,7 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_nationkey = nation.n_nationkey)) otherCondition=() build RFs:RF4 n_nationkey->[s_nationkey,c_nationkey]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = supplier.s_nationkey) and (lineitem.l_suppkey = supplier.s_suppkey)) otherCondition=() build RFs:RF2 s_suppkey->[l_suppkey];RF3 s_nationkey->[c_nationkey]
+------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = supplier.s_nationkey) and (lineitem.l_suppkey = supplier.s_suppkey)) otherCondition=() build RFs:RF2 s_suppkey->[l_suppkey]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((lineitem.l_orderkey = orders.o_orderkey)) otherCondition=() build RFs:RF1 o_orderkey->[l_orderkey]
 ------------------------------PhysicalProject
@@ -26,7 +26,7 @@ PhysicalResultSink
 ------------------------------------------PhysicalOlapScan[orders] apply RFs: RF0
 ------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF4
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[supplier] apply RFs: RF4


### PR DESCRIPTION
## Proposed changes
after set expand_runtime_filter_by_inner_join, RFGenerator generates more rfs, and hence there are some rfs have the same filter effect. This pr detect the redunant rfs, and remove one of them

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

