### PR TITLE
[fix](jdbc catalog) Ensure Proper Closure of Existing JdbcClient Before Creation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -165,6 +165,9 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     @Override
     protected void initLocalObjectsImpl() {
+        if (jdbcClient != null) {
+            jdbcClient.closeClient();
+        }
         JdbcClientConfig jdbcClientConfig = new JdbcClientConfig()
                 .setCatalog(this.name)
                 .setUser(getJdbcUser())

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -169,7 +169,13 @@ public abstract class JdbcClient {
     }
 
     public void closeClient() {
-        dataSource.close();
+        try {
+            if (dataSource != null) {
+                dataSource.close();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to close data source", e);
+        }
     }
 
     public Connection getConnection() throws JdbcClientException {
@@ -190,7 +196,7 @@ public abstract class JdbcClient {
                 try {
                     closeable.close();
                 } catch (Exception e) {
-                    throw new JdbcClientException("Can not close : ", e);
+                    LOG.warn("Failed to close jdbc resource: ", e);
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Prevent possible duplicate creation of jdbcclient, which may lead to connection pool leaks

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

