### PR TITLE
[improvement](group_commit) Empty wal should be deleted when replaying it

### DIFF
--- a/be/src/olap/wal/wal_reader.cpp
+++ b/be/src/olap/wal/wal_reader.cpp
@@ -86,6 +86,9 @@ Status WalReader::read_block(PBlock& block) {
 }
 
 Status WalReader::read_header(std::string& col_ids) {
+    if (file_reader->size() == 0) {
+        return Status::DataQualityError("empty file");
+    }
     size_t bytes_read = 0;
     std::string magic_str;
     magic_str.resize(k_wal_magic_length);

--- a/be/src/olap/wal/wal_table.cpp
+++ b/be/src/olap/wal/wal_table.cpp
@@ -98,7 +98,7 @@ Status WalTable::_relay_wal_one_by_one() {
             doris::wal_fail << 1;
             LOG(WARNING) << "failed to replay wal=" << wal_info->get_wal_path()
                          << ", st=" << st.to_string();
-            if (!st.is<ErrorCode::NOT_FOUND>() && !st.is<ErrorCode::CORRUPTION>()) {
+            if (!st.is<ErrorCode::NOT_FOUND>() && !st.is<ErrorCode::DATA_QUALITY_ERROR>()) {
                 need_retry_wals.push_back(wal_info);
             } else {
                 need_delete_wals.push_back(wal_info);

--- a/be/src/olap/wal/wal_table.cpp
+++ b/be/src/olap/wal/wal_table.cpp
@@ -98,7 +98,7 @@ Status WalTable::_relay_wal_one_by_one() {
             doris::wal_fail << 1;
             LOG(WARNING) << "failed to replay wal=" << wal_info->get_wal_path()
                          << ", st=" << st.to_string();
-            if (!st.is<ErrorCode::NOT_FOUND>()) {
+            if (!st.is<ErrorCode::NOT_FOUND>() && !st.is<ErrorCode::CORRUPTION>()) {
                 need_retry_wals.push_back(wal_info);
             } else {
                 need_delete_wals.push_back(wal_info);


### PR DESCRIPTION
## Proposed changes
Empty wal file can never be recovered, so it should be deleted when replaying task found it.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

