### PR TITLE
[fix](regression test)Make index compaction cases nonCouncurrent

### DIFF
--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_dup_keys.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_dup_keys.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_index_compaction_dup_keys", "p0") {
+suite("test_index_compaction_dup_keys", "nonConcurrent") {
     def tableName = "test_index_compaction_dup_keys"
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_null.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_null.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_index_compaction_null", "p0") {
+suite("test_index_compaction_null", "nonConcurrent") {
     def tableName = "test_index_compaction_null_dups"
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_unique_keys.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_unique_keys.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_index_compaction_unique_keys", "p0") {
+suite("test_index_compaction_unique_keys", "nonConcurrent") {
     def tableName = "test_index_compaction_unique_keys"
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]


### PR DESCRIPTION
## Proposed changes

Index compaction cases will change be config `inverted_index_compaction_enabled` during test. 
When they run concurrently, they will affect each other.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

