### PR TITLE
[bug](function) fix date_sub function failed when arg type is datev2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -148,9 +148,10 @@ public class TimestampArithmeticExpr extends Expr {
         }
         // could try cast to date first, then cast to datetime
         if (t1 == PrimitiveType.VARCHAR || t1 == PrimitiveType.STRING) {
-            if (((StringLiteral) getChild(0)).canConvertToDateType(Type.DATEV2)) {
+            Expr expr = getChild(0);
+            if ((expr instanceof StringLiteral) && ((StringLiteral) expr).canConvertToDateType(Type.DATEV2)) {
                 try {
-                    setChild(0, new DateLiteral(((StringLiteral) getChild(0)).getValue(), Type.DATEV2));
+                    setChild(0, new DateLiteral(((StringLiteral) expr).getValue(), Type.DATEV2));
                 } catch (AnalysisException e) {
                     return Type.INVALID;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -146,6 +146,17 @@ public class TimestampArithmeticExpr extends Expr {
         if (t1 == PrimitiveType.DATEV2) {
             return Type.DATEV2;
         }
+        // could try cast to date first, then cast to datetime
+        if (t1 == PrimitiveType.VARCHAR || t1 == PrimitiveType.STRING) {
+            if (((StringLiteral) getChild(0)).canConvertToDateType(Type.DATEV2)) {
+                try {
+                    setChild(0, new DateLiteral(((StringLiteral) getChild(0)).getValue(), Type.DATEV2));
+                } catch (AnalysisException e) {
+                    return Type.INVALID;
+                }
+                return Type.DATEV2;
+            }
+        }
         if (PrimitiveType.isImplicitCast(t1, PrimitiveType.DATETIME)) {
             if (Config.enable_date_conversion) {
                 if (t1 == PrimitiveType.NULL_TYPE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -188,6 +188,11 @@ public class FEFunctions {
         return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 
+    @FEFunction(name = "days_sub", argTypes = { "DATETIMEV2", "INT" }, returnType = "DATETIMEV2")
+    public static DateLiteral daysSubDateTimeV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
     @FEFunction(name = "days_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral daysSubDateV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -168,6 +168,11 @@ public class FEFunctions {
         return dateAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 
+    @FEFunction(name = "date_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
+    public static DateLiteral dateSubDateV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return dateAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
     @FEFunction(name = "years_sub", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")
     public static DateLiteral yearsSub(LiteralExpr date, LiteralExpr year) throws AnalysisException {
         return yearsAdd(date, new IntLiteral(-(int) year.getLongValue()));
@@ -180,6 +185,11 @@ public class FEFunctions {
 
     @FEFunction(name = "days_sub", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")
     public static DateLiteral daysSub(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
+    @FEFunction(name = "days_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
+    public static DateLiteral daysSubDateV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -22,14 +22,17 @@ package org.apache.doris.rewrite;
 
 
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.ArithmeticExpr;
 import org.apache.doris.analysis.BetweenPredicate;
 import org.apache.doris.analysis.CaseExpr;
 import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.InformationFunction;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TimestampArithmeticExpr;
 import org.apache.doris.analysis.VariableExpr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
@@ -96,7 +99,8 @@ public class FoldConstantsRule implements ExprRewriteRule {
         // of the Expr tree. Assumes the bottom-up application of this rule. Constant
         // children should have been folded at this point.
         for (Expr child : expr.getChildren()) {
-            if (!child.isLiteral() && !(child instanceof CastExpr)) {
+            if (!child.isLiteral() && !(child instanceof CastExpr) && !((child instanceof FunctionCallExpr
+                    || child instanceof ArithmeticExpr || child instanceof TimestampArithmeticExpr))) {
                 return expr;
             }
         }

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -424,4 +424,26 @@ suite("test_delete") {
     """
     sql "set enable_fold_constant_by_be = true;"
     sql "DELETE FROM test2  WHERE col_2 = cast(123.45 as decimalv2(10,3));"
+
+    sql "drop table if exists test3"
+    sql """
+            CREATE TABLE `test3` (
+            `statistic_date` datev2 NULL,
+            `project_name` varchar(20) NULL ,
+            `brand` varchar(30) NULL ,
+            `vehicle_status` varchar(30) NULL ,
+            `abnormal_note` varchar(30) NULL ,
+            `inv_qty` bigint(20) NULL ,
+            `age_120_qty` bigint(20) NULL ,
+            `create_date` datetime NULL ,
+            `zparvin` varchar(50) NULL,
+            `tonnage` varchar(50) NULL 
+            ) ENGINE=OLAP
+            DISTRIBUTED BY HASH(`statistic_date`, `project_name`) BUCKETS 10
+            PROPERTIES (
+                "replication_allocation" = "tag.location.default: 1"
+            ); 
+    """
+    sql "set experimental_enable_nereids_planner = false;"
+    sql "delete from test3 where statistic_date >= date_sub('2024-01-16',INTERVAL 1 day);"
 }


### PR DESCRIPTION
## Proposed changes
```
delete from test3 where statistic_date >= date_sub('2024-01-16',INTERVAL 1 day);

statistic_date column type is date, and date_sub('2024-01-16',INTERVAL 1 day) need fold constant in FE,
before it's not register date type params function.
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

