### PR TITLE
[fix](statistics)Refresh follower FE cache after alter column stats. Support alter index column stats.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1403,7 +1403,12 @@ alter_stmt ::=
     | KW_ALTER KW_TABLE table_name:tbl KW_MODIFY KW_COLUMN ident:columnName
       KW_SET KW_STATS LPAREN key_value_map:map RPAREN opt_partition_names:partitionNames
     {:
-        RESULT = new AlterColumnStatsStmt(tbl, columnName, map, partitionNames);
+        RESULT = new AlterColumnStatsStmt(tbl, null, columnName, map, partitionNames);
+    :}
+    | KW_ALTER KW_TABLE table_name:tbl KW_INDEX ident:idx KW_MODIFY KW_COLUMN ident:columnName
+      KW_SET KW_STATS LPAREN key_value_map:map RPAREN opt_partition_names:partitionNames
+    {:
+        RESULT = new AlterColumnStatsStmt(tbl, idx, columnName, map, partitionNames);
     :}
     | KW_ALTER KW_TABLE table_name:tbl KW_SET LPAREN key_value_map:properties RPAREN
     {:

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
@@ -101,6 +101,18 @@ public class ColStatsData {
         this.updateTime = row.get(13);
     }
 
+    public ColStatsData(String id, long catalogId, long dbId, long tblId, long idxId, String colId, String partId,
+                        ColumnStatistic columnStatistic) {
+        this.statsId = new StatsId(id, catalogId, dbId, tblId, idxId, colId, partId);
+        this.count = Math.round(columnStatistic.count);
+        this.ndv = Math.round(columnStatistic.ndv);
+        this.nullCount = Math.round(columnStatistic.numNulls);
+        this.minLit = columnStatistic.minExpr == null ? null : columnStatistic.minExpr.getStringValue();
+        this.maxLit = columnStatistic.maxExpr == null ? null : columnStatistic.maxExpr.getStringValue();
+        this.dataSizeInBytes = Math.round(columnStatistic.dataSize);
+        this.updateTime = columnStatistic.updatedTime;
+    }
+
     public String toSQL(boolean roundByParentheses) {
         StringJoiner sj = null;
         if (roundByParentheses) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -247,6 +247,7 @@ public class StatisticsRepository {
         String min = alterColumnStatsStmt.getValue(StatsType.MIN_VALUE);
         String max = alterColumnStatsStmt.getValue(StatsType.MAX_VALUE);
         String dataSize = alterColumnStatsStmt.getValue(StatsType.DATA_SIZE);
+        long indexId = alterColumnStatsStmt.getIndexId();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder();
         String colName = alterColumnStatsStmt.getColumnName();
         Column column = objects.table.getColumn(colName);
@@ -282,10 +283,10 @@ public class StatisticsRepository {
 
         ColumnStatistic columnStatistic = builder.build();
         Map<String, String> params = new HashMap<>();
-        params.put("id", constructId(objects.table.getId(), -1, colName));
+        params.put("id", constructId(objects.table.getId(), indexId, colName));
         params.put("catalogId", String.valueOf(objects.catalog.getId()));
         params.put("dbId", String.valueOf(objects.db.getId()));
-        params.put("idxId", "-1");
+        params.put("idxId", String.valueOf(indexId));
         params.put("tblId", String.valueOf(objects.table.getId()));
         params.put("colId", String.valueOf(colName));
         params.put("count", String.valueOf(columnStatistic.count));
@@ -299,8 +300,10 @@ public class StatisticsRepository {
             // update table granularity statistics
             params.put("partId", "NULL");
             StatisticsUtil.execUpdate(INSERT_INTO_COLUMN_STATISTICS, params);
-            Env.getCurrentEnv().getStatisticsCache()
-                    .updateColStatsCache(objects.table.getId(), -1, colName, columnStatistic);
+            ColStatsData data = new ColStatsData(constructId(objects.table.getId(), indexId, colName),
+                    objects.catalog.getId(), objects.db.getId(), objects.table.getId(), indexId, colName,
+                    null, columnStatistic);
+            Env.getCurrentEnv().getStatisticsCache().syncColStats(data);
             AnalysisInfo mockedJobInfo = new AnalysisInfoBuilder()
                     .setTblUpdateTime(System.currentTimeMillis())
                     .setColName("")

--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -410,6 +410,48 @@ suite("test_analyze_mv") {
     verifyTaskStatus(result_sample, "mva_MIN__`value3`", "mv3")
     verifyTaskStatus(result_sample, "mva_SUM__CAST(`value1` AS BIGINT)", "mv3")
 
+    // Test alter column stats
+    sql """drop stats mvTestDup"""
+    sql """alter table mvTestDup modify column key1 set stats ('ndv'='1', 'num_nulls'='1', 'min_value'='10', 'max_value'='40', 'row_count'='50');"""
+    sql """alter table mvTestDup index mv3 modify column mv_key1 set stats ('ndv'='5', 'num_nulls'='0', 'min_value'='0', 'max_value'='4', 'row_count'='5');"""
+    sql """alter table mvTestDup index mv3 modify column `mva_SUM__CAST(``value1`` AS BIGINT)` set stats ('ndv'='10', 'num_nulls'='2', 'min_value'='1', 'max_value'='5', 'row_count'='11');"""
+
+    def result = sql """show column cached stats mvTestDup(key1)"""
+    assertEquals(1, result.size())
+    assertEquals("key1", result[0][0])
+    assertEquals("N/A", result[0][1])
+    assertEquals("50.0", result[0][2])
+    assertEquals("1.0", result[0][3])
+    assertEquals("1.0", result[0][4])
+    assertEquals("0.0", result[0][5])
+    assertEquals("0.0", result[0][6])
+    assertEquals("10", result[0][7])
+    assertEquals("40", result[0][8])
+
+    result = sql """show column cached stats mvTestDup(mv_key1)"""
+    assertEquals(1, result.size())
+    assertEquals("mv_key1", result[0][0])
+    assertEquals("mv3", result[0][1])
+    assertEquals("5.0", result[0][2])
+    assertEquals("5.0", result[0][3])
+    assertEquals("0.0", result[0][4])
+    assertEquals("0.0", result[0][5])
+    assertEquals("0.0", result[0][6])
+    assertEquals("0", result[0][7])
+    assertEquals("4", result[0][8])
+
+    result = sql """show column cached stats mvTestDup(`mva_SUM__CAST(``value1`` AS BIGINT)`)"""
+    assertEquals(1, result.size())
+    assertEquals("mva_SUM__CAST(`value1` AS BIGINT)", result[0][0])
+    assertEquals("mv3", result[0][1])
+    assertEquals("11.0", result[0][2])
+    assertEquals("10.0", result[0][3])
+    assertEquals("2.0", result[0][4])
+    assertEquals("0.0", result[0][5])
+    assertEquals("0.0", result[0][6])
+    assertEquals("1", result[0][7])
+    assertEquals("5", result[0][8])
+
     sql """drop database if exists test_analyze_mv"""
 }
 


### PR DESCRIPTION
1. Refresh follower FE cache after alter column stats. So that follower could update the cached stats too.
2. Support alter index column stats.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

