### PR TITLE
[fix](query state) Print correct DML state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -326,7 +326,6 @@ public class StmtExecutor {
         }
         builder.taskState(!isFinished && context.getState().getStateType().equals(MysqlStateType.OK) ? "RUNNING"
                 : context.getState().toString());
-        LOG.info("Query {} state {}", DebugUtil.printId(context.queryId()), context.getState().toString());
         builder.user(context.getQualifiedUser());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -326,6 +326,7 @@ public class StmtExecutor {
         }
         builder.taskState(!isFinished && context.getState().getStateType().equals(MysqlStateType.OK) ? "RUNNING"
                 : context.getState().toString());
+        LOG.info("Query {} state {}", DebugUtil.printId(context.queryId()), context.getState().toString());
         builder.user(context.getQualifiedUser());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());
@@ -502,6 +503,11 @@ public class StmtExecutor {
                     LOG.debug("fall back to legacy planner on statement:\n{}", originStmt.originStmt);
                     parsedStmt = null;
                     planner = null;
+                    // Attention: currently exception from nereids does not mean an Exception to user terminal
+                    // unless user does not allow fallback to lagency planner. But state of query
+                    // has already been set to Error in this case, it will have some side effect on profile result
+                    // and audit log. So we need to reset state to OK if query cancel be processd by lagency.
+                    context.getState().reset();
                     context.getState().setNereids(false);
                     executeByLegacy(queryId);
                 }


### PR DESCRIPTION
before
```txt
2024-01-29 12:07:11,383 [query] |Client=[127.0.0.1:39108](http://127.0.0.1:39108/)|User=root|Db=demo|State=OK|ErrorCode=1105|ErrorMessage=Unexpected exception: Nereids DML is disabled, will try to fall back to the original planner|Time(ms)=38|ScanBytes=0|ScanRows=0|ReturnRows=7|StmtId=40|QueryId=203710eaf8454a-80888796dfcfcb21|IsQuery=false|isNereids=false|feIp=[127.0.0.1](http://127.0.0.1/)|Stmt=insert into et1 select * from et1|CpuTimeMS=0|SqlHash=894f0ddbdc81f008cd426fd1781af154|peakMemoryBytes=0|SqlDigest=|TraceId=|WorkloadGroup=|FuzzyVariables=
```
after
```txt
2024-01-29 12:29:10,695 [query] |Client=127.0.0.1:36838|User=root|Db=demo|State=OK|ErrorCode=0|ErrorMessage=|Time(ms)=231|ScanBytes=0|ScanRows=0|ReturnRows=7|StmtId=4|QueryId=f026249775834bd7-9ac993ef697ee880|IsQuery=false|isNereids=false|feIp=127.0.0.1|Stmt=insert into et1 select * from et1|CpuTimeMS=0|SqlHash=894f0ddbdc81f008cd426fd1781af154|peakMemoryBytes=0|SqlDigest=|TraceId=|WorkloadGroup=|FuzzyVariables=
```

ErrorCodes change from 1105 to 0

And we can see correct query state in profile
![8415ec38-4e83-4d8e-ad5b-0c0c755c14ba](https://github.com/apache/doris/assets/42906151/3925d21c-2304-40c4-bc28-350ede50ab7f)

