### PR TITLE
[improvement](statistics) Remove useless async loader code. (#31380)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
@@ -18,7 +18,6 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.qe.InternalQueryExecutionException;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -27,18 +26,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.DiscardOldestPolicy;
 
 public class ColumnStatisticsCacheLoader extends StatisticsCacheLoader<Optional<ColumnStatistic>> {
 
     private static final Logger LOG = LogManager.getLogger(ColumnStatisticsCacheLoader.class);
-
-    private static final ThreadPoolExecutor singleThreadPool = ThreadPoolManager.newDaemonFixedThreadPool(
-            StatisticConstants.RETRY_LOAD_THREAD_POOL_SIZE,
-            StatisticConstants.RETRY_LOAD_QUEUE_SIZE, "STATS_RELOAD",
-            true,
-            new DiscardOldestPolicy());
 
     @Override
     protected Optional<ColumnStatistic> doLoad(StatisticsCacheKey key) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class StatisticsCache {
 
@@ -74,21 +73,6 @@ public class StatisticsCache {
                     .refreshAfterWrite(Duration.ofHours(StatisticConstants.STATISTICS_CACHE_REFRESH_INTERVAL))
                     .executor(threadPool)
                     .buildAsync(histogramCacheLoader);
-
-    {
-        threadPool.submit(() -> {
-            while (true) {
-                try {
-                    columnStatisticsCacheLoader.removeExpiredInProgressing();
-                    histogramCacheLoader.removeExpiredInProgressing();
-                } catch (Throwable t) {
-                    // IGNORE
-                }
-                Thread.sleep(TimeUnit.MINUTES.toMillis(15));
-            }
-
-        });
-    }
 
     public ColumnStatistic getColumnStatistics(long catalogId, long dbId, long tblId, long idxId, String colName) {
         ConnectContext ctx = ConnectContext.get();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
@@ -22,77 +22,28 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 
 public abstract class StatisticsCacheLoader<V> implements AsyncCacheLoader<StatisticsCacheKey, V> {
 
     private static final Logger LOG = LogManager.getLogger(StatisticsCacheLoader.class);
 
-    private final Map<StatisticsCacheKey, CompletableFutureWithCreateTime<V>> inProgressing = new HashMap<>();
-
     @Override
     public @NonNull CompletableFuture<V> asyncLoad(
             @NonNull StatisticsCacheKey key,
             @NonNull Executor executor) {
-        CompletableFutureWithCreateTime<V> cfWrapper = inProgressing.get(key);
-        if (cfWrapper != null) {
-            return cfWrapper.cf;
-        }
         CompletableFuture<V> future = CompletableFuture.supplyAsync(() -> {
             long startTime = System.currentTimeMillis();
             try {
                 return doLoad(key);
             } finally {
                 long endTime = System.currentTimeMillis();
-                LOG.info("Query BE for column stats:{}-{} end time:{} cost time:{}", key.tableId, key.colName,
-                        endTime, endTime - startTime);
-                removeFromIProgressing(key);
+                LOG.info("Load statistic cache [{}] cost time ms:{}", key, endTime - startTime);
             }
         }, executor);
-        putIntoIProgressing(key,
-                new CompletableFutureWithCreateTime<V>(System.currentTimeMillis(), future));
         return future;
     }
 
     protected abstract V doLoad(StatisticsCacheKey k);
-
-    private static class CompletableFutureWithCreateTime<V> extends CompletableFuture<V> {
-
-        public final long startTime;
-        public final CompletableFuture<V> cf;
-        private final long expiredTimeMilli = TimeUnit.MINUTES.toMillis(30);
-
-        public CompletableFutureWithCreateTime(long startTime, CompletableFuture<V> cf) {
-            this.startTime = startTime;
-            this.cf = cf;
-        }
-
-        public boolean isExpired() {
-            return System.currentTimeMillis() - startTime > expiredTimeMilli;
-        }
-    }
-
-    private void putIntoIProgressing(StatisticsCacheKey k, CompletableFutureWithCreateTime<V> v) {
-        synchronized (inProgressing) {
-            inProgressing.put(k, v);
-        }
-    }
-
-    private void removeFromIProgressing(StatisticsCacheKey k) {
-        synchronized (inProgressing) {
-            inProgressing.remove(k);
-        }
-    }
-
-    public void removeExpiredInProgressing() {
-        // Quite simple logic that would complete very fast.
-        // Lock on object to avoid ConcurrentModificationException.
-        synchronized (inProgressing) {
-            inProgressing.entrySet().removeIf(e -> e.getValue().isExpired());
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -289,7 +289,7 @@ public class CacheTest extends TestWithFeService {
                 Assertions.assertEquals(6, columnStatistic.minValue);
                 Assertions.assertEquals(7, columnStatistic.maxValue);
             } else {
-                System.out.println("Cached is not loaded, skip test.");
+                System.out.println("Cache is not loaded, skip test.");
             }
         } catch (Throwable t) {
             t.printStackTrace();


### PR DESCRIPTION
Google caffeine asyncLoad implementation has the logic to avoid repeat call of loading function. Remove the useless code.

backport https://github.com/apache/doris/pull/31380

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

