### PR TITLE
[fix](scan) crashing caused by unlocked reading of tablet

### DIFF
--- a/be/src/olap/parallel_scanner_builder.cpp
+++ b/be/src/olap/parallel_scanner_builder.cpp
@@ -168,7 +168,10 @@ Status ParallelScannerBuilder<ParentType>::_load() {
     for (auto&& [tablet, version] : _tablets) {
         const auto tablet_id = tablet->tablet_id();
         auto& rowsets = _all_rowsets[tablet_id];
-        RETURN_IF_ERROR(tablet->capture_consistent_rowsets({0, version}, &rowsets));
+        {
+            std::shared_lock read_lock(tablet->get_header_lock());
+            RETURN_IF_ERROR(tablet->capture_consistent_rowsets({0, version}, &rowsets));
+        }
 
         for (auto& rowset : rowsets) {
             RETURN_IF_ERROR(rowset->load());

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -310,6 +310,9 @@ public:
 
             _blocks_queue_buffered = std::move(_blocks_queue);
         }
+
+        // `get_block_from_queue` should not be called concurrently from multiple threads,
+        // so here no need to lock.
         *block = std::move(_blocks_queue_buffered.front());
         _blocks_queue_buffered.pop_front();
 


### PR DESCRIPTION
## Proposed changes

```
#0  doris::VersionGraph::capture_consistent_versions (this=0x7f7a929f9918, spec_version=..., version_path=0x7f7dd47cefb0) at /root/doris/be/src/olap/version_graph.cpp:591
#1  0x000055dc7de53b62 in doris::TimestampedVersionTracker::capture_consistent_versions (this=<optimized out>, spec_version=..., version_path=0x7d1bf) at /root/doris/be/src/olap/version_graph.cpp:330
#2  0x000055dc7dcdad07 in doris::Tablet::capture_consistent_versions (this=0x7f7a929f9810, spec_version=..., version_path=0x7d1bf, version_path@entry=0x7f7dd47cefb0, skip_missing_version=false, quiet=176) at /root/doris/be/src/olap/tablet.cpp:884
#3  0x000055dc7dcd5c28 in doris::Tablet::capture_consistent_rowsets (this=0x7f7a8803e340, spec_version=..., rowsets=0x7f78123ae8c0) at /root/doris/be/src/olap/tablet.cpp:950
#4  0x000055dc819b06ae in doris::ParallelScannerBuilder<doris::pipeline::OlapScanLocalState>::_load (this=0x7f7dd47cf190) at /root/doris/be/src/olap/parallel_scanner_builder.cpp:171
#5  0x000055dc819b0579 in doris::ParallelScannerBuilder<doris::pipeline::OlapScanLocalState>::build_scanners (this=0x7f7a8803e340, scanners=...) at /root/doris/be/src/olap/parallel_scanner_builder.cpp:30
#6  0x000055dc865a17cc in doris::pipeline::OlapScanLocalState::_init_scanners (this=0x7f76a02e4400, scanners=0x7f7dd47cf380) at /root/doris/be/src/pipeline/exec/olap_scan_operator.cpp:311
#7  0x000055dc865ada07 in doris::pipeline::ScanLocalState<doris::pipeline::OlapScanLocalState>::_prepare_scanners (this=0x7f7a8803e340, this@entry=0x7f76a02e4400) at /root/doris/be/src/pipeline/exec/scan_operator.cpp:1200
#8  0x000055dc865ad6dc in doris::pipeline::ScanLocalState<doris::pipeline::OlapScanLocalState>::open (this=0x7f76a02e4400, state=0x7f7846c0ac00) at /root/doris/be/src/pipeline/exec/scan_operator.cpp:158
#9  0x000055dc86acbccd in doris::pipeline::PipelineXTask::_open (this=0x7f7a14f66a00) at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:199
#10 0x000055dc86acc4ba in doris::pipeline::PipelineXTask::execute (this=0x7f7a14f66a00, eos=0x7f7dd47cf937) at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:235
#11 0x000055dc86ad5729 in doris::pipeline::TaskScheduler::_do_work (this=0x7f7e51b762c0, index=4) at /root/doris/be/src/pipeline/task_scheduler.cpp:286
#12 0x000055dc7e0ed2a5 in doris::ThreadPool::dispatch_thread (this=0x7f7e51b35400) at /root/doris/be/src/util/threadpool.cpp:543
#13 0x000055dc7e0e3d91 in std::function<void ()>::operator()() const (this=0x0) at /root/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
#14 doris::Thread::supervise_thread (arg=0x7f7e5cc0a780) at /root/doris/be/src/util/thread.cpp:498
#15 0x00007f7e727f1609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#16 0x00007f7e72a9e163 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

