### PR TITLE
[Fix](Variant) fix variant root may be emtpy in `OlapColumnDataConvertorVariant::set_source_column`

### DIFF
--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -1073,6 +1073,13 @@ void OlapBlockDataConvertor::OlapColumnDataConvertorVariant::set_source_column(
                               nullable_column->get_nested_column());
 
     const_cast<ColumnObject&>(variant).finalize_if_not();
+    if (variant.is_null_root()) {
+        auto root_type = make_nullable(std::make_shared<ColumnObject::MostCommonType>());
+        auto root_col = root_type->create_column();
+        root_col->insert_many_defaults(variant.rows());
+        const_cast<ColumnObject&>(variant).create_root(root_type, std::move(root_col));
+        variant.check_consistency();
+    }
     auto root_of_variant = variant.get_root();
     auto nullable = assert_cast<const ColumnNullable*>(root_of_variant.get());
     CHECK(nullable);

--- a/regression-test/suites/variant_p0/multi_var.groovy
+++ b/regression-test/suites/variant_p0/multi_var.groovy
@@ -40,4 +40,9 @@ suite("regression_test_variant_multi_var", "variant_type"){
     qt_sql """select cast(v["k1"] as tinyint), cast(v2["k2"] as text), cast(v3["k3"] as string), cast(v["k7"] as tinyint), cast(v2["k8"] as text), cast(v3["k9"] as double) from ${table_name} order by k, 1, 2, 3, 4, 5, 6 limit 10"""
     qt_sql """select cast(v["k1"] as tinyint), cast(v2["k2"] as text), cast(v3["k3"] as string), cast(v["k7"] as tinyint), cast(v2["k8"] as text), cast(v3["k9"] as double) from ${table_name} where k > 200 order by k, 1, 2, 3, 4, 5, 6 limit 10"""
     qt_sql """select cast(v["k1"] as tinyint), cast(v2["k2"] as text), cast(v3["k3"] as string), cast(v["k7"] as tinyint), cast(v2["k8"] as text), cast(v3["k9"] as double) from ${table_name} where k > 300 order by k, 1, 2, 3, 4, 5, 6 limit 10"""
+
+    sql "alter table ${table_name} add column v4 variant default null"
+    for (int i = 0; i < 20; i++) {
+        sql """insert into ${table_name}  values (1, '{"a" : 1}', '{"a" : 1}', '{"a" : 1}', '{"a" : 1}', '{"a" : 1}')"""
+    }
 }


### PR DESCRIPTION
…torVariant::set_source_column`

When compaction, if some segments miss variant root, there is chance to get emtpy root variant.So add some defence code in OlapColumnDataConvertorVariant to prevent from accessing null root

```
5# doris::vectorized::ColumnObject::Subcolumn::get_finalized_column_ptr() const at /mnt/ssd01/selectdb-doris-package/enterprise-core/be/src/vec/columns/column_object.cpp:556
 6# doris::vectorized::OlapBlockDataConvertor::OlapColumnDataConvertorVariant::set_source_column(doris::vectorized::ColumnWithTypeAndName const&, unsigned long, unsigned long) at /mnt/ssd01/selectdb-doris-package/enterprise-core/be/src
/vec/olap/olap_data_convertor.cpp:1076
 7# doris::vectorized::OlapBlockDataConvertor::set_source_content(doris::vectorized::Block const*, unsigned long, unsigned long) at /mnt/ssd01/selectdb-doris-package/enterprise-core/be/src/vec/olap/olap_data_convertor.cpp:207
 8# doris::segment_v2::SegmentWriter::append_block(doris::vectorized::Block const*, unsigned long, unsigned long) at /mnt/ssd01/selectdb-doris-package/enterprise-core/be/src/olap/rowset/segment_v2/segment_writer.cpp:727
 9# doris::VerticalBetaRowsetWriter::add_columns(doris::vectorized::Block const*, std::vector > const&, bool, unsigned int) at /mnt/ssd01/selectdb-doris-package/enterprise-core/be/src/olap/row
set/vertical_beta_rowset_writer.cpp:125
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

