### PR TITLE
[fix](insert into) 'output_tuple_slot_num should be equal to output_expr_num' when insert into unique table with sequence column map

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -929,10 +929,11 @@ public class NativeInsertStmt extends InsertStmt {
                         && col.getName().equals(Column.SEQUENCE_COL)
                         && ((OlapTable) targetTable).getSequenceMapCol() != null) {
                     if (resultExprByName.stream().map(Pair::key)
-                            .anyMatch(key -> key.equals(((OlapTable) targetTable).getSequenceMapCol()))) {
+                            .anyMatch(key -> key.equalsIgnoreCase(((OlapTable) targetTable).getSequenceMapCol()))) {
                         resultExprByName.add(Pair.of(Column.SEQUENCE_COL,
                                 resultExprByName.stream()
-                                        .filter(p -> p.key().equals(((OlapTable) targetTable).getSequenceMapCol()))
+                                        .filter(p -> p.key()
+                                                .equalsIgnoreCase(((OlapTable) targetTable).getSequenceMapCol()))
                                         .map(Pair::value).findFirst().orElse(null)));
                     }
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2489,7 +2489,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 if (!col.getType().isFixedPointType() && !col.getType().isDateType()) {
                     throw new DdlException("Sequence type only support integer types and date types");
                 }
-                olapTable.setSequenceMapCol(sequenceMapCol);
+                olapTable.setSequenceMapCol(col.getName());
                 olapTable.setSequenceInfo(col.getType());
             }
         } catch (Exception e) {

--- a/regression-test/suites/correctness_p0/test_sequence_col_default_value.groovy
+++ b/regression-test/suites/correctness_p0/test_sequence_col_default_value.groovy
@@ -36,7 +36,7 @@ suite("test_sequence_col_default_value") {
         PROPERTIES (
             "replication_allocation" = "tag.location.default: 1",
             "enable_unique_key_merge_on_write" = "true",
-            "function_column.sequence_col" = 'write_time'
+            "function_column.sequence_col" = 'WRITE_TIME'
         );
     """
 


### PR DESCRIPTION
## Proposed changes

1. create table
```
 CREATE TABLE t4 (
    `id` int(11) NOT NULL,
    `NAME` varchar(50) NULL,
    `score` int(11) NULL 
) ENGINE=OLAP
UNIQUE KEY(`id`, `name`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
    "replication_num" = "1",
    "function_column.sequence_col" = "SCORE"
);
```
2. insert into
```
mysql> insert into t4 values(1, 'a', 100);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CANCELLED][INVALID_ARGUMENT]output_tuple_slot_num 6 should be equal to output_expr_num 5
```

the problem here is the `"function_column.sequence_col" = "SCORE"` and `score int(11) NULL` is case inconsistency.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

