### PR TITLE
[Fix](Export) Fix the bug that `tablets_num` is always zero in `show export` result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -150,6 +150,8 @@ public class ExportJob implements Writable {
     private ExportFailMsg failMsg;
     @SerializedName("outfileInfo")
     private String outfileInfo;
+    @SerializedName("tabletsNum")
+    private Integer tabletsNum;
     // progress has two functions at EXPORTING stage:
     // 1. when progress < 100, it indicates exporting
     // 2. set progress = 100 ONLY when exporting progress is completely done
@@ -186,7 +188,6 @@ public class ExportJob implements Writable {
 
     private ExportExportingTask task;
 
-    private List<TScanRangeLocations> tabletLocations = Lists.newArrayList();
     // backend_address => snapshot path
     private List<Pair<TNetworkAddress, String>> snapshotPaths = Lists.newArrayList();
 
@@ -341,6 +342,7 @@ public class ExportJob implements Writable {
         }
 
         Integer tabletsAllNum = tabletIdList.size();
+        this.tabletsNum = tabletsAllNum;
         Integer tabletsNumPerQuery = tabletsAllNum / this.parallelNum;
         Integer tabletsNumPerQueryRemainder = tabletsAllNum - tabletsNumPerQuery * this.parallelNum;
 
@@ -355,13 +357,13 @@ public class ExportJob implements Writable {
                         + "set parallelism to tablets num.", id, tabletsAllNum, this.parallelNum);
         }
         for (int i = 0; i < outfileNum; ++i) {
-            Integer tabletsNum = tabletsNumPerQuery;
+            Integer realTabletsNum = tabletsNumPerQuery;
             if (tabletsNumPerQueryRemainder > 0) {
-                tabletsNum = tabletsNum + 1;
+                realTabletsNum = realTabletsNum + 1;
                 --tabletsNumPerQueryRemainder;
             }
-            ArrayList<Long> tablets = new ArrayList<>(tabletIdList.subList(start, start + tabletsNum));
-            start += tabletsNum;
+            ArrayList<Long> tablets = new ArrayList<>(tabletIdList.subList(start, start + realTabletsNum));
+            start += realTabletsNum;
             // Since export does not support the alias, here we pass the null value.
             // we can not use this.tableRef.getAlias(),
             // because the constructor of `Tableref` will convert this.tableRef.getAlias()
@@ -547,8 +549,8 @@ public class ExportJob implements Writable {
         return this.stmtExecutorList.get(idx);
     }
 
-    public List<TScanRangeLocations> getTabletLocations() {
-        return tabletLocations;
+    public Integer getTabletsNum() {
+        return this.tabletsNum;
     }
 
     public List<Pair<TNetworkAddress, String>> getSnapshotPaths() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -58,7 +58,6 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.task.ExportExportingTask;
 import org.apache.doris.thrift.TNetworkAddress;
-import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
@@ -422,7 +422,7 @@ public class ExportMgr extends MasterDaemon {
         infoMap.put("format", job.getFormat());
         infoMap.put("line_delimiter", job.getLineDelimiter());
         infoMap.put("columns", job.getColumns());
-        infoMap.put("tablet_num", job.getTabletLocations() == null ? -1 : job.getTabletLocations().size());
+        infoMap.put("tablet_num", job.getTabletsNum());
         infoMap.put("max_file_size", job.getMaxFileSize());
         infoMap.put("delete_existing_files", job.getDeleteExistingFiles());
         jobInfo.add(new Gson().toJson(infoMap));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Bug description:
when we exec `show export`, the `tablets_num` is always zero:
```sql
*************************** 7. row ***************************
      JobId: 58303
      Label: export_672f66ec-592e-4cd6-8329-13f5a89d93b7
      State: FINISHED
   Progress: 100%
   TaskInfo: {"partitions":["*"],"max_file_size":"256MB","delete_existing_files":"","columns":"","format":"orc","broker":"HDFS","column_separator":"\t","line_delimiter":"\n","db":"default_cluster:testLi","tbl":"customer","tablet_num":0}
       Path: hdfs://xxxx/
 CreateTime: 2024-01-09 11:41:02
  StartTime: 2024-01-09 11:41:32
 FinishTime: 2024-01-09 11:43:03
    Timeout: 3600
   ErrorMsg: NULL
OutfileInfo: [
  {
    "fileNumber": "7",
    "totalRows": "30000000",
    "fileSize": "1669449988bytes",
    "url": "hdfs://xxxx"
  }
] 
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

