### PR TITLE
[fix](nereids)should not infer predicate for nullaware anti-join (#30924)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
@@ -78,7 +78,6 @@ public class InferPredicates extends DefaultPlanRewriter<JobContext> implements 
                 break;
             case LEFT_OUTER_JOIN:
             case LEFT_ANTI_JOIN:
-            case NULL_AWARE_LEFT_ANTI_JOIN:
                 right = inferNewPredicate(right, expressions);
                 break;
             case RIGHT_OUTER_JOIN:


### PR DESCRIPTION
pick from master #30924
commit id 900382e02e0c1809c8d2c90b4ae5d8e521b10352

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

