### PR TITLE
[chore](log) change merge-on-write correctness check log to VLOG_NOTICE

### DIFF
--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -793,9 +793,9 @@ Status BaseTablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
         RowsetIdUnorderedSet rowsetids;
         for (const auto& rowset : specified_rowsets) {
             rowsetids.emplace(rowset->rowset_id());
-            LOG(INFO) << "[tabletID:" << tablet_id() << "]"
-                      << "[add_sentinel_mark_to_delete_bitmap][end_version:" << end_version << "]"
-                      << "add:" << rowset->rowset_id();
+            VLOG_NOTICE << "[tabletID:" << tablet_id() << "]"
+                        << "[add_sentinel_mark_to_delete_bitmap][end_version:" << end_version << "]"
+                        << "add:" << rowset->rowset_id();
         }
         add_sentinel_mark_to_delete_bitmap(delete_bitmap.get(), rowsetids);
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In some doris test pipeline, config::enable_merge_on_write_correctness_check is true, there prints too much logs like
```
I20240225 16:05:34.922104 11749 base_tablet.cpp:796] [tabletID:10033][add_sentinel_mark_to_delete_bitmap][end_version:3058]add:0200000000003878084f8a87d326f46b0bdb5feda10a579b
```
change the log level to VLOG_NOTICE, only print it when we need to debug a problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

