### PR TITLE
[fix](regression test) publish txn don't check schema change new tablets

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -465,7 +465,7 @@ public class Config extends ConfigBase {
             "Check the replicas which are doing schema change when publish transaction. Do not turn off this check "
             + " under normal circumstances. It's only temporarily skip check if publish version and schema change have"
             + " dead lock" })
-    public static boolean publish_version_check_alter_replica = false;
+    public static boolean publish_version_check_alter_replica = true;
 
     @ConfField(mutable = true, masterOnly = true, description = {"单个事务 publish 失败打日志间隔",
             "print log interval for publish transaction failed interval"})

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -465,7 +465,7 @@ public class Config extends ConfigBase {
             "Check the replicas which are doing schema change when publish transaction. Do not turn off this check "
             + " under normal circumstances. It's only temporarily skip check if publish version and schema change have"
             + " dead lock" })
-    public static boolean publish_version_check_alter_replica = true;
+    public static boolean publish_version_check_alter_replica = false;
 
     @ConfField(mutable = true, masterOnly = true, description = {"单个事务 publish 失败打日志间隔",
             "print log interval for publish transaction failed interval"})

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -71,6 +71,9 @@ enable_job_schedule_second_for_test = true
 enable_workload_group = true
 publish_topic_info_interval_ms = 1000
 
+# publish version don't check schema change tablets
+publish_version_check_alter_replica = false
+
 disable_decimalv2 = false
 disable_datev1 = false
 

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -71,6 +71,9 @@ enable_job_schedule_second_for_test = true
 enable_workload_group = true
 publish_topic_info_interval_ms = 1000
 
+# publish version don't check schema change tablets
+publish_version_check_alter_replica = false
+
 master_sync_policy = WRITE_NO_SYNC
 replica_sync_policy = WRITE_NO_SYNC
 


### PR DESCRIPTION
publish txn don't check schema change new tablets.

for schema change, even if the the new tablets load data, but when after it starting to covert history data, it will clear its data, so at that time, when check version exists will failed.

for simplify, publish txn don't check new tablets.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

