### PR TITLE
[improvement](cmake) Move DLLVM_PROFILE into service/CMakeLists.txt

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -660,7 +660,7 @@ set(BUILD_SHARED_LIBS OFF)
 
 option(ENABLE_CLANG_COVERAGE "coverage option" OFF)
 if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
-    add_compile_options(-fprofile-instr-generate -fcoverage-mapping -DLLVM_PROFILE)
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate)
 endif ()
 

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -33,6 +33,9 @@ if (${MAKE_TEST} STREQUAL "OFF")
         doris_main.cpp
     )
 
+    if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
+        target_compile_definitions(doris_be PRIVATE -DLLVM_PROFILE)
+    endif ()
     pch_reuse(doris_be)
 
     # This permits libraries loaded by dlopen to link to the symbols in the program.


### PR DESCRIPTION
## Proposed changes

Move DLLVM_PROFILE into service/CMakeLists.txt

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

