### PR TITLE
[fix](group commit) Fix replay wal core because undefined TLoadSourceType

### DIFF
--- a/be/src/olap/wal/wal_table.cpp
+++ b/be/src/olap/wal/wal_table.cpp
@@ -259,6 +259,8 @@ Status WalTable::_handle_stream_load(int64_t wal_id, const std::string& wal,
     ctx->auth.token = "relay_wal"; // this is a fake, fe not check it now
     ctx->auth.user = "admin";
     ctx->group_commit = false;
+    ctx->load_type = TLoadType::MANUL_LOAD;
+    ctx->load_src_type = TLoadSourceType::RAW;
     auto st = _http_stream_action->process_put(nullptr, ctx);
     if (st.ok()) {
         // wait stream load finish


### PR DESCRIPTION
## Proposed changes

```
*** SIGSEGV address not mapped to object (@0x70) received by PID 3539569 (TID 3539924 OR 0x7fde59c8d700) from PID 112;
 stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/meiyi/clion_workspace/doris_master2/be/src/common/signal_handler.h:417
 1# 0x00007FDFF97DB570 in /lib64/libc.so.6
 2# std::_Rb_tree<int, std::pair<int const, long>, std::_Select1st<std::pair<int const, long> >, std::less<int>, std::allocator<std::pair<int const, long> > >::begin() at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:996
 3# std::map<int, long, std::less<int>, std::allocator<std::pair<int const, long> > >::begin() at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:357
 4# doris::KafkaLoadInfo::reset_offset() at /mnt/disk2/meiyi/clion_workspace/doris_master2/be/src/runtime/stream_load/stream_load_context.h:67
 5# doris::StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<doris::StreamLoadContext>)::$_0::operator()(doris::RuntimeState*, doris::Status*) const at /mnt/disk2/meiyi/clion_workspace/doris_master2/be/src/runtime/stream_load/stream_load_executor.cpp:127
 6# void std::__invoke_impl<void, doris::StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<doris::StreamLoadContext>)::$_0&, doris::RuntimeState*, doris::Status*>(std::__invoke_other, doris::StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<doris::StreamLoadContext>)::$_0&, doris::RuntimeState*&&, doris::Status*&&) at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

