### PR TITLE
[fix](join) JoinHashTable::pre_build_idxs should be const

### DIFF
--- a/be/src/vec/common/hash_table/join_hash_table.h
+++ b/be/src/vec/common/hash_table/join_hash_table.h
@@ -234,17 +234,16 @@ public:
 
     bool has_null_key() { return _has_null_key; }
 
-    void pre_build_idxs(std::vector<uint32>& buckets, const uint8_t* null_map) {
-        const auto first_at_bucket_size = first[bucket_size];
+    void pre_build_idxs(std::vector<uint32>& buckets, const uint8_t* null_map) const {
         if (null_map) {
-            first[bucket_size] = bucket_size; // distinguish between not matched and null
+            for (unsigned int& bucket : buckets) {
+                bucket = bucket == bucket_size ? bucket_size : first[bucket];
+            }
+        } else {
+            for (unsigned int& bucket : buckets) {
+                bucket = first[bucket];
+            }
         }
-
-        for (unsigned int& bucket : buckets) {
-            bucket = first[bucket];
-        }
-
-        first[bucket_size] = first_at_bucket_size;
     }
 
 private:


### PR DESCRIPTION
## Proposed changes

For shared hash table, `JoinHashTable::pre_build_idxs` modify the hash table result to crash.

```
==8770==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6180005ef080 at pc 0x55888aae5de7 bp 0x7f41c8dae380 sp 0x7f41c8dae378
READ of size 4 at 0x6180005ef080 thread T275 (PipeNoGSchePool)
    #0 0x55888aae5de6 in doris::JoinHashTable>::find_null_aware_with_other_conjuncts(unsigned long const*, unsigned int const*, int, unsigned int, int, unsigned int*, unsigned int*, unsigned char*, bool)::'lambda'()::operator()() const /root/doris/be/src/vec/common/hash_table/join_hash_table.h:164:29
    #1 0x55888aae4a99 in doris::JoinHashTable>::find_null_aware_with_other_conjuncts(unsigned long const*, unsigned int const*, int, unsigned int, int, unsigned int*, unsigned int*, unsigned char*, bool) /root/doris/be/src/vec/common/hash_table/join_hash_table.h:197:13
    #2 0x55888ab0a092 in doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::do_process>>, true, true>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long) /root/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:199:48
    #3 0x55888ab0910e in auto doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto)::operator(), std::integral_constant>(auto, auto) const /root/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:633:23
    #4 0x55888ab08e2e in auto std::__invoke_impl::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto), std::integral_constant, std::integral_constant>(std::__invoke_other, auto&&, std::integral_constant&&, std::integral_constant&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #5 0x55888ab08db6 in std::__invoke_result, std::integral_constant>::type std::__invoke::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto), std::integral_constant, std::integral_constant>(auto&&, std::integral_constant&&, std::integral_constant&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #6 0x55888aaff9e5 in std::__detail::__variant::__gen_vtable_impl (*)(doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto)&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&)>, std::integer_sequence>::__visit_invoke(doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto)&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013:11
    #7 0x55888aaff7d4 in decltype(auto) std::__do_visit, doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto), std::variant, std::integral_constant>, std::variant, std::integral_constant>>(auto&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714:14
    #8 0x55888a9ca7cf in decltype(auto) std::visit::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool)::'lambda'(auto, auto), std::variant, std::integral_constant>, std::variant, std::integral_constant>>(auto&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1769:9
    #9 0x55888a9ca51d in doris::Status doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>::process>>>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool, bool) /root/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:631:5
    #10 0x558887ba5dbc in auto doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0::operator()>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant, std::integral_constant>(doris::vectorized::MethodOneNumber>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant, std::integral_constant) const /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:399:9
    #11 0x558887ba5a9e in void std::__invoke_impl>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant, std::integral_constant>(std::__invoke_other, doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::MethodOneNumber>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant&&, std::integral_constant&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #12 0x558887ba5996 in std::__invoke_result>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant, std::integral_constant>::type std::__invoke>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant, std::integral_constant>(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::MethodOneNumber>>&, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>&, std::integral_constant&&, std::integral_constant&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #13 0x558887b3cdaf in std::__detail::__variant::__gen_vtable_impl (*)(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&)>, std::integer_sequence>::__visit_invoke(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013:11
    #14 0x558887b31bd6 in decltype(auto) std::__do_visit, doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>, std::variant, std::integral_constant>>(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714:14
    #15 0x558887b20f85 in decltype(auto) std::visit>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>, std::variant, std::integral_constant>>(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>, doris::vectorized::MethodKeysFixed>, true>, doris::vectorized::MethodKeysFixed>, false>>&, std::variant, doris::vectorized::ProcessHashTableProbe<2, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<8, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<1, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<4, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<3, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<5, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<7, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<9, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<10, doris::vectorized::HashJoinNode>, doris::vectorized::ProcessHashTableProbe<11, doris::vectorized::HashJoinNode>>&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1769:9
    #16 0x558887b1f31d in doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:399:9
    #17 0x5588a172497e in doris::Status std::__invoke_impl(std::__invoke_memfun_deref, doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::HashJoinNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #18 0x5588a17246c1 in std::__invoke_result::type std::__invoke(doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::HashJoinNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #19 0x5588a17245e8 in doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::__call(std::tuple&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #20 0x5588a1724369 in doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()(doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #21 0x5588a1724209 in doris::Status std::__invoke_impl, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_other, std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #22 0x5588a1724149 in std::enable_if, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #23 0x5588a1723ca9 in std::_Function_handler, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>>::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #24 0x5588747e6bf2 in std::function::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #25 0x5588747d7a61 in doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function const&, bool) /root/doris/be/src/exec/exec_node.cpp:564:9
    #26 0x5588a171ab63 in doris::pipeline::StatefulOperator::get_block(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) /root/doris/be/src/pipeline/exec/operator.h:426:13
    #27 0x5588a2efd960 in doris::pipeline::PipelineTask::execute(bool*) /root/doris/be/src/pipeline/pipeline_task.cpp:299:13
    #28 0x5588a317d4fc in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:287:28
    #29 0x5588a318e0ca in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #30 0x5588a318dee6 in std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #31 0x5588a318de45 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #32 0x5588a318dc9f in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #33 0x5588a318dba6 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #34 0x5588a318db18 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #35 0x5588a318d72e in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #36 0x5588710855e6 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #37 0x5588752323ea in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:48:27
    #38 0x55887521bf8e in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #39 0x558875246e65 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #40 0x558875246d0e in std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #41 0x558875246c86 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #42 0x558875246b1f in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #43 0x558875246a26 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #44 0x558875246998 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #45 0x5588752465ee in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #46 0x5588710855e6 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #47 0x5588751e17a3 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #48 0x7f43a2a3f608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #49 0x7f43a2cec132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

