### PR TITLE
[fix](be-ut) Fix unstable test cases

### DIFF
--- a/be/test/agent/task_worker_pool_test.cpp
+++ b/be/test/agent/task_worker_pool_test.cpp
@@ -90,19 +90,15 @@ TEST(TaskWorkerPoolTest, PriorTaskWorkerPool) {
     EXPECT_EQ(normal_count.load(), 2);
     EXPECT_EQ(high_prior_count.load(), 3);
 
-    workers.submit_task(task);
-    workers.submit_task(task);
-    workers.submit_task(task); // Pending and ignored when stop
-    std::this_thread::sleep_for(100ms);
     workers.stop();
 
     EXPECT_EQ(normal_count.load(), 2);
-    EXPECT_EQ(high_prior_count.load(), 5);
+    EXPECT_EQ(high_prior_count.load(), 3);
 
     workers.submit_task(task); // Ignore
 
     EXPECT_EQ(normal_count.load(), 2);
-    EXPECT_EQ(high_prior_count.load(), 5);
+    EXPECT_EQ(high_prior_count.load(), 3);
 }
 
 TEST(TaskWorkerPoolTest, ReportWorkerPool) {

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -623,7 +623,7 @@ public:
     }
 
     void TearDown() override {
-        _server->Stop(1000);
+        _server->Stop(0);
         CHECK_EQ(0, _server->Join());
         SAFE_DELETE(_server);
         k_engine.reset();


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

The following cases are unstable.
1. LoadStreamMgrTest
2. TaskWorkerPoolTest.PriorTaskWorkerPool

## Rationales
1. LoadStreamMgrTest
  It is related to timeout. If we investigate the examples in BRPC, we will find the timeout is usually set to `0` rather than a specific number.
2. TaskWorkerPoolTest.PriorTaskWorkerPool
  The order of the threads for the lock contentions is undetermined.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

