### PR TITLE
[feature](Cloud) Support restore HDFS meta data in Meta Service && Add storage vault property

### DIFF
--- a/cloud/src/meta-service/keys.cpp
+++ b/cloud/src/meta-service/keys.cpp
@@ -120,7 +120,8 @@ static void encode_prefix(const T& t, std::string* key) {
 
     key->push_back(CLOUD_USER_KEY_SPACE01);
     // Prefixes for key families
-    if        constexpr (std::is_same_v<T, InstanceKeyInfo>) {
+    if        constexpr (std::is_same_v<T, InstanceKeyInfo>
+                      || std::is_same_v<T, StorageVaultKeyInfo>) {
         encode_bytes(INSTANCE_KEY_PREFIX, key);
     } else if constexpr (std::is_same_v<T, TxnLabelKeyInfo>
                       || std::is_same_v<T, TxnInfoKeyInfo>
@@ -170,6 +171,11 @@ static void encode_prefix(const T& t, std::string* key) {
 
 void instance_key(const InstanceKeyInfo& in, std::string* out) {
     encode_prefix(in, out); // 0x01 "instance" ${instance_id}
+}
+
+void storage_vault_key(const StorageVaultKeyInfo& in, std::string* out) {
+    encode_prefix(in, out);
+    encode_bytes(std::get<1>(in), out);
 }
 
 //==============================================================================

--- a/cloud/src/meta-service/keys.cpp
+++ b/cloud/src/meta-service/keys.cpp
@@ -67,6 +67,7 @@ namespace doris::cloud {
 [[maybe_unused]] static const char* COPY_JOB_KEY_INFIX        = "job";
 [[maybe_unused]] static const char* COPY_FILE_KEY_INFIX       = "loading_file";
 [[maybe_unused]] static const char* STAGE_KEY_INFIX           = "stage";
+[[maybe_unused]] static const char* VAULT_KEY_PREFIX          = "storage_vault";
 
 // clang-format on
 
@@ -120,8 +121,7 @@ static void encode_prefix(const T& t, std::string* key) {
 
     key->push_back(CLOUD_USER_KEY_SPACE01);
     // Prefixes for key families
-    if        constexpr (std::is_same_v<T, InstanceKeyInfo>
-                      || std::is_same_v<T, StorageVaultKeyInfo>) {
+    if        constexpr (std::is_same_v<T, InstanceKeyInfo>) {
         encode_bytes(INSTANCE_KEY_PREFIX, key);
     } else if constexpr (std::is_same_v<T, TxnLabelKeyInfo>
                       || std::is_same_v<T, TxnInfoKeyInfo>
@@ -171,11 +171,6 @@ static void encode_prefix(const T& t, std::string* key) {
 
 void instance_key(const InstanceKeyInfo& in, std::string* out) {
     encode_prefix(in, out); // 0x01 "instance" ${instance_id}
-}
-
-void storage_vault_key(const StorageVaultKeyInfo& in, std::string* out) {
-    encode_prefix(in, out);
-    encode_bytes(std::get<1>(in), out);
 }
 
 //==============================================================================
@@ -461,6 +456,16 @@ std::string system_meta_service_encryption_key_info_key() {
     encode_bytes("meta-service", &ret);
     encode_bytes("encryption_key_info", &ret);
     return ret;
+}
+
+//==============================================================================
+// Storage Vault keys
+//==============================================================================
+
+void storage_vault_key(const StorageVaultKeyInfo& in, std::string* out) {
+    encode_bytes(VAULT_KEY_PREFIX, out);
+    encode_bytes(std::get<0>(in), out);
+    encode_bytes(std::get<1>(in), out);
 }
 
 //==============================================================================

--- a/cloud/src/meta-service/keys.h
+++ b/cloud/src/meta-service/keys.h
@@ -178,8 +178,14 @@ using MetaPendingDeleteBitmapInfo = BasicKeyInfo<24 , std::tuple<std::string, in
 //                                                      0:instance_id 1:db_id  2:job_id
 using RLJobProgressKeyInfo = BasicKeyInfo<25, std::tuple<std::string, int64_t, int64_t>>;
 
+//                                                      0:instance_id 1:vault_id
+using StorageVaultKeyInfo = BasicKeyInfo<26, std::tuple<std::string, std::string>>;
+
 void instance_key(const InstanceKeyInfo& in, std::string* out);
 static inline std::string instance_key(const InstanceKeyInfo& in) { std::string s; instance_key(in, &s); return s; }
+
+void storage_vault_key(const StorageVaultKeyInfo& in, std::string* out);
+static inline std::string storage_vault_key(const StorageVaultKeyInfo& in) { std::string s; storage_vault_key(in, &s); return s; }
 
 std::string txn_key_prefix(std::string_view instance_id);
 void txn_label_key(const TxnLabelKeyInfo& in, std::string* out);

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -287,8 +287,8 @@ void MetaServiceImpl::get_obj_store_info(google::protobuf::RpcController* contro
     response->mutable_obj_info()->CopyFrom(instance.obj_info());
 }
 
-// The next avaiable vault id would be max(max(obj info id), max(vault id)) + 1.
-static std::string next_avaiable_vault_id(const InstanceInfoPB& instance) {
+// The next available vault id would be max(max(obj info id), max(vault id)) + 1.
+static std::string next_available_vault_id(const InstanceInfoPB& instance) {
     size_t vault_id = 0;
     auto cmp = [](size_t prev, const auto& last) {
         size_t last_id = 0;
@@ -317,7 +317,7 @@ static int add_hdfs_storage_valut(InstanceInfoPB& instance, TxnKv* txn_kv,
         return -1;
     }
     std::string key;
-    std::string vault_id = next_avaiable_vault_id(instance);
+    std::string vault_id = next_available_vault_id(instance);
     storage_vault_key({instance.instance_id(), vault_id}, &key);
     StorageVaultPB vault;
     vault.set_id(vault_id);
@@ -544,7 +544,7 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
         ObjectStoreInfoPB last_item;
         last_item.set_ctime(time);
         last_item.set_mtime(time);
-        last_item.set_id(next_avaiable_vault_id(instance));
+        last_item.set_id(next_available_vault_id(instance));
         if (request->obj().has_user_id()) {
             last_item.set_user_id(request->obj().user_id());
         }
@@ -836,7 +836,7 @@ static int create_instance_with_object_info(const InstanceInfoPB& instance,
     obj_info->set_provider(obj.provider());
     std::ostringstream oss;
     // create instance's s3 conf, id = 1
-    obj_info->set_id(next_avaiable_vault_id(instance));
+    obj_info->set_id(next_available_vault_id(instance));
     auto now_time = std::chrono::system_clock::now();
     uint64_t time =
             std::chrono::duration_cast<std::chrono::seconds>(now_time.time_since_epoch()).count();

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -212,9 +212,9 @@ static int fetch_all_storage_valut(std::string storage_valut_key, std::string_vi
         msg = "failed to parse InstanceInfoPB";
         return -1;
     }
-    if (storage_valut.has_hdfs_infos()) {
+    if (storage_valut.has_hdfs_info()) {
         auto* hdfs_info = response->add_hdfs_info();
-        *hdfs_info = storage_valut.hdfs_infos();
+        *hdfs_info = storage_valut.hdfs_info();
         return 0;
     }
     return 0;
@@ -307,7 +307,7 @@ static std::string next_avaiable_vault_id(const InstanceInfoPB& instance) {
 }
 
 static int add_hdfs_storage_valut(InstanceInfoPB& instance, TxnKv* txn_kv,
-                                  const AlterHdfsParams& hdfs_param, MetaServiceCode& code,
+                                  const AlterHdfsVaultInfo& hdfs_param, MetaServiceCode& code,
                                   std::string& msg) {
     if (std::find_if(instance.storage_vault_names().begin(), instance.storage_vault_names().end(),
                      [&hdfs_param](const auto& name) { return name == hdfs_param.vault_name(); }) !=
@@ -322,7 +322,7 @@ static int add_hdfs_storage_valut(InstanceInfoPB& instance, TxnKv* txn_kv,
     StorageVaultPB vault;
     vault.set_id(vault_id);
     vault.set_name(hdfs_param.vault_name());
-    *vault.mutable_hdfs_infos() = hdfs_param.hdfs();
+    *vault.mutable_hdfs_info() = hdfs_param.hdfs();
     std::string val = vault.SerializeAsString();
     std::unique_ptr<Transaction> txn;
     TxnErrorCode err = txn_kv->create_txn(&txn);
@@ -881,7 +881,7 @@ void MetaServiceImpl::create_instance(google::protobuf::RpcController* controlle
     }
     // TODO(ByteYue): Reclaim the vault if the following procedure failed
     if (request->has_hdfs_info()) {
-        AlterHdfsParams hdfs_param;
+        AlterHdfsVaultInfo hdfs_param;
         hdfs_param.set_vault_name("Default");
         *hdfs_param.mutable_hdfs() = request->hdfs_info();
         if (0 != add_hdfs_storage_valut(instance, txn_kv_.get(), hdfs_param, code, msg)) {

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -303,7 +303,6 @@ static std::string next_avaiable_vault_id(const InstanceInfoPB& instance) {
 
         return prev_value > last_id ? prev : std::to_string(last_id);
     };
-    ;
     return std::accumulate(
             instance.resource_ids().begin(), instance.resource_ids().end(),
             std::accumulate(instance.obj_info().begin(), instance.obj_info().end(), vault_id, cmp),

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -313,6 +313,13 @@ static std::string next_avaiable_vault_id(const InstanceInfoPB& instance) {
 static int add_hdfs_storage_valut(InstanceInfoPB& instance, TxnKv* txn_kv,
                                   const AlterHdfsParams& hdfs_param, MetaServiceCode& code,
                                   std::string& msg) {
+    if (std::find_if(instance.storage_vault_names().begin(), instance.storage_vault_names().end(),
+                     [&hdfs_param](const auto& name) { return name == hdfs_param.vault_name(); }) !=
+        instance.storage_vault_names().end()) {
+        code = MetaServiceCode::ALREADY_EXISTED;
+        msg = fmt::format("vault_name={} already created", hdfs_param.vault_name());
+        return -1;
+    }
     std::string key;
     std::string vault_id = next_avaiable_vault_id(instance);
     storage_vault_key({instance.instance_id(), vault_id}, &key);

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -513,6 +513,9 @@ int InstanceRecycler::recycle_deleted_instance() {
     std::string start_job_tablet_key = job_tablet_key({instance_id_, 0, 0, 0, 0});
     std::string end_job_tablet_key = job_tablet_key({instance_id_, INT64_MAX, 0, 0, 0});
     txn->remove(start_job_tablet_key, end_job_tablet_key);
+    std::string start_vault_key = storage_vault_key({instance_id_, 0});
+    std::string end_vault_key = storage_vault_key({instance_id_, INT64_MAX});
+    txn->remove(start_vault_key, end_vault_key);
     err = txn->commit();
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to delete all kv, instance_id=" << instance_id_ << ", err=" << err;

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -513,8 +513,10 @@ int InstanceRecycler::recycle_deleted_instance() {
     std::string start_job_tablet_key = job_tablet_key({instance_id_, 0, 0, 0, 0});
     std::string end_job_tablet_key = job_tablet_key({instance_id_, INT64_MAX, 0, 0, 0});
     txn->remove(start_job_tablet_key, end_job_tablet_key);
-    std::string start_vault_key = storage_vault_key({instance_id_, 0});
-    std::string end_vault_key = storage_vault_key({instance_id_, INT64_MAX});
+    StorageVaultKeyInfo key_info0 {instance_id_, ""};
+    StorageVaultKeyInfo key_info1 {instance_id_, "\xff"};
+    std::string start_vault_key = storage_vault_key(key_info0);
+    std::string end_vault_key = storage_vault_key(key_info1);
     txn->remove(start_vault_key, end_vault_key);
     err = txn->commit();
     if (err != TxnErrorCode::TXN_OK) {

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -5039,11 +5039,11 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ADD_HDFS_INFO);
-        AlterHdfsVaultInfo hdfs;
-        hdfs.set_vault_name("test_alter_add_hdfs_info");
+        StorageVaultPB hdfs;
+        hdfs.set_name("test_alter_add_hdfs_info");
         HdfsVaultInfo params;
 
-        hdfs.mutable_hdfs()->CopyFrom(params);
+        hdfs.mutable_hdfs_info()->CopyFrom(params);
         req.mutable_hdfs()->CopyFrom(hdfs);
 
         brpc::Controller cntl;
@@ -5062,11 +5062,11 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ADD_HDFS_INFO);
-        AlterHdfsVaultInfo hdfs;
-        hdfs.set_vault_name("test_alter_add_hdfs_info_1");
+        StorageVaultPB hdfs;
+        hdfs.set_name("test_alter_add_hdfs_info_1");
         HdfsVaultInfo params;
 
-        hdfs.mutable_hdfs()->CopyFrom(params);
+        hdfs.mutable_hdfs_info()->CopyFrom(params);
         req.mutable_hdfs()->CopyFrom(hdfs);
 
         brpc::Controller cntl;

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -334,9 +334,11 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         req.set_instance_id("test_instance_with_hdfs_info");
         req.set_user_id("test_user");
         req.set_name("test_name");
-        HdfsParams hdfs;
-        hdfs.set_fs_name("test_name_node");
-        hdfs.set_user("test_user");
+        HdfsVaultInfo hdfs;
+        HdfsBuildConf conf;
+        conf.set_fs_name("test_name_node");
+        conf.set_user("test_user");
+        hdfs.mutable_build_conf()->CopyFrom(conf);
         req.mutable_hdfs_info()->CopyFrom(hdfs);
 
         auto sp = SyncPoint::get_instance();
@@ -5037,9 +5039,9 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ADD_HDFS_INFO);
-        AlterHdfsParams hdfs;
+        AlterHdfsVaultInfo hdfs;
         hdfs.set_vault_name("test_alter_add_hdfs_info");
-        HdfsParams params;
+        HdfsVaultInfo params;
 
         hdfs.mutable_hdfs()->CopyFrom(params);
         req.mutable_hdfs()->CopyFrom(hdfs);
@@ -5060,9 +5062,9 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ADD_HDFS_INFO);
-        AlterHdfsParams hdfs;
+        AlterHdfsVaultInfo hdfs;
         hdfs.set_vault_name("test_alter_add_hdfs_info_1");
-        HdfsParams params;
+        HdfsVaultInfo params;
 
         hdfs.mutable_hdfs()->CopyFrom(params);
         req.mutable_hdfs()->CopyFrom(hdfs);

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -5065,6 +5065,7 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         HdfsParams params;
 
         hdfs.mutable_hdfs()->CopyFrom(params);
+        req.mutable_hdfs()->CopyFrom(hdfs);
 
         brpc::Controller cntl;
         AlterObjStoreInfoResponse res;

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -306,7 +306,7 @@ TEST(MetaServiceTest, CreateInstanceTest) {
     {
         brpc::Controller cntl;
         CreateInstanceRequest req;
-        req.set_instance_id("test_instance");
+        req.set_instance_id("test_instance_without_hdfs_and_obj");
         req.set_user_id("test_user");
         req.set_name("test_name");
 
@@ -331,7 +331,7 @@ TEST(MetaServiceTest, CreateInstanceTest) {
     {
         brpc::Controller cntl;
         CreateInstanceRequest req;
-        req.set_instance_id("test_instance");
+        req.set_instance_id("test_instance_with_hdfs_info");
         req.set_user_id("test_user");
         req.set_name("test_name");
         HdfsParams hdfs;
@@ -5029,7 +5029,7 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoResponse res;
         meta_service->alter_obj_store_info(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
     }
 
     // update successful
@@ -5042,12 +5042,13 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         HdfsParams params;
 
         hdfs.mutable_hdfs()->CopyFrom(params);
+        req.mutable_hdfs()->CopyFrom(hdfs);
 
         brpc::Controller cntl;
         AlterObjStoreInfoResponse res;
         meta_service->alter_obj_store_info(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
         InstanceInfoPB instance;
         get_test_instance(instance);
         ASSERT_EQ(*(instance.resource_ids().begin()), "2");
@@ -5069,7 +5070,7 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         AlterObjStoreInfoResponse res;
         meta_service->alter_obj_store_info(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
         InstanceInfoPB instance;
         get_test_instance(instance);
         ASSERT_EQ(*(instance.resource_ids().begin() + 1), "3");

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -5050,8 +5050,8 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         InstanceInfoPB instance;
         get_test_instance(instance);
-        ASSERT_EQ(instance.resource_ids().begin(), "2");
-        ASSERT_EQ(instance.storage_vault_names().begin(), "test_alter_add_hdfs_info");
+        ASSERT_EQ(*(instance.resource_ids().begin()), "2");
+        ASSERT_EQ(*(instance.storage_vault_names().begin()), "test_alter_add_hdfs_info");
     }
 
     // to test if the vault id is expected
@@ -5072,8 +5072,8 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         InstanceInfoPB instance;
         get_test_instance(instance);
-        ASSERT_EQ(instance.resource_ids().begin() + 1, "3");
-        ASSERT_EQ(instance.storage_vault_names().begin() + 1, "test_alter_add_hdfs_info_1");
+        ASSERT_EQ(*(instance.resource_ids().begin() + 1), "3");
+        ASSERT_EQ(*(instance.storage_vault_names().begin() + 1), "test_alter_add_hdfs_info_1");
     }
 
     SyncPoint::get_instance()->disable_processing();

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -5054,6 +5054,28 @@ TEST(MetaServiceTest, AddHdfsInfoTest) {
         ASSERT_EQ(instance.storage_vault_names().begin(), "test_alter_add_hdfs_info");
     }
 
+    // to test if the vault id is expected
+    {
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ADD_HDFS_INFO);
+        AlterHdfsParams hdfs;
+        hdfs.set_vault_name("test_alter_add_hdfs_info_1");
+        HdfsParams params;
+
+        hdfs.mutable_hdfs()->CopyFrom(params);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_obj_store_info(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        InstanceInfoPB instance;
+        get_test_instance(instance);
+        ASSERT_EQ(instance.resource_ids().begin() + 1, "3");
+        ASSERT_EQ(instance.storage_vault_names().begin() + 1, "test_alter_add_hdfs_info_1");
+    }
+
     SyncPoint::get_instance()->disable_processing();
     SyncPoint::get_instance()->clear_all_call_backs();
 }

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -74,8 +74,8 @@ message InstanceInfoPB {
     optional RamUserPB iam_user = 12;
     optional bool sse_enabled = 13;
 
-    repeated string resource_ids = 100; // 新加 vault 的 resource id 采用 max_resource_id + 1
-    repeated string storage_vault_names = 101; // 建表时从这里找到 vault name -> resource id 的映射
+    repeated string resource_ids = 100;
+    repeated string storage_vault_names = 101;
 }
 
 message StagePB {
@@ -717,11 +717,6 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
-message AlterHdfsVaultInfo {
-    optional string vault_name = 1;
-    optional HdfsVaultInfo hdfs = 2;
-}
-
 message AlterObjStoreInfoRequest {
     enum Operation {
         UNKNOWN         = 0;
@@ -734,7 +729,7 @@ message AlterObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
-    optional AlterHdfsVaultInfo hdfs = 4;
+    optional StorageVaultPB hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -193,20 +193,24 @@ message ObjectStoreInfoPB {
 message StorageVaultPB {
     optional string id = 1;
     optional string name = 2;
-    optional HdfsParams hdfs_infos = 3; // HdfsResource
+    optional HdfsVaultInfo hdfs_info = 3; // HdfsResource
 }
 
-message HdfsParams {
-    optional string fs_name = 1;
+message HdfsBuildConf {
+    message HdfsConfKVPair {
+        required string key = 1;
+        required string value = 2;
+    }
+    optional string fs_name = 1; // name_node
     optional string user = 2;
     optional string hdfs_kerberos_principal = 3;
     optional string hdfs_kerberos_keytab = 4;
-    repeated HdfsConf hdfs_confs = 5;
+    repeated HdfsConfKVPair hdfs_confs = 5;
 }
 
-message HdfsConf {
-    optional string key = 1;
-    optional string value = 2;
+message HdfsVaultInfo {
+    optional HdfsBuildConf build_conf = 1;
+    optional string prefix = 2;
 }
 
 //==============================================================================
@@ -713,10 +717,10 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
-message AlterHdfsParams {
-        optional string vault_name = 1;
-        optional HdfsParams hdfs = 2;
-    }
+message AlterHdfsVaultInfo {
+    optional string vault_name = 1;
+    optional HdfsVaultInfo hdfs = 2;
+}
 
 message AlterObjStoreInfoRequest {
     enum Operation {
@@ -730,7 +734,7 @@ message AlterObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
-    optional AlterHdfsParams hdfs = 4;
+    optional AlterHdfsVaultInfo hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -750,7 +754,7 @@ message UpdateAkSkResponse {
 message GetObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     repeated ObjectStoreInfoPB obj_info = 2;
-    repeated HdfsParams hdfs_info = 3;
+    repeated HdfsVaultInfo hdfs_info = 3;
 };
 
 message CreateTabletsRequest {
@@ -868,7 +872,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
-    optional HdfsParams hdfs_info = 7;
+    optional HdfsVaultInfo hdfs_info = 7;
 }
 
 message CreateInstanceResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -193,23 +193,20 @@ message ObjectStoreInfoPB {
 message StorageVaultPB {
     optional string id = 1;
     optional string name = 2;
-    optional HdfsInfoPB hdfs_infos = 3; // HdfsResource
+    optional HdfsParams hdfs_infos = 3; // HdfsResource
 }
 
-message HdfsInfoPB {
-    enum Provider {
-        OSS = 0;
-        S3 =  1;
-        COS = 2;
-        OBS = 3;
-        BOS = 4;
-    }
-    optional int64 ctime = 1;
-    optional int64 mtime = 2;
-    optional Provider provider = 3;
-    optional string external_endpoint = 4;
-    optional string user_id = 5;
-    optional EncryptionInfoPB encryption_info = 6;
+message HdfsParams {
+    optional string fs_name = 1;
+    optional string user = 2;
+    optional string hdfs_kerberos_principal = 3;
+    optional string hdfs_kerberos_keytab = 4;
+    repeated HdfsConf hdfs_confs = 5;
+}
+
+message HdfsConf {
+    optional string key = 1;
+    optional string value = 2;
 }
 
 //==============================================================================
@@ -716,6 +713,11 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
+message AlterHdfsParams {
+        optional string vault_name = 1;
+        optional HdfsParams hdfs = 2;
+    }
+
 message AlterObjStoreInfoRequest {
     enum Operation {
         UNKNOWN         = 0;
@@ -728,7 +730,7 @@ message AlterObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
-    optional HdfsInfoPB hdfs = 4;
+    optional AlterHdfsParams hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -748,6 +750,7 @@ message UpdateAkSkResponse {
 message GetObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     repeated ObjectStoreInfoPB obj_info = 2;
+    repeated HdfsParams hdfs_info = 3;
 };
 
 message CreateTabletsRequest {
@@ -865,7 +868,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
-    optional HdfsInfoPB hdfs_info = 7;
+    optional HdfsParams hdfs_info = 7;
 }
 
 message CreateInstanceResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -73,6 +73,9 @@ message InstanceInfoPB {
     optional RamUserPB ram_user = 11;
     optional RamUserPB iam_user = 12;
     optional bool sse_enabled = 13;
+
+    repeated string resource_ids = 100; // 新加 vault 的 resource id 采用 max_resource_id + 1
+    repeated string storage_vault_names = 101; // 建表时从这里找到 vault name -> resource id 的映射
 }
 
 message StagePB {
@@ -185,6 +188,28 @@ message ObjectStoreInfoPB {
     optional string user_id = 13;
     optional EncryptionInfoPB encryption_info = 14;
     optional bool sse_enabled = 15;
+}
+
+message StorageVaultPB {
+    optional string id = 1;
+    optional string name = 2;
+    optional HdfsInfoPB hdfs_infos = 3; // HdfsResource
+}
+
+message HdfsInfoPB {
+    enum Provider {
+        OSS = 0;
+        S3 =  1;
+        COS = 2;
+        OBS = 3;
+        BOS = 4;
+    }
+    optional int64 ctime = 1;
+    optional int64 mtime = 2;
+    optional Provider provider = 3;
+    optional string external_endpoint = 4;
+    optional string user_id = 5;
+    optional EncryptionInfoPB encryption_info = 6;
 }
 
 //==============================================================================
@@ -697,10 +722,13 @@ message AlterObjStoreInfoRequest {
         UPDATE_AK_SK    = 1;
         ADD_OBJ_INFO    = 2;
         LEGACY_UPDATE_AK_SK = 3;
+
+        ADD_HDFS_INFO = 100;
     }
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
+    optional HdfsInfoPB hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -837,6 +865,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
+    optional HdfsInfoPB hdfs_info = 7;
 }
 
 message CreateInstanceResponse {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
This pr is part of `HDFS support for Compute Storage separation`. The main purpose of this is one that add support for hdfs meta data restore for Meta Service. And we introduce one item called `storage vault` which would be described in details in following pr.

TODO:
1. Reclaim the key value on FDB when the add hdfs info action failed.
2. Adjust BE code to refresh it's local obj/hdfs info using the new `get_obj_info` rpc interface
3. Adjust FE code to support Create table stmt with `storage vault` property.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

