### PR TITLE
[Fix](executor)Fix start be core caused by query statistics report

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -373,8 +373,13 @@ void Daemon::block_spill_gc_thread() {
 
 void Daemon::query_runtime_statistics_thread() {
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::report_query_statistics_interval_ms))) {
-        ExecEnv::GetInstance()->runtime_query_statistics_mgr()->report_runtime_query_statistics();
+                   std::chrono::milliseconds(config::report_query_statistics_interval_ms)) &&
+           !k_doris_exit) {
+        if (ExecEnv::GetInstance()->initialized()) {
+            ExecEnv::GetInstance()
+                    ->runtime_query_statistics_mgr()
+                    ->report_runtime_query_statistics();
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes
Only 2.0 has this problem.

```
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1707064552 (unix time) try "date -d @1707064552" if you are using GNU date ***
*** Current BE git commitID: 1fca8826ce ***
*** SIGSEGV address not mapped to object (@0x98) received by PID 1184837 (TID 1185049 OR 0x7f7f1de71700) from PID 152; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at doris_branch-2.0/doris/be/src/common/signal_handler.h:417
 1# 0x00007F7FDC0770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F7FDC07002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F7FE44F7090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::RuntimeQueryStatiticsMgr::report_runtime_query_statistics() at doris_branch-2.0/doris/be/src/runtime/runtime_query_statistics_mgr.cpp:40
 6# doris::Daemon::query_runtime_statistics_thread() at doris_branch-2.0/doris/be/src/common/daemon.cpp:375
 7# doris::Daemon::start()::$_6::operator()() const at doris_branch-2.0/doris/be/src/common/daemon.cpp:489
 8# void std::__invoke_impl<void, doris::Daemon::start()::$_6&>(std::__invoke_other, doris::Daemon::start()::$_6&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
 9# std::enable_if<is_invocable_r_v<void, doris::Daemon::start()::$_6&>, void>::type std::__invoke_r<void, doris::Daemon::start()::$_6&>(doris::Daemon::start()::$_6&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
10# std::_Function_handler<void (), doris::Daemon::start()::$_6>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
11# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
12# doris::Thread::supervise_thread(void*) at doris_branch-2.0/doris/be/src/util/thread.cpp:498
13# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
14# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```