### PR TITLE
[opt](plsql) Fix procedure key compatibility

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3333,7 +3333,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         List<Expression> arguments = ctx.expression().stream()
                 .<Expression>map(this::typedVisit)
                 .collect(ImmutableList.toImmutableList());
-        UnboundFunction unboundFunction = new UnboundFunction(procedureName.getDb(), procedureName.getName(),
+        UnboundFunction unboundFunction = new UnboundFunction(procedureName.getDbName(), procedureName.getName(),
                 true, arguments);
         return new CallCommand(unboundFunction, getOriginSql(ctx));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateProcedureCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateProcedureCommand.java
@@ -54,11 +54,7 @@ public class CreateProcedureCommand extends Command implements ForwardWithSync {
 
     @Override
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        // TODO, removeCached needs to be synchronized to all Observer FEs.
-        // Even if it is always executed on the Master FE, it still has to deal with Master switching.
-        ctx.getPlSqlOperation().getExec().functions.removeCached(procedureName.toString());
-        client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDb(),
-                ctx.getQualifiedUser(), source, isForce);
+        ctx.getPlSqlOperation().getExec().functions.save(procedureName, source, isForce);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/FuncNameInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/FuncNameInfo.java
@@ -114,10 +114,8 @@ public class FuncNameInfo {
                     db = FeConstants.INTERNAL_DB_NAME;
                 }
             }
-            if (Strings.isNullOrEmpty(db)) {
-                Optional<DatabaseIf> dbInstance = ctx.getCatalog(ctl).getDb(db);
-                dbId = dbInstance.map(DatabaseIf::getId).orElse(-1L);
-            }
+            Optional<DatabaseIf> dbInstance = ctx.getCatalog(ctl).getDb(db);
+            dbId = dbInstance.map(DatabaseIf::getId).orElse(-1L);
             if (Strings.isNullOrEmpty(name)) {
                 throw new AnalysisException("procedure/function/package name is null");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/FuncNameInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/FuncNameInfo.java
@@ -176,7 +176,6 @@ public class FuncNameInfo {
     }
 
     public String toString() {
-        analyze(ConnectContext.get());
         return nameParts.stream().map(Utils::quoteIfNeeded).reduce((left, right) -> left + "." + right).orElse("");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/Exec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/Exec.java
@@ -1625,7 +1625,7 @@ public class Exec extends org.apache.doris.nereids.PLParserBaseVisitor<Integer> 
         FuncNameInfo procedureName = new FuncNameInfo(nameParts);
         Package packCallContext = exec.getPackageCallContext();
         boolean executed = false;
-        Package pack = findPackage(procedureName.getDb());
+        Package pack = findPackage(procedureName.getDbName());
         if (pack != null) {
             executed = pack.execFunc(procedureName.getName(), params);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
@@ -66,7 +66,7 @@ public class DorisFunctionRegistry implements FunctionRegistry {
     @Override
     public void remove(FuncNameInfo procedureName) {
         try {
-            client.dropPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId());
+            client.dropPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtlId(), procedureName.getDbId());
         } catch (Exception e) {
             throw new RuntimeException("failed to remove procedure", e);
         }
@@ -151,7 +151,7 @@ public class DorisFunctionRegistry implements FunctionRegistry {
     }
 
     private Optional<PlsqlStoredProcedure> getProc(FuncNameInfo procedureName) {
-        return Optional.ofNullable(client.getPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(),
+        return Optional.ofNullable(client.getPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtlId(),
                 procedureName.getDbId()));
     }
 
@@ -197,7 +197,8 @@ public class DorisFunctionRegistry implements FunctionRegistry {
     public void save(FuncNameInfo procedureName, String source, boolean isForce) {
         try {
             // TODO support packageName
-            client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId(), "",
+            client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtlId(), procedureName.getDbId(),
+                    "",
                     ConnectContext.get().getQualifiedUser(), source, isForce);
         } catch (Exception e) {
             throw new RuntimeException("failed to save procedure", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
@@ -68,7 +68,7 @@ public class DorisFunctionRegistry implements FunctionRegistry {
         try {
             client.dropPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId());
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("failed to remove procedure", e);
         }
     }
 
@@ -195,9 +195,13 @@ public class DorisFunctionRegistry implements FunctionRegistry {
 
     @Override
     public void save(FuncNameInfo procedureName, String source, boolean isForce) {
-        // TODO support packageName
-        client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId(), "",
-                ConnectContext.get().getQualifiedUser(), source, isForce);
+        try {
+            // TODO support packageName
+            client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId(), "",
+                    ConnectContext.get().getQualifiedUser(), source, isForce);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to save procedure", e);
+        }
     }
 
     private void saveInCache(String name, ParserRuleContext procCtx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/DorisFunctionRegistry.java
@@ -66,8 +66,7 @@ public class DorisFunctionRegistry implements FunctionRegistry {
     @Override
     public void remove(FuncNameInfo procedureName) {
         try {
-            client.dropPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(),
-                    procedureName.getDb());
+            client.dropPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -124,8 +123,8 @@ public class DorisFunctionRegistry implements FunctionRegistry {
         }
     }
 
-    private void callWithParameters(Expr_func_paramsContext ctx, ParserRuleContext procCtx,
-            HashMap<String, Var> out, ArrayList<Var> actualParams) {
+    private void callWithParameters(Expr_func_paramsContext ctx, ParserRuleContext procCtx, HashMap<String, Var> out,
+            ArrayList<Var> actualParams) {
         if (procCtx instanceof Create_function_stmtContext) {
             Create_function_stmtContext func = (Create_function_stmtContext) procCtx;
             InMemoryFunctionRegistry.setCallParameters(func.multipartIdentifier().getText(), ctx, actualParams,
@@ -152,9 +151,8 @@ public class DorisFunctionRegistry implements FunctionRegistry {
     }
 
     private Optional<PlsqlStoredProcedure> getProc(FuncNameInfo procedureName) {
-        return Optional.ofNullable(
-                client.getPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(),
-                        procedureName.getDb()));
+        return Optional.ofNullable(client.getPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(),
+                procedureName.getDbId()));
     }
 
     private ArrayList<Var> getActualCallParameters(Expr_func_paramsContext actual) {
@@ -179,7 +177,7 @@ public class DorisFunctionRegistry implements FunctionRegistry {
         }
         trace(ctx, "CREATE FUNCTION " + procedureName.toString());
         saveInCache(procedureName.toString(), ctx);
-        saveStoredProc(procedureName, Exec.getFormattedText(ctx), ctx.REPLACE() != null);
+        save(procedureName, Exec.getFormattedText(ctx), ctx.REPLACE() != null);
     }
 
     @Override
@@ -192,12 +190,13 @@ public class DorisFunctionRegistry implements FunctionRegistry {
         }
         trace(ctx, "CREATE PROCEDURE " + procedureName.toString());
         saveInCache(procedureName.toString(), ctx);
-        saveStoredProc(procedureName, Exec.getFormattedText(ctx), ctx.REPLACE() != null);
+        save(procedureName, Exec.getFormattedText(ctx), ctx.REPLACE() != null);
     }
 
-    private void saveStoredProc(FuncNameInfo procedureName, String source, boolean isForce) {
-        client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(),
-                procedureName.getDb(),
+    @Override
+    public void save(FuncNameInfo procedureName, String source, boolean isForce) {
+        // TODO support packageName
+        client.addPlsqlStoredProcedure(procedureName.getName(), procedureName.getCtl(), procedureName.getDbId(), "",
                 ConnectContext.get().getQualifiedUser(), source, isForce);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/FunctionRegistry.java
@@ -32,6 +32,8 @@ public interface FunctionRegistry {
 
     void addUserProcedure(Create_procedure_stmtContext ctx);
 
+    void save(FuncNameInfo procedureName, String source, boolean isForce);
+
     boolean exists(FuncNameInfo procedureName);
 
     void remove(FuncNameInfo procedureName);

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/InMemoryFunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/functions/InMemoryFunctionRegistry.java
@@ -56,6 +56,11 @@ public class InMemoryFunctionRegistry implements FunctionRegistry {
     }
 
     @Override
+    public void save(FuncNameInfo procedureName, String source, boolean isForce) {
+        throw new RuntimeException("InMemoryFunctionRegistry no support save");
+    }
+
+    @Override
     public boolean exists(FuncNameInfo procedureName) {
         return funcMap.containsKey(procedureName.toString()) || procMap.containsKey(procedureName.toString());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlManager.java
@@ -50,7 +50,7 @@ public class PlsqlManager implements Writable {
 
     public void addPlsqlStoredProcedure(PlsqlStoredProcedure procedure, boolean isForce) {
         PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogName(),
-                procedure.getDbName());
+                procedure.getDbId());
         if (isForce) {
             nameToStoredProcedures.put(plsqlProcedureKey, procedure);
         } else if (nameToStoredProcedures.putIfAbsent(plsqlProcedureKey, procedure) != null) {
@@ -62,7 +62,7 @@ public class PlsqlManager implements Writable {
 
     public void replayAddPlsqlStoredProcedure(PlsqlStoredProcedure procedure) {
         PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogName(),
-                procedure.getDbName());
+                procedure.getDbId());
         nameToStoredProcedures.put(plsqlProcedureKey, procedure);
         LOG.info("Replay add stored procedure success: {}", plsqlProcedureKey);
     }
@@ -84,7 +84,7 @@ public class PlsqlManager implements Writable {
 
     public void addPackage(PlsqlPackage pkg, boolean isForce) {
         PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogName(),
-                pkg.getDbName());
+                pkg.getDbId());
         nameToPackages.put(plsqlProcedureKey, pkg);
         if (isForce) {
             nameToPackages.put(plsqlProcedureKey, pkg);
@@ -97,7 +97,7 @@ public class PlsqlManager implements Writable {
 
     public void replayAddPlsqlPackage(PlsqlPackage pkg) {
         PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogName(),
-                pkg.getDbName());
+                pkg.getDbId());
         nameToPackages.put(plsqlProcedureKey, pkg);
         LOG.info("Replay add plsql package success: {}", plsqlProcedureKey);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlManager.java
@@ -49,7 +49,7 @@ public class PlsqlManager implements Writable {
     }
 
     public void addPlsqlStoredProcedure(PlsqlStoredProcedure procedure, boolean isForce) {
-        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogName(),
+        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogId(),
                 procedure.getDbId());
         if (isForce) {
             nameToStoredProcedures.put(plsqlProcedureKey, procedure);
@@ -61,7 +61,7 @@ public class PlsqlManager implements Writable {
     }
 
     public void replayAddPlsqlStoredProcedure(PlsqlStoredProcedure procedure) {
-        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogName(),
+        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(procedure.getName(), procedure.getCatalogId(),
                 procedure.getDbId());
         nameToStoredProcedures.put(plsqlProcedureKey, procedure);
         LOG.info("Replay add stored procedure success: {}", plsqlProcedureKey);
@@ -83,7 +83,7 @@ public class PlsqlManager implements Writable {
     }
 
     public void addPackage(PlsqlPackage pkg, boolean isForce) {
-        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogName(),
+        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogId(),
                 pkg.getDbId());
         nameToPackages.put(plsqlProcedureKey, pkg);
         if (isForce) {
@@ -96,7 +96,7 @@ public class PlsqlManager implements Writable {
     }
 
     public void replayAddPlsqlPackage(PlsqlPackage pkg) {
-        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogName(),
+        PlsqlProcedureKey plsqlProcedureKey = new PlsqlProcedureKey(pkg.getName(), pkg.getCatalogId(),
                 pkg.getDbId());
         nameToPackages.put(plsqlProcedureKey, pkg);
         LOG.info("Replay add plsql package success: {}", plsqlProcedureKey);

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlMetaClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlMetaClient.java
@@ -41,63 +41,66 @@ public class PlsqlMetaClient {
     public PlsqlMetaClient() {
     }
 
-    public void addPlsqlStoredProcedure(String name, String catalogName, String dbName, String ownerName, String source,
+    public void addPlsqlStoredProcedure(String name, String catalogName, long dbId, String packageName,
+            String ownerName, String source,
             boolean isForce) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
-                    .addPlsqlStoredProcedure(new PlsqlStoredProcedure(name, catalogName, dbName, ownerName, source),
+                    .addPlsqlStoredProcedure(
+                            new PlsqlStoredProcedure(name, catalogName, dbId, packageName, ownerName, source),
                             isForce);
         } else {
-            addPlsqlStoredProcedureThrift(name, catalogName, dbName, ownerName, source, isForce);
+            addPlsqlStoredProcedureThrift(name, catalogName, dbId, packageName, ownerName, source, isForce);
         }
     }
 
-    public void dropPlsqlStoredProcedure(String name, String catalogName, String dbName) {
+    public void dropPlsqlStoredProcedure(String name, String catalogName, long dbId) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
-                    .dropPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbName));
+                    .dropPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbId));
         } else {
-            dropStoredProcedureThrift(name, catalogName, dbName);
+            dropStoredProcedureThrift(name, catalogName, dbId);
         }
     }
 
-    public PlsqlStoredProcedure getPlsqlStoredProcedure(String name, String catalogName, String dbName) {
+    public PlsqlStoredProcedure getPlsqlStoredProcedure(String name, String catalogName, long dbId) {
         return Env.getCurrentEnv().getPlsqlManager()
-                .getPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbName));
+                .getPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbId));
     }
 
-    public void addPlsqlPackage(String name, String catalogName, String dbName, String ownerName, String header,
+    public void addPlsqlPackage(String name, String catalogName, long dbId, String ownerName, String header,
             String body) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
-                    .addPackage(new PlsqlPackage(name, catalogName, dbName, ownerName, header, body),
+                    .addPackage(new PlsqlPackage(name, catalogName, dbId, ownerName, header, body),
                             false);
         } else {
-            addPlsqlPackageThrift(name, catalogName, dbName, ownerName, header, body);
+            addPlsqlPackageThrift(name, catalogName, dbId, ownerName, header, body);
         }
     }
 
-    public void dropPlsqlPackage(String name, String catalogName, String dbName) {
+    public void dropPlsqlPackage(String name, String catalogName, long dbId) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
-            Env.getCurrentEnv().getPlsqlManager().dropPackage(new PlsqlProcedureKey(name, catalogName, dbName));
+            Env.getCurrentEnv().getPlsqlManager().dropPackage(new PlsqlProcedureKey(name, catalogName, dbId));
         } else {
-            dropPlsqlPackageThrift(name, catalogName, dbName);
+            dropPlsqlPackageThrift(name, catalogName, dbId);
         }
     }
 
-    public PlsqlPackage getPlsqlPackage(String name, String catalogName, String dbName) {
-        return Env.getCurrentEnv().getPlsqlManager().getPackage(new PlsqlProcedureKey(name, catalogName, dbName));
+    public PlsqlPackage getPlsqlPackage(String name, String catalogName, long dbId) {
+        return Env.getCurrentEnv().getPlsqlManager().getPackage(new PlsqlProcedureKey(name, catalogName, dbId));
     }
 
-    protected void addPlsqlStoredProcedureThrift(String name, String catalogName, String dbName, String ownerName,
+    protected void addPlsqlStoredProcedureThrift(String name, String catalogName, long dbId, String packageName,
+            String ownerName,
             String source, boolean isForce) {
         TPlsqlStoredProcedure tPlsqlStoredProcedure = new TPlsqlStoredProcedure().setName(name)
-                .setCatalogName(catalogName)
-                .setDbName(dbName).setOwnerName(ownerName).setSource(source);
+                .setCatalogName(catalogName).setDbId(dbId)
+                .setPackageName(packageName).setOwnerName(ownerName).setSource(source);
         TAddPlsqlStoredProcedureRequest tAddPlsqlStoredProcedureRequest = new TAddPlsqlStoredProcedureRequest()
                 .setPlsqlStoredProcedure(tPlsqlStoredProcedure);
         tAddPlsqlStoredProcedureRequest.setIsForce(isForce);
@@ -110,9 +113,9 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void dropStoredProcedureThrift(String name, String catalogName, String dbName) {
+    protected void dropStoredProcedureThrift(String name, String catalogName, long dbId) {
         TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName)
-                .setDbName(dbName);
+                .setDbId(dbId);
         TDropPlsqlStoredProcedureRequest tDropPlsqlStoredProcedureRequest
                 = new TDropPlsqlStoredProcedureRequest().setPlsqlProcedureKey(
                 tPlsqlProcedureKey);
@@ -125,10 +128,10 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void addPlsqlPackageThrift(String name, String catalogName, String dbName, String ownerName,
+    protected void addPlsqlPackageThrift(String name, String catalogName, long dbId, String ownerName,
             String header, String body) {
         TPlsqlPackage tPlsqlPackage = new TPlsqlPackage().setName(name).setCatalogName(catalogName)
-                .setDbName(dbName).setOwnerName(ownerName).setHeader(header).setBody(body);
+                .setDbId(dbId).setOwnerName(ownerName).setHeader(header).setBody(body);
         TAddPlsqlPackageRequest tAddPlsqlPackageRequest = new TAddPlsqlPackageRequest()
                 .setPlsqlPackage(tPlsqlPackage);
 
@@ -140,9 +143,9 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void dropPlsqlPackageThrift(String name, String catalogName, String dbName) {
+    protected void dropPlsqlPackageThrift(String name, String catalogName, long dbId) {
         TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName)
-                .setDbName(dbName);
+                .setDbId(dbId);
         TDropPlsqlPackageRequest tDropPlsqlPackageRequest = new TDropPlsqlPackageRequest().setPlsqlProcedureKey(
                 tPlsqlProcedureKey);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlMetaClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlMetaClient.java
@@ -41,65 +41,65 @@ public class PlsqlMetaClient {
     public PlsqlMetaClient() {
     }
 
-    public void addPlsqlStoredProcedure(String name, String catalogName, long dbId, String packageName,
+    public void addPlsqlStoredProcedure(String name, long catalogId, long dbId, String packageName,
             String ownerName, String source,
             boolean isForce) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
                     .addPlsqlStoredProcedure(
-                            new PlsqlStoredProcedure(name, catalogName, dbId, packageName, ownerName, source),
+                            new PlsqlStoredProcedure(name, catalogId, dbId, packageName, ownerName, source),
                             isForce);
         } else {
-            addPlsqlStoredProcedureThrift(name, catalogName, dbId, packageName, ownerName, source, isForce);
+            addPlsqlStoredProcedureThrift(name, catalogId, dbId, packageName, ownerName, source, isForce);
         }
     }
 
-    public void dropPlsqlStoredProcedure(String name, String catalogName, long dbId) {
+    public void dropPlsqlStoredProcedure(String name, long catalogId, long dbId) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
-                    .dropPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbId));
+                    .dropPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogId, dbId));
         } else {
-            dropStoredProcedureThrift(name, catalogName, dbId);
+            dropStoredProcedureThrift(name, catalogId, dbId);
         }
     }
 
-    public PlsqlStoredProcedure getPlsqlStoredProcedure(String name, String catalogName, long dbId) {
+    public PlsqlStoredProcedure getPlsqlStoredProcedure(String name, long catalogId, long dbId) {
         return Env.getCurrentEnv().getPlsqlManager()
-                .getPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogName, dbId));
+                .getPlsqlStoredProcedure(new PlsqlProcedureKey(name, catalogId, dbId));
     }
 
-    public void addPlsqlPackage(String name, String catalogName, long dbId, String ownerName, String header,
+    public void addPlsqlPackage(String name, long catalogId, long dbId, String ownerName, String header,
             String body) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
             Env.getCurrentEnv().getPlsqlManager()
-                    .addPackage(new PlsqlPackage(name, catalogName, dbId, ownerName, header, body),
+                    .addPackage(new PlsqlPackage(name, catalogId, dbId, ownerName, header, body),
                             false);
         } else {
-            addPlsqlPackageThrift(name, catalogName, dbId, ownerName, header, body);
+            addPlsqlPackageThrift(name, catalogId, dbId, ownerName, header, body);
         }
     }
 
-    public void dropPlsqlPackage(String name, String catalogName, long dbId) {
+    public void dropPlsqlPackage(String name, long catalogId, long dbId) {
         checkPriv();
         if (Env.getCurrentEnv().isMaster()) {
-            Env.getCurrentEnv().getPlsqlManager().dropPackage(new PlsqlProcedureKey(name, catalogName, dbId));
+            Env.getCurrentEnv().getPlsqlManager().dropPackage(new PlsqlProcedureKey(name, catalogId, dbId));
         } else {
-            dropPlsqlPackageThrift(name, catalogName, dbId);
+            dropPlsqlPackageThrift(name, catalogId, dbId);
         }
     }
 
-    public PlsqlPackage getPlsqlPackage(String name, String catalogName, long dbId) {
-        return Env.getCurrentEnv().getPlsqlManager().getPackage(new PlsqlProcedureKey(name, catalogName, dbId));
+    public PlsqlPackage getPlsqlPackage(String name, long catalogId, long dbId) {
+        return Env.getCurrentEnv().getPlsqlManager().getPackage(new PlsqlProcedureKey(name, catalogId, dbId));
     }
 
-    protected void addPlsqlStoredProcedureThrift(String name, String catalogName, long dbId, String packageName,
+    protected void addPlsqlStoredProcedureThrift(String name, long catalogId, long dbId, String packageName,
             String ownerName,
             String source, boolean isForce) {
         TPlsqlStoredProcedure tPlsqlStoredProcedure = new TPlsqlStoredProcedure().setName(name)
-                .setCatalogName(catalogName).setDbId(dbId)
+                .setCatalogId(catalogId).setDbId(dbId)
                 .setPackageName(packageName).setOwnerName(ownerName).setSource(source);
         TAddPlsqlStoredProcedureRequest tAddPlsqlStoredProcedureRequest = new TAddPlsqlStoredProcedureRequest()
                 .setPlsqlStoredProcedure(tPlsqlStoredProcedure);
@@ -113,8 +113,8 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void dropStoredProcedureThrift(String name, String catalogName, long dbId) {
-        TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName)
+    protected void dropStoredProcedureThrift(String name, long catalogId, long dbId) {
+        TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogId(catalogId)
                 .setDbId(dbId);
         TDropPlsqlStoredProcedureRequest tDropPlsqlStoredProcedureRequest
                 = new TDropPlsqlStoredProcedureRequest().setPlsqlProcedureKey(
@@ -128,9 +128,9 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void addPlsqlPackageThrift(String name, String catalogName, long dbId, String ownerName,
+    protected void addPlsqlPackageThrift(String name, long catalogId, long dbId, String ownerName,
             String header, String body) {
-        TPlsqlPackage tPlsqlPackage = new TPlsqlPackage().setName(name).setCatalogName(catalogName)
+        TPlsqlPackage tPlsqlPackage = new TPlsqlPackage().setName(name).setCatalogId(catalogId)
                 .setDbId(dbId).setOwnerName(ownerName).setHeader(header).setBody(body);
         TAddPlsqlPackageRequest tAddPlsqlPackageRequest = new TAddPlsqlPackageRequest()
                 .setPlsqlPackage(tPlsqlPackage);
@@ -143,8 +143,8 @@ public class PlsqlMetaClient {
         }
     }
 
-    protected void dropPlsqlPackageThrift(String name, String catalogName, long dbId) {
-        TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName)
+    protected void dropPlsqlPackageThrift(String name, long catalogId, long dbId) {
+        TPlsqlProcedureKey tPlsqlProcedureKey = new TPlsqlProcedureKey().setName(name).setCatalogId(catalogId)
                 .setDbId(dbId);
         TDropPlsqlPackageRequest tDropPlsqlPackageRequest = new TDropPlsqlPackageRequest().setPlsqlProcedureKey(
                 tPlsqlProcedureKey);

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlPackage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlPackage.java
@@ -39,8 +39,8 @@ public class PlsqlPackage implements Writable {
     @SerializedName(value = "catalogName")
     private String catalogName;
 
-    @SerializedName(value = "dbName")
-    private String dbName;
+    @SerializedName(value = "dbId")
+    private long dbId;
 
     @SerializedName(value = "ownerName")
     private String ownerName;
@@ -57,12 +57,12 @@ public class PlsqlPackage implements Writable {
     }
 
     public TPlsqlPackage toThrift() {
-        return new TPlsqlPackage().setName(name).setCatalogName(catalogName).setDbName(dbName).setOwnerName(ownerName)
+        return new TPlsqlPackage().setName(name).setCatalogName(catalogName).setDbId(dbId).setOwnerName(ownerName)
                 .setHeader(header).setBody(body);
     }
 
     public static PlsqlPackage fromThrift(TPlsqlPackage pkg) {
-        return new PlsqlPackage(pkg.getName(), pkg.getCatalogName(), pkg.getDbName(), pkg.getOwnerName(),
+        return new PlsqlPackage(pkg.getName(), pkg.getCatalogName(), pkg.getDbId(), pkg.getOwnerName(),
                 pkg.getHeader(), pkg.getBody());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlPackage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlPackage.java
@@ -36,8 +36,8 @@ public class PlsqlPackage implements Writable {
     @SerializedName(value = "name")
     private String name;
 
-    @SerializedName(value = "catalogName")
-    private String catalogName;
+    @SerializedName(value = "catalogId")
+    private long catalogId;
 
     @SerializedName(value = "dbId")
     private long dbId;
@@ -57,12 +57,12 @@ public class PlsqlPackage implements Writable {
     }
 
     public TPlsqlPackage toThrift() {
-        return new TPlsqlPackage().setName(name).setCatalogName(catalogName).setDbId(dbId).setOwnerName(ownerName)
+        return new TPlsqlPackage().setName(name).setCatalogId(catalogId).setDbId(dbId).setOwnerName(ownerName)
                 .setHeader(header).setBody(body);
     }
 
     public static PlsqlPackage fromThrift(TPlsqlPackage pkg) {
-        return new PlsqlPackage(pkg.getName(), pkg.getCatalogName(), pkg.getDbId(), pkg.getOwnerName(),
+        return new PlsqlPackage(pkg.getName(), pkg.getCatalogId(), pkg.getDbId(), pkg.getOwnerName(),
                 pkg.getHeader(), pkg.getBody());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlProcedureKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlProcedureKey.java
@@ -37,29 +37,29 @@ public class PlsqlProcedureKey implements Writable {
     @SerializedName(value = "name")
     private String name;
 
-    @SerializedName(value = "catalogName")
-    private String catalogName;
+    @SerializedName(value = "catalogId")
+    private long catalogId;
 
     @SerializedName(value = "dbId")
     private long dbId;
 
-    public PlsqlProcedureKey(String name, String catalogName, long dbId) {
+    public PlsqlProcedureKey(String name, long catalogId, long dbId) {
         this.name = name;
-        this.catalogName = catalogName;
+        this.catalogId = catalogId;
         this.dbId = dbId;
     }
 
     public TPlsqlProcedureKey toThrift() {
-        return new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName).setDbId(dbId);
+        return new TPlsqlProcedureKey().setName(name).setCatalogId(catalogId).setDbId(dbId);
     }
 
     public static PlsqlProcedureKey fromThrift(TPlsqlProcedureKey key) {
-        return new PlsqlProcedureKey(key.getName(), key.getCatalogName(), key.getDbId());
+        return new PlsqlProcedureKey(key.getName(), key.getCatalogId(), key.getDbId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, catalogName, dbId);
+        return Objects.hash(name, catalogId, dbId);
     }
 
     @Override
@@ -67,14 +67,14 @@ public class PlsqlProcedureKey implements Writable {
         if (!(obj instanceof PlsqlProcedureKey)) {
             return false;
         }
-        return Objects.equals(this.name, ((PlsqlProcedureKey) obj).name) && Objects.equals(this.catalogName,
-                ((PlsqlProcedureKey) obj).catalogName)
+        return Objects.equals(this.name, ((PlsqlProcedureKey) obj).name) && Objects.equals(this.catalogId,
+                ((PlsqlProcedureKey) obj).catalogId)
                 && Objects.equals(this.dbId, ((PlsqlProcedureKey) obj).dbId);
     }
 
     @Override
     public String toString() {
-        return "name:" + name + ", catalogName:" + catalogName + ", dbId:" + dbId;
+        return "name:" + name + ", catalogName:" + catalogId + ", dbId:" + dbId;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlProcedureKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlProcedureKey.java
@@ -40,26 +40,26 @@ public class PlsqlProcedureKey implements Writable {
     @SerializedName(value = "catalogName")
     private String catalogName;
 
-    @SerializedName(value = "dbName")
-    private String dbName;
+    @SerializedName(value = "dbId")
+    private long dbId;
 
-    public PlsqlProcedureKey(String name, String catalogName, String dbName) {
+    public PlsqlProcedureKey(String name, String catalogName, long dbId) {
         this.name = name;
         this.catalogName = catalogName;
-        this.dbName = dbName;
+        this.dbId = dbId;
     }
 
     public TPlsqlProcedureKey toThrift() {
-        return new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName).setDbName(dbName);
+        return new TPlsqlProcedureKey().setName(name).setCatalogName(catalogName).setDbId(dbId);
     }
 
     public static PlsqlProcedureKey fromThrift(TPlsqlProcedureKey key) {
-        return new PlsqlProcedureKey(key.getName(), key.getCatalogName(), key.getDbName());
+        return new PlsqlProcedureKey(key.getName(), key.getCatalogName(), key.getDbId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, catalogName, dbName);
+        return Objects.hash(name, catalogName, dbId);
     }
 
     @Override
@@ -69,12 +69,12 @@ public class PlsqlProcedureKey implements Writable {
         }
         return Objects.equals(this.name, ((PlsqlProcedureKey) obj).name) && Objects.equals(this.catalogName,
                 ((PlsqlProcedureKey) obj).catalogName)
-                && Objects.equals(this.dbName, ((PlsqlProcedureKey) obj).dbName);
+                && Objects.equals(this.dbId, ((PlsqlProcedureKey) obj).dbId);
     }
 
     @Override
     public String toString() {
-        return "name:" + name + ", catalogName:" + catalogName + ", dbName:" + dbName;
+        return "name:" + name + ", catalogName:" + catalogName + ", dbId:" + dbId;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlStoredProcedure.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlStoredProcedure.java
@@ -36,8 +36,8 @@ public class PlsqlStoredProcedure implements Writable {
     @SerializedName(value = "name")
     private String name;
 
-    @SerializedName(value = "catalogName")
-    private String catalogName;
+    @SerializedName(value = "catalogId")
+    private long catalogId;
 
     @SerializedName(value = "dbId")
     private long dbId;
@@ -52,12 +52,12 @@ public class PlsqlStoredProcedure implements Writable {
     private String source;
 
     public TPlsqlStoredProcedure toThrift() {
-        return new TPlsqlStoredProcedure().setName(name).setCatalogName(catalogName).setDbId(dbId)
+        return new TPlsqlStoredProcedure().setName(name).setCatalogId(catalogId).setDbId(dbId)
                 .setPackageName(packageName).setOwnerName(ownerName).setSource(source);
     }
 
     public static PlsqlStoredProcedure fromThrift(TPlsqlStoredProcedure procedure) {
-        return new PlsqlStoredProcedure(procedure.getName(), procedure.getCatalogName(), procedure.getDbId(),
+        return new PlsqlStoredProcedure(procedure.getName(), procedure.getCatalogId(), procedure.getDbId(),
                 procedure.getPackageName(), procedure.getOwnerName(), procedure.source);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlStoredProcedure.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/metastore/PlsqlStoredProcedure.java
@@ -39,8 +39,11 @@ public class PlsqlStoredProcedure implements Writable {
     @SerializedName(value = "catalogName")
     private String catalogName;
 
-    @SerializedName(value = "dbName")
-    private String dbName;
+    @SerializedName(value = "dbId")
+    private long dbId;
+
+    @SerializedName(value = "packageName")
+    private String packageName;
 
     @SerializedName(value = "ownerName")
     private String ownerName;
@@ -49,13 +52,13 @@ public class PlsqlStoredProcedure implements Writable {
     private String source;
 
     public TPlsqlStoredProcedure toThrift() {
-        return new TPlsqlStoredProcedure().setName(name).setCatalogName(catalogName).setDbName(dbName)
-                .setOwnerName(ownerName).setSource(source);
+        return new TPlsqlStoredProcedure().setName(name).setCatalogName(catalogName).setDbId(dbId)
+                .setPackageName(packageName).setOwnerName(ownerName).setSource(source);
     }
 
     public static PlsqlStoredProcedure fromThrift(TPlsqlStoredProcedure procedure) {
-        return new PlsqlStoredProcedure(procedure.getName(), procedure.getCatalogName(), procedure.getDbName(),
-                procedure.getOwnerName(), procedure.source);
+        return new PlsqlStoredProcedure(procedure.getName(), procedure.getCatalogName(), procedure.getDbId(),
+                procedure.getPackageName(), procedure.getOwnerName(), procedure.source);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/packages/DorisPackageRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/packages/DorisPackageRegistry.java
@@ -78,18 +78,18 @@ public class DorisPackageRegistry implements PackageRegistry {
     }
 
     private PlsqlPackage findPackage(String name) throws TException {
-        return client.getPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getName(),
+        return client.getPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getId(),
                 ConnectContext.get().getCurrentDbId());
     }
 
     @Override
     public void dropPackage(String name) {
-        client.dropPlsqlPackage(name, ConnectContext.get().getCurrentCatalog().getName(),
+        client.dropPlsqlPackage(name, ConnectContext.get().getCurrentCatalog().getId(),
                 ConnectContext.get().getCurrentDbId());
     }
 
     private void savePackage(String name, String header, String body) {
-        client.addPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getName(),
+        client.addPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getId(),
                 ConnectContext.get().getCurrentDbId(), ConnectContext.get().getQualifiedUser(), header, body);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/packages/DorisPackageRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/packages/DorisPackageRegistry.java
@@ -79,17 +79,17 @@ public class DorisPackageRegistry implements PackageRegistry {
 
     private PlsqlPackage findPackage(String name) throws TException {
         return client.getPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getName(),
-                ConnectContext.get().getDatabase());
+                ConnectContext.get().getCurrentDbId());
     }
 
     @Override
     public void dropPackage(String name) {
         client.dropPlsqlPackage(name, ConnectContext.get().getCurrentCatalog().getName(),
-                ConnectContext.get().getDatabase());
+                ConnectContext.get().getCurrentDbId());
     }
 
     private void savePackage(String name, String header, String body) {
         client.addPlsqlPackage(name.toUpperCase(), ConnectContext.get().getCurrentCatalog().getName(),
-                ConnectContext.get().getDatabase(), ConnectContext.get().getQualifiedUser(), header, body);
+                ConnectContext.get().getCurrentDbId(), ConnectContext.get().getQualifiedUser(), header, body);
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1161,15 +1161,16 @@ struct TRestoreSnapshotResult {
 struct TPlsqlStoredProcedure {
     1: optional string name
     2: optional string catalogName
-    3: optional string dbName
-    4: optional string ownerName
-    5: optional string source
+    3: optional i64 dbId
+    4: optional string packageName
+    5: optional string ownerName
+    6: optional string source
 }
 
 struct TPlsqlPackage {
     1: optional string name
     2: optional string catalogName
-    3: optional string dbName
+    3: optional i64 dbId
     4: optional string ownerName
     5: optional string header
     6: optional string body
@@ -1178,7 +1179,7 @@ struct TPlsqlPackage {
 struct TPlsqlProcedureKey {
     1: optional string name
     2: optional string catalogName
-    3: optional string dbName
+    3: optional i64 dbId
 }
 
 struct TAddPlsqlStoredProcedureRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1160,7 +1160,7 @@ struct TRestoreSnapshotResult {
 
 struct TPlsqlStoredProcedure {
     1: optional string name
-    2: optional string catalogName
+    2: optional i64 catalogId
     3: optional i64 dbId
     4: optional string packageName
     5: optional string ownerName
@@ -1169,7 +1169,7 @@ struct TPlsqlStoredProcedure {
 
 struct TPlsqlPackage {
     1: optional string name
-    2: optional string catalogName
+    2: optional i64 catalogId
     3: optional i64 dbId
     4: optional string ownerName
     5: optional string header
@@ -1178,7 +1178,7 @@ struct TPlsqlPackage {
 
 struct TPlsqlProcedureKey {
     1: optional string name
-    2: optional string catalogName
+    2: optional i64 catalogId
     3: optional i64 dbId
 }
 


### PR DESCRIPTION
## Proposed changes

1. use dbId replace dbName, because dbName may be renamed by Alter.
2. procedure key add package name (only reserved, currently no plans to support package)
3. Optimize procedure create and exception

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

