### PR TITLE
[Fix](compile) fix compile failure on be

### DIFF
--- a/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
+++ b/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
@@ -37,9 +37,6 @@
 
 namespace doris::vectorized {
 
-// const static std::string NUMBER = std::string {"number"};
-// const static std::string ZERO = std::string {"zero"};
-
 VNumbersTVF::VNumbersTVF(TupleId tuple_id, const TupleDescriptor* tuple_desc)
         : VDataGenFunctionInf(tuple_id, tuple_desc) {}
 

--- a/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
+++ b/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
@@ -37,8 +37,8 @@
 
 namespace doris::vectorized {
 
-const static std::string NUMBER = std::string {"number"};
-const static std::string ZERO = std::string {"zero"};
+// const static std::string NUMBER = std::string {"number"};
+// const static std::string ZERO = std::string {"zero"};
 
 VNumbersTVF::VNumbersTVF(TupleId tuple_id, const TupleDescriptor* tuple_desc)
         : VDataGenFunctionInf(tuple_id, tuple_desc) {}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
/data/home/felixwluo/dev/doris-master/doris/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp:40:26: error: unused variable 'NUMBER' [-Werror,-Wunused-const-variable]
   40 | const static std::string NUMBER = std::string {"number"};
      |                          ^~~~~~
/data/home/felixwluo/dev/doris-master/doris/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp:41:26: error: unused variable 'ZERO' [-Werror,-Wunused-const-variable]
   41 | const static std::string ZERO = std::string {"zero"};
      |                          ^~~~
2 errors generated.

fix：Delete unused variables

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

