### PR TITLE
[bugfix](export command)  Export exceptions when use legacy optimizer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -246,7 +246,7 @@ public class ExportCommand extends Command implements ForwardWithSync {
         exportJob.setTableName(tblName);
         exportJob.setExportTable(table);
         exportJob.setTableId(table.getId());
-
+        exportJob.setOrigStmt(ctx.getExecutor().getOriginStmt());
         // set partitions
         exportJob.setPartitionNames(this.partitionsNames);
         // set where expression

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -246,7 +246,9 @@ public class ExportCommand extends Command implements ForwardWithSync {
         exportJob.setTableName(tblName);
         exportJob.setExportTable(table);
         exportJob.setTableId(table.getId());
-        exportJob.setOrigStmt(ctx.getExecutor().getOriginStmt());
+        if (ctx.getExecutor() != null) {
+            exportJob.setOrigStmt(ctx.getExecutor().getOriginStmt());
+        }
         // set partitions
         exportJob.setPartitionNames(this.partitionsNames);
         // set where expression


### PR DESCRIPTION
## Proposed changes

Issue Number: close #30645

<!--Describe your changes.-->

Exception information will not be thrown when exporting exceptions, theck this #30645 

The actual exception is `Exporting results to local disk is not allowed.To enable this feature, you need to add enable_outfile_to_local=true in fe.conf and restart FE`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

