### PR TITLE
[Fix](ParquetReader)Fix date type push down to parquet error

### DIFF
--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -241,7 +241,7 @@ private:
                     min_value.from_unixtime(min_date_value * 24 * 60 * 60, ctz);
                     max_value.from_unixtime(max_date_value * 24 * 60 * 60, ctz);
 
-                    // as VecDateTimeValue can not compare date and datetime, so need 
+                    // as VecDateTimeValue can not compare date and datetime, so need
                     // cast to date here
                     if constexpr (std::is_same_v<CppType, VecDateTimeValue>) {
                         min_value.cast_to_date();

--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -240,6 +240,13 @@ private:
                               std::is_same_v<CppType, DateV2Value<DateV2ValueType>>) {
                     min_value.from_unixtime(min_date_value * 24 * 60 * 60, ctz);
                     max_value.from_unixtime(max_date_value * 24 * 60 * 60, ctz);
+
+                    // as VecDateTimeValue can not compare date and datetime, so need 
+                    // cast to date here
+                    if constexpr (std::is_same_v<CppType, VecDateTimeValue>) {
+                        min_value.cast_to_date();
+                        max_value.cast_to_date();
+                    }
                 } else {
                     return false;
                 }


### PR DESCRIPTION
## Proposed changes

in Parquet reader, the Doris Date type conjunct like day="2024-01-08"  will push down to parquet reader to read the data in parquet.  And we got some data like day="2024-01-08"  in parquet file, however the  we got nothing now.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

