### PR TITLE
[Fix](schema change) fix the bug that non light schema change tables can rename column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4543,7 +4543,7 @@ public class Env {
         Map<Long, MaterializedIndexMeta> indexIdToMeta = table.getIndexIdToMeta();
         for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
             // rename column is not implemented for table without column unique id.
-            if (entry.getValue().getMaxColUniqueId() < 0) {
+            if (entry.getValue().getMaxColUniqueId() <= 0) {
                 throw new DdlException("not implemented for table without column unique id,"
                         + " which are created with property 'light_schema_change'.");
             }


### PR DESCRIPTION
## How to reproduce the problem
1 crate table in 1.1
2 Upgrade to version 1.2
3 rename column
4 select * from table，Report an error.

## reason
Tables disable light schema change are not allowed to perform column rename. However, when upgrading from 1.1 to 1.2, maxColUniqueId will be initialized to 0, resulting in invalid judgment
