### PR TITLE
[fix](nereids) forbid create table with illegal auto partition expr

### DIFF
--- a/regression-test/suites/partition_p0/auto_partition/test_auto_list_partition.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_list_partition.groovy
@@ -287,10 +287,6 @@ suite("test_auto_list_partition") {
     """
     sql """ insert into stream_load_list_test_table_string_key values (1,"20"), (2," ");"""
     sql """ insert into stream_load_list_test_table_string_key values (3,"!"), (4,"! ");"""
-    test {
-        sql """ insert into stream_load_list_test_table_string_key values (5,"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA")"""
-        exception "Partition name's length is over limit of 50."
-    }
     result12 = sql "show partitions from stream_load_list_test_table_string_key"
     logger.info("${result12}")
     assertEquals(result12.size(), 4)

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -344,6 +344,7 @@ suite("test_auto_partition_behavior") {
     }
 
     sql "set experimental_enable_nereids_planner=true;"
+    sql "set enable_fallback_to_original_planner=false;"
     test{
         sql """
             create table illegal(
@@ -351,6 +352,21 @@ suite("test_auto_partition_behavior") {
                 k1 datetime(6) NOT null
             )
             auto partition by range date_trunc(k0, k1, 'hour')
+            (
+            )
+            DISTRIBUTED BY HASH(`k0`) BUCKETS 2
+            properties("replication_num" = "1");
+        """
+        exception "partition expr date_trunc is illegal!"
+    }
+    // test displacement of partition function
+    test{
+        sql """
+            create table illegal(
+                k0 datetime(6) NOT null,
+                k1 int NOT null
+            )
+            auto partition by range date_trunc(k1, 'hour')
             (
             )
             DISTRIBUTED BY HASH(`k0`) BUCKETS 2

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -256,8 +256,8 @@ suite("test_auto_partition_behavior") {
     }
 
     // PROHIBIT different timeunit of interval when use both auto & dynamic partition
+    sql "set experimental_enable_nereids_planner=true;"
     test{
-        sql "set experimental_enable_nereids_planner=true;"
         sql """
             CREATE TABLE tbl3
             (
@@ -280,8 +280,9 @@ suite("test_auto_partition_behavior") {
         """
         exception "If support auto partition and dynamic partition at same time, they must have the same interval unit."
     }
+
+    sql "set experimental_enable_nereids_planner=false;"
     test{
-        sql "set experimental_enable_nereids_planner=false;"
         sql """
             CREATE TABLE tbl3
             (
@@ -323,5 +324,38 @@ suite("test_auto_partition_behavior") {
         sql """insert into `long_value` values ("jwklefjklwehrnkjlwbfjkwhefkjhwjkefhkjwehfkjwehfkjwehfkjbvkwebconqkcqnocdmowqmosqmojwnqknrviuwbnclkmwkj");"""
 
         exception "Partition name's length is over limit of 50."
+    }
+
+    // illegal partiton definetion
+    sql "set experimental_enable_nereids_planner=false;"
+    test{
+        sql """
+            create table illegal(
+                k0 datetime(6) NOT null,
+                k1 datetime(6) NOT null
+            )
+            auto partition by range date_trunc(k0, k1, 'hour')
+            (
+            )
+            DISTRIBUTED BY HASH(`k0`) BUCKETS 2
+            properties("replication_num" = "1");
+        """
+        exception "auto create partition only support one slotRef in function expr"
+    }
+
+    sql "set experimental_enable_nereids_planner=true;"
+    test{
+        sql """
+            create table illegal(
+                k0 datetime(6) NOT null,
+                k1 datetime(6) NOT null
+            )
+            auto partition by range date_trunc(k0, k1, 'hour')
+            (
+            )
+            DISTRIBUTED BY HASH(`k0`) BUCKETS 2
+            properties("replication_num" = "1");
+        """
+        exception "partition expr date_trunc is illegal!"
     }
 }

--- a/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
+++ b/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
@@ -74,7 +74,6 @@ suite("multi_thread_load", "p1,nonConcurrent") { // stress case should use resou
             def sout = new StringBuilder(), serr = new StringBuilder()
             proc.consumeProcessOutput(sout, serr)
             proc.waitForOrKill(7200000)
-            // logger.info("std out: " + sout + "std err: " + serr)
         }
     }
 
@@ -152,10 +151,6 @@ suite("multi_thread_load", "p1,nonConcurrent") { // stress case should use resou
         proc.waitForOrKill(600000) // 10 minutes
     }
 
-    // for (int i = 0; i < data_count; i++) {
-    //     logger.info("try to run " + i + " : " + cm_list[i])
-    //     load_threads.add(Thread.startDaemon{concurrent_load(cm_list[i])})
-    // }
     load_threads.add(Thread.startDaemon{concurrent_load(cm_list[0])})
     load_threads.add(Thread.startDaemon{concurrent_load(cm_list[1])})
     load_threads.add(Thread.startDaemon{concurrent_load(cm_list[2])})

--- a/regression-test/suites/partition_p2/auto_partition/high_concur_load/stress_test_high_concurrency_load.groovy
+++ b/regression-test/suites/partition_p2/auto_partition/high_concur_load/stress_test_high_concurrency_load.groovy
@@ -179,12 +179,12 @@ suite("stress_test_high_concurrency_load") {
     }
 
     def row_count_range = sql """select count(*) from ${tb_name2};"""
-    assertTrue(cur_rows * data_count == row_count_range[0][0])
+    assertTrue(cur_rows * data_count == row_count_range[0][0], "${cur_rows * data_count}, ${row_count_range[0][0]}")
     def partition_res_range = sql """show partitions from ${tb_name2} order by PartitionName;"""
     for (int i = 0; i < partition_res_range.size(); i++) {
         for (int j = i+1; j < partition_res_range.size(); j++) {
             if (partition_res_range[i][6] == partition_res_range[j][6]) {
-                assertTrue(false)
+                assertTrue(false, "$i, $j")
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
```
mysql> create table illegal(
    -> k0 datetime(6) NOT null,
    -> k1 datetime(6) NOT null
    -> )
    -> auto partition by range date_trunc(k0, k1, 'hour')
    -> (
    -> )
    -> DISTRIBUTED BY HASH(`k0`) BUCKETS 2
    -> properties("replication_num" = "1");
Query OK, 0 rows affected (0.15 sec)
```

now:
```
mysql> create table illegal( k0 datetime(6) NOT null, k1 datetime(6) NOT null ) auto partition by range date_trunc(k0, k1, 'hour') ( ) DISTRIBUTED BY HASH(`k0`) BUCKETS 2 properties("replication_num" = "1");
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = partition expr date_trunc is illegal!
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

