### PR TITLE
[fix](pipeline) Fix data race of executing fragment

### DIFF
--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -289,7 +289,7 @@ private:
     std::shared_ptr<QueryStatistics> _cpu_statistics = nullptr;
     // This shared ptr is never used. It is just a reference to hold the object.
     // There is a weak ptr in runtime filter manager to reference this object.
-    std::shared_ptr<RuntimeFilterMergeControllerEntity> _merge_controller_handler;
+    std::atomic<std::shared_ptr<RuntimeFilterMergeControllerEntity>> _merge_controller_handler;
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix bug like:
```log
=================================================================
==169535==ERROR: AddressSanitizer: heap-use-after-free on address 0x603009e8a958 at pc 0x55572ac09471 bp 0x7fd181a8b410 sp 0x7fd181a8b408
WRITE of size 4 at 0x603009e8a958 thread T371 (FragmentMgrThre)
#0 0x55572ac09470 in __gnu_cxx::__exchange_and_add(int volatile*, int) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:66:12
#1 0x55572ac09470 in __gnu_cxx::__exchange_and_add_dispatch(int*, int) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:101:14
#2 0x55572ac09470 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:165:6
#3 0x55572ac09470 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_count<(__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:721:15
#4 0x55572ac09470 in std::__shared_ptr<doris::RuntimeFilterMergeControllerEntity, (__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_ptr<doris::RuntimeFilterMergeControllerEntity, (__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1148:69
#5 0x55572ac09470 in std::shared_ptr<doris::RuntimeFilterMergeControllerEntity>::operator=(std::shared_ptr<doris::RuntimeFilterMergeControllerEntity> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:359:65
#6 0x55572ac09470 in doris::QueryContext::set_merge_controller_handler(std::shared_ptr<doris::RuntimeFilterMergeControllerEntity>&) /root/doris/be/src/runtime/query_context.h:219:35
#7 0x55572ac09470 in doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::operator()(int) const /root/doris/be/src/runtime/fragment_mgr.cpp:890:24
#8 0x55572ac24bcd in doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1::operator()() const /root/doris/be/src/runtime/fragment_mgr.cpp:911:41
#9 0x55572ac24bcd in void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
#10 0x55572ac24bcd in std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>(doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
#11 0x55572ac24bcd in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
#12 0x55572b3b694c in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
#13 0x55572b394678 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
#14 0x55572b394678 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
#15 0x7fd3cea22608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
#16 0x7fd3ceccf132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x603009e8a958 is located 8 bytes inside of 32-byte region [0x603009e8a950,0x603009e8a970)
freed by thread T328 (FragmentMgrThre) here:
#0 0x55572861a80d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x134fd80d) (BuildId: 00172c11cd562b81)
#1 0x55572ac08bd8 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:184:10
#2 0x55572ac08bd8 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_count<(__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:721:15
#3 0x55572ac08bd8 in std::__shared_ptr<doris::RuntimeFilterMergeControllerEntity, (__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_ptr<doris::RuntimeFilterMergeControllerEntity, (__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1148:69
#4 0x55572ac08bd8 in std::shared_ptr<doris::RuntimeFilterMergeControllerEntity>::operator=(std::shared_ptr<doris::RuntimeFilterMergeControllerEntity> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:359:65
#5 0x55572ac08bd8 in doris::QueryContext::set_merge_controller_handler(std::shared_ptr<doris::RuntimeFilterMergeControllerEntity>&) /root/doris/be/src/runtime/query_context.h:219:35
#6 0x55572ac08bd8 in doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::operator()(int) const /root/doris/be/src/runtime/fragment_mgr.cpp:890:24
#7 0x55572ac24bcd in doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1::operator()() const /root/doris/be/src/runtime/fragment_mgr.cpp:911:41
#8 0x55572ac24bcd in void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
#9 0x55572ac24bcd in std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&>(doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
#10 0x55572ac24bcd in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
#11 0x55572b3b694c in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
#12 0x55572b394678 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
#13 0x55572b394678 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
#14 0x7fd3cea22608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

