### PR TITLE
[chore](third-party) Link protobuf with zlib statically

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -166,10 +166,12 @@ jobs:
             'llvm@16'
           )
 
-          brew install "${packages[@]}"
+          brew install "${packages[@]}" || true
 
       - name: Build
         run: |
+          export MACOSX_DEPLOYMENT_TARGET=12.0
+
           cd thirdparty
           ./build-thirdparty.sh -j "$(nproc)"
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -434,7 +434,7 @@ build_protobuf() {
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -Dprotobuf_BUILD_SHARED_LIBS=OFF \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -Dprotobuf_WITH_ZLIB_DEFAULT=ON \
+        -DZLIB_LIBRARY="${TP_LIB_DIR}/libz.a" \
         -Dprotobuf_ABSL_PROVIDER=package \
         -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" ../..
 


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

We should link `protobuf` with `libz.a` explicitly, otherwise `protoc` may not be executable due to the missing `libz.1.dylib`.

```shell
2024-02-20T12:24:31.6008030Z [1/60] Generating orc_proto.pb.h, orc_proto.pb.cc
2024-02-20T12:24:31.6037700Z FAILED: c++/src/orc_proto.pb.h c++/src/orc_proto.pb.cc /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/doris_build/c++/src/orc_proto.pb.h /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/doris_build/c++/src/orc_proto.pb.cc 
2024-02-20T12:24:31.6049230Z cd /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/doris_build/c++/src && /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/bin/protoc -I /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/proto --cpp_out="/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/doris_build/c++/src" /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/proto/orc_proto.proto
2024-02-20T12:24:31.6058110Z dyld[63187]: Library not loaded: /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib/libz.1.dylib
2024-02-20T12:24:31.6066740Z   Referenced from: <E61D5786-D6C3-3E10-B0FA-3D4C0DEEAC8D> /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/bin/protoc-3.21.11.0
2024-02-20T12:24:31.6080530Z   Reason: tried: '/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib/libz.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib/libz.1.dylib' (no such file), '/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib/libz.1.dylib' (no such file), '/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib64/libz.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib64/libz.1.dylib' (no such file), '/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/lib64/libz.1.dylib' (no such file)
2024-02-20T12:24:31.6096780Z /bin/sh: line 1: 63187 Abort trap: 6           /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/installed/bin/protoc -I /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/proto --cpp_out="/Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/doris_build/c++/src" /Users/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/orc-1.9.0/proto/orc_proto.proto
2024-02-20T12:24:31.6102840Z ninja: build stopped: subcommand failed.
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

