### PR TITLE
[Fix](executor)Fix query runtime statistics report failed

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -612,10 +612,9 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
         // This may be a first fragment request of the query.
         // Create the query fragments context.
         query_ctx = QueryContext::create_shared(query_id, params.fragment_num_on_host, _exec_env,
-                                                params.query_options);
+                                                params.query_options, params.coord);
         RETURN_IF_ERROR(DescriptorTbl::create(&(query_ctx->obj_pool), params.desc_tbl,
                                               &(query_ctx->desc_tbl)));
-        query_ctx->coord_addr = params.coord;
         // set file scan range params
         if (params.__isset.file_scan_params) {
             query_ctx->file_scan_range_params_map = params.file_scan_params;

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -34,12 +34,13 @@ public:
 };
 
 QueryContext::QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* exec_env,
-                           const TQueryOptions& query_options)
+                           const TQueryOptions& query_options, TNetworkAddress coord_addr)
         : fragment_num(total_fragment_num),
           timeout_second(-1),
           _query_id(query_id),
           _exec_env(exec_env),
           _query_options(query_options) {
+    this->coord_addr = coord_addr;
     _start_time = VecDateTimeValue::local_time();
     _shared_hash_table_controller.reset(new vectorized::SharedHashTableController());
     _shared_scanner_controller.reset(new vectorized::SharedScannerController());

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -70,7 +70,7 @@ class QueryContext {
 
 public:
     QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* exec_env,
-                 const TQueryOptions& query_options);
+                 const TQueryOptions& query_options, TNetworkAddress coord_addr);
 
     ~QueryContext();
 


### PR DESCRIPTION
## Proposed changes
```
W20240218 17:18:13.858228 2119962 doris_main.cpp:126] thrift internal message: TSocket::open() getaddrinfo() <Host:  Port: 0>Name or service not known
W20240218 17:18:13.858318 2119962 status.h:383] meet error status: [THRIFT_RPC_ERROR]Couldn't open transport for :0 (Could not resolve host for client socket.)

        0#  doris::ThriftClientImpl::open() at /tools/ldb_v17/1/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
        1#  doris::ClientCacheHelper::_create_client(doris::TNetworkAddress const&, std::function<doris::ThriftClientImpl* (doris::TNetworkAddress const&, void**)>&, void**, int) at /git/res-iso/be/src/common/status.h:452
        2#  doris::ClientCacheHelper::get_client(doris::TNetworkAddress const&, std::function<doris::ThriftClientImpl* (doris::TNetworkAddress const&, void**)>&, void**, int) at /git/res-iso/be/src/common/status.h:452
        3#  doris::ClientConnection<doris::FrontendServiceClient>::ClientConnection(doris::ClientCache<doris::FrontendServiceClient>*, doris::TNetworkAddress const&, int, doris::Status*, int) at /git/res-iso/be/src/common/status.h:348
        4#  doris::RuntimeQueryStatiticsMgr::report_runtime_query_statistics() at /git/res-iso/be/src/runtime/runtime_query_statistics_mgr.cpp:83
        5#  doris::Daemon::report_runtime_query_statistics_thread() at /tools/ldb_v17/1/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/chrono:510
        6#  doris::Thread::supervise_thread(void*) at /tools/ldb_v17/1/bin/../usr/include/pthread.h:562
        7#  start_thread
        8#  __clone
```