### PR TITLE
[Fix](grace-exit) BE gracefully exit when port conflicts

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -255,7 +255,7 @@ Status StorageEngine::_init_store_map() {
 Status StorageEngine::_init_stream_load_recorder(const std::string& stream_load_record_path) {
     LOG(INFO) << "stream load record path: " << stream_load_record_path;
     // init stream load record rocksdb
-    _stream_load_recorder = StreamLoadRecorder::create_unique(stream_load_record_path);
+    _stream_load_recorder = StreamLoadRecorder::create_shared(stream_load_record_path);
     if (_stream_load_recorder == nullptr) {
         RETURN_NOT_OK_STATUS_WITH_WARN(
                 Status::MemoryAllocFailed("allocate memory for StreamLoadRecorder failed"),

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -548,7 +548,11 @@ void ExecEnv::destroy() {
     _memtable_memory_limiter.reset();
     _delta_writer_v2_pool.reset();
     _load_stream_stub_pool.reset();
-    SAFE_STOP(_storage_engine);
+
+    // StorageEngine must be destoried before _page_no_cache_mem_tracker.reset and _cache_manager destory
+    // shouldn't use SAFE_STOP. otherwise will lead to twice stop.
+    _storage_engine.reset();
+
     SAFE_SHUTDOWN(_buffered_reader_prefetch_thread_pool);
     SAFE_SHUTDOWN(_s3_file_upload_thread_pool);
     SAFE_SHUTDOWN(_join_node_thread_pool);
@@ -572,10 +576,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_schema_cache);
     SAFE_DELETE(_segment_loader);
     SAFE_DELETE(_row_cache);
-
-    // StorageEngine must be destoried before _page_no_cache_mem_tracker.reset
-    // StorageEngine must be destoried before _cache_manager destory
-    _storage_engine.reset();
 
     // Free resource after threads are stopped.
     // Some threads are still running, like threads created by _new_load_stream_mgr ...

--- a/be/src/runtime/stream_load/stream_load_recorder.h
+++ b/be/src/runtime/stream_load/stream_load_recorder.h
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <stdint.h>
-
 #include <atomic>
+#include <cstdint>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -39,7 +39,7 @@ class StreamLoadRecorder {
     ENABLE_FACTORY_CREATOR(StreamLoadRecorder);
 
 public:
-    StreamLoadRecorder(const std::string& root_path);
+    StreamLoadRecorder(std::string root_path);
 
     virtual ~StreamLoadRecorder();
 
@@ -47,12 +47,12 @@ public:
 
     Status put(const std::string& key, const std::string& value);
 
-    Status get_batch(const std::string& start, const int batch_size,
+    Status get_batch(const std::string& start, int batch_size,
                      std::map<std::string, std::string>* stream_load_records);
 
 private:
     std::string _root_path;
-    rocksdb::DBWithTTL* _db = nullptr;
+    std::unique_ptr<rocksdb::DBWithTTL> _db;
     std::vector<rocksdb::ColumnFamilyHandle*> _handles;
 
     std::atomic<int64_t> _last_compaction_time;

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -489,7 +489,6 @@ int main(int argc, char** argv) {
     status = doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths, broken_paths);
     if (status != Status::OK()) {
         std::cerr << "failed to init doris storage engine, res=" << status;
-        LOG(ERROR) << "failed to init doris storage engine, res=" << status;
         return 0;
     }
 
@@ -511,7 +510,6 @@ int main(int argc, char** argv) {
     status = be_server->start();
     if (!status.ok()) {
         std::cerr << "Doris BE server did not start correctly, exiting\n";
-        LOG(ERROR) << "Doris BE server did not start correctly, exiting";
         exit(-1);
     }
 
@@ -521,7 +519,6 @@ int main(int argc, char** argv) {
     status = brpc_service->start(doris::config::brpc_port, doris::config::brpc_num_threads);
     if (!status.ok()) {
         std::cerr << "BRPC service did not start correctly, exiting\n";
-        LOG(ERROR) << "BRPC service did not start correctly, exiting";
         exit(-1);
     }
 
@@ -531,7 +528,6 @@ int main(int argc, char** argv) {
     status = http_service->start();
     if (!status.ok()) {
         std::cerr << "Doris Be http service did not start correctly, exiting\n";
-        LOG(ERROR) << "Doris Be http service did not start correctly, exiting";
         exit(-1);
     }
 
@@ -544,7 +540,6 @@ int main(int argc, char** argv) {
 
     if (!heartbeat_status.ok()) {
         std::cerr << "Heartbeat services did not start correctly, exiting";
-        LOG(ERROR) << "Heartbeat services did not start correctly, exiting";
         exit(-1);
     }
 
@@ -552,7 +547,6 @@ int main(int argc, char** argv) {
     if (!status.ok()) {
         std::cerr << "Doris BE HeartBeat Service did not start correctly, exiting: " << status
                   << '\n';
-        LOG(ERROR) << "Doris BE HeartBeat Service did not start correctly, exiting: " << status;
         exit(-1);
     }
 
@@ -567,8 +561,6 @@ int main(int argc, char** argv) {
     if (!status.ok()) {
         std::cerr << "Arrow Flight Service did not start correctly, exiting, " << status.to_string()
                   << '\n';
-        LOG(ERROR) << "Arrow Flight Service did not start correctly, exiting, "
-                   << status.to_string();
         exit(-1);
     }
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -488,8 +488,9 @@ int main(int argc, char** argv) {
     auto* exec_env(doris::ExecEnv::GetInstance());
     status = doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths, broken_paths);
     if (status != Status::OK()) {
+        std::cerr << "failed to init doris storage engine, res=" << status;
         LOG(ERROR) << "failed to init doris storage engine, res=" << status;
-        exit(-1);
+        return 0;
     }
 
     // begin to start services
@@ -509,9 +510,9 @@ int main(int argc, char** argv) {
 
     status = be_server->start();
     if (!status.ok()) {
-        LOG(ERROR) << "Doris Be server did not start correctly, exiting";
-        doris::shutdown_logging();
-        exit(1);
+        std::cerr << "Doris BE server did not start correctly, exiting\n";
+        LOG(ERROR) << "Doris BE server did not start correctly, exiting";
+        exit(-1);
     }
 
     // 2. bprc service
@@ -519,9 +520,9 @@ int main(int argc, char** argv) {
             std::make_unique<doris::BRpcService>(exec_env);
     status = brpc_service->start(doris::config::brpc_port, doris::config::brpc_num_threads);
     if (!status.ok()) {
+        std::cerr << "BRPC service did not start correctly, exiting\n";
         LOG(ERROR) << "BRPC service did not start correctly, exiting";
-        doris::shutdown_logging();
-        exit(1);
+        exit(-1);
     }
 
     // 3. http service
@@ -529,9 +530,9 @@ int main(int argc, char** argv) {
             exec_env, doris::config::webserver_port, doris::config::webserver_num_workers);
     status = http_service->start();
     if (!status.ok()) {
+        std::cerr << "Doris Be http service did not start correctly, exiting\n";
         LOG(ERROR) << "Doris Be http service did not start correctly, exiting";
-        doris::shutdown_logging();
-        exit(1);
+        exit(-1);
     }
 
     // 4. heart beat server
@@ -542,16 +543,17 @@ int main(int argc, char** argv) {
             doris::config::heartbeat_service_thread_count, master_info);
 
     if (!heartbeat_status.ok()) {
+        std::cerr << "Heartbeat services did not start correctly, exiting";
         LOG(ERROR) << "Heartbeat services did not start correctly, exiting";
-        doris::shutdown_logging();
-        exit(1);
+        exit(-1);
     }
 
     status = heartbeat_thrift_server->start();
     if (!status.ok()) {
+        std::cerr << "Doris BE HeartBeat Service did not start correctly, exiting: " << status
+                  << '\n';
         LOG(ERROR) << "Doris BE HeartBeat Service did not start correctly, exiting: " << status;
-        doris::shutdown_logging();
-        exit(1);
+        exit(-1);
     }
 
     // 5. arrow flight service
@@ -563,10 +565,11 @@ int main(int argc, char** argv) {
     doris::Daemon daemon;
     daemon.start();
     if (!status.ok()) {
+        std::cerr << "Arrow Flight Service did not start correctly, exiting, " << status.to_string()
+                  << '\n';
         LOG(ERROR) << "Arrow Flight Service did not start correctly, exiting, "
                    << status.to_string();
-        doris::shutdown_logging();
-        exit(1);
+        exit(-1);
     }
 
     while (!doris::k_doris_exit) {

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -145,7 +145,7 @@ Status ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() {
 
     // _started == true only if preServe was called. May be false if there was an exception
     // after preServe that was caught by Supervise, causing it to reset the error condition.
-    if (_thrift_server->_started == false) {
+    if (!_thrift_server->_started) {
         std::stringstream ss;
         ss << "ThriftServer '" << _thrift_server->_name << "' (on port: " << _thrift_server->_port
            << ") did not start correctly ";


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

almost fixed. still some bugs in rocksdb itself when in Release mode

before:
coredump in somewhere

now log:
```
Doris BE server did not start correctly, exiting
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

