### PR TITLE
[improvement](nereids) Composite predicate supports range predicate when rewritting by materialzied view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -493,26 +493,6 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                         : ExpressionUtils.and(residualCompensatePredicates));
     }
 
-    private boolean containsNullRejectSlot(Set<Set<Slot>> requireNoNullableViewSlot,
-            Set<Expression> queryPredicates,
-            SlotMapping queryToViewMapping,
-            CascadesContext cascadesContext) {
-        Set<Expression> queryPulledUpPredicates = queryPredicates.stream()
-                .flatMap(expr -> ExpressionUtils.extractConjunction(expr).stream())
-                .collect(Collectors.toSet());
-        Set<Expression> nullRejectPredicates = ExpressionUtils.inferNotNull(queryPulledUpPredicates,
-                cascadesContext);
-        Set<Expression> queryUsedNeedRejectNullSlotsViewBased = nullRejectPredicates.stream()
-                .map(expression -> TypeUtils.isNotNull(expression).orElse(null))
-                .filter(Objects::nonNull)
-                .map(expr -> ExpressionUtils.replace((Expression) expr, queryToViewMapping.toSlotReferenceMap()))
-                .collect(Collectors.toSet());
-        // query pulledUp predicates should have null reject predicates and contains any require noNullable slot
-        return !queryPulledUpPredicates.containsAll(nullRejectPredicates)
-                && requireNoNullableViewSlot.stream().noneMatch(
-                        set -> Sets.intersection(set, queryUsedNeedRejectNullSlotsViewBased).isEmpty());
-    }
-
     /**
      * Check the queryPredicates contains the required nullable slot
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -473,7 +473,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 queryStructInfo,
                 viewStructInfo,
                 viewToQuerySlotMapping,
-                comparisonResult);
+                comparisonResult,
+                cascadesContext);
         // residual compensate
         final Set<Expression> residualCompensatePredicates = Predicates.compensateResidualPredicate(
                 queryStructInfo,
@@ -490,6 +491,26 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                         : ExpressionUtils.and(rangeCompensatePredicates),
                 residualCompensatePredicates.isEmpty() ? BooleanLiteral.TRUE
                         : ExpressionUtils.and(residualCompensatePredicates));
+    }
+
+    private boolean containsNullRejectSlot(Set<Set<Slot>> requireNoNullableViewSlot,
+            Set<Expression> queryPredicates,
+            SlotMapping queryToViewMapping,
+            CascadesContext cascadesContext) {
+        Set<Expression> queryPulledUpPredicates = queryPredicates.stream()
+                .flatMap(expr -> ExpressionUtils.extractConjunction(expr).stream())
+                .collect(Collectors.toSet());
+        Set<Expression> nullRejectPredicates = ExpressionUtils.inferNotNull(queryPulledUpPredicates,
+                cascadesContext);
+        Set<Expression> queryUsedNeedRejectNullSlotsViewBased = nullRejectPredicates.stream()
+                .map(expression -> TypeUtils.isNotNull(expression).orElse(null))
+                .filter(Objects::nonNull)
+                .map(expr -> ExpressionUtils.replace((Expression) expr, queryToViewMapping.toSlotReferenceMap()))
+                .collect(Collectors.toSet());
+        // query pulledUp predicates should have null reject predicates and contains any require noNullable slot
+        return !queryPulledUpPredicates.containsAll(nullRejectPredicates)
+                && requireNoNullableViewSlot.stream().noneMatch(
+                        set -> Sets.intersection(set, queryUsedNeedRejectNullSlotsViewBased).isEmpty());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -75,6 +75,9 @@ public class MaterializedViewUtils {
                 break;
             }
         }
+        if (columnExpr == null) {
+            return Optional.empty();
+        }
         if (!(columnExpr instanceof SlotReference)) {
             return Optional.empty();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.EqualPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
@@ -77,6 +78,17 @@ public class PredicatesSplitter {
                 rangePredicates.add(comparisonPredicate);
             } else {
                 residualPredicates.add(comparisonPredicate);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitInPredicate(InPredicate inPredicate, Void context) {
+            if (containOnlyColumnRef(inPredicate.getCompareExpr(), true)
+                    && (ExpressionUtils.isAllLiteral(inPredicate.getOptions()))) {
+                rangePredicates.add(inPredicate);
+            } else {
+                residualPredicates.add(inPredicate);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
@@ -161,7 +161,6 @@ public class StructInfo {
                 // Record this, will be used in top level expression shuttle later, see the method
                 // ExpressionLineageReplacer#visitGroupPlan
                 namedExprIdAndExprMapping.putAll(replaceContext.getExprIdExpressionMap());
-                // record hash condition
             });
             List<Expression> otherJoinConjuncts = edge.getOtherJoinConjuncts();
             if (!otherJoinConjuncts.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
@@ -161,6 +161,7 @@ public class StructInfo {
                 // Record this, will be used in top level expression shuttle later, see the method
                 // ExpressionLineageReplacer#visitGroupPlan
                 namedExprIdAndExprMapping.putAll(replaceContext.getExprIdExpressionMap());
+                // record hash condition
             });
             List<Expression> otherJoinConjuncts = edge.getOtherJoinConjuncts();
             if (!otherJoinConjuncts.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -65,12 +65,12 @@ import java.util.stream.Collectors;
  * a in (1,2,3) and a in (4,5,6) => false
  * The logic is as follows:
  * 1. for `And` expression.
- *    1. extract conjunctions then build `ValueDesc` for each conjunction
- *    2. grouping according to `reference`, `ValueDesc` in the same group can perform intersect
- *    for example:
- *    a > 1 and a > 2
- *    1. a > 1 => RangeValueDesc((1...+∞)), a > 2 => RangeValueDesc((2...+∞))
- *    2. (1...+∞) intersect (2...+∞) => (2...+∞)
+ * 1. extract conjunctions then build `ValueDesc` for each conjunction
+ * 2. grouping according to `reference`, `ValueDesc` in the same group can perform intersect
+ * for example:
+ * a > 1 and a > 2
+ * 1. a > 1 => RangeValueDesc((1...+∞)), a > 2 => RangeValueDesc((2...+∞))
+ * 2. (1...+∞) intersect (2...+∞) => (2...+∞)
  * 2. for `Or` expression (similar to `And`).
  * todo: support a > 10 and (a < 10 or a > 20 ) => a > 20
  */
@@ -98,8 +98,8 @@ public class SimplifyRange extends AbstractExpressionRewriteRule {
         private ValueDesc buildRange(ComparisonPredicate predicate) {
             Expression rewrite = ExpressionRuleExecutor.normalize(predicate);
             Expression right = rewrite.child(1);
-            // only handle `NumericType`
-            if (right.isLiteral() && right.getDataType().isNumericType()) {
+            // only handle `NumericType` and `DateLikeType`
+            if (right.isLiteral() && (right.getDataType().isNumericType() || right.getDataType().isDateLikeType())) {
                 return ValueDesc.range((ComparisonPredicate) rewrite);
             }
             return new UnknownValue(predicate);
@@ -132,9 +132,10 @@ public class SimplifyRange extends AbstractExpressionRewriteRule {
 
         @Override
         public ValueDesc visitInPredicate(InPredicate inPredicate, Void context) {
-            // only handle `NumericType`
+            // only handle `NumericType` and `DateLikeType`
             if (ExpressionUtils.isAllLiteral(inPredicate.getOptions())
-                    && ExpressionUtils.matchNumericType(inPredicate.getOptions())) {
+                    && (ExpressionUtils.matchNumericType(inPredicate.getOptions())
+                    || ExpressionUtils.matchDateLikeType(inPredicate.getOptions()))) {
                 return ValueDesc.discrete(inPredicate);
             }
             return new UnknownValue(inPredicate);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -65,12 +65,12 @@ import java.util.stream.Collectors;
  * a in (1,2,3) and a in (4,5,6) => false
  * The logic is as follows:
  * 1. for `And` expression.
- * 1. extract conjunctions then build `ValueDesc` for each conjunction
- * 2. grouping according to `reference`, `ValueDesc` in the same group can perform intersect
- * for example:
- * a > 1 and a > 2
- * 1. a > 1 => RangeValueDesc((1...+∞)), a > 2 => RangeValueDesc((2...+∞))
- * 2. (1...+∞) intersect (2...+∞) => (2...+∞)
+ *    1. extract conjunctions then build `ValueDesc` for each conjunction
+ *    2. grouping according to `reference`, `ValueDesc` in the same group can perform intersect
+ *    for example:
+ *    a > 1 and a > 2
+ *    1. a > 1 => RangeValueDesc((1...+∞)), a > 2 => RangeValueDesc((2...+∞))
+ *    2. (1...+∞) intersect (2...+∞) => (2...+∞)
  * 2. for `Or` expression (similar to `And`).
  * todo: support a > 10 and (a < 10 or a > 20 ) => a > 20
  */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -494,7 +494,7 @@ public class ExpressionUtils {
         List<MarkJoinSlotReference> markJoinSlotReferenceList =
                 ((Set<MarkJoinSlotReference>) predicate
                         .collect(MarkJoinSlotReference.class::isInstance)).stream()
-                        .collect(Collectors.toList());
+                                .collect(Collectors.toList());
         int markSlotSize = markJoinSlotReferenceList.size();
         int maxMarkSlotCount = 4;
         // if the conjunct has mark slot, and maximum 4 mark slots(for performance)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -460,6 +460,10 @@ public class ExpressionUtils {
         return children.stream().allMatch(c -> c.getDataType().isNumericType());
     }
 
+    public static boolean matchDateLikeType(List<Expression> children) {
+        return children.stream().allMatch(c -> c.getDataType().isDateLikeType());
+    }
+
     public static boolean hasNullLiteral(List<Expression> children) {
         return children.stream().anyMatch(c -> c instanceof NullLiteral);
     }
@@ -490,7 +494,7 @@ public class ExpressionUtils {
         List<MarkJoinSlotReference> markJoinSlotReferenceList =
                 ((Set<MarkJoinSlotReference>) predicate
                         .collect(MarkJoinSlotReference.class::isInstance)).stream()
-                                .collect(Collectors.toList());
+                        .collect(Collectors.toList());
         int markSlotSize = markJoinSlotReferenceList.size();
         int maxMarkSlotCount = 4;
         // if the conjunct has mark slot, and maximum 4 mark slots(for performance)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -86,8 +86,7 @@ public class SimplifyRangeTest {
         assertRewrite("(TA > 10 or TA > 20) and (TB > 10 and TB > 20)", "TA > 10 and TB > 20");
         assertRewrite("((TB > 30 and TA > 40) and TA > 20) and (TB > 10 and TB > 20)", "TB > 30 and TA > 40");
         assertRewrite("(TA > 10 and TB > 10) or (TB > 10 and TB > 20)", "TA > 10 and TB > 10 or TB > 20");
-        assertRewrite("((TA > 10 or TA > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))",
-                "(TA > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
+        assertRewrite("((TA > 10 or TA > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))", "(TA > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
         assertRewrite("TA in (1,2,3) and TA > 10", "FALSE");
         assertRewrite("TA in (1,2,3) and TA >= 1", "TA in (1,2,3)");
         assertRewrite("TA in (1,2,3) and TA > 1", "((TA = 2) OR (TA = 3))");
@@ -107,12 +106,10 @@ public class SimplifyRangeTest {
         assertRewrite("TA in (1) and TA in (1)", "TA = 1");
         assertRewrite("(TA > 3 and TA < 1) and TB < 5", "FALSE");
         assertRewrite("(TA > 3 and TA < 1) or TB < 5", "TB < 5");
-        assertRewrite("((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1",
-                "((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1");
+        assertRewrite("((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1", "((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1");
 
         assertRewrite("TA + TC", "TA + TC");
-        assertRewrite("(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)",
-                "(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)");
+        assertRewrite("(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)", "(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)");
         assertRewrite("(TA + TC > 3 and TA + TC < 1) or (TA + TC > 7 and TA + TC < 5)", "FALSE");
         assertRewrite("TA + TC > 3 and TA + TC < 1", "FALSE");
         assertRewrite("TA + TC >= 3 and TA + TC < 3", "TA + TC >= 3 and TA + TC < 3");
@@ -132,14 +129,11 @@ public class SimplifyRangeTest {
         assertRewrite("(TA + TC > 1 or TA + TC > 10) and TA + TC > 20", "TA + TC > 20");
         assertRewrite("(TA + TC + TB > 1 or TA + TC + TB > 10) and TA + TC + TB > 20", "TA + TC + TB > 20");
         assertRewrite("TA + TC > 10 or TA + TC > 10", "TA + TC > 10");
-        assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB < 20)",
-                "TA + TC > 10 and (TB > 10 and TB < 20) ");
+        assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB < 20)", "TA + TC > 10 and (TB > 10 and TB < 20) ");
         assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB > 20)", "TA + TC > 10 and TB > 20");
-        assertRewrite("((TB > 30 and TA + TC > 40) and TA + TC > 20) and (TB > 10 and TB > 20)",
-                "TB > 30 and TA + TC > 40");
+        assertRewrite("((TB > 30 and TA + TC > 40) and TA + TC > 20) and (TB > 10 and TB > 20)", "TB > 30 and TA + TC > 40");
         assertRewrite("(TA + TC > 10 and TB > 10) or (TB > 10 and TB > 20)", "TA + TC > 10 and TB > 10 or TB > 20");
-        assertRewrite("((TA + TC > 10 or TA + TC > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))",
-                "(TA + TC > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
+        assertRewrite("((TA + TC > 10 or TA + TC > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))", "(TA + TC > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
         assertRewrite("TA + TC in (1,2,3) and TA + TC > 10", "FALSE");
         assertRewrite("TA + TC in (1,2,3) and TA + TC >= 1", "TA + TC in (1,2,3)");
         assertRewrite("TA + TC in (1,2,3) and TA + TC > 1", "((TA + TC = 2) OR (TA + TC = 3))");
@@ -228,6 +222,74 @@ public class SimplifyRangeTest {
         assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') and TB < date '2024-01-05'", "FALSE");
         assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') or TB < date '2024-01-05'",
                 "TB < date '2024-01-05'");
+    }
+
+    @Test
+    public void testSimplifyDateTime() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(SimplifyRange.INSTANCE));
+        // assertRewrite("TA", "TA");
+        assertRewrite(
+                "(TA >= timestamp '2024-01-01 00:00:00' and TA <= timestamp '2024-01-03 00:00:00') or (TA > timestamp '2024-01-05 00:00:00' and TA < timestamp '2024-01-07 00:00:00')",
+                "(TA >= timestamp '2024-01-01 00:00:00' and TA <= timestamp '2024-01-03 00:00:00') or (TA > timestamp '2024-01-05 00:00:00' and TA < timestamp '2024-01-07 00:00:00')");
+        assertRewrite(
+                "(TA > timestamp '2024-01-03 00:00:10' and TA < timestamp '2024-01-01 00:00:10') or (TA > timestamp '2024-01-07 00:00:10'and TA < timestamp '2024-01-05 00:00:10')",
+                "FALSE");
+        assertRewrite("TA > timestamp '2024-01-03 00:00:10' and TA < timestamp '2024-01-01 01:00:00'", "FALSE");
+        assertRewrite("TA >= timestamp '2024-01-01 00:00:10' and TA < timestamp '2024-01-01 00:00:10'",
+                "TA >= timestamp '2024-01-01 00:00:10' and TA < timestamp '2024-01-01 00:00:10'");
+        assertRewrite("TA = timestamp '2024-01-01 10:00:10' and TA > timestamp '2024-01-10 00:00:10'", "FALSE");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' or TA < timestamp '2024-01-01 00:00:10'",
+                "TA > timestamp '2024-01-05 00:00:10' or TA < timestamp '2024-01-01 00:00:10'");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' or TA > timestamp '2024-01-01 00:00:10' or TA > timestamp '2024-01-10 00:00:10'",
+                "TA > timestamp '2024-01-01 00:00:10'");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' or TA > timestamp '2024-01-01 00:00:10' or TA < timestamp '2024-01-10 00:00:10'", "TA IS NOT NULL");
+        assertRewriteNotNull("TA > timestamp '2024-01-05 00:00:10' or TA > timestamp '2024-01-01 00:00:10' or TA < timestamp '2024-01-10 00:00:10'", "TRUE");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' and TA > timestamp '2024-01-01 00:00:10' and TA > timestamp '2024-01-10 00:00:15'",
+                "TA > timestamp '2024-01-10 00:00:15'");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' and TA > timestamp '2024-01-01 00:00:10' and TA < timestamp '2024-01-10 00:00:10'",
+                "TA > timestamp '2024-01-05 00:00:10' and TA < timestamp '2024-01-10 00:00:10'");
+        assertRewrite("TA > timestamp '2024-01-05 00:00:10' or TA < timestamp '2024-01-05 00:00:10'",
+                "TA > timestamp '2024-01-05 00:00:10' or TA < timestamp '2024-01-05 00:00:10'");
+        assertRewrite("TA > timestamp '2024-01-01 00:02:10' or TA < timestamp '2024-01-10 00:02:10'", "TA IS NOT NULL");
+        assertRewriteNotNull("TA > timestamp '2024-01-01 00:00:00' or TA < timestamp '2024-01-10 00:00:00'", "TRUE");
+        assertRewrite("TA > timestamp '2024-01-05 01:00:00' and TA < timestamp '2024-01-10 01:00:00'",
+                "TA > timestamp '2024-01-05 01:00:00' and TA < timestamp '2024-01-10 01:00:00'");
+        assertRewrite("TA > timestamp '2024-01-05 01:00:00' and TA > timestamp '2024-01-10 01:00:00'", "TA > timestamp '2024-01-10 01:00:00'");
+        assertRewrite("(TA > timestamp '2024-01-01 01:00:00' and TA > timestamp '2024-01-10 01:00:00') or TA > timestamp '2024-01-20 01:00:00'",
+                "TA > timestamp '2024-01-10 01:00:00'");
+        assertRewrite("(TA > timestamp '2024-01-01 01:00:00' or TA > timestamp '2024-01-10 01:00:00') and TA > timestamp '2024-01-20 01:00:00'",
+                "TA > timestamp '2024-01-20 01:00:00'");
+        assertRewrite("TA > timestamp '2024-01-05 01:00:00' or TA > timestamp '2024-01-05 01:00:00'", "TA > timestamp '2024-01-05 01:00:00'");
+        assertRewrite(
+                "(TA > timestamp '2024-01-10 01:00:00' or TA > timestamp '2024-01-20 01:00:00') and (TB > timestamp '2024-01-10 01:00:00' and TB < timestamp '2024-01-20 01:00:00')",
+                "TA > timestamp '2024-01-10 01:00:00' and (TB > timestamp '2024-01-10 01:00:00' and TB < timestamp '2024-01-20 01:00:00') ");
+        assertRewrite("TA in (timestamp '2024-01-01 01:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 03:00:00') and TA > timestamp '2024-01-10 01:00:00'",
+                "FALSE");
+        assertRewrite("TA in (timestamp '2024-01-01 01:00:00',timestamp '2024-01-02 01:50:00',timestamp '2024-01-03 02:00:00') and TA >= timestamp '2024-01-01'",
+                "TA in (timestamp '2024-01-01 01:00:00',timestamp '2024-01-02 01:50:00',timestamp '2024-01-03 02:00:00')");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') and TA > timestamp '2024-01-01 02:10:00'",
+                "((TA = timestamp '2024-01-02 02:00:00') OR (TA = timestamp '2024-01-03 02:00:00'))");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') or TA >= timestamp '2024-01-01 01:00:00'",
+                "TA >= timestamp '2024-01-01 01:00:00'");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00')", "TA in (timestamp '2024-01-01 02:00:00')");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') and TA < timestamp '2024-01-10 02:00:00'",
+                "TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00')");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') and TA < timestamp '2024-01-01 02:00:00'",
+                "FALSE");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') and TA < timestamp '2024-01-01 02:00:01'",
+                "TA = timestamp '2024-01-01 02:00:00'");
+        assertRewrite("TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') or TA < timestamp '2024-01-01 01:00:00'",
+                "TA in (timestamp '2024-01-01 02:00:00',timestamp '2024-01-02 02:00:00',timestamp '2024-01-03 02:00:00') or TA < timestamp '2024-01-01 01:00:00'");
+        assertRewrite("TA in (timestamp '2024-01-01 00:00:00',timestamp '2024-01-02 00:00:00') or TA in (timestamp '2024-01-02 00:00:00', timestamp '2024-01-03 00:00:00')",
+                "TA in (timestamp '2024-01-01 00:00:00',timestamp '2024-01-02 00:00:00',timestamp '2024-01-03 00:00:00')");
+        assertRewrite("TA in (timestamp '2024-01-01 00:50:00',timestamp '2024-01-02 00:50:00') and TA in (timestamp '2024-01-03 00:50:00', timestamp '2024-01-04 00:50:00')",
+                "FALSE");
+        assertRewrite("TA = timestamp '2024-01-03 00:50:00' and TA = timestamp '2024-01-01 00:50:00'", "FALSE");
+        assertRewrite("TA in (timestamp '2024-01-01 00:50:00') and TA in (timestamp '2024-01-03 00:50:00')", "FALSE");
+        assertRewrite("TA in (timestamp '2024-01-03 00:50:00') and TA in (timestamp '2024-01-03 00:50:00')", "TA = timestamp '2024-01-03 00:50:00'");
+        assertRewrite("(TA > timestamp '2024-01-03 00:50:00' and TA < timestamp '2024-01-01 00:50:00') and TB < timestamp '2024-01-05 00:50:00'", "FALSE");
+        assertRewrite("(TA > timestamp '2024-01-03 00:50:00' and TA < timestamp '2024-01-01 00:50:00') or TB < timestamp '2024-01-05 00:50:00'",
+                "TB < timestamp '2024-01-05 00:50:00'");
     }
 
     private void assertRewrite(String expression, String expected) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -25,7 +25,6 @@ import org.apache.doris.nereids.rules.expression.rules.SimplifyRange;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
@@ -87,7 +86,8 @@ public class SimplifyRangeTest {
         assertRewrite("(TA > 10 or TA > 20) and (TB > 10 and TB > 20)", "TA > 10 and TB > 20");
         assertRewrite("((TB > 30 and TA > 40) and TA > 20) and (TB > 10 and TB > 20)", "TB > 30 and TA > 40");
         assertRewrite("(TA > 10 and TB > 10) or (TB > 10 and TB > 20)", "TA > 10 and TB > 10 or TB > 20");
-        assertRewrite("((TA > 10 or TA > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))", "(TA > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
+        assertRewrite("((TA > 10 or TA > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))",
+                "(TA > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
         assertRewrite("TA in (1,2,3) and TA > 10", "FALSE");
         assertRewrite("TA in (1,2,3) and TA >= 1", "TA in (1,2,3)");
         assertRewrite("TA in (1,2,3) and TA > 1", "((TA = 2) OR (TA = 3))");
@@ -107,10 +107,12 @@ public class SimplifyRangeTest {
         assertRewrite("TA in (1) and TA in (1)", "TA = 1");
         assertRewrite("(TA > 3 and TA < 1) and TB < 5", "FALSE");
         assertRewrite("(TA > 3 and TA < 1) or TB < 5", "TB < 5");
-        assertRewrite("((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1", "((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1");
+        assertRewrite("((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1",
+                "((IA = 1 AND SC ='1') OR SC = '1212') AND IA =1");
 
         assertRewrite("TA + TC", "TA + TC");
-        assertRewrite("(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)", "(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)");
+        assertRewrite("(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)",
+                "(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)");
         assertRewrite("(TA + TC > 3 and TA + TC < 1) or (TA + TC > 7 and TA + TC < 5)", "FALSE");
         assertRewrite("TA + TC > 3 and TA + TC < 1", "FALSE");
         assertRewrite("TA + TC >= 3 and TA + TC < 3", "TA + TC >= 3 and TA + TC < 3");
@@ -130,11 +132,14 @@ public class SimplifyRangeTest {
         assertRewrite("(TA + TC > 1 or TA + TC > 10) and TA + TC > 20", "TA + TC > 20");
         assertRewrite("(TA + TC + TB > 1 or TA + TC + TB > 10) and TA + TC + TB > 20", "TA + TC + TB > 20");
         assertRewrite("TA + TC > 10 or TA + TC > 10", "TA + TC > 10");
-        assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB < 20)", "TA + TC > 10 and (TB > 10 and TB < 20) ");
+        assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB < 20)",
+                "TA + TC > 10 and (TB > 10 and TB < 20) ");
         assertRewrite("(TA + TC > 10 or TA + TC > 20) and (TB > 10 and TB > 20)", "TA + TC > 10 and TB > 20");
-        assertRewrite("((TB > 30 and TA + TC > 40) and TA + TC > 20) and (TB > 10 and TB > 20)", "TB > 30 and TA + TC > 40");
+        assertRewrite("((TB > 30 and TA + TC > 40) and TA + TC > 20) and (TB > 10 and TB > 20)",
+                "TB > 30 and TA + TC > 40");
         assertRewrite("(TA + TC > 10 and TB > 10) or (TB > 10 and TB > 20)", "TA + TC > 10 and TB > 10 or TB > 20");
-        assertRewrite("((TA + TC > 10 or TA + TC > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))", "(TA + TC > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
+        assertRewrite("((TA + TC > 10 or TA + TC > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))",
+                "(TA + TC > 5 and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))");
         assertRewrite("TA + TC in (1,2,3) and TA + TC > 10", "FALSE");
         assertRewrite("TA + TC in (1,2,3) and TA + TC >= 1", "TA + TC in (1,2,3)");
         assertRewrite("TA + TC in (1,2,3) and TA + TC > 1", "((TA + TC = 2) OR (TA + TC = 3))");
@@ -163,42 +168,66 @@ public class SimplifyRangeTest {
     public void testSimplifyDate() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(SimplifyRange.INSTANCE));
         // assertRewrite("TA", "TA");
-        assertRewrite("(TA >= date '2024-01-01' and TA <= date '2024-01-03') or (TA > date '2024-01-05' and TA < date '2024-01-07')",
+        assertRewrite(
+                "(TA >= date '2024-01-01' and TA <= date '2024-01-03') or (TA > date '2024-01-05' and TA < date '2024-01-07')",
                 "(TA >= date '2024-01-01' and TA <= date '2024-01-03') or (TA > date '2024-01-05' and TA < date '2024-01-07')");
-        assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') or (TA > date '2024-01-07'and TA < date '2024-01-05')", "FALSE");
+        assertRewrite(
+                "(TA > date '2024-01-03' and TA < date '2024-01-01') or (TA > date '2024-01-07'and TA < date '2024-01-05')",
+                "FALSE");
         assertRewrite("TA > date '2024-01-03' and TA < date '2024-01-01'", "FALSE");
-        assertRewrite("TA >= date '2024-01-01' and TA < date '2024-01-01'", "TA >= date '2024-01-01' and TA < date '2024-01-01'");
+        assertRewrite("TA >= date '2024-01-01' and TA < date '2024-01-01'",
+                "TA >= date '2024-01-01' and TA < date '2024-01-01'");
         assertRewrite("TA = date '2024-01-01' and TA > date '2024-01-10'", "FALSE");
-        assertRewrite("TA > date '2024-01-05' or TA < date '2024-01-01'", "TA > date '2024-01-05' or TA < date '2024-01-01'");
-        assertRewrite("TA > date '2024-01-05' or TA > date '2024-01-01' or TA > date '2024-01-10'", "TA > date '2024-01-01'");
+        assertRewrite("TA > date '2024-01-05' or TA < date '2024-01-01'",
+                "TA > date '2024-01-05' or TA < date '2024-01-01'");
+        assertRewrite("TA > date '2024-01-05' or TA > date '2024-01-01' or TA > date '2024-01-10'",
+                "TA > date '2024-01-01'");
         assertRewrite("TA > date '2024-01-05' or TA > date '2024-01-01' or TA < date '2024-01-10'", "TA IS NOT NULL");
         assertRewriteNotNull("TA > date '2024-01-05' or TA > date '2024-01-01' or TA < date '2024-01-10'", "TRUE");
-        assertRewrite("TA > date '2024-01-05' and TA > date '2024-01-01' and TA > date '2024-01-10'", "TA > date '2024-01-10'");
-        assertRewrite("TA > date '2024-01-05' and TA > date '2024-01-01' and TA < date '2024-01-10'", "TA > date '2024-01-05' and TA < date '2024-01-10'");
-        assertRewrite("TA > date '2024-01-05' or TA < date '2024-01-05'", "TA > date '2024-01-05' or TA < date '2024-01-05'");
+        assertRewrite("TA > date '2024-01-05' and TA > date '2024-01-01' and TA > date '2024-01-10'",
+                "TA > date '2024-01-10'");
+        assertRewrite("TA > date '2024-01-05' and TA > date '2024-01-01' and TA < date '2024-01-10'",
+                "TA > date '2024-01-05' and TA < date '2024-01-10'");
+        assertRewrite("TA > date '2024-01-05' or TA < date '2024-01-05'",
+                "TA > date '2024-01-05' or TA < date '2024-01-05'");
         assertRewrite("TA > date '2024-01-01' or TA < date '2024-01-10'", "TA IS NOT NULL");
         assertRewriteNotNull("TA > date '2024-01-01' or TA < date '2024-01-10'", "TRUE");
-        assertRewrite("TA > date '2024-01-05' and TA < date '2024-01-10'", "TA > date '2024-01-05' and TA < date '2024-01-10'");
+        assertRewrite("TA > date '2024-01-05' and TA < date '2024-01-10'",
+                "TA > date '2024-01-05' and TA < date '2024-01-10'");
         assertRewrite("TA > date '2024-01-05' and TA > date '2024-01-10'", "TA > date '2024-01-10'");
-        assertRewrite("(TA > date '2024-01-01' and TA > date '2024-01-10') or TA > date '2024-01-20'", "TA > date '2024-01-10'");
-        assertRewrite("(TA > date '2024-01-01' or TA > date '2024-01-10') and TA > date '2024-01-20'", "TA > date '2024-01-20'");
+        assertRewrite("(TA > date '2024-01-01' and TA > date '2024-01-10') or TA > date '2024-01-20'",
+                "TA > date '2024-01-10'");
+        assertRewrite("(TA > date '2024-01-01' or TA > date '2024-01-10') and TA > date '2024-01-20'",
+                "TA > date '2024-01-20'");
         assertRewrite("TA > date '2024-01-05' or TA > date '2024-01-05'", "TA > date '2024-01-05'");
-        assertRewrite("(TA > date '2024-01-10' or TA > date '2024-01-20') and (TB > date '2024-01-10' and TB < date '2024-01-20')", "TA > date '2024-01-10' and (TB > date '2024-01-10' and TB < date '2024-01-20') ");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA > date '2024-01-10'", "FALSE");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA >= date '2024-01-01'", "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA > date '2024-01-01'", "((TA = date '2024-01-02') OR (TA = date '2024-01-03'))");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA >= date '2024-01-01'", "TA >= date '2024-01-01'");
+        assertRewrite(
+                "(TA > date '2024-01-10' or TA > date '2024-01-20') and (TB > date '2024-01-10' and TB < date '2024-01-20')",
+                "TA > date '2024-01-10' and (TB > date '2024-01-10' and TB < date '2024-01-20') ");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA > date '2024-01-10'",
+                "FALSE");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA >= date '2024-01-01'",
+                "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA > date '2024-01-01'",
+                "((TA = date '2024-01-02') OR (TA = date '2024-01-03'))");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA >= date '2024-01-01'",
+                "TA >= date '2024-01-01'");
         assertRewrite("TA in (date '2024-01-01')", "TA in (date '2024-01-01')");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA < date '2024-01-10'", "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA < date '2024-01-01'", "FALSE");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA < date '2024-01-01'", "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA < date '2024-01-01'");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02') or TA in (date '2024-01-02', date '2024-01-03')", "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
-        assertRewrite("TA in (date '2024-01-01',date '2024-01-02') and TA in (date '2024-01-03', date '2024-01-04')", "FALSE");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA < date '2024-01-10'",
+                "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') and TA < date '2024-01-01'",
+                "FALSE");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA < date '2024-01-01'",
+                "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or TA < date '2024-01-01'");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02') or TA in (date '2024-01-02', date '2024-01-03')",
+                "TA in (date '2024-01-01',date '2024-01-02',date '2024-01-03')");
+        assertRewrite("TA in (date '2024-01-01',date '2024-01-02') and TA in (date '2024-01-03', date '2024-01-04')",
+                "FALSE");
         assertRewrite("TA = date '2024-01-03' and TA = date '2024-01-01'", "FALSE");
         assertRewrite("TA in (date '2024-01-01') and TA in (date '2024-01-03')", "FALSE");
         assertRewrite("TA in (date '2024-01-03') and TA in (date '2024-01-03')", "TA = date '2024-01-03'");
         assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') and TB < date '2024-01-05'", "FALSE");
-        assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') or TB < date '2024-01-05'", "TB < date '2024-01-05'");
+        assertRewrite("(TA > date '2024-01-03' and TA < date '2024-01-01') or TB < date '2024-01-05'",
+                "TB < date '2024-01-05'");
     }
 
     private void assertRewrite(String expression, String expected) {
@@ -231,9 +260,6 @@ public class SimplifyRangeTest {
             String name = ((UnboundSlot) expression).getName();
             mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0))));
             return mem.get(name);
-        }
-        if (expression instanceof VarcharLiteral) {
-            expression.isLiteral();
         }
         return hasNewChildren ? expression.withChildren(children) : expression;
     }

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
@@ -158,92 +158,92 @@ suite("filter_equal_or_notequal_case") {
         where l_shipdate = '2023-10-17'
         """
 
-//    create_mv_lineitem(mv_name, mtmv_sql)
-//    def job_name = getJobName(db, mv_name)
-//    waitingMTMVTaskFinished(job_name)
-//
-//    // mv equal and sql equal
-//    def query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-17'
-//        """
-//    def res_tmp = sql """explain ${query_sql}"""
-//    logger.info("res_temp:" + res_tmp)
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//    // mv equal and sql not equal
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate != '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv equal and sql equal and number is difference
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    mtmv_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate != '2023-10-17'
-//        """
-//
-//    create_mv_lineitem(mv_name, mtmv_sql)
-//    job_name = getJobName(db, mv_name)
-//    waitingMTMVTaskFinished(job_name)
-//
-//    // mv not equal and sql equal
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv not equal and sql not equal
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate != '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//
+    create_mv_lineitem(mv_name, mtmv_sql)
+    def job_name = getJobName(db, mv_name)
+    waitingMTMVTaskFinished(job_name)
+
+    // mv equal and sql equal
+    def query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-17'
+        """
+    def res_tmp = sql """explain ${query_sql}"""
+    logger.info("res_temp:" + res_tmp)
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // mv equal and sql not equal
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate != '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv equal and sql equal and number is difference
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    mtmv_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate != '2023-10-17'
+        """
+
+    create_mv_lineitem(mv_name, mtmv_sql)
+    job_name = getJobName(db, mv_name)
+    waitingMTMVTaskFinished(job_name)
+
+    // mv not equal and sql equal
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv not equal and sql not equal
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate != '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+
     mtmv_sql = """
         select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
         from lineitem_1
@@ -255,182 +255,181 @@ suite("filter_equal_or_notequal_case") {
     create_mv_lineitem(mv_name, mtmv_sql)
     job_name = getJobName(db, mv_name)
     waitingMTMVTaskFinished(job_name)
-//
-//    // mv is range and sql equal and filter not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-16'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql equal and filter in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // Todo: It is not currently supported and is expected to be
-//    // mv is range and sql equal and filter in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//    // mv is range and sql is range and sql range is bigger than mv
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-16'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql is range and sql range is not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate < '2023-10-16'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql is range and sql range is bigger than mv
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//    // mv is range and sql is range and sql range is not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate < '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql is range and sql range is bigger than mv
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-18'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//    // mv is range and sql is range and sql range is not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate < '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql is range and sql range is bigger than mv
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-17'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // mv is range and sql is range and sql range is not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
-//
-//    // sql range is not in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate in ('2023-10-17')
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        notContains "${mv_name}(${mv_name})"
-//    }
-//
-//    // sql range is in mv range
-//    // single value
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate in ('2023-10-18')
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
+
+    // mv is range and sql equal and filter not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-16'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql equal and filter in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql equal and filter in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // mv is range and sql is range and sql range is bigger than mv
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-16'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql is range and sql range is not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate < '2023-10-16'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql is range and sql range is bigger than mv
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // mv is range and sql is range and sql range is not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate < '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql is range and sql range is bigger than mv
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-18'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // mv is range and sql is range and sql range is not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate < '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql is range and sql range is bigger than mv
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-17'
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // mv is range and sql is range and sql range is not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // sql range is not in mv range
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate in ('2023-10-17')
+        """
+    explain {
+        sql("${query_sql}")
+        notContains "${mv_name}(${mv_name})"
+    }
+
+    // sql range is in mv range
+    // single value
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate in ('2023-10-18')
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
 
     // multi value
     query_sql = """

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
@@ -284,18 +284,18 @@ suite("filter_equal_or_notequal_case") {
 
     // Todo: It is not currently supported and is expected to be
     // mv is range and sql equal and filter in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate = '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate = '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
 
     // mv is range and sql is range and sql range is bigger than mv
     query_sql = """
@@ -350,20 +350,19 @@ suite("filter_equal_or_notequal_case") {
         notContains "${mv_name}(${mv_name})"
     }
 
-    // Todo: It is not currently supported and is expected to be
     // mv is range and sql is range and sql range is bigger than mv
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate > '2023-10-19'
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
 
     // mv is range and sql is range and sql range is not in mv range
     query_sql = """
@@ -418,20 +417,34 @@ suite("filter_equal_or_notequal_case") {
         notContains "${mv_name}(${mv_name})"
     }
 
-    // Todo: It is not currently supported and is expected to be
     // sql range is in mv range
-//    query_sql = """
-//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-//        from lineitem_1
-//        left join orders_1
-//        on lineitem_1.l_orderkey = orders_1.o_orderkey
-//        where l_shipdate in ('2023-10-18')
-//        """
-//    explain {
-//        sql("${query_sql}")
-//        contains "${mv_name}(${mv_name})"
-//    }
-//    compare_res(query_sql + " order by 1,2,3,4")
+    // single value
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate in ('2023-10-18')
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+    // multi value
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate in ('2023-10-18', '2023-11-18')
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
 
     // sql range like mv range
     query_sql = """
@@ -491,6 +504,20 @@ suite("filter_equal_or_notequal_case") {
         left join orders_1
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-19'
+        """
+    explain {
+        sql("${query_sql}")
+        contains "${mv_name}(${mv_name})"
+    }
+    compare_res(query_sql + " order by 1,2,3,4")
+
+
+    query_sql = """
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+        from lineitem_1
+        left join orders_1
+        on lineitem_1.l_orderkey = orders_1.o_orderkey
+        where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
         """
     explain {
         sql("${query_sql}")

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
@@ -164,9 +164,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv equal and sql equal
     def query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey  
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate = '2023-10-17'
         """
@@ -180,9 +180,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv equal and sql not equal
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate != '2023-10-17'
         """
@@ -193,9 +193,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv equal and sql equal and number is difference
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate = '2023-10-19'
         """
@@ -205,9 +205,9 @@ suite("filter_equal_or_notequal_case") {
     }
 
     mtmv_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate != '2023-10-17'
         """
@@ -218,9 +218,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv not equal and sql equal
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate = '2023-10-17'
         """
@@ -231,9 +231,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv not equal and sql not equal
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate != '2023-10-17'
         """
@@ -245,9 +245,9 @@ suite("filter_equal_or_notequal_case") {
 
 
     mtmv_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey  
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-17'
         """
@@ -258,9 +258,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql equal and filter not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate = '2023-10-16'
         """
@@ -271,9 +271,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql equal and filter in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate = '2023-10-17'
         """
@@ -298,9 +298,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is bigger than mv
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-16'
         """
@@ -311,9 +311,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate < '2023-10-16'
         """
@@ -324,9 +324,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is bigger than mv
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-17'
         """
@@ -338,9 +338,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate < '2023-10-17'
         """
@@ -365,9 +365,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate < '2023-10-19'
         """
@@ -378,9 +378,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is bigger than mv
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey  
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-17'
         """
@@ -391,9 +391,9 @@ suite("filter_equal_or_notequal_case") {
 
     // mv is range and sql is range and sql range is not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
         """
@@ -405,9 +405,9 @@ suite("filter_equal_or_notequal_case") {
 
     // sql range is not in mv range
     query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
+        from lineitem_1 
+        left join orders_1 
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate in ('2023-10-17')
         """

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
@@ -158,96 +158,96 @@ suite("filter_equal_or_notequal_case") {
         where l_shipdate = '2023-10-17'
         """
 
-    create_mv_lineitem(mv_name, mtmv_sql)
-    def job_name = getJobName(db, mv_name)
-    waitingMTMVTaskFinished(job_name)
-
-    // mv equal and sql equal
-    def query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey  
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-17'
-        """
-    def res_tmp = sql """explain ${query_sql}"""
-    logger.info("res_temp:" + res_tmp)
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-    // mv equal and sql not equal
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate != '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv equal and sql equal and number is difference
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-19'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
+//    create_mv_lineitem(mv_name, mtmv_sql)
+//    def job_name = getJobName(db, mv_name)
+//    waitingMTMVTaskFinished(job_name)
+//
+//    // mv equal and sql equal
+//    def query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-17'
+//        """
+//    def res_tmp = sql """explain ${query_sql}"""
+//    logger.info("res_temp:" + res_tmp)
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // mv equal and sql not equal
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate != '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv equal and sql equal and number is difference
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-19'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    mtmv_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate != '2023-10-17'
+//        """
+//
+//    create_mv_lineitem(mv_name, mtmv_sql)
+//    job_name = getJobName(db, mv_name)
+//    waitingMTMVTaskFinished(job_name)
+//
+//    // mv not equal and sql equal
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv not equal and sql not equal
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate != '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//
     mtmv_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate != '2023-10-17'
-        """
-
-    create_mv_lineitem(mv_name, mtmv_sql)
-    job_name = getJobName(db, mv_name)
-    waitingMTMVTaskFinished(job_name)
-
-    // mv not equal and sql equal
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv not equal and sql not equal
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate != '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-
-    mtmv_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey  
-        from lineitem_1 
-        left join orders_1 
+        select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
+        from lineitem_1
+        left join orders_1
         on lineitem_1.l_orderkey = orders_1.o_orderkey
         where l_shipdate > '2023-10-17'
         """
@@ -255,182 +255,182 @@ suite("filter_equal_or_notequal_case") {
     create_mv_lineitem(mv_name, mtmv_sql)
     job_name = getJobName(db, mv_name)
     waitingMTMVTaskFinished(job_name)
-
-    // mv is range and sql equal and filter not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-16'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql equal and filter in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // Todo: It is not currently supported and is expected to be
-    // mv is range and sql equal and filter in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate = '2023-10-19'
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-    // mv is range and sql is range and sql range is bigger than mv
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate > '2023-10-16'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql is range and sql range is not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate < '2023-10-16'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql is range and sql range is bigger than mv
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate > '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-    // mv is range and sql is range and sql range is not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate < '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql is range and sql range is bigger than mv
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate > '2023-10-19'
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-    // mv is range and sql is range and sql range is not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate < '2023-10-19'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql is range and sql range is bigger than mv
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey  
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-17'
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // mv is range and sql is range and sql range is not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
-
-    // sql range is not in mv range
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey 
-        from lineitem_1 
-        left join orders_1 
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate in ('2023-10-17')
-        """
-    explain {
-        sql("${query_sql}")
-        notContains "${mv_name}(${mv_name})"
-    }
-
-    // sql range is in mv range
-    // single value
-    query_sql = """
-        select l_shipdate, o_orderdate, l_partkey, l_suppkey
-        from lineitem_1
-        left join orders_1
-        on lineitem_1.l_orderkey = orders_1.o_orderkey
-        where l_shipdate in ('2023-10-18')
-        """
-    explain {
-        sql("${query_sql}")
-        contains "${mv_name}(${mv_name})"
-    }
-    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // mv is range and sql equal and filter not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-16'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql equal and filter in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // Todo: It is not currently supported and is expected to be
+//    // mv is range and sql equal and filter in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate = '2023-10-19'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // mv is range and sql is range and sql range is bigger than mv
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate > '2023-10-16'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql is range and sql range is not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate < '2023-10-16'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql is range and sql range is bigger than mv
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate > '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // mv is range and sql is range and sql range is not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate < '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql is range and sql range is bigger than mv
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate > '2023-10-18'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // mv is range and sql is range and sql range is not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate < '2023-10-19'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql is range and sql range is bigger than mv
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate > '2023-10-16' and l_shipdate < '2023-10-17'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // mv is range and sql is range and sql range is not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate > '2023-10-17' and l_shipdate < '2023-10-19'
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
+//
+//    // sql range is not in mv range
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate in ('2023-10-17')
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        notContains "${mv_name}(${mv_name})"
+//    }
+//
+//    // sql range is in mv range
+//    // single value
+//    query_sql = """
+//        select l_shipdate, o_orderdate, l_partkey, l_suppkey
+//        from lineitem_1
+//        left join orders_1
+//        on lineitem_1.l_orderkey = orders_1.o_orderkey
+//        where l_shipdate in ('2023-10-18')
+//        """
+//    explain {
+//        sql("${query_sql}")
+//        contains "${mv_name}(${mv_name})"
+//    }
+//    compare_res(query_sql + " order by 1,2,3,4")
 
     // multi value
     query_sql = """


### PR DESCRIPTION
## Proposed changes
It supports predicate composite as following:
materialized view define
>        select l_shipdate, o_orderdate, l_partkey, l_suppkey
>        from lineitem_1
>        left join orders_1
>        on lineitem_1.l_orderkey = orders_1.o_orderkey
>        where l_shipdate > '2023-10-19'


the query as following can be rewritten by the materialized view above
>        select l_shipdate, o_orderdate, l_partkey, l_suppkey
>        from lineitem_1
>        left join orders_1
>        on lineitem_1.l_orderkey = orders_1.o_orderkey
>        where l_shipdate > '2023-10-25'

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

