### PR TITLE
[chore](conf) change default expr depth limit in fe to 600

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -780,7 +780,7 @@ public class Config extends ConfigBase {
      * Do not set this if you know what you are doing.
      */
     @ConfField(mutable = true)
-    public static int expr_depth_limit = 3000;
+    public static int expr_depth_limit = 600;
 
     // Configurations for backup and restore
     /**


### PR DESCRIPTION
since BE default value for expr depth limit is 600, change FE default value to 600 to ensure they are same.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

