### PR TITLE
[fix](load) delete bytes_appended debug point which may cause bad page

### DIFF
--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -64,10 +64,7 @@ public:
 
     const Path& path() const { return _path; }
 
-    size_t bytes_appended() const {
-        DBUG_EXECUTE_IF("FileWriter.bytes_appended.zero_bytes_appended", { return 0; });
-        return _bytes_appended;
-    }
+    size_t bytes_appended() const { return _bytes_appended; }
 
     std::shared_ptr<FileSystem> fs() const { return _fs; }
 

--- a/regression-test/suites/fault_injection_p0/test_load_stream_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_load_stream_fault_injection.groovy
@@ -143,8 +143,6 @@ suite("load_stream_fault_injection", "nonConcurrent") {
     load_with_injection("LocalFileSystem.create_file_impl.open_file_failed", "")
     // LoadStreamWriter append_data meet null file writer error
     load_with_injection("LoadStreamWriter.append_data.null_file_writer", "")
-    // LoadStreamWriter append_data meet bytes_appended and real file size not match error
-    load_with_injection("FileWriter.bytes_appended.zero_bytes_appended", "")
     // LoadStreamWriter close_segment meet not inited error
     load_with_injection("LoadStreamWriter.close_segment.uninited_writer", "")
     // LoadStreamWriter close_segment meet not bad segid error


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

F20240229 05:10:37.714732 2801470 tablet.cpp:2911] Check failed: expected_st || st.is() unexpected error status while lookup_row_key:[CORRUPTION]Bad page: too small size (0), file=/mnt/hdd03/ci/branch21-data/doris.HDD/data/1/10124/779557774/020000000003f960ce4d7ae53de30448374c635caabfc090_0.dat


When running this injection case, the statistical information is executed in the background, which may cause the table of statistical information to generate a bad page.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

