### PR TITLE
[Fix](Show-Delete)Missing delete job info causes query exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteInfo.java
@@ -60,12 +60,19 @@ public class DeleteInfo implements Writable, GsonPostProcessable {
     @SerializedName(value = "partitionName")
     private String partitionName;
 
-    public DeleteInfo(long dbId, long tableId, String tableName, List<String> deleteConditions) {
+    public DeleteInfo(long dbId, long tableId, String tableName, List<String> deleteConditions,
+                      boolean noPartitionSpecified, List<Long> partitionIds, List<String> partitionNames) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.tableName = tableName;
         this.deleteConditions = deleteConditions;
         this.createTimeMs = System.currentTimeMillis();
+        this.noPartitionSpecified = noPartitionSpecified;
+        if (!noPartitionSpecified) {
+            Preconditions.checkState(partitionIds.size() == partitionNames.size());
+            this.partitionIds = partitionIds;
+            this.partitionNames = partitionNames;
+        }
     }
 
     public long getDbId() {
@@ -90,13 +97,6 @@ public class DeleteInfo implements Writable, GsonPostProcessable {
 
     public boolean isNoPartitionSpecified() {
         return noPartitionSpecified;
-    }
-
-    public void setPartitions(boolean noPartitionSpecified, List<Long> partitionIds, List<String> partitionNames) {
-        this.noPartitionSpecified = noPartitionSpecified;
-        Preconditions.checkState(partitionIds.size() == partitionNames.size());
-        this.partitionIds = partitionIds;
-        this.partitionNames = partitionNames;
     }
 
     public List<Long> getPartitionIds() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -490,6 +490,7 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
     public static class Builder {
 
         public DeleteJob buildWith(BuildParams params) throws Exception {
+            boolean noPartitionSpecified = params.getPartitionNames().isEmpty();
             List<Partition> partitions = getSelectedPartitions(params.getTable(),
                     params.getPartitionNames(), params.getDeleteConditions());
             Map<Long, Short> partitionReplicaNum = partitions.stream()
@@ -504,8 +505,11 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             String label = DELETE_PREFIX + UUID.randomUUID();
             //generate jobId
             long jobId = Env.getCurrentEnv().getNextId();
+            List<String> partitionNames = partitions.stream().map(Partition::getName).collect(Collectors.toList());
+            List<Long> partitionIds = partitions.stream().map(Partition::getId).collect(Collectors.toList());
             DeleteInfo deleteInfo = new DeleteInfo(params.getDb().getId(), params.getTable().getId(),
-                    params.getTable().getName(), getDeleteCondString(params.getDeleteConditions()));
+                    params.getTable().getName(), getDeleteCondString(params.getDeleteConditions()),
+                    noPartitionSpecified, partitionIds, partitionNames);
             DeleteJob deleteJob = new DeleteJob(jobId, -1, label, partitionReplicaNum, deleteInfo);
             long replicaNum = partitions.stream().mapToLong(Partition::getAllReplicaCount).sum();
             deleteJob.setPartitions(partitions);

--- a/regression-test/suites/show_p0/test_show_delete.groovy
+++ b/regression-test/suites/show_p0/test_show_delete.groovy
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_delete") {
+    def tableName = "test_show_delete_table"
+    sql """drop table if exists ${tableName}"""
+    
+    sql """
+             CREATE TABLE IF NOT EXISTS ${tableName}
+        (
+            `datetime` DATE NOT NULL COMMENT "['0000-01-01', '9999-12-31']",
+            `type` TINYINT NOT NULL COMMENT "[-128, 127]",
+            `user_id` decimal(9,3) COMMENT "[-9223372036854775808, 9223372036854775807]"
+        )
+        UNIQUE KEY(`datetime`)
+        PARTITION BY RANGE(`datetime`)
+        (
+                PARTITION `Feb` VALUES LESS THAN ("2022-03-01"),
+                PARTITION `Mar` VALUES LESS THAN ("2022-04-01")
+        )
+        DISTRIBUTED BY HASH(`datetime`) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+
+    sql """insert into ${tableName} values ('2022-02-01', 1, 1.1), ('2022-03-01', 2, 2.2)"""
+
+    sql """ set delete_without_partition = true"""
+    // don't care nereids planner
+    sql """ delete from ${tableName} PARTITION Mar  where type ='2'"""
+    sql """ delete from ${tableName}   where type ='1'"""
+    def showDeleteResult = sql """ show delete"""
+    //When we test locally, multiple history results will be included, so size will be >= 2
+    assert showDeleteResult.size() >= 2
+    def count = 0
+    showDeleteResult.each { row ->
+
+        if (row[3] == 'type EQ "2"') {
+           assert row[1] == 'Mar'
+            count++
+            return
+        }
+        if (row[3] == 'type EQ "1"') {
+            assert row[1] == '*'
+            count++
+            return
+        }
+        
+    }
+    assert count == showDeleteResult.size()
+
+}


### PR DESCRIPTION
## What happend


Delete when no partition is specified, and then execute show delete to report an error.



```log
java.lang.NullPointerException: null
        at com.google.common.base.Joiner.join(Joiner.java:204) ~[guava-32.1.2-jre.jar:?]

        at org.apache.doris.load.DeleteHandler.getDeleteInfosByDb(DeleteHandler.java:276) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.ShowExecutor.handleShowDelete(ShowExecutor.java:1579) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:327) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:2356) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:813) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:509) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:462) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:245) ~[doris-fe.jar:1.2-SNAPSHOT]

        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:193) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:246) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]

        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_151]

        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_151]

        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_151]
```

### Affected branches
- master
## Change

When executing delete, part of the job information is not set. Add the corresponding information.

**Since it only affects the master version and the persistent information of delete is deleted regularly, there is not to do compatibility with historical error data.**