### PR TITLE
[opt](scanner) optimize the number of threads of scanners, follow up #28640

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -236,7 +236,7 @@ DEFINE_Int32(doris_scanner_thread_pool_thread_num, "-1");
 DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> bool {
     if (config == -1) {
         CpuInfo::init();
-        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 4);
+        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 2);
     }
     return true;
 });


### PR DESCRIPTION
## Proposed changes

follow up #28640, `doris_scanner_thread_pool_thread_num` may be to large in machines with 128 cores.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

