### PR TITLE
[Refactor](executor)Remove useless statistics report path

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -942,8 +942,7 @@ Status PipelineFragmentContext::send_report(bool done) {
              [this](auto&& PH1) { return update_status(std::forward<decltype(PH1)>(PH1)); },
              [this](auto&& PH1, auto&& PH2) {
                  cancel(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
-             },
-             _query_ctx->get_query_statistics()},
+             }},
             std::dynamic_pointer_cast<PipelineFragmentContext>(shared_from_this()));
 }
 

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1312,8 +1312,7 @@ Status PipelineXFragmentContext::send_report(bool done) {
              TUniqueId(), _backend_num, _runtime_state.get(),
              std::bind(&PipelineFragmentContext::update_status, this, std::placeholders::_1),
              std::bind(&PipelineFragmentContext::cancel, this, std::placeholders::_1,
-                       std::placeholders::_2),
-             nullptr},
+                       std::placeholders::_2)},
             std::dynamic_pointer_cast<PipelineXFragmentContext>(shared_from_this()));
 }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -221,13 +221,6 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
 
     DCHECK(req.runtime_state != nullptr);
 
-    if (req.query_statistics) {
-        // use to report 'insert into select'
-        TQueryStatistics queryStatistics;
-        req.query_statistics->to_thrift(&queryStatistics);
-        params.__set_query_statistics(queryStatistics);
-    }
-
     if (req.runtime_state->query_type() == TQueryType::LOAD && !req.done && req.status.ok()) {
         // this is a load plan, and load is not finished, just make a brief report
         params.__set_loaded_rows(req.runtime_state->num_rows_load_total());

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -517,8 +517,7 @@ void PlanFragmentExecutor::send_report(bool done) {
             _runtime_state.get(),
             std::bind(&PlanFragmentExecutor::update_status, this, std::placeholders::_1),
             std::bind(&PlanFragmentExecutor::cancel, this, std::placeholders::_1,
-                      std::placeholders::_2),
-            _query_ctx->get_query_statistics()};
+                      std::placeholders::_2)};
     // This will send a report even if we are cancelled.  If the query completed correctly
     // but fragments still need to be cancelled (e.g. limit reached), the coordinator will
     // be waiting for a final report and profile.

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -60,7 +60,6 @@ struct ReportStatusRequest {
     RuntimeState* runtime_state;
     std::function<Status(Status)> update_fn;
     std::function<void(const PPlanFragmentCancelReason&, const std::string&)> cancel_fn;
-    std::shared_ptr<QueryStatistics> query_statistics;
 };
 // Save the common components of fragments in a query.
 // Some components like DescriptorTbl may be very large

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -478,7 +478,7 @@ struct TReportExecStatusParams {
 
   23: optional list<TDetailedReportParams> detailed_report
 
-  24: optional TQueryStatistics query_statistics
+  24: optional TQueryStatistics query_statistics // deprecated
 
   25: TReportWorkloadRuntimeStatusParams report_workload_runtime_status
 }


### PR DESCRIPTION
## Proposed changes
TReportExecStatusParams.query_statistics is useless in FE, should remove it.