### PR TITLE
[config](load) set default memtable_flush_running_count_limit to 2

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -592,7 +592,7 @@ DEFINE_mInt64(write_buffer_size, "104857600");
 // max buffer size used in memtable for the aggregated table, default 400MB
 DEFINE_mInt64(write_buffer_size_for_agg, "419430400");
 // max parallel flush task per memtable writer
-DEFINE_mInt32(memtable_flush_running_count_limit, "5");
+DEFINE_mInt32(memtable_flush_running_count_limit, "2");
 
 DEFINE_Int32(load_process_max_memory_limit_percent, "50"); // 50%
 


### PR DESCRIPTION
## Proposed changes

1 memtable flushing and 1 memtable waiting in the queue should be enough to keep the flush thread busy.

This PR reduces memory pressure especially when tablet count is high.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

