### PR TITLE
[fix](group commit) Stream load row count is incorrect when enable pipeline load

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -101,7 +101,7 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
                         ctx->number_loaded_rows);
             }
         } else {
-            if (ctx->group_commit && status->is<DATA_QUALITY_ERROR>()) {
+            if (ctx->group_commit) {
                 ctx->number_total_rows = state->num_rows_load_total();
                 ctx->number_loaded_rows = state->num_rows_load_success();
                 ctx->number_filtered_rows = state->num_rows_load_filtered();


### PR DESCRIPTION
## Proposed changes

1. enable pipeline load
2. do a group commit stream load and the input file contains invalid rows
3. the returned `"NumberTotalRows"` is incorrect because the error in pipeline is `[CANCELLED][DATA_QUALITY_ERROR]too many filtered rows`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

