### PR TITLE
[fix](regression) set rf type to 4 to forbid fuzzy rf_type in shape check

### DIFF
--- a/regression-test/suites/nereids_shape_check/load.groovy
+++ b/regression-test/suites/nereids_shape_check/load.groovy
@@ -53,7 +53,7 @@ suite("broadcastJoin") {
     sql "set enable_nereids_planner=true"
     sql "set forbid_unknown_col_stats=true"
     sql "set enable_fallback_to_original_planner=false"
-
+    sql "set runtime_filter_type=4"
     sql """
     alter table t1 modify column code set stats('row_count'='7846', 'ndv'='10000', 'num_nulls'='0', 'min_value'='999999', 'max_value'='999999', 'data_size'='5.7');
     """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

