### PR TITLE
[fix](Nereids) try to add element into immutable set when create RF

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -33,8 +33,8 @@ import org.apache.doris.thrift.TPartitionType;
 import org.apache.doris.thrift.TPlanFragment;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -169,8 +169,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     public PlanFragment(PlanFragmentId id, PlanNode root, DataPartition partition,
             Set<RuntimeFilterId> builderRuntimeFilterIds, Set<RuntimeFilterId> targetRuntimeFilterIds) {
         this(id, root, partition);
-        this.builderRuntimeFilterIds = ImmutableSet.copyOf(builderRuntimeFilterIds);
-        this.targetRuntimeFilterIds = ImmutableSet.copyOf(targetRuntimeFilterIds);
+        this.builderRuntimeFilterIds = Sets.newHashSet(builderRuntimeFilterIds);
+        this.targetRuntimeFilterIds = Sets.newHashSet(targetRuntimeFilterIds);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

exception thrown
```
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Unexpected exception: null
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:588) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:453) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:443) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:435) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:584) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:841) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_312]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_312]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_312]
Caused by: java.lang.UnsupportedOperationException
        at com.google.common.collect.ImmutableCollection.add(ImmutableCollection.java:268) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.planner.PlanFragment.setTargetRuntimeFilterIds(PlanFragment.java:231) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.RuntimeFilter.assignToPlanNodes(RuntimeFilter.java:648) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.RuntimeFilterTranslator.finalize(RuntimeFilterTranslator.java:180) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.RuntimeFilterTranslator.createLegacyRuntimeFilter(RuntimeFilterTranslator.java:174) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.lambda$null$40(PhysicalPlanTranslator.java:1233) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:1.8.0_312]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.lambda$visitPhysicalHashJoin$41(PhysicalPlanTranslator.java:1233) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.Optional.ifPresent(Optional.java:159) ~[?:1.8.0_312]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalHashJoin(PhysicalPlanTranslator.java:1231) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalHashJoin(PhysicalPlanTranslator.java:216) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin.accept(PhysicalHashJoin.java:128) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalProject(PhysicalPlanTranslator.java:1595) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalProject(PhysicalPlanTranslator.java:216) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalProject.accept(PhysicalProject.java:96) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalDistribute(PhysicalPlanTranslator.java:270) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalDistribute(PhysicalPlanTranslator.java:216) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute.accept(PhysicalDistribute.java:87) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:355) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:216) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink.accept(PhysicalResultSink.java:70) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.translatePlan(PhysicalPlanTranslator.java:243) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.plan(NereidsPlanner.java:142) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:584) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 9 more
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

