### PR TITLE
[feature](profile )merge of profiles can be disabled by profile level.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -42,12 +42,15 @@ import java.util.Map;
  */
 public class Profile {
     private static final Logger LOG = LogManager.getLogger(Profile.class);
+    private static final int MergedProfileLevel = 1;
     private RuntimeProfile rootProfile;
     private SummaryProfile summaryProfile;
     private AggregatedProfile aggregatedProfile;
     private ExecutionProfile executionProfile;
     private boolean isFinished;
     private Map<Integer, String> planNodeMap;
+
+    private int profileLevel = 3;
 
     public Profile(String name, boolean isEnable) {
         this.rootProfile = new RuntimeProfile(name);
@@ -86,6 +89,7 @@ public class Profile {
             rootProfile.setIsPipelineX(isPipelineX);
             ProfileManager.getInstance().pushProfile(this);
             this.isFinished = isFinished;
+            this.profileLevel = profileLevel;
         } catch (Throwable t) {
             LOG.warn("update profile failed", t);
             throw t;
@@ -105,15 +109,22 @@ public class Profile {
         // add summary to builder
         summaryProfile.prettyPrint(builder);
         LOG.info(builder.toString());
-        builder.append("\n MergedProfile \n");
-        aggregatedProfile.getAggregatedFragmentsProfile(planNodeMap).prettyPrint(builder, "     ");
+        if (this.profileLevel == MergedProfileLevel) {
+            try {
+                builder.append("\n MergedProfile \n");
+                aggregatedProfile.getAggregatedFragmentsProfile(planNodeMap).prettyPrint(builder, "     ");
+            } catch (Throwable aggProfileException) {
+                LOG.warn("build merged simple profile failed", aggProfileException);
+                builder.append("build merged simple profile failed");
+            }
+        }
         try {
             builder.append("\n");
             executionProfile.getExecutionProfile().prettyPrint(builder, "");
             LOG.info(builder.toString());
         } catch (Throwable aggProfileException) {
-            LOG.warn("build merged simple profile failed", aggProfileException);
-            builder.append("build merged simple profile failed");
+            LOG.warn("build profile failed", aggProfileException);
+            builder.append("build  profile failed");
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -715,7 +715,7 @@ public class SessionVariable implements Serializable, Writable {
     public int parallelPipelineTaskNum = 0;
 
     @VariableMgr.VarAttr(name = PROFILE_LEVEL, fuzzy = true)
-    public int profileLevel = 3;
+    public int profileLevel = 1;
 
     @VariableMgr.VarAttr(name = MAX_INSTANCE_NUM)
     public int maxInstanceNum = 64;


### PR DESCRIPTION
## Proposed changes

The merging of profiles requires ensuring the correctness of the profiles themselves. However, if merging is intended for troubleshooting correctness issues through profiles, errors may occur.

Moreover, the 'try-catch' does not catch exceptions related to profile merging. If merging fails, even the normal profile cannot be obtained.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

