### PR TITLE
[fix](regression) spare .testfile to make disk checker happy when injecting fault

### DIFF
--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -41,6 +41,7 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "io/fs/path.h"
+#include "olap/data_dir.h"
 #include "util/doris_metrics.h"
 
 namespace doris {
@@ -201,7 +202,10 @@ Status LocalFileWriter::_close(bool sync) {
     }
 
     DBUG_EXECUTE_IF("LocalFileWriter.close.failed", {
-        return Status::IOError("cannot close {}: {}", _path.native(), std::strerror(errno));
+        // spare '.testfile' to make bad disk checker happy
+        if (_path.filename().compare(kTestFilePath)) {
+            return Status::IOError("cannot close {}: {}", _path.native(), std::strerror(errno));
+        }
     });
 
     _closed = true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Supplement to #29477 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

