### PR TITLE
[fix](inverted index)Remove the strong check for `parser` when creating a table with inverted index

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InvertedIndexUtil.java
@@ -104,9 +104,6 @@ public class InvertedIndexUtil {
         String parser = null;
         if (properties != null) {
             parser = properties.get(INVERTED_INDEX_PARSER_KEY);
-            if (parser == null && !properties.isEmpty()) {
-                throw new AnalysisException("Invalid index properties, parser must not be none");
-            }
             checkInvertedIndexProperties(properties);
         }
 

--- a/regression-test/suites/inverted_index_p0/test_properties.groovy
+++ b/regression-test/suites/inverted_index_p0/test_properties.groovy
@@ -132,7 +132,7 @@ suite("test_properties", "p0"){
             "replication_allocation" = "tag.location.default: 1"
         );
     """
-    create_table_with_inverted_index_properties(invalid_property_key, "Invalid index properties, parser must not be none")
+    create_table_with_inverted_index_properties(invalid_property_key, "Invalid inverted index property key:")
     assertEquals(success, false)
 
     def invalid_property_key2 = """
@@ -171,7 +171,7 @@ suite("test_properties", "p0"){
         CREATE TABLE IF NOT EXISTS ${indexTblName}(
             `id` int(11) NULL,
             `c` text NULL,
-            INDEX c_idx(`c`) USING INVERTED PROPERTIES("parser"="english", "ignore_above"="non_numeric") COMMENT ''
+            INDEX c_idx(`c`) USING INVERTED PROPERTIES("ignore_above"="non_numeric") COMMENT ''
         ) ENGINE=OLAP
         DUPLICATE KEY(`id`)
         COMMENT 'OLAP'


### PR DESCRIPTION
…ng a table with inverted index

## Proposed changes

When creating a table with inverted index, the `parser` property is `none` in default.
But the index without a `parser` can also have other properties, such as `ignore_above`.
This strong check will cause table creation failure with inverted index, which `parser` is omit and have other properties.
So we remove the check here to create a table successfully.
 
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

