### PR TITLE
[refine](pipelinex) get sink local state does not require an id.

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -149,7 +149,7 @@ public:
                 SourceState source_state) override;
 
     bool should_dry_run(RuntimeState* state) override {
-        return _is_broadcast_join && !state->get_sink_local_state(operator_id())
+        return _is_broadcast_join && !state->get_sink_local_state()
                                               ->cast<HashJoinBuildSinkLocalState>()
                                               ._should_build_hash_table;
     }

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -235,7 +235,7 @@ std::string DataSinkOperatorXBase::debug_string(int indentation_level) const {
 }
 
 std::string DataSinkOperatorXBase::debug_string(RuntimeState* state, int indentation_level) const {
-    return state->get_sink_local_state(operator_id())->debug_string(indentation_level);
+    return state->get_sink_local_state()->debug_string(indentation_level);
 }
 
 Status DataSinkOperatorXBase::init(const TDataSink& tsink) {
@@ -493,8 +493,7 @@ Status StreamingOperatorX<LocalStateType>::get_block(RuntimeState* state, vector
 template <typename LocalStateType>
 Status StatefulOperatorX<LocalStateType>::get_block(RuntimeState* state, vectorized::Block* block,
                                                     SourceState& source_state) {
-    auto& local_state = state->get_local_state(OperatorX<LocalStateType>::operator_id())
-                                ->template cast<LocalStateType>();
+    auto& local_state = get_local_state(state);
     if (need_more_input_data(state)) {
         local_state._child_block->clear_column_data();
         RETURN_IF_ERROR(OperatorX<LocalStateType>::_child_x->get_block_after_projects(

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -544,8 +544,8 @@ public:
 
     [[nodiscard]] bool is_source() const override { return false; }
 
-    Status close(RuntimeState* state, Status exec_status) {
-        auto result = state->get_sink_local_state_result(operator_id());
+    static Status close(RuntimeState* state, Status exec_status) {
+        auto result = state->get_sink_local_state_result();
         if (!result) {
             return result.error();
         }
@@ -608,7 +608,7 @@ public:
 
     using LocalState = LocalStateType;
     [[nodiscard]] LocalState& get_local_state(RuntimeState* state) const {
-        return state->get_sink_local_state(operator_id())->template cast<LocalState>();
+        return state->get_sink_local_state()->template cast<LocalState>();
     }
 };
 
@@ -675,8 +675,10 @@ public:
             : OperatorX<LocalStateType>(pool, tnode, operator_id, descs) {}
     virtual ~StatefulOperatorX() = default;
 
+    using OperatorX<LocalStateType>::get_local_state;
+
     [[nodiscard]] Status get_block(RuntimeState* state, vectorized::Block* block,
-                                   SourceState& source_state) override;
+                                   SourceState& source_state) final;
 
     [[nodiscard]] virtual Status pull(RuntimeState* state, vectorized::Block* block,
                                       SourceState& source_state) const = 0;

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -91,9 +91,9 @@ Status PipelineXTask::prepare(const TPipelineInstanceParams& local_params, const
     std::vector<TScanRangeParams> no_scan_ranges;
     auto scan_ranges = find_with_default(local_params.per_node_scan_ranges,
                                          _operators.front()->node_id(), no_scan_ranges);
-    auto* parent_profile = _state->get_sink_local_state(_sink->operator_id())->profile();
+    auto* parent_profile = _state->get_sink_local_state()->profile();
     query_ctx->register_query_statistics(
-            _state->get_sink_local_state(_sink->operator_id())->get_query_statistics_ptr());
+            _state->get_sink_local_state()->get_query_statistics_ptr());
 
     for (int op_idx = _operators.size() - 1; op_idx >= 0; op_idx--) {
         auto& op = _operators[op_idx];
@@ -135,7 +135,7 @@ Status PipelineXTask::_extract_dependencies() {
         }
     }
     {
-        auto* local_state = _state->get_sink_local_state(_sink->operator_id());
+        auto* local_state = _state->get_sink_local_state();
         auto* dep = local_state->dependency();
         DCHECK(dep != nullptr);
         _write_dependencies = dep;
@@ -206,7 +206,7 @@ Status PipelineXTask::_open() {
             RETURN_IF_ERROR(st);
         }
     }
-    RETURN_IF_ERROR(_state->get_sink_local_state(_sink->operator_id())->open(_state));
+    RETURN_IF_ERROR(_state->get_sink_local_state()->open(_state));
     _opened = true;
     return Status::OK();
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -490,13 +490,13 @@ void RuntimeState::emplace_sink_local_state(
     _sink_local_state = std::move(state);
 }
 
-doris::pipeline::PipelineXSinkLocalStateBase* RuntimeState::get_sink_local_state(int) {
+doris::pipeline::PipelineXSinkLocalStateBase* RuntimeState::get_sink_local_state() {
     return _sink_local_state.get();
 }
 
-Result<RuntimeState::SinkLocalState*> RuntimeState::get_sink_local_state_result(int id) {
+Result<RuntimeState::SinkLocalState*> RuntimeState::get_sink_local_state_result() {
     if (!_sink_local_state) {
-        return ResultError(Status::InternalError("_op_id_to_sink_local_state id:{} is null", id));
+        return ResultError(Status::InternalError("_op_id_to_sink_local_state not exist"));
     }
     return _sink_local_state.get();
 }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -548,9 +548,9 @@ public:
 
     void emplace_sink_local_state(int id, std::unique_ptr<SinkLocalState> state);
 
-    SinkLocalState* get_sink_local_state(int id);
+    SinkLocalState* get_sink_local_state();
 
-    Result<SinkLocalState*> get_sink_local_state_result(int id);
+    Result<SinkLocalState*> get_sink_local_state_result();
 
     void resize_op_id_to_local_state(int operator_size);
 


### PR DESCRIPTION
## Proposed changes

The current runtime state is one pipeline task per task, and within one task, there will only be one sink.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

