### PR TITLE
[Feature](profile)add shuffle send rows/bytes

### DIFF
--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -40,6 +40,7 @@ class TDataSink;
 class TExpr;
 class TPipelineFragmentParams;
 class TOlapTableSink;
+class QueryStatistics;
 
 namespace vectorized {
 class Block;
@@ -48,7 +49,7 @@ class Block;
 // Superclass of all data sinks.
 class DataSink {
 public:
-    DataSink(const RowDescriptor& desc) : _row_desc(desc) {}
+    DataSink(const RowDescriptor& desc);
     virtual ~DataSink() {}
 
     virtual Status init(const TDataSink& thrift_sink);
@@ -103,6 +104,8 @@ public:
 
     virtual bool can_write() { return true; }
 
+    std::shared_ptr<QueryStatistics> get_query_statistics_ptr();
+
 private:
     static bool _has_inverted_index_or_partial_update(TOlapTableSink sink);
 
@@ -124,6 +127,8 @@ protected:
         _output_rows_counter = ADD_COUNTER_WITH_LEVEL(_profile, "RowsProduced", TUnit::UNIT, 1);
         _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);
     }
+
+    std::shared_ptr<QueryStatistics> _query_statistics = nullptr;
 };
 
 } // namespace doris

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -255,7 +255,7 @@ Status ExecNode::create_tree_helper(RuntimeState* state, ObjectPool* pool,
     // Step 1 Create current ExecNode according to current thrift plan node.
     ExecNode* cur_exec_node = nullptr;
     RETURN_IF_ERROR(create_node(state, pool, cur_plan_node, descs, &cur_exec_node));
-    if (cur_exec_node != nullptr) {
+    if (cur_exec_node != nullptr && state->get_query_ctx()) {
         state->get_query_ctx()->register_query_statistics(cur_exec_node->get_query_statistics());
     }
 

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -273,7 +273,6 @@ private:
     static constexpr int QUEUE_CAPACITY_FACTOR = 64;
     std::shared_ptr<ExchangeSinkQueueDependency> _queue_dependency;
     std::shared_ptr<Dependency> _finish_dependency;
-    QueryStatistics* _statistics = nullptr;
     std::atomic<bool> _should_stop {false};
 };
 

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -342,7 +342,9 @@ Status OperatorX<LocalStateType>::setup_local_state(RuntimeState* state, LocalSt
 
 PipelineXSinkLocalStateBase::PipelineXSinkLocalStateBase(DataSinkOperatorXBase* parent,
                                                          RuntimeState* state)
-        : _parent(parent), _state(state) {}
+        : _parent(parent), _state(state) {
+    _query_statistics = std::make_shared<QueryStatistics>();
+}
 
 PipelineXLocalStateBase::PipelineXLocalStateBase(RuntimeState* state, OperatorXBase* parent)
         : _num_rows_returned(0),

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -111,7 +111,7 @@ public:
     //  override in Scan  MultiCastSink
     virtual RuntimeFilterDependency* filterdependency() { return nullptr; }
 
-    std::shared_ptr<QueryStatistics> query_statistics_ptr() { return _query_statistics; }
+    std::shared_ptr<QueryStatistics> get_query_statistics_ptr() { return _query_statistics; }
 
 protected:
     friend class OperatorXBase;
@@ -424,6 +424,8 @@ public:
     // override in exchange sink , AsyncWriterSink
     virtual Dependency* finishdependency() { return nullptr; }
 
+    std::shared_ptr<QueryStatistics> get_query_statistics_ptr() { return _query_statistics; }
+
 protected:
     DataSinkOperatorXBase* _parent = nullptr;
     RuntimeState* _state = nullptr;
@@ -447,6 +449,8 @@ protected:
     RuntimeProfile::Counter* _exec_timer = nullptr;
     RuntimeProfile::Counter* _memory_used_counter = nullptr;
     RuntimeProfile::Counter* _peak_memory_usage_counter = nullptr;
+
+    std::shared_ptr<QueryStatistics> _query_statistics = nullptr;
 };
 
 class DataSinkOperatorXBase : public OperatorBase {

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -92,6 +92,9 @@ Status PipelineXTask::prepare(const TPipelineInstanceParams& local_params, const
     auto scan_ranges = find_with_default(local_params.per_node_scan_ranges,
                                          _operators.front()->node_id(), no_scan_ranges);
     auto* parent_profile = _state->get_sink_local_state(_sink->operator_id())->profile();
+    query_ctx->register_query_statistics(
+            _state->get_sink_local_state(_sink->operator_id())->get_query_statistics_ptr());
+
     for (int op_idx = _operators.size() - 1; op_idx >= 0; op_idx--) {
         auto& op = _operators[op_idx];
         auto& deps = get_upstream_dependency(op->operator_id());
@@ -105,7 +108,7 @@ Status PipelineXTask::prepare(const TPipelineInstanceParams& local_params, const
         RETURN_IF_ERROR(op->setup_local_state(_state, info));
         parent_profile = _state->get_local_state(op->operator_id())->profile();
         query_ctx->register_query_statistics(
-                _state->get_local_state(op->operator_id())->query_statistics_ptr());
+                _state->get_local_state(op->operator_id())->get_query_statistics_ptr());
     }
 
     _block = doris::vectorized::Block::create_unique();

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -40,10 +40,11 @@ void NodeStatistics::from_pb(const PNodeStatistics& node_statistics) {
 }
 
 void QueryStatistics::merge(const QueryStatistics& other) {
-    scan_rows += other.scan_rows;
-    scan_bytes += other.scan_bytes;
-    int64_t other_cpu_time = other.cpu_nanos.load(std::memory_order_relaxed);
-    cpu_nanos += other_cpu_time;
+    scan_rows += other.scan_rows.load(std::memory_order_relaxed);
+    scan_bytes += other.scan_bytes.load(std::memory_order_relaxed);
+    cpu_nanos += other.cpu_nanos.load(std::memory_order_relaxed);
+    shuffle_send_bytes += other.shuffle_send_bytes.load(std::memory_order_relaxed);
+    shuffle_send_rows += other.shuffle_send_rows.load(std::memory_order_relaxed);
 
     int64_t other_peak_mem = other.max_peak_memory_bytes.load(std::memory_order_relaxed);
     if (other_peak_mem > this->max_peak_memory_bytes) {
@@ -85,6 +86,8 @@ void QueryStatistics::to_thrift(TQueryStatistics* statistics) const {
     statistics->__set_max_peak_memory_bytes(max_peak_memory_bytes.load(std::memory_order_relaxed));
     statistics->__set_current_used_memory_bytes(
             current_used_memory_bytes.load(std::memory_order_relaxed));
+    statistics->__set_shuffle_send_bytes(shuffle_send_bytes.load(std::memory_order_relaxed));
+    statistics->__set_shuffle_send_rows(shuffle_send_rows.load(std::memory_order_relaxed));
 }
 
 void QueryStatistics::from_pb(const PQueryStatistics& statistics) {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -765,6 +765,9 @@ Status BlockSerializer<Parent>::serialize_block(const Block* src, PBlock* dest, 
         COUNTER_UPDATE(_parent->_bytes_sent_counter, compressed_bytes * num_receivers);
         COUNTER_UPDATE(_parent->_uncompressed_bytes_counter, uncompressed_bytes * num_receivers);
         COUNTER_UPDATE(_parent->_compress_timer, src->get_compress_time());
+        _parent->get_query_statistics_ptr()->add_shuffle_send_bytes(compressed_bytes *
+                                                                    num_receivers);
+        _parent->get_query_statistics_ptr()->add_shuffle_send_rows(src->rows() * num_receivers);
     }
 
     return Status::OK();

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditEvent.java
@@ -88,6 +88,10 @@ public class AuditEvent {
     public String stmt = "";
     @AuditField(value = "CpuTimeMS")
     public long cpuTimeMs = -1;
+    @AuditField(value = "ShuffleSendBytes")
+    public long shuffleSendBytes = -1;
+    @AuditField(value = "ShuffleSendRows")
+    public long shuffleSendRows = -1;
     @AuditField(value = "SqlHash")
     public String sqlHash = "";
     @AuditField(value = "peakMemoryBytes")

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
@@ -70,6 +70,8 @@ public class WorkloadRuntimeStatusMgr {
                     auditEvent.scanBytes = queryStats.scan_bytes;
                     auditEvent.peakMemoryBytes = queryStats.max_peak_memory_bytes;
                     auditEvent.cpuTimeMs = queryStats.cpu_ms;
+                    auditEvent.shuffleSendBytes = queryStats.shuffle_send_bytes;
+                    auditEvent.shuffleSendRows = queryStats.shuffle_send_rows;
                 }
                 Env.getCurrentAuditEventProcessor().handleAuditEvent(auditEvent);
             }
@@ -139,6 +141,7 @@ public class WorkloadRuntimeStatusMgr {
         } else {
             long currentTime = System.currentTimeMillis();
             for (Map.Entry<String, TQueryStatistics> entry : params.query_statistics_map.entrySet()) {
+                LOG.info("log2109 queryid={}, shuffle={}", entry.getKey(), entry.getValue().shuffle_send_bytes);
                 queryIdMap.put(entry.getKey(), entry.getValue());
                 queryLastReportTime.put(entry.getKey(), currentTime);
             }
@@ -175,6 +178,8 @@ public class WorkloadRuntimeStatusMgr {
         dst.scan_rows += src.scan_rows;
         dst.scan_bytes += src.scan_bytes;
         dst.cpu_ms += src.cpu_ms;
+        dst.shuffle_send_bytes += src.shuffle_send_bytes;
+        dst.shuffle_send_rows += src.shuffle_send_rows;
         if (dst.max_peak_memory_bytes < src.max_peak_memory_bytes) {
             dst.max_peak_memory_bytes = src.max_peak_memory_bytes;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ActiveQueriesTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ActiveQueriesTableValuedFunction.java
@@ -46,6 +46,8 @@ public class ActiveQueriesTableValuedFunction extends MetadataTableValuedFunctio
             new Column("ScanBytes", PrimitiveType.BIGINT),
             new Column("BePeakMemoryBytes", PrimitiveType.BIGINT),
             new Column("CurrentUsedMemoryBytes", PrimitiveType.BIGINT),
+            new Column("ShuffleSendBytes", PrimitiveType.BIGINT),
+            new Column("ShuffleSendRows", PrimitiveType.BIGINT),
             new Column("Database", ScalarType.createStringType()),
             new Column("FrontendInstance", ScalarType.createStringType()),
             new Column("Sql", ScalarType.createStringType()));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -441,7 +441,11 @@ public class MetadataGenerator {
             trow.addToColumnValue(new TCell().setLongVal(qs.scan_bytes));
             trow.addToColumnValue(new TCell().setLongVal(qs.max_peak_memory_bytes));
             trow.addToColumnValue(new TCell().setLongVal(qs.current_used_memory_bytes));
+            trow.addToColumnValue(new TCell().setLongVal(qs.shuffle_send_bytes));
+            trow.addToColumnValue(new TCell().setLongVal(qs.shuffle_send_rows));
         } else {
+            trow.addToColumnValue(new TCell().setLongVal(0L));
+            trow.addToColumnValue(new TCell().setLongVal(0L));
             trow.addToColumnValue(new TCell().setLongVal(0L));
             trow.addToColumnValue(new TCell().setLongVal(0L));
             trow.addToColumnValue(new TCell().setLongVal(0L));

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -406,6 +406,8 @@ struct TQueryStatistics {
     5: optional i64 max_peak_memory_bytes
     6: optional i64 current_used_memory_bytes
     7: optional i64 workload_group_id
+    8: optional i64 shuffle_send_bytes
+    9: optional i64 shuffle_send_rows
 }
 
 struct TReportWorkloadRuntimeStatusParams {


### PR DESCRIPTION
## Proposed changes

1 Add Metrics ShuffleSendBytes/ShuffleSendRows in fe.audit.log and tvf active_queries, it means rows and bytes after serialize which DataSinkNode send.
2 

```
mysql [(none)]>desc function active_queries();
+------------------------+--------+------+-------+---------+-------+
| Field                  | Type   | Null | Key   | Default | Extra |
+------------------------+--------+------+-------+---------+-------+
| BeHost                 | TEXT   | No   | false | NULL    | NONE  |
| BePort                 | BIGINT | No   | false | NULL    | NONE  |
| QueryId                | TEXT   | No   | false | NULL    | NONE  |
| StartTime              | TEXT   | No   | false | NULL    | NONE  |
| QueryTimeMs            | BIGINT | No   | false | NULL    | NONE  |
| WorkloadGroupId        | BIGINT | No   | false | NULL    | NONE  |
| QueryCpuTimeMs         | BIGINT | No   | false | NULL    | NONE  |
| ScanRows               | BIGINT | No   | false | NULL    | NONE  |
| ScanBytes              | BIGINT | No   | false | NULL    | NONE  |
| BePeakMemoryBytes      | BIGINT | No   | false | NULL    | NONE  |
| CurrentUsedMemoryBytes | BIGINT | No   | false | NULL    | NONE  |
| ShuffleSendBytes       | BIGINT | No   | false | NULL    | NONE  |
| ShuffleSendRows        | BIGINT | No   | false | NULL    | NONE  |
| Database               | TEXT   | No   | false | NULL    | NONE  |
| FrontendInstance       | TEXT   | No   | false | NULL    | NONE  |
| Sql                    | TEXT   | No   | false | NULL    | NONE  |
+------------------------+--------+------+-------+---------+-------+
16 rows in set (0.01 sec)
```


```
mysql [(none)]>select QueryId,StartTime,QueryCpuTimeMs,ScanRows,ScanBytes,BePeakMemoryBytes,`Database`,FrontendInstance,ShuffleSendBytes,ShuffleSendRows from active_queries()\G;
*************************** 1. row ***************************
          QueryId: 774cc4b1cce448c7-b4c841b7b9d08923
        StartTime: 2024-01-27 13:53:27
   QueryCpuTimeMs: 28117
         ScanRows: 61352378
        ScanBytes: 21630189568
BePeakMemoryBytes: 1537534202
         Database: hits
 FrontendInstance: vm-10
 ShuffleSendBytes: 145682448
  ShuffleSendRows: 1175400
1 row in set (0.01 sec)

ERROR: 
No query specified
```

```
User=root|Ctl=internal|Db=hits|State=EOF|ErrorCode=0|ErrorMessage=|Time(ms)=30630|ScanBytes=27821867008|ScanRows=81032736|ReturnRows=11|StmtId=30|QueryId=774cc4b1cce448c7-b4c841b7b9d08923|IsQuery=true|isNereids=true|feIp=|Stmt=SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(length(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25|CpuTimeMS=38940|ShuffleSendBytes=333564448|ShuffleSendRows=2689024|SqlHash=b03d48a7e6849912003ad1cff9519957|peakMemoryBytes=2391511673|SqlDigest=d41d8cd98f00b204e9800998ecf8427e|TraceId=|WorkloadGroup=normal|FuzzyVariables=
```