### PR TITLE
[fix](fe) Fix `BackendHbResponse` serialization compatibility problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -129,7 +129,6 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         bePort = in.readInt();
         httpPort = in.readInt();
         brpcPort = in.readInt();
-        arrowFlightSqlPort = in.readInt();
     }
 
     @Override


### PR DESCRIPTION
* Similar to https://github.com/apache/doris/pull/30337

* Between branch-1.2-lts and branch-2.1, `FrontendHbResponse` has upgrade compatiblity problem, because `arrowFlightSqlPort` field, only metaVerserion less than FeMetaVersion.VERSION_121 will call `BackendHbResponse.readField`

* Introduced by https://github.com/apache/doris/pull/24314

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

