### PR TITLE
[Bug] doris cloud ms does not start even though process is not running

### DIFF
--- a/cloud/script/start.sh
+++ b/cloud/script/start.sh
@@ -45,7 +45,7 @@ process=doris_cloud
 if [[ -f "${DORIS_HOME}/bin/${process}.pid" ]]; then
     pid=$(cat "${DORIS_HOME}/bin/${process}.pid")
     if [[ "${pid}" != "" ]]; then
-        if ! pgrep -f "${pid}" 2>&1 | grep doris_cloud >/dev/null 2>&1; then
+        if kill -0 "$(cat "${DORIS_HOME}/bin/${process}.pid")" >/dev/null 2>&1; then
             echo "pid file existed, ${process} have already started, pid=${pid}"
             exit 1
         fi


### PR DESCRIPTION
## Proposed changes

Issue Number: close #30945 

if doris_cloud is not running then the old pid file should be removed and proceed to start the process.

pgrep matches the pid, this will not work; pgrep matched on process name
the existing code can we modified to fix this,
if ! pgrep -f doris_cloud 2>&1 | grep "${pid}" >/dev/null 2>&1; then

but this change also is not correct. if there is another process by the name doris_cloud then pgrep will return incorrect pid, which will again cause incorrect behavior.
rather than using pgrep, we should use kill command, passing the doris_cloud pid file as input.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

