### PR TITLE
[fix](doc) update array-intersect

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array-intersect.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array-intersect.md
@@ -75,7 +75,7 @@ mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_varchar;
 |    1 | ['hello', 'world', 'c++']  | ['I', 'am', 'c++']               | ['c++']                     |
 |    2 | ['a1', 'equals', 'b1']     | ['a2', 'equals', 'b2']           | ['equals']                  |
 |    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | [NULL, 'value']             |
-|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', 'value']        |
+|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', NULL, 'value']  |
 +------+----------------------------+----------------------------------+-----------------------------+
 
 mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_decimal;

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array-intersect.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array-intersect.md
@@ -74,7 +74,7 @@ mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_varchar;
 |    1 | ['hello', 'world', 'c++']  | ['I', 'am', 'c++']               | ['c++']                     |
 |    2 | ['a1', 'equals', 'b1']     | ['a2', 'equals', 'b2']           | ['equals']                  |
 |    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | [NULL, 'value']             |
-|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', 'value']        |
+|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', NULL, 'value']  |
 +------+----------------------------+----------------------------------+-----------------------------+
 
 mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_decimal;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The follow query returns null element but the doc did not include it.

```
select array_intersect(['hasnull', NULL, 'value'], ['hasnull', NULL, 'value'] )
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

