### PR TITLE
[config](move-memtable) set StreamWait timeout default to 10min

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -775,7 +775,7 @@ DEFINE_Int64(load_stream_max_buf_size, "20971520"); // 20MB
 // brpc streaming messages_in_batch
 DEFINE_Int32(load_stream_messages_in_batch, "128");
 // brpc streaming StreamWait seconds on EAGAIN
-DEFINE_Int32(load_stream_eagain_wait_seconds, "60");
+DEFINE_Int32(load_stream_eagain_wait_seconds, "600");
 // max tasks per flush token in load stream
 DEFINE_Int32(load_stream_flush_token_max_tasks, "15");
 // max wait flush token time in load stream


### PR DESCRIPTION
## Proposed changes

In pressure tests, stream wait timeout is too low, causing errors when writing replicas.

Increase StreamWait timeout to 10 min, to match `load_stream_max_wait_flush_token_time_ms`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

