### PR TITLE
[Fix](executor)Fix Grayscale upgrade be code dump when report statistics

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1162,6 +1162,8 @@ DEFINE_mInt64(enable_debug_log_timeout_secs, "0");
 DEFINE_Int32(ignore_invalid_partition_id_rowset_num, "0");
 
 DEFINE_mInt32(report_query_statistics_interval_ms, "3000");
+// 30s
+DEFINE_mInt32(query_statistics_reserve_timeout_ms, "30000");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1238,6 +1238,7 @@ DECLARE_mBool(enable_column_type_check);
 DECLARE_Int32(ignore_invalid_partition_id_rowset_num);
 
 DECLARE_mInt32(report_query_statistics_interval_ms);
+DECLARE_mInt32(query_statistics_reserve_timeout_ms);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/runtime/runtime_query_statistics_mgr.h
+++ b/be/src/runtime/runtime_query_statistics_mgr.h
@@ -32,8 +32,9 @@ public:
     ~QueryStatisticsCtx() = default;
 
     std::vector<std::shared_ptr<QueryStatistics>> qs_list;
-    std::atomic<bool> is_query_finished;
+    bool is_query_finished;
     TNetworkAddress fe_addr;
+    int64_t query_finish_time;
 };
 
 class RuntimeQueryStatiticsMgr {


### PR DESCRIPTION
## Proposed changes
Runtime report query statistics not support BE version > FE version.

```
terminate called after throwing an instance of 'apache::thrift::TApplicationException'
  what():  Internal error processing reportExecStatus
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1704951346 (unix time) try "date -d @1704951346" if you are using GNU date ***
*** Current BE git commitID: ffe215b968 ***
*** SIGABRT unknown detail explain (@0x46e0020cad3) received by PID 2149075 (TID 2152771 OR 0x7f9d3e994700) from PID 2149075; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/wangbo/git/res-iso/be/src/common/signal_handler.h:417
 1# 0x00007FA489AC9400 in /lib64/libc.so.6
 2# __GI_raise in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x000055CC3BD10D81 in /mnt/disk2/wangbo/runtime/master/be/lib/doris_be
 7# 0x000055CC3BD10ED4 in /mnt/disk2/wangbo/runtime/master/be/lib/doris_be
 8# doris::FrontendServiceClient::recv_reportExecStatus(doris::TReportExecStatusResult&) in /mnt/disk2/wangbo/runtime/master/be/lib/doris_be
 9# doris::RuntimeQueryStatiticsMgr::report_runtime_query_statistics() at /mnt/disk2/wangbo/git/res-iso/be/src/runtime/runtime_query_statistics_mgr.cpp:89
10# doris::Daemon::report_runtime_query_statistics_thread() at /mnt/disk2/wangbo/git/res-iso/be/src/common/daemon.cpp:360
11# doris::Thread::supervise_thread(void*) at /mnt/disk2/wangbo/git/res-iso/be/src/util/thread.cpp:499
12# start_thread in /lib64/libpthread.so.0
13# __GI___clone in /lib64/libc.so.6
```