### PR TITLE
[chore](removelogs) remove debug query timeout logs

### DIFF
--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -48,7 +48,6 @@ public:
             }
 
             if (!status().ok()) {
-                //LOG(INFO) << "yyyy status not ok " << debug_string();
                 return _process_status;
             }
         }
@@ -61,12 +60,10 @@ public:
             // if done, then eos is returned to indicate that the scan operator finished.
             if (_blocks_queues[id].empty()) {
                 *eos = done();
-                //LOG(INFO) << "yyyy queue is empty and ctx finished " << debug_string();
                 return Status::OK();
             }
             if (_process_status.is<ErrorCode::CANCELLED>()) {
                 *eos = true;
-                //LOG(INFO) << "yyyy process status is cancelled " << debug_string();
                 return Status::OK();
             }
             *block = std::move(_blocks_queues[id].front());
@@ -85,7 +82,6 @@ public:
             }
 
             if (_blocks_queues[id].empty()) {
-                //LOG(INFO) << "yyyy block queue is empty, try to resched ctx " << debug_string();
                 this->reschedule_scanner_ctx();
             }
         }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -48,7 +48,7 @@ public:
             }
 
             if (!status().ok()) {
-                LOG(INFO) << "yyyy status not ok " << debug_string();
+                //LOG(INFO) << "yyyy status not ok " << debug_string();
                 return _process_status;
             }
         }
@@ -61,12 +61,12 @@ public:
             // if done, then eos is returned to indicate that the scan operator finished.
             if (_blocks_queues[id].empty()) {
                 *eos = done();
-                LOG(INFO) << "yyyy queue is empty and ctx finished " << debug_string();
+                //LOG(INFO) << "yyyy queue is empty and ctx finished " << debug_string();
                 return Status::OK();
             }
             if (_process_status.is<ErrorCode::CANCELLED>()) {
                 *eos = true;
-                LOG(INFO) << "yyyy process status is cancelled " << debug_string();
+                //LOG(INFO) << "yyyy process status is cancelled " << debug_string();
                 return Status::OK();
             }
             *block = std::move(_blocks_queues[id].front());
@@ -85,7 +85,7 @@ public:
             }
 
             if (_blocks_queues[id].empty()) {
-                LOG(INFO) << "yyyy block queue is empty, try to resched ctx " << debug_string();
+                //LOG(INFO) << "yyyy block queue is empty, try to resched ctx " << debug_string();
                 this->reschedule_scanner_ctx();
             }
         }

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -482,7 +482,6 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
     // calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
     // to schedule that scanner right away, and in that schedule run, the scanner may be marked as closed
     // before we call the following if() block.
-    //LOG(INFO) << "yyyy one scanner finished " << debug_string();
     {
         --_num_running_scanners;
         if (scanner->_scanner->need_to_close()) {
@@ -504,8 +503,6 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
         if (!submit_status.ok()) {
             set_status_on_error(submit_status, false);
         }
-    } else {
-        //LOG(INFO) << "yyyy should be sched == false, not sched" << debug_string();
     }
 }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -505,7 +505,7 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
             set_status_on_error(submit_status, false);
         }
     } else {
-        LOG(INFO) << "yyyy should be sched == false, not sched. " << debug_string();
+        //LOG(INFO) << "yyyy should be sched == false, not sched" << debug_string();
     }
 }
 

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -140,14 +140,14 @@ Status ScannerScheduler::init(ExecEnv* env) {
 }
 
 Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx) {
-    LOG(INFO) << "yyyy submit scanner ctx " << ctx->debug_string();
+    //LOG(INFO) << "yyyy submit scanner ctx " << ctx->debug_string();
     if (ctx->done()) {
-        LOG(INFO) << "yyyy ctx is done, not submit" << ctx->debug_string();
+        //LOG(INFO) << "yyyy ctx is done, not submit" << ctx->debug_string();
         return Status::EndOfFile("ScannerContext is done");
     }
     ctx->queue_idx = (_queue_idx++ % QUEUE_NUM);
     if (!_pending_queues[ctx->queue_idx]->blocking_put(ctx)) {
-        LOG(INFO) << "yyyy put to queue failed, not submit" << ctx->debug_string();
+        //LOG(INFO) << "yyyy put to queue failed, not submit" << ctx->debug_string();
         return Status::InternalError("failed to submit scanner context to scheduler");
     }
     return Status::OK();
@@ -181,21 +181,21 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                   << " maybe finished";
         return;
     }
-    LOG(INFO) << "yyyy scheduled, query " << ctx->debug_string();
+    //LOG(INFO) << "yyyy scheduled, query " << ctx->debug_string();
     MonotonicStopWatch watch;
     watch.reset();
     watch.start();
     ctx->incr_num_ctx_scheduling(1);
 
     if (ctx->done()) {
-        LOG(INFO) << "yyyy ctx done, " << ctx->debug_string();
+        //LOG(INFO) << "yyyy ctx done, " << ctx->debug_string();
         return;
     }
 
     std::list<std::weak_ptr<ScannerDelegate>> this_run;
     ctx->get_next_batch_of_scanners(&this_run);
     if (this_run.empty()) {
-        LOG(INFO) << "yyyy run is empty, skip, " << ctx->debug_string();
+        //LOG(INFO) << "yyyy run is empty, skip, " << ctx->debug_string();
         // There will be 2 cases when this_run is empty:
         // 1. The blocks queue reaches limit.
         //      The consumer will continue scheduling the ctx.

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -140,14 +140,11 @@ Status ScannerScheduler::init(ExecEnv* env) {
 }
 
 Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx) {
-    //LOG(INFO) << "yyyy submit scanner ctx " << ctx->debug_string();
     if (ctx->done()) {
-        //LOG(INFO) << "yyyy ctx is done, not submit" << ctx->debug_string();
         return Status::EndOfFile("ScannerContext is done");
     }
     ctx->queue_idx = (_queue_idx++ % QUEUE_NUM);
     if (!_pending_queues[ctx->queue_idx]->blocking_put(ctx)) {
-        //LOG(INFO) << "yyyy put to queue failed, not submit" << ctx->debug_string();
         return Status::InternalError("failed to submit scanner context to scheduler");
     }
     return Status::OK();
@@ -181,21 +178,18 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                   << " maybe finished";
         return;
     }
-    //LOG(INFO) << "yyyy scheduled, query " << ctx->debug_string();
     MonotonicStopWatch watch;
     watch.reset();
     watch.start();
     ctx->incr_num_ctx_scheduling(1);
 
     if (ctx->done()) {
-        //LOG(INFO) << "yyyy ctx done, " << ctx->debug_string();
         return;
     }
 
     std::list<std::weak_ptr<ScannerDelegate>> this_run;
     ctx->get_next_batch_of_scanners(&this_run);
     if (this_run.empty()) {
-        //LOG(INFO) << "yyyy run is empty, skip, " << ctx->debug_string();
         // There will be 2 cases when this_run is empty:
         // 1. The blocks queue reaches limit.
         //      The consumer will continue scheduling the ctx.

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -197,13 +197,13 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
             if (_scanner_ctx) {
                 DCHECK(!_eos && _num_scanners->value() > 0);
                 RETURN_IF_ERROR(_scanner_ctx->init());
-                LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
-                          << " submit scanner ctx " << _scanner_ctx->debug_string();
+                //LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
+                //          << " submit scanner ctx " << _scanner_ctx->debug_string();
                 RETURN_IF_ERROR(_state->exec_env()->scanner_scheduler()->submit(_scanner_ctx));
             }
             if (_shared_scan_opt) {
-                LOG(INFO) << "instance shared scan enabled"
-                          << print_id(state->fragment_instance_id());
+                //LOG(INFO) << "instance shared scan enabled"
+                //          << print_id(state->fragment_instance_id());
                 _shared_scanner_controller->set_scanner_context(id(),
                                                                 _eos ? nullptr : _scanner_ctx);
             }
@@ -222,8 +222,8 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
         if (_scanner_ctx) {
             RETURN_IF_ERROR(_scanner_ctx->init());
 
-            LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
-                      << " submit scanner ctx " << _scanner_ctx->debug_string();
+            //LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
+            //          << " submit scanner ctx " << _scanner_ctx->debug_string();
             RETURN_IF_ERROR(_state->exec_env()->scanner_scheduler()->submit(_scanner_ctx));
         }
     }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -197,8 +197,6 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
             if (_scanner_ctx) {
                 DCHECK(!_eos && _num_scanners->value() > 0);
                 RETURN_IF_ERROR(_scanner_ctx->init());
-                //LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
-                //          << " submit scanner ctx " << _scanner_ctx->debug_string();
                 RETURN_IF_ERROR(_state->exec_env()->scanner_scheduler()->submit(_scanner_ctx));
             }
             if (_shared_scan_opt) {
@@ -221,9 +219,6 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
                               : Status::OK());
         if (_scanner_ctx) {
             RETURN_IF_ERROR(_scanner_ctx->init());
-
-            //LOG(INFO) << "yyyy instance " << print_id(state->fragment_instance_id())
-            //          << " submit scanner ctx " << _scanner_ctx->debug_string();
             RETURN_IF_ERROR(_state->exec_env()->scanner_scheduler()->submit(_scanner_ctx));
         }
     }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -200,8 +200,8 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
                 RETURN_IF_ERROR(_state->exec_env()->scanner_scheduler()->submit(_scanner_ctx));
             }
             if (_shared_scan_opt) {
-                //LOG(INFO) << "instance shared scan enabled"
-                //          << print_id(state->fragment_instance_id());
+                LOG(INFO) << "instance shared scan enabled"
+                          << print_id(state->fragment_instance_id());
                 _shared_scanner_controller->set_scanner_context(id(),
                                                                 _eos ? nullptr : _scanner_ctx);
             }

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -78,4 +78,4 @@ max_sys_mem_available_low_water_mark_bytes=69206016
 user_files_secure_path=/
 enable_debug_points=true
 # debug scanner context dead loop
-enable_debug_log_timeout_secs=300
+enable_debug_log_timeout_secs=0


### PR DESCRIPTION
## Proposed changes

1. remove scanner context debug logs.
2. disable operator timeout debug logs.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

