### PR TITLE
[Bug](pipeline) fix pipeline task execute without wait second start rpc

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -246,16 +246,13 @@ Status PipelineTask::execute(bool* eos) {
                 set_state(PipelineTaskState::BLOCKED_FOR_SOURCE);
                 return Status::OK();
             }
-            // here check dependency first.
-            // even if status is not ok, as have dependency to push back to queue again.
-            if (has_dependency()) {
+            //if status is not ok, and have dependency to push back to queue again.
+            if (!_open_status.ok() && has_dependency()) {
                 set_state(PipelineTaskState::BLOCKED_FOR_DEPENDENCY);
                 return Status::OK();
-            } else {
-                if (!_open_status.ok()) { // not ok and no dependency, return error to cancel.
-                    return _open_status;
-                }
             }
+            // not ok and no dependency, return error to cancel.
+            RETURN_IF_ERROR(_open_status);
         }
         if (has_dependency()) {
             set_state(PipelineTaskState::BLOCKED_FOR_DEPENDENCY);

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -324,6 +324,7 @@ protected:
     // 3 update task statistics(update _queue_level/_core_id)
     int _queue_level = 0;
     int _core_id = 0;
+    Status _open_status = Status::OK();
 
     RuntimeProfile* _parent_profile = nullptr;
     std::unique_ptr<RuntimeProfile> _task_profile;


### PR DESCRIPTION
## Proposed changes
task execute should wait the second start rpc.
if task execute without wait rpc and meet some error in node open function.
the query will be canceled, and remove query_id from query_map.
so when the second start rpc arrival will not found query_id.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

