### PR TITLE
[chore] Use info level in recordCreatePartitionFailedMsg() due to intersection happens all the time

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -591,7 +591,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private void recordCreatePartitionFailedMsg(String dbName, String tableName, String msg, long tableId) {
-        LOG.warn("dynamic add partition failed: {}, db: {}, table: {}", msg, dbName, tableName);
+        LOG.info("dynamic add partition failed: {}, db: {}, table: {}", msg, dbName, tableName);
         createOrUpdateRuntimeInfo(tableId, DYNAMIC_PARTITION_STATE, State.ERROR.toString());
         createOrUpdateRuntimeInfo(tableId, CREATE_PARTITION_MSG, msg);
     }


### PR DESCRIPTION
![image](https://github.com/apache/doris/assets/6919662/28133204-5b5e-42b0-b1f6-38bcfd84dd9f)
