### PR TITLE
[fix](group_commit) GroupCommitBlockSink shoud not use load_block_queue when creating load task fail

### DIFF
--- a/be/src/olap/wal/wal_writer.cpp
+++ b/be/src/olap/wal/wal_writer.cpp
@@ -48,6 +48,9 @@ Status WalWriter::init() {
 }
 
 Status WalWriter::finalize() {
+    if (!_file_writer) {
+        return Status::InternalError("wal writer is null,fail to close file={}", _file_name);
+    }
     auto st = _file_writer->close();
     if (!st.ok()) {
         LOG(WARNING) << "fail to close wal " << _file_name;
@@ -56,6 +59,9 @@ Status WalWriter::finalize() {
 }
 
 Status WalWriter::append_blocks(const PBlockArray& blocks) {
+    if (!_file_writer) {
+        return Status::InternalError("wal writer is null,fail to write file={}", _file_name);
+    }
     size_t total_size = 0;
     size_t offset = 0;
     for (const auto& block : blocks) {
@@ -85,6 +91,9 @@ Status WalWriter::append_blocks(const PBlockArray& blocks) {
 }
 
 Status WalWriter::append_header(uint32_t version, std::string col_ids) {
+    if (!_file_writer) {
+        return Status::InternalError("wal writer is null,fail to write file={}", _file_name);
+    }
     size_t total_size = 0;
     uint64_t length = col_ids.size();
     total_size += k_wal_magic_length;

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -211,8 +211,11 @@ Status GroupCommitTable::get_first_block_load_queue(
             if (!_need_plan_fragment) {
                 _need_plan_fragment = true;
                 RETURN_IF_ERROR(_thread_pool->submit_func([&] {
-                    [[maybe_unused]] auto st =
-                            _create_group_commit_load(load_block_queue, be_exe_version);
+                    auto st = _create_group_commit_load(load_block_queue, be_exe_version);
+                    if (!st.ok()) {
+                        LOG(WARNING) << "fail to create block queue,st=" << st.to_string();
+                        load_block_queue.reset();
+                    }
                 }));
             }
             _cv.wait_for(l, std::chrono::seconds(4));
@@ -307,8 +310,6 @@ Status GroupCommitTable::_create_group_commit_load(
                 result.wait_internal_group_commit_finish, result.group_commit_interval_ms,
                 result.group_commit_data_bytes);
         std::unique_lock l(_lock);
-        _load_block_queues.emplace(instance_id, load_block_queue);
-        _need_plan_fragment = false;
         //create wal
         if (!is_pipeline) {
             RETURN_IF_ERROR(load_block_queue->create_wal(
@@ -320,6 +321,8 @@ Status GroupCommitTable::_create_group_commit_load(
                     pipeline_params.fragment.output_sink.olap_table_sink.schema.slot_descs,
                     be_exe_version));
         }
+        _load_block_queues.emplace(instance_id, load_block_queue);
+        _need_plan_fragment = false;
         _cv.notify_all();
     }
     st = _exec_plan_fragment(_db_id, _table_id, label, txn_id, is_pipeline, params,


### PR DESCRIPTION
## Proposed changes
When creating load task fail, wal write maye be null, so need to check nullptr before use it. And the corresponding load_block_queue should not be used to append block.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

