### PR TITLE
[pipelineX](bug) Fix aggregate crash if open failed

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -157,6 +157,7 @@ Status AggSinkLocalState::open(RuntimeState* state) {
         // _create_agg_status may acquire a lot of memory, may allocate failed when memory is very few
         RETURN_IF_CATCH_EXCEPTION(static_cast<void>(_create_agg_status(_agg_data->without_key)));
     }
+    Base::_shared_state->ready_to_execute = true;
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -330,9 +330,9 @@ public:
         agg_arena_pool = std::make_unique<vectorized::Arena>();
     }
     ~AggSharedState() override {
-        if (probe_expr_ctxs.empty()) {
+        if (probe_expr_ctxs.empty() && ready_to_execute) {
             _close_without_key();
-        } else {
+        } else if (ready_to_execute) {
             _close_with_serialized_key();
         }
     }
@@ -366,6 +366,7 @@ public:
     };
     MemoryRecord mem_usage_record;
     bool agg_data_created_without_key = false;
+    std::atomic<bool> ready_to_execute = false;
 
 private:
     void _close_with_serialized_key() {


### PR DESCRIPTION
## Proposed changes

*** SIGSEGV address not mapped to object (@0x1d9c50) received by PID 2020091 (TID 2023349 OR 0x7f0de9af6700) from PID 1940560; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:417
 1# 0x00007F134DA000A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 3# 0x00007F134D9F902C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 4# 0x00007F1352F39090 in /lib/x86_64-linux-gnu/libc.so.6
 5# je_free_default at ../src/jemalloc.c:3014
 6# doris::vectorized::IAggregateFunctionDataHelper<doris::vectorized::AggregateFunctionUniqExactData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, doris::vectorized::AggregateFunctionUniq<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::vectorized::AggregateFunctionUniqExactData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::destroy(char*) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/aggregate_functions/aggregate_function.h:497
 7# doris::pipeline::AggSharedState::~AggSharedState() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/dependency.h:354
 8# doris::pipeline::AggSharedState::~AggSharedState() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/dependency.h:352
 9# std::_Rb_tree<int, std::pair<int const, std::shared_ptr<doris::pipeline::BasicSharedState> >, std::_Select1st<std::pair<int const, std::shared_ptr<doris::pipeline::BasicSharedState> > >, std::less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::BasicSharedState> > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::BasicSharedState> > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1889
10# doris::pipeline::PipelineXTask::finalize() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:310
11# doris::pipeline::TaskScheduler::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
12# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:273
13# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
14# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

