### PR TITLE
[fix](tools) Fix non-standard code in tpch/tpcds dbgen tools leading to compilation failure

### DIFF
--- a/tools/tpcds-tools/README.md
+++ b/tools/tpcds-tools/README.md
@@ -24,8 +24,9 @@ follow the steps below:
 
 ### 1. build tpc-ds dsdgen dsqgen tool.
 
-    export PATH=/usr/bin/:$PATH
     ./bin/build-tpcds-tools.sh
+
+    If the build failed in dbgen tools' compilation, update your GCC version or change all "TPC-DS_Tools_v3.2.0new.zip" in build-tpcds-dbgen.sh to "TPC-DS_Tools_v3.2.0.zip"
 
 ### 2. generate tpc-ds data. use -h for more infomations.
 

--- a/tools/tpcds-tools/bin/build-tpcds-tools.sh
+++ b/tools/tpcds-tools/bin/build-tpcds-tools.sh
@@ -47,12 +47,12 @@ check_prerequest "unzip -h" "unzip"
 
 # download tpcds tools package first
 if [[ -d "${CURDIR}/DSGen-software-code-3.2.0rc1" ]]; then
-    echo "If you want to rebuild TPC-DS_Tools_v3.2.0 again, please delete ${CURDIR}/DSGen-software-code-3.2.0rc1 first." && exit 1
-elif [[ -f "${CURDIR}/TPC-DS_Tools_v3.2.0.zip" ]]; then
-    unzip TPC-DS_Tools_v3.2.0.zip -d "${CURDIR}/"
+    echo "If you want to rebuild TPC-DS_Tools_v3.2.0 again, please delete ${CURDIR}/DSGen-software-code-3.2.0rc1 first."
+elif [[ -f "${CURDIR}/TPC-DS_Tools_v3.2.0new.zip" ]]; then
+    unzip TPC-DS_Tools_v3.2.0new.zip -d "${CURDIR}/"
 else
-    wget "https://doris-build-1308700295.cos.ap-beijing.myqcloud.com/tools/TPC-DS_Tools_v3.2.0.zip"
-    unzip TPC-DS_Tools_v3.2.0.zip -d "${CURDIR}/"
+    wget "https://doris-build-1308700295.cos.ap-beijing.myqcloud.com/tools/TPC-DS_Tools_v3.2.0new.zip"
+    unzip TPC-DS_Tools_v3.2.0new.zip -d "${CURDIR}/"
 fi
 
 # compile tpcds-dsdgen

--- a/tools/tpch-tools/README.md
+++ b/tools/tpch-tools/README.md
@@ -26,6 +26,8 @@ follow the steps below:
 
     ./bin/build-tpch-dbgen.sh
 
+    If the build failed in dbgen tools' compilation, update your GCC version or change download link used by wget in build-tpch-dbgen.sh from ".../TPC-H_Tools_v3.0.0new.zip" to ".../TPC-H_Tools_v3.0.0.zip"
+
 ### 2. generate tpc-h data. use -h for more infomations.
 
     ./bin/gen-tpch-data.sh -s 1

--- a/tools/tpch-tools/bin/build-tpch-dbgen.sh
+++ b/tools/tpch-tools/bin/build-tpch-dbgen.sh
@@ -38,7 +38,7 @@ check_prerequest() {
     local CMD=$1
     local NAME=$2
     if ! ${CMD}; then
-        echo "${NAME} is missing. This script depends on unzip to extract files from TPC-H_Tools_v3.0.0.zip"
+        echo "${NAME} is missing. This script depends on unzip to extract files from TPC-H_Tools_v3.0.0new.zip"
         exit 1
     fi
 }
@@ -48,10 +48,10 @@ check_prerequest "unzip -h" "unzip"
 # download tpch tools pacage first
 if [[ -d ${TPCH_DBGEN_DIR} ]]; then
     echo "Dir ${TPCH_DBGEN_DIR} already exists. No need to download."
-    echo "If you want to download TPC-H_Tools_v3.0.0 again, please delete this dir first."
+    echo "If you want to download TPC-H_Tools_v3.0.0new again, please delete this dir first."
 else
-    wget "https://doris-build-1308700295.cos.ap-beijing.myqcloud.com/tools/TPC-H_Tools_v3.0.0.zip"
-    unzip TPC-H_Tools_v3.0.0.zip -d "${CURDIR}/"
+    wget "https://doris-build-1308700295.cos.ap-beijing.myqcloud.com/tools/TPC-H_Tools_v3.0.0new.zip"
+    unzip TPC-H_Tools_v3.0.0new.zip -d "${CURDIR}/"
 fi
 
 # modify tpcd.h


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. removed some duplicated declares in TPCH's dbgen code
2. add flag '-fcommon' for TPCDS's dbgen tool's build (https://godbolt.org/z/sr4adhn93 could prove that's correct)

all the changes was tested successfully

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

