### PR TITLE
[improvement](statistics)Improve show column stats performance. (#31298)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -179,4 +179,8 @@ public class ShowColumnStatsStmt extends ShowStmt {
     public boolean isCached() {
         return cached;
     }
+
+    public boolean isAllColumns() {
+        return columnNames == null;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -104,6 +104,11 @@ public class StatisticsRepository {
             + " ${inPredicate}"
             + " AND part_id IS NOT NULL";
 
+    private static final String FETCH_TABLE_STATISTICS = "SELECT * FROM "
+            + FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.STATISTIC_TBL_NAME
+            + " WHERE tbl_id = ${tblId}"
+            + " AND part_id IS NULL";
+
     public static ColumnStatistic queryColumnStatisticsByName(long tableId, long indexId, String colName) {
         ResultRow resultRow = queryColumnStatisticById(tableId, indexId, colName);
         if (resultRow == null) {
@@ -126,6 +131,14 @@ public class StatisticsRepository {
         return queryPartitionStatistics(dbObjects.table.getId(),
                 colName, partitionIds).stream().map(ColumnStatistic::fromResultRow).collect(
                 Collectors.toList());
+    }
+
+    public static List<ResultRow> queryColumnStatisticsForTable(long tableId)
+            throws AnalysisException {
+        Map<String, String> params = new HashMap<>();
+        params.put("tblId", String.valueOf(tableId));
+        List<ResultRow> rows = StatisticsUtil.executeQuery(FETCH_TABLE_STATISTICS, params);
+        return rows == null ? Collections.emptyList() : rows;
     }
 
     public static ResultRow queryColumnStatisticById(long tblId, long indexId, String colName) {


### PR DESCRIPTION
Use table id to query statistics table while show all columns stats for the table. Before, we were using id, which will execute one sql for each column. Now, we use table id to fetch result of all columns with one sql.

backport https://github.com/apache/doris/pull/31298

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

