### PR TITLE
[improvement](statistics)Stop analyze quickly after user close auto analyze. #29809

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -59,24 +59,32 @@ public class StatisticsAutoCollector extends StatisticsCollector {
 
     @Override
     protected void collect() {
-        if (!StatisticsUtil.inAnalyzeTime(LocalTime.now(TimeUtils.getTimeZone().toZoneId()))) {
-            analysisTaskExecutor.clear();
-            return;
-        }
-        if (StatisticsUtil.enableAutoAnalyze()) {
+        if (canCollect()) {
             analyzeAll();
         }
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private void analyzeAll() {
+    protected boolean canCollect() {
+        return StatisticsUtil.enableAutoAnalyze()
+            && StatisticsUtil.inAnalyzeTime(LocalTime.now(TimeUtils.getTimeZone().toZoneId()));
+    }
+
+    protected void analyzeAll() {
         List<CatalogIf> catalogs = getCatalogsInOrder();
         for (CatalogIf ctl : catalogs) {
+            if (!canCollect()) {
+                analysisTaskExecutor.clear();
+                break;
+            }
             if (!ctl.enableAutoAnalyze()) {
                 continue;
             }
             List<DatabaseIf> dbs = getDatabasesInOrder(ctl);
             for (DatabaseIf<TableIf> databaseIf : dbs) {
+                if (!canCollect()) {
+                    analysisTaskExecutor.clear();
+                    break;
+                }
                 if (StatisticConstants.SYSTEM_DBS.contains(databaseIf.getFullName())) {
                     continue;
                 }
@@ -109,6 +117,10 @@ public class StatisticsAutoCollector extends StatisticsCollector {
         List<AnalysisInfo> analysisInfos = constructAnalysisInfo(databaseIf);
         for (AnalysisInfo analysisInfo : analysisInfos) {
             try {
+                if (!canCollect()) {
+                    analysisTaskExecutor.clear();
+                    break;
+                }
                 analysisInfo = getReAnalyzeRequiredPart(analysisInfo);
                 if (analysisInfo == null) {
                     continue;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
@@ -462,5 +463,75 @@ public class StatisticsAutoCollectorTest {
         for (BaseAnalysisTask task : analysisTasks.values()) {
             Assertions.assertNotNull(task.getTableSample());
         }
+    }
+
+    @Test
+    public void testDisableAuto1() throws Exception {
+        InternalCatalog catalog1 = new InternalCatalog();
+        List<CatalogIf> catalogs = Lists.newArrayList();
+        catalogs.add(catalog1);
+
+        new MockUp<StatisticsAutoCollector>() {
+            @Mock
+            public List<CatalogIf> getCatalogsInOrder() {
+                return catalogs;
+            }
+
+            @Mock
+            protected boolean canCollect() {
+                return false;
+            }
+
+        };
+
+        StatisticsAutoCollector sac = new StatisticsAutoCollector();
+        new Expectations(catalog1) {{
+                catalog1.enableAutoAnalyze();
+                times = 0;
+            }};
+
+        sac.analyzeAll();
+    }
+
+    @Test
+    public void testDisableAuto2() throws Exception {
+        InternalCatalog catalog1 = new InternalCatalog();
+        List<CatalogIf> catalogs = Lists.newArrayList();
+        catalogs.add(catalog1);
+
+        Database db1 = new Database();
+        List<DatabaseIf<? extends TableIf>> dbs = Lists.newArrayList();
+        dbs.add(db1);
+
+        new MockUp<StatisticsAutoCollector>() {
+            int count = 0;
+            boolean[] canCollectReturn = {true, false};
+            @Mock
+            public List<CatalogIf> getCatalogsInOrder() {
+                return catalogs;
+            }
+
+            @Mock
+            public List<DatabaseIf<? extends TableIf>> getDatabasesInOrder(CatalogIf<DatabaseIf> catalog) {
+                return dbs;
+            }
+
+                @Mock
+            protected boolean canCollect() {
+                return canCollectReturn[count++];
+            }
+
+        };
+
+        StatisticsAutoCollector sac = new StatisticsAutoCollector();
+        new Expectations(catalog1, db1) {{
+                catalog1.enableAutoAnalyze();
+                result = true;
+                times = 1;
+                db1.getFullName();
+                times = 0;
+            }};
+
+        sac.analyzeAll();
     }
 }


### PR DESCRIPTION
Stop analyze quickly after user close auto analyze.
backport https://github.com/apache/doris/pull/29809

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

