### PR TITLE
[minor](Cooldown) Log the old rowset id when uploading rowset to S3

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1978,7 +1978,8 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     LOG(INFO) << "Upload rowset " << old_rowset->version() << " " << new_rowset_id.to_string()
               << " to " << dest_fs->root_path().native() << ", tablet_id=" << tablet_id()
               << ", duration=" << duration.count() << ", capacity=" << old_rowset->data_disk_size()
-              << ", tp=" << old_rowset->data_disk_size() / duration.count();
+              << ", tp=" << old_rowset->data_disk_size() / duration.count()
+              << ", old rowset_id=" << old_rowset->rowset_id().to_string();
 
     // gen a new rowset
     auto new_rowset_meta = std::make_shared<RowsetMeta>();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Sometimes the old rowsets might not be garbage collected in time. And we lack a way to trace the old rowset so i add this log to trace it based on the rowset id it has. 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

