### PR TITLE
[bug](bitmap) should return error status when execute failed

### DIFF
--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -361,7 +361,7 @@ public:
             const auto& str_column = static_cast<const ColumnString&>(*argument_column);
             const ColumnString::Chars& data = str_column.get_chars();
             const ColumnString::Offsets& offsets = str_column.get_offsets();
-            static_cast<void>(Impl::vector(data, offsets, res, null_map, input_rows_count));
+            RETURN_IF_ERROR(Impl::vector(data, offsets, res, null_map, input_rows_count));
         } else if constexpr (std::is_same_v<typename Impl::ArgumentType, DataTypeArray>) {
             auto argument_type = remove_nullable(
                     assert_cast<const DataTypeArray&>(*block.get_by_position(arguments[0]).type)
@@ -375,19 +375,19 @@ public:
 
             WhichDataType which_type(argument_type);
             if (which_type.is_int8()) {
-                static_cast<void>(Impl::template vector<ColumnInt8>(
-                        offset_column_data, nested_column, nested_null_map, res, null_map));
+                RETURN_IF_ERROR(Impl::template vector<ColumnInt8>(offset_column_data, nested_column,
+                                                                  nested_null_map, res, null_map));
             } else if (which_type.is_uint8()) {
-                static_cast<void>(Impl::template vector<ColumnUInt8>(
+                RETURN_IF_ERROR(Impl::template vector<ColumnUInt8>(
                         offset_column_data, nested_column, nested_null_map, res, null_map));
             } else if (which_type.is_int16()) {
-                static_cast<void>(Impl::template vector<ColumnInt16>(
+                RETURN_IF_ERROR(Impl::template vector<ColumnInt16>(
                         offset_column_data, nested_column, nested_null_map, res, null_map));
             } else if (which_type.is_int32()) {
-                static_cast<void>(Impl::template vector<ColumnInt32>(
+                RETURN_IF_ERROR(Impl::template vector<ColumnInt32>(
                         offset_column_data, nested_column, nested_null_map, res, null_map));
             } else if (which_type.is_int64()) {
-                static_cast<void>(Impl::template vector<ColumnInt64>(
+                RETURN_IF_ERROR(Impl::template vector<ColumnInt64>(
                         offset_column_data, nested_column, nested_null_map, res, null_map));
             } else {
                 return Status::RuntimeError("Illegal column {} of argument of function {}",

--- a/be/src/vec/functions/function_bitmap_variadic.cpp
+++ b/be/src/vec/functions/function_bitmap_variadic.cpp
@@ -250,8 +250,8 @@ public:
         auto& vec_res = col_res->get_data();
         vec_res.resize(input_rows_count);
 
-        static_cast<void>(Impl::vector_vector(argument_columns, argument_size, input_rows_count,
-                                              vec_res, col_res_nulls));
+        RETURN_IF_ERROR(Impl::vector_vector(argument_columns, argument_size, input_rows_count,
+                                            vec_res, col_res_nulls));
         if (!use_default_implementation_for_nulls() && result_info.type->is_nullable()) {
             block.replace_by_position(
                     result, ColumnNullable::create(std::move(col_res), std::move(col_res_nulls)));

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -156,7 +156,7 @@ public:
         for (size_t i = 0; i < argument_size && remaining_rows; ++i) {
             temporary_block.get_by_position(0).column =
                     block.get_by_position(filtered_args[i]).column;
-            static_cast<void>(
+            RETURN_IF_ERROR(
                     func_is_not_null->execute(context, temporary_block, {0}, 1, input_rows_count));
 
             auto res_column =

--- a/be/src/vec/functions/function_encryption.cpp
+++ b/be/src/vec/functions/function_encryption.cpp
@@ -138,9 +138,8 @@ public:
             chars_list[i] = &col_str->get_chars();
         }
 
-        static_cast<void>(Impl::vector_vector(offsets_list, chars_list, input_rows_count,
-                                              result_data, result_offset,
-                                              result_null_map->get_data()));
+        RETURN_IF_ERROR(Impl::vector_vector(offsets_list, chars_list, input_rows_count, result_data,
+                                            result_offset, result_null_map->get_data()));
         block.get_by_position(result).column =
                 ColumnNullable::create(std::move(result_data_column), std::move(result_null_map));
         return Status::OK();

--- a/be/src/vec/functions/function_hex.cpp
+++ b/be/src/vec/functions/function_hex.cpp
@@ -77,7 +77,7 @@ public:
         auto& result_data = result_data_column->get_chars();
         auto& result_offset = result_data_column->get_offsets();
 
-        static_cast<void>(
+        RETURN_IF_ERROR(
                 Impl::vector(argument_column, input_rows_count, result_data, result_offset));
         block.replace_by_position(result, std::move(result_data_column));
         return Status::OK();

--- a/be/src/vec/functions/function_ifnull.h
+++ b/be/src/vec/functions/function_ifnull.h
@@ -118,8 +118,7 @@ public:
 
         auto func_if = SimpleFunctionFactory::instance().get_function(
                 "if", if_columns, block.get_by_position(result).type);
-        static_cast<void>(
-                func_if->execute(context, temporary_block, {0, 1, 2}, 3, input_rows_count));
+        RETURN_IF_ERROR(func_if->execute(context, temporary_block, {0, 1, 2}, 3, input_rows_count));
         block.get_by_position(result).column = temporary_block.get_by_position(3).column;
         return Status::OK();
     }

--- a/be/src/vec/functions/function_quantile_state.cpp
+++ b/be/src/vec/functions/function_quantile_state.cpp
@@ -148,11 +148,9 @@ public:
             const DataTypePtr& nested_data_type =
                     static_cast<const DataTypeNullable*>(data_type.get())->get_nested_type();
             WhichDataType nested_which(nested_data_type);
-            static_cast<void>(
-                    execute_internal<true>(column, data_type, column_result, compression));
+            RETURN_IF_ERROR(execute_internal<true>(column, data_type, column_result, compression));
         } else {
-            static_cast<void>(
-                    execute_internal<false>(column, data_type, column_result, compression));
+            RETURN_IF_ERROR(execute_internal<false>(column, data_type, column_result, compression));
         }
         if (status.ok()) {
             block.replace_by_position(result, std::move(column_result));

--- a/be/src/vec/functions/function_reverse.h
+++ b/be/src/vec/functions/function_reverse.h
@@ -46,9 +46,8 @@ public:
         ColumnPtr& src_column = block.get_by_position(arguments[0]).column;
         if (const ColumnString* col_string = check_and_get_column<ColumnString>(src_column.get())) {
             auto col_res = ColumnString::create();
-            static_cast<void>(ReverseImpl::vector(col_string->get_chars(),
-                                                  col_string->get_offsets(), col_res->get_chars(),
-                                                  col_res->get_offsets()));
+            RETURN_IF_ERROR(ReverseImpl::vector(col_string->get_chars(), col_string->get_offsets(),
+                                                col_res->get_chars(), col_res->get_offsets()));
             block.replace_by_position(result, std::move(col_res));
         } else if (check_column<ColumnArray>(src_column.get())) {
             return ArrayReverseImpl::_execute(block, arguments, result, input_rows_count);

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -23,6 +23,7 @@
 
 #include <string_view>
 
+#include "common/status.h"
 #include "runtime/string_search.hpp"
 #include "util/url_coding.h"
 #include "vec/columns/column_string.h"
@@ -492,13 +493,13 @@ struct Trim1Impl {
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
         const ColumnPtr column = block.get_by_position(arguments[0]).column;
-        if (auto col = assert_cast<const ColumnString*>(column.get())) {
+        if (const auto* col = assert_cast<const ColumnString*>(column.get())) {
             auto col_res = ColumnString::create();
             char blank[] = " ";
             StringRef rhs(blank, 1);
-            static_cast<void>(TrimUtil<is_ltrim, is_rtrim>::vector(
+            RETURN_IF_ERROR((TrimUtil<is_ltrim, is_rtrim>::vector(
                     col->get_chars(), col->get_offsets(), rhs, col_res->get_chars(),
-                    col_res->get_offsets()));
+                    col_res->get_offsets())));
             block.replace_by_position(result, std::move(col_res));
         } else {
             return Status::RuntimeError("Illegal column {} of argument of function {}",
@@ -530,9 +531,9 @@ struct Trim2Impl {
                 const char* raw_rhs = reinterpret_cast<const char*>(&(col_right->get_chars()[0]));
                 ColumnString::Offset rhs_size = col_right->get_offsets()[0];
                 StringRef rhs(raw_rhs, rhs_size);
-                static_cast<void>(TrimUtil<is_ltrim, is_rtrim>::vector(
+                RETURN_IF_ERROR((TrimUtil<is_ltrim, is_rtrim>::vector(
                         col->get_chars(), col->get_offsets(), rhs, col_res->get_chars(),
-                        col_res->get_offsets()));
+                        col_res->get_offsets())));
                 block.replace_by_position(result, std::move(col_res));
             } else {
                 return Status::RuntimeError("Illegal column {} of argument of function {}",

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -693,8 +693,8 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
-        static_cast<void>(NullOrEmptyImpl::execute(context, block, arguments, result,
-                                                   input_rows_count, false));
+        RETURN_IF_ERROR(NullOrEmptyImpl::execute(context, block, arguments, result,
+                                                 input_rows_count, false));
         return Status::OK();
     }
 };
@@ -714,8 +714,8 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
-        static_cast<void>(NullOrEmptyImpl::execute(context, block, arguments, result,
-                                                   input_rows_count, true));
+        RETURN_IF_ERROR(NullOrEmptyImpl::execute(context, block, arguments, result,
+                                                 input_rows_count, true));
         return Status::OK();
     }
 };

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -350,7 +350,7 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
             for (int i = 0; i < input_rows_count; i++) {
                 const auto pattern_val = str_patterns->get_data_at(i);
                 const auto value_val = values->get_data_at(i);
-                static_cast<void>((state->scalar_function)(
+                RETURN_IF_ERROR((state->scalar_function)(
                         const_cast<vectorized::LikeSearchState*>(&state->search_state), value_val,
                         pattern_val, &vec_res[i]));
             }

--- a/regression-test/data/query_p0/sql_functions/case_function/case_null1.csv
+++ b/regression-test/data/query_p0/sql_functions/case_function/case_null1.csv
@@ -4,8 +4,8 @@ kejc8^H
 
 
 
-)ꪁ
+*
 
 
 
-kꪁNhR
+kNhR


### PR DESCRIPTION
## Proposed changes
because it's not return error status, it's will be coredump in follow steps.
```
mysql [(none)]>select bitmap_from_base64("aGVsbG9fd29ybGQ=");
ERROR 1105 (HY000): RpcException, msg: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason
```

if return error status, the query could be cancelled rather than code dump
```
mysql [(none)]>select bitmap_from_base64("aGVsbG9fd29ybGQ=");
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[CANCELLED]bitmap_from_base64 decode failed: base64: aGVsbG9fd29ybGQ=
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

