### PR TITLE
[fix](bdbje) Initializing and starting the first fe node will cause an exception when the disk is insufficient.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -207,7 +207,8 @@ public class BDBEnvironment {
                         LOG.warn("", e1);
                     }
                 } else {
-                    LOG.error("error to open replicated environment. will exit.", e);
+                    LOG.error("error to open replicated environment,"
+                            + "Maybe it's due to insufficient disk. will exit.", e);
                     System.exit(-1);
                 }
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<img width="1299" alt="38bffceac452bed9207665df2941c0d" src="https://github.com/apache/doris/assets/48236177/e38b9f03-1c4a-4cd8-b71e-da30b210bb17">


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

