### PR TITLE
[pipelineX](bug) Fix core dump if union has no children

### DIFF
--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -182,7 +182,8 @@ Status UnionSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* b
     local_state.reached_limit(block, eos);
     //have executing const expr, queue have no data anymore, and child could be closed
     *eos = (_child_size == 0 && !local_state._need_read_for_const_expr) ||
-           (local_state._shared_state->data_queue.is_all_finish() && !_has_data(state));
+           (_child_size > 0 && local_state._shared_state->data_queue.is_all_finish() &&
+            !_has_data(state));
 
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

*** SIGSEGV address not mapped to object (@0xf4) received by PID 11324 (TID 13531 OR 0x7f94304d0700) from PID 244; stack trace: ***
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48797&linesState=48797&logView=flowAware)   0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:417
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48798&linesState=48798&logView=flowAware)   1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48799&linesState=48799&logView=flowAware)   2# JVM_handle_linux_signal in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48800&linesState=48800&logView=flowAware)   3# signalHandler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48801&linesState=48801&logView=flowAware)   4# 0x00007F96C32EB090 in /lib/x86_64-linux-gnu/libc.so.6
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48802&linesState=48802&logView=flowAware)   5# doris::pipeline::DataQueue::is_all_finish() at /root/doris/be/src/pipeline/exec/data_queue.cpp:183
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48803&linesState=48803&logView=flowAware)   6# doris::pipeline::UnionSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/pipeline/exec/union_source_operator.cpp:185
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48804&linesState=48804&logView=flowAware)   7# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/pipeline/pipeline_x/operator.cpp:210
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48805&linesState=48805&logView=flowAware)   8# doris::pipeline::PipelineXTask::execute(bool*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48806&linesState=48806&logView=flowAware)   9# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:334
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48807&linesState=48807&logView=flowAware)  10# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:551
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48808&linesState=48808&logView=flowAware)  11# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48809&linesState=48809&logView=flowAware)  12# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
[16:54:50 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0RegressionPipelineX/360441?buildTab=log&focusLine=48810&linesState=48810&logView=flowAware)  13# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

