### PR TITLE
[fix](Nereids): AssertNumRowsElement shouldn't be expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/AssertNumRowsElement.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/AssertNumRowsElement.java
@@ -17,22 +17,14 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
-import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
-import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
-import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.util.Utils;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Number of rows returned by inspection in subquery.
  */
-public class AssertNumRowsElement extends Expression implements LeafExpression, AlwaysNotNullable {
+public class AssertNumRowsElement {
     /**
      * Assertion type.
      */
@@ -51,7 +43,6 @@ public class AssertNumRowsElement extends Expression implements LeafExpression, 
 
     public AssertNumRowsElement(long desiredNumOfRows, String subqueryString,
             Assertion assertion) {
-        super(ImmutableList.of());
         this.desiredNumOfRows = desiredNumOfRows;
         this.subqueryString = subqueryString;
         this.assertion = assertion;
@@ -70,30 +61,11 @@ public class AssertNumRowsElement extends Expression implements LeafExpression, 
     }
 
     @Override
-    public AssertNumRowsElement withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.isEmpty());
-        return this;
-    }
-
-    @Override
     public String toString() {
         return Utils.toSqlString("AssertNumRowsElement",
                 "desiredNumOfRows",
                 Long.toString(desiredNumOfRows),
                 "assertion", assertion);
-    }
-
-    @Override
-    public String toSql() {
-        return toString();
-    }
-
-    @Override
-    public String getExpressionName() {
-        if (!this.exprName.isPresent()) {
-            this.exprName = Optional.of(Utils.normalizeName(assertion.name().toLowerCase(), DEFAULT_EXPRESSION_NAME));
-        }
-        return this.exprName.get();
     }
 
     @Override
@@ -105,18 +77,13 @@ public class AssertNumRowsElement extends Expression implements LeafExpression, 
             return false;
         }
         AssertNumRowsElement that = (AssertNumRowsElement) o;
-        return Objects.equals(this.desiredNumOfRows, that.getDesiredNumOfRows())
-                && Objects.equals(this.subqueryString, that.getSubqueryString())
-                && Objects.equals(this.assertion, that.getAssertion());
+        return this.desiredNumOfRows == that.getDesiredNumOfRows()
+                && this.subqueryString.equals(that.getSubqueryString())
+                && this.assertion.equals(that.getAssertion());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(desiredNumOfRows, subqueryString, assertion);
-    }
-
-    @Override
-    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-        return visitor.visitAssertNumRowsElement(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -252,8 +252,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
      * Whether the expression is a constant.
      */
     public boolean isConstant() {
-        if (this instanceof AssertNumRowsElement
-                || this instanceof AggregateFunction
+        if (this instanceof AggregateFunction
                 || this instanceof Lambda
                 || this instanceof MaxValue
                 || this instanceof OrderExpression

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
@@ -29,7 +29,6 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.Any;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
-import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.BinaryOperator;
 import org.apache.doris.nereids.trees.expressions.BitAnd;
@@ -431,10 +430,6 @@ public abstract class ExpressionVisitor<R, C>
 
     public R visitListQuery(ListQuery listQuery, C context) {
         return visitSubqueryExpr(listQuery, context);
-    }
-
-    public R visitAssertNumRowsElement(AssertNumRowsElement assertNumRowsElement, C context) {
-        return visit(assertNumRowsElement, context);
     }
 
     public R visitGroupingScalarFunction(GroupingScalarFunction groupingScalarFunction, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
@@ -91,7 +91,7 @@ public class LogicalAssertNumRows<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public List<? extends Expression> getExpressions() {
-        return ImmutableList.of(assertNumRowsElement);
+        return ImmutableList.of();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalAssertNumRows.java
@@ -94,7 +94,7 @@ public class PhysicalAssertNumRows<CHILD_TYPE extends Plan> extends PhysicalUnar
 
     @Override
     public List<? extends Expression> getExpressions() {
-        return ImmutableList.of(assertNumRowsElement);
+        return ImmutableList.of();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

AssertNumRowsElement shouldn't be expression

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

