### PR TITLE
[fix](jdbc catalog) Fix Resource Closing Logic After Connection Abort

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutor.java
@@ -134,32 +134,18 @@ public class JdbcExecutor {
                     LOG.error("Error cancelling statement", e);
                 }
             }
-            if (conn != null && resultSet != null) {
+
+            boolean shouldAbort = conn != null && resultSet != null
+                    && (tableType == TOdbcTableType.MYSQL || tableType == TOdbcTableType.SQLSERVER);
+            if (shouldAbort) {
                 abortReadConnection(conn, resultSet, tableType);
-                try {
-                    resultSet.close();
-                } catch (SQLException e) {
-                    LOG.error("Error closing resultSet", e);
-                }
-                try {
-                    stmt.close();
-                } catch (SQLException e) {
-                    LOG.error("Error closing statement", e);
-                }
+            }
+
+            if (!shouldAbort) {
+                closeResources(resultSet, stmt, conn);
             }
         } finally {
-            if (conn != null && !conn.isClosed()) {
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    LOG.error("Error closing connection", e);
-                }
-            }
-        }
-
-        if (config.getConnectionPoolMinSize() == 0) {
-            // Close and remove the datasource if necessary
-            if (druidDataSource != null) {
+            if (config.getConnectionPoolMinSize() == 0 && druidDataSource != null) {
                 druidDataSource.close();
                 JdbcDataSource.getDataSource().getSourcesMap().remove(config.createCacheKey());
                 druidDataSource = null;
@@ -167,10 +153,28 @@ public class JdbcExecutor {
         }
     }
 
+    private void closeResources(AutoCloseable... closeables) {
+        for (AutoCloseable closeable : closeables) {
+            if (closeable != null) {
+                try {
+                    if (closeable instanceof Connection) {
+                        if (!((Connection) closeable).isClosed()) {
+                            closeable.close();
+                        }
+                    } else {
+                        closeable.close();
+                    }
+                } catch (Exception e) {
+                    LOG.error("Cannot close resource: ", e);
+                }
+            }
+        }
+    }
+
     public void abortReadConnection(Connection connection, ResultSet resultSet, TOdbcTableType tableType)
             throws SQLException {
         if (!resultSet.isAfterLast() && (tableType == TOdbcTableType.MYSQL || tableType == TOdbcTableType.SQLSERVER)) {
-            // Abort connection before closing. Without this, the MySQL driver
+            // Abort connection before closing. Without this, the MySQL/SQLServer driver
             // attempts to drain the connection by reading all the results.
             connection.abort(MoreExecutors.directExecutor());
         }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutor.java
@@ -137,7 +137,7 @@ public class JdbcExecutor {
 
             boolean shouldAbort = conn != null && resultSet != null
                     && (tableType == TOdbcTableType.MYSQL || tableType == TOdbcTableType.SQLSERVER);
-            boolean aborted = false; // 用于记录是否执行了abort操作
+            boolean aborted = false; // Used to record whether the abort operation is performed
             if (shouldAbort) {
                 aborted = abortReadConnection(conn, resultSet, tableType);
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR addresses an issue where resources were attempted to be closed even after the connection had been aborted, which is unnecessary as aborting the connection should release all related resources including ResultSet and Statement. The changes ensure that resources are only explicitly closed if the abort method has not been called. This prevents potential errors and aligns the resource management practices with JDBC specifications.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

