### PR TITLE
[improve](stream-load) do not print stack trace when get data from pipe meet cancel

### DIFF
--- a/be/src/io/fs/stream_load_pipe.cpp
+++ b/be/src/io/fs/stream_load_pipe.cpp
@@ -64,7 +64,7 @@ Status StreamLoadPipe::read_at_impl(size_t /*offset*/, Slice result, size_t* byt
         }
         // cancelled
         if (_cancelled) {
-            return Status::InternalError("cancelled: {}", _cancelled_reason);
+            return Status::InternalError<false>("cancelled: {}", _cancelled_reason);
         }
         // finished
         if (_buf_queue.empty()) {
@@ -168,7 +168,7 @@ Status StreamLoadPipe::_read_next_buffer(std::unique_ptr<uint8_t[]>* data, size_
     }
     // cancelled
     if (_cancelled) {
-        return Status::InternalError("cancelled: {}", _cancelled_reason);
+        return Status::InternalError<false>("cancelled: {}", _cancelled_reason);
     }
     // finished
     if (_buf_queue.empty()) {
@@ -210,7 +210,7 @@ Status StreamLoadPipe::_append(const ByteBufferPtr& buf, size_t proto_byte_size)
             }
         }
         if (_cancelled) {
-            return Status::InternalError("cancelled: {}", _cancelled_reason);
+            return Status::InternalError<false>("cancelled: {}", _cancelled_reason);
         }
         _buf_queue.push_back(buf);
         if (_use_proto) {


### PR DESCRIPTION
## Proposed changes

Do not print stack trace when get data from pipe meet cancel, for the stack cannot obtain valid information.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

