### PR TITLE
[pipelineX](bug) Fix use-after-free when BE exits

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -602,7 +602,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_workload_sched_mgr);
     SAFE_DELETE(_task_group_manager);
-    SAFE_DELETE(_without_group_task_scheduler);
     SAFE_DELETE(_file_cache_factory);
     SAFE_DELETE(_runtime_filter_timer_queue);
     // TODO(zhiqiang): Maybe we should call shutdown before release thread pool?
@@ -638,6 +637,9 @@ void ExecEnv::destroy() {
     // NOTE: runtime query statistics mgr could be visited by query and daemon thread
     // so it should be created before all query begin and deleted after all query and daemon thread stoppped
     SAFE_DELETE(_runtime_query_statistics_mgr);
+
+    // We should free task scheduler finally because task queue / scheduler maybe used by pipelineX.
+    SAFE_DELETE(_without_group_task_scheduler);
 
     LOG(INFO) << "Doris exec envorinment is destoried.";
 }


### PR DESCRIPTION
## Proposed changes

==9442==ERROR: AddressSanitizer: heap-use-after-free on address 0x606001182270 at pc 0x5611971d511d bp 0x7fff9dc4ba70 sp 0x7fff9dc4ba68
READ of size 8 at 0x606001182270 thread T0
    #0 0x5611971d511c in doris::pipeline::PipelineXTask::wake_up() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:396:41
    #1 0x561196f9c4f6 in doris::pipeline::Dependency::set_ready() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_x/dependency.cpp:53:15
    #2 0x56119513e71e in doris::vectorized::VDataStreamRecvr::SenderQueue::try_set_dep_ready_without_lock() /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:132:22
    #3 0x561195144033 in doris::vectorized::VDataStreamRecvr::SenderQueue::close() /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:323:9
    #4 0x561195149ded in doris::vectorized::VDataStreamRecvr::close() /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:502:28
    #5 0x561195125361 in doris::vectorized::VDataStreamMgr::~VDataStreamMgr() /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_mgr.cpp:46:36
    #6 0x561167766510 in doris::ExecEnv::destroy() /home/zcp/repo_center/doris_master/doris/be/src/runtime/exec_env_init.cpp:621:5
    #7 0x561164204c24 in main /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:600:15
    #8 0x7f32e4771082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #9 0x561164127029 in _start (/mnt/hdd01/ci/master-deploy/be/lib/doris_be+0x252dc029) (BuildId: 3012c18a6d4e997c)

0x606001182270 is located 16 bytes inside of 56-byte region [0x606001182260,0x606001182298)
freed by thread T0 here:
    #0 0x5611641fad9d in operator delete(void*) (/mnt/hdd01/ci/master-deploy/be/lib/doris_be+0x253afd9d) (BuildId: 3012c18a6d4e997c)
    #1 0x56116779933e in __gnu_cxx::new_allocator, (__gnu_cxx::_Lock_policy)2>>::deallocate(std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>*, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:139:2
    #2 0x561167799300 in std::allocator, (__gnu_cxx::_Lock_policy)2>>::deallocate(std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>*, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:187:27
    #3 0x561167799300 in std::allocator_traits, (__gnu_cxx::_Lock_policy)2>>>::deallocate(std::allocator, (__gnu_cxx::_Lock_policy)2>>&, std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>*, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:492:13
    #4 0x5611677989b7 in std::__allocated_ptr, (__gnu_cxx::_Lock_policy)2>>>::~__allocated_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/allocated_ptr.h:73:4
    #5 0x561167798ece in std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>::_M_destroy() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:538:7
    #6 0x56116421749c in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:184:10
    #7 0x561164216f39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #8 0x56116777a09a in std::__shared_ptr::~__shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #9 0x561167773b04 in std::shared_ptr::~shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
    #10 0x5611971fc5af in doris::pipeline::TaskScheduler::~TaskScheduler() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:204:1
    #11 0x561167765d9f in doris::ExecEnv::destroy() /home/zcp/repo_center/doris_master/doris/be/src/runtime/exec_env_init.cpp:605:5
    #12 0x561164204c24 in main /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:600:15
    #13 0x7f32e4771082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

