### PR TITLE
[Fix](nereids)Disable getting partition related table and column when self join

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -350,7 +350,6 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                         });
     }
 
-
     @Test
     public void getRelatedTableInfoSelfJoinTest() {
         PlanChecker.from(connectContext)
@@ -366,7 +365,6 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                             Assertions.assertFalse(relatedTableInfo.isPresent());
                         });
     }
-
 
     @Test
     public void getRelatedTableInfoUseRightTest() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -350,6 +350,24 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                         });
     }
 
+
+    @Test
+    public void getRelatedTableInfoSelfJoinTest() {
+        PlanChecker.from(connectContext)
+                .checkExplain("    select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 1\n"
+                                + "    from lineitem_list_partition t1\n"
+                                + "    join lineitem_list_partition t2\n"
+                                + "    on t1.l_shipdate = t2.l_shipdate\n"
+                                + "    group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey",
+                        nereidsPlanner -> {
+                            Plan rewrittenPlan = nereidsPlanner.getRewrittenPlan();
+                            Optional<RelatedTableInfo> relatedTableInfo =
+                                    MaterializedViewUtils.getRelatedTableInfo("l_orderkey", rewrittenPlan);
+                            Assertions.assertFalse(relatedTableInfo.isPresent());
+                        });
+    }
+
+
     @Test
     public void getRelatedTableInfoUseRightTest() {
         PlanChecker.from(connectContext)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -65,6 +65,37 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                 + "PROPERTIES (\n"
                 + "  \"replication_num\" = \"1\"\n"
                 + ")");
+
+        createTable("CREATE TABLE `lineitem_list_partition` (\n"
+                + "      `l_orderkey` BIGINT not NULL,\n"
+                + "      `l_linenumber` INT NULL,\n"
+                + "      `l_partkey` INT NULL,\n"
+                + "      `l_suppkey` INT NULL,\n"
+                + "      `l_quantity` DECIMAL(15, 2) NULL,\n"
+                + "      `l_extendedprice` DECIMAL(15, 2) NULL,\n"
+                + "      `l_discount` DECIMAL(15, 2) NULL,\n"
+                + "      `l_tax` DECIMAL(15, 2) NULL,\n"
+                + "      `l_returnflag` VARCHAR(1) NULL,\n"
+                + "      `l_linestatus` VARCHAR(1) NULL,\n"
+                + "      `l_commitdate` DATE NULL,\n"
+                + "      `l_receiptdate` DATE NULL,\n"
+                + "      `l_shipinstruct` VARCHAR(25) NULL,\n"
+                + "      `l_shipmode` VARCHAR(10) NULL,\n"
+                + "      `l_comment` VARCHAR(44) NULL,\n"
+                + "      `l_shipdate` DATE NULL\n"
+                + "    ) ENGINE=OLAP\n"
+                + "    DUPLICATE KEY(l_orderkey, l_linenumber, l_partkey, l_suppkey )\n"
+                + "    COMMENT 'OLAP'\n"
+                + "    PARTITION BY list(l_orderkey) (\n"
+                + "    PARTITION p1 VALUES in ('1'),\n"
+                + "    PARTITION p2 VALUES in ('2'),\n"
+                + "    PARTITION p3 VALUES in ('3')\n"
+                + "    )\n"
+                + "    DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 3\n"
+                + "    PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\"\n"
+                + "    )");
+
         createTable("CREATE TABLE IF NOT EXISTS orders  (\n"
                 + "  O_ORDERKEY       INTEGER NOT NULL,\n"
                 + "  O_CUSTKEY        INTEGER NOT NULL,\n"
@@ -82,6 +113,30 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                 + "PROPERTIES (\n"
                 + "  \"replication_num\" = \"1\"\n"
                 + ")");
+
+        createTable("CREATE TABLE `orders_list_partition` (\n"
+                + "      `o_orderkey` BIGINT not NULL,\n"
+                + "      `o_custkey` INT NULL,\n"
+                + "      `o_orderstatus` VARCHAR(1) NULL,\n"
+                + "      `o_totalprice` DECIMAL(15, 2)  NULL,\n"
+                + "      `o_orderpriority` VARCHAR(15) NULL,\n"
+                + "      `o_clerk` VARCHAR(15) NULL,\n"
+                + "      `o_shippriority` INT NULL,\n"
+                + "      `o_comment` VARCHAR(79) NULL,\n"
+                + "      `o_orderdate` DATE NULL\n"
+                + "    ) ENGINE=OLAP\n"
+                + "    DUPLICATE KEY(`o_orderkey`, `o_custkey`)\n"
+                + "    COMMENT 'OLAP'\n"
+                + "    PARTITION BY list(o_orderkey) (\n"
+                + "    PARTITION p1 VALUES in ('1'),\n"
+                + "    PARTITION p2 VALUES in ('2'),\n"
+                + "    PARTITION p3 VALUES in ('3'),\n"
+                + "    PARTITION p4 VALUES in ('4')\n"
+                + "    )\n"
+                + "    DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 3\n"
+                + "    PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\"\n"
+                + "    )");
         createTable("CREATE TABLE IF NOT EXISTS partsupp (\n"
                 + "  PS_PARTKEY     INTEGER NOT NULL,\n"
                 + "  PS_SUPPKEY     INTEGER NOT NULL,\n"
@@ -141,7 +196,7 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                 + "    DUPLICATE KEY(l_orderkey, l_linenumber, l_partkey, l_suppkey )\n"
                 + "    COMMENT 'OLAP'\n"
                 + "    AUTO PARTITION BY range date_trunc(`l_shipdate`, 'day') ()\n"
-                + "    DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96\n"
+                + "    DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 3\n"
                 + "    PROPERTIES (\n"
                 + "       \"replication_num\" = \"1\"\n"
                 + "    );\n"
@@ -272,6 +327,25 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                             checkRelatedTableInfo(relatedTableInfo,
                                     "lineitem",
                                     "L_SHIPDATE",
+                                    true);
+                        });
+    }
+
+    @Test
+    public void getRelatedTableInfoLeftAntiJoinTest() {
+        PlanChecker.from(connectContext)
+                .checkExplain("        select l_shipdate, l_orderkey, count(l_shipdate), count(l_orderkey) \n"
+                                + "        from lineitem_list_partition\n"
+                                + "        left anti join orders_list_partition\n"
+                                + "        on l_shipdate = o_orderdate\n"
+                                + "        group by l_shipdate, l_orderkey",
+                        nereidsPlanner -> {
+                            Plan rewrittenPlan = nereidsPlanner.getRewrittenPlan();
+                            Optional<RelatedTableInfo> relatedTableInfo =
+                                    MaterializedViewUtils.getRelatedTableInfo("l_orderkey", rewrittenPlan);
+                            checkRelatedTableInfo(relatedTableInfo,
+                                    "lineitem_list_partition",
+                                    "l_orderkey",
                                     true);
                         });
     }


### PR DESCRIPTION
## Proposed changes

the following sql is the definition for materialized view 
if `l_shipdate` is the partitiion column for table `lineitem_list_partition`, the  materialized view  can not refresh incrementally

>
>select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
>                                from lineitem_list_partition t1
>                                join lineitem_list_partition t2
>                                on t1.l_shipdate = t2.l_shipdate
>                                group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

