### PR TITLE
[feat](Nereids): make alias has the same slot id with its namedexpression child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -46,18 +46,23 @@ public class Alias extends NamedExpression implements UnaryExpression {
      * @param name alias name
      */
     public Alias(Expression child, String name) {
-        this(StatementScopeIdGenerator.newExprId(), child, name, false);
+        this(child instanceof NamedExpression
+                ? ((Slot) child).getExprId()
+                : StatementScopeIdGenerator.newExprId(),
+                child, name, false);
     }
 
     public Alias(Expression child) {
-        this(StatementScopeIdGenerator.newExprId(), child, child.toSql(), true);
+        this(child instanceof NamedExpression
+                ? ((Slot) child).getExprId()
+                : StatementScopeIdGenerator.newExprId(), child, child.toSql(), true);
     }
 
     public Alias(ExprId exprId, Expression child, String name) {
         this(exprId, ImmutableList.of(child), name, ImmutableList.of(), false);
     }
 
-    public Alias(ExprId exprId, Expression child, String name, boolean nameFromChild) {
+    private Alias(ExprId exprId, Expression child, String name, boolean nameFromChild) {
         this(exprId, ImmutableList.of(child), name, ImmutableList.of(), nameFromChild);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/EliminateJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/EliminateJoinTest.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class EliminateJoinTest extends SqlTestBase {
@@ -120,7 +119,6 @@ class EliminateJoinTest extends SqlTestBase {
         dropConstraint("alter table T2 drop constraint pk");
     }
 
-    @Disabled
     @Test
     void testLOJWithPKFKAndUK1() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("INFER_PREDICATES");
@@ -154,7 +152,6 @@ class EliminateJoinTest extends SqlTestBase {
         dropConstraint("alter table T3 drop constraint uk");
     }
 
-    @Disabled
     @Test
     void testLOJWithPKFKAndUK2() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("INFER_PREDICATES");


### PR DESCRIPTION
## Proposed changes
make alias has the same slot id with its namedexpression child

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

