### PR TITLE
[Bug](agg-state) fix not match function when agg combinator function has alias

### DIFF
--- a/be/src/vec/data_types/data_type_agg_state.h
+++ b/be/src/vec/data_types/data_type_agg_state.h
@@ -14,20 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-// This file is copied from
-// https://github.com/ClickHouse/ClickHouse/blob/master/src/DataTypes/DataTypeString.h
-// and modified by Doris
 
 #pragma once
 
-#include <gen_cpp/Types_types.h>
 #include <gen_cpp/data.pb.h>
-#include <glog/logging.h>
-#include <stddef.h>
-#include <stdint.h>
-
-#include <memory>
-#include <string>
 
 #include "common/exception.h"
 #include "common/status.h"
@@ -41,22 +31,14 @@
 #include "vec/data_types/data_type_string.h"
 #include "vec/data_types/serde/data_type_fixedlengthobject_serde.h"
 
-namespace doris {
-namespace vectorized {
-class BufferWritable;
-class IColumn;
-class ReadBuffer;
-} // namespace vectorized
-} // namespace doris
-
 namespace doris::vectorized {
 
 class DataTypeAggState : public DataTypeString {
 public:
     DataTypeAggState(DataTypes sub_types, bool result_is_nullable, std::string function_name)
             : _result_is_nullable(result_is_nullable),
-              _sub_types(sub_types),
-              _function_name(function_name) {
+              _sub_types(std::move(sub_types)),
+              _function_name(std::move(function_name)) {
         _agg_function = AggregateFunctionSimpleFactory::instance().get(_function_name, _sub_types,
                                                                        _result_is_nullable);
         if (_agg_function == nullptr) {
@@ -73,11 +55,11 @@ public:
                            _function_name, _result_is_nullable, get_types_string());
     }
 
+    std::string get_function_name() const { return _function_name; }
+
     TypeIndex get_type_id() const override { return TypeIndex::AggState; }
 
-    TypeDescriptor get_type_as_type_descriptor() const override {
-        return TypeDescriptor(TYPE_AGG_STATE);
-    }
+    TypeDescriptor get_type_as_type_descriptor() const override { return {TYPE_AGG_STATE}; }
 
     doris::FieldType get_storage_field_type() const override {
         return doris::FieldType::OLAP_FIELD_TYPE_AGG_STATE;

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -166,9 +166,7 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
         }
 
         std::string type_function_name =
-                assert_cast<const DataTypeAggState*>(argument_types[0].get())
-                        ->get_nested_function()
-                        ->get_name();
+                assert_cast<const DataTypeAggState*>(argument_types[0].get())->get_function_name();
         if (type_function_name + AGG_UNION_SUFFIX == _fn.name.function_name) {
             if (_data_type->is_nullable()) {
                 return Status::InternalError(

--- a/regression-test/data/datatype_p0/agg_state/test_agg_state.out
+++ b/regression-test/data/datatype_p0/agg_state/test_agg_state.out
@@ -44,3 +44,9 @@
 -- !max_by_null --
 \N	\N
 
+-- !ndv --
+1
+
+-- !approx_count_distinct --
+1
+

--- a/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
@@ -73,4 +73,7 @@ suite("test_agg_state") {
         sql "select avg_state(1) from d_table;"
         exception "write_column_to_pb with type ColumnFixedLengthObject"
     }
+
+    qt_ndv """select ndv_merge(t) from (select ndv_union(ndv_state(1)) as t from d_table group by k1)p;"""
+    qt_approx_count_distinct """select approx_count_distinct_merge(t) from (select approx_count_distinct_union(approx_count_distinct_state(1)) as t from d_table group by k1)p;"""
 }


### PR DESCRIPTION
## Proposed changes
fix not match function when agg combinator function has alias


```sql
mysql [test]>select approx_count_distinct_merge(t) from (select approx_count_distinct_union(approx_count_distinct_state(1)) as t from d_table group by k1)p;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[INTERNAL_ERROR]AggState(function_name=ndv,result_is_nullable=false,arguments=[Int8]) not match function ndv_merge
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

