### PR TITLE
[feature](merge-cloud) Make MetaService compatible with selectdb cloud

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -145,4 +145,7 @@ CONF_Bool(focus_add_kms_data_key, "false");
 CONF_Bool(enable_txn_store_retry, "false");
 CONF_Int32(txn_store_retry_times, "20");
 
+// The secondary package name of the MetaService.
+CONF_String(secondary_package_name, "");
+
 } // namespace doris::cloud::config

--- a/cloud/src/meta-service/meta_server.cpp
+++ b/cloud/src/meta-service/meta_server.cpp
@@ -75,7 +75,14 @@ int MetaServer::start(brpc::Server* server) {
     // Add service
     auto meta_service = std::make_unique<MetaServiceImpl>(txn_kv_, rc_mgr, rate_limiter);
     auto meta_service_proxy = new MetaServiceProxy(std::move(meta_service));
-    server->AddService(meta_service_proxy, brpc::SERVER_OWNS_SERVICE);
+
+    brpc::ServiceOptions options;
+    options.ownership = brpc::SERVER_OWNS_SERVICE;
+    if (!config::secondary_package_name.empty()) {
+        LOG(INFO) << "Add MetaService with secondary package name " << config::secondary_package_name;
+        options.secondary_package_name = config::secondary_package_name;
+    }
+    server->AddService(meta_service_proxy, options);
 
     return 0;
 }

--- a/thirdparty/patches/brpc-1.4.0-secondary-package-name.patch
+++ b/thirdparty/patches/brpc-1.4.0-secondary-package-name.patch
@@ -1,0 +1,64 @@
+diff --git a/src/brpc/server.cpp b/src/brpc/server.cpp
+index 2087cbcf..7aede561 100644
+--- a/src/brpc/server.cpp
++++ b/src/brpc/server.cpp
+@@ -1267,6 +1267,14 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
+     // defined `option (idl_support) = true' or not.
+     const bool is_idl_support = sd->file()->options().GetExtension(idl_support);
+ 
++    std::string secondary_full_name;
++    if (!svc_opt.secondary_package_name.empty()) {
++        secondary_full_name.reserve(svc_opt.secondary_package_name.size() + 1 + sd->name().size());
++        secondary_full_name.append(svc_opt.secondary_package_name);
++        secondary_full_name.push_back('.');
++        secondary_full_name.append(sd->name());
++    }
++
+     Tabbed* tabbed = dynamic_cast<Tabbed*>(service);
+     for (int i = 0; i < sd->method_count(); ++i) {
+         const google::protobuf::MethodDescriptor* md = sd->method(i);
+@@ -1282,6 +1290,14 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
+         mp.method = md;
+         mp.status = new MethodStatus;
+         _method_map[md->full_name()] = mp;
++        if (!secondary_full_name.empty()) {
++            std::string secondary_method_name;
++            secondary_method_name.reserve(secondary_full_name.size() + 1 + md->name().size());
++            secondary_method_name.append(secondary_full_name);
++            secondary_method_name.push_back('.');
++            secondary_method_name.append(md->name());
++            _method_map[secondary_method_name] = mp;
++        }
+         if (is_idl_support && sd->name() != sd->full_name()/*has ns*/) {
+             MethodProperty mp2 = mp;
+             mp2.own_method_status = false;
+@@ -1306,6 +1322,9 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
+         is_builtin_service, svc_opt.ownership, service, NULL };
+     _fullname_service_map[sd->full_name()] = ss;
+     _service_map[sd->name()] = ss;
++    if (!secondary_full_name.empty()) {
++        _fullname_service_map[secondary_full_name] = ss;
++    }
+     if (is_builtin_service) {
+         ++_builtin_service_count;
+     } else {
+diff --git a/src/brpc/server.h b/src/brpc/server.h
+index 0974ce12..32c7e5a3 100644
+--- a/src/brpc/server.h
++++ b/src/brpc/server.h
+@@ -309,6 +309,15 @@ struct ServiceOptions {
+     // decode json array to protobuf message which contains a single repeated field.
+     // Default: false.
+     bool pb_single_repeated_to_array;
++
++    // The secondary package name.
++    //
++    // If this option is non-empty, service and methods will be used to register
++    // service and methods, and either package name can be used to locate service
++    // and methods.
++    //
++    // This option is useful when the service package name has been changed.
++    std::string secondary_package_name;
+ };
+ 
+ // Represent ports inside [min_port, max_port]


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

An patch for brpc is added, to maintain compatibility between the old and new versions of the service, when modifying the package name of the proto file.

This patch adds a service option 'secondary_package_name', and the bRPC will add the service with the two package names.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

