### PR TITLE
[bug](proc) Fix Kerberos issue in HDFS with run_kinit

### DIFF
--- a/be/src/io/hdfs_builder.h
+++ b/be/src/io/hdfs_builder.h
@@ -57,6 +57,7 @@ private:
     bool need_kinit {false};
     std::string hdfs_kerberos_keytab;
     std::string hdfs_kerberos_principal;
+    std::string hdfs_kerberos_ticket_path;
 };
 
 THdfsParams parse_properties(const std::map<std::string, std::string>& properties);


### PR DESCRIPTION
## Proposed changes
![bug1](https://github.com/apache/doris/assets/40750255/226e4dca-6231-4596-9dc3-2fc4a0b95597)

![bug](https://github.com/apache/doris/assets/40750255/57594f22-1e79-4ef5-a260-bca7cc686183)

Address the issue where run_kinit passes a local variable pointer to the
builder in HDFS under a Kerberos scenario. This leads to the variable memory
being released after run_kinit ends, causing createHDFSBuilder to fail in
retrieving kerberos_chache_path, resulting in a Kerberos error.

Replace the use of hdfsBuilderConfSetStr when setting the parameter
hadoop.security.kerberos.ticket.cache.path. Instead, use the provided
hdfsBuilderSetKerbTicketCachePath from Hadoop for successful configuration.

This fix ensures proper memory management and correct usage of Hadoop's
APIs for Kerberos configuration


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

