### PR TITLE
[fix](be) The size of the hive catalog read exceeds the limit, causin…

### DIFF
--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <fmt/core.h>
+
 #include <cassert>
 #include <cstring>
 
@@ -65,9 +67,11 @@ private:
 
     void ALWAYS_INLINE check_chars_length(size_t total_length, size_t element_number) const {
         if (UNLIKELY(total_length > MAX_STRING_SIZE)) {
-            throw Exception(ErrorCode::STRING_OVERFLOW_IN_VEC_ENGINE,
+            throw Exception(
+                    fmt::format(
                             "string column length is too large: total_length={}, element_number={}",
-                            total_length, element_number);
+                            total_length, element_number),
+                    ErrorCode::STRING_OVERFLOW_IN_VEC_ENGINE);
         }
     }
 

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -23,9 +23,11 @@
 #include <cassert>
 #include <cstring>
 
+#include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_impl.h"
 #include "vec/common/assert_cast.h"
+#include "vec/common/exception.h"
 #include "vec/common/memcmp_small.h"
 #include "vec/common/memcpy_small.h"
 #include "vec/common/pod_array.h"
@@ -63,8 +65,9 @@ private:
 
     void ALWAYS_INLINE check_chars_length(size_t total_length, size_t element_number) const {
         if (UNLIKELY(total_length > MAX_STRING_SIZE)) {
-            LOG(FATAL) << "string column length is too large: total_length=" << total_length
-                       << " ,element_number=" << element_number;
+            throw Exception(ErrorCode::STRING_OVERFLOW_IN_VEC_ENGINE,
+                            "string column length is too large: total_length={}, element_number={}",
+                            total_length, element_number);
         }
     }
 


### PR DESCRIPTION
…g a fatal result

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
core:
#6  0x000055b946e9fa79 in google::LogMessageFatal::~LogMessageFatal() ()
#7  0x000055b942b3b115 in doris::vectorized::ColumnString::check_chars_length (element_number=<optimized out>, 
    total_length=<optimized out>, this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/ostream:170
#8  doris::vectorized::ColumnString::insert_many_strings (this=<optimized out>, strings=<optimized out>, num=4064)
    at /data/doris-1.x/be/src/vec/columns/column_string.h:270
#9  0x000055b946a3548c in doris::vectorized::OrcReader::_decode_string_column (this=this@entry=0x7fb3e9866700, col_name=..., 
    data_column=..., type_kind=@0x7fb97edf40e0: orc::DECIMAL, cvb=cvb@entry=0x7fb42c6490c0, num_values=4064)
    at /data/doris-1.x/be/src/vec/common/cow.h:208
#10 0x000055b946a40300 in doris::vectorized::OrcReader::_orc_column_to_doris_column (this=this@entry=0x7fb3e9866700, 
    col_name=..., doris_column=..., data_type=..., orc_column_type=0x7fb42c568e80, cvb=0x7fb42c6490c0, num_values=4064)
    at /data/doris-1.x/be/src/vec/exec/format/orc/vorc_reader.cpp:737
#11 0x000055b946a42d50 in doris::vectorized::OrcReader::get_next_block (this=0x7fb3e9866700, block=0x7fb5a58e7380, 
    read_rows=0x7fb97edf4318, eof=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/stl_vector.h:1043
#12 0x000055b946a03ad8 in doris::vectorized::VFileScanner::_get_block_impl (this=0x7fb3dd5bb400, state=<optimized out>, 
    block=0x7fb5a58e7380, eof=0x7fb97edf4539) at /var/local/ldb-toolchain/include/c++/11/bits/unique_ptr.h:421
#13 0x000055b9469cf329 in doris::vectorized::VScanner::get_block (this=this@entry=0x7fb3dd5bb400, 
    state=state@entry=0x7fb41eef4f00, block=block@entry=0x7fb5a58e7380, eof=eof@entry=0x7fb97edf4539)
    at /data/doris-1.x/be/src/vec/exec/scan/vscanner.cpp:54
#14 0x000055b9469cc682 in doris::vectorized::ScannerScheduler::_scanner_scan (this=<optimized out>, 
    scheduler=<optimized out>, ctx=0x7fba388f8000, scanner=0x7fb3dd5bb400)
    at /data/doris-1.x/be/src/vec/exec/scan/scanner_scheduler.cpp:247
#15 0x000055b941cd3b15 in std::function<void ()>::operator()() const (this=<optimized out>)
    at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556
#16 doris::FunctionRunnable::run (this=<optimized out>) at /data/doris-1.x/be/src/util/threadpool.cpp:46
#17 doris::ThreadPool::dispatch_thread (this=0x7fba3c350180) at /data/doris-1.x/be/src/util/threadpool.cpp:535
#18 0x000055b941cc8f6f in std::function<void ()>::operator()() const (this=0x7fba48812e98)
    at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556
#19 doris::Thread::supervise_thread (arg=0x7fba48812e80) at /data/doris-1.x/be/src/util/thread.cpp:454
#20 0x00007fba647adea5 in start_thread () from /lib64/libpthread.so.0
#21 0x00007fba64ac09fd in clone () from /lib64/libc.so.6

Reason:
Because the total length of the orc file exceeds 0xffffffff, it will be fatal

fix:
I think we can throw an exception here instead of making the be service core, the be service unavailable has a big impact.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

