### PR TITLE
[fix](regression) fault injection may cause fd to be closed twice

### DIFF
--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -200,6 +200,7 @@ Status LocalFileWriter::_close(bool sync) {
     if (0 != ::close(_fd)) {
         return localfs_error(errno, fmt::format("failed to close {}", _path.native()));
     }
+    _closed = true;
 
     DBUG_EXECUTE_IF("LocalFileWriter.close.failed", {
         // spare '.testfile' to make bad disk checker happy
@@ -208,7 +209,6 @@ Status LocalFileWriter::_close(bool sync) {
         }
     });
 
-    _closed = true;
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

