### PR TITLE
[improve](backup) Skip all backup/restore jobs if max allowd option is set to 0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -516,6 +516,12 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     private void addBackupOrRestoreJob(long dbId, AbstractJob job) {
+        // If there are too many backup/restore jobs, it may cause OOM.  If the job num option is set to 0,
+        // skip all backup/restore jobs.
+        if (Config.max_backup_restore_job_num_per_db <= 0) {
+            return;
+        }
+
         jobLock.lock();
         try {
             Deque<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.computeIfAbsent(dbId, k -> Lists.newLinkedList());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If there are too many backup/restore jobs, it may cause OOM. This PR allows the user to skip all backup/restore jobs if max_backup_restore_job_num_per_db is set to 0.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

