### PR TITLE
[opt](profile) Fix print profile In query close

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -889,7 +889,6 @@ void PipelineFragmentContext::_close_fragment_instance() {
             _fragment_watcher.elapsed_time());
     static_cast<void>(send_report(true));
     if (_is_report_success) {
-        std::stringstream ss;
         // Compute the _local_time_percent before pretty_print the runtime_profile
         // Before add this operation, the print out like that:
         // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
@@ -897,11 +896,16 @@ void PipelineFragmentContext::_close_fragment_instance() {
         // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
         // We can easily know the exec node execute time without child time consumed.
         _runtime_state->runtime_profile()->compute_time_in_profile();
-        _runtime_state->runtime_profile()->pretty_print(&ss);
-        if (_runtime_state->load_channel_profile()) {
-            _runtime_state->load_channel_profile()->pretty_print(&ss);
+        if (VLOG_FILE_IS_ON) {
+            std::stringstream ss;
+            VLOG_FILE << "Reporting final, profile for instance "
+                      << _runtime_state->fragment_instance_id();
+            _runtime_state->runtime_profile()->pretty_print(&ss);
+            if (_runtime_state->load_channel_profile()) {
+                _runtime_state->load_channel_profile()->pretty_print(&ss);
+            }
+            LOG(INFO) << ss.str();
         }
-        LOG(INFO) << ss.str();
     }
     // all submitted tasks done
     _exec_env->fragment_mgr()->remove_pipeline_context(

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1256,7 +1256,6 @@ void PipelineXFragmentContext::_close_fragment_instance() {
     _runtime_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
     static_cast<void>(send_report(true));
     if (_is_report_success) {
-        std::stringstream ss;
         // Compute the _local_time_percent before pretty_print the runtime_profile
         // Before add this operation, the print out like that:
         // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
@@ -1264,11 +1263,16 @@ void PipelineXFragmentContext::_close_fragment_instance() {
         // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
         // We can easily know the exec node execute time without child time consumed.
         _runtime_state->runtime_profile()->compute_time_in_profile();
-        _runtime_state->runtime_profile()->pretty_print(&ss);
-        if (_runtime_state->load_channel_profile()) {
-            _runtime_state->load_channel_profile()->pretty_print(&ss);
+        if (VLOG_FILE_IS_ON) {
+            std::stringstream ss;
+            VLOG_FILE << "Reporting final, profile for instance "
+                      << _runtime_state->fragment_instance_id();
+            _runtime_state->runtime_profile()->pretty_print(&ss);
+            if (_runtime_state->load_channel_profile()) {
+                _runtime_state->load_channel_profile()->pretty_print(&ss);
+            }
+            LOG(INFO) << ss.str();
         }
-        LOG(INFO) << ss.str();
     }
     // all submitted tasks done
     _exec_env->fragment_mgr()->remove_pipeline_context(

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -625,7 +625,6 @@ void PlanFragmentExecutor::close() {
         }
 
         if (_is_report_success) {
-            std::stringstream ss;
             // Compute the _local_time_percent before pretty_print the runtime_profile
             // Before add this operation, the print out like that:
             // UNION_NODE (id=0):(Active: 56.720us, non-child: 00.00%)
@@ -633,12 +632,17 @@ void PlanFragmentExecutor::close() {
             // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
             // We can easily know the exec node execute time without child time consumed.
             profile()->compute_time_in_profile();
-            profile()->pretty_print(&ss);
-            if (load_channel_profile()) {
-                // load_channel_profile()->compute_time_in_profile();  // TODO load channel profile add timer
-                load_channel_profile()->pretty_print(&ss);
+            if (VLOG_FILE_IS_ON) {
+                std::stringstream ss;
+                VLOG_FILE << "Reporting final, profile for instance "
+                          << _runtime_state->fragment_instance_id();
+                profile()->pretty_print(&ss);
+                if (load_channel_profile()) {
+                    // load_channel_profile()->compute_time_in_profile();  // TODO load channel profile add timer
+                    load_channel_profile()->pretty_print(&ss);
+                }
+                LOG(INFO) << ss.str();
             }
-            LOG(INFO) << ss.str();
         }
     }
 


### PR DESCRIPTION
## Proposed changes

profile printed when query close, Its byte count is relatively high in the be.INFO log, about 20%.
this affects analysis logs and may also have a performance penalty.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

