### PR TITLE
[fix](jsonb) increase noavx2 jsonb parser key length limit from 64 to 256 bytes

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -451,7 +451,7 @@ public:
     static const int sMaxKeyId = 65535;
     typedef uint16_t keyid_type;
 
-    static const uint8_t sMaxKeyLen = 64;
+    static const uint8_t sMaxKeyLen = 256;
 
     // size of the key. 0 indicates it is stored as id
     uint8_t klen() const { return size_; }

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -451,7 +451,7 @@ public:
     static const int sMaxKeyId = 65535;
     typedef uint16_t keyid_type;
 
-    static const uint8_t sMaxKeyLen = 256;
+    static const uint8_t sMaxKeyLen = (uint8_t)256;
 
     // size of the key. 0 indicates it is stored as id
     uint8_t klen() const { return size_; }

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -451,7 +451,7 @@ public:
     static const int sMaxKeyId = 65535;
     typedef uint16_t keyid_type;
 
-    static const uint8_t sMaxKeyLen = (uint8_t)256;
+    static const uint16_t sMaxKeyLen = 256;
 
     // size of the key. 0 indicates it is stored as id
     uint8_t klen() const { return size_; }

--- a/be/src/util/jsonb_error.h
+++ b/be/src/util/jsonb_error.h
@@ -85,7 +85,7 @@ private:
             "Invalid json value type",
             "Invalid scalar value",
             "Invalid key string",
-            "Key length exceeds maximum size allowed (64 bytes)",
+            "Key length exceeds maximum size allowed (256 bytes)",
             "Invalid string value",
             "Invalid JSON object",
             "Invalid JSON array",


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Increase noavx2 jsonb parser key length limit from 64 to 256 bytes to allow larger key for noavx2 env.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

