### PR TITLE
[fix](Nereids) decimalv3 cast in fe produce wrong data (#29808)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyCastRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyCastRule.java
@@ -82,14 +82,15 @@ public class SimplifyCastRule extends AbstractExpressionRewriteRule {
                                 ((VarcharType) castType).getLen());
                     }
                 } else if (castType instanceof DecimalV2Type) {
+                    DecimalV2Type decimalV2Type = (DecimalV2Type) castType;
                     if (child instanceof TinyIntLiteral) {
-                        return new DecimalLiteral(new BigDecimal(((TinyIntLiteral) child).getValue()));
+                        return new DecimalLiteral(decimalV2Type, new BigDecimal(((TinyIntLiteral) child).getValue()));
                     } else if (child instanceof SmallIntLiteral) {
-                        return new DecimalLiteral(new BigDecimal(((SmallIntLiteral) child).getValue()));
+                        return new DecimalLiteral(decimalV2Type, new BigDecimal(((SmallIntLiteral) child).getValue()));
                     } else if (child instanceof IntegerLiteral) {
-                        return new DecimalLiteral(new BigDecimal(((IntegerLiteral) child).getValue()));
+                        return new DecimalLiteral(decimalV2Type, new BigDecimal(((IntegerLiteral) child).getValue()));
                     } else if (child instanceof BigIntLiteral) {
-                        return new DecimalLiteral(new BigDecimal(((BigIntLiteral) child).getValue()));
+                        return new DecimalLiteral(decimalV2Type, new BigDecimal(((BigIntLiteral) child).getValue()));
                     }
                 } else if (castType instanceof DecimalV3Type) {
                     DecimalV3Type decimalV3Type = (DecimalV3Type) castType;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -81,6 +81,7 @@ public class DecimalLiteral extends Literal {
         boolean valid = true;
         if (precision != -1 && scale != -1) {
             if (precision < realPrecision || scale < realScale
+                    || realPrecision - realScale > precision - scale
                     || realPrecision - realScale > DecimalV2Type.MAX_PRECISION - DecimalV2Type.MAX_SCALE) {
                 valid = false;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -93,7 +93,7 @@ public class DecimalV3Literal extends Literal {
         int realScale = value.scale();
         boolean valid = true;
         if (precision != -1 && scale != -1) {
-            if (precision < realPrecision || scale < realScale) {
+            if (precision < realPrecision || scale < realScale || precision - scale < realPrecision - realScale) {
                 valid = false;
             }
         } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -200,13 +200,13 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
 
         // decimal literal
         assertRewrite(new Cast(new TinyIntLiteral((byte) 1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal(1)));
+                new DecimalLiteral(new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new SmallIntLiteral((short) 1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal(1)));
+                new DecimalLiteral(new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new IntegerLiteral(1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal(1)));
+                new DecimalLiteral(new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new BigIntLiteral(1L), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal(1)));
+                new DecimalLiteral(new BigDecimal("1.000000000")));
     }
 
     @Test

--- a/regression-test/suites/nereids_syntax_p0/cast.groovy
+++ b/regression-test/suites/nereids_syntax_p0/cast.groovy
@@ -229,6 +229,11 @@ suite("cast") {
         sql """select cast(k5 as time) ct from test order by ct;"""
         exception "cannot cast"
     }
+    test {
+        sql "select cast(12 as decimalv3(2,1))"
+        exception "Arithmetic overflow"
+    }
+
     // date
     test {
         sql """select cast(k10 as time) ct from test order by ct;"""


### PR DESCRIPTION
case:
```
MySQL root@127.0.0.1:test> select cast(12 as decimalv3(2,1))
+-----------------------------+
| cast(12 as DECIMALV3(2, 1)) |
+-----------------------------+
| 12.0                        |
+-----------------------------+
```

decimalv2 literal will generate wrong result too. But it is not only bugs in planner, but also have bugs in executor. So we need fix executor bug in another PR.

pick from master #29808
commi id 88ef595e39a11be96c0b4338dcba1ed08c3a199e

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

