### PR TITLE
[fix](thirdparty) patch brpc 1.4.0 to fix stream rpc

### DIFF
--- a/thirdparty/patches/brpc-1.4.0-fix-stream-rpc-set-connected.patch
+++ b/thirdparty/patches/brpc-1.4.0-fix-stream-rpc-set-connected.patch
@@ -1,0 +1,41 @@
+From 9acc6ef89d8770d5516953e2eadf0c27a7d424fc Mon Sep 17 00:00:00 2001
+From: Kaijie Chen <ckj@apache.org>
+Date: Sun, 28 Jan 2024 15:58:31 +0800
+Subject: [PATCH] fix set connected for stream rpc
+
+---
+ src/brpc/policy/baidu_rpc_protocol.cpp | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/src/brpc/policy/baidu_rpc_protocol.cpp b/src/brpc/policy/baidu_rpc_protocol.cpp
+index 0239960e..c47903a6 100644
+--- a/src/brpc/policy/baidu_rpc_protocol.cpp
++++ b/src/brpc/policy/baidu_rpc_protocol.cpp
+@@ -234,6 +234,11 @@ void SendRpcResponse(int64_t correlation_id,
+     // Send rpc response over stream even if server side failed to create
+     // stream for some reasons.
+     if(cntl->has_remote_stream()){
++        if(stream_ptr) {
++            // Now it's ok the mark this server-side stream as connectted as all the
++            // written user data would follower the RPC response.
++            ((Stream*)stream_ptr->conn())->SetConnected();
++        }
+         // Send the response over stream to notify that this stream connection
+         // is successfully built.
+         // Response_stream can be INVALID_STREAM_ID when error occurs.
+@@ -249,12 +254,6 @@ void SendRpcResponse(int64_t correlation_id,
+             }
+             return;
+         }
+-
+-        if(stream_ptr) {
+-            // Now it's ok the mark this server-side stream as connectted as all the
+-            // written user data would follower the RPC response.
+-            ((Stream*)stream_ptr->conn())->SetConnected();
+-        }
+     } else{
+         // Have the risk of unlimited pending responses, in which case, tell
+         // users to set max_concurrency.
+-- 
+2.39.3
+


### PR DESCRIPTION
## Proposed changes

A brpc bug is causing upstream fail to receive on_closed messages.
This affects memtable on sink node in Doris, causing close_wait timeout.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

