### PR TITLE
[bug](scan) Fix missing shared tablet header lock

### DIFF
--- a/be/src/olap/parallel_scanner_builder.cpp
+++ b/be/src/olap/parallel_scanner_builder.cpp
@@ -46,8 +46,11 @@ Status ParallelScannerBuilder<ParentType>::_build_scanners_by_rowid(
 
         TabletReader::ReadSource reade_source_with_delete_info;
         if (!_state->skip_delete_predicate()) {
-            RETURN_IF_ERROR(tablet->capture_rs_readers(
-                    {0, version}, &reade_source_with_delete_info.rs_splits, false));
+            {
+                std::shared_lock rdlock(tablet->get_header_lock());
+                RETURN_IF_ERROR(tablet->capture_rs_readers(
+                        {0, version}, &reade_source_with_delete_info.rs_splits, false));
+            }
             reade_source_with_delete_info.fill_delete_predicates();
         }
 


### PR DESCRIPTION
## Proposed changes

`Tablet::capture_rs_readers` is not thread safe in this version, must hold shared tablet header lock when calling `Tablet::capture_rs_readers`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

