### PR TITLE
[fix][cloud] cloud meta service get_instance error handling fix

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1871,7 +1871,7 @@ std::pair<MetaServiceCode, std::string> MetaServiceImpl::get_instance_info(
     std::shared_ptr<Transaction> txn(txn0.release());
     auto [c0, m0] = resource_mgr_->get_instance(txn, cloned_instance_id, instance);
     if (c0 != TxnErrorCode::TXN_OK) {
-        return {cast_as<ErrCategory::READ>(err), "failed to get instance, info=" + m0};
+        return {cast_as<ErrCategory::READ>(c0), "failed to get instance, info=" + m0};
     }
 
     // maybe do not decrypt ak/sk?


### PR DESCRIPTION
## Proposed changes

Issue Number: close #31044 

~/temp$ curl "127.0.0.1:5000/MetaService/http/get_instance?token=greedisgood9999&instance_id=cloud_instance_1";
{
    "code": "INTERNAL_ERROR",
    "msg": "failed to get instance, info=failed to get instance, instance_id=cloud_instance_1 err=KeyNotFound",
    "result": {}
}

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

