### PR TITLE
[Fix](Job)Incorrect task query result of insert type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -21,11 +21,11 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.job.exception.JobException;
 import org.apache.doris.job.task.AbstractTask;
 import org.apache.doris.load.FailMsg;
+import org.apache.doris.load.loadv2.LoadJob;
 import org.apache.doris.load.loadv2.LoadStatistic;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.commands.InsertIntoTableCommand;
@@ -89,7 +89,7 @@ public class InsertTask extends AbstractTask {
 
     @Getter
     @Setter
-    private InsertJob jobInfo;
+    private LoadJob jobInfo;
     private TaskType taskType = TaskType.PENDING;
     private MergeType mergeType = MergeType.APPEND;
 
@@ -127,7 +127,7 @@ public class InsertTask extends AbstractTask {
     }
 
     public InsertTask(String labelName, InsertIntoTableCommand insertInto,
-                       ConnectContext ctx, StmtExecutor executor, LoadStatistic statistic) {
+                      ConnectContext ctx, StmtExecutor executor, LoadStatistic statistic) {
         this.labelName = labelName;
         this.command = insertInto;
         this.userIdentity = ctx.getCurrentUserIdentity();
@@ -216,23 +216,27 @@ public class InsertTask extends AbstractTask {
             // if task not start, load job is null,return pending task show info
             return getPendingTaskTVFInfo();
         }
-        trow.addToColumnValue(new TCell().setStringVal(String.valueOf(jobInfo.getJobId())));
+        trow.addToColumnValue(new TCell().setStringVal(String.valueOf(jobInfo.getId())));
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(getJobId())));
         trow.addToColumnValue(new TCell().setStringVal(labelName));
-        trow.addToColumnValue(new TCell().setStringVal(jobInfo.getJobStatus().name()));
+        trow.addToColumnValue(new TCell().setStringVal(jobInfo.getState().name()));
         // err msg
-        String errMsg = FeConstants.null_string;
+        String errMsg = "";
         if (failMsg != null) {
             errMsg = "type:" + failMsg.getCancelType() + "; msg:" + failMsg.getMsg();
         }
         trow.addToColumnValue(new TCell().setStringVal(errMsg));
         // create time
-        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getCreateTimeMs())));
+        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getCreateTimestamp())));
         // load end time
-        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getFinishTimeMs())));
+        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getFinishTimestamp())));
         // tracking url
         trow.addToColumnValue(new TCell().setStringVal(trackingUrl));
-        trow.addToColumnValue(new TCell().setStringVal(loadStatistic.toJson()));
+        if (null != loadStatistic) {
+            trow.addToColumnValue(new TCell().setStringVal(loadStatistic.toJson()));
+        } else {
+            trow.addToColumnValue(new TCell().setStringVal(""));
+        }
         trow.addToColumnValue(new TCell().setStringVal(userIdentity.getQualifiedUser()));
         return trow;
     }
@@ -244,11 +248,11 @@ public class InsertTask extends AbstractTask {
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(getJobId())));
         trow.addToColumnValue(new TCell().setStringVal(getJobId() + LABEL_SPLITTER + getTaskId()));
         trow.addToColumnValue(new TCell().setStringVal(getStatus().name()));
-        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
+        trow.addToColumnValue(new TCell().setStringVal(""));
         trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(getCreateTimeMs())));
-        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
-        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
-        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
+        trow.addToColumnValue(new TCell().setStringVal(""));
+        trow.addToColumnValue(new TCell().setStringVal(""));
+        trow.addToColumnValue(new TCell().setStringVal(""));
         trow.addToColumnValue(new TCell().setStringVal(userIdentity.getQualifiedUser()));
         return trow;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -137,16 +137,21 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
      * @param ifExists is is true, if job not exist,we will ignore job not exist exception, else throw exception
      */
     public void unregisterJob(String jobName, boolean ifExists) throws JobException {
-        T dropJob = null;
-        for (T job : jobMap.values()) {
-            if (job.getJobName().equals(jobName)) {
-                dropJob = job;
+        try {
+            T dropJob = null;
+            for (T job : jobMap.values()) {
+                if (job.getJobName().equals(jobName)) {
+                    dropJob = job;
+                }
             }
+            if (dropJob == null && ifExists) {
+                return;
+            }
+            dropJob(dropJob, jobName);
+        } catch (Exception e) {
+            log.error("drop job error, jobName:" + jobName, e);
+            throw new JobException("unregister job error, jobName:" + jobName);
         }
-        if (dropJob == null && ifExists) {
-            return;
-        }
-        dropJob(dropJob, jobName);
     }
 
     private void dropJob(T dropJob, String jobName) throws JobException {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -284,6 +284,7 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
         for (T job : jobMap.values()) {
             if (job.getJobName().equals(jobName)) {
                 job.cancelTaskById(taskId);
+                job.logUpdateOperation();
                 return;
             }
         }
@@ -378,6 +379,7 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
         }
     }
 
+    //todo it's not belong to JobManager
     public void cancelLoadJob(CancelLoadStmt cs)
             throws JobException, AnalysisException, DdlException {
         String dbName = cs.getDbName();

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
@@ -184,8 +184,8 @@ public class JobScheduler<T extends AbstractJob<?, C>, C> implements Closeable {
         }
         for (Map.Entry<Long, T> entry : jobMap.entrySet()) {
             T job = entry.getValue();
-            if (job.getJobStatus().equals(JobStatus.FINISHED)) {
-                clearFinishedJob(job);
+            if (job.getJobStatus().equals(JobStatus.FINISHED) || job.getJobStatus().equals(JobStatus.STOPPED)) {
+                clearEndJob(job);
                 continue;
             }
             if (!job.getJobStatus().equals(JobStatus.RUNNING) && !job.getJobConfig().checkIsTimerJob()) {
@@ -195,7 +195,7 @@ public class JobScheduler<T extends AbstractJob<?, C>, C> implements Closeable {
         }
     }
 
-    private void clearFinishedJob(T job) {
+    private void clearEndJob(T job) {
         if (job.getFinishTimeMs() + FINISHED_JOB_CLEANUP_THRESHOLD_TIME_MS < System.currentTimeMillis()) {
             return;
         }

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -71,9 +71,18 @@ suite("test_base_insert_job") {
        CREATE JOB ${jobName}  ON SCHEDULE every 1 second   comment 'test' DO insert into ${tableName} (timestamp, type, user_id) values ('2023-03-18','1','12213');
     """
     Thread.sleep(2500)
-    def jobs = sql """select * from ${tableName}"""
-    println jobs
-    assert 3 >= jobs.size() >= (2 as Boolean) //at least 2 records, some times 3 records
+    sql """
+        PAUSE JOB where jobname =  '${jobName}'
+    """
+    def tblDatas = sql """select * from ${tableName}"""
+    println tblDatas
+    assert 3 >= tblDatas.size() >= (2 as Boolean) //at least 2 records, some times 3 records
+    def pauseJobId = sql """select id from jobs("type"="insert") where Name='${jobName}'"""
+    def taskStatus = sql """select status from tasks("type"="insert") where jobid= '${pauseJobId.get(0).get(0)}'"""
+    println taskStatus
+    for (int i = 0; i < taskStatus.size(); i++) {
+        assert taskStatus.get(i).get(0) != "FAILED"||taskStatus.get(i).get(0) != "STOPPED"||taskStatus.get(i).get(0) != "STOPPED"
+    }
     sql """
        CREATE JOB ${jobMixedName}  ON SCHEDULE every 1 second  DO insert into ${tableName} (timestamp, type, user_id) values ('2023-03-18','1','12213');
     """
@@ -132,9 +141,8 @@ suite("test_base_insert_job") {
     sql """cancel  task where jobName='${jobName}' and taskId= ${taskId}"""
     def cancelTask = sql """ select status from tasks("type"="insert") where jobid= ${onceJobId}"""
     println cancelTask
-    //check task status
-    assert cancelTask.size() == 1
-    assert cancelTask.get(0).get(0) == "CANCELED"
+    //check task size is 0, cancel task where be deleted
+    assert cancelTask.size() == 0
     // check table data
     def dataCount1 = sql """select count(1) from ${tableName}"""
     assert dataCount1.get(0).get(0) == 0
@@ -161,14 +169,14 @@ suite("test_base_insert_job") {
     assert job.size() == 1
     def jobId = job.get(0).get(0);
     def tasks = sql """ select status from tasks("type"="insert") where jobid= ${jobId}  """
-    assert tasks.size() == 1
+    assert tasks.size() == 0
     sql """
         RESUME JOB where jobname =  '${jobName}'
     """
     Thread.sleep(2500)
     def resumeTasks = sql """ select status from tasks("type"="insert") where jobid= ${jobId}  """
     println resumeTasks
-    assert resumeTasks.size() == 2
+    assert resumeTasks.size() == 1
     // assert same job name
     try {
         sql """


### PR DESCRIPTION
- IdToTask has no persistence, so the queried task will be lost once it is restarted.

- The cancel task does not update metadata after being removed from the running task.

- tvf displays an error when some fields in the query task result are empty

- cycle scheduling job should not be STOP when task fail

## Proposed changes

<img width="1340" alt="image" src="https://github.com/apache/doris/assets/16631152/721f83f2-af9b-466a-9e39-83b278397fd8">
- Completed jobs are still obtained from the loadmanager.
- 
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

