### PR TITLE
[fix](catalog)Make sure external table fetched dbId before call getRowCount. (#31379)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -284,6 +284,14 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
 
     @Override
     public long getRowCount() {
+        // Return 0 if makeSureInitialized throw exception.
+        // For example, init hive table may throw NotSupportedException.
+        try {
+            makeSureInitialized();
+        } catch (Exception e) {
+            LOG.warn("Failed to initialize table {}.{}.{}", catalog.getName(), dbName, name, e);
+            return 0;
+        }
         // All external table should get external row count from cache.
         return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache().getCachedRowCount(catalog.getId(), dbId, id);
     }


### PR DESCRIPTION
Call external table makeSureInitialized before get row count cache. Otherwise, the dbId value could be 0 which will fail to load row count cache.

backport https://github.com/apache/doris/pull/31379

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

