### PR TITLE
[fix](statistics)Refresh follower FE cache after alter column stats. Support alter index column stats (#31108)

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1356,7 +1356,12 @@ alter_stmt ::=
     | KW_ALTER KW_TABLE table_name:tbl KW_MODIFY KW_COLUMN ident:columnName
       KW_SET KW_STATS LPAREN key_value_map:map RPAREN opt_partition_names:partitionNames
     {:
-        RESULT = new AlterColumnStatsStmt(tbl, columnName, map, partitionNames);
+        RESULT = new AlterColumnStatsStmt(tbl, null, columnName, map, partitionNames);
+    :}
+    | KW_ALTER KW_TABLE table_name:tbl KW_INDEX ident:idx KW_MODIFY KW_COLUMN ident:columnName
+      KW_SET KW_STATS LPAREN key_value_map:map RPAREN opt_partition_names:partitionNames
+    {:
+        RESULT = new AlterColumnStatsStmt(tbl, idx, columnName, map, partitionNames);
     :}
     | KW_ALTER KW_TABLE table_name:tbl KW_SET LPAREN key_value_map:properties RPAREN
     {:

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
@@ -101,6 +101,18 @@ public class ColStatsData {
         this.updateTime = row.get(13);
     }
 
+    public ColStatsData(String id, long catalogId, long dbId, long tblId, long idxId, String colId, String partId,
+                        ColumnStatistic columnStatistic) {
+        this.statsId = new StatsId(id, catalogId, dbId, tblId, idxId, colId, partId);
+        this.count = Math.round(columnStatistic.count);
+        this.ndv = Math.round(columnStatistic.ndv);
+        this.nullCount = Math.round(columnStatistic.numNulls);
+        this.minLit = columnStatistic.minExpr == null ? null : columnStatistic.minExpr.getStringValue();
+        this.maxLit = columnStatistic.maxExpr == null ? null : columnStatistic.maxExpr.getStringValue();
+        this.dataSizeInBytes = Math.round(columnStatistic.dataSize);
+        this.updateTime = columnStatistic.updatedTime;
+    }
+
     public String toSQL(boolean roundByParentheses) {
         StringJoiner sj = null;
         if (roundByParentheses) {


### PR DESCRIPTION
1. Refresh follower FE cache after alter column stats. So that follower could update the cached stats too.
2. Support alter index column stats.

backport https://github.com/apache/doris/pull/31108

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

