### PR TITLE
[improvement](memtracker) should counter memory usage to query when exchange sink buffer rpc

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -93,6 +93,7 @@ ExchangeSinkBuffer<Parent>::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId de
           _dest_node_id(dest_node_id),
           _sender_id(send_id),
           _be_number(be_number),
+          _state(state),
           _context(state->get_query_ctx()) {}
 
 template <typename Parent>
@@ -281,6 +282,8 @@ Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
                 // This means ExchangeSinkBuffer Ojbect already destroyed, not need run failed any more.
                 return;
             }
+            // attach task for memory tracker and query id when core
+            SCOPED_ATTACH_TASK(_state);
             _failed(id, err);
         });
         send_callback->start_rpc_time = GetCurrentTimeNanos();
@@ -293,6 +296,8 @@ Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
                 // This means ExchangeSinkBuffer Ojbect already destroyed, not need run failed any more.
                 return;
             }
+            // attach task for memory tracker and query id when core
+            SCOPED_ATTACH_TASK(_state);
             set_rpc_time(id, start_rpc_time, result.receive_time());
             Status s(Status::create(result.status()));
             if (s.is<ErrorCode::END_OF_FILE>()) {
@@ -356,6 +361,8 @@ Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
                 // This means ExchangeSinkBuffer Ojbect already destroyed, not need run failed any more.
                 return;
             }
+            // attach task for memory tracker and query id when core
+            SCOPED_ATTACH_TASK(_state);
             _failed(id, err);
         });
         send_callback->start_rpc_time = GetCurrentTimeNanos();
@@ -368,6 +375,8 @@ Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
                 // This means ExchangeSinkBuffer Ojbect already destroyed, not need run failed any more.
                 return;
             }
+            // attach task for memory tracker and query id when core
+            SCOPED_ATTACH_TASK(_state);
             set_rpc_time(id, start_rpc_time, result.receive_time());
             Status s(Status::create(result.status()));
             if (s.is<ErrorCode::END_OF_FILE>()) {

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -257,6 +257,7 @@ private:
     int _sender_id;
     int _be_number;
     std::atomic<int64_t> _rpc_count = 0;
+    RuntimeState _state = nullptr;
     QueryContext* _context = nullptr;
 
     Status _send_rpc(InstanceLoId);

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -257,7 +257,7 @@ private:
     int _sender_id;
     int _be_number;
     std::atomic<int64_t> _rpc_count = 0;
-    RuntimeState _state = nullptr;
+    RuntimeState* _state = nullptr;
     QueryContext* _context = nullptr;
 
     Status _send_rpc(InstanceLoId);

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -211,7 +211,6 @@ void PipelineTask::set_task_queue(TaskQueue* task_queue) {
 Status PipelineTask::execute(bool* eos) {
     SCOPED_TIMER(_task_profile->total_time_counter());
     SCOPED_TIMER(_exec_timer);
-    SCOPED_ATTACH_TASK(_state);
     int64_t time_spent = 0;
 
     ThreadCpuStopWatch cpu_time_stop_watch;

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -286,6 +286,8 @@ public:
         }
     }
 
+    RuntimeState* runtime_state() { return _state; }
+
 protected:
     void _finish_p_dependency() {
         for (const auto& p : _pipeline->_parents) {

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -214,7 +214,6 @@ Status PipelineXTask::_open() {
 Status PipelineXTask::execute(bool* eos) {
     SCOPED_TIMER(_task_profile->total_time_counter());
     SCOPED_TIMER(_exec_timer);
-    SCOPED_ATTACH_TASK(_state);
     int64_t time_spent = 0;
 
     ThreadCpuStopWatch cpu_time_stop_watch;


### PR DESCRIPTION
## Proposed changes

1. should count memory usage when rpc callback, because it may create or release some memory.
2. should attach task at the beginning of task execution, not only in task execute, should also count memory in task close because it may release memory in close method.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

