### PR TITLE
[regression-test][conf] add master_sync_policy = WRITE_NO_SYNC replic…

### DIFF
--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -109,3 +109,6 @@ enable_workload_group = true
 
 sys_log_verbose_modules = org.apache.doris.persist.EditLog,org.apache.doris.journal.bdbje.BDBJEJournal
 
+master_sync_policy = WRITE_NO_SYNC
+replica_sync_policy = WRITE_NO_SYNC
+


### PR DESCRIPTION
…a_sync_policy = WRITE_NO_SYNC

There is no power off scene in regression-test, so add these two configure has no side-effect.

no-need to merge to branch-2.0

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

