### PR TITLE
[feature](Cloud) Support create storage vault stmt

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -675,7 +675,8 @@ terminal String
     KW_EXECUTE,
     KW_LINES,
     KW_IGNORE,
-    KW_CONVERT_LSC;
+    KW_CONVERT_LSC,
+    KW_VAULT;
 
 terminal COMMA, COLON, DOT, DOTDOTDOT, AT, STAR, LPAREN, RPAREN, SEMICOLON, LBRACKET, RBRACKET, LBRACE, RBRACE, DIVIDE, MOD, ADD, SUBTRACT, PLACEHOLDER, ARROW;
 terminal BITAND, BITOR, BITXOR, BITNOT;
@@ -1914,6 +1915,11 @@ create_stmt ::=
     | KW_CREATE KW_RESOURCE opt_if_not_exists:ifNotExists ident_or_text:resourceName opt_properties:properties
     {:
         RESULT = new CreateResourceStmt(false, ifNotExists, resourceName, properties);
+    :}
+    /* storage vault */
+    | KW_CREATE KW_STORAGE KW_VAULT opt_if_not_exists:ifNotExists ident_or_text:storageVaultName opt_properties:properties
+    {:
+        RESULT = new CreateStorageVaultStmt(ifNotExists, storageVaultName, properties);
     :}
     /* workload group*/
     | KW_CREATE KW_WORKLOAD KW_GROUP opt_if_not_exists:ifNotExists ident_or_text:workloadGroupName opt_properties:properties

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeNameFormat;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+
+import java.util.Map;
+
+// CREATE STORAGE VAULT vault_name
+// PROPERTIES (key1 = value1, ...)
+public class CreateStorageVaultStmt extends DdlStmt {
+    private static final String TYPE = "type";
+
+    private final boolean ifNotExists;
+    private final String vaultName;
+    private final Map<String, String> properties;
+    private VaultType vaultType;
+
+    public CreateResourceStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
+        this.ifNotExists = ifNotExists;
+        this.vaultName = vaultName;
+        this.properties = properties;
+        this.vaultType = vaultType.UNKNOWN;
+    }
+
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    public String getVaultName() {
+        return vaultName;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public VaultType getVaultType() {
+        return vaultType;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws UserException {
+        super.analyze(analyzer);
+
+        // check auth
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
+        }
+
+        // check name
+        FeNameFormat.checkStorageVaultName(resourceName);
+
+        // check type in properties
+        if (properties == null || properties.isEmpty()) {
+            throw new AnalysisException("Storage Vault properties can't be null");
+        }
+        String type = properties.get(TYPE);
+        if (type == null) {
+            throw new AnalysisException("Storage Vault type can't be null");
+        }
+        resourceType = ResourceType.fromString(type);
+        if (resourceType == ResourceType.UNKNOWN) {
+            throw new AnalysisException("Unsupported Storage Vault type: " + type);
+        }
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE ");
+        sb.append("STORAGE VAULT '").append(vaultName).append("' ");
+        sb.append("PROPERTIES(").append(new PrintableMap<>(properties, " = ", true, false, true)).append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -18,8 +18,8 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.StorageVault;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -38,9 +38,9 @@ public class CreateStorageVaultStmt extends DdlStmt {
     private final boolean ifNotExists;
     private final String vaultName;
     private final Map<String, String> properties;
-    private VaultType vaultType;
+    private StorageVault.StorageVaultType vaultType;
 
-    public CreateResourceStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
+    public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.vaultName = vaultName;
         this.properties = properties;
@@ -51,7 +51,7 @@ public class CreateStorageVaultStmt extends DdlStmt {
         return ifNotExists;
     }
 
-    public String getVaultName() {
+    public String getStorageVaultName() {
         return vaultName;
     }
 
@@ -59,7 +59,7 @@ public class CreateStorageVaultStmt extends DdlStmt {
         return properties;
     }
 
-    public VaultType getVaultType() {
+    public StorageVault.StorageVaultType getStorageVaultType() {
         return vaultType;
     }
 
@@ -73,7 +73,7 @@ public class CreateStorageVaultStmt extends DdlStmt {
         }
 
         // check name
-        FeNameFormat.checkStorageVaultName(resourceName);
+        FeNameFormat.checkStorageVaultName(vaultName);
 
         // check type in properties
         if (properties == null || properties.isEmpty()) {
@@ -83,8 +83,8 @@ public class CreateStorageVaultStmt extends DdlStmt {
         if (type == null) {
             throw new AnalysisException("Storage Vault type can't be null");
         }
-        resourceType = ResourceType.fromString(type);
-        if (resourceType == ResourceType.UNKNOWN) {
+        vaultType = StorageVault.StorageVaultType.fromString(type);
+        if (vaultType == StorageVault.StorageVaultType.UNKNOWN) {
             throw new AnalysisException("Unsupported Storage Vault type: " + type);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -440,6 +440,7 @@ public class Env {
 
     private BrokerMgr brokerMgr;
     private ResourceMgr resourceMgr;
+    private StorageVaultMgr storageVaultMgr;
 
     private GlobalTransactionMgrIface globalTransactionMgr;
 
@@ -687,6 +688,7 @@ public class Env {
 
         this.brokerMgr = new BrokerMgr();
         this.resourceMgr = new ResourceMgr();
+        this.storageVaultMgr = new StorageVaultMgr();
 
         this.globalTransactionMgr = EnvFactory.getInstance().createGlobalTransactionMgr(this);
 
@@ -792,6 +794,10 @@ public class Env {
 
     public ResourceMgr getResourceMgr() {
         return resourceMgr;
+    }
+
+    public StorageVaultMgr getStorageVaultMgr() {
+        return storageVaultMgr;
     }
 
     public static GlobalTransactionMgrIface getCurrentGlobalTransactionMgr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -37,6 +37,7 @@ import java.util.Map;
  * (
  * "type" = "hdfs",
  * "fs.defaultFS" = "hdfs://10.220.147.151:8020",
+ * "fs.prefix" = "",
  * "hadoop.username" = "root"
  * );
  */
@@ -44,6 +45,7 @@ public class HdfsStorageVault extends StorageVault {
     private static final Logger LOG = LogManager.getLogger(HdfsStorageVault.class);
     public static final String HADOOP_FS_PREFIX = "dfs.";
     public static String HADOOP_FS_NAME = "fs.defaultFS";
+    public static String HADOOP_PREFIX = "fs.prefix";
     public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
     public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";
     public static String DSF_NAMESERVICES = "dfs.nameservices";
@@ -85,25 +87,28 @@ public class HdfsStorageVault extends StorageVault {
                     && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 
-    public static Cloud.HdfsInfo generateHdfsParam(Map<String, String> properties) {
-        Cloud.HdfsInfo.Builder hdfsInfoBuilder =
-                    Cloud.HdfsInfo.newBuilder();
+    public static Cloud.HdfsVaultInfo generateHdfsParam(Map<String, String> properties) {
+        Cloud.HdfsVaultInfo.Builder hdfsVaultInfoBuilder =
+                    Cloud.HdfsVaultInfo.newBuilder();
+        Cloud.HdfsBuildConf.Builder hdfsConfBuilder = Cloud.HdfsBuildConf.newBuilder();
         for (Map.Entry<String, String> property : properties.entrySet()) {
             if (property.getKey().equalsIgnoreCase(HADOOP_FS_NAME)) {
-                hdfsInfoBuilder.setFsName(property.getValue());
+                hdfsConfBuilder.setFsName(property.getValue());
+            } else if (property.getKey().equalsIgnoreCase(HADOOP_PREFIX)) {
+                hdfsVaultInfoBuilder.setPrefix(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_USER_NAME)) {
-                hdfsInfoBuilder.setUser(property.getValue());
+                hdfsConfBuilder.setUser(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL)) {
-                hdfsInfoBuilder.setHdfsKerberosPrincipal(property.getValue());
+                hdfsConfBuilder.setHdfsKerberosPrincipal(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB)) {
-                hdfsInfoBuilder.setHdfsKerberosKeytab(property.getValue());
+                hdfsConfBuilder.setHdfsKerberosKeytab(property.getValue());
             } else {
-                Cloud.HdfsConf.Builder hdfsConfBuilder = Cloud.HdfsConf.newBuilder();
-                hdfsConfBuilder.setKey(property.getKey());
-                hdfsConfBuilder.setValue(property.getValue());
-                hdfsInfoBuilder.addHdfsConfs(hdfsConfBuilder.build());
+                Cloud.HdfsBuildConf.HdfsConfKVPair.Builder conf = Cloud.HdfsBuildConf.HdfsConfKVPair.newBuilder();
+                conf.setKey(property.getKey());
+                conf.setValue(property.getValue());
+                hdfsConfBuilder.addHdfsConfs(conf.build());
             }
         }
-        return hdfsInfoBuilder.build();
+        return hdfsVaultInfoBuilder.setBuildConf(hdfsConfBuilder.build()).build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -18,11 +18,8 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.cloud.proto.Cloud;
-import org.apache.doris.cloud.rpc.MetaServiceProxy;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.common.security.authentication.AuthenticationConfig;
-import org.apache.doris.rpc.RpcException;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -74,15 +74,13 @@ public class HdfsStorageVault extends StorageVault {
         try {
             Cloud.AlterObjStoreInfoResponse response =
                     MetaServiceProxy.getInstance().alterObjStoreInfo(requestBuilder.build());
-            if (!response.hasStatus() || !response.getStatus().hasCode()) {
-                if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
-                        && ifNotExists()) {
-                    return;
-                }
-                if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
-                    LOG.warn("failed to alter storage vault response: {} ", response);
-                    throw new DdlException(response.getStatus().getMsg());
-                }
+            if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
+                    && ifNotExists()) {
+                return;
+            }
+            if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
+                LOG.warn("failed to alter storage vault response: {} ", response);
+                throw new DdlException(response.getStatus().getMsg());
             }
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.cloud.proto.Cloud;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.proc.BaseProcResult;
+import org.apache.doris.common.security.authentication.AuthenticationConfig;
+
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+/**
+ * HDFS resource
+ * <p>
+ * Syntax:
+ * CREATE STORAGE VAULT "remote_hdfs"
+ * PROPERTIES
+ * (
+ * "type" = "hdfs",
+ * "fs.defaultFS" = "hdfs://10.220.147.151:8020",
+ * "hadoop.username" = "root"
+ * );
+ */
+public class HdfsStorageVault extends StorageVault {
+    public static final String HADOOP_FS_PREFIX = "dfs.";
+    public static String HADOOP_FS_NAME = "fs.defaultFS";
+    public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
+    public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";
+    public static String DSF_NAMESERVICES = "dfs.nameservices";
+    public static final String HDFS_PREFIX = "hdfs:";
+    public static final String HDFS_FILE_PREFIX = "hdfs://";
+
+    @SerializedName(value = "properties")
+    private Map<String, String> properties;
+
+    public HdfsStorageVault(String name) {
+        super(name, StorageVault.StorageVaultType.HDFS);
+        properties = Maps.newHashMap();
+    }
+
+    @Override
+    public void modifyProperties(Map<String, String> properties) throws DdlException {
+        for (Map.Entry<String, String> kv : properties.entrySet()) {
+            replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+        }
+        super.modifyProperties(properties);
+    }
+
+    @Override
+    protected void setProperties(Map<String, String> properties) throws DdlException {
+        // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
+        // We should disable short circuit read if they are not both set because it will cause performance down.
+        if (!(enableShortCircuitRead(properties))) {
+            properties.put(HADOOP_SHORT_CIRCUIT, "false");
+        }
+        this.properties = properties;
+    }
+
+    @Override
+    public Map<String, String> getCopiedProperties() {
+        return Maps.newHashMap(properties);
+    }
+
+    @Override
+    protected void getProcNodeData(BaseProcResult result) {
+        // String lowerCaseType = type.name().toLowerCase();
+        // for (Map.Entry<String, String> entry : properties.entrySet()) {
+        //     result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+        // }
+    }
+
+    public static boolean enableShortCircuitRead(Map<String, String> properties) {
+        return "true".equalsIgnoreCase(properties.getOrDefault(HADOOP_SHORT_CIRCUIT, "false"))
+                    && properties.containsKey(HADOOP_SOCKET_PATH);
+    }
+
+    public static Cloud.HdfsParams generateHdfsParam(Map<String, String> properties) {
+        Cloud.HdfsParams.Builder hdfsParamsBuilder =
+                    Cloud.HdfsParams.newBuilder();
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            if (property.getKey().equalsIgnoreCase(HADOOP_FS_NAME)) {
+                hdfsParamsBuilder.setFsName(property.getValue());
+            } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_USER_NAME)) {
+                hdfsParamsBuilder.setUser(property.getValue());
+            } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL)) {
+                hdfsParamsBuilder.setHdfsKerberosPrincipal(property.getValue());
+            } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB)) {
+                hdfsParamsBuilder.setHdfsKerberosKeytab(property.getValue());
+            } else {
+                Cloud.HdfsConf.Builder hdfsConfBuilder = Cloud.HdfsConf.newBuilder();
+                hdfsConfBuilder.setKey(property.getKey());
+                hdfsConfBuilder.setValue(property.getValue());
+                hdfsParamsBuilder.addHdfsConfs(hdfsConfBuilder.build());
+            }
+        }
+        return hdfsParamsBuilder.build();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -20,22 +20,11 @@ package org.apache.doris.catalog;
 import org.apache.doris.analysis.CreateStorageVaultStmt;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.io.DeepCopy;
-import org.apache.doris.common.io.Text;
-import org.apache.doris.common.io.Writable;
-import org.apache.doris.common.proc.BaseProcResult;
-import org.apache.doris.persist.gson.GsonPostProcessable;
-import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.base.Strings;
-import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -1,0 +1,213 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.analysis.CreateStorageVaultStmt;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.io.DeepCopy;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.proc.BaseProcResult;
+import org.apache.doris.persist.gson.GsonPostProcessable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public abstract class StorageVault implements Writable, GsonPostProcessable {
+    private static final Logger LOG = LogManager.getLogger(OdbcCatalogResource.class);
+    public static final String REFERENCE_SPLIT = "@";
+    public static final String INCLUDE_DATABASE_LIST = "include_database_list";
+    public static final String EXCLUDE_DATABASE_LIST = "exclude_database_list";
+    public static final String LOWER_CASE_META_NAMES = "lower_case_meta_names";
+    public static final String META_NAMES_MAPPING = "meta_names_mapping";
+
+    public enum StorageVaultType {
+        UNKNOWN,
+        S3,
+        HDFS;
+
+        public static StorageVaultType fromString(String storageVaultTypeType) {
+            for (StorageVaultType type : StorageVaultType.values()) {
+                if (type.name().equalsIgnoreCase(storageVaultTypeType)) {
+                    return type;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
+    @SerializedName(value = "name")
+    protected String name;
+    @SerializedName(value = "type")
+    protected StorageVaultType type;
+    @SerializedName(value = "id")
+    protected String id;
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+
+    public void writeLock() {
+        lock.writeLock().lock();
+    }
+
+    public void writeUnlock() {
+        lock.writeLock().unlock();
+    }
+
+    public void readLock() {
+        lock.readLock().lock();
+    }
+
+    public void readUnlock() {
+        lock.readLock().unlock();
+    }
+
+    public StorageVault() {
+    }
+
+    public StorageVault(String name, StorageVaultType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public static StorageVault fromStmt(CreateStorageVaultStmt stmt) throws DdlException {
+        StorageVault storageVault = getStorageVaultInstance(stmt.getStorageVaultType(), stmt.getStorageVaultName());
+        storageVault.setProperties(stmt.getProperties());
+        return storageVault;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get StorageVault instance by StorageVault name and type
+     * @param type
+     * @param name
+     * @return
+     * @throws DdlException
+     */
+    private static StorageVault getStorageVaultInstance(StorageVaultType type, String name) throws DdlException {
+        StorageVault vault;
+        switch (type) {
+            // case S3:
+            //     vault = new S3StorageVault(name);
+            //     break;
+            case HDFS:
+                vault = new HdfsStorageVault(name);
+                break;
+            default:
+                throw new DdlException("Unknown StorageVault type: " + type);
+        }
+
+        return vault;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public StorageVaultType getType() {
+        return type;
+    }
+
+    /**
+     * Modify properties in child resources
+     * @param properties
+     * @throws DdlException
+     */
+    public void modifyProperties(Map<String, String> properties) throws DdlException {
+        notifyUpdate(properties);
+    }
+
+    /**
+     * Check properties in child resources
+     * @param properties
+     * @throws AnalysisException
+     */
+    public void checkProperties(Map<String, String> properties) throws AnalysisException { }
+
+    protected void replaceIfEffectiveValue(Map<String, String> properties, String key, String value) {
+        if (!Strings.isNullOrEmpty(value)) {
+            properties.put(key, value);
+        }
+    }
+
+    /**
+     * Set and check the properties in child resources
+     */
+    protected abstract void setProperties(Map<String, String> properties) throws DdlException;
+
+    public abstract Map<String, String> getCopiedProperties();
+
+    /**
+     * Fill BaseProcResult with different properties in child resources
+     * ResourceMgr.RESOURCE_PROC_NODE_TITLE_NAMES format:
+     * | Name | ResourceType | Key | Value |
+     */
+    protected abstract void getProcNodeData(BaseProcResult result);
+
+    @Override
+    public String toString() {
+        return GsonUtils.GSON.toJson(this);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    public static Resource read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, Resource.class);
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+    }
+
+    @Override
+    public Resource clone() {
+        Resource copied = DeepCopy.copy(this, Resource.class, FeConstants.meta_version);
+        if (copied == null) {
+            LOG.warn("failed to clone odbc resource: " + getName());
+            return null;
+        }
+        return copied;
+    }
+
+    private void notifyUpdate(Map<String, String> properties) {
+    }
+
+    public void applyDefaultProperties() {}
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -51,10 +51,10 @@ public class StorageVaultMgr {
     @VisibleForTesting
     public void createHdfsVault(StorageVault vault) throws DdlException {
         HdfsStorageVault hdfsStorageVault = (HdfsStorageVault) vault;
-        Cloud.HdfsInfo hdfsInfos = HdfsStorageVault.generateHdfsParam(hdfsStorageVault.getCopiedProperties());
-        Cloud.AlterHdfsInfo.Builder alterHdfsInfoBuilder = Cloud.AlterHdfsInfo.newBuilder();
-        alterHdfsInfoBuilder.setVaultName(hdfsStorageVault.getName());
-        alterHdfsInfoBuilder.setHdfs(hdfsInfos);
+        Cloud.HdfsVaultInfo hdfsInfos = HdfsStorageVault.generateHdfsParam(hdfsStorageVault.getCopiedProperties());
+        Cloud.StorageVaultPB.Builder alterHdfsInfoBuilder = Cloud.StorageVaultPB.newBuilder();
+        alterHdfsInfoBuilder.setName(hdfsStorageVault.getName());
+        alterHdfsInfoBuilder.setHdfsInfo(hdfsInfos);
         Cloud.AlterObjStoreInfoRequest.Builder requestBuilder
                 = Cloud.AlterObjStoreInfoRequest.newBuilder();
         requestBuilder.setOp(Cloud.AlterObjStoreInfoRequest.Operation.ADD_HDFS_INFO);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class StorageVaultMgr {
+    private static final Logger LOG = LogManager.getLogger(StorageVaultMgr.class);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -43,6 +43,7 @@ public class StorageVaultMgr {
             case S3:
                 throw new DdlException("Currently S3 is not support.");
             case UNKNOWN:
+            default:
                 throw new DdlException("Only support S3, HDFS storage vault.");
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -17,9 +17,24 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.analysis.CreateStorageVaultStmt;
+import org.apache.doris.common.DdlException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class StorageVaultMgr {
     private static final Logger LOG = LogManager.getLogger(StorageVaultMgr.class);
+
+    public StorageVaultMgr() {}
+
+    // TODO(ByteYue): The CreateStorageVault should only be handled by master
+    // which indicates we can maintains one <VaultName, VaultId> map in FE master
+
+    public void createStorageVaultResource(CreateStorageVaultStmt stmt) throws Exception {
+        if (stmt.getStorageVaultType() == StorageVault.StorageVaultType.UNKNOWN) {
+            throw new DdlException("Only support S3, HDFS storage vault.");
+        }
+        StorageVault.fromStmt(stmt).alterMetaService();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
@@ -296,6 +296,16 @@ public class MetaServiceClient {
         return blockingStub.alterCluster(request);
     }
 
+    public Cloud.AlterObjStoreInfoResponse alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) {
+        if (!request.hasCloudUniqueId()) {
+            Cloud.AlterObjStoreInfoRequest.Builder builder =
+                    Cloud.AlterObjStoreInfoRequest.newBuilder();
+            builder.mergeFrom(request);
+            return blockingStub.alterObjStoreInfo(builder.setCloudUniqueId(Config.cloud_unique_id).build());
+        }
+        return blockingStub.alterObjStoreInfo(request);
+    }
+
     public Cloud.GetDeleteBitmapUpdateLockResponse
             getDeleteBitmapUpdateLock(Cloud.GetDeleteBitmapUpdateLockRequest request) {
         if (!request.hasCloudUniqueId()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
@@ -581,4 +581,18 @@ public class MetaServiceProxy {
             throw new RpcException(metaAddress.hostname, e.getMessage(), e);
         }
     }
+
+    public Cloud.AlterObjStoreInfoResponse
+            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+        if (metaServiceHostPort == null) {
+            throw new RpcException("", "cloud mode, please configure cloud_unique_id and meta_service_endpoint");
+        }
+        TNetworkAddress metaAddress = new TNetworkAddress(metaServiceHostPort.first, metaServiceHostPort.second);
+        try {
+            final MetaServiceClient client = getProxy(metaAddress);
+            return client.alterObjStoreInfo(request);
+        } catch (Exception e) {
+            throw new RpcException(metaAddress.hostname, e.getMessage(), e);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -135,6 +135,10 @@ public class FeNameFormat {
         }
     }
 
+    public static void checkStorageVaultName(String vaultName) throws AnalysisException {
+        checkCommonName("vault", vaultName);
+    }
+
     public static void checkWorkloadGroupName(String workloadGroupName) throws AnalysisException {
         checkCommonName("workload group", workloadGroupName);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -73,6 +73,7 @@ import org.apache.doris.analysis.CreateResourceStmt;
 import org.apache.doris.analysis.CreateRoleStmt;
 import org.apache.doris.analysis.CreateRoutineLoadStmt;
 import org.apache.doris.analysis.CreateSqlBlockRuleStmt;
+import org.apache.doris.analysis.CreateStorageVaultStmt;
 import org.apache.doris.analysis.CreateTableAsSelectStmt;
 import org.apache.doris.analysis.CreateTableLikeStmt;
 import org.apache.doris.analysis.CreateTableStmt;
@@ -400,6 +401,8 @@ public class DdlExecutor {
             Env.getCurrentEnv().getAnalysisManager().dropAnalyzeJob(analyzeJobStmt);
         } else if (ddlStmt instanceof AlterRepositoryStmt) {
             env.getBackupHandler().alterRepository((AlterRepositoryStmt) ddlStmt);
+        } else if (ddlStmt instanceof CreateStorageVaultStmt) {
+            env.getStorageVaultMgr().createStorageVaultResource((CreateStorageVaultStmt) ddlStmt);
         } else {
             LOG.warn("Unkown statement " + ddlStmt.getClass());
             throw new DdlException("Unknown statement.");

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateStorageVaultStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateStorageVaultStmtTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Resource;
+import org.apache.doris.catalog.Resource.ResourceType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.Maps;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class CreateResourceStmtTest {
+    private Analyzer analyzer;
+    private String resourceName1;
+    private String resourceName2;
+    private String resourceName3;
+
+    @Before()
+    public void setUp() {
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        resourceName1 = "spark0";
+        resourceName2 = "odbc";
+        resourceName3 = "s3";
+    }
+
+    @Test
+    public void testNormal(@Mocked Env env, @Injectable AccessControllerManager accessManager)
+            throws UserException {
+        new Expectations() {
+            {
+                env.getAccessManager();
+                result = accessManager;
+                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
+                result = true;
+            }
+        };
+
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("type", "spark");
+        CreateResourceStmt stmt = new CreateResourceStmt(true, false, resourceName1, properties);
+        stmt.analyze(analyzer);
+        Assert.assertEquals(resourceName1, stmt.getResourceName());
+        Assert.assertEquals(Resource.ResourceType.SPARK, stmt.getResourceType());
+        Assert.assertEquals("CREATE EXTERNAL RESOURCE 'spark0' PROPERTIES(\"type\"  =  \"spark\")", stmt.toSql());
+
+        properties = Maps.newHashMap();
+        properties.put("type", "odbc_catalog");
+        stmt = new CreateResourceStmt(true, false, resourceName2, properties);
+        Config.enable_odbc_mysql_broker_table = true;
+        stmt.analyze(analyzer);
+        Assert.assertEquals(resourceName2, stmt.getResourceName());
+        Assert.assertEquals(Resource.ResourceType.ODBC_CATALOG, stmt.getResourceType());
+        Assert.assertEquals("CREATE EXTERNAL RESOURCE 'odbc' PROPERTIES(\"type\"  =  \"odbc_catalog\")", stmt.toSql());
+
+        properties = Maps.newHashMap();
+        properties.put("type", "s3");
+        stmt = new CreateResourceStmt(true, false, resourceName3, properties);
+        stmt.analyze(analyzer);
+        Assert.assertEquals(resourceName3, stmt.getResourceName());
+        Assert.assertEquals(ResourceType.S3, stmt.getResourceType());
+        Assert.assertEquals("CREATE EXTERNAL RESOURCE 's3' PROPERTIES(\"type\"  =  \"s3\")", stmt.toSql());
+
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testUnsupportedResourceType(@Mocked Env env, @Injectable AccessControllerManager accessManager)
+            throws UserException {
+        new Expectations() {
+            {
+                env.getAccessManager();
+                result = accessManager;
+                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
+                result = true;
+            }
+        };
+
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("type", "hadoop");
+        CreateResourceStmt stmt = new CreateResourceStmt(true, false, resourceName1, properties);
+        stmt.analyze(analyzer);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateStorageVaultStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateStorageVaultStmtTest.java
@@ -18,10 +18,8 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.Resource;
-import org.apache.doris.catalog.Resource.ResourceType;
+import org.apache.doris.catalog.StorageVault.StorageVaultType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -37,18 +35,14 @@ import org.junit.Test;
 
 import java.util.Map;
 
-public class CreateResourceStmtTest {
+public class CreateStorageVaultStmtTest {
     private Analyzer analyzer;
-    private String resourceName1;
-    private String resourceName2;
-    private String resourceName3;
+    private String vaultName;
 
     @Before()
     public void setUp() {
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
-        resourceName1 = "spark0";
-        resourceName2 = "odbc";
-        resourceName3 = "s3";
+        vaultName = "hdfs";
     }
 
     @Test
@@ -64,29 +58,12 @@ public class CreateResourceStmtTest {
         };
 
         Map<String, String> properties = Maps.newHashMap();
-        properties.put("type", "spark");
-        CreateResourceStmt stmt = new CreateResourceStmt(true, false, resourceName1, properties);
+        properties.put("type", "hdfs");
+        CreateStorageVaultStmt stmt = new CreateStorageVaultStmt(true, vaultName, properties);
         stmt.analyze(analyzer);
-        Assert.assertEquals(resourceName1, stmt.getResourceName());
-        Assert.assertEquals(Resource.ResourceType.SPARK, stmt.getResourceType());
-        Assert.assertEquals("CREATE EXTERNAL RESOURCE 'spark0' PROPERTIES(\"type\"  =  \"spark\")", stmt.toSql());
-
-        properties = Maps.newHashMap();
-        properties.put("type", "odbc_catalog");
-        stmt = new CreateResourceStmt(true, false, resourceName2, properties);
-        Config.enable_odbc_mysql_broker_table = true;
-        stmt.analyze(analyzer);
-        Assert.assertEquals(resourceName2, stmt.getResourceName());
-        Assert.assertEquals(Resource.ResourceType.ODBC_CATALOG, stmt.getResourceType());
-        Assert.assertEquals("CREATE EXTERNAL RESOURCE 'odbc' PROPERTIES(\"type\"  =  \"odbc_catalog\")", stmt.toSql());
-
-        properties = Maps.newHashMap();
-        properties.put("type", "s3");
-        stmt = new CreateResourceStmt(true, false, resourceName3, properties);
-        stmt.analyze(analyzer);
-        Assert.assertEquals(resourceName3, stmt.getResourceName());
-        Assert.assertEquals(ResourceType.S3, stmt.getResourceType());
-        Assert.assertEquals("CREATE EXTERNAL RESOURCE 's3' PROPERTIES(\"type\"  =  \"s3\")", stmt.toSql());
+        Assert.assertEquals(vaultName, stmt.getStorageVaultName());
+        Assert.assertEquals(StorageVaultType.HDFS, stmt.getStorageVaultType());
+        Assert.assertEquals("CREATE STORAGE VAULT 'hdfs' PROPERTIES(\"type\"  =  \"hdfs\")", stmt.toSql());
 
     }
 
@@ -104,7 +81,7 @@ public class CreateResourceStmtTest {
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("type", "hadoop");
-        CreateResourceStmt stmt = new CreateResourceStmt(true, false, resourceName1, properties);
+        CreateStorageVaultStmt stmt = new CreateStorageVaultStmt(true, vaultName, properties);
         stmt.analyze(analyzer);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -36,24 +36,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class HdfsStorageVaultTest {
     private StorageVaultMgr mgr = new StorageVaultMgr();
-    Method method;
 
     @Before
     public void setUp() throws Exception {
         Config.cloud_unique_id = "cloud_unique_id";
         Config.meta_service_endpoint = "127.0.0.1:20121";
-        Class<?> myClass = StorageVaultMgr.class;
-        String methodName = "createHdfsVault";
-        method = myClass.getDeclaredMethod(methodName, StorageVault.class);
-        method.setAccessible(true);
     }
 
     StorageVault createHdfsVault(String name, Map<String, String> properties) throws DdlException {
@@ -77,7 +70,7 @@ public class HdfsStorageVaultTest {
         StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
                 "type", "hdfs",
                 "path", "abs/"));
-        method.invoke(mgr, vault);
+        mgr.createHdfsVault(vault);
     }
 
     @Test
@@ -89,11 +82,11 @@ public class HdfsStorageVaultTest {
                     alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
-                if (existed.contains(request.getHdfs().getVaultName())) {
+                if (existed.contains(request.getHdfs().getName())) {
                     status.setCode(MetaServiceCode.ALREADY_EXISTED);
                 } else {
                     status.setCode(MetaServiceCode.OK);
-                    existed.add(request.getHdfs().getVaultName());
+                    existed.add(request.getHdfs().getName());
                 }
                 resp.setStatus(status.build());
                 resp.setStorageVaultId("1");
@@ -103,10 +96,10 @@ public class HdfsStorageVaultTest {
         StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
                 "type", "hdfs",
                 "path", "abs/"));
-        method.invoke(mgr, vault);
-        Assertions.assertThrows(InvocationTargetException.class,
+        mgr.createHdfsVault(vault);
+        Assertions.assertThrows(DdlException.class,
                 () -> {
-                    method.invoke(mgr, vault);
+                    mgr.createHdfsVault(vault);
                 });
     }
 
@@ -117,7 +110,7 @@ public class HdfsStorageVaultTest {
             public Cloud.AlterObjStoreInfoResponse
                     alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                if (!request.getHdfs().hasVaultName() || request.getHdfs().getVaultName().isEmpty()) {
+                if (!request.getHdfs().hasName() || request.getHdfs().getName().isEmpty()) {
                     resp.setStatus(MetaServiceResponseStatus.newBuilder()
                                 .setCode(MetaServiceCode.INVALID_ARGUMENT).build());
                 } else {
@@ -130,9 +123,9 @@ public class HdfsStorageVaultTest {
         StorageVault vault = createHdfsVault("", ImmutableMap.of(
                 "type", "hdfs",
                 "path", "abs/"));
-        Assertions.assertThrows(InvocationTargetException.class,
+        Assertions.assertThrows(DdlException.class,
                 () -> {
-                    method.invoke(mgr, vault);
+                    mgr.createHdfsVault(vault);
                 });
     }
 
@@ -145,11 +138,11 @@ public class HdfsStorageVaultTest {
                     alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
-                if (existed.contains(request.getHdfs().getVaultName())) {
+                if (existed.contains(request.getHdfs().getName())) {
                     status.setCode(MetaServiceCode.ALREADY_EXISTED);
                 } else {
                     status.setCode(MetaServiceCode.OK);
-                    existed.add(request.getHdfs().getVaultName());
+                    existed.add(request.getHdfs().getName());
                 }
                 resp.setStatus(status.build());
                 resp.setStorageVaultId("1");
@@ -160,6 +153,6 @@ public class HdfsStorageVaultTest {
         vault.modifyProperties(ImmutableMap.of(
                 "type", "hdfs",
                 "path", "abs/"));
-        method.invoke(mgr, vault);
+        mgr.createHdfsVault(vault);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -1,3 +1,4 @@
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -58,7 +58,7 @@ public class HdfsStorageVaultTest {
         new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
             @Mock
             public Cloud.AlterObjStoreInfoResponse
-            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                    alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
                 resp.setStorageVaultId("1");
@@ -77,7 +77,7 @@ public class HdfsStorageVaultTest {
             private Set<String> existed = new HashSet<>();
             @Mock
             public Cloud.AlterObjStoreInfoResponse
-            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                    alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
                 if (existed.contains(request.getHdfs().getVaultName())) {
@@ -106,11 +106,11 @@ public class HdfsStorageVaultTest {
         new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
             @Mock
             public Cloud.AlterObjStoreInfoResponse
-            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                    alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 if (!request.getHdfs().hasVaultName() || request.getHdfs().getVaultName().isEmpty()) {
-                    resp.setStatus(MetaServiceResponseStatus.newBuilder().
-                                setCode(MetaServiceCode.INVALID_ARGUMENT).build());
+                    resp.setStatus(MetaServiceResponseStatus.newBuilder()
+                                .setCode(MetaServiceCode.INVALID_ARGUMENT).build());
                 } else {
                     resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
                 }
@@ -133,7 +133,7 @@ public class HdfsStorageVaultTest {
             private Set<String> existed = new HashSet<>();
             @Mock
             public Cloud.AlterObjStoreInfoResponse
-            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                    alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
                 Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
                 MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
                 if (existed.contains(request.getHdfs().getVaultName())) {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -1,0 +1,155 @@
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.catalog;
+
+
+import org.apache.doris.catalog.HdfsStorageVault;
+import org.apache.doris.catalog.StorageVault;
+import org.apache.doris.cloud.proto.Cloud;
+import org.apache.doris.cloud.proto.Cloud.MetaServiceCode;
+import org.apache.doris.cloud.proto.Cloud.MetaServiceResponseStatus;
+import org.apache.doris.cloud.rpc.MetaServiceProxy;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.rpc.RpcException;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class HdfsStorageVaultTest {
+
+    @Before
+    public void setUp() {
+        Config.cloud_unique_id = "cloud_unique_id";
+        Config.meta_service_endpoint = "127.0.0.1:20121";
+    }
+
+    StorageVault createHdfsVault(String name, Map<String, String> properties) throws DdlException {
+        HdfsStorageVault vault = new HdfsStorageVault(name, false);
+        vault.modifyProperties(properties);
+        return vault;
+    }
+
+    @Test
+    public void testAlterMetaServiceNormal() throws DdlException {
+        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
+            @Mock
+            public Cloud.AlterObjStoreInfoResponse
+            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
+                resp.setStorageVaultId("1");
+                return resp.build();
+            }
+        };
+        StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
+                "type", "hdfs",
+                "path", "abs/"));
+        vault.alterMetaService();
+    }
+
+    @Test
+    public void testAlterMetaServiceWithDuplicateName() throws DdlException {
+        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
+            private Set<String> existed = new HashSet<>();
+            @Mock
+            public Cloud.AlterObjStoreInfoResponse
+            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
+                if (existed.contains(request.getHdfs().getVaultName())) {
+                    status.setCode(MetaServiceCode.ALREADY_EXISTED);
+                } else {
+                    status.setCode(MetaServiceCode.OK);
+                    existed.add(request.getHdfs().getVaultName());
+                }
+                resp.setStatus(status.build());
+                resp.setStorageVaultId("1");
+                return resp.build();
+            }
+        };
+        StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
+                "type", "hdfs",
+                "path", "abs/"));
+        vault.alterMetaService();
+        Assertions.assertThrows(DdlException.class,
+                () -> {
+                    vault.alterMetaService();
+                });
+    }
+
+    @Test
+    public void testAlterMetaServiceWithMissingFiels() throws DdlException {
+        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
+            @Mock
+            public Cloud.AlterObjStoreInfoResponse
+            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                if (!request.getHdfs().hasVaultName() || request.getHdfs().getVaultName().isEmpty()) {
+                    resp.setStatus(MetaServiceResponseStatus.newBuilder().
+                                setCode(MetaServiceCode.INVALID_ARGUMENT).build());
+                } else {
+                    resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
+                }
+                resp.setStorageVaultId("1");
+                return resp.build();
+            }
+        };
+        StorageVault vault = createHdfsVault("", ImmutableMap.of(
+                "type", "hdfs",
+                "path", "abs/"));
+        Assertions.assertThrows(DdlException.class,
+                () -> {
+                    vault.alterMetaService();
+                });
+    }
+
+    @Test
+    public void testAlterMetaServiceIfNotExists() throws DdlException {
+        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
+            private Set<String> existed = new HashSet<>();
+            @Mock
+            public Cloud.AlterObjStoreInfoResponse
+            alterObjStoreInfo(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
+                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
+                if (existed.contains(request.getHdfs().getVaultName())) {
+                    status.setCode(MetaServiceCode.ALREADY_EXISTED);
+                } else {
+                    status.setCode(MetaServiceCode.OK);
+                    existed.add(request.getHdfs().getVaultName());
+                }
+                resp.setStatus(status.build());
+                resp.setStorageVaultId("1");
+                return resp.build();
+            }
+        };
+        StorageVault vault = new HdfsStorageVault("name", true);
+        vault.modifyProperties(ImmutableMap.of(
+                "type", "hdfs",
+                "path", "abs/"));
+        vault.alterMetaService();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -45,6 +45,7 @@ import java.util.Set;
 public class HdfsStorageVaultTest {
     private StorageVaultMgr mgr = new StorageVaultMgr();
     Method method;
+
     @Before
     public void setUp() throws Exception {
         Config.cloud_unique_id = "cloud_unique_id";

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -74,8 +74,8 @@ message InstanceInfoPB {
     optional RamUserPB iam_user = 12;
     optional bool sse_enabled = 13;
 
-    repeated string resource_ids = 100; // 新加 vault 的 resource id 采用 max_resource_id + 1
-    repeated string storage_vault_names = 101; // 建表时从这里找到 vault name -> resource id 的映射
+    repeated string resource_ids = 100;
+    repeated string storage_vault_names = 101;
 }
 
 message StagePB {
@@ -193,20 +193,24 @@ message ObjectStoreInfoPB {
 message StorageVaultPB {
     optional string id = 1;
     optional string name = 2;
-    optional HdfsInfo hdfs_infos = 3; // HdfsResource
+    optional HdfsVaultInfo hdfs_info = 3; // HdfsResource
 }
 
-message HdfsInfo {
-    optional string fs_name = 1;
+message HdfsBuildConf {
+    message HdfsConfKVPair {
+        required string key = 1;
+        required string value = 2;
+    }
+    optional string fs_name = 1; // name_node
     optional string user = 2;
     optional string hdfs_kerberos_principal = 3;
     optional string hdfs_kerberos_keytab = 4;
-    repeated HdfsConf hdfs_confs = 5;
+    repeated HdfsConfKVPair hdfs_confs = 5;
 }
 
-message HdfsConf {
-    optional string key = 1;
-    optional string value = 2;
+message HdfsVaultInfo {
+    optional HdfsBuildConf build_conf = 1;
+    optional string prefix = 2;
 }
 
 //==============================================================================
@@ -713,11 +717,6 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
-message AlterHdfsInfo{
-        optional string vault_name = 1;
-        optional HdfsInfo hdfs = 2;
-}
-
 message AlterObjStoreInfoRequest {
     enum Operation {
         UNKNOWN         = 0;
@@ -730,7 +729,7 @@ message AlterObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
-    optional AlterHdfsInfo hdfs = 4;
+    optional StorageVaultPB hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -751,7 +750,7 @@ message UpdateAkSkResponse {
 message GetObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     repeated ObjectStoreInfoPB obj_info = 2;
-    repeated HdfsInfo hdfs_info = 3;
+    repeated HdfsVaultInfo hdfs_info = 3;
 };
 
 message CreateTabletsRequest {
@@ -869,7 +868,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
-    optional HdfsInfo hdfs_info = 7;
+    optional HdfsVaultInfo hdfs_info = 7;
 }
 
 message CreateInstanceResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -735,6 +735,7 @@ message AlterObjStoreInfoRequest {
 
 message AlterObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
+    optional string storage_vault_id = 2;
 }
 
 message UpdateAkSkRequest {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -193,10 +193,10 @@ message ObjectStoreInfoPB {
 message StorageVaultPB {
     optional string id = 1;
     optional string name = 2;
-    optional HdfsParams hdfs_infos = 3; // HdfsResource
+    optional HdfsInfo hdfs_infos = 3; // HdfsResource
 }
 
-message HdfsParams {
+message HdfsInfo {
     optional string fs_name = 1;
     optional string user = 2;
     optional string hdfs_kerberos_principal = 3;
@@ -713,10 +713,10 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
-message AlterHdfsParams {
+message AlterHdfsInfo{
         optional string vault_name = 1;
-        optional HdfsParams hdfs = 2;
-    }
+        optional HdfsInfo hdfs = 2;
+}
 
 message AlterObjStoreInfoRequest {
     enum Operation {
@@ -730,7 +730,7 @@ message AlterObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
-    optional AlterHdfsParams hdfs = 4;
+    optional AlterHdfsInfo hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -751,7 +751,7 @@ message UpdateAkSkResponse {
 message GetObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     repeated ObjectStoreInfoPB obj_info = 2;
-    repeated HdfsParams hdfs_info = 3;
+    repeated HdfsInfo hdfs_info = 3;
 };
 
 message CreateTabletsRequest {
@@ -869,7 +869,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
-    optional HdfsParams hdfs_info = 7;
+    optional HdfsInfo hdfs_info = 7;
 }
 
 message CreateInstanceResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -73,6 +73,9 @@ message InstanceInfoPB {
     optional RamUserPB ram_user = 11;
     optional RamUserPB iam_user = 12;
     optional bool sse_enabled = 13;
+
+    repeated string resource_ids = 100; // 新加 vault 的 resource id 采用 max_resource_id + 1
+    repeated string storage_vault_names = 101; // 建表时从这里找到 vault name -> resource id 的映射
 }
 
 message StagePB {
@@ -185,6 +188,25 @@ message ObjectStoreInfoPB {
     optional string user_id = 13;
     optional EncryptionInfoPB encryption_info = 14;
     optional bool sse_enabled = 15;
+}
+
+message StorageVaultPB {
+    optional string id = 1;
+    optional string name = 2;
+    optional HdfsParams hdfs_infos = 3; // HdfsResource
+}
+
+message HdfsParams {
+    optional string fs_name = 1;
+    optional string user = 2;
+    optional string hdfs_kerberos_principal = 3;
+    optional string hdfs_kerberos_keytab = 4;
+    repeated HdfsConf hdfs_confs = 5;
+}
+
+message HdfsConf {
+    optional string key = 1;
+    optional string value = 2;
 }
 
 //==============================================================================
@@ -691,16 +713,24 @@ message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
 };
 
+message AlterHdfsParams {
+        optional string vault_name = 1;
+        optional HdfsParams hdfs = 2;
+    }
+
 message AlterObjStoreInfoRequest {
     enum Operation {
         UNKNOWN         = 0;
         UPDATE_AK_SK    = 1;
         ADD_OBJ_INFO    = 2;
         LEGACY_UPDATE_AK_SK = 3;
+
+        ADD_HDFS_INFO = 100;
     }
     optional string cloud_unique_id = 1; // For auth
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
+    optional AlterHdfsParams hdfs = 4;
 }
 
 message AlterObjStoreInfoResponse {
@@ -720,6 +750,7 @@ message UpdateAkSkResponse {
 message GetObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     repeated ObjectStoreInfoPB obj_info = 2;
+    repeated HdfsParams hdfs_info = 3;
 };
 
 message CreateTabletsRequest {
@@ -837,6 +868,7 @@ message CreateInstanceRequest {
     optional ObjectStoreInfoPB obj_info = 4;
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
+    optional HdfsParams hdfs_info = 7;
 }
 
 message CreateInstanceResponse {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This pr is part of `HDFS support for compute storage separation`. This pr introduces the create logic for storage vault. And make one new property name when creating table. Also it would call the rpc interface of Meta Service to check if the corresponding storage vault exists or not along with the add storage vault interface of Meta service. 

You can create one storage vault using the following stmt

```sql
CREATE STORAGE VAULT hdfs_vault PROPERTIES (
   "type"="hdfs",
   "username"="user",
   "password"="passwd",
   "dfs.nameservices" = "my_ha",
   "dfs.ha.namenodes.my_ha" = "my_namenode1, my_namenode2",
   "dfs.namenode.rpc-address.my_ha.my_namenode1" = "nn1_host:rpc_port",
   "dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
   "dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
);

```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

