### PR TITLE
[opt](scanner) optimize the number of scanners

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -236,11 +236,10 @@ DEFINE_Int32(doris_scanner_thread_pool_thread_num, "-1");
 DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> bool {
     if (config == -1) {
         CpuInfo::init();
-        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 4);
+        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 2);
     }
     return true;
 });
-DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
 // number of olap scanner thread pool queue size
 DEFINE_Int32(doris_scanner_thread_pool_queue_size, "102400");
 // default thrift client connect timeout(in seconds)
@@ -914,7 +913,14 @@ DEFINE_mBool(enable_simdjson_reader, "true");
 
 DEFINE_mBool(enable_query_like_bloom_filter, "true");
 // number of s3 scanner thread pool size
-DEFINE_Int32(doris_remote_scanner_thread_pool_thread_num, "48");
+DEFINE_Int32(doris_remote_scanner_thread_pool_thread_num, "-1");
+DEFINE_Validator(doris_remote_scanner_thread_pool_thread_num, [](const int config) -> bool {
+    if (config == -1) {
+        CpuInfo::init();
+        doris_remote_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 2);
+    }
+    return true;
+});
 // number of s3 scanner thread pool queue size
 DEFINE_Int32(doris_remote_scanner_thread_pool_queue_size, "102400");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -280,9 +280,6 @@ DECLARE_mInt64(doris_blocking_priority_queue_wait_timeout_ms);
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool
 DECLARE_mInt32(doris_scanner_thread_pool_thread_num);
-// max number of remote scanner thread pool size
-// if equal to -1, value is std::max(512, CpuInfo::num_cores() * 10)
-DECLARE_Int32(doris_max_remote_scanner_thread_pool_thread_num);
 // number of olap scanner thread pool queue size
 DECLARE_Int32(doris_scanner_thread_pool_queue_size);
 // default thrift client connect timeout(in seconds)

--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -38,8 +38,8 @@ Status FileScanLocalState::_init_scanners(std::list<vectorized::VScannerSPtr>* s
     }
 
     auto& p = _parent->cast<FileScanOperatorX>();
-    size_t shard_num =
-            std::min<size_t>(config::doris_scanner_thread_pool_thread_num, _scan_ranges.size());
+    size_t shard_num = std::min<size_t>(config::doris_remote_scanner_thread_pool_thread_num,
+                                        _scan_ranges.size());
     _kv_cache.reset(new vectorized::ShardedKVCache(shard_num));
     for (auto& scan_range : _scan_ranges) {
         std::unique_ptr<vectorized::VFileScanner> scanner = vectorized::VFileScanner::create_unique(
@@ -60,8 +60,8 @@ std::string FileScanLocalState::name_suffix() const {
 
 void FileScanLocalState::set_scan_ranges(RuntimeState* state,
                                          const std::vector<TScanRangeParams>& scan_ranges) {
-    int max_scanners =
-            config::doris_scanner_thread_pool_thread_num / state->query_parallel_instance_num();
+    int max_scanners = config::doris_remote_scanner_thread_pool_thread_num /
+                       state->query_parallel_instance_num();
     max_scanners = max_scanners == 0 ? 1 : max_scanners;
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {

--- a/be/src/vec/exec/scan/new_file_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_file_scan_node.cpp
@@ -60,8 +60,8 @@ Status NewFileScanNode::prepare(RuntimeState* state) {
 
 void NewFileScanNode::set_scan_ranges(RuntimeState* state,
                                       const std::vector<TScanRangeParams>& scan_ranges) {
-    int max_scanners =
-            config::doris_scanner_thread_pool_thread_num / state->query_parallel_instance_num();
+    int max_scanners = config::doris_remote_scanner_thread_pool_thread_num /
+                       state->query_parallel_instance_num();
     max_scanners = max_scanners == 0 ? 1 : max_scanners;
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {
@@ -117,8 +117,8 @@ Status NewFileScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
     }
 
     // TODO: determine kv cache shard num
-    size_t shard_num =
-            std::min<size_t>(config::doris_scanner_thread_pool_thread_num, _scan_ranges.size());
+    size_t shard_num = std::min<size_t>(config::doris_remote_scanner_thread_pool_thread_num,
+                                        _scan_ranges.size());
     _kv_cache.reset(new ShardedKVCache(shard_num));
     for (auto& scan_range : _scan_ranges) {
         std::unique_ptr<VFileScanner> scanner =

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -81,11 +81,7 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
     if (limit < 0) {
         limit = -1;
     }
-    _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
-    _max_thread_num *= num_parallel_instances;
-    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
-    DCHECK(_max_thread_num > 0);
-    _max_thread_num = std::min(_max_thread_num, (int32_t)_scanners.size());
+    _max_thread_num = _scanners.size();
     // 1. Calculate max concurrency
     // For select * from table limit 10; should just use one thread.
     if ((_parent && _parent->should_run_serial()) ||
@@ -129,11 +125,7 @@ ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VS
     if (limit < 0) {
         limit = -1;
     }
-    _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
-    _max_thread_num *= num_parallel_instances;
-    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
-    DCHECK(_max_thread_num > 0);
-    _max_thread_num = std::min(_max_thread_num, (int32_t)_scanners.size());
+    _max_thread_num = _scanners.size();
     // 1. Calculate max concurrency
     // For select * from table limit 10; should just use one thread.
     if ((_parent && _parent->should_run_serial()) ||

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -81,7 +81,11 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
     if (limit < 0) {
         limit = -1;
     }
-    _max_thread_num = _scanners.size();
+    _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
+    _max_thread_num *= num_parallel_instances;
+    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
+    DCHECK(_max_thread_num > 0);
+    _max_thread_num = std::min(_max_thread_num, (int32_t)_scanners.size());
     // 1. Calculate max concurrency
     // For select * from table limit 10; should just use one thread.
     if ((_parent && _parent->should_run_serial()) ||
@@ -125,7 +129,11 @@ ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VS
     if (limit < 0) {
         limit = -1;
     }
-    _max_thread_num = _scanners.size();
+    _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
+    _max_thread_num *= num_parallel_instances;
+    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
+    DCHECK(_max_thread_num > 0);
+    _max_thread_num = std::min(_max_thread_num, (int32_t)_scanners.size());
     // 1. Calculate max concurrency
     // For select * from table limit 10; should just use one thread.
     if ((_parent && _parent->should_run_serial()) ||

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -119,11 +119,7 @@ Status ScannerScheduler::init(ExecEnv* env) {
             config::doris_scanner_thread_pool_queue_size, "local_scan");
 
     // 3. remote scan thread pool
-    _remote_thread_pool_max_size = config::doris_max_remote_scanner_thread_pool_thread_num != -1
-                                           ? config::doris_max_remote_scanner_thread_pool_thread_num
-                                           : std::max(512, CpuInfo::num_cores() * 10);
-    _remote_thread_pool_max_size =
-            std::max(_remote_thread_pool_max_size, config::doris_scanner_thread_pool_thread_num);
+    _remote_thread_pool_max_size = config::doris_remote_scanner_thread_pool_thread_num;
     _remote_scan_thread_pool = std::make_unique<PriorityThreadPool>(
             _remote_thread_pool_max_size, config::doris_remote_scanner_thread_pool_queue_size,
             "RemoteScanThreadPool");

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -382,20 +382,25 @@ There are two ways to configure BE configuration items:
 #### `doris_scanner_thread_pool_queue_size`
 
 * Type: int32
-* Description: The queue length of the Scanner thread pool. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool waiting to be scheduled, and after the number of submitted tasks exceeds the length of the thread pool queue, subsequent submitted tasks will be blocked until there is a empty slot in the queue.
+* Description: The queue length of the Scanner thread pool to read local files. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool waiting to be scheduled, and after the number of submitted tasks exceeds the length of the thread pool queue, subsequent submitted tasks will be blocked until there is a empty slot in the queue.
 * Default value: 102400
 
 #### `doris_scanner_thread_pool_thread_num`
 
 * Type: int32
-* Description: The number of threads in the Scanner thread pool. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool to be scheduled. This parameter determines the size of the Scanner thread pool.
-* Default value: 48
+* Description: The number of threads in the Scanner thread pool to read local files. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool to be scheduled. This parameter determines the size of the Scanner thread pool.
+* Default value: vcores * 2
 
-#### `doris_max_remote_scanner_thread_pool_thread_num`
+#### `doris_remote_scanner_thread_pool_queue_size`
 
 * Type: int32
-* Description: Max thread number of Remote scanner thread pool. Remote scanner thread pool is used for scan task of all external data sources.
-* Default: 512
+* Description: The queue length of the Scanner thread pool to read remote files. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool waiting to be scheduled, and after the number of submitted tasks exceeds the length of the thread pool queue, subsequent submitted tasks will be blocked until there is a empty slot in the queue.
+* Default value: 102400
+
+#### `doris_remote_scanner_thread_pool_thread_num`
+* Type: int32
+* Description: The number of threads in the Scanner thread pool to read remote files. In Doris' scanning tasks, each Scanner will be submitted as a thread task to the thread pool to be scheduled. This parameter determines the size of the Scanner thread pool.
+* Default value: vcores * 2
 
 #### `enable_prefetch`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -393,20 +393,26 @@ BE 重启后该配置将失效。如果想持久化修改结果，使用如下�
 #### `doris_scanner_thread_pool_queue_size`
 
 * 类型：int32
-* 描述：Scanner线程池的队列长度。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，而提交的任务数目超过线程池队列的长度之后，后续提交的任务将阻塞直到队列之中有新的空缺。
+* 描述：Scanner线程池读取本地文件的队列长度。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，而提交的任务数目超过线程池队列的长度之后，后续提交的任务将阻塞直到队列之中有新的空缺。
 * 默认值：102400
 
 #### `doris_scanner_thread_pool_thread_num`
 
 * 类型：int32
-* 描述：Scanner线程池线程数目。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，该参数决定了Scanner线程池的大小。
-* 默认值：48
+* 描述：Scanner线程池读取本地文件的线程数目。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，该参数决定了Scanner线程池的大小。
+* 默认值：vcores * 2
 
-#### `doris_max_remote_scanner_thread_pool_thread_num`
+#### `doris_remote_scanner_thread_pool_queue_size`
 
 * 类型：int32
-* 描述：Remote scanner thread pool 的最大线程数。Remote scanner thread pool 用于除内表外的所有 scan 任务的执行。
-* 默认值：512
+* 描述：Scanner线程池读取远程文件的队列长度。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，而提交的任务数目超过线程池队列的长度之后，后续提交的任务将阻塞直到队列之中有新的空缺。
+* 默认值：102400
+
+#### `doris_remote_scanner_thread_pool_thread_num`
+
+* 类型：int32
+* 描述：Scanner线程池读取远程文件的线程数目。在Doris的扫描任务之中，每一个Scanner会作为一个线程task提交到线程池之中等待被调度，该参数决定了Scanner线程池的大小。
+* 默认值：vcores * 2
 
 #### `enable_prefetch`
 


### PR DESCRIPTION
## Proposed changes

Three optimizations:
1. `doris_scanner_thread_pool_thread_num` controls the number of threads in the scanner thread pool to read **local files**, and the number of scanners of each ScanNode to read local files.
2. `doris_remote_scanner_thread_pool_thread_num` controls the number of threads in the scanner thread pool to read **remote files**, and the number of scanners of each ScanNode to read remote files.
3. remove `doris_max_remote_scanner_thread_pool_thread_num`, because it semantics as parameter `doris_remote_scanner_thread_pool_thread_num`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

