### PR TITLE
[fix](audit) The time field in the audit log table is set to the millisecond level

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -68,7 +68,7 @@ public class InternalSchema {
         // audit table
         AUDIT_SCHEMA = new ArrayList<>();
         AUDIT_SCHEMA.add(new ColumnDef("query_id", TypeDef.createVarchar(48), true));
-        AUDIT_SCHEMA.add(new ColumnDef("time", TypeDef.create(PrimitiveType.DATETIMEV2), true));
+        AUDIT_SCHEMA.add(new ColumnDef("time", TypeDef.createDatetimeV2(3), true));
         AUDIT_SCHEMA.add(new ColumnDef("client_ip", TypeDef.createVarchar(128), true));
         AUDIT_SCHEMA.add(new ColumnDef("user", TypeDef.createVarchar(128), true));
         AUDIT_SCHEMA.add(new ColumnDef("catalog", TypeDef.createVarchar(128), true));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -68,7 +68,7 @@ public class InternalSchema {
         // audit table
         AUDIT_SCHEMA = new ArrayList<>();
         AUDIT_SCHEMA.add(new ColumnDef("query_id", TypeDef.createVarchar(48), true));
-        AUDIT_SCHEMA.add(new ColumnDef("time", TypeDef.create(PrimitiveType.DATETIME), true));
+        AUDIT_SCHEMA.add(new ColumnDef("time", TypeDef.create(PrimitiveType.DATETIMEV2), true));
         AUDIT_SCHEMA.add(new ColumnDef("client_ip", TypeDef.createVarchar(128), true));
         AUDIT_SCHEMA.add(new ColumnDef("user", TypeDef.createVarchar(128), true));
         AUDIT_SCHEMA.add(new ColumnDef("catalog", TypeDef.createVarchar(128), true));

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -142,7 +142,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
 
     private void fillLogBuffer(AuditEvent event, StringBuilder logBuffer) {
         logBuffer.append(event.queryId).append("\t");
-        logBuffer.append(TimeUtils.longToTimeString(event.timestamp)).append("\t");
+        logBuffer.append(TimeUtils.longToTimeStringWithms(event.timestamp)).append("\t");
         logBuffer.append(event.clientIp).append("\t");
         logBuffer.append(event.user).append("\t");
         logBuffer.append(event.ctl).append("\t");


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

1、The time field type in the audit log is set to milliseconds

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

