### PR TITLE
[fix](paimon) fix hadoop.username does not take effect in paimon catalog

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
@@ -17,7 +17,12 @@
 
 package org.apache.doris.hudi;
 
+import org.apache.doris.common.security.authentication.AuthenticationConfig;
+import org.apache.doris.common.security.authentication.HadoopUGI;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import sun.management.VMManagement;
 
 import java.io.BufferedReader;
@@ -32,7 +37,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class Utils {
-
     public static long getCurrentProcId() {
         try {
             RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
@@ -78,5 +82,10 @@ public class Utils {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't kill process PID " + pid, e);
         }
+    }
+
+    public static HoodieTableMetaClient getMetaClient(Configuration conf, String basePath) {
+        return HadoopUGI.ugiDoAs(AuthenticationConfig.getKerberosConfig(conf), () -> HoodieTableMetaClient.builder()
+                .setConf(conf).setBasePath(basePath).build());
     }
 }

--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
@@ -17,13 +17,7 @@
 
 package org.apache.doris.hudi;
 
-import org.apache.doris.common.security.authentication.AuthenticationConfig;
-import org.apache.doris.common.security.authentication.HadoopUGI;
-
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import sun.management.VMManagement;
 
 import java.io.BufferedReader;
@@ -34,7 +28,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.security.PrivilegedExceptionAction;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -85,25 +78,5 @@ public class Utils {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't kill process PID " + pid, e);
         }
-    }
-
-    public static HoodieTableMetaClient getMetaClient(Configuration conf, String basePath) {
-        UserGroupInformation ugi = HadoopUGI.loginWithUGI(AuthenticationConfig.getKerberosConfig(conf));
-        HoodieTableMetaClient metaClient;
-        if (ugi != null) {
-            try {
-                ugi.checkTGTAndReloginFromKeytab();
-                metaClient = ugi.doAs(
-                        (PrivilegedExceptionAction<HoodieTableMetaClient>) () -> HoodieTableMetaClient.builder()
-                                .setConf(conf).setBasePath(basePath).build());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            } catch (InterruptedException e) {
-                throw new RuntimeException("Cannot get hudi client.", e);
-            }
-        } else {
-            metaClient = HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
-        }
-        return metaClient;
     }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
@@ -32,6 +32,7 @@ public abstract class AuthenticationConfig {
      * @return true if the config is valid, otherwise false.
      */
     public abstract boolean isValid();
+
     /**
      * get kerberos config from hadoop conf
      * @param conf config

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
@@ -17,12 +17,9 @@
 
 package org.apache.doris.common.security.authentication;
 
-import lombok.Data;
 import org.apache.hadoop.conf.Configuration;
 
-@Data
 public abstract class AuthenticationConfig {
-
     public static String HADOOP_USER_NAME = "hadoop.username";
     public static String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
     public static String HADOOP_KERBEROS_PRINCIPAL = "hadoop.kerberos.principal";
@@ -31,8 +28,10 @@ public abstract class AuthenticationConfig {
     public static String HIVE_KERBEROS_PRINCIPAL = "hive.metastore.kerberos.principal";
     public static String HIVE_KERBEROS_KEYTAB = "hive.metastore.kerberos.keytab.file";
 
-    private boolean isValid;
-
+    /**
+     * @return true if the config is valid, otherwise false.
+     */
+    public abstract boolean isValid();
     /**
      * get kerberos config from hadoop conf
      * @param conf config

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -18,6 +18,8 @@
 package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.security.authentication.AuthenticationConfig;
+import org.apache.doris.common.security.authentication.HadoopUGI;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.SessionContext;
@@ -25,12 +27,15 @@ import org.apache.doris.datasource.property.constants.PaimonProperties;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.FileSystemCatalog;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.options.Options;
 
 import java.util.ArrayList;
@@ -44,6 +49,7 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     public static final String PAIMON_HMS = "hms";
     protected String catalogType;
     protected Catalog catalog;
+    protected AuthenticationConfig authConf;
 
     private static final List<String> REQUIRED_PROPERTIES = ImmutableList.of(
             PaimonProperties.WAREHOUSE
@@ -54,13 +60,20 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    protected void init() {
-        super.init();
-    }
-
-    public Catalog getCatalog() {
-        makeSureInitialized();
-        return catalog;
+    protected void initLocalObjectsImpl() {
+        Configuration conf = new Configuration();
+        for (Map.Entry<String, String> propEntry : this.catalogProperty.getHadoopProperties().entrySet()) {
+            conf.set(propEntry.getKey(), propEntry.getValue());
+        }
+        if (catalog instanceof FileSystemCatalog) {
+            authConf = AuthenticationConfig.getKerberosConfig(conf,
+                    AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL,
+                    AuthenticationConfig.HADOOP_KERBEROS_KEYTAB);
+        } else if (catalog instanceof HiveCatalog) {
+            authConf = AuthenticationConfig.getKerberosConfig(conf,
+                    AuthenticationConfig.HIVE_KERBEROS_PRINCIPAL,
+                    AuthenticationConfig.HIVE_KERBEROS_KEYTAB);
+        }
     }
 
     public String getCatalogType() {
@@ -69,36 +82,40 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     }
 
     protected List<String> listDatabaseNames() {
-        return new ArrayList<>(catalog.listDatabases());
+        return HadoopUGI.ugiDoAs(authConf, () -> new ArrayList<>(catalog.listDatabases()));
     }
 
     @Override
     public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
         makeSureInitialized();
-        return catalog.tableExists(Identifier.create(dbName, tblName));
+        return HadoopUGI.ugiDoAs(authConf, () -> catalog.tableExists(Identifier.create(dbName, tblName)));
     }
 
     @Override
     public List<String> listTableNames(SessionContext ctx, String dbName) {
         makeSureInitialized();
-        List<String> tableNames = null;
-        try {
-            tableNames = catalog.listTables(dbName);
-        } catch (Catalog.DatabaseNotExistException e) {
-            LOG.warn("DatabaseNotExistException", e);
-        }
-        return tableNames;
+        return HadoopUGI.ugiDoAs(authConf, () -> {
+            List<String> tableNames = null;
+            try {
+                tableNames = catalog.listTables(dbName);
+            } catch (Catalog.DatabaseNotExistException e) {
+                LOG.warn("DatabaseNotExistException", e);
+            }
+            return tableNames;
+        });
     }
 
     public org.apache.paimon.table.Table getPaimonTable(String dbName, String tblName) {
         makeSureInitialized();
-        org.apache.paimon.table.Table table = null;
-        try {
-            table = catalog.getTable(Identifier.create(dbName, tblName));
-        } catch (Catalog.TableNotExistException e) {
-            LOG.warn("TableNotExistException", e);
-        }
-        return table;
+        return HadoopUGI.ugiDoAs(authConf, () -> {
+            org.apache.paimon.table.Table table = null;
+            try {
+                table = catalog.getTable(Identifier.create(dbName, tblName));
+            } catch (Catalog.TableNotExistException e) {
+                LOG.warn("TableNotExistException", e);
+            }
+            return table;
+        });
     }
 
     protected String getPaimonCatalogType(String catalogType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
@@ -42,6 +42,7 @@ public class PaimonFileExternalCatalog extends PaimonExternalCatalog {
     protected void initLocalObjectsImpl() {
         catalogType = PAIMON_FILESYSTEM;
         catalog = createCatalog();
+        super.initLocalObjectsImpl();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -474,8 +474,8 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
 
         if (getTFileType() == TFileType.FILE_HDFS) {
             THdfsParams tHdfsParams = HdfsResource.generateHdfsParam(locationProperties);
-            String fsNmae = getLocationProperties().get(HdfsResource.HADOOP_FS_NAME);
-            tHdfsParams.setFsName(fsNmae);
+            String fsName = getLocationProperties().get(HdfsResource.HADOOP_FS_NAME);
+            tHdfsParams.setFsName(fsName);
             fileScanRangeParams.setHdfsParams(tHdfsParams);
         }
 


### PR DESCRIPTION
## Proposed changes

Follow up #30844.
1. Extract some redundant code about UGI.
2. Fix bug that when creating filesystem based paimon catalog, the `hadoop.username` does not take effect.

error like:
```
Caused by: java.lang.RuntimeException: org.apache.hadoop.ipc.RemoteException(org.apache.ranger.authorization.hadoop.exceptions.RangerAccessControlException): Permission denied: user=xxx, access=READ_EXECUTE, inode="/user/xxx/paimon"
        at org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer$RangerAccessControlEnforcer.checkPermission(RangerHdfsAuthorizer.java:466)
        at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkPermission(FSPermissionChecker.java:193)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1896)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1880)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPathAccess(FSDirectory.java:1830)
        at org.apache.hadoop.hdfs.server.namenode.FSDirStatAndListingOp.getListingInt(FSDirStatAndListingOp.java:78)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getListing(FSNamesystem.java:3890)
        at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getListing(NameNodeRpcServer.java:1150)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getListing(ClientNamenodeProtocolServerSideTranslatorPB.java:740)
        at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:528)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1086)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1029)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:957)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1762)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2957)

        at org.apache.paimon.catalog.FileSystemCatalog.uncheck(FileSystemCatalog.java:145) ~[paimon-core-0.6.0-incubating.jar:0.6.0-incubating]
        at org.apache.paimon.catalog.FileSystemCatalog.listDatabases(FileSystemCatalog.java:60) ~[paimon-core-0.6.0-incubating.jar:0.6.0-incubating]
        at org.apache.doris.datasource.paimon.PaimonExternalCatalog.lambda$listDatabaseNames$0(PaimonExternalCatalog.java:85) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_341]
        at javax.security.auth.Subject.doAs(Subject.java:422) ~[?:1.8.0_341]
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.doris.common.security.authentication.HadoopUGI.ugiDoAs(HadoopUGI.java:109) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
        ... 19 more
Caused by: org.apache.hadoop.ipc.RemoteException: Permission denied: user=xxx, access=READ_EXECUTE, inode="/user/xxx/paimon"
        at org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer$RangerAccessControlEnforcer.checkPermission(RangerHdfsAuthorizer.java:466)
        at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkPermission(FSPermissionChecker.java:193)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1896)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1880)
        at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPathAccess(FSDirectory.java:1830)
        at org.apache.hadoop.hdfs.server.namenode.FSDirStatAndListingOp.getListingInt(FSDirStatAndListingOp.java:78)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getListing(FSNamesystem.java:3890)
        at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getListing(NameNodeRpcServer.java:1150)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getListing(ClientNamenodeProtocolServerSideTranslatorPB.java:740)
        at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:528)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1086)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1029)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:957)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1762)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2957)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

