### PR TITLE
[opt](catalog) cache the converted properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -106,6 +106,7 @@ public abstract class ExternalCatalog
     private String comment;
     // A cached and being converted properties for external catalog.
     // generated from catalog properties.
+    private final byte[] lock = new byte[0];
     private Map<String, String> convertedProperties = null;
 
     public ExternalCatalog() {
@@ -431,7 +432,7 @@ public abstract class ExternalCatalog
         if (convertedProperties != null) {
             return convertedProperties;
         }
-        synchronized (convertedProperties) {
+        synchronized (lock) {
             if (convertedProperties != null) {
                 return convertedProperties;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -302,7 +302,7 @@ public abstract class ExternalCatalog
     public void onRefresh(boolean invalidCache) {
         this.objectCreated = false;
         this.initialized = false;
-        synchronized (this.convertedProperties) {
+        synchronized (this.lock) {
             this.convertedProperties = null;
         }
         this.invalidCacheInInit = invalidCache;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -106,7 +106,7 @@ public abstract class ExternalCatalog
     private String comment;
     // A cached and being converted properties for external catalog.
     // generated from catalog properties.
-    private final byte[] lock = new byte[0];
+    private byte[] propLock = new byte[0];
     private Map<String, String> convertedProperties = null;
 
     public ExternalCatalog() {
@@ -302,7 +302,7 @@ public abstract class ExternalCatalog
     public void onRefresh(boolean invalidCache) {
         this.objectCreated = false;
         this.initialized = false;
-        synchronized (this.lock) {
+        synchronized (this.propLock) {
             this.convertedProperties = null;
         }
         this.invalidCacheInInit = invalidCache;
@@ -432,7 +432,7 @@ public abstract class ExternalCatalog
         if (convertedProperties != null) {
             return convertedProperties;
         }
-        synchronized (lock) {
+        synchronized (propLock) {
             if (convertedProperties != null) {
                 return convertedProperties;
             }
@@ -569,6 +569,7 @@ public abstract class ExternalCatalog
                 }
             }
         }
+        this.propLock = new byte[0];
     }
 
     public void addDatabaseForTest(ExternalDatabase<? extends ExternalTable> db) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalogTest.java
@@ -54,6 +54,7 @@ public class JdbcExternalCatalogTest {
         Map<String, String> newProperties = Maps.newHashMap();
         newProperties.put(JdbcResource.CONNECTION_POOL_MIN_SIZE, "2");
         jdbcExternalCatalog.getCatalogProperty().modifyCatalogProps(newProperties);
+        jdbcExternalCatalog.notifyPropertiesUpdated(newProperties);
         JdbcExternalCatalog replayJdbcCatalog2 = (JdbcExternalCatalog) CatalogFactory.createFromLog(
                 jdbcExternalCatalog.constructEditLog());
         Map<String, String> properties2 = replayJdbcCatalog2.getProperties();


### PR DESCRIPTION
## Proposed changes

convert properties may be a heavy operation, so we cache the result.

```
        at sun.misc.URLClassPath.getNextLoader(URLClassPath.java:480)
        - waiting to lock <0x00000005e99cca00> (a sun.misc.URLClassPath)
        at sun.misc.URLClassPath.findResource(URLClassPath.java:225)
        at java.net.URLClassLoader$2.run(URLClassLoader.java:577)
        at java.net.URLClassLoader$2.run(URLClassLoader.java:575)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findResource(URLClassLoader.java:574)
        at java.lang.ClassLoader.getResource(ClassLoader.java:1089)
        at org.apache.hadoop.conf.Configuration.getResource(Configuration.java:2839)
        at org.apache.hadoop.conf.Configuration.getStreamReader(Configuration.java:3113)
        at org.apache.hadoop.conf.Configuration.loadResource(Configuration.java:3072)
        at org.apache.hadoop.conf.Configuration.loadResources(Configuration.java:3045)
        at org.apache.hadoop.conf.Configuration.loadProps(Configuration.java:2923)
        - locked <0x000000065cfe78a8> (a org.apache.hadoop.hive.conf.HiveConf)
        at org.apache.hadoop.conf.Configuration.getProps(Configuration.java:2905)
        - locked <0x000000065cfe78a8> (a org.apache.hadoop.hive.conf.HiveConf)
        at org.apache.hadoop.conf.Configuration.iterator(Configuration.java:2968)
        at org.apache.hadoop.hive.conf.HiveConf.getProperties(HiveConf.java:5134)
        at org.apache.hadoop.hive.conf.HiveConf.getAllProperties(HiveConf.java:5130)
        at org.apache.hadoop.hive.conf.HiveConf.initialize(HiveConf.java:5147)
        at org.apache.hadoop.hive.conf.HiveConf.<init>(HiveConf.java:5102)
        at org.apache.doris.datasource.property.PropertyConverter.getPropertiesFromDLFConf(PropertyConverter.java:377)
        at org.apache.doris.datasource.property.PropertyConverter.convertToDLFProperties(PropertyConverter.java:365)
        at org.apache.doris.datasource.property.PropertyConverter.convertToMetaProperties(PropertyConverter.java:89)
        at org.apache.doris.datasource.ExternalCatalog.getProperties(ExternalCatalog.java:407)
        at org.apache.doris.datasource.hive.HiveMetaStoreCache.getFileCache(HiveMetaStoreCache.java:378)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

