### PR TITLE
[fix](catalog recycle bin) table partition meta is error if recover partition in some case

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CATALOG-RECYCLE-BIN.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CATALOG-RECYCLE-BIN.md
@@ -50,6 +50,8 @@ The meaning of each column is as follows:
         TableId：             id of table
         PartitionId：         id of partition
         DropTime：            drop time of meta information
+        DataSize：            the amount of data. If the type is database, this value includes the data size of the recycled tables and partitions in the database
+        RemoteDataSize：      the amount of data on remote storage(hdfs or object storage). If the type is database, this value includes the remote data size of the recycled tables and partitions in the database
 ```
 
 ### Example

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-CATALOG-RECYCLE-BIN.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-CATALOG-RECYCLE-BIN.md
@@ -54,6 +54,8 @@ SHOW CATALOG RECYCLE BIN [ WHERE NAME [ = "name" | LIKE "name_matcher"] ]
         TableId：             table对应的id
         PartitionId：         partition对应的id
         DropTime：            元数据放入回收站的时间
+        DataSize：            数据量. 如果元数据类型是database, 该值包含了database下在回收站中的所有table和partition的数据量
+        RemoteDataSize：      remote storage(hdfs或对象存储)的数据量. 如果元数据类型是database, 该值包含了database下在回收站中的所有table和partition的remote storage数据量
 ```
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -799,10 +799,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
 
         PartitionInfo partitionInfo = table.getPartitionInfo();
-        Range<PartitionKey> recoverRange = recoverPartitionInfo.getRange();
         PartitionItem recoverItem = null;
         if (partitionInfo.getType() == PartitionType.RANGE) {
-            recoverItem = new RangePartitionItem(recoverRange);
+            recoverItem = new RangePartitionItem(recoverPartitionInfo.getRange());
         } else if (partitionInfo.getType() == PartitionType.LIST) {
             recoverItem = recoverPartitionInfo.getListPartitionItem();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -810,14 +810,17 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             throw new DdlException("Can not recover partition[" + partitionName + "]. Partition item conflict.");
         }
 
-        // recover partition
+        // check if partition name exists
         Partition recoverPartition = recoverPartitionInfo.getPartition();
         Preconditions.checkState(recoverPartition.getName().equalsIgnoreCase(partitionName));
         if (!Strings.isNullOrEmpty(newPartitionName)) {
             if (table.checkPartitionNameExist(newPartitionName)) {
                 throw new DdlException("Partition name[" + newPartitionName + "] is already used");
             }
+            recoverPartition.setName(newPartitionName);
         }
+
+        // recover partition
         table.addPartition(recoverPartition);
         if (!Strings.isNullOrEmpty(newPartitionName)) {
             table.renamePartition(partitionName, newPartitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -822,9 +822,6 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
         // recover partition
         table.addPartition(recoverPartition);
-        if (!Strings.isNullOrEmpty(newPartitionName)) {
-            table.renamePartition(partitionName, newPartitionName);
-        }
 
         // recover partition info
         long partitionId = recoverPartition.getId();

--- a/regression-test/suites/catalog_recycle_bin_p0/recover.groovy
+++ b/regression-test/suites/catalog_recycle_bin_p0/recover.groovy
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("recover") {
+    def table = "test_recover"
+
+    // create table and insert data
+    sql """ drop table if exists ${table} """
+    sql """
+    create table ${table} (
+        `id` int(11),
+        `name` varchar(128),
+        `da` date
+    )
+    engine=olap
+    duplicate key(id)
+    partition by range(da)(
+        PARTITION p3 VALUES LESS THAN ('2023-01-01'),
+        PARTITION p4 VALUES LESS THAN ('2024-01-01'),
+        PARTITION p5 VALUES LESS THAN ('2025-01-01')
+    )
+    distributed by hash(id) buckets 2
+    properties(
+        "replication_num"="1",
+        "light_schema_change"="true"
+    );
+    """
+
+    sql """ insert into ${table} values(1, 'a', '2022-01-02'); """
+    sql """ insert into ${table} values(2, 'a', '2023-01-02'); """
+    sql """ insert into ${table} values(3, 'a', '2024-01-02'); """
+
+    // drop partition
+    sql """ ALTER TABLE ${table} DROP PARTITION p3; """
+
+    // add partition with the same name as the dropped partition
+    sql """ alter table ${table} add PARTITION p3 VALUES LESS THAN("2026-01-01"); """
+    sql """ insert into ${table} values(4, 'a', '2025-01-02'); """
+    sql """ insert into ${table} PARTITION(p3) values (5, 'a', '2025-01-02'); """
+
+    // recover partition use new name
+    sql """ recover partition p3 as p6 from regression_test_catalog_recycle_bin_p0.${table}; """
+
+    // insert into partition p3
+    sql """ insert into ${table} PARTITION(p3) values (6, 'a', '2025-01-02'); """
+}


### PR DESCRIPTION
## Proposed changes

If recover partition use a new partition name:
```
recover partition p3 as p6 from db2.tbl1;
```

if the table contains a partition `p3`, the table partition meta data `idToPartition` and `nameToPartition` is inconsistent: 
![p2](https://github.com/apache/doris/assets/4094707/787b9a41-b0b3-4ea2-a0ab-00ccf986c9f9)



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

