### PR TITLE
[fix](merge-cloud) Ignore uninit cloud delta writers

### DIFF
--- a/be/src/cloud/cloud_tablets_channel.h
+++ b/be/src/cloud/cloud_tablets_channel.h
@@ -41,7 +41,7 @@ public:
                  PTabletWriterAddBlockResult* res, bool* finished) override;
 
 private:
-    Status _init_writers_by_parition_ids(const std::unordered_set<int64_t>& partition_ids);
+    Status _init_writers_by_partition_ids(const std::unordered_set<int64_t>& partition_ids);
 
     CloudStorageEngine& _engine;
 };

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -611,10 +611,13 @@ void BaseTabletsChannel::_build_tablet_to_rowidxs(
     // tests show that a relatively coarse-grained read lock here performs better under multicore scenario
     // see: https://github.com/apache/doris/pull/28552
     std::shared_lock<std::shared_mutex> rlock(_broken_tablets_lock);
+    if (request.is_single_tablet_block()) {
+        // The cloud mode need the tablet ids to prepare rowsets.
+        int64_t tablet_id = request.tablet_ids(0);
+        tablet_to_rowidxs->emplace(tablet_id, std::initializer_list<uint32_t> {0});
+        return;
+    }
     for (uint32_t i = 0; i < request.tablet_ids_size(); ++i) {
-        if (request.is_single_tablet_block()) {
-            break;
-        }
         int64_t tablet_id = request.tablet_ids(i);
         if (_is_broken_tablet(tablet_id)) {
             // skip broken tablets


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The strict mode means strict filtering of column type conversions during import. Sometimes all inputs are filtered, but the partition ID is still set, and the writer is not initialized. This PR will skip those cloud delta writers when they close the tablets channel.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

