### PR TITLE
[Fix](Top-N opt) evicting quering rowsets in prior to correct use_count

### DIFF
--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -230,7 +230,10 @@ Status RowIDFetcher::fetch(const vectorized::ColumnPtr& column_row_ids,
     std::vector<PRowLocation> rows_locs;
     rows_locs.reserve(rows_locs.size());
     RETURN_IF_ERROR(_merge_rpc_results(mget_req, resps, cntls, res_block, &rows_locs));
-
+    if (rows_locs.size() != res_block->rows() || rows_locs.size() != column_row_ids->size()) {
+        return Status::InternalError("Miss matched return row loc count {}, expected {}, input {}",
+                                     rows_locs.size(), res_block->rows(), column_row_ids->size());
+    }
     // Final sort by row_ids sequence, since row_ids is already sorted if need
     std::map<GlobalRowLoacation, size_t> positions;
     for (size_t i = 0; i < rows_locs.size(); ++i) {


### PR DESCRIPTION
…nt

This addresses the scenario where a rowset cannot be removed.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

