### PR TITLE
[feature](StoragePolicy) Add one http action to add storage policy back

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/AddStoragePolicyAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/AddStoragePolicyAction.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.restv2;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
+import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
+import org.apache.doris.httpv2.rest.RestBaseController;
+import org.apache.doris.policy.StoragePolicy;
+
+import com.google.common.collect.Maps;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping("/rest/v2")
+public class AddStoragePolicyAction extends RestBaseController {
+
+    private static final Logger LOG = LogManager.getLogger(AddStoragePolicyAction.class);
+
+    @RequestMapping(path = "/api/storage_policy", method = RequestMethod.POST)
+    public Object clusterOverview(@RequestBody StoragePolicyVo body,
+            HttpServletRequest request, HttpServletResponse response) {
+        if (Config.enable_all_http_auth) {
+            executeCheckPassword(request, response);
+        }
+
+        try {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return redirectToMasterOrException(request, response);
+            }
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        }
+
+        StoragePolicy storagePolicy = new StoragePolicy(body.getPolicyId(), body.getPolicyName());
+        try {
+            storagePolicy.init(body.toPropertiesMap(), true);
+            Env.getCurrentEnv().getPolicyMgr().addPolicy(storagePolicy);
+            return ResponseEntityBuilder.ok();
+        } catch (UserException e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class StoragePolicyVo {
+        private String policyName;
+        private long policyId;
+        private String storageResource;
+        private long cooldownTimestampMs;
+        private long cooldownTtl;
+
+        public Map<String, String> toPropertiesMap() {
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("storage_resource", storageResource);
+            properties.put("cooldown_datetime", Long.toString(cooldownTimestampMs));
+            properties.put("cooldown_ttl", Long.toString(cooldownTtl));
+            return properties;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -320,6 +320,8 @@ public class PolicyMgr implements Writable {
                 if (policy instanceof RowPolicy) {
                     dropTablePolicies((RowPolicy) policy);
                 }
+                LOG.info("the policy {} with id {} has been dropped", policy.getPolicyName(),
+                        policy.getId());
                 return true;
             }
             return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -318,7 +318,7 @@ public class PolicyMgr implements Writable {
                     ((StoragePolicy) policy).removeResourceReference();
                     StoragePolicy storagePolicy = (StoragePolicy) policy;
                     LOG.info("the policy {} with id {} resource {} has been dropped",
-                        storagePolicy.getPolicyName(), storagePolicy.getId(), storagePolicy.getStorageResource());
+                            storagePolicy.getPolicyName(), storagePolicy.getId(), storagePolicy.getStorageResource());
                 }
                 if (policy instanceof RowPolicy) {
                     dropTablePolicies((RowPolicy) policy);

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -144,6 +144,31 @@ public class PolicyMgr implements Writable {
     }
 
     /**
+     * Create policy through http api.
+     **/
+    public void addPolicy(Policy policy) throws UserException {
+        writeLock();
+        try {
+            boolean storagePolicyExists = false;
+            if (PolicyTypeEnum.STORAGE == policy.getType()) {
+                // The name of the storage policy remains globally unique until it is renamed by user.
+                // So we could just compare the policy name to check if there are redundant ones.
+                // Otherwise two storage policy share one same name but with different resource name
+                // will not be filtered. See github #25025 for more details.
+                storagePolicyExists = getPoliciesByType(PolicyTypeEnum.STORAGE)
+                        .stream().anyMatch(p -> p.getPolicyName().equals(policy.getPolicyName()));
+            }
+            if (storagePolicyExists || existPolicy(policy)) {
+                throw new DdlException("the policy " + policy.getPolicyName() + " already create");
+            }
+            unprotectedAdd(policy);
+            Env.getCurrentEnv().getEditLog().logCreatePolicy(policy);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
      * Drop policy through stmt.
      **/
     public void dropPolicy(DropPolicyStmt stmt) throws DdlException, AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -316,12 +316,13 @@ public class PolicyMgr implements Writable {
             if (policy.matchPolicy(log)) {
                 if (policy instanceof StoragePolicy) {
                     ((StoragePolicy) policy).removeResourceReference();
+                    StoragePolicy storagePolicy = (StoragePolicy) policy;
+                    LOG.info("the policy {} with id {} resource {} has been dropped",
+                        storagePolicy.getPolicyName(), storagePolicy.getId(), storagePolicy.getStorageResource());
                 }
                 if (policy instanceof RowPolicy) {
                     dropTablePolicies((RowPolicy) policy);
                 }
-                LOG.info("the policy {} with id {} has been dropped", policy.getPolicyName(),
-                        policy.getId());
                 return true;
             }
             return false;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Previously, the implementation of dropping a storage policy did not check whether the policy was being used by a partition. This could lead to mistakenly deleting a policy that is currently in use. In order to provide a fallback for such situations, this HTTP action has been introduced to re-add a policy with the same storage policy id back to the FE. This ensures that in subsequent rpc between FE and BE, the policy is resent to the BE.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

