### PR TITLE
[improvement](statistics)Catch load column stats exception, avoid print too much stack info to fe.out

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
@@ -42,18 +42,25 @@ public class ColumnStatisticsCacheLoader extends StatisticsCacheLoader<Optional<
 
     @Override
     protected Optional<ColumnStatistic> doLoad(StatisticsCacheKey key) {
-        // Load from statistics table.
-        Optional<ColumnStatistic> columnStatistic = loadFromStatsTable(key);
-        if (columnStatistic.isPresent()) {
-            return columnStatistic;
-        }
-        // Load from data source metadata
+        Optional<ColumnStatistic> columnStatistic = Optional.empty();
         try {
-            TableIf table = StatisticsUtil.findTable(key.catalogId, key.dbId, key.tableId);
-            columnStatistic = table.getColumnStatistic(key.colName);
-        } catch (Exception e) {
-            LOG.debug(String.format("Exception to get column statistics by metadata. [Catalog:%d, DB:%d, Table:%d]",
-                    key.catalogId, key.dbId, key.tableId), e);
+            // Load from statistics table.
+            columnStatistic = loadFromStatsTable(key);
+            if (columnStatistic.isPresent()) {
+                return columnStatistic;
+            }
+            // Load from data source metadata
+            try {
+                TableIf table = StatisticsUtil.findTable(key.catalogId, key.dbId, key.tableId);
+                columnStatistic = table.getColumnStatistic(key.colName);
+            } catch (Exception e) {
+                LOG.debug(String.format("Exception to get column statistics by metadata. [Catalog:{}, DB:{}, Table:{}]",
+                        key.catalogId, key.dbId, key.tableId), e);
+            }
+        } catch (Throwable t) {
+            LOG.warn("Failed to load stats for column [Catalog:{}, DB:{}, Table:{}, Column:{}], Reason: {}",
+                    key.catalogId, key.dbId, key.tableId, key.colName, t.getMessage());
+            LOG.debug(t);
         }
         return columnStatistic;
     }


### PR DESCRIPTION
Before, the error stack info will print to fe.out when stats cache failed to load stats for a column, because the exception is not catched. This pr cache the exception and print log to fe.log

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

