### PR TITLE
[fix](gc) fix a core introduced by #30854

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1089,7 +1089,6 @@ void StorageEngine::start_delete_unused_rowset() {
                 }
                 it = _unused_rowsets.erase(it);
             } else {
-                ++it;
                 if (rs.use_count() != 1) {
                     ++due_to_use_count;
                 } else if (!rs->need_delete_file()) {
@@ -1097,6 +1096,7 @@ void StorageEngine::start_delete_unused_rowset() {
                 } else {
                     ++due_to_delayed_expired_ts;
                 }
+                ++it;
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

introduced by #30854, if `it` is the end of the map `_unused_rowsets`, program will core.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

