### PR TITLE
[fix](deploy) K8s deploy manager cannot get group host info by endpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/deploy/impl/K8sDeployManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/deploy/impl/K8sDeployManager.java
@@ -117,20 +117,22 @@ public class K8sDeployManager extends DeployManager {
 
         LOG.info("use domainLTD: {}", domainLTD);
 
-        //Fill NodeTypeAttr.subAttr1 with statefulName
-        //If serviceName is configured, the corresponding statefulSetName must be configured
-        for (NodeType nodeType : NodeType.values()) {
-            NodeTypeAttr nodeTypeAttr = nodeTypeAttrMap.get(nodeType);
-            if (nodeTypeAttr.hasService()) {
-                String statefulSetEnvName = getStatefulSetEnvName(nodeType);
-                Log.info("Env name of: {} is: {}", nodeType.name(), statefulSetEnvName);
-                String statefulSetName = Strings.nullToEmpty(System.getenv(statefulSetEnvName));
-                if (Strings.isNullOrEmpty(statefulSetName)) {
-                    LOG.error("failed to init statefulSetName: {}", statefulSetEnvName);
-                    System.exit(-1);
+        if (Config.enable_fqdn_mode) {
+            //Fill NodeTypeAttr.subAttr1 with statefulName
+            //If serviceName is configured, the corresponding statefulSetName must be configured
+            for (NodeType nodeType : NodeType.values()) {
+                NodeTypeAttr nodeTypeAttr = nodeTypeAttrMap.get(nodeType);
+                if (nodeTypeAttr.hasService()) {
+                    String statefulSetEnvName = getStatefulSetEnvName(nodeType);
+                    Log.info("Env name of: {} is: {}", nodeType.name(), statefulSetEnvName);
+                    String statefulSetName = Strings.nullToEmpty(System.getenv(statefulSetEnvName));
+                    if (Strings.isNullOrEmpty(statefulSetName)) {
+                        LOG.error("failed to init statefulSetName: {}", statefulSetEnvName);
+                        System.exit(-1);
+                    }
+                    LOG.info("use statefulSetName: {}, {}", nodeType.name(), statefulSetName);
+                    nodeTypeAttr.setSubAttr(statefulSetName);
                 }
-                LOG.info("use statefulSetName: {}, {}", nodeType.name(), statefulSetName);
-                nodeTypeAttr.setSubAttr(statefulSetName);
             }
         }
 


### PR DESCRIPTION
cherry-pick #27813 from master

K8s deploy manager cannot get group host info by endpoint. If we get group host info by endpoint, there is no need to init statefulset.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

