### PR TITLE
[optimize](inverted index) Use inverted index filter null field

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -852,6 +852,8 @@ bool SegmentIterator::_check_apply_by_inverted_index(ColumnPredicate* pred, bool
         // can apply 'match qeury' and 'equal query' and 'list query' for fulltext index.
         return (pred_in_compound ? pred->type() == PredicateType::MATCH
                                  : (pred->type() == PredicateType::MATCH ||
+                                    pred->type() == PredicateType::IS_NULL ||
+                                    pred->type() == PredicateType::IS_NOT_NULL ||
                                     PredicateTypeTraits::is_equal_or_list(pred->type())));
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
We saved segment level null bitmap in the inverted index, so we can use it to filter null field to accelerate query.
after this change:
![image](https://github.com/apache/doris/assets/54385456/c9edacad-baff-4e59-8bbc-23459c2e1773)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

