### PR TITLE
[fix](regression-test) fix non stable case test_bitmap_index (#29592)

### DIFF
--- a/regression-test/suites/index_p0/test_bitmap_index.groovy
+++ b/regression-test/suites/index_p0/test_bitmap_index.groovy
@@ -318,7 +318,7 @@ suite("test_bitmap_index") {
             """
         max_try_secs = 60
         while (max_try_secs--) {
-            String res = getJobState(tbName3)
+            String res = getJobState(tbName4)
             if (res == "FINISHED" || res == "CANCELLED") {
                 assertEquals("FINISHED", res)
                 sleep(3000)
@@ -417,7 +417,7 @@ suite("test_bitmap_index") {
             """
         max_try_secs = 60
         while (max_try_secs--) {
-            String res = getJobState(tbName3)
+            String res = getJobState(tbName5)
             if (res == "FINISHED" || res == "CANCELLED") {
                 assertEquals("FINISHED", res)
                 sleep(3000)


### PR DESCRIPTION
Wrong wait getJobState make this case not stable.

Master && Branch2.0 both have this problem.

## Proposed changes

cherry-pick (#29592) to 2.0

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

