### PR TITLE
[improve](log) print the exception stack trace when schema change failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -222,6 +222,7 @@ public abstract class AlterJobV2 implements Writable {
                     break;
             }
         } catch (Exception e) {
+            LOG.error("failed to run alter job {}", jobId, e);
             cancelImpl(e.getMessage());
         }
     }


### PR DESCRIPTION
## Proposed changes

For a failed schema change job:
```
| 279497 | recover_with_schema_change0 | 2024-02-20 14:52:04.240 | 2024-02-20 14:52:05.386 | recover_with_schema_change0 | 279498  | 279481        | 1:103963454   | 88082         | CANCELLED | 279498 | NULL     | 2592000 |
```

only found the error msg is:
```
2024-02-20 14:52:05,386 INFO (schema-change-pool-1|656) [SchemaChangeJobV2.cancelImpl():729] cancel SCHEMA_CHANGE job 279497, err: 279498
2024-02-20 14:52:05,392 INFO (schema-change-pool-1|656) [SchemaChangeJobV2.cancelImpl():733] set table's state to NORMAL when cancel, table id: 279480, job id: 279497
```

should print the stack trace:
```
2024-02-20 14:52:05,385 ERROR (schema-change-pool-1|656) [AlterJobV2.run():225] failed to run alter job 279497
java.lang.NullPointerException: 279498
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:921) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.alter.SchemaChangeJobV2.onFinished(SchemaChangeJobV2.java:642) ~[doris-fe.jar:1.2-SNAPSHOT
]
        at org.apache.doris.alter.SchemaChangeJobV2.runRunningJob(SchemaChangeJobV2.java:586) ~[doris-fe.jar:1.2-SNAPS
HOT]
        at org.apache.doris.alter.AlterJobV2.run(AlterJobV2.java:219) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.alter.SchemaChangeHandler.lambda$null$0(SchemaChangeHandler.java:1655) ~[doris-fe.jar:1.2-
SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_131]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

