### PR TITLE
[Fix](Nereids) Fix datatype length wrong when string contains chinese (#29885)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -21,8 +21,11 @@ import org.apache.doris.nereids.types.DataType;
 
 import java.util.Objects;
 
-/** StringLikeLiteral. */
+/**
+ * StringLikeLiteral.
+ */
 public abstract class StringLikeLiteral extends Literal {
+    public static final int CHINESE_CHAR_BYTE_LENGTH = 4;
     public final String value;
 
     public StringLikeLiteral(String value, DataType dataType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -256,4 +256,16 @@ public class Utils {
     public static <T> List<T> copyRequiredList(List<T> list) {
         return ImmutableList.copyOf(Objects.requireNonNull(list, "non-null list is required"));
     }
+
+    /**
+     * Check the content if contains chinese or not, if true when contains chinese or false
+     */
+    public static boolean containChinese(String text) {
+        for (char textChar : text.toCharArray()) {
+            if (Character.UnicodeScript.of(textChar) == Character.UnicodeScript.HAN) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/UtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/UtilsTest.java
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The tests for utils
+ */
+public class UtilsTest {
+    @Test
+    public void containChinese() {
+        String chinese = "123数据库";
+        Assertions.assertTrue(Utils.containChinese(chinese));
+
+        String en = "database123";
+        Assertions.assertFalse(Utils.containChinese(en));
+    }
+}


### PR DESCRIPTION
## Proposed changes

The commit id is 0c5dd1a8
The pr is #29885

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

