### PR TITLE
[memoryleak](execontext) dctor should be virtual to avoid memory leak

### DIFF
--- a/be/src/runtime/task_execution_context.h
+++ b/be/src/runtime/task_execution_context.h
@@ -45,6 +45,8 @@ struct HasTaskExecutionCtx {
     template <typename T>
     HasTaskExecutionCtx(T* state) : task_exec_ctx_(state->get_task_execution_context()) {}
 
+    virtual ~HasTaskExecutionCtx() = default;
+
 public:
     inline TaskExecutionContextSPtr task_exec_ctx() const { return task_exec_ctx_.lock(); }
     inline Weak weak_task_exec_ctx() const { return task_exec_ctx_; }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

