### PR TITLE
[fix](statistics)Release StmtExecutor in AnalysisTask object when sql execution finished to release memory.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -317,6 +317,8 @@ public abstract class BaseAnalysisTask {
                 LOG.debug("End cost time in millisec: " + (System.currentTimeMillis() - startTime)
                         + " Analyze SQL: " + sql + " QueryId: " + queryId);
             }
+            // Release the reference to stmtExecutor, reduce memory usage.
+            stmtExecutor = null;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
@@ -183,14 +184,23 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
                     tbl.getName(), col.getName());
             return null;
         }
+        long startTime = System.currentTimeMillis();
         Map<String, String> params = new HashMap<>();
         params.put("dbName", db.getFullName());
         params.put("colName", StatisticsUtil.escapeColumnName(info.colName));
         params.put("tblName", tbl.getName());
         params.put("index", getIndex());
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
-        stmtExecutor = new StmtExecutor(context.connectContext, stringSubstitutor.replace(BASIC_STATS_TEMPLATE));
-        return stmtExecutor.executeInternalQuery().get(0);
+        String sql = stringSubstitutor.replace(BASIC_STATS_TEMPLATE);
+        stmtExecutor = new StmtExecutor(context.connectContext, sql);
+        ResultRow resultRow = stmtExecutor.executeInternalQuery().get(0);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Cost time in millisec: " + (System.currentTimeMillis() - startTime)
+                    + " Min max SQL: " + sql + " QueryId: " + DebugUtil.printId(stmtExecutor.getContext().queryId()));
+        }
+        // Release the reference to stmtExecutor, reduce memory usage.
+        stmtExecutor = null;
+        return resultRow;
     }
 
     /**


### PR DESCRIPTION
Release useless StmtExecutor reference in time to reduce memory useage.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

