### PR TITLE
[fix][doc] one of the Chinese document references is missing

### DIFF
--- a/docs/en/docs/data-table/hit-the-rollup.md
+++ b/docs/en/docs/data-table/hit-the-rollup.md
@@ -128,7 +128,7 @@ Doris automatically hits the ROLLUP table.
 
 #### ROLLUP in Duplicate Model
 
-Because the Duplicate model has no aggregate semantics. So the ROLLLUP in this model has lost the meaning of "scroll up". It's just to adjust the column order to hit the prefix index. In the next section, we will introduce prefix index in [data model prefix index](./data-model.md), and how to use ROLLUP to change prefix index in order to achieve better query efficiency.
+Because the Duplicate model has no aggregate semantics. So the ROLLLUP in this model has lost the meaning of "scroll up". It's just to adjust the column order to hit the prefix index. In the next section, we will introduce prefix index in [data model prefix index](https://doris.apache.org/docs/data-table/index/index-overview/#prefix-index), and how to use ROLLUP to change prefix index in order to achieve better query efficiency.
 
 ## ROLLUP adjusts prefix index
 

--- a/docs/zh-CN/docs/data-table/hit-the-rollup.md
+++ b/docs/zh-CN/docs/data-table/hit-the-rollup.md
@@ -130,7 +130,7 @@ Doris 执行这些sql时会自动命中这个 ROLLUP 表。
 
 ### Duplicate 模型中的 ROLLUP
 
-因为 Duplicate 模型没有聚合的语意。所以该模型中的 ROLLUP，已经失去了“上卷”这一层含义。而仅仅是作为调整列顺序，以命中前缀索引的作用。我们将在[前缀索引](./index/prefix-index.md)详细介绍前缀索引，以及如何使用ROLLUP改变前缀索引，以获得更好的查询效率。
+因为 Duplicate 模型没有聚合的语意。所以该模型中的 ROLLUP，已经失去了“上卷”这一层含义。而仅仅是作为调整列顺序，以命中前缀索引的作用。我们将在[前缀索引](https://doris.apache.org/zh-CN/docs/data-table/index/index-overview/#前缀索引)详细介绍前缀索引，以及如何使用ROLLUP改变前缀索引，以获得更好的查询效率。
 
 ## ROLLUP 调整前缀索引
 


### PR DESCRIPTION
## Proposed changes

english & chinese link should redirect to data-table/index/index-overview/#prefix-index

Issue Number: close #31132 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

