### PR TITLE
[Fix] Only datetime and datetimev2 types can use current_timestamp as column default value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -542,6 +542,16 @@ public class ColumnDef {
             default:
                 throw new AnalysisException("Unsupported type: " + type);
         }
+        if (null != defaultValueExprDef && defaultValueExprDef.getExprName().equals("now")) {
+            switch (primitiveType) {
+                case DATETIME:
+                case DATETIMEV2:
+                    break;
+                default:
+                    throw new AnalysisException("Types other than DATETIME and DATETIMEV2 "
+                            + "cannot use current_timestamp as the default value");
+            }
+        }
     }
 
     public String toSql() {

--- a/regression-test/suites/ddl_p0/test_current_timestamp_as_column_default_value.groovy
+++ b/regression-test/suites/ddl_p0/test_current_timestamp_as_column_default_value.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_current_timestamp_as_column_default_value") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    sql "DROP TABLE IF EXISTS test_default4"
+    sql """create table test_default4(a int, b int) distributed by hash(a) properties('replication_num'="1");"""
+
+    sql "DROP TABLE IF EXISTS test_default10"
+    test {
+        sql """create table test_default10(a int, b varchar(100) default current_timestamp) 
+        distributed by hash(a) properties('replication_num'="1");"""
+        exception "Types other than DATETIME and DATETIMEV2 cannot use current_timestamp as the default value"
+    }
+
+    test{
+        sql """alter table test_default4 add column dt varchar(100) default current_timestamp"""
+        exception "Types other than DATETIME and DATETIMEV2 cannot use current_timestamp as the default value"
+    }
+
+    sql "SET enable_nereids_planner=false"
+    sql "DROP TABLE IF EXISTS test_default10"
+    test {
+        sql """create table test_default10(a int, b varchar(100) default current_timestamp) 
+        distributed by hash(a) properties('replication_num'="1");"""
+        exception "Types other than DATETIME and DATETIMEV2 cannot use current_timestamp as the default value"
+    }
+
+    test{
+        sql "alter table test_default4 add column dt varchar(100) default current_timestamp"
+        exception "Types other than DATETIME and DATETIMEV2 cannot use current_timestamp as the default value"
+    }
+}

--- a/regression-test/suites/nereids_rules_p0/grouping_sets/slot_both_appear_in_agg_fun_and_grouping_sets.groovy
+++ b/regression-test/suites/nereids_rules_p0/grouping_sets/slot_both_appear_in_agg_fun_and_grouping_sets.groovy
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 suite("slot_both_appear_in_agg_fun_and_grouping_sets") {
-
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
     sql """
          DROP TABLE IF EXISTS table_10_undef_undef4
         """


### PR DESCRIPTION
for this kind of sql:
```sql
create table test_default10(a int, b varchar(100) default current_timestamp) distributed by hash(a) properties('replication_num'="1");
```
add check:
 Types other than DATETIME and DATETIMEV2 cannot use current_timestamp as the default value