### PR TITLE
[fix](nereids)should always call visitBoundFunction first when binding ElementAt function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -200,7 +200,8 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
 
     @Override
     public Expression visitElementAt(ElementAt elementAt, ExpressionRewriteContext context) {
-        if (PushDownToProjectionFunction.validToPushDown(elementAt)) {
+        Expression boundFunction = visitBoundFunction(elementAt, context);
+        if (PushDownToProjectionFunction.validToPushDown(boundFunction)) {
             if (ConnectContext.get() != null
                     && ConnectContext.get().getSessionVariable() != null
                     && !ConnectContext.get().getSessionVariable().isEnableRewriteElementAtToSlot()) {
@@ -214,7 +215,7 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
             // rewrite to slot and bound this slot
             return ElementAtToSlot.rewriteToSlot(elementAt, (SlotReference) slot);
         }
-        return visitBoundFunction(elementAt, context);
+        return boundFunction;
     }
 
     /**


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

