### PR TITLE
[fix](mysql-channel) initialize mysql serializer by default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/DummyMysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/DummyMysqlChannel.java
@@ -27,9 +27,6 @@ import java.nio.ByteBuffer;
  * And don't need to allocate a real ByteBuffer.
  */
 public class DummyMysqlChannel extends MysqlChannel {
-    public DummyMysqlChannel() {
-        this.serializer = MysqlSerializer.newInstance();
-    }
 
     public void setSequenceId(int sequenceId) {
         this.sequenceId = sequenceId;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -75,7 +75,7 @@ public class MysqlChannel {
     protected boolean isSslHandshaking;
     private SSLEngine sslEngine;
 
-    protected volatile MysqlSerializer serializer;
+    protected volatile MysqlSerializer serializer = MysqlSerializer.newInstance();
 
     // mysql flag CLIENT_DEPRECATE_EOF
     private boolean clientDeprecatedEOF;
@@ -111,8 +111,6 @@ public class MysqlChannel {
             remoteHostPortString = connection.getPeerAddress().toString();
             remoteIp = connection.getPeerAddress().toString();
         }
-        // The serializer and buffers should only be created if this is a real MysqlChannel
-        this.serializer = MysqlSerializer.newInstance();
         this.defaultBuffer = ByteBuffer.allocate(16 * 1024);
         this.headerByteBuffer = ByteBuffer.allocate(PACKET_HEADER_LEN);
         this.sendBuffer = ByteBuffer.allocate(2 * 1024 * 1024);


### PR DESCRIPTION
## Proposed changes

Mysql serializer is used by all sub classes. Make it initialized by default to avoid NPE.

