### PR TITLE
[improve](stream-load) add observability on receiving HTTP request

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -208,6 +208,8 @@ public:
     int64_t pre_commit_txn_cost_nanos = 0;
     int64_t read_data_cost_nanos = 0;
     int64_t write_data_cost_nanos = 0;
+    int64_t receive_and_read_data_cost_nanos = 0;
+    int64_t begin_receive_and_read_data_cost_nanos = 0;
 
     std::string error_url = "";
     // if label already be used, set existing job's status here

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -68,7 +68,7 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
 // submit this params
 #ifndef BE_TEST
     ctx->start_write_data_nanos = MonotonicNanos();
-    LOG(INFO) << "begin to execute job. label=" << ctx->label << ", txn_id=" << ctx->txn_id
+    LOG(INFO) << "begin to execute stream load. label=" << ctx->label << ", txn_id=" << ctx->txn_id
               << ", query_id=" << print_id(ctx->put_result.params.params.query_id);
     Status st;
     auto exec_fragment = [ctx, this](RuntimeState* state, Status* status) {
@@ -148,6 +148,14 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
                 static_cast<void>(this->commit_txn(ctx.get()));
             }
         }
+
+        LOG(INFO) << "finished to execute stream load. label=" << ctx->label
+                  << ", txn_id=" << ctx->txn_id
+                  << ", query_id=" << print_id(ctx->put_result.params.params.query_id)
+                  << ", receive_data_cost_ms="
+                  << (ctx->receive_and_read_data_cost_nanos - ctx->read_data_cost_nanos) / 1000000
+                  << ", read_data_cost_ms=" << ctx->read_data_cost_nanos / 1000000
+                  << ", write_data_cost_ms=" << ctx->write_data_cost_nanos / 1000000;
     };
 
     if (ctx->put_result.__isset.params) {


### PR DESCRIPTION
## Proposed changes

We meet occasional slow stream-load, ReadDataTimeMs is very fast but WriteDataTimeMs is too long, according to some logs, it can be inferred that data from receive to vtablet_writer is slow, but can not judge the root cause is the scanner slow or is it slow to receive data. Finally, finding the network is too slow, but it costs lots of time. Therefore, recording the time on receiving HTTP request is helpful to users to know why the load is slow.

### Observability effect
**bvar**
![dIK2Q8phqj](https://github.com/apache/doris/assets/77738092/4afa75ed-85d7-4522-833b-85349ab46496)
![BkrtkIfR93](https://github.com/apache/doris/assets/77738092/6df59e20-0c66-4a6e-98bd-f1d158ba481e)

**logs**
```
finished to execute stream load. label=5fb08e7b-bfa4-440a-881f-81097ab986c5, txn_id=23043, query_id=f54a858b9118ef65-9f9f6e362c689ea4, receive_data_co
st_ms=216, read_data_cost_ms=7803, write_data_cost_ms=9437
```



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

