### PR TITLE
[fix](dynamic partition) fix create too many dynamic partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -574,22 +574,22 @@ public class DynamicPartitionUtil {
         // If create_history_partition is true, will pre-create history partition according the valid value from
         // start and history_partition_num.
         //
-        int expectCreatePartitionNum = 0;
+        long expectCreatePartitionNum = 0;
         if (!createHistoryPartition) {
             start = 0;
-            expectCreatePartitionNum = end - start;
+            expectCreatePartitionNum = (long) end - start;
         } else {
             int historyPartitionNum = Integer.parseInt(analyzedProperties.getOrDefault(
                     DynamicPartitionProperty.HISTORY_PARTITION_NUM,
                     String.valueOf(DynamicPartitionProperty.NOT_SET_HISTORY_PARTITION_NUM)));
             if (historyPartitionNum != DynamicPartitionProperty.NOT_SET_HISTORY_PARTITION_NUM) {
-                expectCreatePartitionNum = end - Math.max(start, -historyPartitionNum);
+                expectCreatePartitionNum = (long) end - Math.max(start, -historyPartitionNum);
             } else {
                 if (start == Integer.MIN_VALUE) {
                     throw new DdlException("Provide start or history_partition_num property"
-                            + " when creating history partition");
+                            + " when create_history_partition=true. Otherwise set create_history_partition=false");
                 }
-                expectCreatePartitionNum = end - start;
+                expectCreatePartitionNum = (long) end - start;
             }
         }
         if (hasEnd && (expectCreatePartitionNum > Config.max_dynamic_partition_num)

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -641,7 +641,8 @@ public class DynamicPartitionTableTest {
                 + ");";
         // start and history_partition_num are not set, can not create history partition
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "Provide start or history_partition_num property when creating history partition",
+                "Provide start or history_partition_num property when create_history_partition=true. "
+                        + "Otherwise set create_history_partition=false",
                 () -> createTable(createOlapTblStmt));
 
         String createOlapTblStmt2 = "CREATE TABLE test.`dynamic_partition3` (\n"

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
@@ -34,8 +34,19 @@ suite("test_dynamic_partition_with_alter") {
             "dynamic_partition.create_history_partition"="true",
             "dynamic_partition.replication_allocation" = "tag.location.default: 1")
         """
+
     result = sql "show partitions from ${tbl}"
     assertEquals(7, result.size())
+
+    test {
+        sql "alter table ${tbl} set ('dynamic_partition.start' = '-2147483648')"
+        exception "Provide start or history_partition_num property"
+    }
+
+    test {
+        sql "alter table ${tbl} set ('dynamic_partition.start' = '-2147483647')"
+        exception "Too many dynamic partitions"
+    }
 
     // modify distributed column comment, then try to add too more dynamic partition
     sql """ alter table ${tbl} modify column k1 comment 'new_comment_for_k1' """


### PR DESCRIPTION
For dynamic partitions,  the expect created partition num = dynamic_partition.end - dynamic_partition.start.
By default,  fe limit 500(Config.max_dynamic_partition_num) dynamic partitions.

But if dynamic_partition.start is near  int.min_value， the expect create partition num will be overflow and become a negative number.  Then check created partition num < Config.max_dynamic_partition_num is ok.

For example:  if start = -2147483647 (int.min_value + 1)， end = 1, then end - start =   -2147483648 < 0

So change the expect create partition num to long to avoid overflow.


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

