### PR TITLE
[BugFix](ParquetReader) Branch 1.2 lts fix parquet pushdown error

### DIFF
--- a/be/src/olap/row_cursor.cpp
+++ b/be/src/olap/row_cursor.cpp
@@ -51,7 +51,8 @@ Status RowCursor::_init(const std::vector<uint32_t>& columns) {
             return Status::Error<INIT_FAILED>();
         }
         _variable_len += column_schema(cid)->get_variable_len();
-        if (_schema->column(cid)->type() == OLAP_FIELD_TYPE_STRING || _schema->column(cid)->type() == OLAP_FIELD_TYPE_JSONB) {
+        if (_schema->column(cid)->type() == OLAP_FIELD_TYPE_STRING ||
+            _schema->column(cid)->type() == OLAP_FIELD_TYPE_JSONB) {
             ++_string_field_count;
         }
     }
@@ -221,7 +222,8 @@ Status RowCursor::allocate_memory_for_string_type(TabletSchemaSPtr schema) {
     char** long_text_ptr = _long_text_buf;
     for (auto cid : _schema->column_ids()) {
         fixed_ptr = _fixed_buf + _schema->column_offset(cid);
-        if (_schema->column(cid)->type() == OLAP_FIELD_TYPE_STRING || _schema->column(cid)->type() == OLAP_FIELD_TYPE_JSONB) {
+        if (_schema->column(cid)->type() == OLAP_FIELD_TYPE_STRING ||
+            _schema->column(cid)->type() == OLAP_FIELD_TYPE_JSONB) {
             Slice* slice = reinterpret_cast<Slice*>(fixed_ptr + 1);
             _schema->mutable_column(cid)->set_long_text_buf(long_text_ptr);
             slice->data = *(long_text_ptr);

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -35,8 +35,6 @@
 #include "util/types.h"
 #include "util/uid_util.h"
 
-
-
 namespace doris {
 
 ExportSink::ExportSink(ObjectPool* pool, const RowDescriptor& row_desc,

--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -220,6 +220,13 @@ private:
                               std::is_same_v<CppType, DateV2Value<DateV2ValueType>>) {
                     min_value.from_unixtime(min_date_value * 24 * 60 * 60, ctz);
                     max_value.from_unixtime(max_date_value * 24 * 60 * 60, ctz);
+
+                    // as DateTimeValue can not compare date and datetime, so need 
+                    // cast to date here
+                    if constexpr (std::is_same_v<CppType, DateTimeValue>) {
+                        min_value.cast_to_date();
+                        max_value.cast_to_date();
+                    }
                 } else {
                     return false;
                 }

--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -221,7 +221,7 @@ private:
                     min_value.from_unixtime(min_date_value * 24 * 60 * 60, ctz);
                     max_value.from_unixtime(max_date_value * 24 * 60 * 60, ctz);
 
-                    // as DateTimeValue can not compare date and datetime, so need 
+                    // as DateTimeValue can not compare date and datetime, so need
                     // cast to date here
                     if constexpr (std::is_same_v<CppType, DateTimeValue>) {
                         min_value.cast_to_date();


### PR DESCRIPTION
## Proposed changes

in Parquet reader, the Doris Date type conjunct like day="2024-01-08" will push down to parquet reader to read the data in parquet. And we got some data like day="2024-01-08" in parquet file, however the we got nothing now.

bp #30075
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

