### PR TITLE
[fix](move-memtable) use signed integer when calculating remain ms

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -551,8 +551,8 @@ Status VTabletWriterV2::close(Status exec_status) {
 
         {
             SCOPED_TIMER(_close_load_timer);
-            auto remain_ms = _state->execution_timeout() * 1000 -
-                             _timeout_watch.elapsed_time() / 1000 / 1000;
+            int64_t remain_ms = static_cast<int64_t>(_state->execution_timeout()) * 1000 -
+                                _timeout_watch.elapsed_time() / 1000 / 1000;
             if (remain_ms <= 0) {
                 LOG(WARNING) << "load timed out before close waiting, load_id="
                              << print_id(_load_id);

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -551,15 +551,15 @@ Status VTabletWriterV2::close(Status exec_status) {
 
         {
             SCOPED_TIMER(_close_load_timer);
-            int64_t remain_ms = static_cast<int64_t>(_state->execution_timeout()) * 1000 -
-                                _timeout_watch.elapsed_time() / 1000 / 1000;
-            if (remain_ms <= 0) {
-                LOG(WARNING) << "load timed out before close waiting, load_id="
-                             << print_id(_load_id);
-                return Status::TimedOut("load timed out before close waiting");
-            }
             for (const auto& [_, streams] : _streams_for_node) {
                 for (const auto& stream : streams->streams()) {
+                    int64_t remain_ms = static_cast<int64_t>(_state->execution_timeout()) * 1000 -
+                                        _timeout_watch.elapsed_time() / 1000 / 1000;
+                    if (remain_ms <= 0) {
+                        LOG(WARNING) << "load timed out before close waiting, load_id="
+                                     << print_id(_load_id);
+                        return Status::TimedOut("load timed out before close waiting");
+                    }
                     RETURN_IF_ERROR(stream->close_wait(remain_ms));
                 }
             }


### PR DESCRIPTION
## Proposed changes

`remain_ms` should be a signed value.
Also, we should update remain_ms before each close_wait.

```
(gdb) p remain_ms
$10 = 18446744073709551611
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

