### PR TITLE
[fix](Nereids): eliminate redundant join condition after inferring condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/FindHashConditionForJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/FindHashConditionForJoin.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.util.JoinUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 
 import java.util.List;
 
@@ -61,10 +62,10 @@ public class FindHashConditionForJoin extends OneRewriteRuleFactory {
                 return join;
             }
 
-            List<Expression> combinedHashJoinConjuncts = new ImmutableList.Builder<Expression>()
-                    .addAll(join.getHashJoinConjuncts())
-                    .addAll(extractedHashJoinConjuncts)
-                    .build();
+            List<Expression> combinedHashJoinConjuncts = Streams
+                    .concat(join.getHashJoinConjuncts().stream(), extractedHashJoinConjuncts.stream())
+                    .distinct()
+                    .collect(ImmutableList.toImmutableList());
             JoinType joinType = join.getJoinType();
             if (joinType == JoinType.CROSS_JOIN && !combinedHashJoinConjuncts.isEmpty()) {
                 joinType = JoinType.INNER_JOIN;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/CompareOuterJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/CompareOuterJoinTest.java
@@ -28,10 +28,12 @@ import org.apache.doris.nereids.rules.exploration.mv.mapping.RelationMapping;
 import org.apache.doris.nereids.rules.exploration.mv.mapping.SlotMapping;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.HyperGraphBuilder;
 import org.apache.doris.nereids.util.PlanChecker;
 
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +71,8 @@ class CompareOuterJoinTest extends SqlTestBase {
 
     @Test
     void testRandomQuery() {
-        Plan p1 = new HyperGraphBuilder().randomBuildPlanWith(3, 3);
+        Plan p1 = new HyperGraphBuilder(Sets.newHashSet(JoinType.INNER_JOIN))
+                .randomBuildPlanWith(3, 3);
         p1 = PlanChecker.from(connectContext, p1)
                 .analyze()
                 .rewrite()


### PR DESCRIPTION
## Proposed changes

eliminate redundant join when find hashing join condition
such as for plan:
```
T1 join T2 on T1.id = T2.id join T3 on T1.id = T3.id and T2.id = T3.id 
```
we infer a new predicate T1.id = T2.id which is redundant. Therefore we need to eliminate it when find hash condition


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

