### PR TITLE
[BugFix](MultiCatalog) Iceberg table get split fail  when use date type conjunct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -611,6 +611,10 @@ public class DateLiteral extends LiteralExpr {
         }
     }
 
+    public boolean isDateType() {
+        return this.type.isDate() || this.type.isDateV2();
+    }
+
     @Override
     public String getStringValue() {
         char[] dateTimeChars = new char[26]; // Enough to hold "YYYY-MM-DD HH:MM:SS.mmmmmm"

--- a/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/util/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/util/IcebergUtils.java
@@ -369,7 +369,11 @@ public class IcebergUtils {
             return boolLiteral.getValue();
         } else if (expr instanceof DateLiteral) {
             DateLiteral dateLiteral = (DateLiteral) expr;
-            return dateLiteral.unixTimestamp(TimeUtils.getTimeZone()) * MILLIS_TO_NANO_TIME;
+            if (dateLiteral.isDateType()) {
+                return dateLiteral.getStringValue();
+            } else {
+                return dateLiteral.unixTimestamp(TimeUtils.getTimeZone()) * MILLIS_TO_NANO_TIME;
+            }
         } else if (expr instanceof DecimalLiteral) {
             DecimalLiteral decimalLiteral = (DecimalLiteral) expr;
             return decimalLiteral.getValue();


### PR DESCRIPTION
## Proposed changes

1, have iceberg table with partitioned by date type column "day"

2 execute select * from test_table where day = "2022-01-01" will  get nothing while the data exist in iceberg table, just we transfer the DateLiteral("2022-01-01") to datetime, cause we can not get the split correctly.

bp #30162


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

