### PR TITLE
[Opt](exec) enable top opt in string, float, double type

### DIFF
--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -75,6 +75,8 @@ Status RuntimePredicate::init(const PrimitiveType type, const bool nulls_first) 
         _get_value_fn = get_double_value;
         break;
     }
+    case PrimitiveType::TYPE_CHAR:
+    case PrimitiveType::TYPE_VARCHAR:
     case PrimitiveType::TYPE_STRING: {
         _get_value_fn = get_string_value;
         break;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
@@ -127,8 +127,7 @@ public class TopNScanOpt extends PlanPostProcessor {
         if (!firstKey.isColumnFromTable()) {
             return topN;
         }
-        if (firstKey.getDataType().isStringLikeType()
-                || firstKey.getDataType().isFloatType()
+        if (firstKey.getDataType().isFloatType()
                 || firstKey.getDataType().isDoubleType()) {
             return topN;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -543,8 +543,7 @@ public class OriginalPlanner extends Planner {
                     && sortNode.getLimit() <= ConnectContext.get().getSessionVariable().topnOptLimitThreshold
                     && sortNode.getSortInfo().getOrigOrderingExprs().size() > 0) {
                 Expr firstSortExpr = sortNode.getSortInfo().getOrigOrderingExprs().get(0);
-                if (firstSortExpr instanceof SlotRef && !firstSortExpr.getType().isStringType()
-                        && !firstSortExpr.getType().isFloatingPointType()) {
+                if (firstSortExpr instanceof SlotRef && !firstSortExpr.getType().isFloatingPointType()) {
                     OlapScanNode scanNode = (OlapScanNode) child;
                     if (scanNode.isDupKeysOrMergeOnWrite()) {
                         sortNode.setUseTopnOpt(true);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopNRuntimeFilterTest.java
@@ -49,21 +49,6 @@ public class TopNRuntimeFilterTest extends SSBTestBase {
         Assertions.assertTrue(localTopN.getPhysicalTopN().isEnableRuntimeFilter());
     }
 
-    // topn rf do not apply on string-like and float column
-    @Test
-    public void testNotUseTopNRf() {
-        String sql = "select * from customer order by c_name limit 5";
-        PlanChecker checker = PlanChecker.from(connectContext).analyze(sql)
-                .rewrite()
-                .implement();
-        PhysicalPlan plan = checker.getPhysicalPlan();
-        plan = new PlanPostProcessors(checker.getCascadesContext()).process(plan);
-        Assertions.assertInstanceOf(PhysicalDeferMaterializeTopN.class, plan.children().get(0).child(0));
-        PhysicalDeferMaterializeTopN<? extends Plan> localTopN
-                = (PhysicalDeferMaterializeTopN<? extends Plan>) plan.child(0).child(0);
-        Assertions.assertFalse(localTopN.getPhysicalTopN().isEnableRuntimeFilter());
-    }
-
     @Test
     public void testNotUseTopNRfForComplexCase() {
         String sql = "select * from (select 1) tl join (select * from customer order by c_custkey limit 5) tb";


### PR DESCRIPTION
## Proposed changes

before：
```
select l_shipinstruct from lineitem order by l_shipinstruct limit 100;

14s
```

after:
```
select l_shipinstruct from lineitem order by l_shipinstruct limit 100;

2.2s
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

