### PR TITLE
[improvement](statistics)Remove useless async loader code.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
@@ -18,7 +18,6 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.qe.InternalQueryExecutionException;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -27,18 +26,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.DiscardOldestPolicy;
 
 public class ColumnStatisticsCacheLoader extends BasicAsyncCacheLoader<StatisticsCacheKey, Optional<ColumnStatistic>> {
 
     private static final Logger LOG = LogManager.getLogger(ColumnStatisticsCacheLoader.class);
-
-    private static final ThreadPoolExecutor singleThreadPool = ThreadPoolManager.newDaemonFixedThreadPool(
-            StatisticConstants.RETRY_LOAD_THREAD_POOL_SIZE,
-            StatisticConstants.RETRY_LOAD_QUEUE_SIZE, "STATS_RELOAD",
-            true,
-            new DiscardOldestPolicy());
 
     @Override
     protected Optional<ColumnStatistic> doLoad(StatisticsCacheKey key) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class StatisticsCache {
 
@@ -74,21 +73,6 @@ public class StatisticsCache {
                     .refreshAfterWrite(Duration.ofHours(StatisticConstants.STATISTICS_CACHE_REFRESH_INTERVAL))
                     .executor(threadPool)
                     .buildAsync(histogramCacheLoader);
-
-    {
-        threadPool.submit(() -> {
-            while (true) {
-                try {
-                    columnStatisticsCacheLoader.removeExpiredInProgressing();
-                    histogramCacheLoader.removeExpiredInProgressing();
-                } catch (Throwable t) {
-                    // IGNORE
-                }
-                Thread.sleep(TimeUnit.MINUTES.toMillis(15));
-            }
-
-        });
-    }
 
     public ColumnStatistic getColumnStatistics(long catalogId, long dbId, long tblId, long idxId, String colName) {
         ConnectContext ctx = ConnectContext.get();

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -266,7 +266,7 @@ public class CacheTest extends TestWithFeService {
                 Assertions.assertEquals(6, columnStatistic.minValue);
                 Assertions.assertEquals(7, columnStatistic.maxValue);
             } else {
-                System.out.println("Cached is not loaded, skip test.");
+                System.out.println("Cache is not loaded, skip test.");
             }
         } catch (Throwable t) {
             t.printStackTrace();


### PR DESCRIPTION
Google caffeine asyncLoad implementation has the logic to avoid repeat call of loading function. Remove the useless code.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

