### PR TITLE
[bug](node) fix enable shared scan return wrong instances

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1344,7 +1344,7 @@ public class OlapScanNode extends ScanNode {
         if (ConnectContext.get().getSessionVariable().getEnablePipelineEngine()
                 && !ConnectContext.get().getSessionVariable().getEnablePipelineXEngine()
                 && ConnectContext.get().getSessionVariable().getEnableSharedScan()) {
-            return ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
+            return ConnectContext.get().getSessionVariable().getParallelExecInstanceNum() * scanBackendIds.size();
         }
         if (ConnectContext.get().getSessionVariable().getEnablePipelineXEngine()
                 && ConnectContext.get().getSessionVariable().isIgnoreStorageDataDistribution()) {


### PR DESCRIPTION
## Proposed changes
when enable shared scan and enable pipeline, so it's will return instance num
but is we have more than one BE, it's still return 1 and will generate wrong plan. 

<img width="409" alt="shared_scan" src="https://github.com/apache/doris/assets/87313068/3e1c0ce0-93da-4723-a05f-554b3892f20a">

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

