### PR TITLE
[fix](memory leak) LikeState leak in Doris BE

### DIFF
--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -264,6 +264,7 @@ private:
     Status _append_rf_into_conjuncts(std::vector<VExpr*>& vexprs);
 
     Status _normalize_conjuncts();
+    void _close_expr_inside_stale_ctxs(VExpr* expr, VExpr* new_root);
     Status _normalize_predicate(VExpr* conjunct_expr_root, VExpr** output_expr);
     Status _eval_const_conjuncts(VExpr* vexpr, VExprContext* expr_ctx, PushDownType* pdt);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close https://github.com/apache/doris/issues/30319

<!--Describe your changes.-->

1. after `VScanNode::_append_rf_into_conjuncts`, old `VExprContext` saved into `_stale_vexpr_ctxs`, but old and new `VExprContext` share the same VExpr tree.
2. after `VScanNode::_normalize_conjuncts`, the VExpr tree changed inside new `VExprContext`, it also changed the VExpr tree inside old `VExprContext`
3. at last when we try to close `_stale_vexpr_ctxs`, some VExpr node already lost, so we do not close it correctly.


The key point of the reproduce steps:
a) trigger runtime filter, make old context save into _stale_vexpr_ctxs
b) part of the VExpr pushed down, make the VExpr tree changed


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

