### PR TITLE
[enhancement](segcompaction) refine segcompaction policy for wide-table

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -964,6 +964,9 @@ DEFINE_Bool(enable_segcompaction, "true");
 // Max number of segments allowed in a single segcompaction task.
 DEFINE_Int32(segcompaction_batch_size, "10");
 
+// the score threshold for last batch
+DEFINE_Int32(segcompaction_last_batch_score, "1000");
+
 // Max row count allowed in a single source segment, bigger segments will be skipped.
 DEFINE_Int32(segcompaction_candidate_max_rows, "1048576");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1013,6 +1013,9 @@ DECLARE_Bool(enable_segcompaction);
 // Max number of segments allowed in a single segcompaction task.
 DECLARE_Int32(segcompaction_batch_size);
 
+// the score threshold for last batch
+DECLARE_Int32(segcompaction_last_batch_score);
+
 // Max row count allowed in a single source segment, bigger segments will be skipped.
 DECLARE_Int32(segcompaction_candidate_max_rows);
 

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -235,10 +235,11 @@ private:
     Status _wait_flying_segcompaction();
     Status _create_segment_writer_for_segcompaction(
             std::unique_ptr<segment_v2::SegmentWriter>* writer, int64_t begin, int64_t end);
-    Status _segcompaction_if_necessary();
+    Status _segcompaction_if_necessary(bool last_batch = false);
     Status _segcompaction_rename_last_segments();
     Status _load_noncompacted_segment(segment_v2::SegmentSharedPtr& segment, int32_t segment_id);
-    Status _find_longest_consecutive_small_segment(SegCompactionCandidatesSharedPtr& segments);
+    Status _find_longest_consecutive_small_segment(SegCompactionCandidatesSharedPtr& segments,
+                                                   bool last_batch = false);
     bool _is_segcompacted() const { return _num_segcompacted > 0; }
     bool _check_and_set_is_doing_segcompaction();
     Status _rename_compacted_segments(int64_t begin, int64_t end);

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -122,7 +122,7 @@ protected:
     }
 
     // (k1 int, k2 varchar(20), k3 int) keys (k1, k2)
-    void create_tablet_schema(TabletSchemaSPtr tablet_schema, KeysType keystype) {
+    void create_tablet_schema(TabletSchemaSPtr tablet_schema, KeysType keystype, int num_value_col=1) {
         TabletSchemaPB tablet_schema_pb;
         tablet_schema_pb.set_keys_type(keystype);
         tablet_schema_pb.set_num_short_key_columns(2);
@@ -152,15 +152,18 @@ protected:
         column_2->set_is_nullable(true);
         column_2->set_is_bf_column(false);
 
-        ColumnPB* column_3 = tablet_schema_pb.add_column();
-        column_3->set_unique_id(3);
-        column_3->set_name("v1");
-        column_3->set_type("INT");
-        column_3->set_length(4);
-        column_3->set_is_key(false);
-        column_3->set_is_nullable(false);
-        column_3->set_is_bf_column(false);
-        column_3->set_aggregation("SUM");
+        for (int i = 1; i <= num_value_col; i++) {
+            ColumnPB* v_column = tablet_schema_pb.add_column();
+            v_column->set_unique_id(2+i);
+            v_column->set_name(fmt::format("v{}", i));
+            v_column->set_type("INT");
+            v_column->set_length(4);
+            v_column->set_is_key(false);
+            v_column->set_is_nullable(false);
+            v_column->set_is_bf_column(false);
+            v_column->set_default_value(std::to_string(i*10));
+            v_column->set_aggregation("SUM");
+        }
 
         tablet_schema->init_from_pb(tablet_schema_pb);
     }
@@ -274,6 +277,112 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
         ls.push_back("10047_4.dat");
         ls.push_back("10047_5.dat");
         ls.push_back("10047_6.dat");
+        EXPECT_TRUE(check_dir(ls));
+    }
+
+    { // read
+        RowsetReaderContext reader_context;
+        reader_context.tablet_schema = tablet_schema;
+        // use this type to avoid cache from other ut
+        reader_context.reader_type = READER_CUMULATIVE_COMPACTION;
+        reader_context.need_ordered_result = true;
+        std::vector<uint32_t> return_columns = {0, 1, 2};
+        reader_context.return_columns = &return_columns;
+        reader_context.stats = &_stats;
+
+        // without predicates
+        {
+            RowsetReaderSharedPtr rowset_reader;
+            create_and_init_rowset_reader(rowset.get(), reader_context, &rowset_reader);
+
+            uint32_t num_rows_read = 0;
+            bool eof = false;
+            while (!eof) {
+                std::shared_ptr<vectorized::Block> output_block =
+                        std::make_shared<vectorized::Block>(
+                                tablet_schema->create_block(return_columns));
+                s = rowset_reader->next_block(output_block.get());
+                if (s != Status::OK()) {
+                    eof = true;
+                }
+                EXPECT_GT(output_block->rows(), 0);
+                EXPECT_EQ(return_columns.size(), output_block->columns());
+                for (int i = 0; i < output_block->rows(); ++i) {
+                    vectorized::ColumnPtr col0 = output_block->get_by_position(0).column;
+                    vectorized::ColumnPtr col1 = output_block->get_by_position(1).column;
+                    vectorized::ColumnPtr col2 = output_block->get_by_position(2).column;
+                    auto field1 = (*col0)[i];
+                    auto field2 = (*col1)[i];
+                    auto field3 = (*col2)[i];
+                    uint32_t k1 = *reinterpret_cast<uint32_t*>((char*)(&field1));
+                    uint32_t k2 = *reinterpret_cast<uint32_t*>((char*)(&field2));
+                    uint32_t v3 = *reinterpret_cast<uint32_t*>((char*)(&field3));
+                    EXPECT_EQ(100 * v3 + k2, k1);
+                    num_rows_read++;
+                }
+                output_block->clear();
+            }
+            EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
+            EXPECT_EQ(rowset->rowset_meta()->num_rows(), num_rows_read);
+            EXPECT_TRUE(rowset_reader->get_segment_num_rows(&segment_num_rows).ok());
+            size_t total_num_rows = 0;
+            for (const auto& i : segment_num_rows) {
+                total_num_rows += i;
+            }
+            EXPECT_EQ(total_num_rows, num_rows_read);
+        }
+    }
+}
+
+TEST_F(SegCompactionTest, SegCompactionWideTable) {
+    config::enable_segcompaction = true;
+    Status s;
+    TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema, AGG_KEYS, 2000);
+
+    RowsetSharedPtr rowset;
+    const int num_segments = 18;
+    const uint32_t rows_per_segment = 4096;
+    config::segcompaction_candidate_max_rows = 6000; // set threshold above
+                                                     // rows_per_segment
+    config::segcompaction_batch_size = 10;
+    std::vector<uint32_t> segment_num_rows;
+    { // write `num_segments * rows_per_segment` rows to rowset
+        RowsetWriterContext writer_context;
+        create_rowset_writer_context(10047, tablet_schema, &writer_context);
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        s = RowsetFactory::create_rowset_writer(writer_context, false, &rowset_writer);
+        EXPECT_EQ(Status::OK(), s);
+
+        RowCursor input_row;
+        input_row.init(tablet_schema);
+
+        // for segment "i", row "rid"
+        // k1 := rid*10 + i
+        // k2 := k1 * 10
+        // k3 := rid
+        for (int i = 0; i < num_segments; ++i) {
+            vectorized::Arena arena;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &arena);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &arena);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &arena);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+            sleep(1);
+        }
+
+        EXPECT_EQ(Status::OK(), rowset_writer->build(rowset));
+        std::vector<std::string> ls;
+        ls.push_back("10047_0.dat");
+        ls.push_back("10047_1.dat");
         EXPECT_TRUE(check_dir(ls));
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. For a wide table, we need to strictly control the number of segments, because the compaction and select* queries of a wide table are very memory intensive. Specifically, each column iterator will preload a page (64KB), so for a table 5000 columns wide, a segment with all columns open at the same time will consume at least 320MB of memory.
2. at the same time for a wide table, because a memtable can store less rows, wide table load tasks tends to generate more segments.
3. segcompaction can effectively reduce the number of segments, but it will not process the last few segments that are less than `segcompaction_batch_size`. this is not a problem for normal tables, but for wide tables, the wider the table, the more we should minimize the number of segments.

**Optimization effect**:
- For a table with 5000 columns and 18 segment generated in a rowset, the preloaded page will consume 5.7GB of memory for a select * of that rowset.
- If segment compaction is turned on, under the previous default policy, 9 segments will eventually be generated and select * will consume 2.8GB of memory
- With this patch, only 2 segments will be generated and select* will consume 640MB of memory


I'll be submitting an optimization to adaptively adjust the batch size based on the table width later on

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

