### PR TITLE
[fix](JDK17) The objects stored in PriorityQueue must implement the Comparable interface

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueueToken.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueueToken.java
@@ -28,8 +28,13 @@ import java.util.concurrent.locks.ReentrantLock;
 // used to mark QueryQueue offer result
 // if offer failed, then need to cancel query
 // and return failed reason to user client
-public class QueueToken {
+public class QueueToken implements Comparable<QueueToken> {
     private static final Logger LOG = LogManager.getLogger(QueueToken.class);
+
+    @Override
+    public int compareTo(QueueToken other) {
+        return Long.compare(this.tokenId, other.getTokenId());
+    }
 
     enum TokenState {
         ENQUEUE_SUCCESS,
@@ -136,4 +141,7 @@ public class QueueToken {
         return tokenId == other.tokenId;
     }
 
+    public long getTokenId() {
+        return tokenId;
+    }
 }

--- a/regression-test/suites/datatype_p0/nested_types/query/array_functions/test_array_zip_array_enumerate_uniq.groovy
+++ b/regression-test/suites/datatype_p0/nested_types/query/array_functions/test_array_zip_array_enumerate_uniq.groovy
@@ -25,7 +25,7 @@ suite("test_array_zip_array_enumerate_uniq", "p0") {
                SELECT array_zip();
                 """
     } catch (Exception ex) {
-        assertTrue(ex.getMessage().contains("errCode = 2, detailMessage = Unexpected exception: 0"))
+        assertTrue(ex.getMessage().contains("errCode = 2, detailMessage = Unexpected exception: "))
     }
 
     try {


### PR DESCRIPTION
## Proposed changes

Issue Number:  #30484 

The objects stored in PriorityQueue must implement the Comparable interface or passed into the customized `Comparator`. 

If we don't do this, run the program in the JDK17 environment will report an exception:
```java
Caused by: java.lang.AssertionError: Expect exception msg contains 'query wait timeout', but meet
'java.sql.SQLException: ClassCastException,
msg: class org.apache.doris.resource.workloadgroup.QueueToken cannot be cast to class java.lang.Comparable 
(org.apache.doris.resource.workloadgroup.QueueToken is in unnamed module of loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap')'
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

