### PR TITLE
[improvement](statistics)Optimize drop stats operation.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
@@ -53,7 +53,10 @@ public class DropStatsStmt extends DdlStmt {
     private Set<String> columnNames;
     // Flag to drop external table row count in table_statistics.
     private boolean dropTableRowCount;
+    private boolean isAllColumns;
 
+    private long catalogId;
+    private long dbId;
     private long tblId;
 
     public DropStatsStmt(boolean dropExpired) {
@@ -100,10 +103,13 @@ public class DropStatsStmt extends DdlStmt {
         DatabaseIf db = catalog.getDbOrAnalysisException(dbName);
         TableIf table = db.getTableOrAnalysisException(tblName);
         tblId = table.getId();
+        dbId = db.getId();
+        catalogId = catalog.getId();
         // check permission
         checkAnalyzePriv(db.getFullName(), table.getName());
         // check columnNames
         if (columnNames != null) {
+            isAllColumns = false;
             for (String cName : columnNames) {
                 if (table.getColumn(cName) == null) {
                     ErrorReport.reportAnalysisException(
@@ -115,6 +121,7 @@ public class DropStatsStmt extends DdlStmt {
                 }
             }
         } else {
+            isAllColumns = true;
             columnNames = table.getColumns().stream().map(Column::getName).collect(Collectors.toSet());
         }
     }
@@ -123,8 +130,20 @@ public class DropStatsStmt extends DdlStmt {
         return tblId;
     }
 
+    public long getDbId() {
+        return dbId;
+    }
+
+    public long getCatalogIdId() {
+        return catalogId;
+    }
+
     public Set<String> getColumnNames() {
         return columnNames;
+    }
+
+    public boolean isAllColumns() {
+        return isAllColumns;
     }
 
     public boolean dropTableRowCount() {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3097,7 +3097,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (tableStats == null) {
             return new TStatus(TStatusCode.OK);
         }
-        analysisManager.invalidateLocalStats(target.tableId, target.columns, tableStats);
+        analysisManager.invalidateLocalStats(target.catalogId, target.dbId, target.tableId, target.columns, tableStats);
         return new TStatus(TStatusCode.OK);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
@@ -23,14 +23,26 @@ import java.util.Set;
 
 public class InvalidateStatsTarget {
 
+    @SerializedName("catalogId")
+    public final long catalogId;
+
+    @SerializedName("dbId")
+    public final long dbId;
+
     @SerializedName("tableId")
     public final long tableId;
 
     @SerializedName("columns")
     public final Set<String> columns;
 
-    public InvalidateStatsTarget(long tableId, Set<String> columns) {
+    public InvalidateStatsTarget(long catalogId, long dbId, long tableId, Set<String> columns, boolean isAllColumns) {
+        this.catalogId = catalogId;
+        this.dbId = dbId;
         this.tableId = tableId;
-        this.columns = columns;
+        if (isAllColumns) {
+            this.columns = null;
+        } else {
+            this.columns = columns;
+        }
     }
 }


### PR DESCRIPTION
Before, drop stats operation need to call columns * followers times of isMaster() function and the same times of rpc to drop remote column stats. This pr is to reduce the rpc calls and use more efficient way to check master node instead of using isMaster()

backport https://github.com/apache/doris/pull/30144

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

