### PR TITLE
[fix](move-memtable) only do close wait on the last sink

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -316,6 +316,10 @@ Status LoadStreamStub::close_wait(int64_t timeout_ms) {
     if (_is_closed.load()) {
         return _check_cancel();
     }
+    // if there are other sinks remaining, let the last sink handle close wait
+    if (_use_cnt > 0) {
+        return Status::OK();
+    }
     if (timeout_ms <= 0) {
         timeout_ms = config::close_load_stream_timeout_ms;
     }


### PR DESCRIPTION
## Proposed changes

If data distribution is not balanced among all sinks, some sink may finish very fast while others are still writing.
The fast sinks may wait a long period of time and trigger close_wait timeout.

This PR changes this behavior, the first N-1 sinks will not wait for stream close.
Only the last one will do close wait and handle commit info.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

