### PR TITLE
[fix]inconsistent behavior between get_instance and other cloud get_* api

### DIFF
--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -329,9 +329,11 @@ static HttpResponse process_get_value(MetaServiceImpl* service, brpc::Controller
 }
 
 static HttpResponse process_get_instance_info(MetaServiceImpl* service, brpc::Controller* ctrl) {
-    auto& uri = ctrl->http_request().uri();
-    std::string_view instance_id = http_query(uri, "instance_id");
-    std::string_view cloud_unique_id = http_query(uri, "cloud_unique_id");
+    GetInstanceRequest req;
+    PARSE_MESSAGE_OR_RETURN(ctrl, req);
+
+    std::string_view instance_id = req.instance_id();
+    std::string_view cloud_unique_id = req.cloud_unique_id();
 
     InstanceInfoPB instance;
     auto [code, msg] = service->get_instance_info(std::string(instance_id),


### PR DESCRIPTION
## Proposed changes

Issue Number: close #31049 

$ curl "127.0.0.1:5000/MetaService/http/get_instance?token=greedisgood9999" -d "{
            \"instance_id\": \"cloud_instance_0\"
        }";
{
    "code": "OK",
    "msg": "",
    "result": {
        "user_id": "minioadmin",
        "instance_id": "cloud_instance_0",
        "name": "cloud_instance_0",
        "clusters": [
            {
                "cluster_id": "RESERVED_CLUSTER_ID_FOR_SQL_SERVER",
                "cluster_name": "RESERVED_CLUSTER_NAME_FOR_SQL_SERVER",
                "type": "SQL",
                "nodes": [
                    {
                        "cloud_unique_id": "cloud_unique_id_sql_server00",
                        "ip": "192.168.0.106",
                        "ctime": "1708233217",
                        "mtime": "1708233217",
                        "edit_log_port": 9010,
                        "node_type": "FE_MASTER"
                    }
                ]
            }
        ],
        "obj_info": [
            {
                "ctime": "1708233200",
                "mtime": "1708233200",
                "id": "1",
                "ak": "doris123",
                "sk": "doris123",
                "bucket": "doris",
                "prefix": "",
                "endpoint": "http://127.0.0.1:9000",
                "region": "us-east-1",
                "provider": "S3",
                "external_endpoint": "http://127.0.0.1:9000",
                "encryption_info": {
                    "encryption_method": "AES_256_ECB",
                    "key_id": "1"
                },
                "sse_enabled": false
            }
        ],
        "status": "NORMAL",
        "iam_user": {
            "user_id": "",
            "ak": "",
            "sk": "",
            "external_id": "cloud_instance_0"
        },
        "sse_enabled": false
    }
}

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

