### PR TITLE
[minor](Prefetch) log slow prefetch io operation

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1144,7 +1144,7 @@ DEFINE_Int32(ingest_binlog_work_pool_size, "-1");
 // Download binlog rate limit, unit is KB/s, 0 means no limit
 DEFINE_Int32(download_binlog_rate_limit_kbs, "0");
 
-DEFINE_mInt32(buffered_reader_read_timeout_ms, "20000");
+DEFINE_mInt32(buffered_reader_read_timeout_ms, "600000");
 
 DEFINE_Bool(enable_snapshot_action, "false");
 

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -356,6 +356,8 @@ struct PrefetchBuffer : std::enable_shared_from_this<PrefetchBuffer> {
     size_t merge_small_ranges(size_t off, int range_index) const;
 };
 
+constexpr int64_t s_max_pre_buffer_size = 4 * 1024 * 1024; // 4MB
+
 /**
  * A buffered reader that prefetch data in the daemon thread pool.
  *
@@ -420,7 +422,6 @@ private:
     PrefetchRange _file_range;
     const std::vector<PrefetchRange>* _random_access_ranges = nullptr;
     const IOContext* _io_ctx = nullptr;
-    int64_t s_max_pre_buffer_size = 4 * 1024 * 1024; // 4MB
     std::vector<std::shared_ptr<PrefetchBuffer>> _pre_buffers;
     int64_t _whole_pre_buffer_size;
     bool _initialized = false;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Loosen the timeout condition for prefetch io and log the slow operation.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

