### PR TITLE
[fix](nereids)PushdownFilterThroughGenerate rule can push part of predicates down

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/lateral_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/lateral_view.groovy
@@ -98,4 +98,10 @@ suite("nereids_lateral_view") {
 	sql """ insert into test_explode_bitmap values(2, '22', bitmap_from_string("22,33,44"));"""
 	qt_sql_explode_bitmap """ select dt, e1 from test_explode_bitmap lateral view explode_bitmap(user_id) tmp1 as e1 order by dt, e1;"""
 
+    explain {
+            sql("SELECT * FROM nlv_test LATERAL VIEW explode_numbers(c1) lv1 AS clv1 where c1 < 10 and clv1 > 0;")
+            contains("PREDICATES: c1")
+            contains("PREDICATES: clv1")
+    }
+
 }


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/31057

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

