### PR TITLE
[fix](HDFS) Create hdfs fs with it's resource id to prevent data loss for cold heat separation

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1252,7 +1252,8 @@ void push_storage_policy_callback(StorageEngine& engine, const TAgentTaskRequest
             Status st;
             std::shared_ptr<io::HdfsFileSystem> fs;
             if (existed_resource.fs == nullptr) {
-                st = io::HdfsFileSystem::create(resource.hdfs_storage_param, "", nullptr, &fs);
+                st = io::HdfsFileSystem::create(resource.hdfs_storage_param,
+                                                std::to_string(resource.id), "", nullptr, &fs);
             } else {
                 fs = std::static_pointer_cast<io::HdfsFileSystem>(existed_resource.fs);
             }

--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -93,7 +93,8 @@ Status FileFactory::create_file_writer(TFileType::type type, ExecEnv* env,
     case TFileType::FILE_HDFS: {
         THdfsParams hdfs_params = parse_properties(properties);
         std::shared_ptr<io::HdfsFileSystem> fs;
-        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &fs));
+        RETURN_IF_ERROR(
+                io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr, &fs));
         RETURN_IF_ERROR(fs->create_file(path, &file_writer));
         break;
     }
@@ -188,7 +189,7 @@ Status FileFactory::create_hdfs_reader(const THdfsParams& hdfs_params,
                                        std::shared_ptr<io::FileSystem>* hdfs_file_system,
                                        io::FileReaderSPtr* reader, RuntimeProfile* profile) {
     std::shared_ptr<io::HdfsFileSystem> fs;
-    RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, fd.fs_name, profile, &fs));
+    RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, "", fd.fs_name, profile, &fs));
     RETURN_IF_ERROR(fs->open_file(fd.path, reader, &reader_options));
     *hdfs_file_system = std::move(fs);
     return Status::OK();

--- a/be/src/io/fs/benchmark/hdfs_benchmark.hpp
+++ b/be/src/io/fs/benchmark/hdfs_benchmark.hpp
@@ -95,7 +95,8 @@ public:
         std::shared_ptr<io::HdfsFileSystem> fs;
         io::FileWriterPtr writer;
         THdfsParams hdfs_params = parse_properties(_conf_map);
-        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &fs));
+        RETURN_IF_ERROR(
+                io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr, &fs));
         RETURN_IF_ERROR(fs->create_file(file_path, &writer));
         return write(state, writer.get());
     }
@@ -116,7 +117,8 @@ public:
         auto new_file_path = file_path + "_new";
         THdfsParams hdfs_params = parse_properties(_conf_map);
         std::shared_ptr<io::HdfsFileSystem> fs;
-        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &fs));
+        RETURN_IF_ERROR(
+                io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr, &fs));
 
         auto start = std::chrono::high_resolution_clock::now();
         RETURN_IF_ERROR(fs->rename(file_path, new_file_path));
@@ -143,7 +145,8 @@ public:
 
         std::shared_ptr<io::HdfsFileSystem> fs;
         THdfsParams hdfs_params = parse_properties(_conf_map);
-        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &fs));
+        RETURN_IF_ERROR(
+                io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr, &fs));
 
         auto start = std::chrono::high_resolution_clock::now();
         bool res = false;

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -121,8 +121,9 @@ Status HdfsFileHandleCache::get_file(const std::shared_ptr<HdfsFileSystem>& fs, 
     return Status::OK();
 }
 
-Status HdfsFileSystem::create(const THdfsParams& hdfs_params, const std::string& fs_name,
-                              RuntimeProfile* profile, std::shared_ptr<HdfsFileSystem>* fs) {
+Status HdfsFileSystem::create(const THdfsParams& hdfs_params, std::string id,
+                              const std::string& fs_name, RuntimeProfile* profile,
+                              std::shared_ptr<HdfsFileSystem>* fs) {
 #ifdef USE_HADOOP_HDFS
     if (!config::enable_java_support) {
         return Status::InternalError(
@@ -130,13 +131,13 @@ Status HdfsFileSystem::create(const THdfsParams& hdfs_params, const std::string&
                 "true.");
     }
 #endif
-    (*fs).reset(new HdfsFileSystem(hdfs_params, fs_name, profile));
+    (*fs).reset(new HdfsFileSystem(hdfs_params, std::move(id), fs_name, profile));
     return (*fs)->connect();
 }
 
-HdfsFileSystem::HdfsFileSystem(const THdfsParams& hdfs_params, const std::string& fs_name,
-                               RuntimeProfile* profile)
-        : RemoteFileSystem("", "", FileSystemType::HDFS),
+HdfsFileSystem::HdfsFileSystem(const THdfsParams& hdfs_params, std::string id,
+                               const std::string& fs_name, RuntimeProfile* profile)
+        : RemoteFileSystem("", std::move(id), FileSystemType::HDFS),
           _hdfs_params(hdfs_params),
           _fs_handle(nullptr),
           _profile(profile) {

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -104,7 +104,7 @@ private:
 class HdfsFileHandleCache;
 class HdfsFileSystem final : public RemoteFileSystem {
 public:
-    static Status create(const THdfsParams& hdfs_params, const std::string& path,
+    static Status create(const THdfsParams& hdfs_params, std::string id, const std::string& path,
                          RuntimeProfile* profile, std::shared_ptr<HdfsFileSystem>* fs);
 
     ~HdfsFileSystem() override;
@@ -139,7 +139,7 @@ private:
 
 private:
     friend class HdfsFileWriter;
-    HdfsFileSystem(const THdfsParams& hdfs_params, const std::string& path,
+    HdfsFileSystem(const THdfsParams& hdfs_params, std::string id, const std::string& path,
                    RuntimeProfile* profile);
     const THdfsParams& _hdfs_params;
     std::string _fs_name;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -108,7 +108,8 @@ Status SnapshotLoader::init(TStorageBackendType::type type, const std::string& l
     } else if (TStorageBackendType::type::HDFS == type) {
         THdfsParams hdfs_params = parse_properties(_prop);
         std::shared_ptr<io::HdfsFileSystem> fs;
-        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &fs));
+        RETURN_IF_ERROR(
+                io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr, &fs));
         _remote_fs = std::move(fs);
     } else if (TStorageBackendType::type::BROKER == type) {
         std::shared_ptr<io::BrokerFileSystem> fs;

--- a/be/src/vec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/vec/sink/writer/vfile_result_writer.cpp
@@ -398,8 +398,8 @@ Status VFileResultWriter::_delete_dir() {
     case TStorageBackendType::HDFS: {
         THdfsParams hdfs_params = parse_properties(_file_opts->broker_properties);
         std::shared_ptr<io::HdfsFileSystem> hdfs_fs = nullptr;
-        RETURN_IF_ERROR(
-                io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, nullptr, &hdfs_fs));
+        RETURN_IF_ERROR(io::HdfsFileSystem::create(hdfs_params, "", hdfs_params.fs_name, nullptr,
+                                                   &hdfs_fs));
         file_system = hdfs_fs;
         break;
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The resource and it's corresponding file system is stored in one map<resource_id, std::shared_ptr<FS>>. Unfortunately, the former implementation for `HDFSFileSystem::Create` would ignore the resource id and the pass one empty string as a new resource id which would make different resource share one same resource id, resulting losing all the resources file system information.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

