### PR TITLE
[fix](group_commit) Wal file should be removed from _wal_path_map when renaming it to tmp directory

### DIFF
--- a/be/src/olap/wal/wal_manager.cpp
+++ b/be/src/olap/wal/wal_manager.cpp
@@ -535,6 +535,15 @@ Status WalManager::rename_to_tmp_path(const std::string wal, int64_t table_id, i
         return Status::InternalError("rename fail on path " + wal);
     }
     LOG(INFO) << "rename wal from " << wal << " to " << wal_path.string();
+    {
+        std::lock_guard<std::shared_mutex> wrlock(_wal_path_lock);
+        auto it = _wal_path_map.find(wal_id);
+        if (it != _wal_path_map.end()) {
+            _wal_path_map.erase(wal_id);
+        } else {
+            LOG(WARNING) << "can't find " << wal_id << " in _wal_path_map when trying to rename";
+        }
+    }
     erase_wal_queue(table_id, wal_id);
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes
Just like delete wal file, renaming file also need to remove wal from _wal_path_map

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

