### PR TITLE
[improvement](hudi)Obtain partition information through HMS's API

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/hudi.md
+++ b/docs/en/docs/lakehouse/multi-catalog/hudi.md
@@ -55,6 +55,12 @@ CREATE CATALOG hudi PROPERTIES (
 );
 ```
 
+Optional configuration parameters:
+
+|name|description|default|
+|---|---|---|
+|use_hive_sync_partition|Use hms synchronized partition data|false|
+
 ## Column Type Mapping
 
 Same as that in Hive Catalogs. See the relevant section in [Hive](./hive.md).

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/hudi.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/hudi.md
@@ -55,6 +55,12 @@ CREATE CATALOG hudi PROPERTIES (
 );
 ```
 
+可选配置参数：
+
+|参数名|说明|默认值|
+|---|---|---|
+|use_hive_sync_partition|使用hms已同步的分区数据|false|
+
 ## 列类型映射
 
 和 Hive Catalog 一致，可参阅 [Hive Catalog](./hive.md) 中 **列类型映射** 一节。

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -104,6 +104,9 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
     private static final String SPARK_STATS_MAX_LEN = ".avgLen";
     private static final String SPARK_STATS_HISTOGRAM = ".histogram";
 
+    private static final String USE_HIVE_SYNC_PARTITION = "use_hive_sync_partition";
+
+
     static {
         SUPPORTED_HIVE_FILE_FORMATS = Sets.newHashSet();
         SUPPORTED_HIVE_FILE_FORMATS.add("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
@@ -225,6 +228,14 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
         }
         String inputFormatName = remoteTable.getSd().getInputFormat();
         return "org.apache.hudi.hadoop.HoodieParquetInputFormat".equals(inputFormatName);
+    }
+
+    /**
+     * Some data lakes (such as Hudi) will synchronize their partition information to HMS,
+     * then we can quickly obtain the partition information of the table from HMS.
+     */
+    public boolean useHiveSyncPartition() {
+        return Boolean.parseBoolean(catalog.getProperties().getOrDefault(USE_HIVE_SYNC_PARTITION, "false"));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -19,9 +19,10 @@ package org.apache.doris.datasource.hudi.source;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.datasource.CacheException;
-import org.apache.doris.datasource.HMSExternalCatalog;
-import org.apache.doris.planner.external.TablePartitionValues;
-import org.apache.doris.planner.external.TablePartitionValues.TablePartitionKey;
+import org.apache.doris.datasource.TablePartitionValues;
+import org.apache.doris.datasource.TablePartitionValues.TablePartitionKey;
+import org.apache.doris.datasource.hive.HMSExternalCatalog;
+import org.apache.doris.datasource.hive.HMSExternalTable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -84,7 +84,7 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
     }
 
     public TablePartitionValues getSnapshotPartitionValues(HMSExternalTable table,
-            HoodieTableMetaClient tableMetaClient, String timestamp) {
+            HoodieTableMetaClient tableMetaClient, String timestamp, boolean useHiveSyncPartition) {
         Preconditions.checkState(catalogId == table.getCatalog().getId());
         Option<String[]> partitionColumns = tableMetaClient.getTableConfig().getPartitionFields();
         if (!partitionColumns.isPresent()) {
@@ -97,7 +97,7 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
         }
         long lastTimestamp = Long.parseLong(lastInstant.get().getTimestamp());
         if (Long.parseLong(timestamp) == lastTimestamp) {
-            return getPartitionValues(table, tableMetaClient);
+            return getPartitionValues(table, tableMetaClient, useHiveSyncPartition);
         }
         List<String> partitionNameAndValues = getPartitionNamesBeforeOrEquals(timeline, timestamp);
         List<String> partitionNames = Arrays.asList(partitionColumns.get());
@@ -108,7 +108,8 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
         return partitionValues;
     }
 
-    public TablePartitionValues getPartitionValues(HMSExternalTable table, HoodieTableMetaClient tableMetaClient)
+    public TablePartitionValues getPartitionValues(HMSExternalTable table, HoodieTableMetaClient tableMetaClient,
+                                                   boolean useHiveSyncPartition)
             throws CacheException {
         Preconditions.checkState(catalogId == table.getCatalog().getId());
         Option<String[]> partitionColumns = tableMetaClient.getTableConfig().getPartitionFields();
@@ -142,13 +143,17 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
                 }
                 HMSExternalCatalog catalog = (HMSExternalCatalog) table.getCatalog();
                 List<String> partitionNames;
-                // When a Hudi table is synchronized to HMS, the partition information is also synchronized,
-                // so even if the metastore is not enabled in the Hudi table
-                //     (for example, if the Metastore is false for a Hudi table created with Flink),
-                // we can still obtain the partition information through the HMS API.
-                partitionNames = catalog.getClient().listPartitionNames(table.getDbName(), table.getName());
-                if (partitionNames.size() == 0) {
-                    LOG.warn("Failed to get partitions from hms api, switch it from hudi api.");
+                if (useHiveSyncPartition) {
+                    // When a Hudi table is synchronized to HMS, the partition information is also synchronized,
+                    // so even if the metastore is not enabled in the Hudi table
+                    //     (for example, if the Metastore is false for a Hudi table created with Flink),
+                    // we can still obtain the partition information through the HMS API.
+                    partitionNames = catalog.getClient().listPartitionNames(table.getDbName(), table.getName());
+                    if (partitionNames.size() == 0) {
+                        LOG.warn("Failed to get partitions from hms api, switch it from hudi api.");
+                        partitionNames = getAllPartitionNames(tableMetaClient);
+                    }
+                } else {
                     partitionNames = getAllPartitionNames(tableMetaClient);
                 }
                 List<String> partitionColumnsList = Arrays.asList(partitionColumns.get());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -142,6 +142,10 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
                 }
                 HMSExternalCatalog catalog = (HMSExternalCatalog) table.getCatalog();
                 List<String> partitionNames;
+                // When a Hudi table is synchronized to HMS, the partition information is also synchronized,
+                // so even if the metastore is not enabled in the Hudi table
+                //     (for example, if the Metastore is false for a Hudi table created with Flink),
+                // we can still obtain the partition information through the HMS API.
                 partitionNames = catalog.getClient().listPartitionNames(table.getDbName(), table.getName());
                 if (partitionNames.size() == 0) {
                     LOG.warn("Failed to get partitions from hms api, switch it from hudi api.");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -83,6 +83,8 @@ public class HudiScanNode extends HiveScanNode {
 
     private final AtomicLong noLogsSplitNum = new AtomicLong(0);
 
+    private final boolean useHiveSyncPartition;
+
     /**
      * External file scan node for Query Hudi table
      * needCheckColumnPriv: Some of ExternalFileScanNode do not need to check column priv
@@ -102,6 +104,7 @@ public class HudiScanNode extends HiveScanNode {
                 LOG.debug("Hudi table {} is a mor table, and will use JNI to read data in BE", hmsTable.getName());
             }
         }
+        useHiveSyncPartition = hmsTable.useHiveSyncPartition();
     }
 
     @Override
@@ -171,9 +174,10 @@ public class HudiScanNode extends HiveScanNode {
                     .getExtMetaCacheMgr().getHudiPartitionProcess(hmsTable.getCatalog());
             TablePartitionValues partitionValues;
             if (snapshotTimestamp.isPresent()) {
-                partitionValues = processor.getSnapshotPartitionValues(hmsTable, metaClient, snapshotTimestamp.get());
+                partitionValues = processor.getSnapshotPartitionValues(
+                    hmsTable, metaClient, snapshotTimestamp.get(), useHiveSyncPartition);
             } else {
-                partitionValues = processor.getPartitionValues(hmsTable, metaClient);
+                partitionValues = processor.getPartitionValues(hmsTable, metaClient, useHiveSyncPartition);
             }
             if (partitionValues != null) {
                 // 2. prune partitions by expr


### PR DESCRIPTION
## Proposed changes

When a Hudi table is synchronized to HMS, the partition information is also synchronized, so even if the metastore is not enabled in the Hudi table (for example, if the Metastore is false for a Hudi table created with Flink), you can still obtain the partition information through the HMS API.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

