### PR TITLE
[fix](backup) fix concurrent upload and release snapshot crash

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -381,11 +381,10 @@ Status S3FileSystem::upload_impl(const Path& local_file, const Path& remote_file
                                                               local_file.native(), full_path(key)));
     }
 
-    auto file_size = std::filesystem::file_size(local_file);
+    auto size = handle->GetBytesTransferred();
     LOG(INFO) << "Upload " << local_file.native() << " to s3, endpoint=" << _s3_conf.endpoint
               << ", bucket=" << _s3_conf.bucket << ", key=" << key
-              << ", duration=" << duration.count() << ", capacity=" << file_size
-              << ", tp=" << (file_size) / duration.count();
+              << ", duration=" << duration.count() << ", bytes=" << size;
 
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In upload implementation, filesystem::size throws an exception if the specified file, which is removed by the release snapshot task, does not exist.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

