### PR TITLE
[pipelineX](fix) Fix use-after-free MultiCastSourceDependency

### DIFF
--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -63,6 +63,10 @@ public:
             : PipelineXSinkLocalState<AnalyticSinkDependency>(parent, state) {}
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
+    Status close(RuntimeState* state, Status exec_status) override {
+        _shared_state->release_sink_dep();
+        return PipelineXSinkLocalState<AnalyticSinkDependency>::close(state, exec_status);
+    }
 
 private:
     friend class AnalyticSinkOperatorX;
@@ -70,11 +74,13 @@ private:
     bool _refresh_need_more_input() {
         auto need_more_input = _whether_need_next_partition(_shared_state->found_partition_end);
         if (need_more_input) {
-            _shared_state->source_dep->block();
+            if (!_shared_state->source_released_flag) {
+                _shared_state->source_dep->block();
+            }
             _dependency->set_ready();
         } else {
             _dependency->block();
-            _shared_state->source_dep->set_ready();
+            _dependency->set_ready_to_read();
         }
         return need_more_input;
     }

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -74,9 +74,7 @@ private:
     bool _refresh_need_more_input() {
         auto need_more_input = _whether_need_next_partition(_shared_state->found_partition_end);
         if (need_more_input) {
-            if (!_shared_state->source_released_flag) {
-                _shared_state->source_dep->block();
-            }
+            _dependency->set_block_to_read();
             _dependency->set_ready();
         } else {
             _dependency->block();

--- a/be/src/pipeline/exec/analytic_source_operator.h
+++ b/be/src/pipeline/exec/analytic_source_operator.h
@@ -83,13 +83,12 @@ private:
         auto need_more_input = _whether_need_next_partition(_shared_state->found_partition_end);
         if (need_more_input) {
             _dependency->block();
+            _dependency->set_ready_to_write();
             if (!_shared_state->sink_released_flag) {
                 _shared_state->sink_dep->set_ready();
             }
         } else {
-            if (!_shared_state->sink_released_flag) {
-                _shared_state->sink_dep->block();
-            }
+            _dependency->set_block_to_write();
             _dependency->set_ready();
         }
         return need_more_input;

--- a/be/src/pipeline/exec/analytic_source_operator.h
+++ b/be/src/pipeline/exec/analytic_source_operator.h
@@ -83,9 +83,13 @@ private:
         auto need_more_input = _whether_need_next_partition(_shared_state->found_partition_end);
         if (need_more_input) {
             _dependency->block();
-            _shared_state->sink_dep->set_ready();
+            if (!_shared_state->sink_released_flag) {
+                _shared_state->sink_dep->set_ready();
+            }
         } else {
-            _shared_state->sink_dep->block();
+            if (!_shared_state->sink_released_flag) {
+                _shared_state->sink_dep->block();
+            }
             _dependency->set_ready();
         }
         return need_more_input;

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -154,6 +154,13 @@ Status MultiCastDataStreamSourceLocalState::init(RuntimeState* state, LocalState
     return Status::OK();
 }
 
+Status MultiCastDataStreamSourceLocalState::close(RuntimeState* state) {
+    RETURN_IF_ERROR(Base::close(state));
+    _shared_state->multi_cast_data_streamer.released_dependency(
+            _parent->cast<Parent>()._consumer_id);
+    return Status::OK();
+}
+
 Status MultiCastDataStreamerSourceOperatorX::get_block(RuntimeState* state,
                                                        vectorized::Block* block,
                                                        SourceState& source_state) {

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -155,9 +155,9 @@ Status MultiCastDataStreamSourceLocalState::init(RuntimeState* state, LocalState
 }
 
 Status MultiCastDataStreamSourceLocalState::close(RuntimeState* state) {
-    RETURN_IF_ERROR(Base::close(state));
     _shared_state->multi_cast_data_streamer.released_dependency(
             _parent->cast<Parent>()._consumer_id);
+    RETURN_IF_ERROR(Base::close(state));
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.h
@@ -117,7 +117,7 @@ public:
         RETURN_IF_ERROR(_acquire_runtime_filter());
         return Status::OK();
     }
-
+    Status close(RuntimeState* state) override;
     friend class MultiCastDataStreamerSourceOperatorX;
 
     RuntimeFilterDependency* filterdependency() override { return _filter_dependency.get(); }

--- a/be/src/pipeline/exec/multi_cast_data_streamer.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_streamer.cpp
@@ -116,6 +116,7 @@ void MultiCastDataStreamer::_set_ready_for_read() {
     size_t i = 0;
     for (auto* dep : _dependencies) {
         if (_dependencies_release_flag[i]) {
+            i++;
             continue;
         }
         DCHECK(dep);

--- a/be/src/pipeline/exec/multi_cast_data_streamer.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_streamer.cpp
@@ -104,15 +104,23 @@ void MultiCastDataStreamer::_set_ready_for_read(int sender_idx) {
     if (_dependencies.empty()) {
         return;
     }
+    if (_dependencies_release_flag[sender_idx]) {
+        return;
+    }
     auto* dep = _dependencies[sender_idx];
     DCHECK(dep);
     dep->set_ready();
 }
 
 void MultiCastDataStreamer::_set_ready_for_read() {
+    size_t i = 0;
     for (auto* dep : _dependencies) {
+        if (_dependencies_release_flag[i]) {
+            continue;
+        }
         DCHECK(dep);
         dep->set_ready();
+        i++;
     }
 }
 

--- a/be/src/pipeline/exec/multi_cast_data_streamer.h
+++ b/be/src/pipeline/exec/multi_cast_data_streamer.h
@@ -38,10 +38,14 @@ public:
                           bool with_dependencies = false)
             : _row_desc(row_desc),
               _profile(pool->add(new RuntimeProfile("MultiCastDataStreamSink"))),
-              _cast_sender_count(cast_sender_count) {
+              _cast_sender_count(cast_sender_count),
+              _dependencies_release_flag(cast_sender_count) {
         _sender_pos_to_read.resize(cast_sender_count, _multi_cast_blocks.end());
         if (with_dependencies) {
             _dependencies.resize(cast_sender_count, nullptr);
+            for (size_t i = 0; i < cast_sender_count; i++) {
+                _dependencies_release_flag[i] = false;
+            }
         }
 
         _peak_mem_usage = ADD_COUNTER(profile(), "PeakMemUsage", TUnit::BYTES);
@@ -79,6 +83,8 @@ public:
         _block_reading(sender_idx);
     }
 
+    void released_dependency(int sender_idx) { _dependencies_release_flag[sender_idx] = true; }
+
 private:
     void _set_ready_for_read(int sender_idx);
     void _set_ready_for_read();
@@ -97,6 +103,7 @@ private:
     RuntimeProfile::Counter* _process_rows = nullptr;
     RuntimeProfile::Counter* _peak_mem_usage = nullptr;
 
+    std::vector<std::atomic<bool>> _dependencies_release_flag;
     std::vector<MultiCastSourceDependency*> _dependencies;
 };
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/multi_cast_data_streamer.h
+++ b/be/src/pipeline/exec/multi_cast_data_streamer.h
@@ -83,7 +83,10 @@ public:
         _block_reading(sender_idx);
     }
 
-    void released_dependency(int sender_idx) { _dependencies_release_flag[sender_idx] = true; }
+    void released_dependency(int sender_idx) {
+        std::unique_lock<std::mutex> lc(_release_lock);
+        _dependencies_release_flag[sender_idx] = true;
+    }
 
 private:
     void _set_ready_for_read(int sender_idx);
@@ -103,6 +106,7 @@ private:
     RuntimeProfile::Counter* _process_rows = nullptr;
     RuntimeProfile::Counter* _peak_mem_usage = nullptr;
 
+    std::mutex _release_lock;
     std::vector<std::atomic<bool>> _dependencies_release_flag;
     std::vector<MultiCastSourceDependency*> _dependencies;
 };

--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -219,7 +219,7 @@ void SetProbeSinkOperatorX<is_intersect>::_finalize_probe(
         local_state._shared_state->probe_finished_children_dependency[_cur_child_id + 1]
                 ->set_ready();
     } else {
-        local_state._shared_state->source_dep->set_ready();
+        local_state._dependency->set_ready_to_read();
     }
 }
 

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -93,7 +93,7 @@ Status SetSinkOperatorX<is_intersect>::sink(RuntimeState* state, vectorized::Blo
             local_state._shared_state->probe_finished_children_dependency[_cur_child_id + 1]
                     ->set_ready();
             if (_child_quantity == 1) {
-                local_state._shared_state->source_dep->set_ready();
+                local_state._dependency->set_ready_to_read();
             }
         }
     }

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -189,4 +189,13 @@ void LocalExchangeSharedState::sub_running_sink_operators() {
     }
 }
 
+LocalExchangeSharedState::LocalExchangeSharedState(int num_instances)
+        : dependencies_release_flag(num_instances) {
+    source_dependencies.resize(num_instances, nullptr);
+    mem_trackers.resize(num_instances, nullptr);
+    for (size_t i = 0; i < num_instances; i++) {
+        dependencies_release_flag[i] = false;
+    }
+}
+
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -623,6 +623,7 @@ public:
         size_t i = 0;
         for (auto& dep : source_dependencies) {
             if (dependencies_release_flag[i]) {
+                i++;
                 continue;
             }
             DCHECK(dep);

--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp
@@ -62,8 +62,8 @@ std::string LocalExchangeSourceLocalState::debug_string(int indentation_level) c
 }
 
 Status LocalExchangeSourceLocalState::close(RuntimeState* state) {
-    RETURN_IF_ERROR(Base::close(state));
     _shared_state->dependencies_release_flag[_channel_id] = true;
+    RETURN_IF_ERROR(Base::close(state));
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.h
@@ -48,6 +48,7 @@ public:
 
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     std::string debug_string(int indentation_level) const override;
+    Status close(RuntimeState* state) override;
 
 private:
     friend class LocalExchangeSourceOperatorX;

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -338,15 +338,15 @@ Status PipelineXLocalState<DependencyType>::init(RuntimeState* state, LocalState
             _shared_state =
                     (typename DependencyType::SharedState*)_dependency->shared_state().get();
 
-            _shared_state->source_dep = info.dependency;
-            _shared_state->sink_dep = deps.front();
+            _shared_state->source_dep = info.dependency.get();
+            _shared_state->sink_dep = deps.front().get();
         } else if constexpr (!is_fake_shared) {
             _dependency->set_shared_state(deps.front()->shared_state());
             _shared_state =
                     (typename DependencyType::SharedState*)_dependency->shared_state().get();
 
-            _shared_state->source_dep = info.dependency;
-            _shared_state->sink_dep = deps.front();
+            _shared_state->source_dep = info.dependency.get();
+            _shared_state->sink_dep = deps.front().get();
         }
     }
 
@@ -377,6 +377,9 @@ template <typename DependencyType>
 Status PipelineXLocalState<DependencyType>::close(RuntimeState* state) {
     if (_closed) {
         return Status::OK();
+    }
+    if (_shared_state) {
+        _shared_state->release_source_dep();
     }
     if constexpr (!std::is_same_v<DependencyType, FakeDependency>) {
         COUNTER_SET(_wait_for_dependency_timer, _dependency->watcher_elapse_time());

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -739,7 +739,7 @@ Status PipelineXFragmentContext::_add_local_exchange_impl(
                                             is_shuffled_hash_join, shuffle_idx_to_instance_idx));
 
     // 2. Create and initialize LocalExchangeSharedState.
-    auto shared_state = LocalExchangeSharedState::create_shared();
+    auto shared_state = LocalExchangeSharedState::create_shared(_num_instances);
     switch (data_distribution.distribution_type) {
     case ExchangeType::HASH_SHUFFLE:
         shared_state->exchanger = ShuffleExchanger::create_unique(
@@ -771,8 +771,6 @@ Status PipelineXFragmentContext::_add_local_exchange_impl(
         return Status::InternalError("Unsupported local exchange type : " +
                                      std::to_string((int)data_distribution.distribution_type));
     }
-    shared_state->source_dependencies.resize(_num_instances, nullptr);
-    shared_state->mem_trackers.resize(_num_instances, nullptr);
     auto sink_dep = std::make_shared<LocalExchangeSinkDependency>(sink_id, local_exchange_id,
                                                                   _runtime_state->get_query_ctx());
     sink_dep->set_shared_state(shared_state);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -3982,7 +3982,9 @@ public class Coordinator implements CoordInterface {
         if (enablePipelineEngine) {
             for (PipelineExecContext ctx : pipelineExecContexts.values()) {
                 if (enablePipelineXEngine) {
-                    ctx.attachPipelineProfileToFragmentProfile();
+                    synchronized (this) {
+                        ctx.attachPipelineProfileToFragmentProfile();
+                    }
                 } else {
                     ctx.profileStream()
                             .forEach(p -> executionProfile.addInstanceProfile(ctx.profileFragmentId, p));


### PR DESCRIPTION
## Proposed changes

1. Fix use-after-free
2. Fix potential memory leak caused by loop shared pointers.
3. Fix concurrent exception in Coordinator.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

