### PR TITLE
[fix](regression) cloud_p0 should not enable group_commit

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -22,7 +22,6 @@ enable_merge_on_write_correctness_check=true
 enable_debug_points=true
 prioritize_query_perf_in_compaction = true
 cumulative_compaction_min_deltas = 5
-wait_internal_group_commit_finish=true
 #p0 parameter
 meta_service_endpoint = 127.0.0.1:5000
 cloud_unique_id = cloud_unique_id_compute_node0

--- a/regression-test/pipeline/cloud_p0/conf/fe_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/fe_custom.conf
@@ -29,9 +29,6 @@ max_query_profile_num=1000
 statistics_sql_mem_limit_in_bytes=21474836480
 cpu_resource_limit_per_analyze_task=-1
 
-group_commit_interval_ms_default_value=2
-wait_internal_group_commit_finish=true
-
 priority_networks=127.0.0.1/24
 cloud_http_port=18030
 meta_service_endpoint=127.0.0.1:5000


### PR DESCRIPTION
## Proposed changes

The cloud_p0 pipeline failed because run in group commit:
http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/353352?buildTab=tests&name=load&status=failed&expandedTest=build%3A%28id%3A353352%29%2Cid%3A2000000951


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

