### PR TITLE
[fix](compile) be cannot compile on MacOS (#26155)

### DIFF
--- a/be/src/vec/common/memcmp_small.h
+++ b/be/src/vec/common/memcmp_small.h
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <cstdint>
 
-namespace detail {
+namespace doris::vectorized::detail {
 
 template <typename T>
 int cmp(T a, T b) {
@@ -32,7 +32,7 @@ int cmp(T a, T b) {
     return 0;
 }
 
-} // namespace detail
+} // namespace doris::vectorized::detail
 
 /// We can process uninitialized memory in the functions below.
 /// Results don't depend on the values inside uninitialized memory but Memory Sanitizer cannot see it.
@@ -63,11 +63,11 @@ int memcmp_small_allow_overflow15(const Char* a, size_t a_size, const Char* b, s
 
             if (offset >= min_size) break;
 
-            return detail::cmp(a[offset], b[offset]);
+            return doris::vectorized::detail::cmp(a[offset], b[offset]);
         }
     }
 
-    return detail::cmp(a_size, b_size);
+    return doris::vectorized::detail::cmp(a_size, b_size);
 }
 
 /** Variant when memory regions have same size.
@@ -86,7 +86,7 @@ int memcmp_small_allow_overflow15(const Char* a, const Char* b, size_t size) {
 
             if (offset >= size) return 0;
 
-            return detail::cmp(a[offset], b[offset]);
+            return doris::vectorized::detail::cmp(a[offset], b[offset]);
         }
     }
 
@@ -126,7 +126,7 @@ int memcmp_small_multiple_of16(const Char* a, const Char* b, size_t size) {
 
         if (mask) {
             offset += __builtin_ctz(mask);
-            return detail::cmp(a[offset], b[offset]);
+            return doris::vectorized::detail::cmp(a[offset], b[offset]);
         }
     }
 
@@ -144,7 +144,7 @@ int memcmp16(const Char* a, const Char* b) {
 
     if (mask) {
         auto offset = __builtin_ctz(mask);
-        return detail::cmp(a[offset], b[offset]);
+        return doris::vectorized::detail::cmp(a[offset], b[offset]);
     }
 
     return 0;
@@ -186,7 +186,7 @@ int memcmp_small_allow_overflow15(const Char* a, size_t a_size, const Char* b, s
     if (auto res = memcmp(a, b, std::min(a_size, b_size)))
         return res;
     else
-        return detail::cmp(a_size, b_size);
+        return doris::vectorized::detail::cmp(a_size, b_size);
 }
 
 template <typename Char>

--- a/be/src/vec/common/memcpy_small.h
+++ b/be/src/vec/common/memcpy_small.h
@@ -46,7 +46,7 @@
   * Use with caution.
   */
 
-namespace detail {
+namespace doris::vectorized::detail {
 inline void memcpy_small_allow_read_write_overflow15_impl(char* __restrict dst,
                                                           const char* __restrict src, ssize_t n) {
     while (n > 0) {
@@ -58,15 +58,15 @@ inline void memcpy_small_allow_read_write_overflow15_impl(char* __restrict dst,
         n -= 16;
     }
 }
-} // namespace detail
+} // namespace doris::vectorized::detail
 
 /** Works under assumption, that it's possible to read up to 15 excessive bytes after end of 'src' region
   *  and to write any garbage into up to 15 bytes after end of 'dst' region.
   */
 inline void memcpy_small_allow_read_write_overflow15(void* __restrict dst,
                                                      const void* __restrict src, size_t n) {
-    detail::memcpy_small_allow_read_write_overflow15_impl(reinterpret_cast<char*>(dst),
-                                                          reinterpret_cast<const char*>(src), n);
+    doris::vectorized::detail::memcpy_small_allow_read_write_overflow15_impl(
+            reinterpret_cast<char*>(dst), reinterpret_cast<const char*>(src), n);
 }
 
 /** NOTE There was also a function, that assumes, that you could read any bytes inside same memory page of src.

--- a/be/src/vec/common/string_utils/string_utils.cpp
+++ b/be/src/vec/common/string_utils/string_utils.cpp
@@ -20,7 +20,7 @@
 
 #include "vec/common/string_utils/string_utils.h"
 
-namespace detail {
+namespace doris::vectorized::detail {
 
 bool starts_with(const std::string& s, const char* prefix, size_t prefix_size) {
     return s.size() >= prefix_size && 0 == memcmp(s.data(), prefix, prefix_size);
@@ -31,4 +31,4 @@ bool ends_with(const std::string& s, const char* suffix, size_t suffix_size) {
            0 == memcmp(s.data() + s.size() - suffix_size, suffix, suffix_size);
 }
 
-} // namespace detail
+} // namespace doris::vectorized::detail

--- a/be/src/vec/common/string_utils/string_utils.h
+++ b/be/src/vec/common/string_utils/string_utils.h
@@ -24,27 +24,27 @@
 #include <cstring>
 #include <string>
 
-namespace detail {
+namespace doris::vectorized::detail {
 bool starts_with(const std::string& s, const char* prefix, size_t prefix_size);
 bool ends_with(const std::string& s, const char* suffix, size_t suffix_size);
-} // namespace detail
+} // namespace doris::vectorized::detail
 
 inline bool starts_with(const std::string& s, const std::string& prefix) {
-    return detail::starts_with(s, prefix.data(), prefix.size());
+    return doris::vectorized::detail::starts_with(s, prefix.data(), prefix.size());
 }
 
 inline bool ends_with(const std::string& s, const std::string& suffix) {
-    return detail::ends_with(s, suffix.data(), suffix.size());
+    return doris::vectorized::detail::ends_with(s, suffix.data(), suffix.size());
 }
 
 /// With GCC, strlen is evaluated compile time if we pass it a constant
 /// string that is known at compile time.
 inline bool starts_with(const std::string& s, const char* prefix) {
-    return detail::starts_with(s, prefix, strlen(prefix));
+    return doris::vectorized::detail::starts_with(s, prefix, strlen(prefix));
 }
 
 inline bool ends_with(const std::string& s, const char* suffix) {
-    return detail::ends_with(s, suffix, strlen(suffix));
+    return doris::vectorized::detail::ends_with(s, suffix, strlen(suffix));
 }
 
 /// Given an integer, return the adequate suffix for


### PR DESCRIPTION
build on MacOS meet error: reference to 'detail' is ambiguous. Because there is a detail namespace under std

## Proposed changes

cherry-pick #26155 to branch 2.0, otherwise we compile failed with following errors:
```
/Users/zhuxiaoli/Codes/doris-2.0/be/src/vec/common/memcpy_small.h:68:5: error: reference to 'detail' is ambiguous
    detail::memcpy_small_allow_read_write_overflow15_impl(reinterpret_cast<char*>(dst),
    ^
/Users/zhuxiaoli/Codes/doris-2.0/be/src/vec/common/memcpy_small.h:49:11: note: candidate found by name lookup is 'detail'
namespace detail {
          ^
/Users/zhuxiaoli/Codes/doris-2.0/be/../thirdparty/installed/include/boost/multiprecision/cpp_int/limits.hpp:15:11: note: candidate found by name lookup is 'std::detail'
namespace detail {
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

