### PR TITLE
[fix](regression-test) test_nested_type_with_rowstore is flaky

### DIFF
--- a/regression-test/suites/datatype_p0/nested_types/query/test_nested_type_with_rowstore.groovy
+++ b/regression-test/suites/datatype_p0/nested_types/query/test_nested_type_with_rowstore.groovy
@@ -51,6 +51,8 @@ suite("test_nested_type_with_rowstore") {
             }
     }
 
+    sql "sync"
+
     // select and check
     qt_sql """ select * from ct_table order by id;"""
     // point sql


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

partial update succeeded but data is not updated, this case has a low probability of failure, and it looks like it may be caused by not adding the sync statement
```
Check tag 'sql' failed, line 1, CHAR result mismatch.
Expect cell is: apache doris
But real is: doris1line 1 mismatch
ExpectRow: [1, apache doris, {"jsonk1":123,"jsonk2":456}, [100, 200], {"k1":10}, {"a": 1, "b": 2}]
RealRow: [1, doris1, {"jsonk1":123,"jsonk2":456}, [100, 200], {"k1":10}, {"a": 1, "b": 2}]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

