### PR TITLE
[Refactor](executor)refactor workload group log fron WARNING to INFO

### DIFF
--- a/be/src/agent/cgroup_cpu_ctl.cpp
+++ b/be/src/agent/cgroup_cpu_ctl.cpp
@@ -33,7 +33,7 @@ Status CgroupCpuCtl::init() {
     }
 
     if (access(_doris_cgroup_cpu_path.c_str(), F_OK) != 0) {
-        LOG(ERROR) << "doris cgroup cpu path not exists, path=" << _doris_cgroup_cpu_path;
+        LOG(INFO) << "doris cgroup cpu path not exists, path=" << _doris_cgroup_cpu_path;
         return Status::InternalError<false>("doris cgroup cpu path {} not exists.",
                                             _doris_cgroup_cpu_path);
     }

--- a/be/src/agent/workload_group_listener.cpp
+++ b/be/src/agent/workload_group_listener.cpp
@@ -53,8 +53,8 @@ void WorkloadGroupListener::handle_topic_info(const std::vector<TopicInfo>& topi
         Status ret2 = _exec_env->task_group_manager()->upsert_cg_task_scheduler(&task_group_info,
                                                                                 _exec_env);
         if (!ret2.ok()) {
-            LOG(WARNING) << "upsert task sche failed, tg_id=" << task_group_info.id
-                         << ", reason=" << ret2.to_string();
+            LOG(INFO) << "upsert task sche failed, tg_id=" << task_group_info.id
+                      << ", reason=" << ret2.to_string();
         }
 
         LOG(INFO) << "update task group finish, tg info=" << tg->debug_string()


### PR DESCRIPTION
## Proposed changes

Refactor workload group log fron WARNING to INFO, to avoid print too much log in BE.warning when cgroup path is not specified.