### PR TITLE
[cherry-pick](udf) fix java-udf coredump as get env return nullptr (#30986)

### DIFF
--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -48,6 +48,7 @@
 #include "util/binary_cast.hpp"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
+#include "util/uid_util.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
@@ -71,6 +72,7 @@ Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& para
 
     TQueryGlobals query_globals = params.query_globals;
     _query_id = params.query_id;
+    LOG(INFO) << "start fold fold_query_id: " << print_id(_query_id);
     // init
     RETURN_IF_ERROR(_init(query_globals, params.query_options));
     // only after init operation, _mem_tracker is ready
@@ -123,7 +125,7 @@ Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& para
         expr_result_map->insert({m.first, pexpr_result_map});
     }
     //TODO: will be delete the debug log after find problem of timeout.
-    LOG(INFO) << "finish fold_query_id: " << query_id_string();
+    LOG(INFO) << "finish fold_query_id: " << print_id(_query_id);
     return Status::OK();
 }
 

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -122,7 +122,8 @@ Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& para
         }
         expr_result_map->insert({m.first, pexpr_result_map});
     }
-
+    //TODO: will be delete the debug log after find problem of timeout.
+    LOG(INFO) << "finish fold_query_id: " << query_id_string();
     return Status::OK();
 }
 

--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -424,7 +424,7 @@ Status JavaFunctionCall::close(FunctionContext* context,
     // JNIContext own some resource and its release method depend on JavaFunctionCall
     // has to release the resource before JavaFunctionCall is deconstructed.
     if (jni_ctx) {
-        jni_ctx->close();
+        RETURN_IF_ERROR(jni_ctx->close());
     }
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -176,6 +176,8 @@ public class FoldConstantRuleOnBE extends AbstractExpressionRewriteRule {
             tParams.setQueryOptions(tQueryOptions);
             tParams.setQueryId(context.queryId());
 
+            // TODO: will be delete the debug log after find problem of timeout.
+            LOG.info("fold query {} ", DebugUtil.printId(context.queryId()));
             Future<PConstantExprResult> future =
                     BackendServiceProxy.getInstance().foldConstantExpr(brpcAddress, tParams);
             PConstantExprResult result = future.get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
## Proposed changes


cherry-pick from master https://github.com/apache/doris/pull/30986

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

