### PR TITLE
[fix](mtmv)compatibility metadata without refreshsnapshot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -268,6 +268,10 @@ public class MTMV extends OlapTable {
         relation = materializedView.relation;
         mvPartitionInfo = materializedView.mvPartitionInfo;
         refreshSnapshot = materializedView.refreshSnapshot;
+        // For compatibility
+        if (refreshSnapshot == null) {
+            refreshSnapshot = new MTMVRefreshSnapshot();
+        }
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Previously created mtmv, refreshsnapshot is null

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

