### PR TITLE
[fix](fe) Fix fe cannot start because npe in replayEraseTable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -407,7 +407,15 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         LOG.info("before replay erase table[{}]", tableId);
         RecycleTableInfo tableInfo = idToTable.remove(tableId);
         idToRecycleTime.remove(tableId);
+        if (tableInfo == null) {
+            LOG.warn("tableInfo {} is null, idToTable:{}", tableId, idToTable);
+            return;
+        }
         Table table = tableInfo.getTable();
+        if (table == null) {
+            LOG.warn("tableId {} is null, idToTable:{}", tableId, idToTable);
+            return;
+        }
         if (table.getType() == TableType.OLAP && !Env.isCheckpointThread()) {
             Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, true);
         }


### PR DESCRIPTION
* According to stack, we cannot find the root cause for reproducing the problem, the pr just bypass the problem to make fe start

```
ERROR (stateListener|89) [EditLog.loadJournal():1102] Operation Type 15
java.lang.NullPointerException: null
    at org.apache.doris.catalog.CatalogRecycleBin.replayEraseTable(CatalogRecycleBin.java:411) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.InternalCatalog.replayEraseTable(InternalCatalog.java:967) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env.replayEraseTable(Env.java:3403) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:274) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env.replayJournal(Env.java:2525) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env.transferToMaster(Env.java:1329) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env.access$1200(Env.java:278) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env$4.runOneCycle(Env.java:2435) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

