### PR TITLE
[fix](regression-test) fix err log limit test global impact for setting param

### DIFF
--- a/regression-test/suites/load_p0/stream_load/test_stream_load_err_log_limit.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_err_log_limit.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_stream_load_err_log_limit", "p0") {
+suite("test_stream_load_err_log_limit", "p0, nonConcurrent") {
     sql "show tables"
 
     def tableName = "test_stream_load_err_log_limit_table"


### PR DESCRIPTION
## Proposed changes

If some error log more than 100, it will effect by test_stream_load_err_log_limit.groovy, which introduces by https://github.com/apache/doris/pull/27727

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

