### PR TITLE
[fix](move-memtable) check segment id in add_segment

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -194,7 +194,7 @@ Status TabletStream::add_segment(const PStreamHeader& header, butil::IOBuf* data
                     "segment_id={}",
                     src_id, segid);
         }
-        if (!_segids_mapping[src_id]->size() <= segid) {
+        if (segid >= _segids_mapping[src_id]->size()) {
             return Status::InternalError(
                     "add segment failed, segment is never written, src_id={}, segment_id={}",
                     src_id, segid);

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -189,9 +189,15 @@ Status TabletStream::add_segment(const PStreamHeader& header, butil::IOBuf* data
     {
         std::lock_guard lock_guard(_lock);
         if (!_segids_mapping.contains(src_id)) {
-            LOG(WARNING) << "No segid mapping for src_id " << src_id
-                         << " when ADD_SEGMENT, ignored";
-            return Status::OK();
+            return Status::InternalError(
+                    "add segment failed, no segment written by this src be yet, src_id={}, "
+                    "segment_id={}",
+                    src_id, segid);
+        }
+        if (!_segids_mapping[src_id]->size() <= segid) {
+            return Status::InternalError(
+                    "add segment failed, segment is never written, src_id={}, segment_id={}",
+                    src_id, segid);
         }
         new_segid = _segids_mapping[src_id]->at(segid);
     }


### PR DESCRIPTION
## Proposed changes

Check (src_id, segid) mapping and return error if not found.
Avoid throwing out of range exception.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

