### PR TITLE
[fix](move-memtable) check load timeout before close wait

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -553,6 +553,11 @@ Status VTabletWriterV2::close(Status exec_status) {
             SCOPED_TIMER(_close_load_timer);
             auto remain_ms = _state->execution_timeout() * 1000 -
                              _timeout_watch.elapsed_time() / 1000 / 1000;
+            if (remain_ms <= 0) {
+                LOG(WARNING) << "load timed out before close waiting, load_id="
+                             << print_id(_load_id);
+                return Status::TimedOut("load timed out before close waiting");
+            }
             for (const auto& [_, streams] : _streams_for_node) {
                 for (const auto& stream : streams->streams()) {
                     RETURN_IF_ERROR(stream->close_wait(remain_ms));


### PR DESCRIPTION
## Proposed changes

close wait timeout = load timeout - elapsed time

If remaining time is not positive, return timeout

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

