### PR TITLE
[fix](decimalv2) update set with a decimal literal overflowed make be crash

### DIFF
--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -171,7 +171,7 @@ Status VExpr::create_expr(doris::ObjectPool* pool, const doris::TExprNode& texpr
             return Status::InternalError("Unknown expr node type: {}", texpr_node.node_type);
         }
     } catch (const Exception& e) {
-        return Status::Error(e.code());
+        return Status::Error(e.code(), e.message());
     }
     if (!(*expr)->data_type()) {
         return Status::InvalidArgument("Unknown expr type: {}", texpr_node.node_type);

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -426,7 +426,7 @@ VOlapTableSink::VOlapTableSink(ObjectPool* pool, const RowDescriptor& row_desc,
         : OlapTableSink(pool, row_desc, texprs, status) {
     _is_vectorized = true;
     // From the thrift expressions create the real exprs.
-    vectorized::VExpr::create_expr_trees(pool, texprs, &_output_vexpr_ctxs);
+    *status = vectorized::VExpr::create_expr_trees(pool, texprs, &_output_vexpr_ctxs);
     _name = "VOlapTableSink";
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #30449

<!--Describe your changes.-->

After change:
1. if we do not set `allow_invalid_decimalv2_literal=true` in be, we got following error message:
```
> update test_7 SET value = 0.1234567890123 WHERE id = '123';
ERROR 1105 (HY000): errCode = 2, detailMessage = failed to execute update stmt, query id: 3e1144db6f0d41eb-bb1a43e3c73a62c8, err: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]Invalid decimal(scale: 9) value: 0.1234567890123
```

2. if we set `allow_invalid_decimalv2_literal=true` in be, we can update successfully and the decimal literal is truncated.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

