### PR TITLE
[fix](group_commit) Fix write column id twice problem on wal file

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -311,11 +311,12 @@ Status GroupCommitTable::_create_group_commit_load(
         if (!is_pipeline) {
             RETURN_IF_ERROR(load_block_queue->create_wal(
                     _db_id, _table_id, txn_id, label, _exec_env->wal_mgr(),
-                    params.desc_tbl.slotDescriptors, be_exe_version));
+                    params.fragment.output_sink.olap_table_sink.schema.slot_descs, be_exe_version));
         } else {
             RETURN_IF_ERROR(load_block_queue->create_wal(
                     _db_id, _table_id, txn_id, label, _exec_env->wal_mgr(),
-                    pipeline_params.desc_tbl.slotDescriptors, be_exe_version));
+                    pipeline_params.fragment.output_sink.olap_table_sink.schema.slot_descs,
+                    be_exe_version));
         }
         _cv.notify_all();
     }


### PR DESCRIPTION
## Proposed changes
wal file using desc_tbl.slotDescriptors to record table column id, in some case i found column id will be recorded twice, for example a table has tree column, wal should record column id `0,1,2,`, now it may record `0,1,2,0,1,2`, this pr is used to fix this problem.
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

