### PR TITLE
[log](rpc) print log when offer_failed in internal service

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -190,6 +190,8 @@ void offer_failed(T* response, google::protobuf::Closure* done, const FifoThread
     response->mutable_status()->set_status_code(TStatusCode::CANCELLED);
     response->mutable_status()->add_error_msgs("fail to offer request to the work pool, pool=" +
                                                pool.get_info());
+    LOG(WARNING) << "cancelled due to fail to offer request to the work pool, pool="
+                 << pool.get_info();
 }
 
 template <typename T>


### PR DESCRIPTION
## Proposed changes

Print log when offer_failed in internal service

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

