### PR TITLE
[Fix](Job)TVF Query JOB Concurrent Reading and Writing Causes Exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -50,6 +50,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -128,7 +129,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         this.executeSql = executeSql;
     }
 
-    private List<T> runningTasks = new ArrayList<>();
+    private CopyOnWriteArrayList<T> runningTasks = new CopyOnWriteArrayList<>();
 
     private Lock createTaskLock = new ReentrantLock();
 
@@ -140,7 +141,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         for (T task : runningTasks) {
             task.cancel();
         }
-        runningTasks = new ArrayList<>();
+        runningTasks = new CopyOnWriteArrayList<>();
     }
 
     private static final ImmutableList<String> TITLE_NAMES =
@@ -270,7 +271,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
     public static AbstractJob readFields(DataInput in) throws IOException {
         String jsonJob = Text.readString(in);
         AbstractJob job = GsonUtils.GSON.fromJson(jsonJob, AbstractJob.class);
-        job.runningTasks = new ArrayList<>();
+        job.runningTasks = new CopyOnWriteArrayList();
         job.createTaskLock = new ReentrantLock();
         return job;
     }


### PR DESCRIPTION
## What happend
useing TVF query task error
```
def is_increment_change = { def cur_job_name ->
        def mv_task_infos = sql """select 
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^
            JobName, Status, RefreshMode, NeedRefreshPartitions, CompletedPartitions, Progress 
            from tasks("type"="mv") where JobName="${cur_job_name}" order by CreateTime desc"""
        assert (mv_task_infos.size() == 2)

        def refresh_info = sql """select 
            JobName, Status, RefreshMode, NeedRefreshPartitions, CompletedPartitions, Progress 
            from tasks("type"="mv") where JobName="${cur_job_name}" order by CreateTime desc limit 1;"""
        assert (refresh_info[0][0] == cur_job_name)
        assert (refresh_info[0][1] == "SUCCESS")
        assert (refresh_info[0][2] == "PARTIAL")

Exception:
java.sql.SQLException: errCode = 2, detailMessage = (172.16.0.11)[CANCELLED]failed to call frontend service, reason: Internal error processing fetchSchemaTableData
Issue Number: close #xxx
```

![img_v3_028a_3f7194f3-9cad-4675-bfe0-b693c2e5e06g](https://github.com/apache/doris/assets/16631152/8ffc201e-f1d6-41e3-8d3b-2f62ae8aba69)

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

