### PR TITLE
[fix](nereids)group by expr may be lost in EliminateGroupByConstant rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateGroupByConstant.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateGroupByConstant.java
@@ -67,7 +67,7 @@ public class EliminateGroupByConstant extends OneRewriteRuleFactory {
                     lit = expression;
                 }
             }
-            if (slotGroupByExprs.isEmpty() && lit != null && aggregate.getAggregateFunctions().isEmpty()) {
+            if (slotGroupByExprs.isEmpty() && lit != null) {
                 slotGroupByExprs.add(lit);
             }
             return aggregate.withGroupByAndOutput(ImmutableList.copyOf(slotGroupByExprs), outputExprs);


### PR DESCRIPTION
## Proposed changes

pick from master https://github.com/apache/doris/pull/30274

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

