### PR TITLE
[improvement](group_commit)  Rename fail wal to tmp should only use in test P0 scenario

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1115,6 +1115,7 @@ DEFINE_Int16(bitmap_serialize_version, "1");
 DEFINE_String(group_commit_wal_path, "");
 DEFINE_Int32(group_commit_replay_wal_retry_num, "10");
 DEFINE_Int32(group_commit_replay_wal_retry_interval_seconds, "5");
+DEFINE_Int32(group_commit_replay_wal_retry_interval_max_seconds, "1800");
 DEFINE_Int32(group_commit_relay_wal_threads, "10");
 // This config can be set to limit thread number in group commit request fragment thread pool.
 DEFINE_Int32(group_commit_insert_threads, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1182,6 +1182,7 @@ DECLARE_Int16(bitmap_serialize_version);
 DECLARE_String(group_commit_wal_path);
 DECLARE_Int32(group_commit_replay_wal_retry_num);
 DECLARE_Int32(group_commit_replay_wal_retry_interval_seconds);
+DECLARE_Int32(group_commit_replay_wal_retry_interval_max_seconds);
 DECLARE_mInt32(group_commit_relay_wal_threads);
 // This config can be set to limit thread number in group commit request fragment thread pool.
 DECLARE_mInt32(group_commit_insert_threads);

--- a/be/src/olap/wal/wal_info.cpp
+++ b/be/src/olap/wal/wal_info.cpp
@@ -32,7 +32,7 @@ std::string WalInfo::get_wal_path() {
     return _wal_path;
 }
 
-int64_t WalInfo::get_retry_num() {
+int32_t WalInfo::get_retry_num() {
     return _retry_num;
 }
 

--- a/be/src/olap/wal/wal_info.h
+++ b/be/src/olap/wal/wal_info.h
@@ -23,7 +23,7 @@ public:
     WalInfo(int64_t wal_id, std::string wal_path, int64_t retry_num, int64_t start_time_ms);
     ~WalInfo() = default;
     int64_t get_wal_id();
-    int64_t get_retry_num();
+    int32_t get_retry_num();
     int64_t get_start_time_ms();
     std::string get_wal_path();
     void add_retry_num();
@@ -31,7 +31,7 @@ public:
 private:
     int64_t _wal_id;
     std::string _wal_path;
-    int64_t _retry_num;
+    int32_t _retry_num;
     int64_t _start_time_ms;
 };
 

--- a/be/src/olap/wal/wal_reader.cpp
+++ b/be/src/olap/wal/wal_reader.cpp
@@ -39,14 +39,22 @@ static Status _deserialize(PBlock& block, const std::string& buf) {
 }
 
 Status WalReader::init() {
+    bool exists = false;
+    RETURN_IF_ERROR(io::global_local_filesystem()->exists(_file_name, &exists));
+    if (!exists) {
+        LOG(WARNING) << "not exist wal= " << _file_name;
+        return Status::NotFound("wal {} doesn't exist", _file_name);
+    }
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(_file_name, &file_reader));
     return Status::OK();
 }
 
 Status WalReader::finalize() {
-    auto st = file_reader->close();
-    if (!st.ok()) {
-        LOG(WARNING) << "fail to close wal " << _file_name;
+    if (file_reader != nullptr) {
+        auto st = file_reader->close();
+        if (!st.ok()) {
+            LOG(WARNING) << "fail to close wal " << _file_name << " st= " << st.to_string();
+        }
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes
Rename fail wal to tmp should only use in test P0 scenario

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

