### PR TITLE
[fix](stream-load) print stream load profile for pipeline and pipelinex

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -887,6 +887,21 @@ void PipelineFragmentContext::_close_fragment_instance() {
     _runtime_state->runtime_profile()->total_time_counter()->update(
             _fragment_watcher.elapsed_time());
     static_cast<void>(send_report(true));
+    if (_is_report_success) {
+        std::stringstream ss;
+        // Compute the _local_time_percent before pretty_print the runtime_profile
+        // Before add this operation, the print out like that:
+        // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
+        // After add the operation, the print out like that:
+        // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
+        // We can easily know the exec node execute time without child time consumed.
+        _runtime_state->runtime_profile()->compute_time_in_profile();
+        _runtime_state->runtime_profile()->pretty_print(&ss);
+        if (_runtime_state->load_channel_profile()) {
+            _runtime_state->load_channel_profile()->pretty_print(&ss);
+        }
+        LOG(INFO) << ss.str();
+    }
     // all submitted tasks done
     _exec_env->fragment_mgr()->remove_pipeline_context(
             std::dynamic_pointer_cast<PipelineFragmentContext>(shared_from_this()));

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1244,6 +1244,21 @@ void PipelineXFragmentContext::_close_fragment_instance() {
     Defer defer_op {[&]() { _is_fragment_instance_closed = true; }};
     _runtime_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
     static_cast<void>(send_report(true));
+    if (_is_report_success) {
+        std::stringstream ss;
+        // Compute the _local_time_percent before pretty_print the runtime_profile
+        // Before add this operation, the print out like that:
+        // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
+        // After add the operation, the print out like that:
+        // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
+        // We can easily know the exec node execute time without child time consumed.
+        _runtime_state->runtime_profile()->compute_time_in_profile();
+        _runtime_state->runtime_profile()->pretty_print(&ss);
+        if (_runtime_state->load_channel_profile()) {
+            _runtime_state->load_channel_profile()->pretty_print(&ss);
+        }
+        LOG(INFO) << ss.str();
+    }
     // all submitted tasks done
     _exec_env->fragment_mgr()->remove_pipeline_context(
             std::dynamic_pointer_cast<PipelineXFragmentContext>(shared_from_this()));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Now the pipeline is used by default for load, but the profile doesn't be printed to the log when enable profile for stream load.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

