### PR TITLE
[fix](Nereids) should not generate same exprId for diff column when sink (#30501)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -166,8 +166,14 @@ public class BindSink implements AnalysisRuleFactory {
                                                         + " target table " + table.getName());
                                             }
                                             if (columnToOutput.get(seqCol.get().getName()) != null) {
-                                                columnToOutput.put(column.getName(),
-                                                        columnToOutput.get(seqCol.get().getName()));
+                                                // should generate diff exprId for seq column
+                                                NamedExpression seqColumn = columnToOutput.get(seqCol.get().getName());
+                                                if (seqColumn instanceof Alias) {
+                                                    seqColumn = new Alias(seqColumn.child(0), column.getName());
+                                                } else {
+                                                    seqColumn = new Alias(seqColumn, column.getName());
+                                                }
+                                                columnToOutput.put(column.getName(), seqColumn);
                                             }
                                         } else if (sink.isPartialUpdate()) {
                                             // If the current load is a partial update, the values of unmentioned


### PR DESCRIPTION
pick from master #30501
commit id 608fede57a78f77933a7b4ebd80b523cbccc0848

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

