### PR TITLE
[fix](chore) path gc should consider tablet migration

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -670,7 +670,13 @@ void DataDir::_perform_path_gc_by_tablet(std::vector<std::string>& tablet_paths)
             std::swap(*forward, *backward);
             continue;
         }
-        if (auto tablet = _engine.tablet_manager()->get_tablet(tablet_id); !tablet) {
+        auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
+        if (!tablet || tablet->data_dir() != this) {
+            if (tablet) {
+                LOG(INFO) << "The tablet in path " << path << " is not same with the running one: "
+                          << tablet->data_dir()->_path << "/" << tablet->tablet_path()
+                          << ", might be the old tablet after migration, try to move it to trash";
+            }
             _engine.tablet_manager()->try_delete_unused_tablet_path(this, tablet_id, schema_hash,
                                                                     path);
             --backward;
@@ -714,6 +720,12 @@ void DataDir::_perform_path_gc_by_rowset(const std::vector<std::string>& tablet_
         if (!tablet) {
             // Could not found the tablet, maybe it's a dropped tablet, will be reclaimed
             // in the next time `_perform_path_gc_by_tablet`
+            continue;
+        }
+
+        if (tablet->data_dir() != this) {
+            // Current running tablet is not in same data_dir, maybe it's a tablet after migration,
+            // will be reclaimed in the next time `_perform_path_gc_by_tablet`
             continue;
         }
 

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -673,8 +673,9 @@ void DataDir::_perform_path_gc_by_tablet(std::vector<std::string>& tablet_paths)
         auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
         if (!tablet || tablet->data_dir() != this) {
             if (tablet) {
-                LOG(INFO) << "The tablet in path " << path << " is not same with the running one: "
-                          << tablet->data_dir()->_path << "/" << tablet->tablet_path()
+                LOG(INFO) << "The tablet in path " << path
+                          << " is not same with the running one: " << tablet->data_dir()->_path
+                          << "/" << tablet->tablet_path()
                           << ", might be the old tablet after migration, try to move it to trash";
             }
             _engine.tablet_manager()->try_delete_unused_tablet_path(this, tablet_id, schema_hash,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Background:
1. Migration will create new tablet in different DataDir, the old tablet will be moved to TabletManager::_shutdown_tablets.
2. The migration task won't copy data in stale rowsets to new tablet, so after migration, the new tablet don't contains stale rowsets of old tablet
3. The path GC process will check every path, to make sure if it's an useless tablet, or an useless rowset. If it is, will remove data of these tablets/rowsets

The issue:
1. When path GC got a stale rowset path from the data dir of old tablet, it extract the tablet id and rowset id
2. Then it check if the tablet id exists in TabletManager, and the answer is YES!
3. It got the tablet instance, which is the new tablet, then it check if the stale rowset id from the old tablet path exists in the new tablet instance, and got the answer NO.
4. The path GC process treat the rowset as an useless rowset, since it can't find anyone holds reference to it, then delete  the data of this stale rowset.
5. But some query may still holds reference to this stale rowset, the deletion will cause query failure.

Solution:
1. The lifecycle of all rowsets in a shutdown tablet, should be related with the lifecycle of this tablet
2. We need to differentiate the old tablet and the new one created by migration task, while performing path GC.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

