### PR TITLE
[chore](mac compile) remove using regex to avoid mac compile failed frequently

### DIFF
--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -44,11 +44,6 @@ using std::vector;
 using std::string;
 using std::stringstream;
 
-using boost::regex;
-using boost::regex_error;
-using boost::regex_match;
-using boost::smatch;
-
 using ::google::protobuf::RepeatedPtrField;
 
 namespace doris {
@@ -304,7 +299,7 @@ Status DeleteHandler::parse_condition(const std::string& condition_str, TConditi
         const char* const CONDITION_STR_PATTERN =
                 R"(([\w$#%]+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*('((?:[\s\S]+)?)'|(?:[\s\S]+)?))";
         boost::regex ex(CONDITION_STR_PATTERN);
-        if (regex_match(condition_str, what, ex)) {
+        if (boost::regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {
                 matched = false;
             }


### PR DESCRIPTION
## Proposed changes

if we do not add `boost::` in the codes, we got following errors while compile in Mac.

So here remove unused `using regex`

```
/Users/runner/work/doris/doris/be/src/olap/delete_handler.cpp:205:5: error: reference to 'smatch' is ambiguous
    smatch what;
    ^
/Users/runner/work/doris/doris/be/src/olap/delete_handler.cpp:48:14: note: candidate found by name lookup is 'smatch'
using boost::smatch;
             ^
/usr/local/opt/llvm@16/bin/../include/c++/v1/regex:5397:48: note: candidate found by name lookup is 'std::smatch'
typedef match_results<string::const_iterator>  smatch;
                                               ^
/Users/runner/work/doris/doris/be/src/olap/delete_handler.cpp:215:9: error: reference to 'regex' is ambiguous
        regex ex(CONDITION_STR_PATTERN);
        ^
/Users/runner/work/doris/doris/be/src/olap/delete_handler.cpp:45:14: note: candidate found by name lookup is 'regex'
using boost::regex;
             ^
/usr/local/opt/llvm@16/bin/../include/c++/v1/regex:2613:30: note: candidate found by name lookup is 'std::regex'
typedef basic_regex<char>    regex;
                             ^
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

