### PR TITLE
[fix](block) make columns in block be nullptr when invoke mutate columns to avoid potential errors

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -575,7 +575,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
+        columns[i] = data[i].column ? IColumn::mutate(std::move(data[i].column))
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -463,6 +463,7 @@ static void generate_data(vectorized::Block* block, int8_t k1, int16_t k2, int32
 
     int32_t c5 = seq;
     columns[4]->insert_data((const char*)&c5, sizeof(c2));
+    block.set_columns(std::move(columns));
 }
 
 class TestDeltaWriter : public ::testing::Test {
@@ -636,6 +637,7 @@ TEST_F(TestDeltaWriter, vec_write) {
         date_v2_int = date_v2.to_date_int_val();
         columns[21]->insert_data((const char*)&date_v2_int, sizeof(date_v2_int));
 
+        block.set_columns(std::move(columns));
         res = delta_writer->write(&block, {0});
         ASSERT_TRUE(res.ok());
     }

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -463,7 +463,7 @@ static void generate_data(vectorized::Block* block, int8_t k1, int16_t k2, int32
 
     int32_t c5 = seq;
     columns[4]->insert_data((const char*)&c5, sizeof(c2));
-    block.set_columns(std::move(columns));
+    block->set_columns(std::move(columns));
 }
 
 class TestDeltaWriter : public ::testing::Test {

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -166,6 +166,7 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
         int32_t k3 = -2147483647;
         columns[2]->insert_data((const char*)&k3, sizeof(k3));
 
+        block.set_columns(std::move(columns));
         res = delta_writer->write(&block, {0});
         ASSERT_TRUE(res.ok());
     }

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -257,6 +257,8 @@ protected:
                 }
                 num_rows++;
             }
+
+            block.set_columns(std::move(columns));
             s = rowset_writer->add_block(&block);
             EXPECT_TRUE(s.ok());
             s = rowset_writer->flush();

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -209,6 +209,7 @@ protected:
                 }
                 num_rows++;
             }
+            block.set_columns(std::move(columns));
             s = rowset_writer->add_block(&block);
             EXPECT_TRUE(s.ok());
             s = rowset_writer->flush();

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -369,6 +369,7 @@ void createTablet(TabletSharedPtr* tablet, int64_t replica_id, int32_t schema_ha
         int64_t c4_int = c4.to_int64();
         columns[3]->insert_data((const char*)&c4_int, sizeof(c4));
 
+        block.set_columns(std::move(columns));
         st = delta_writer->write(&block, {0});
         ASSERT_EQ(Status::OK(), st);
     }

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -258,6 +258,7 @@ protected:
                 }
                 num_rows++;
             }
+            block.set_columns(std::move(columns));
             s = rowset_writer->add_block(&block);
             EXPECT_TRUE(s.ok());
             s = rowset_writer->flush();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

