### PR TITLE
[bugfix](core) fix core due to send rpc and request is deconstructed

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -100,9 +100,12 @@ ExchangeSinkBuffer<Parent>::~ExchangeSinkBuffer() = default;
 
 template <typename Parent>
 void ExchangeSinkBuffer<Parent>::close() {
-    _instance_to_broadcast_package_queue.clear();
-    _instance_to_package_queue.clear();
-    _instance_to_request.clear();
+    // Could not clear the queue here, because there maybe a running rpc want to
+    // get a request from the queue, and clear method will release the request
+    // and it will core.
+    //_instance_to_broadcast_package_queue.clear();
+    //_instance_to_package_queue.clear();
+    //_instance_to_request.clear();
 }
 
 template <typename Parent>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
*** Query id: 2f8f6fe4dc06492e-bdaa7c76ece18bf4 ***
*** tablet id: 0 ***
*** Aborted at 1706136845 (unix time) try "date -d @1706136845" if you are using GNU date ***
*** Current BE git commitID: c7360fd014 ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 3140925 (TID 3143573 OR 0x7f3f99a0e700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:417
 1# 0x00007F45D10000A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F45D0FF902C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F45D5A28090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::Status::to_protobuf(doris::PStatus*) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.cpp:49
 6# doris::pipeline::ExchangeSinkBuffer::_send_rpc(long) in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
 7# doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::{lambda(long const&, bool const&, doris::PTransmitDataResult const&, long const&)#1}::operator()(long const&, bool const&, doris::PTransmitDataResult const&, long const&) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/exchange_sink_buffer.cpp:303
 8# doris::pipeline::ExchangeSendCallback::call() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/exchange_sink_buffer.h:182
 9# doris::AutoReleaseClosure >::Run() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/ref_count_closure.h:91
10# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
11# brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
12# brpc::ProcessInputMessage(void*) in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
13# bthread::TaskGroup::task_runner(long) in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
14# bthread_make_fcontext in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

