### PR TITLE
[fix](common) If the properties in DDL is not provided, the mysql client will lost connection.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PrintableMap.java
@@ -93,6 +93,9 @@ public class PrintableMap<K, V> {
 
     @Override
     public String toString() {
+        if (map == null) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder();
         Iterator<Map.Entry<K, V>> iter = showEntries().iterator();
         while (iter.hasNext()) {


### PR DESCRIPTION
[fix](common) If the properties in DDL is not provided, the mysql client will lost connection, and no error message is output on the client side.

## Case

If the properties in DDL is not provided (wrong DDL), the mysql client will lost connection:

```sql
mysql> CREATE EXTERNAL RESOURCE 'mysql_v';
ERROR 2013 (HY000): Lost connection to MySQL server during query
```
The correct error message should appear here.

Here is the stack trace: 
’‘’
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Resource properties can't be null
	at org.apache.doris.analysis.CreateResourceStmt.analyze(CreateResourceStmt.java:84) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:1080) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:728) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:509) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:462) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:245) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:193) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:246) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
2024-01-23 09:31:51,757 WARN (mysql-nio-pool-1|316) [ConnectProcessor.handleQueryException():329] Process one query failed because unknown reason: 
java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "this.map" is null
	at org.apache.doris.common.util.PrintableMap.showEntries(PrintableMap.java:108) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.common.util.PrintableMap.toString(PrintableMap.java:97) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.lang.String.valueOf(Unknown Source) ~[?:?]
	at java.lang.StringBuilder.append(Unknown Source) ~[?:?]
	at org.apache.doris.analysis.CreateResourceStmt.toSql(CreateResourceStmt.java:111) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.AuditLogHelper.logAuditLog(AuditLogHelper.java:101) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.ConnectProcessor.auditAfterExec(ConnectProcessor.java:171) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:267) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:193) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:246) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
‘’‘
It's because **PrintableMap.toString()** does not correctly handle the situation where map is null.

The test results are as follows：

'''sql
mysql> CREATE EXTERNAL RESOURCE 'mysql_v';
ERROR 1105 (HY000): errCode = 2, detailMessage = Resource properties can't be null
'''

## Further comments
The modification is small, please evaluate the side effects of this modification