### PR TITLE
[fix](exec_node) crashing caused by cancelled query in ExecNode

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -558,22 +558,22 @@ Status ExecNode::get_next_after_projects(
         RuntimeState* state, vectorized::Block* block, bool* eos,
         const std::function<Status(RuntimeState*, vectorized::Block*, bool*)>& func,
         bool clear_data) {
-    Defer defer([block, this]() {
-        if (block && !block->empty()) {
-            COUNTER_UPDATE(_output_bytes_counter, block->allocated_bytes());
-            COUNTER_UPDATE(_block_count_counter, 1);
-        }
-    });
     if (_output_row_descriptor) {
         if (clear_data) {
             clear_origin_block();
         }
-        auto status = func(state, &_origin_block, eos);
-        if (UNLIKELY(!status.ok())) return status;
-        return do_projections(&_origin_block, block);
+        RETURN_IF_ERROR(func(state, &_origin_block, eos));
+        RETURN_IF_ERROR(do_projections(&_origin_block, block));
+    } else {
+        RETURN_IF_ERROR(func(state, block, eos));
     }
     _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
-    return func(state, block, eos);
+
+    if (block && !block->empty()) {
+        COUNTER_UPDATE(_output_bytes_counter, block->allocated_bytes());
+        COUNTER_UPDATE(_block_count_counter, 1);
+    }
+    return Status::OK();
 }
 
 Status ExecNode::sink(RuntimeState* state, vectorized::Block* input_block, bool eos) {


### PR DESCRIPTION
## Proposed changes

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f8043726859 in __GI_abort () at abort.c:79
#2  0x000055cea9d910ca in __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x000055cea9d8fa06 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
#4  0x000055cea9d8fa71 in std::terminate () at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:58
#5  0x000055ce769a3b4e in __clang_call_terminate ()
#6  0x000055ce7a13b4e3 in doris::Defer<doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)> const&, bool)::$_0>::~Defer() (this=0x7f7e588d4fa0)
    at /root/doris/be/src/util/defer_op.h:37
#7  0x000055ce7a13b361 in doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)> const&, bool) (this=0x617004fe5980, state=0x61e00577ec80, block=0x60d001371cc0, eos=0x7f7e58a49120,
    func=..., clear_data=true) at /root/doris/be/src/exec/exec_node.cpp:577
#8  0x000055cea615854b in doris::pipeline::SourceOperator<doris::vectorized::VSchemaScanNode>::get_block (this=0x608003a879b0, state=0x61e00577ec80, block=0x60d001371cc0, source_state=@0x617004c29039: doris::pipeline::SourceState::DEPEND_ON_SOURCE)
    at /root/doris/be/src/pipeline/exec/operator.h:394
#9  0x000055cea6a06c62 in doris::pipeline::PipelineTask::execute (this=0x617004c29000, eos=0x7f7e58d5f4b0) at /root/doris/be/src/pipeline/pipeline_task.cpp:284
#10 0x000055cea6c75f9f in doris::pipeline::TaskScheduler::_do_work (this=0x60b000abd3e0, index=6) at /root/doris/be/src/pipeline/task_scheduler.cpp:286
#11 0x000055cea6c8748b in std::__invoke_impl<void, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__f=
    @0x60300060d990: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x55cea6c74360 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __t=@0x60300060d9a8: 0x60b000abd3e0, __args=@0x60300060d9a0: 6)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#12 0x000055cea6c872d7 in std::__invoke<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__fn=
    @0x60300060d990: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x55cea6c74360 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __args=@0x60300060d9a0: 6, __args=@0x60300060d9a0: 6)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#13 0x000055cea6c87236 in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x60300060d990, __args=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#14 0x000055cea6c87090 in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() (this=0x60300060d990) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#15 0x000055cea6c86f97 in std::__invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::__invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (
    __f=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#16 0x000055cea6c86f09 in std::__invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (__fn=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#17 0x000055cea6c86b1f in std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) (__functor=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#18 0x000055ce76b65de7 in std::function<void ()>::operator()() const (this=0x60600118b158) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#19 0x000055ce7ab9592b in doris::FunctionRunnable::run (this=0x60600118b150) at /root/doris/be/src/util/threadpool.cpp:48
#20 0x000055ce7ab7f4cf in doris::ThreadPool::dispatch_thread (this=0x615000273100) at /root/doris/be/src/util/threadpool.cpp:543
#21 0x000055ce7abaa436 in std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__f=@0x6030005e8940: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55ce7ab7d4f0 <doris::ThreadPool::dispatch_thread()>, __t=@0x6030005e8950: 0x615000273100)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#22 0x000055ce7abaa2df in std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__fn=@0x6030005e8940: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55ce7ab7d4f0 <doris::ThreadPool::dispatch_thread()>, __args=@0x6030005e8950: 0x615000273100)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#23 0x000055ce7abaa257 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0x6030005e8940, __args=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#24 0x000055ce7abaa0f0 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() (this=0x6030005e8940) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#25 0x000055ce7aba9ff7 in std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__f=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#26 0x000055ce7aba9f69 in std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__fn=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#27 0x000055ce7aba9b2f in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (__functor=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#28 0x000055ce76b65de7 in std::function<void ()>::operator()() const (this=0x61100021fc58) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#29 0x000055ce7ab44ce4 in doris::Thread::supervise_thread (arg=0x61100021fc40) at /root/doris/be/src/util/thread.cpp:498
#30 0x00007f8043576609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#31 0x00007f8043823133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

