### PR TITLE
[fix](Cooldown) enhance the policy existence check logic when drop storage policy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -156,7 +156,7 @@ public class PolicyMgr implements Writable {
                     if (table instanceof OlapTable) {
                         OlapTable olapTable = (OlapTable) table;
                         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-                        for (Long partitionId: olapTable.getPartitionIds()) {
+                        for (Long partitionId : olapTable.getPartitionIds()) {
                             String policyName = partitionInfo.getDataProperty(partitionId).getStoragePolicy();
                             if (policyName.equals(dropPolicyLog.getPolicyName())) {
                                 throw new DdlException("the policy " + policyName + " is used by table: "

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
@@ -153,9 +154,14 @@ public class PolicyMgr implements Writable {
                 List<Table> tables = db.getTables();
                 for (Table table : tables) {
                     if (table instanceof OlapTable) {
-                        if (((OlapTable) table).getStoragePolicy().equals(dropPolicyLog.getPolicyName())) {
-                            throw new DdlException("the policy " + dropPolicyLog.getPolicyName() + " is used by table: "
+                        OlapTable olapTable = (OlapTable) table;
+                        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+                        for (Long partitionId: olapTable.getPartitionIds()) {
+                            String policyName = partitionInfo.getDataProperty(partitionId).getStoragePolicy();
+                            if (policyName.equals(dropPolicyLog.getPolicyName())) {
+                                throw new DdlException("the policy " + policyName + " is used by table: "
                                     + table.getName());
+                            }
                         }
                     }
                 }

--- a/regression-test/suites/cold_heat_separation/policy/drop.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop.groovy
@@ -110,15 +110,29 @@ suite("drop_policy") {
         """
         assertEquals(storage_exist.call("drop_policy_test_has_table_binded"), true)
 
+        def create_succ_3 = try_sql """
+            CREATE STORAGE POLICY IF NOT EXISTS drop_policy_test_has_table_bind_1
+            PROPERTIES(
+            "storage_resource" = "${resource_table_use}",
+            "cooldown_datetime" = "2025-06-08 00:00:00"
+            );
+        """
+        assertEquals(storage_exist.call("drop_policy_test_has_table_bind_1"), true)
+
         // success
         def create_table_use_created_policy = try_sql """
             CREATE TABLE IF NOT EXISTS create_table_binding_created_policy
             (
                 k1 BIGINT,
-                k2 LARGEINT,
+                k2 date,
                 v1 VARCHAR(2048)
             )
             UNIQUE KEY(k1)
+            PARTITION BY RANGE(k2)(
+                partition p1 VALUES LESS THAN ("2014-01-01") ("storage_policy" = "drop_policy_test_has_table_bind_1"),
+                partition p2 VALUES LESS THAN ("2015-01-01"),
+                partition p3 VALUES LESS THAN ("2016-01-01")
+            )
             DISTRIBUTED BY HASH (k1) BUCKETS 3
             PROPERTIES(
                 "storage_policy" = "drop_policy_test_has_table_binded",
@@ -136,12 +150,22 @@ suite("drop_policy") {
         // fail to drop, there are tables using this policy
         assertEquals(drop_policy_fail_ret, null)
 
+        def drop_policy_fail_ret = try_sql """
+            DROP STORAGE POLICY drop_policy_test_has_table_bind_1
+        """
+        // fail to drop, there are partitions using this policy
+        assertEquals(drop_policy_fail_ret, null)
+
         sql """
         DROP TABLE create_table_binding_created_policy;
         """
 
         sql """
         DROP STORAGE POLICY drop_policy_test_has_table_binded;
+        """
+
+        sql """
+        DROP STORAGE POLICY drop_policy_test_has_table_bind_1;
         """
 
         sql """

--- a/regression-test/suites/cold_heat_separation/policy/drop.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop.groovy
@@ -127,7 +127,7 @@ suite("drop_policy") {
                 k2 date,
                 v1 VARCHAR(2048)
             )
-            UNIQUE KEY(k1)
+            UNIQUE KEY(k1, k2)
             PARTITION BY RANGE(k2)(
                 partition p1 VALUES LESS THAN ("2014-01-01") ("storage_policy" = "drop_policy_test_has_table_bind_1"),
                 partition p2 VALUES LESS THAN ("2015-01-01"),

--- a/regression-test/suites/cold_heat_separation/policy/drop.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop.groovy
@@ -150,7 +150,7 @@ suite("drop_policy") {
         // fail to drop, there are tables using this policy
         assertEquals(drop_policy_fail_ret, null)
 
-        def drop_policy_fail_ret = try_sql """
+        drop_policy_fail_ret = try_sql """
             DROP STORAGE POLICY drop_policy_test_has_table_bind_1
         """
         // fail to drop, there are partitions using this policy


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

As we know that the storage policy's granularity is for the partition which means that former check for table's property `storage policy` is not suitable because when you have one partition specified for another policy different from the table has, the former check logic will not throw exception to terminate the drop action.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

