### PR TITLE
[fix](Hive-Catalog) fix NPE when using jdbc to access Hive metadata

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -144,9 +144,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
             HadoopUGI.tryKrbLogin(this.getName(), AuthenticationConfig.getKerberosConfig(hiveConf,
                     AuthenticationConfig.HIVE_KERBEROS_PRINCIPAL,
                     AuthenticationConfig.HIVE_KERBEROS_KEYTAB));
-            metadataOps = ExternalMetadataOperations.newHiveMetadataOps(hiveConf, jdbcClientConfig, this);
         }
-
+        metadataOps = ExternalMetadataOperations.newHiveMetadataOps(hiveConf, jdbcClientConfig, this);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This bug was introduced by: #30844

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

