### PR TITLE
[refactor](queryctx) move tg related code to task group

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -660,8 +660,7 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                           << ((int)config::enable_cgroup_cpu_soft_limit);
             } else {
                 LOG(INFO) << "Query/load id: " << print_id(query_ctx->query_id())
-                          << " carried group info but can not find group in be, reason: "
-                          << ret.to_string();
+                          << " carried group info but can not find group in be";
             }
         }
 
@@ -673,8 +672,8 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
             if (search == _query_ctx_map.end()) {
                 _query_ctx_map.insert(std::make_pair(query_ctx->query_id(), query_ctx));
                 LOG(INFO) << "Register query/load memory tracker, query/load id: "
-                          << print_id(query_ctx->query_id())
-                          << " limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
+                          << print_id(query_ctx->query_id()) << " limit: "
+                          << PrettyPrinter::print(query_ctx->mem_limit(), TUnit::BYTES);
             } else {
                 // Already has a query fragments context, use it
                 query_ctx = search->second;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -652,7 +652,6 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                 query_ctx->set_task_group(task_group_ptr);
                 _exec_env->runtime_query_statistics_mgr()->set_workload_group_id(print_id(query_id),
                                                                                  tg_id);
-                query_ctx->set_query_scheduler(tg_id);
 
                 LOG(INFO) << "Query/load id: " << print_id(query_ctx->query_id())
                           << ", use task group: " << task_group_ptr->debug_string()

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -646,7 +646,7 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
         if (params.__isset.workload_groups && !params.workload_groups.empty()) {
             uint64_t tg_id = params.workload_groups[0].id;
             taskgroup::TaskGroupPtr task_group_ptr =
-                    _exec_env->task_group_manager()->get_task_group(tg_id);
+                    _exec_env->task_group_manager()->get_task_group_by_id(tg_id);
             if (task_group_ptr != nullptr) {
                 // set task group to queryctx for memory tracker can be removed, see QueryContext's destructor
                 query_ctx->set_task_group(task_group_ptr);

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -646,8 +646,7 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
             taskgroup::TaskGroupPtr task_group_ptr =
                     _exec_env->task_group_manager()->get_task_group_by_id(tg_id);
             if (task_group_ptr != nullptr) {
-                // set task group to queryctx for memory tracker can be removed, see QueryContext's destructor
-                query_ctx->set_task_group(task_group_ptr);
+                RETURN_IF_ERROR(query_ctx->set_task_group(task_group_ptr));
                 _exec_env->runtime_query_statistics_mgr()->set_workload_group_id(print_id(query_id),
                                                                                  tg_id);
 

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -202,4 +202,12 @@ ThreadPool* QueryContext::get_non_pipe_exec_thread_pool() {
     }
 }
 
+void QueryContext::set_task_group(taskgroup::TaskGroupPtr& tg) {
+    _task_group = tg;
+    _task_group->add_query(_query_id);
+    _task_group->add_mem_tracker_limiter(query_mem_tracker);
+    _exec_env->task_group_manager()->get_query_scheduler(
+            _task_group->id(), &_task_scheduler, &_scan_task_scheduler, &_non_pipe_thread_pool);
+}
+
 } // namespace doris

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -21,6 +21,7 @@
 #include "pipeline/pipeline_x/dependency.h"
 #include "runtime/runtime_query_statistics_mgr.h"
 #include "runtime/task_group/task_group_manager.h"
+#include "util/mem_info.h"
 
 namespace doris {
 

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -204,6 +204,11 @@ ThreadPool* QueryContext::get_non_pipe_exec_thread_pool() {
 }
 
 void QueryContext::set_task_group(taskgroup::TaskGroupPtr& tg) {
+    if (tg->is_shutdown()) {
+        // The task group is marked shutdown, then should not put query task
+        // to the task group anymore, just waiting the existing query finished.
+        return;
+    }
     _task_group = tg;
     _task_group->add_query(_query_id);
     _task_group->add_mem_tracker_limiter(query_mem_tracker);

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -50,26 +50,26 @@ QueryContext::QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* 
     timeout_second = query_options.execution_timeout;
 
     bool has_query_mem_tracker = query_options.__isset.mem_limit && (query_options.mem_limit > 0);
-    int64_t bytes_limit = has_query_mem_tracker ? query_options.mem_limit : -1;
-    if (bytes_limit > MemInfo::mem_limit()) {
-        VLOG_NOTICE << "Query memory limit " << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
+    int64_t _bytes_limit = has_query_mem_tracker ? query_options.mem_limit : -1;
+    if (_bytes_limit > MemInfo::mem_limit()) {
+        VLOG_NOTICE << "Query memory limit " << PrettyPrinter::print(_bytes_limit, TUnit::BYTES)
                     << " exceeds process memory limit of "
                     << PrettyPrinter::print(MemInfo::mem_limit(), TUnit::BYTES)
                     << ". Using process memory limit instead";
-        bytes_limit = MemInfo::mem_limit();
+        _bytes_limit = MemInfo::mem_limit();
     }
     if (query_options.query_type == TQueryType::SELECT) {
         query_mem_tracker = std::make_shared<MemTrackerLimiter>(
                 MemTrackerLimiter::Type::QUERY, fmt::format("Query#Id={}", print_id(_query_id)),
-                bytes_limit);
+                _bytes_limit);
     } else if (query_options.query_type == TQueryType::LOAD) {
         query_mem_tracker = std::make_shared<MemTrackerLimiter>(
                 MemTrackerLimiter::Type::LOAD, fmt::format("Load#Id={}", print_id(_query_id)),
-                bytes_limit);
+                _bytes_limit);
     } else { // EXTERNAL
         query_mem_tracker = std::make_shared<MemTrackerLimiter>(
                 MemTrackerLimiter::Type::LOAD, fmt::format("External#Id={}", print_id(_query_id)),
-                bytes_limit);
+                _bytes_limit);
     }
     if (query_options.__isset.is_report_success && query_options.is_report_success) {
         query_mem_tracker->enable_print_log_usage();

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -185,12 +185,6 @@ void QueryContext::register_cpu_statistics() {
     }
 }
 
-void QueryContext::set_query_scheduler(uint64_t tg_id) {
-    auto* tg_mgr = _exec_env->task_group_manager();
-    tg_mgr->get_query_scheduler(tg_id, &_task_scheduler, &_scan_task_scheduler,
-                                &_non_pipe_thread_pool);
-}
-
 doris::pipeline::TaskScheduler* QueryContext::get_pipe_exec_scheduler() {
     if (_task_group) {
         if (_task_scheduler) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -203,7 +203,7 @@ ThreadPool* QueryContext::get_non_pipe_exec_thread_pool() {
     }
 }
 
-void QueryContext::set_task_group(taskgroup::TaskGroupPtr& tg) {
+Status QueryContext::set_task_group(taskgroup::TaskGroupPtr& tg) {
     _task_group = tg;
     // Should add query first, then the task group will not be deleted.
     // see task_group_manager::delete_task_group_by_ids

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -150,7 +150,11 @@ public:
 
     vectorized::RuntimePredicate& get_runtime_predicate() { return _runtime_predicate; }
 
-    void set_task_group(taskgroup::TaskGroupPtr& tg) { _task_group = tg; }
+    void set_task_group(taskgroup::TaskGroupPtr& tg) {
+        _task_group = tg;
+        _task_group->add_query(_query_id);
+        _task_group->add_mem_tracker_limiter(query_mem_tracker);
+    }
 
     int execution_timeout() const {
         return _query_options.__isset.execution_timeout ? _query_options.execution_timeout

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -150,13 +150,7 @@ public:
 
     vectorized::RuntimePredicate& get_runtime_predicate() { return _runtime_predicate; }
 
-    void set_task_group(taskgroup::TaskGroupPtr& tg) {
-        _task_group = tg;
-        _task_group->add_query(_query_id);
-        _task_group->add_mem_tracker_limiter(query_mem_tracker);
-        _exec_env->task_group_manager()->get_query_scheduler(
-                _task_group->id(), &_task_scheduler, &_scan_task_scheduler, &_non_pipe_thread_pool);
-    }
+    void set_task_group(taskgroup::TaskGroupPtr& tg);
 
     int execution_timeout() const {
         return _query_options.__isset.execution_timeout ? _query_options.execution_timeout

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -209,6 +209,8 @@ public:
 
     ThreadPool* get_non_pipe_exec_thread_pool();
 
+    int64_t mem_limit() { return _bytes_limit; }
+
 public:
     DescriptorTbl* desc_tbl = nullptr;
     bool set_rsc_info = false;
@@ -242,6 +244,7 @@ private:
     TUniqueId _query_id;
     ExecEnv* _exec_env = nullptr;
     VecDateTimeValue _start_time;
+    int64_t _bytes_limit = 0;
 
     // A token used to submit olap scanner to the "_limited_scan_thread_pool",
     // This thread pool token is created from "_limited_scan_thread_pool" from exec env.

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -154,6 +154,8 @@ public:
         _task_group = tg;
         _task_group->add_query(_query_id);
         _task_group->add_mem_tracker_limiter(query_mem_tracker);
+        _exec_env->task_group_manager()->get_query_scheduler(
+                _task_group->id(), &_task_scheduler, &_scan_task_scheduler, &_non_pipe_thread_pool);
     }
 
     int execution_timeout() const {
@@ -195,16 +197,6 @@ public:
 
     TUniqueId query_id() const { return _query_id; }
 
-    void set_task_scheduler(pipeline::TaskScheduler* task_scheduler) {
-        _task_scheduler = task_scheduler;
-    }
-
-    pipeline::TaskScheduler* get_task_scheduler() { return _task_scheduler; }
-
-    void set_scan_task_scheduler(vectorized::SimplifiedScanScheduler* scan_task_scheduler) {
-        _scan_task_scheduler = scan_task_scheduler;
-    }
-
     vectorized::SimplifiedScanScheduler* get_scan_scheduler() { return _scan_task_scheduler; }
 
     pipeline::Dependency* get_execution_dependency() { return _execution_dependency.get(); }
@@ -218,8 +210,6 @@ public:
     void register_cpu_statistics();
 
     std::shared_ptr<QueryStatistics> get_cpu_statistics() { return _cpu_statistics; }
-
-    void set_query_scheduler(uint64_t wg_id);
 
     doris::pipeline::TaskScheduler* get_pipe_exec_scheduler();
 

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -150,7 +150,7 @@ public:
 
     vectorized::RuntimePredicate& get_runtime_predicate() { return _runtime_predicate; }
 
-    void set_task_group(taskgroup::TaskGroupPtr& tg);
+    Status set_task_group(taskgroup::TaskGroupPtr& tg);
 
     int execution_timeout() const {
         return _query_options.__isset.execution_timeout ? _query_options.execution_timeout

--- a/be/src/runtime/task_group/task_group.h
+++ b/be/src/runtime/task_group/task_group.h
@@ -29,6 +29,7 @@
 #include <unordered_set>
 
 #include "common/status.h"
+#include "service/backend_options.h"
 #include "util/hash_util.hpp"
 
 namespace doris {

--- a/be/src/runtime/task_group/task_group.h
+++ b/be/src/runtime/task_group/task_group.h
@@ -97,18 +97,21 @@ public:
     }
 
     void add_query(TUniqueId query_id) {
-        std::unique_lock<std::shared_mutex> wlock;
+        std::unique_lock<std::shared_mutex> wlock(_mutex);
         _query_id_set.insert(query_id);
     }
 
     void remove_query(TUniqueId query_id) {
-        std::unique_lock<std::shared_mutex> wlock;
+        std::unique_lock<std::shared_mutex> wlock(_mutex);
         _query_id_set.erase(query_id);
     }
 
     void shutdown() { _is_shutdown = true; }
 
-    int query_num() { return _query_id_set.size(); }
+    int query_num() {
+        std::shared_lock<std::shared_mutex> r_lock(_mutex);
+        return _query_id_set.size();
+    }
 
     bool is_shutdown() { return _is_shutdown; }
 

--- a/be/src/runtime/task_group/task_group.h
+++ b/be/src/runtime/task_group/task_group.h
@@ -96,9 +96,15 @@ public:
         return _memory_limit > 0;
     }
 
-    void add_query(TUniqueId query_id) { _query_id_set.insert(query_id); }
+    void add_query(TUniqueId query_id) {
+        std::unique_lock<std::shared_mutex> wlock;
+        _query_id_set.insert(query_id);
+    }
 
-    void remove_query(TUniqueId query_id) { _query_id_set.erase(query_id); }
+    void remove_query(TUniqueId query_id) {
+        std::unique_lock<std::shared_mutex> wlock;
+        _query_id_set.erase(query_id);
+    }
 
     void shutdown() { _is_shutdown = true; }
 

--- a/be/src/runtime/task_group/task_group_manager.cpp
+++ b/be/src/runtime/task_group/task_group_manager.cpp
@@ -276,34 +276,6 @@ void TaskGroupManager::delete_task_group_by_ids(std::set<uint64_t> used_wg_id) {
               << "ms, deleted group size:" << deleted_tg_ids.size();
 }
 
-Status TaskGroupManager::add_query_to_group(uint64_t tg_id, TUniqueId query_id,
-                                            TaskGroupPtr* tg_ptr) {
-    std::lock_guard<std::shared_mutex> write_lock(_group_mutex);
-    auto tg_iter = _task_groups.find(tg_id);
-    if (tg_iter != _task_groups.end()) {
-        if (tg_iter->second->is_shutdown()) {
-            return Status::InternalError<false>("workload group {} is shutdown.", tg_id);
-        }
-        tg_iter->second->add_query(query_id);
-        *tg_ptr = tg_iter->second;
-        return Status::OK();
-    } else {
-        return Status::InternalError<false>("can not find workload group {}.", tg_id);
-    }
-}
-
-void TaskGroupManager::remove_query_from_group(uint64_t tg_id, TUniqueId query_id) {
-    std::lock_guard<std::shared_mutex> write_lock(_group_mutex);
-    auto tg_iter = _task_groups.find(tg_id);
-    if (tg_iter != _task_groups.end()) {
-        tg_iter->second->remove_query(query_id);
-    } else {
-        //NOTE: This should never happen
-        LOG(INFO) << "can not find task group when remove query, tg:" << tg_id
-                  << ", query_id:" << print_id(query_id);
-    }
-}
-
 void TaskGroupManager::stop() {
     for (auto& task_sche : _tg_sche_map) {
         task_sche.second->stop();

--- a/be/src/runtime/task_group/task_group_manager.h
+++ b/be/src/runtime/task_group/task_group_manager.h
@@ -69,20 +69,6 @@ public:
                              vectorized::SimplifiedScanScheduler** scan_sched,
                              ThreadPool** non_pipe_thread_pool);
 
-    TaskGroupPtr get_task_group(uint64_t tg_id) {
-        std::lock_guard<std::shared_mutex> write_lock(_group_mutex);
-        auto tg_iter = _task_groups.find(tg_id);
-        if (tg_iter != _task_groups.end()) {
-            if (tg_iter->second->is_shutdown()) {
-                LOG(INFO) << "workload group " << tg_id << " is shutdown";
-                return nullptr;
-            }
-            return tg_iter->second;
-        } else {
-            return nullptr;
-        }
-    }
-
 private:
     std::shared_mutex _group_mutex;
     std::unordered_map<uint64_t, TaskGroupPtr> _task_groups;


### PR DESCRIPTION
## Proposed changes

1. init query ctx memtracker in queryctx constructor
2. set all task group related property during set taskgroup

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

