### PR TITLE
[fix](cmake) Fix be cmake coverage linker flag #30386

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -660,6 +660,7 @@ set(BUILD_SHARED_LIBS OFF)
 option(ENABLE_CLANG_COVERAGE "coverage option" OFF)
 if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping -DLLVM_PROFILE)
+    add_link_options(-fprofile-instr-generate)
 endif ()
 
 if (MAKE_TEST)


### PR DESCRIPTION
## Proposed changes

Fix be cmake coverage linker flag


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

