### PR TITLE
[fix](decimalv2) Fix cast to decimalv2 overflow

### DIFF
--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -188,7 +188,8 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
         nested = std::make_shared<vectorized::DataTypeBitMap>();
         break;
     case TYPE_DECIMALV2:
-        nested = std::make_shared<vectorized::DataTypeDecimal<vectorized::Decimal128V2>>(27, 9);
+        nested = std::make_shared<vectorized::DataTypeDecimal<vectorized::Decimal128V2>>(
+                col_desc.precision, col_desc.scale);
         break;
     case TYPE_QUANTILE_STATE:
         nested = std::make_shared<vectorized::DataTypeQuantileState>();


### PR DESCRIPTION
before
```sql
select cast(12 as decimalv2(2,1))
--------------

+---------------------------+
| cast(12 as DECIMAL(2, 1)) |
+---------------------------+
|                      12.0 |
+---------------------------+
1 row in set (0.04 sec)
```
after
```sql
select cast(12 as decimalv2(2,1))
--------------

ERROR 1105 (HY000): errCode = 2, detailMessage = (xx)[CANCELLED][E-124] Arithmetic overflow, convert failed from 120, expected data is [-99, 99]
```