### PR TITLE
[fix](move-memtable) check all streams for failed reason

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -572,9 +572,11 @@ Status VTabletWriterV2::close(Status exec_status) {
             }
             auto backends = _location->find_tablet(tablet_id)->node_ids;
             for (auto& backend_id : backends) {
-                auto failed_tablets = _streams_for_node[backend_id]->streams()[0]->failed_tablets();
-                if (failed_tablets.contains(tablet_id)) {
-                    return failed_tablets[tablet_id];
+                for (const auto& stream : _streams_for_node[backend_id]->streams()) {
+                    const auto& failed_tablets = stream->failed_tablets();
+                    if (failed_tablets.contains(tablet_id)) {
+                        return failed_tablets.at(tablet_id);
+                    }
                 }
             }
             DCHECK(false) << "failed tablet " << tablet_id << " should have failed reason";


### PR DESCRIPTION
## Proposed changes

The `failed_tablets` map is not shared among streams to the same backend.
We should check all streams for failed reason, otherwise this check may fail:

```
F20240111 04:00:19.187731 11070 vtablet_writer_v2.cpp:584] Check failed: false failed tablet 10026 should have failed reason
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

