### PR TITLE
[enhancement](docs) Clarify JAR file locations for JDBC catalog

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -54,7 +54,7 @@ PROPERTIES ("key" = "value", ...)
 | `only_specified_database` | No              | false         | Whether only the specified database should be synchronized.                                                              |
 | `lower_case_meta_names`   | No              | false         | Whether to synchronize the database name, table name and column name of the external JDBC data source in lowercase.      |
 | `meta_names_mapping`      | No              |               | When the JDBC external data source has the same name but different case, e.g. DORIS and doris, Doris reports an error when querying the catalog due to ambiguity. In this case, the `meta_names_mapping` parameter needs to be specified to resolve the conflict. |
-| `include_database_list`   | No              |               | When `only_specified_database = true`，only synchronize the specified databases. Separate using `,`. Database names are case sensitive. |
+| `include_database_list`   | No              |               | When `only_specified_database = true`，only synchronize the specified databases. Separate with `,`. Database name is case sensitive. |
 | `exclude_database_list`   | No              |               | When `only_specified_database = true`，do not synchronize the specified databases. Separate with `,`. Database name is case sensitive. |
 
 ### Driver path

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -61,7 +61,7 @@ PROPERTIES ("key" = "value", ...)
 
 `driver_url` can be specified in three ways:
 
-1. File name. For example, `mysql-connector-java-8.0.25.jar`. Place the the JAR file in a directory `jdbc_drivers` under the Doris `fe` and `be` installation directories. I.e. create two directories `/fe/jdbc_drivers` and `/be/jdbc_drivers` and place a JAR file in each of them. You may have to create the `jdbc_drivers` directories manually. Make sure the directories are readable and preferably owned by the Doris user. You can change the location of the files by modifying the `jdbc_drivers_dir` property in the `fe.conf` and `be.conf` configuration files.
+1. File name. For example, `mysql-connector-java-8.0.25.jar`. Place the the JAR file in a directory `jdbc_drivers` under the Doris `fe` and `be` installation directories. I.e. create two directories `/fe/jdbc_drivers` and `/be/jdbc_drivers` and place a JAR file in each of them. You may have to create the `jdbc_drivers` directories manually. Make sure the directories are readable and preferably owned by the Doris user. You can change the location of the driver files by modifying the `jdbc_drivers_dir` property in the `fe.conf` and `be.conf` configuration files.
 
 2. Local absolute path. For example, `file:///path/to/mysql-connector-java-8.0.25.jar`. Please place the JAR file in the specified paths of FE/BE node.
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -27,64 +27,64 @@ under the License.
 
 # JDBC
 
-JDBC Catalogs in Doris are connected to external data sources using the standard JDBC protocol.
+JDBC catalogs in Doris allows for connecting to external data sources using the standard JDBC protocol.
 
-Once connected, Doris will ingest metadata of databases and tables from the external data sources in order to enable quick access to external data.
+Once connected, Doris will ingest database and table metadata in order to enable quick access to data in the external data sources.
 
 ## Usage
 
-Supported datas sources include MySQL, PostgreSQL, Oracle, SQLServer, Clickhouse, Doris, SAP HANA, Trino and OceanBase.
+Supported data sources are MySQL, PostgreSQL, Oracle, SQLServer, Clickhouse, Doris, SAP HANA, Trino and OceanBase.
 
 ## Syntax
 
 ```sql
 CREATE CATALOG <catalog_name>
-PROPERTIES ("key"="value", ...)
+PROPERTIES ("key" = "value", ...)
 ```
 
 ## Parameter Description
 
 | Parameter                 | Required or Not | Default Value | Description                                                                                                              |
 |---------------------------|-----------------|---------------|--------------------------------------------------------------------------------------------------------------------------|
-| `user`                    | Yes             |               | Username in relation to the corresponding database                                                                       |
-| `password`                | Yes             |               | Password for the corresponding database                                                                                  |
+| `user`                    | Yes             |               | Username for the external database                                                                                       |
+| `password`                | Yes             |               | Password for the external database                                                                                       |
 | `jdbc_url `               | Yes             |               | JDBC connection string                                                                                                   |
-| `driver_url `             | Yes             |               | JDBC Driver Jar                                                                                                          |
-| `driver_class `           | Yes             |               | JDBC Driver Class                                                                                                        |
-| `only_specified_database` | No              | "false"       | Whether only the database specified to be synchronized.                                                                  |
-| `lower_case_meta_names`   | No              | "false"       | Whether to synchronize the database name, table name and column name of jdbc external data source in lowercase.          |
-| `meta_names_mapping`      | No              | ""            | When the jdbc external data source has the same name but different case, such as DORIS and doris, Doris reports an error when querying the Catalog due to ambiguity. In this case, the `meta_names_mapping` parameter needs to be configured to resolve the conflict. |
-| `include_database_list`   | No              | ""            | When only_specified_database=true，only synchronize the specified databases. split with ','. db name is case sensitive.   |
-| `exclude_database_list`   | No              | ""            | When only_specified_database=true，do not synchronize the specified databases. split with ','. db name is case sensitive. |
+| `driver_url `             | Yes             |               | JDBC driver JAR file                                                                                                     |
+| `driver_class `           | Yes             |               | JDBC driver class                                                                                                        |
+| `only_specified_database` | No              | false         | Whether only the specified database should be synchronized.                                                              |
+| `lower_case_meta_names`   | No              | false         | Whether to synchronize the database name, table name and column name of the external JDBC data source in lowercase.      |
+| `meta_names_mapping`      | No              |               | When the JDBC external data source has the same name but different case, e.g. DORIS and doris, Doris reports an error when querying the catalog due to ambiguity. In this case, the `meta_names_mapping` parameter needs to be specified to resolve the conflict. |
+| `include_database_list`   | No              |               | When `only_specified_database = true`，only synchronize the specified databases. Separate using `,`. Database names are case sensitive. |
+| `exclude_database_list`   | No              |               | When `only_specified_database = true`，do not synchronize the specified databases. Separate with `,`. Database name is case sensitive. |
 
 ### Driver path
 
 `driver_url` can be specified in three ways:
 
-1. File name. For example,  `mysql-connector-java-8.0.25.jar`. Please place the Jar file package in  `jdbc_drivers/`  under the FE/BE deployment directory in advance so the system can locate the file. You can change the location of the file by modifying  `jdbc_drivers_dir`  in fe.conf and be.conf.
+1. File name. For example, `mysql-connector-java-8.0.25.jar`. Place the the JAR file in a directory `jdbc_drivers` under the Doris `fe` and `be` installation directories. I.e. create two directories `/fe/jdbc_drivers` and `/be/jdbc_drivers` and place a JAR file in each of them. You may have to create the `jdbc_drivers` directories manually. Make sure the directories are readable and preferably owned by the Doris user. You can change the location of the files by modifying the `jdbc_drivers_dir` property in the `fe.conf` and `be.conf` configuration files.
 
-2. Local absolute path. For example, `file:///path/to/mysql-connector-java-8.0.25.jar`. Please place the Jar file package in the specified paths of FE/BE node.
+2. Local absolute path. For example, `file:///path/to/mysql-connector-java-8.0.25.jar`. Please place the JAR file in the specified paths of FE/BE node.
 
-3. HTTP address. For example, `https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/jdbc_driver/mysql-connector-java-8.0.25.jar`. The system will download the Driver file from the HTTP address. This only supports HTTP services with no authentication requirements.
+3. HTTP address. For example, `https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/jdbc_driver/mysql-connector-java-8.0.25.jar`. The system will download the driver file from the HTTP address. This only supports HTTP and HTTPS services with no authentication requirements.
 
 **Driver package security**
 
-In order to prevent the use of a Driver Jar package with an unallowed path when creating the Catalog, Doris will perform path management and checksum checking on the Jar package.
+In order to prevent the use of a driver JAR package with a disallowed path when creating the catalog, Doris will perform path management and checksum checking on the JAR package.
 
-1. For the above method 1, the `jdbc_drivers_dir` configured by the Doris default user and all Jar packages in its directory are safe and will not be path checked.
+1. For the above method 1, the `jdbc_drivers_dir` configured by the Doris default user and all JAR packages in its directory are safe and will not be path checked.
 
-2. For the above methods 2 and 3, Doris will check the source of the Jar package. The checking rules are as follows:
+2. For the above methods 2 and 3, Doris will check the source of the JAR package. The checking rules are as follows:
 
-   * Control the allowed driver package paths through the FE configuration item `jdbc_driver_secure_path`. This configuration item can configure multiple paths, separated by semicolons. When this item is configured, Doris will check whether the prefix of the driver_url path in the Catalog properties is in `jdbc_driver_secure_path`. If not, it will refuse to create the Catalog.
-   * This parameter defaults to `*`, which means Jar packages of all paths are allowed.
+   * Control the allowed driver package paths through the FE configuration item `jdbc_driver_secure_path`. This configuration item can configure multiple paths, separated by semicolons. When this item is configured, Doris will check whether the prefix of the `driver_url` path in the catalog properties is in `jdbc_driver_secure_path`. If not, it will refuse to create the catalog.
+   * This parameter defaults to `*`, which means JAR packages of all paths are allowed.
    * If the configuration `jdbc_driver_secure_path` is empty, driver packages for all paths are not allowed, which means that the driver package can only be specified using method 1 above.
 
    > If you configure `jdbc_driver_secure_path = "file:///path/to/jdbc_drivers;http://path/to/jdbc_drivers"`, only `file:///path/to/jdbc_drivers` or `http:// is allowed The driver package path starting with path/to/jdbc_drivers`.
 
-3. When creating a Catalog, you can specify the checksum of the driver package through the `checksum` parameter. Doris will verify the driver package after loading the driver package. If the verification fails, it will refuse to create the Catalog.
+3. When creating a catalog, you can specify the checksum of the driver package through the `checksum` parameter. Doris will verify the driver package after loading the driver package. If the verification fails, it will refuse to create the catalog.
 
 :::warning
-The above verification will only be performed when the Catalog is created. For already created Catalogs, verification will not be performed again.
+The above verification will only be performed when the catalog is created. For already created catalogs, verification will not be performed again.
 :::
 
 ### Lowercase name synchronization
@@ -108,9 +108,9 @@ Since FE has the `lower_case_table_names` parameter, it will affect the table na
   lower_case_meta_names = false, the case is consistent with the source library.
   lower_case_meta_names = true, lowercase repository table column names.
 
-If the parameter configuration when creating the Catalog matches the lowercase conversion rule in the above rules, Doris will convert the corresponding name to lowercase and store it in Doris. When querying, you need to use the lowercase name displayed by Doris.
+If the parameter configuration when creating the catalog matches the lowercase conversion rule in the above rules, Doris will convert the corresponding name to lowercase and store it in Doris. When querying, you need to use the lowercase name displayed by Doris.
 
-If the external data source has the same name but different case, such as DORIS and doris, Doris will report an error when querying the Catalog due to ambiguity. In this case, you need to configure the `meta_names_mapping` parameter to resolve the conflict.
+If the external data source has the same name but different case, such as DORIS and doris, Doris will report an error when querying the catalog due to ambiguity. In this case, you need to configure the `meta_names_mapping` parameter to resolve the conflict.
 
 The `meta_names_mapping` parameter accepts a Json format string with the following format:
 
@@ -152,7 +152,7 @@ The `meta_names_mapping` parameter accepts a Json format string with the followi
 }
 ```
 
-When filling this configuration into the statement that creates the Catalog, there are double quotes in Json, so you need to escape the double quotes or directly use single quotes to wrap the Json string when filling in.
+When filling this configuration into the statement that creates the catalog, there are double quotes in Json, so you need to escape the double quotes or directly use single quotes to wrap the Json string when filling in.
 
 ```sql
 CREATE CATALOG jdbc_catalog PROPERTIES (
@@ -174,7 +174,7 @@ CREATE CATALOG jdbc_catalog PROPERTIES (
 
 **Notice:**
 
-JDBC Catalog has the following three stages for mapping rules for external table case:
+JDBC catalog has the following three stages for mapping rules for external table case:
 
 * Doris versions prior to 2.0.3
 
@@ -182,7 +182,7 @@ JDBC Catalog has the following three stages for mapping rules for external table
 
   When querying Oracle, all library names and table names will be converted to uppercase before querying Oracle, for example:
 
-  Oracle has the TEST table in the TEST space. When Doris creates the Catalog, set `lower_case_table_names` to `true`, then Doris can query the TEST table through `select * from oracle_catalog.test.test`, and Doris will automatically format test.test into TEST.TEST is sent to Oracle. It should be noted that this is the default behavior, which also means that lowercase table names in Oracle cannot be queried.
+  Oracle has the TEST table in the TEST space. When Doris creates the catalog, set `lower_case_table_names` to `true`, then Doris can query the TEST table through `select * from oracle_catalog.test.test`, and Doris will automatically format test.test into TEST.TEST is sent to Oracle. It should be noted that this is the default behavior, which also means that lowercase table names in Oracle cannot be queried.
 
 * Doris 2.0.3 version:
 
@@ -190,7 +190,7 @@ JDBC Catalog has the following three stages for mapping rules for external table
 
   However, if the library, table, or column names differ only in case, such as `Doris` and `doris`, Doris cannot query them due to ambiguity.
 
-  And when the `lower_case_table_names` parameter of the FE parameter is set to `1` or `2`, the `lower_case_table_names` parameter of the JDBC Catalog must be set to `true`. If the `lower_case_table_names` of the FE parameter is set to `0`, the JDBC Catalog parameter can be `true` or `false`, defaulting to `false`.
+  And when the `lower_case_table_names` parameter of the FE parameter is set to `1` or `2`, the `lower_case_table_names` parameter of the JDBC catalog must be set to `true`. If the `lower_case_table_names` of the FE parameter is set to `0`, the JDBC catalog parameter can be `true` or `false`, defaulting to `false`.
 
 * Doris 2.1.0 and later versions:
 
@@ -198,7 +198,7 @@ JDBC Catalog has the following three stages for mapping rules for external table
 
   For specific rules, please refer to the introduction of `lower_case_meta_names` at the beginning of this section.
 
-  Users who have previously set the JDBC Catalog `lower_case_table_names` parameter will automatically have `lower_case_table_names` converted to `lower_case_meta_names` when upgrading to 2.0.4.
+  Users who have previously set the JDBC catalog `lower_case_table_names` parameter will automatically have `lower_case_table_names` converted to `lower_case_meta_names` when upgrading to 2.0.4.
 
 ### Specify synchronization database:
 
@@ -256,7 +256,7 @@ If there is a limit keyword in the query, Doris will translate it into semantics
 
 ## Write Data
 
-After the JDBC Catalog is established in Doris, you can write data directly through the insert into statement, or write the results of the query executed by Doris into the JDBC Catalog, or import data from one JDBC Catalog to another JDBC Catalog.
+After the JDBC catalog is established in Doris, you can write data directly through the insert into statement, or write the results of the query executed by Doris into the JDBC catalog, or import data from one JDBC catalog to another JDBC catalog.
 
 ### Example
 
@@ -267,7 +267,7 @@ insert into mysql_catalog.mysql_database.mysql_table select * from table;
 
 ### Transaction
 
-In Doris, data is written to External Tables in batches. If the ingestion process is interrupted, rollbacks might be required. That's why JDBC Catalog Tables support data writing transactions. You can utilize this feature by setting the session variable: `enable_odbc_transcation `.
+In Doris, data is written to External Tables in batches. If the ingestion process is interrupted, rollbacks might be required. That's why JDBC catalog tables support data writing transactions. You can utilize this feature by setting the session variable: `enable_odbc_transcation `.
 
 ```
 set enable_odbc_transcation = true; 
@@ -279,12 +279,12 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 In Doris, each Frontend (FE) and Backend (BE) node maintains a connection pool, thus avoiding the need to frequently open and close individual connections to data sources. Each connection within this pool can be used to establish a connection to a data source and perform queries. After operations are completed, connections are returned to the pool for reuse. This not only enhances performance but also reduces system load during connection establishment, and helps to prevent hitting the maximum connection limits of the data sources.
 
-The following Catalog configuration properties are available for tuning the behavior of the connection pool:
+The following catalog configuration properties are available for tuning the behavior of the connection pool:
 
 | Parameter Name                  | Default Value  | Description and Behavior                                                                                                                                                                                                                                                                                                                                                                          |
 |---------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `connection_pool_min_size`      | 1              | Defines the minimum number of connections that the pool will maintain, ensuring that this number of connections remains active when the keep-alive mechanism is enabled.                                                                                                                                                                                                                          |
-| `connection_pool_max_size`      | 10             | Specifies the maximum number of connections allowed in the pool. Each Catalog corresponding to every FE or BE node can hold up to this number of connections.                                                                                                                                                                                                                                     |
+| `connection_pool_max_size`      | 10             | Specifies the maximum number of connections allowed in the pool. Each catalog corresponding to every FE or BE node can hold up to this number of connections.                                                                                                                                                                                                                                     |
 | `connection_pool_max_wait_time` | 5000           | Determines the maximum amount of time, in milliseconds, that the client will wait for a connection from the pool if none is immediately available.                                                                                                                                                                                                                                                |
 | `connection_pool_max_life_time` | 1800000        | Sets the maximum lifetime of connections in the pool, in milliseconds. Connections exceeding this set time limit will be forcibly closed. Additionally, half of this value is used as the minimum evictable idle time for the pool. Connections reaching this idle time are considered for eviction, and the eviction task runs at intervals of one-tenth of the `connection_pool_max_life_time`. |
 | `connection_pool_keep_alive`    | false          | Effective only on BE nodes, it controls whether to keep connections that have reached the minimum evictable idle time but not the maximum lifetime active. It is kept false by default to avoid unnecessary resource usage.                                                                                                                                                                       |
@@ -293,37 +293,37 @@ To prevent an accumulation of unused connection pool caches on the BE, the BE `j
 
 ## Guide
 
-### View the JDBC Catalog
+### View the JDBC catalog
 
-You can query all Catalogs in the current Doris cluster through SHOW CATALOGS:
+You can query all catalogs in the current Doris cluster through SHOW CATALOGS:
 
 ```sql
 SHOW CATALOGS;
 ```
 
-Query the creation statement of a Catalog through SHOW CREATE CATALOG:
+Query the creation statement of a catalog through SHOW CREATE CATALOG:
 
 ```sql
 SHOW CREATE CATALOG <catalog_name>;
 ```
 
-### Drop the JDBC Catalog
+### Drop the JDBC catalog
 
-A Catalog can be deleted via DROP CATALOG:
+A catalog can be deleted via DROP CATALOG:
 
 ```sql
 DROP CATALOG <catalog_name>;
 ```
 
-### Query the JDBC Catalog
+### Query the JDBC catalog
 
-1. Use SWITCH to switch the Catalog in effect for the current session:
+1. Use SWITCH to switch the catalog in effect for the current session:
 
     ```sql
     SWITCH <catalog_name>;
     ```
 
-2. Query all libraries under the current Catalog through SHOW DATABASES:
+2. Query all libraries under the current catalog through SHOW DATABASES:
 
     ```sql
     SHOW DATABASES FROM <catalog_name>;
@@ -341,7 +341,7 @@ DROP CATALOG <catalog_name>;
 
    Or directly use `USE <catalog_name>.<database_name>;` to switch the Database that takes effect in the current session
 
-4. Query all tables under the current Catalog through SHOW TABLES:
+4. Query all tables under the current catalog through SHOW TABLES:
 
     ```sql
     SHOW TABLES FROM <catalog_name>.<database_name>;
@@ -355,7 +355,7 @@ DROP CATALOG <catalog_name>;
     SHOW TABLES;
     ```
 
-5. Query the data of a table under the current Catalog through SELECT:
+5. Query the data of a table under the current catalog through SELECT:
 
     ```sql
     SELECT * FROM <table_name>;
@@ -363,7 +363,7 @@ DROP CATALOG <catalog_name>;
 
 ## SQL Passthrough
 
-In versions prior to Doris 2.0.3, users could only perform query operations (SELECT) through the JDBC Catalog.
+In versions prior to Doris 2.0.3, users could only perform query operations (SELECT) through the JDBC catalog.
 Starting from version Doris 2.0.4, users can perform DDL (Data Definition Language) and DML (Data Manipulation Language) operations on JDBC data sources using the `CALL` command.
 
 ```
@@ -372,7 +372,7 @@ CALL EXECUTE_STMT("catalog_name", "raw_stmt_string");
 
 The `EXECUTE_STMT()` procedure involves two parameters:
 
-- Catalog Name: Currently, only the Jdbc Catalog is supported.
+- Catalog Name: Currently, only the JDBC catalog is supported.
 - Execution Statement: Currently, only DDL and DML statements are supported. These statements must use the syntax specific to the JDBC data source.
 
 ```
@@ -385,13 +385,13 @@ CALL EXECUTE_STMT("jdbc_catalog", "create table db1.tbl2 (k1 int)");
 
 ### Principles and Limitations
 
-Through the `CALL EXECUTE_STMT()` command, Doris directly sends the SQL statements written by the user to the JDBC data source associated with the Catalog for execution. Therefore, this operation has the following limitations:
+Through the `CALL EXECUTE_STMT()` command, Doris directly sends the SQL statements written by the user to the JDBC data source associated with the catalog for execution. Therefore, this operation has the following limitations:
 
 - The SQL statements must be in the syntax specific to the data source, as Doris does not perform syntax and semantic checks.
-- It is recommended that table names in SQL statements be fully qualified, i.e., in the `db.tbl` format. If the `db` is not specified, the db name specified in the JDBC Catalog's JDBC URL will be used.
-- SQL statements cannot reference tables outside of the JDBC data source, nor can they reference Doris's tables. However, they can reference tables within the JDBC data source that have not been synchronized to the Doris JDBC Catalog.
+- It is recommended that table names in SQL statements be fully qualified, i.e., in the `db.tbl` format. If the `db` is not specified, the db name specified in the JDBC catalog JDBC URL will be used.
+- SQL statements cannot reference tables outside of the JDBC data source, nor can they reference Doris's tables. However, they can reference tables within the JDBC data source that have not been synchronized to the Doris JDBC catalog.
 - When executing DML statements, it is not possible to obtain the number of rows inserted, updated, or deleted; success of the command execution can only be confirmed.
-- Only users with LOAD permissions on the Catalog can execute this command.
+- Only users with LOAD permissions on the catalog can execute this command.
 
 ## Supported Datasoures
 
@@ -403,9 +403,9 @@ Through the `CALL EXECUTE_STMT()` command, Doris directly sends the SQL statemen
 
 ```sql
 CREATE CATALOG jdbc_mysql PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:mysql://127.0.0.1:3306/demo",
     "driver_url" = "mysql-connector-java-5.1.47.jar",
     "driver_class" = "com.mysql.jdbc.Driver"
@@ -416,9 +416,9 @@ CREATE CATALOG jdbc_mysql PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_mysql PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:mysql://127.0.0.1:3306/demo",
     "driver_url" = "mysql-connector-java-8.0.25.jar",
     "driver_class" = "com.mysql.cj.jdbc.Driver"
@@ -430,8 +430,8 @@ CREATE CATALOG jdbc_mysql PROPERTIES (
 |  Doris   |    MySQL     |
 |:--------:|:------------:|
 | Catalog  | MySQL Server |
-| Database |   Database   |
-|  Table   |    Table     |
+| Database | Database     |
+| Table    | Table        |
 
 #### Type Mapping
 
@@ -473,9 +473,9 @@ CREATE CATALOG jdbc_mysql PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_postgresql PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:postgresql://127.0.0.1:5432/demo",
     "driver_url" = "postgresql-42.5.1.jar",
     "driver_class" = "org.postgresql.Driver"
@@ -488,9 +488,9 @@ As for data mapping from PostgreSQL to Doris, one Database in Doris corresponds 
 
 |  Doris   | PostgreSQL |
 |:--------:|:----------:|
-| Catalog  |  Database  |
-| Database |   Schema   |
-|  Table   |   Table    |
+| Catalog  | Database   |
+| Database | Schema     |
+| Table    | Table      |
 
 :::tip
 Doris obtains all schemas that PG user can access through the SQL statement: `select nspname from pg_namespace where has_schema_privilege('<UserName>', nspname, 'USAGE');` and map these schemas to doris database.   
@@ -529,9 +529,9 @@ Doris obtains all schemas that PG user can access through the SQL statement: `se
 
 ```sql
 CREATE CATALOG jdbc_oracle PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:oracle:thin:@127.0.0.1:1521:helowin",
     "driver_url" = "ojdbc8.jar",
     "driver_class" = "oracle.jdbc.driver.OracleDriver"
@@ -545,8 +545,8 @@ As for data mapping from Oracle to Doris, one Database in Doris corresponds to o
 |  Doris   |  Oracle  |
 |:--------:|:--------:|
 | Catalog  | Database |
-| Database |   User   |
-|  Table   |  Table   |
+| Database | User     |
+| Table    | Table    |
 
 **NOTE:** Synchronizing Oracle's SYNONYM TABLE is not currently supported.
 
@@ -573,9 +573,9 @@ As for data mapping from Oracle to Doris, one Database in Doris corresponds to o
 
 ```sql
 CREATE CATALOG jdbc_sqlserve PROPERTIES (
-    "type"="jdbc",
-    "user"="SA",
-    "password"="Doris123456",
+    "type" = "jdbc",
+    "user" = "SA",
+    "password" = "Doris123456",
     "jdbc_url" = "jdbc:sqlserver://localhost:1433;DataBaseName=doris_test",
     "driver_url" = "mssql-jdbc-11.2.3.jre8.jar",
     "driver_class" = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
@@ -589,8 +589,8 @@ As for data mapping from SQLServer to Doris, one Database in Doris corresponds t
 |  Doris   | SQLServer |
 |:--------:|:---------:|
 | Catalog  | Database  |
-| Database |  Schema   |
-|  Table   |   Table   |
+| Database | Schema    |
+| Table    | Table     |
 
 #### Type Mapping
 
@@ -614,28 +614,28 @@ As for data mapping from SQLServer to Doris, one Database in Doris corresponds t
 
 ### Doris
 
-Jdbc Catalog also support to connect another Doris database:
+The JDBC catalog supports connecting to another Doris database:
 
-* mysql 5.7 Driver
+* MySQL 5.7 driver
 
 ```sql
 CREATE CATALOG jdbc_doris PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:mysql://127.0.0.1:9030?useSSL=false",
     "driver_url" = "mysql-connector-java-5.1.47.jar",
     "driver_class" = "com.mysql.jdbc.Driver"
 )
 ```
 
-* mysql 8 Driver
+* MySQL 8 driver
 
 ```sql
 CREATE CATALOG jdbc_doris PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:mysql://127.0.0.1:9030?useSSL=false",
     "driver_url" = "mysql-connector-java-8.0.25.jar",
     "driver_class" = "com.mysql.cj.jdbc.Driver"
@@ -672,9 +672,9 @@ CREATE CATALOG jdbc_doris PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_clickhouse PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:clickhouse://127.0.0.1:8123/demo",
     "driver_url" = "clickhouse-jdbc-0.4.2-all.jar",
     "driver_class" = "com.clickhouse.jdbc.ClickHouseDriver"
@@ -686,8 +686,8 @@ CREATE CATALOG jdbc_clickhouse PROPERTIES (
 |  Doris   |    ClickHouse     |
 |:--------:|:-----------------:|
 | Catalog  | ClickHouse Server |
-| Database |     Database      |
-|  Table   |       Table       |
+| Database | Database          |
+| Table    | Table             |
 
 #### Type Mapping
 
@@ -717,9 +717,9 @@ CREATE CATALOG jdbc_clickhouse PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_hana PROPERTIES (
-    "type"="jdbc",
-    "user"="SYSTEM",
-    "password"="SAPHANA",
+    "type" = "jdbc",
+    "user" = "SYSTEM",
+    "password" = "SAPHANA",
     "jdbc_url" = "jdbc:sap://localhost:31515/TEST",
     "driver_url" = "ngdbc.jar",
     "driver_class" = "com.sap.db.jdbc.Driver"
@@ -731,8 +731,8 @@ CREATE CATALOG jdbc_hana PROPERTIES (
 |  Doris   | SAP HANA |
 |:--------:|:--------:|
 | Catalog  | Database |
-| Database |  Schema  |
-|  Table   |  Table   |
+| Database | Schema  |
+| Table    | Table   |
 
 #### Type Mapping
 
@@ -767,9 +767,9 @@ CREATE CATALOG jdbc_hana PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_trino PROPERTIES (
-    "type"="jdbc",
-    "user"="hadoop",
-    "password"="",
+    "type" = "jdbc",
+    "user" = "hadoop",
+    "password" = "",
     "jdbc_url" = "jdbc:trino://localhost:9000/hive",
     "driver_url" = "trino-jdbc-389.jar",
     "driver_class" = "io.trino.jdbc.TrinoDriver"
@@ -780,9 +780,9 @@ CREATE CATALOG jdbc_trino PROPERTIES (
 
 ```sql
 CREATE CATALOG jdbc_presto PROPERTIES (
-    "type"="jdbc",
-    "user"="hadoop",
-    "password"="",
+    "type" = "jdbc",
+    "user" = "hadoop",
+    "password" = "",
     "jdbc_url" = "jdbc:presto://localhost:9000/hive",
     "driver_url" = "presto-jdbc-0.280.jar",
     "driver_class" = "com.facebook.presto.jdbc.PrestoDriver"
@@ -791,13 +791,13 @@ CREATE CATALOG jdbc_presto PROPERTIES (
 
 #### Hierarchy Mapping
 
-When mapping Trino, Doris's Database corresponds to a Schema under the specified Catalog in Trino (such as "hive" in the `jdbc_url` parameter in the example). The Table under the Database of Doris corresponds to the Tables under the Schema in Trino. That is, the mapping relationship is as follows:
+When mapping Trino, Doris's Database corresponds to a Schema under the specified catalog in Trino (such as "hive" in the `jdbc_url` parameter in the example). The Table under the Database of Doris corresponds to the Tables under the Schema in Trino. That is, the mapping relationship is as follows:
 
 |  Doris   | Trino/Presto |
 |:--------:|:------------:|
-| Catalog  |   Catalog    |
-| Database |    Schema    |
-|  Table   |    Table     |
+| Catalog  | Catalog      |
+| Database | Schema       |
+| Table    | Table        |
 
 
 #### Type Mapping
@@ -826,9 +826,9 @@ When mapping Trino, Doris's Database corresponds to a Schema under the specified
 
 ```sql
 CREATE CATALOG jdbc_oceanbase PROPERTIES (
-    "type"="jdbc",
-    "user"="root",
-    "password"="123456",
+    "type" = "jdbc",
+    "user" = "root",
+    "password" = "123456",
     "jdbc_url" = "jdbc:oceanbase://127.0.0.1:2881/demo",
     "driver_url" = "oceanbase-client-2.4.2.jar",
     "driver_class" = "com.oceanbase.jdbc.Driver"
@@ -901,8 +901,8 @@ It is recommended to use the following versions of Driver to connect to the corr
 
     The optional parameters are: `EXCEPTION`, `CONVERT_TO_NULL`, `ROUND`, respectively: exception error reporting, converted to NULL value, converted to "0001-01-01 00:00:00";
 
-    You need to add `zeroDateTimeBehavior=convertToNull` to the end of the JDBC connection string when creating the Catalog `jdbc_url`, such as `"jdbc_url" = "jdbc:mysql://127.0.0.1:3306/test?zeroDateTimeBehavior=convertToNull"`
-    In this case, JDBC will convert 0000-00-00 or 0000-00-00 00:00:00 into null, and then Doris will process all Date/DateTime type columns in the current Catalog as nullable types, so that It can be read normally.
+    You need to add `zeroDateTimeBehavior=convertToNull` to the end of the JDBC connection string when creating the catalog `jdbc_url`, such as `"jdbc_url" = "jdbc:mysql://127.0.0.1:3306/test?zeroDateTimeBehavior=convertToNull"`
+    In this case, JDBC will convert 0000-00-00 or 0000-00-00 00:00:00 into null, and then Doris will process all Date/DateTime type columns in the current catalog as nullable types, so that It can be read normally.
 
 4. When reading the MySQL table or other tables, a class loading failure occurs.
 
@@ -939,7 +939,7 @@ It is recommended to use the following versions of Driver to connect to the corr
     You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
     ```
 
-   You can add `?useSSL=false` to the end of the JDBC connection string when creating the Catalog, such as `"jdbc_url" = "jdbc:mysql://127.0.0.1:3306/test?useSSL=false"`
+   You can add `?useSSL=false` to the end of the JDBC connection string when creating the catalog, such as `"jdbc_url" = "jdbc:mysql://127.0.0.1:3306/test?useSSL=false"`
 
 6. When using JDBC to query large amounts of MYSQL data, if the query is occasionally successful, the following error will occasionally be reported. When this error occurs, all MYSQL connections are disconnected and cannot be connected to MYSQL SERVER. After a while, mysql returns to normal. , but the previous connections are gone:
 
@@ -979,7 +979,7 @@ It is recommended to use the following versions of Driver to connect to the corr
     unable to find valid certification path to requested target". ClientConnectionId:a92f3817-e8e6-4311-bc21-7c66
     ```
 
-   You can add `encrypt=false` to the end of the JDBC connection string when creating the Catalog, such as `"jdbc_url" = "jdbc:sqlserver://127.0.0.1:1433;DataBaseName=doris_test;encrypt=false"`
+   You can add `encrypt=false` to the end of the JDBC connection string when creating the catalog, such as `"jdbc_url" = "jdbc:sqlserver://127.0.0.1:1433;DataBaseName=doris_test;encrypt=false"`
 
 9. `Non supported character set (add orai18n.jar in your classpath): ZHS16GBK` exception occurs when reading Oracle
 


### PR DESCRIPTION
This PR is clarifying some aspects of the JDBC catalog (which is really cool btw) under the lakehouse section in the docs based on the first-time experience of creating an external catalog.

* It was not very easy to understand that you need to create _two_ `jdbc_drivers` directories and put JDBC driver JAR files in each. Clarified that in the `parameter` > `driver_url` section.
* Changed `Catalog` to `catalog` starting with lower-case, as `catalog` is a concept and not a proper noun.
* In properties sections, consistently use space around equals, i.e. `"key" = "value"` instead of `"key"="value"`, as the former seems to be the convention in the docs.
* Changed "Jar" to "JAR", as it is an abbreviation.

Online page URL: https://doris.apache.org/docs/lakehouse/multi-catalog/jdbc