### PR TITLE
[Fix](Export) Fix the NPE exception when cancel an export job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -130,6 +130,7 @@ public class ExportExportingTask extends MasterTask {
                             job.getTableName().getDb());
                     OlapTable table = db.getOlapTableOrAnalysisException(job.getTableName().getTbl());
                     table.readLock();
+                    Map<String, Long> partitionToVersion = job.getPartitionToVersion();
                     try {
                         SelectStmt selectStmt = selectStmtList.get(idx);
                         List<Long> tabletIds = selectStmt.getTableRefs().get(0).getSampleTabletIds();
@@ -138,7 +139,7 @@ public class ExportExportingTask extends MasterTask {
                                     tabletId);
                             Partition partition = table.getPartition(tabletMeta.getPartitionId());
                             long nowVersion = partition.getVisibleVersion();
-                            long oldVersion = job.getPartitionToVersion().get(partition.getName());
+                            long oldVersion = partitionToVersion.get(partition.getName());
                             if (nowVersion != oldVersion) {
                                 LOG.warn("Tablet {} has changed version, old version = {}, now version = {}",
                                         tabletId, oldVersion, nowVersion);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This pr fixes two things:

1. Fix the NPE exception when cancel an export job.
   When exporting a table and importing data to the table at the same time, Doris will terminat this Export Job task. In this case, an NPE exception will be reported if you cancel this Export

2. Modify a logic
    If `parallelism` property is set to `1`, Doris does not terminate the Export Job when exporting a table and importing data on the table at the same time.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

