### PR TITLE
[fix](merge-cloud) Disable memtable on sink node & unique key merge on write

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -29,7 +29,7 @@
 #include <ostream>
 #include <string>
 
-#include "common/config.h"
+#include "cloud/config.h"
 #include "runtime/query_context.h"
 #include "runtime/query_statistics.h"
 #include "vec/sink/async_writer_sink.h"
@@ -151,6 +151,10 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         DCHECK(thrift_sink.__isset.olap_table_sink);
         if (state->query_options().enable_memtable_on_sink_node &&
             !_has_inverted_index_or_partial_update(thrift_sink.olap_table_sink)) {
+            if (config::is_cloud_mode()) {
+                return Status::InternalError(
+                        "memtable on sink node is not supported in cloud mode");
+            }
             sink->reset(new vectorized::VOlapTableSinkV2(pool, row_desc, output_exprs));
         } else {
             sink->reset(new vectorized::VOlapTableSink(pool, row_desc, output_exprs));

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/common/util/CloudPropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/common/util/CloudPropertyAnalyzer.java
@@ -45,7 +45,9 @@ public class CloudPropertyAnalyzer extends PropertyAnalyzer {
                 RewriteProperty.replace(DynamicPartitionProperty.REPLICATION_NUM,
                         String.valueOf(ReplicaAllocation.DEFAULT_ALLOCATION.getTotalReplicaNum())),
                 RewriteProperty.replace(DynamicPartitionProperty.REPLICATION_ALLOCATION,
-                        ReplicaAllocation.DEFAULT_ALLOCATION.toCreateStmt())
+                        ReplicaAllocation.DEFAULT_ALLOCATION.toCreateStmt()),
+                // FIXME: MOW is not supported in cloud mode yet.
+                RewriteProperty.replace(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE, "false")
                 );
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In cloud mode, both features are not supported.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

