### PR TITLE
[fix] Fix the incorrect class name in the getLogger method call of MysqlTable.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MysqlTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MysqlTable.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MysqlTable extends Table {
-    private static final Logger LOG = LogManager.getLogger(OlapTable.class);
+    private static final Logger LOG = LogManager.getLogger(MysqlTable.class);
 
     private static final String ODBC_CATALOG_RESOURCE = "odbc_catalog_resource";
     private static final String MYSQL_HOST = "host";


### PR DESCRIPTION
Fix the incorrect class name in the getLogger method call of MysqlTable.