### PR TITLE
[fix](fe) Fix `FrontendHbResponse` serialization compatibility problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/FrontendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FrontendHbResponse.java
@@ -120,7 +120,6 @@ public class FrontendHbResponse extends HeartbeatResponse implements Writable {
         name = Text.readString(in);
         queryPort = in.readInt();
         rpcPort = in.readInt();
-        arrowFlightSqlPort = in.readInt();
         replayedJournalId = in.readLong();
     }
 


### PR DESCRIPTION
* Between branch-1.2-lts and branch-2.1, `FrontendHbResponse` has upgrade compatiblity problem, because `arrowFlightSqlPort` field, only metaVerserion less than FeMetaVersion.VERSION_121 will call `FrontendHbResponse.readField`

* Introduced by https://github.com/apache/doris/pull/24314

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

