### PR TITLE
[Fix](seq-col) Fix sequence column check fail 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -128,17 +128,20 @@ public class BindSink implements AnalysisRuleFactory {
                             Optional<Column> seqColInTable = Optional.empty();
                             if (table.getSequenceMapCol() != null) {
                                 if (!sink.getColNames().isEmpty()) {
-                                    if (sink.getColNames().contains(table.getSequenceMapCol())) {
+                                    if (sink.getColNames().stream()
+                                            .anyMatch(c -> c.equalsIgnoreCase(table.getSequenceMapCol()))) {
                                         haveInputSeqCol = true; // case1.a
                                     }
                                 } else {
                                     haveInputSeqCol = true; // case1.b
                                 }
                                 seqColInTable = table.getFullSchema().stream()
-                                        .filter(col -> col.getName().equals(table.getSequenceMapCol())).findFirst();
+                                        .filter(col -> col.getName().equalsIgnoreCase(table.getSequenceMapCol()))
+                                        .findFirst();
                             } else {
                                 if (!sink.getColNames().isEmpty()) {
-                                    if (sink.getColNames().contains(Column.SEQUENCE_COL)) {
+                                    if (sink.getColNames().stream()
+                                            .anyMatch(c -> c.equalsIgnoreCase(Column.SEQUENCE_COL))) {
                                         haveInputSeqCol = true; // case2.a
                                     } // else case2.b
                                 }
@@ -153,7 +156,7 @@ public class BindSink implements AnalysisRuleFactory {
                                             && boundSink.getDmlCommandType() != DMLCommandType.DELETE)) {
                                 if (!seqColInTable.isPresent() || seqColInTable.get().getDefaultValue() == null
                                         || !seqColInTable.get().getDefaultValue()
-                                        .equals(DefaultValue.CURRENT_TIMESTAMP)) {
+                                        .equalsIgnoreCase(DefaultValue.CURRENT_TIMESTAMP)) {
                                     throw new org.apache.doris.common.AnalysisException("Table " + table.getName()
                                             + " has sequence column, need to specify the sequence column");
                                 }


### PR DESCRIPTION
When FE generates plans and reaches the sequence column for rule judgment, an insertion statement that should have been correctly processed fails. This failure occurs because the judgment logic for the sequence part is case-sensitive to column names: the column name is in lowercase in the create table statement, but in uppercase in the insertion statement, causing the sequence column not to be correctly identified. However, Doris itself is case-insensitive to column names. This PR fixes the issue through the use of the ignoreCase method.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

