### PR TITLE
[fix](Nereids) top-n with top project should hit top-n opt (#29971)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
@@ -52,6 +52,14 @@ public class TopNScanOpt extends PlanPostProcessor {
     public Plan visitPhysicalSink(PhysicalSink<? extends Plan> physicalSink, CascadesContext context) {
         if (physicalSink.child() instanceof TopN) {
             return super.visit(physicalSink, context);
+        } else if (physicalSink.child() instanceof Project && physicalSink.child().child(0) instanceof TopN) {
+            PhysicalTopN<?> oldTopN = (PhysicalTopN<?>) physicalSink.child().child(0);
+            PhysicalTopN<?> newTopN = (PhysicalTopN<?>) oldTopN.accept(this, context);
+            if (newTopN == oldTopN) {
+                return physicalSink;
+            } else {
+                return physicalSink.withChildren(physicalSink.child().withChildren(newTopN));
+            }
         }
         return physicalSink;
     }


### PR DESCRIPTION
in PR #29312, we limit top-n opt only enable in simplest cases. in this PR, we let go of some restrictions.

pick from master #29971
commit id ce89a9f07c561317fefe8023047269ea3b264038

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

