### PR TITLE
[Refact](inverted index) use boost regex to resolve stack overflow issues

### DIFF
--- a/be/src/vec/functions/function_tokenize.cpp
+++ b/be/src/vec/functions/function_tokenize.cpp
@@ -20,7 +20,7 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <regex>
+#include <boost/regex.hpp>
 #include <utility>
 
 #include "CLucene/StdHeader.h"
@@ -36,16 +36,18 @@
 namespace doris::vectorized {
 
 Status parse(const std::string& str, std::map<std::string, std::string>& result) {
-    std::regex pattern(
+    boost::regex pattern(
             R"delimiter((?:'([^']*)'|"([^"]*)"|([^,]*))\s*=\s*(?:'([^']*)'|"([^"]*)"|([^,]*)))delimiter");
-    std::smatch matches;
+    boost::smatch matches;
 
     std::string::const_iterator searchStart(str.cbegin());
-    while (std::regex_search(searchStart, str.cend(), matches, pattern)) {
-        std::string key =
-                matches[1].length() ? matches[1] : (matches[2].length() ? matches[2] : matches[3]);
-        std::string value =
-                matches[4].length() ? matches[4] : (matches[5].length() ? matches[5] : matches[6]);
+    while (boost::regex_search(searchStart, str.cend(), matches, pattern)) {
+        std::string key = matches[1].length()
+                                  ? matches[1].str()
+                                  : (matches[2].length() ? matches[2].str() : matches[3].str());
+        std::string value = matches[4].length()
+                                    ? matches[4].str()
+                                    : (matches[5].length() ? matches[5].str() : matches[6].str());
 
         result[key] = value;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Switch to Boost.Regex to resolve stack overflow issues

Modified the parse function to use Boost.Regex instead of std::regex due to stack overflow problems encountered with complex regex processing. This change aims to improve the reliability and efficiency of the parsing operation.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

