### PR TITLE
[fix](pipelineX) fix multi be  may be missing profiles

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -3196,6 +3196,9 @@ public class Coordinator implements CoordInterface {
             this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();
             this.enablePipelineX = enablePipelineX;
             this.executionProfile = executionProfile;
+            if (enablePipelineX) {
+                executionProfile.addFragments(profileFragmentId);
+            }
         }
 
         public Stream<RuntimeProfile> profileStream() {


### PR DESCRIPTION
## Proposed changes

Reason: There might be multiple BEs performing 'markOneFragmentDone,' whereas the original consideration only accounted for a single BE scenario.

Additionally, for pipelineX, the profiles sent are on a per-Fragment basis, resulting in larger profile sizes for each individual transmission.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

