### PR TITLE
[Fix](json) avoid print warn log when parse failed (#30656)

### DIFF
--- a/be/src/runtime/jsonb_value.cpp
+++ b/be/src/runtime/jsonb_value.cpp
@@ -34,7 +34,7 @@ Status JsonBinaryValue::from_json_string(const char* s, int length) {
         error = parser.getErrorCode();
         auto msg = fmt::format("json parse error: {} for value: {}", JsonbErrMsg::getErrMsg(error),
                                std::string_view(s, length));
-        LOG(WARNING) << msg;
+        VLOG_DEBUG << msg;
         return Status::InvalidArgument(msg);
     }
 

--- a/be/src/util/jsonb_parser_simd.h
+++ b/be/src/util/jsonb_parser_simd.h
@@ -100,7 +100,7 @@ public:
 
         if (!pch || len == 0) {
             err_ = JsonbErrType::E_EMPTY_DOCUMENT;
-            LOG(WARNING) << "empty json string";
+            VLOG_DEBUG << "empty json string";
             return false;
         }
 
@@ -144,7 +144,7 @@ public:
             return err_ == JsonbErrType::E_NONE;
         } catch (simdjson::simdjson_error& e) {
             err_ = JsonbErrType::E_EXCEPTION;
-            LOG(WARNING) << "simdjson parse exception: " << e.what();
+            VLOG_DEBUG << "simdjson parse exception: " << e.what();
             return false;
         }
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

