### PR TITLE
[fix](nereids)MarkJoinSlotReference should not implement SlotNotFromChildren

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * A special type of column that will be generated to replace the subquery when unnesting the subquery of MarkJoin.
  */
-public class MarkJoinSlotReference extends SlotReference implements SlotNotFromChildren {
+public class MarkJoinSlotReference extends SlotReference {
     final boolean existsHasAgg;
 
     public MarkJoinSlotReference(String name) {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

