### PR TITLE
[nereids] fix rf push down union

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -658,6 +658,17 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     }
 
     /**
+     * Check runtime filter push down project/distribute pre-conditions.
+     */
+    public static boolean checkPushDownPreconditionsForProjectOrDistribute(RuntimeFilterContext ctx, Slot slot) {
+        if (slot == null || !ctx.aliasTransferMapContains(slot)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Check runtime filter push down pre-conditions, such as builder side join type, etc.
      */
     public static boolean checkPushDownPreconditionsForJoin(AbstractPhysicalJoin physicalJoin,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -241,20 +241,6 @@ public class PhysicalHashJoin<
                     srcExpr, prob, type, buildSideNdv, exprOrder);
         }
 
-        // currently, we can ensure children in the two side are corresponding to the equal_to's.
-        // so right maybe an expression and left is a slot
-        Slot probeSlot = RuntimeFilterGenerator.checkTargetChild(probeExpr);
-
-        // aliasTransMap doesn't contain the key, means that the path from the olap scan to the join
-        // contains join with denied join type. for example: a left join b on a.id = b.id
-        if (!RuntimeFilterGenerator.checkPushDownPreconditionsForJoin(builderNode, ctx, probeSlot)) {
-            return false;
-        }
-        PhysicalRelation scan = ctx.getAliasTransferPair(probeSlot).first;
-        if (!RuntimeFilterGenerator.checkPushDownPreconditionsForRelation(this, scan)) {
-            return false;
-        }
-
         return pushedDown;
     }
 

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query11.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query11.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1998, 1999))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1998, 1999))

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query4.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk,cs_bill_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -38,7 +38,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query5.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query5.out
@@ -15,16 +15,16 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk,sr_store_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0
+------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0 RF1
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
@@ -37,16 +37,16 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF3 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF2 RF3
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
@@ -59,20 +59,20 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF7 web_site_sk->[ws_web_site_sk,ws_web_site_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
+------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF2 wr_item_sk->[ws_item_sk];RF3 wr_order_number->[ws_order_number]
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF4 wr_item_sk->[ws_item_sk];RF5 wr_order_number->[ws_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
+----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5 RF7
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF4
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF6
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query54.out
@@ -13,12 +13,12 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 ss_sold_date_sk->[d_date_sk]
+--------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 ss_sold_date_sk->[d_date_sk]
 ----------------------------PhysicalProject
 ------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
 --------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF6
+------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalAssertNumRows
 --------------------------------------PhysicalDistribute[DistributionSpecGather]
@@ -39,36 +39,36 @@ PhysicalResultSink
 ------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF3 s_county->[ca_county];RF4 s_state->[ca_state]
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+--------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2 RF3 RF4
+--------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashAgg[GLOBAL]
 ------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------------------hashAgg[LOCAL]
 ----------------------------------------------------PhysicalProject
-------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF1 customer_sk->[c_customer_sk]
+------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF2 customer_sk->[c_customer_sk]
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF1
+----------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2
 --------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------------------------------PhysicalProject
-------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=()
+------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
 --------------------------------------------------------------PhysicalProject
 ----------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
 ------------------------------------------------------------------PhysicalUnion
 --------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 --------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 ------------------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------------------------------------PhysicalProject
 ----------------------------------------------------------------------filter((item.i_category = 'Music') and (item.i_class = 'country'))

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query71.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=() build RFs:RF4 t_time_sk->[ws_sold_time_sk,cs_sold_time_sk,ss_sold_time_sk]
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
 ------------------------PhysicalUnion
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3
+----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3 RF4
 --------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 2002))
@@ -26,7 +26,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3 RF4
 --------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 2002))
@@ -35,7 +35,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4
 --------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 2002))

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query74.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query54.out
@@ -16,10 +16,10 @@ PhysicalResultSink
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3
 ----------------------------------PhysicalProject
 ------------------------------------hashAgg[LOCAL]
 --------------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query11.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query11.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (2001, 2002))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (2001, 2002))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query4.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk,cs_bill_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -38,7 +38,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query54.out
@@ -11,19 +11,19 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF5 s_county->[ca_county];RF6 s_state->[ca_state]
-------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ss_sold_date_sk]
+----------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF6 s_county->[ca_county];RF7 s_state->[ca_state]
+------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF4
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF5
 ----------------------------------PhysicalProject
 ------------------------------------hashAgg[LOCAL]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=()
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[cs_bill_customer_sk,ws_bill_customer_sk]
 ------------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[cs_item_sk,ws_item_sk]
@@ -31,10 +31,10 @@ PhysicalResultSink
 --------------------------------------------------PhysicalUnion
 ----------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2
 ----------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
+--------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1 RF2
 --------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------filter((date_dim.d_moy = 5) and (date_dim.d_year = 1998))
@@ -45,10 +45,10 @@ PhysicalResultSink
 ------------------------------------------------------PhysicalOlapScan[item]
 ------------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF4
 ------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF5 RF6
+----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF6 RF7
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query74.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query5.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query5.out
@@ -37,16 +37,16 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF3 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF2 RF3
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
@@ -59,20 +59,20 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF7 web_site_sk->[ws_web_site_sk,ws_web_site_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
+------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF2 wr_item_sk->[ws_item_sk];RF3 wr_order_number->[ws_order_number]
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF4 wr_item_sk->[ws_item_sk];RF5 wr_order_number->[ws_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
+----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5 RF7
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF4
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF6
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query54.out
@@ -20,36 +20,36 @@ PhysicalResultSink
 ----------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=()
 ------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->[ss_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6
 ------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF3 s_county->[ca_county];RF4 s_state->[ca_state]
-------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
+------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 --------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2 RF3 RF4
+----------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 --------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashAgg[GLOBAL]
 --------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------hashAgg[LOCAL]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF1 customer_sk->[c_customer_sk]
+--------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF2 customer_sk->[c_customer_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF1
+------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2
 ----------------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=()
+--------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
 ----------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
 --------------------------------------------------------------------------PhysicalUnion
 ----------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+--------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 ----------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 --------------------------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query71.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=() build RFs:RF4 t_time_sk->[ws_sold_time_sk,cs_sold_time_sk,ss_sold_time_sk]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
@@ -18,7 +18,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3
+------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
@@ -27,7 +27,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
@@ -36,7 +36,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (2001, 2002))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (2001, 2002))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk,cs_bill_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -38,7 +38,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query5.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query5.out
@@ -15,16 +15,16 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk,sr_store_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0
+------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0 RF1
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
@@ -37,16 +37,16 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF3 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF1
+------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF2 RF3
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
@@ -59,20 +59,20 @@ PhysicalResultSink
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF7 web_site_sk->[ws_web_site_sk,ws_web_site_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
 ------------------------------------PhysicalUnion
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
+------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7
 --------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF2 wr_item_sk->[ws_item_sk];RF3 wr_order_number->[ws_order_number]
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF4 wr_item_sk->[ws_item_sk];RF5 wr_order_number->[ws_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
+----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5 RF7
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF4
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF6
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query54.out
@@ -17,39 +17,39 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->[ss_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7
 ------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF3 s_county->[ca_county];RF4 s_state->[ca_state]
-------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
+------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 --------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2 RF3 RF4
+----------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 --------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashAgg[GLOBAL]
 --------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------------------------------hashAgg[LOCAL]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF1 customer_sk->[c_customer_sk]
+--------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF2 customer_sk->[c_customer_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF1
+------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2
 ----------------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=()
+--------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
 ----------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
 --------------------------------------------------------------------------PhysicalUnion
 ----------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+--------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 ----------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 --------------------------------------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=() build RFs:RF4 t_time_sk->[ws_sold_time_sk,cs_sold_time_sk,ss_sold_time_sk]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
@@ -18,7 +18,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3
+------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
@@ -27,7 +27,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
@@ -36,7 +36,7 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4
 ----------------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
@@ -3,7 +3,7 @@
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalProject
-------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((PULL_UP_UNIFIED_OUTPUT_ALIAS = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk,ws_bill_customer_sk]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalProject
 ------------PhysicalUnion
@@ -14,7 +14,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+----------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))
@@ -26,7 +26,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2
 --------------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------------PhysicalProject
 ------------------------------filter(d_year IN (1999, 2000))


### PR DESCRIPTION
## Proposed changes

Current union rf push down only support rf from parent join, but not support ancestor join. 
The pr fixes this problem on project/distribute node's rf pushing down checking.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

