### PR TITLE
[fix](Nereids): create constraint write edit log in lock scope

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -237,29 +237,33 @@ public interface TableIf {
         }
     }
 
-    default void addUniqueConstraint(String name, ImmutableList<String> columns) {
+    default void addUniqueConstraint(String name, ImmutableList<String> columns, boolean replay) {
         writeLock();
         try {
             Map<String, Constraint> constraintMap = getConstraintsMapUnsafe();
             UniqueConstraint uniqueConstraint =  new UniqueConstraint(name, ImmutableSet.copyOf(columns));
             checkConstraintNotExistenceUnsafe(name, uniqueConstraint, constraintMap);
             constraintMap.put(name, uniqueConstraint);
-            Env.getCurrentEnv().getEditLog().logAddConstraint(
-                    new AlterConstraintLog(uniqueConstraint, this));
+            if (!replay) {
+                Env.getCurrentEnv().getEditLog().logAddConstraint(
+                        new AlterConstraintLog(uniqueConstraint, this));
+            }
         } finally {
             writeUnlock();
         }
     }
 
-    default void addPrimaryKeyConstraint(String name, ImmutableList<String> columns) {
+    default void addPrimaryKeyConstraint(String name, ImmutableList<String> columns, boolean replay) {
         writeLock();
         try {
             Map<String, Constraint> constraintMap = getConstraintsMapUnsafe();
             PrimaryKeyConstraint primaryKeyConstraint = new PrimaryKeyConstraint(name, ImmutableSet.copyOf(columns));
             checkConstraintNotExistenceUnsafe(name, primaryKeyConstraint, constraintMap);
             constraintMap.put(name, primaryKeyConstraint);
-            Env.getCurrentEnv().getEditLog().logAddConstraint(
-                    new AlterConstraintLog(primaryKeyConstraint, this));
+            if (!replay) {
+                Env.getCurrentEnv().getEditLog().logAddConstraint(
+                        new AlterConstraintLog(primaryKeyConstraint, this));
+            }
         } finally {
             writeUnlock();
         }
@@ -279,7 +283,7 @@ public interface TableIf {
     }
 
     default void addForeignConstraint(String name, ImmutableList<String> columns,
-            TableIf referencedTable, ImmutableList<String> referencedColumns) {
+            TableIf referencedTable, ImmutableList<String> referencedColumns, boolean replay) {
         writeLock();
         referencedTable.writeLock();
         try {
@@ -293,8 +297,10 @@ public interface TableIf {
                     tryGetPrimaryKeyForForeignKeyUnsafe(requirePrimaryKeyName, referencedTable);
             primaryKeyConstraint.addForeignTable(this);
             constraintMap.put(name, foreignKeyConstraint);
-            Env.getCurrentEnv().getEditLog().logAddConstraint(
-                    new AlterConstraintLog(foreignKeyConstraint, this));
+            if (!replay) {
+                Env.getCurrentEnv().getEditLog().logAddConstraint(
+                        new AlterConstraintLog(foreignKeyConstraint, this));
+            }
         } finally {
             referencedTable.writeUnlock();
             writeUnlock();
@@ -305,17 +311,17 @@ public interface TableIf {
         if (constraint instanceof UniqueConstraint) {
             UniqueConstraint uniqueConstraint = (UniqueConstraint) constraint;
             this.addUniqueConstraint(constraint.getName(),
-                    ImmutableList.copyOf(uniqueConstraint.getUniqueColumnNames()));
+                    ImmutableList.copyOf(uniqueConstraint.getUniqueColumnNames()), true);
         } else if (constraint instanceof PrimaryKeyConstraint) {
             PrimaryKeyConstraint primaryKeyConstraint = (PrimaryKeyConstraint) constraint;
             this.addPrimaryKeyConstraint(primaryKeyConstraint.getName(),
-                    ImmutableList.copyOf(primaryKeyConstraint.getPrimaryKeyNames()));
+                    ImmutableList.copyOf(primaryKeyConstraint.getPrimaryKeyNames()), true);
         } else if (constraint instanceof ForeignKeyConstraint) {
             ForeignKeyConstraint foreignKey = (ForeignKeyConstraint) constraint;
             this.addForeignConstraint(foreignKey.getName(),
                     ImmutableList.copyOf(foreignKey.getForeignKeyNames()),
                     foreignKey.getReferencedTable(),
-                    ImmutableList.copyOf(foreignKey.getReferencedColumnNames()));
+                    ImmutableList.copyOf(foreignKey.getReferencedColumnNames()), true);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -296,7 +296,7 @@ public interface TableIf {
             Env.getCurrentEnv().getEditLog().logAddConstraint(
                     new AlterConstraintLog(foreignKeyConstraint, this));
         } finally {
-            referencedTable.writeLock();
+            referencedTable.writeUnlock();
             writeUnlock();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AddConstraintCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AddConstraintCommand.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.NereidsPlanner;
@@ -30,7 +29,6 @@ import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel
 import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
-import org.apache.doris.persist.AlterConstraintLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
@@ -63,19 +61,16 @@ public class AddConstraintCommand extends Command implements ForwardWithSync {
     @Override
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         Pair<ImmutableList<String>, TableIf> columnsAndTable = extractColumnsAndTable(ctx, constraint.toProject());
-        org.apache.doris.catalog.constraint.Constraint catalogConstraint = null;
         if (constraint.isForeignKey()) {
             Pair<ImmutableList<String>, TableIf> referencedColumnsAndTable
                     = extractColumnsAndTable(ctx, constraint.toReferenceProject());
-            catalogConstraint = columnsAndTable.second.addForeignConstraint(name, columnsAndTable.first,
+            columnsAndTable.second.addForeignConstraint(name, columnsAndTable.first,
                     referencedColumnsAndTable.second, referencedColumnsAndTable.first);
         } else if (constraint.isPrimaryKey()) {
-            catalogConstraint = columnsAndTable.second.addPrimaryKeyConstraint(name, columnsAndTable.first);
+            columnsAndTable.second.addPrimaryKeyConstraint(name, columnsAndTable.first);
         } else if (constraint.isUnique()) {
-            catalogConstraint = columnsAndTable.second.addUniqueConstraint(name, columnsAndTable.first);
+            columnsAndTable.second.addUniqueConstraint(name, columnsAndTable.first);
         }
-        Env.getCurrentEnv().getEditLog().logAddConstraint(
-                new AlterConstraintLog(catalogConstraint, columnsAndTable.second));
     }
 
     private Pair<ImmutableList<String>, TableIf> extractColumnsAndTable(ConnectContext ctx, LogicalPlan plan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AddConstraintCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AddConstraintCommand.java
@@ -65,11 +65,11 @@ public class AddConstraintCommand extends Command implements ForwardWithSync {
             Pair<ImmutableList<String>, TableIf> referencedColumnsAndTable
                     = extractColumnsAndTable(ctx, constraint.toReferenceProject());
             columnsAndTable.second.addForeignConstraint(name, columnsAndTable.first,
-                    referencedColumnsAndTable.second, referencedColumnsAndTable.first);
+                    referencedColumnsAndTable.second, referencedColumnsAndTable.first, false);
         } else if (constraint.isPrimaryKey()) {
-            columnsAndTable.second.addPrimaryKeyConstraint(name, columnsAndTable.first);
+            columnsAndTable.second.addPrimaryKeyConstraint(name, columnsAndTable.first, false);
         } else if (constraint.isUnique()) {
-            columnsAndTable.second.addUniqueConstraint(name, columnsAndTable.first);
+            columnsAndTable.second.addUniqueConstraint(name, columnsAndTable.first, false);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropConstraintCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropConstraintCommand.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -28,7 +27,6 @@ import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel
 import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
-import org.apache.doris.persist.AlterConstraintLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
@@ -58,8 +56,7 @@ public class DropConstraintCommand extends Command implements ForwardWithSync {
     @Override
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         TableIf table = extractTable(ctx, plan);
-        org.apache.doris.catalog.constraint.Constraint catalogConstraint = table.dropConstraint(name);
-        Env.getCurrentEnv().getEditLog().logDropConstraint(new AlterConstraintLog(catalogConstraint, table));
+        table.dropConstraint(name);
     }
 
     private TableIf extractTable(ConnectContext ctx, LogicalPlan plan) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/constraint/ConstraintPersistTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/constraint/ConstraintPersistTest.java
@@ -170,7 +170,7 @@ class ConstraintPersistTest extends TestWithFeService implements PlanPatternMatc
     void externalTableTest() throws Exception {
         ExternalTable externalTable =  new ExternalTable();
         try {
-            externalTable.addPrimaryKeyConstraint("pk", ImmutableList.of("col"));
+            externalTable.addPrimaryKeyConstraint("pk", ImmutableList.of("col"), false);
         } catch (Exception ignore) {
             // ignore
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/constraint/ConstraintPersistTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/constraint/ConstraintPersistTest.java
@@ -169,8 +169,11 @@ class ConstraintPersistTest extends TestWithFeService implements PlanPatternMatc
     @Test
     void externalTableTest() throws Exception {
         ExternalTable externalTable =  new ExternalTable();
-        externalTable.addPrimaryKeyConstraint("pk", ImmutableList.of("col"));
-
+        try {
+            externalTable.addPrimaryKeyConstraint("pk", ImmutableList.of("col"));
+        } catch (Exception ignore) {
+            // ignore
+        }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutput output = new DataOutputStream(outputStream);
         externalTable.write(output);


### PR DESCRIPTION
## Proposed changes

write edit log in lock scope to ensure the order of log sequence.

To avoid the sequence like:
```
add primary key pk1
add foreign key ref pk1
log foreign key
log primary key
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

