### PR TITLE
[fix](gc) handle exceptions during directory traversal

### DIFF
--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -203,23 +203,30 @@ Status LocalFileSystem::list_impl(const Path& dir, bool only_file, std::vector<F
         return Status::OK();
     }
     std::error_code ec;
-    for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
-        if (only_file && !entry.is_regular_file()) {
-            continue;
-        }
-        FileInfo file_info;
-        file_info.file_name = entry.path().filename();
-        file_info.is_file = entry.is_regular_file(ec);
-        if (ec) {
-            break;
-        }
-        if (file_info.is_file) {
-            file_info.file_size = entry.file_size(ec);
+    try {
+        for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+            if (only_file && !entry.is_regular_file()) {
+                continue;
+            }
+            FileInfo file_info;
+            file_info.file_name = entry.path().filename();
+            file_info.is_file = entry.is_regular_file(ec);
             if (ec) {
                 break;
             }
+            if (file_info.is_file) {
+                file_info.file_size = entry.file_size(ec);
+                if (ec) {
+                    break;
+                }
+            }
+            files->push_back(std::move(file_info));
         }
-        files->push_back(std::move(file_info));
+    } catch (const std::filesystem::filesystem_error& e) {
+        // although `directory_iterator(dir, ec)` does not throw an exception,
+        // it may throw an exception during iterator++, so we need to catch the exception here
+        return localfs_error(e.code(), fmt::format("failed to list {}, error message: {}",
+                                                   dir.native(), e.what()));
     }
     if (ec) {
         return localfs_error(ec, fmt::format("failed to list {}", dir.native()));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

to avoid such core, this path was deleted by other threads during traversal
```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: directory iterator cannot advance: Bad file descriptor
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1707026601 (unix time) try "date -d @1707026601" if you are using GNU date ***
*** Current BE git commitID: 92411c7f2c ***
*** SIGABRT unknown detail explain (@0x38ea1d) received by PID 3729949 (TID 3732604 OR 0x7f9ec8014700) from PID 3729949; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/signal_handler.h:417
 1# 0x00007FA5202B7090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x00005647884261C1 in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 7# 0x0000564788426314 in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 8# std::filesystem::__cxx11::directory_iterator::operator++() [clone .cold] at ../../../../../libstdc++-v3/src/c++17/fs_dir.cc:160
 9# doris::io::LocalFileSystem::list_impl(std::filesystem::__cxx11::path const&, bool, std::vector >*, bool*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/io/fs/local_file_system.cpp:186
10# doris::io::FileSystem::list(std::filesystem::__cxx11::path const&, bool, std::vector >*, bool*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/io/fs/file_system.cpp:73
11# doris::DataDir::perform_path_scan() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/data_dir.cpp:803
12# doris::StorageEngine::_path_scan_thread_callback(doris::DataDir*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/olap_server.cpp:381
13# doris::StorageEngine::start_bg_threads()::$_8::operator()() const at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/olap_server.cpp:192
14# void std::__invoke_impl(std::__invoke_other, doris::StorageEngine::start_bg_threads()::$_8&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
15# std::enable_if, void>::type std::__invoke_r(doris::StorageEngine::start_bg_threads()::$_8&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
16# std::_Function_handler::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
18# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/util/thread.cpp:498
19# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
20# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

