### PR TITLE
[fix](Nereids): when predicate contains right output, don't convert outer to anti join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoin.java
@@ -81,7 +81,8 @@ public class ConvertOuterJoinToAntiJoin extends OneRewriteRuleFactory {
                             && rightAlwaysNullSlots.containsAll(p.getInputSlots())))
                     .collect(ImmutableSet.toImmutableSet());
             boolean containRightSlot = predicates.stream()
-                    .anyMatch(s -> join.right().getOutputSet().containsAll(s.getInputSlots()));
+                    .flatMap(p -> p.getInputSlots().stream())
+                    .anyMatch(join.right().getInputSlots()::contains);
             if (!containRightSlot) {
                 res = join.withJoinType(JoinType.LEFT_ANTI_JOIN);
                 res = predicates.isEmpty() ? res : filter.withConjuncts(predicates).withChildren(res);
@@ -94,7 +95,8 @@ public class ConvertOuterJoinToAntiJoin extends OneRewriteRuleFactory {
                             && leftAlwaysNullSlots.containsAll(p.getInputSlots())))
                     .collect(ImmutableSet.toImmutableSet());
             boolean containLeftSlot = predicates.stream()
-                    .anyMatch(s -> join.left().getOutputSet().containsAll(s.getInputSlots()));
+                    .flatMap(p -> p.getInputSlots().stream())
+                    .anyMatch(join.left().getInputSlots()::contains);
             if (!containLeftSlot) {
                 res = join.withJoinType(JoinType.RIGHT_ANTI_JOIN);
                 res = predicates.isEmpty() ? res : filter.withConjuncts(predicates).withChildren(res);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoin.java
@@ -82,7 +82,7 @@ public class ConvertOuterJoinToAntiJoin extends OneRewriteRuleFactory {
                     .collect(ImmutableSet.toImmutableSet());
             boolean containRightSlot = predicates.stream()
                     .flatMap(p -> p.getInputSlots().stream())
-                    .anyMatch(join.right().getInputSlots()::contains);
+                    .anyMatch(join.right().getOutputSet()::contains);
             if (!containRightSlot) {
                 res = join.withJoinType(JoinType.LEFT_ANTI_JOIN);
                 res = predicates.isEmpty() ? res : filter.withConjuncts(predicates).withChildren(res);
@@ -96,7 +96,7 @@ public class ConvertOuterJoinToAntiJoin extends OneRewriteRuleFactory {
                     .collect(ImmutableSet.toImmutableSet());
             boolean containLeftSlot = predicates.stream()
                     .flatMap(p -> p.getInputSlots().stream())
-                    .anyMatch(join.left().getInputSlots()::contains);
+                    .anyMatch(join.left().getOutputSet()::contains);
             if (!containLeftSlot) {
                 res = join.withJoinType(JoinType.RIGHT_ANTI_JOIN);
                 res = predicates.isEmpty() ? res : filter.withConjuncts(predicates).withChildren(res);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoinTest.java
@@ -18,9 +18,12 @@
 package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -50,7 +53,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
         LogicalPlan plan = new LogicalPlanBuilder(scan1)
                 .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
                 .filter(new IsNull(scan2.getOutput().get(0)))
-                .project(ImmutableList.of(0, 1))
+                .projectExprs(ImmutableList.copyOf(scan1.getOutput()))
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
@@ -65,7 +68,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
         LogicalPlan plan = new LogicalPlanBuilder(scan1)
                 .join(scan2, JoinType.RIGHT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
                 .filter(new IsNull(scan1.getOutput().get(0)))
-                .project(ImmutableList.of(2, 3))
+                .projectExprs(ImmutableList.copyOf(scan2.getOutput()))
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
@@ -76,12 +79,67 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
     }
 
     @Test
-    void testEliminateLeftWithPredicate() {
+    void testEliminateLeftWithLeftPredicate() {
+        LogicalPlan plan = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
+                .filter(Sets.newHashSet(
+                        new IsNull(scan2.getOutput().get(0)),
+                        new EqualTo(scan1.getOutput().get(0), new IntegerLiteral(1)))
+                )
+                .projectExprs(ImmutableList.copyOf(scan1.getOutput()))
+                .build();
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .applyTopDown(new InferFilterNotNull())
+                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .printlnTree()
+                .matches(logicalJoin().when(join -> join.getJoinType().isLeftAntiJoin()));
+    }
+
+    @Test
+    void testEliminateLeftWithRightPredicate() {
+        LogicalPlan plan = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
+                .filter(Sets.newHashSet(
+                        new IsNull(scan2.getOutput().get(0)),
+                        new EqualTo(scan2.getOutput().get(0), new IntegerLiteral(1)))
+                )
+                .projectExprs(ImmutableList.copyOf(scan1.getOutput()))
+                .build();
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .applyTopDown(new InferFilterNotNull())
+                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .printlnTree()
+                .matches(logicalJoin().when(join -> join.getJoinType().isLeftOuterJoin()));
+    }
+
+    @Test
+    void testEliminateLeftWithOrPredicate() {
         LogicalPlan plan = new LogicalPlanBuilder(scan1)
                 .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
                 .filter(Sets.newHashSet(
                         new IsNull(scan1.getOutput().get(0)),
                         new Or(new IsNull(scan1.getOutput().get(0)), new IsNull(scan2.getOutput().get(0))))
+                )
+                .projectExprs(ImmutableList.copyOf(scan1.getOutput()))
+                .build();
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .applyTopDown(new InferFilterNotNull())
+                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .printlnTree()
+                .matches(logicalJoin().when(join -> join.getJoinType().isLeftOuterJoin()));
+    }
+
+    @Test
+    void testEliminateLeftWithAndPredicate() {
+        LogicalPlan plan = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
+                .filter(Sets.newHashSet(
+                        new IsNull(scan1.getOutput().get(0)),
+                        new And(new EqualTo(scan1.getOutput().get(0), new IntegerLiteral(1)),
+                                new EqualTo(scan1.getOutput().get(0), new IntegerLiteral(1))))
                 )
                 .project(ImmutableList.of(2, 3))
                 .build();


### PR DESCRIPTION
## Proposed changes

when predicate contains right output, don't convert outer to anti join 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

