### PR TITLE
[regression-test] Analyze each table after loading all tables

### DIFF
--- a/regression-test/suites/brown_p2/load.groovy
+++ b/regression-test/suites/brown_p2/load.groovy
@@ -72,6 +72,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 }

--- a/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
+++ b/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
@@ -98,6 +98,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
     sql """ sync """

--- a/regression-test/suites/tpcds_sf100_dup_without_key_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf100_dup_without_key_p2/load.groovy
@@ -73,6 +73,10 @@ suite('load') {
             rowCount = sql "select count(*) from ${table}"
         }
         assertEquals(rows, rowCount[0][0])
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpcds_sf100_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf100_p2/load.groovy
@@ -73,6 +73,10 @@ suite('load') {
             rowCount = sql "select count(*) from ${table}"
         }
         assertEquals(rows, rowCount[0][0])
+    }
+
+    sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpcds_sf1_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p1/load.groovy
@@ -98,6 +98,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
     sql """ sync """

--- a/regression-test/suites/tpcds_sf1_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p2/load.groovy
@@ -67,6 +67,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
     sql """ sync """

--- a/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
@@ -137,6 +137,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """SET query_timeout=1800"""
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf0.1_unique_p1/load.groovy
+++ b/regression-test/suites/tpch_sf0.1_unique_p1/load.groovy
@@ -74,6 +74,10 @@ suite("load") {
             }
         }
 
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.forEach { tableName, columns ->
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/tpch_sf100_p2/load.groovy
+++ b/regression-test/suites/tpch_sf100_p2/load.groovy
@@ -67,6 +67,10 @@ suite("load") {
                 sleep(5000)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_four_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_four_step/load.groovy
@@ -116,6 +116,10 @@ suite("load_four_step") {
             }
             sleep(5000)
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_one_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_one_step/load.groovy
@@ -72,7 +72,10 @@ suite("load_one_step") {
             }
             sleep(5000)
         }
+    }
 
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_three_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_three_step/load.groovy
@@ -92,6 +92,10 @@ suite("load_three_step") {
             }
             sleep(5000)
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_two_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_two_step/load.groovy
@@ -69,6 +69,10 @@ suite("load_two_step") {
             }
             sleep(5000)
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/load.groovy
@@ -67,6 +67,10 @@ suite("load") {
                 sleep(5000)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
         sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }

--- a/regression-test/suites/tpch_sf1_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_p2/load.groovy
@@ -108,7 +108,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
 
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/tpch_sf1_unique_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_unique_p2/load.groovy
@@ -97,6 +97,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    for (String tableName in tables) {
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/tpch_unique_sql_zstd_bucket1_p0/load.groovy
+++ b/regression-test/suites/tpch_unique_sql_zstd_bucket1_p0/load.groovy
@@ -73,6 +73,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.forEach { tableName, columns ->
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/tpch_unique_sql_zstd_p0/load.groovy
+++ b/regression-test/suites/tpch_unique_sql_zstd_p0/load.groovy
@@ -73,6 +73,10 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.forEach { tableName, columns ->
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/variant_p0/tpch/load.groovy
+++ b/regression-test/suites/variant_p0/tpch/load.groovy
@@ -77,8 +77,11 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
-        // sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
+    // Thread.sleep(70000) // wait for row count report of the tables just loaded
+    // tables.forEach { tableName ->
+    //     sql """ ANALYZE TABLE $tableName WITH SYNC """
+    // }
 
     // def table = "revenue1"
     // sql new File("""${context.file.parent}/ddl/${table}_delete.sql""").text


### PR DESCRIPTION
Analyze may rely on row count reported by BEs, if we analyze immediately
after loading to a table, the row count of the table may be still 0
which may lead to improper behavior of analyze manager.

This change will introduce extra 70 seconds wait time for the cases affected.
"70s" is slightly lager than default value (60s) of tablet_stat_update_interval_second fe.conf.
To reduce this duration, change tablet_stat_update_interval_second
to a smaller value, say 10 seconds and change 70s to 15s.