### PR TITLE
[bugfix](wg) should set task group down after thread pool stopped

### DIFF
--- a/be/src/agent/topic_subscriber.cpp
+++ b/be/src/agent/topic_subscriber.cpp
@@ -45,7 +45,7 @@ void TopicSubscriber::handle_topic_info(const TPublishTopicRequest& topic_reques
         if (topic_request.topic_map.find(listener_pair.first) != topic_request.topic_map.end()) {
             listener_pair.second->handle_topic_info(
                     topic_request.topic_map.at(listener_pair.first));
-            LOG(INFO) << "handle topic " << listener_pair.first << " succ";
+            LOG(INFO) << "handle topic " << listener_pair.first << " successfully";
         }
     }
 }

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -421,7 +421,6 @@ void TaskScheduler::_do_work(size_t index) {
 
 void TaskScheduler::stop() {
     if (!this->_shutdown.load()) {
-        this->_shutdown.store(true);
         if (_task_queue) {
             _task_queue->close();
         }
@@ -432,6 +431,11 @@ void TaskScheduler::stop() {
             _fix_thread_pool->shutdown();
             _fix_thread_pool->wait();
         }
+        // Should set at the ending of the stop to ensure that the
+        // pool is stopped. For example, if there are 2 threads call stop
+        // then if one thread set shutdown = false, then another thread will
+        // not check it and will free task scheduler.
+        this->_shutdown.store(true);
     }
 }
 

--- a/be/src/runtime/task_group/task_group_manager.cpp
+++ b/be/src/runtime/task_group/task_group_manager.cpp
@@ -201,6 +201,7 @@ void TaskGroupManager::delete_task_group_by_ids(std::set<uint64_t> used_wg_id) {
                 task_group_ptr->shutdown();
                 // only when no query running in task group, its resource can be released in BE
                 if (task_group_ptr->query_num() == 0) {
+                    LOG(INFO) << "There is no query in wg " << tg_id << ", delete it.";
                     deleted_tg_ids.insert(tg_id);
                 }
             }


### PR DESCRIPTION
## Proposed changes

If the first delete workload group thread hang and the publish topic thread will timeout. And it will publish again. And another thread will try to delete wg again. And the _shut_down bit is set to true in the first thread. The second thread will not check any more and free task scheduler. It will core.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

