### PR TITLE
[fix](Cooldown) Enhance calculate logic of _has_data_to_cooldown

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2227,14 +2227,20 @@ Status Tablet::_follow_cooldowned_data() {
 bool Tablet::_has_data_to_cooldown() {
     int64_t min_local_version = std::numeric_limits<int64_t>::max();
     RowsetSharedPtr rowset;
+    std::shared_lock meta_rlock(_meta_lock);
     // Ususally once the tablet has done cooldown successfully then the first
     // rowset would always be remote rowset
-    bool has_cooldowned = !_rs_version_map.begin()->second->is_local();
-    std::shared_lock meta_rlock(_meta_lock);
+    bool has_cooldowned = false;
+    for (const auto& [_, rs] : _rs_version_map) {
+        if (!rs->is_local()) {
+            has_cooldowned = true;
+            break;
+        }
+    }
     for (auto& [v, rs] : _rs_version_map) {
         auto predicate = rs->is_local() && v.first < min_local_version;
         if (!has_cooldowned) {
-            predicate &= rs->data_disk_size() > 0;
+            predicate = predicate && (rs->data_disk_size() > 0);
         }
         if (predicate) {
             // this is a local rowset and has data

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2227,9 +2227,16 @@ Status Tablet::_follow_cooldowned_data() {
 bool Tablet::_has_data_to_cooldown() {
     int64_t min_local_version = std::numeric_limits<int64_t>::max();
     RowsetSharedPtr rowset;
+    // Ususally once the tablet has done cooldown successfully then the first
+    // rowset would always be remote rowset
+    bool has_cooldowned = !_rs_version_map.begin()->second->is_local();
     std::shared_lock meta_rlock(_meta_lock);
     for (auto& [v, rs] : _rs_version_map) {
-        if (rs->is_local() && v.first < min_local_version && rs->data_disk_size() > 0) {
+        auto predicate = rs->is_local() && v.first < min_local_version;
+        if (!has_cooldowned) {
+            predicate &= rs->data_disk_size() > 0;
+        }
+        if (predicate) {
             // this is a local rowset and has data
             min_local_version = v.first;
             rowset = rs;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Consider two replica A, B
A: [0-11] [11-20] [20-33] A is the cooldown replica and the [20-33] rowset is empty 
B: [0,15] [11-22] [23-33]

Because the rowset[20-33] of A is empty, then this rowset would not be picked to be cooldown rowset, which means the max cooldown verison would be 20, and 20 is not suitable for replica B which would make B would never follow cooldown.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

