### PR TITLE
[bugfix](timeout) serving_blocks_num may cause timeout, try to fix it

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -505,7 +505,7 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
             set_status_on_error(submit_status, false);
         }
     } else {
-        LOG(INFO) << "yyyy should be sched == false, not sched" << debug_string();
+        LOG(INFO) << "yyyy should be sched == false, not sched. " << debug_string();
     }
 }
 

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -133,10 +133,7 @@ public:
     virtual bool empty_in_queue(int id);
 
     // todo(wb) rethinking how to calculate ```_max_bytes_in_queue``` when executing shared scan
-    inline bool should_be_scheduled() const {
-        return (_cur_bytes_in_queue < _max_bytes_in_queue / 2) &&
-               (_serving_blocks_num < allowed_blocks_num());
-    }
+    inline bool should_be_scheduled() const { return _cur_bytes_in_queue < _max_bytes_in_queue / 2 }
 
     int get_available_thread_slot_num() {
         int thread_slot_num = 0;

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -133,7 +133,9 @@ public:
     virtual bool empty_in_queue(int id);
 
     // todo(wb) rethinking how to calculate ```_max_bytes_in_queue``` when executing shared scan
-    inline bool should_be_scheduled() const { return _cur_bytes_in_queue < _max_bytes_in_queue / 2 }
+    inline bool should_be_scheduled() const {
+        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
+    }
 
     int get_available_thread_slot_num() {
         int thread_slot_num = 0;

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -145,8 +145,6 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx) {
         LOG(INFO) << "yyyy ctx is done, not submit" << ctx->debug_string();
         return Status::EndOfFile("ScannerContext is done");
     }
-    //LOG(WARNING) << "yyyy " << Status::InternalError("Too many scheduled");
-    //LOG(WARNING) << "yyyy " << ctx->debug_string();
     ctx->queue_idx = (_queue_idx++ % QUEUE_NUM);
     if (!_pending_queues[ctx->queue_idx]->blocking_put(ctx)) {
         LOG(INFO) << "yyyy put to queue failed, not submit" << ctx->debug_string();


### PR DESCRIPTION
## Proposed changes

Although serving_blocks_num is an atomic variable. It's ++ and -- are not protected by transfer lock.
I am not sure the memory order of ++ and --. 
 I think it maybe the root cause of query timeout. So that I remove the check and test it in github pipeline.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

