### PR TITLE
[Fix](Job)Fix One-Time type JOB parameter verification error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
@@ -92,6 +92,9 @@ public class JobExecutionConfiguration {
         if (timerDefinition.getStartTimeMs() == null) {
             throw new IllegalArgumentException("startTimeMs cannot be null");
         }
+        if (isImmediate()) {
+            return;
+        }
         if (timerDefinition.getStartTimeMs() < System.currentTimeMillis()) {
             throw new IllegalArgumentException("startTimeMs cannot be less than current time");
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
@@ -36,7 +36,7 @@ public class JobExecutionConfigurationTest {
         configuration.setTimerDefinition(timerDefinition);
 
         List<Long> delayTimes = configuration.getTriggerDelayTimes(
-                0L, 0L,  5000L);
+                0L, 0L, 5000L);
 
         Assertions.assertEquals(1, delayTimes.size());
         Assertions.assertEquals(1, delayTimes.get(0).longValue());
@@ -59,12 +59,23 @@ public class JobExecutionConfigurationTest {
         Assertions.assertEquals(2, delayTimes.size());
         Assertions.assertArrayEquals(new Long[]{100L, 700L}, delayTimes.toArray());
         delayTimes = configuration.getTriggerDelayTimes(
-                   200000L, 0L, 1100000L);
+                200000L, 0L, 1100000L);
         Assertions.assertEquals(1, delayTimes.size());
-        Assertions.assertArrayEquals(new Long[]{ 500L}, delayTimes.toArray());
+        Assertions.assertArrayEquals(new Long[]{500L}, delayTimes.toArray());
         delayTimes = configuration.getTriggerDelayTimes(
                 1001000L, 0L, 1000000L);
         Assertions.assertEquals(1, delayTimes.size());
+    }
+
+    @Test
+    public void testImmediate() {
+        JobExecutionConfiguration configuration = new JobExecutionConfiguration();
+        configuration.setExecuteType(JobExecuteType.ONE_TIME);
+        configuration.setImmediate(true);
+        configuration.setImmediate(true);
+        TimerDefinition timerDefinition = new TimerDefinition();
+        configuration.setTimerDefinition(timerDefinition);
+        configuration.checkParams();
     }
 
 }

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -153,7 +153,10 @@ suite("test_base_insert_job") {
     sql """
           CREATE JOB press  ON SCHEDULE every 10 hour starts CURRENT_TIMESTAMP  comment 'test for test&68686781jbjbhj//ncsa' DO insert into ${tableName}  values  ('2023-07-19', 99, 99);
      """
-    Thread.sleep(2500)
+    Thread.sleep(5000)
+    def pressJob = sql """ select * from jobs("type"="insert") where name='press' """
+    println pressJob
+    
     def recurringTableDatas = sql """ select count(1) from ${tableName} where user_id=99 and type=99 """
     assert recurringTableDatas.get(0).get(0) == 1
     sql """


### PR DESCRIPTION
## What happend
```log
          CREATE JOB insert_recovery_test_base_insert_job  ON SCHEDULE at current_timestamp   comment 'test for test&68686781jbjbhj//ncsa' DO insert into t_test_BASE_inSert_job  values  ('2023-07-19', sleep(10000), 1001);
     ) process failed.
org.apache.doris.common.DdlException: errCode = 2, detailMessage = startTimeMs cannot be less than current time
	at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:195) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2466) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:816) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:514) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:462) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:245) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:193) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:246) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
```
## Proposed changes

The execution time of the job that is executed immediately will be set to the current time, but we will compare it with the current time after assigning it, so it will cause a parameter check error.

## Test
add UT

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

