### PR TITLE
[improvement](statistics)Log one bdbje record for one load transaction. #31619

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -302,7 +302,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         try {
             makeSureInitialized();
         } catch (Exception e) {
-            LOG.warn("Failed to initialize table {}.{}.{}", catalog.name, dbName, name, e);
+            LOG.warn("Failed to initialize table {}.{}.{}", catalog.getName(), dbName, name, e);
             return 0;
         }
         // All external table should get external row count from cache.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -3061,6 +3061,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                     rowsToTruncate += partition.getBaseIndex().getRowCount();
                 }
             } else {
+                rowsToTruncate = olapTable.getRowCount();
                 for (Partition partition : olapTable.getPartitions()) {
                     // If need absolutely correct, should check running txn here.
                     // But if the txn is in prepare state, cann't known which partitions had load data.
@@ -3211,12 +3212,15 @@ public class InternalCatalog implements CatalogIf<Database> {
         } finally {
             olapTable.writeUnlock();
         }
+
+        HashMap<Long, Long> updateRecords = new HashMap<>();
+        updateRecords.put(olapTable.getId(), rowsToTruncate);
         if (truncateEntireTable) {
             // Drop the whole table stats after truncate the entire table
             Env.getCurrentEnv().getAnalysisManager().dropStats(olapTable);
         } else {
             // Update the updated rows in table stats after truncate some partitions.
-            Env.getCurrentEnv().getAnalysisManager().updateUpdatedRows(olapTable.getId(), rowsToTruncate);
+            Env.getCurrentEnv().getAnalysisManager().updateUpdatedRows(updateRecords);
         }
         LOG.info("finished to truncate table {}, partitions: {}", tblRef.getName().toSql(), tblRef.getPartitionNames());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -127,7 +127,9 @@ import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
 import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicy;
 import org.apache.doris.statistics.AnalysisInfo;
+import org.apache.doris.statistics.NewPartitionLoadedEvent;
 import org.apache.doris.statistics.TableStatsMeta;
+import org.apache.doris.statistics.UpdateRowsEvent;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.transaction.TransactionState;
@@ -932,6 +934,16 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_ADD_META_ID_MAPPINGS: {
                 data = MetaIdMappingsLog.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_LOG_UPDATE_ROWS: {
+                data = UpdateRowsEvent.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_LOG_NEW_PARTITION_LOADED: {
+                data = NewPartitionLoadedEvent.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/NewPartitionLoadedEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/NewPartitionLoadedEvent.java
@@ -27,20 +27,25 @@ import com.google.gson.annotations.SerializedName;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 public class NewPartitionLoadedEvent implements Writable {
 
-    @SerializedName("partitionIdToTableId")
-    public final Map<Long, Long> partitionIdToTableId = new HashMap<>();
+    @SerializedName("tableIds")
+    private List<Long> tableIds;
 
     @VisibleForTesting
-    public NewPartitionLoadedEvent() {}
+    public NewPartitionLoadedEvent(List<Long> tableIds) {
+        this.tableIds = tableIds;
+    }
 
     // No need to be thread safe, only publish thread will call this.
-    public void addPartition(long tableId, long partitionId) {
-        partitionIdToTableId.put(tableId, partitionId);
+    public void addTableId(long tableId) {
+        tableIds.add(tableId);
+    }
+
+    public List<Long> getTableIds() {
+        return tableIds;
     }
 
     @Override
@@ -51,7 +56,6 @@ public class NewPartitionLoadedEvent implements Writable {
 
     public static NewPartitionLoadedEvent read(DataInput dataInput) throws IOException {
         String json = Text.readString(dataInput);
-        NewPartitionLoadedEvent newPartitionLoadedEvent = GsonUtils.GSON.fromJson(json, NewPartitionLoadedEvent.class);
-        return newPartitionLoadedEvent;
+        return GsonUtils.GSON.fromJson(json, NewPartitionLoadedEvent.class);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/UpdateRowsEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/UpdateRowsEvent.java
@@ -21,30 +21,24 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class UpdateRowsEvent implements Writable {
 
-    @SerializedName("tableIdToUpdateRows")
-    public final Map<Long, Long> tableIdToUpdateRows = new HashMap<>();
+    @SerializedName("records")
+    private Map<Long, Long> records;
 
-    @VisibleForTesting
-    public UpdateRowsEvent() {}
+    public UpdateRowsEvent(Map<Long, Long> records) {
+        this.records = records;
+    }
 
-    // No need to be thread safe, only publish thread will call this.
-    public void addUpdateRows(long tableId, long rows) {
-        if (tableIdToUpdateRows.containsKey(tableId)) {
-            tableIdToUpdateRows.put(tableId, tableIdToUpdateRows.get(tableId) + rows);
-        } else {
-            tableIdToUpdateRows.put(tableId, rows);
-        }
+    public Map<Long, Long> getRecords() {
+        return records;
     }
 
     @Override
@@ -53,9 +47,8 @@ public class UpdateRowsEvent implements Writable {
         Text.writeString(out, json);
     }
 
-    public static UpdateRowsEvent read(DataInput dataInput) throws IOException {
-        String json = Text.readString(dataInput);
-        UpdateRowsEvent updateRowsEvent = GsonUtils.GSON.fromJson(json, UpdateRowsEvent.class);
-        return updateRowsEvent;
+    public static UpdateRowsEvent read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, UpdateRowsEvent.class);
     }
 }

--- a/regression-test/suites/statistics/test_update_rows_and_partition_first_load.groovy
+++ b/regression-test/suites/statistics/test_update_rows_and_partition_first_load.groovy
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_update_rows_and_partition_first_load", "p2") {
+
+    String ak = getS3AK()
+    String sk = getS3SK()
+    String enabled = context.config.otherConfigs.get("enableBrokerLoad")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        sql """DROP DATABASE IF EXISTS test_update_rows_and_partition_first_load"""
+        sql """CREATE DATABASE test_update_rows_and_partition_first_load"""
+        sql """use test_update_rows_and_partition_first_load"""
+        sql """
+                CREATE TABLE update_rows_test1 (
+                    id int NULL,
+                    name String NULL
+                )ENGINE=OLAP
+                DUPLICATE KEY(`id`)
+                DISTRIBUTED BY HASH(`id`) BUCKETS 3
+                PROPERTIES (
+                    "replication_num" = "1"
+                );
+           """
+
+        sql """
+                CREATE TABLE update_rows_test2 (
+                    id int NULL,
+                    name String NULL
+                )ENGINE=OLAP
+                DUPLICATE KEY(`id`)
+                DISTRIBUTED BY HASH(`id`) BUCKETS 3
+                PROPERTIES (
+                    "replication_num" = "1"
+                );
+           """
+
+        sql """
+             CREATE TABLE `partition_test1` (
+                `id` INT NOT NULL,
+                `name` VARCHAR(25) NOT NULL
+              ) ENGINE=OLAP
+              DUPLICATE KEY(`id`)
+                COMMENT 'OLAP'
+                PARTITION BY RANGE(`id`)
+              (PARTITION p1 VALUES [("0"), ("100")),
+               PARTITION p2 VALUES [("100"), ("200")),
+               PARTITION p3 VALUES [("200"), ("300")))
+              DISTRIBUTED BY HASH(`id`) BUCKETS 1
+              PROPERTIES (
+               "replication_num" = "1");
+             """
+
+        sql """
+             CREATE TABLE `partition_test2` (
+                `id` INT NOT NULL,
+                `name` VARCHAR(25) NOT NULL
+              ) ENGINE=OLAP
+              DUPLICATE KEY(`id`)
+                COMMENT 'OLAP'
+                PARTITION BY RANGE(`id`)
+              (PARTITION p1 VALUES [("0"), ("100")),
+               PARTITION p2 VALUES [("100"), ("200")),
+               PARTITION p3 VALUES [("200"), ("300")))
+              DISTRIBUTED BY HASH(`id`) BUCKETS 1
+              PROPERTIES (
+               "replication_num" = "1");
+             """
+
+        sql """analyze table update_rows_test1 with sync"""
+        sql """analyze table update_rows_test2 with sync"""
+        sql """analyze table partition_test1 with sync"""
+        sql """analyze table partition_test2 with sync"""
+
+        def label = "part_" + UUID.randomUUID().toString().replace("-", "0")
+        sql """
+                LOAD LABEL ${label} (
+                    DATA INFILE("s3://doris-build-1308700295/regression/load/data/update_rows_1.csv")
+                    INTO TABLE update_rows_test1
+                    COLUMNS TERMINATED BY ",",
+                    DATA INFILE("s3://doris-build-1308700295/regression/load/data/update_rows_2.csv")
+                    INTO TABLE update_rows_test2
+                    COLUMNS TERMINATED BY ",",
+                    DATA INFILE("s3://doris-build-1308700295/regression/load/data/update_rows_1.csv")
+                    INTO TABLE partition_test1
+                    COLUMNS TERMINATED BY ",",
+                    DATA INFILE("s3://doris-build-1308700295/regression/load/data/update_rows_2.csv")
+                    INTO TABLE partition_test2
+                    COLUMNS TERMINATED BY ","
+                )
+                WITH S3 (
+                    "AWS_ACCESS_KEY" = "$ak",
+                    "AWS_SECRET_KEY" = "$sk",
+                    "AWS_ENDPOINT" = "cos.ap-beijing.myqcloud.com",
+                    "AWS_REGION" = "ap-beijing"
+                );
+        """
+
+        boolean finished = false;
+        for(int i = 0; i < 120; i++) {
+            def result = sql """show load where label = "$label" """
+            if (result[0][2] == "FINISHED") {
+                finished = true;
+                break;
+            }
+            logger.info("Load not finished, wait one second.")
+            Thread.sleep(1000)
+        }
+        if (finished) {
+            def result = sql """show table stats update_rows_test1"""
+            assertEquals("5", result[0][0])
+            result = sql """show table stats update_rows_test2"""
+            assertEquals("6", result[0][0])
+            result = sql """show table stats partition_test1"""
+            assertEquals("5", result[0][0])
+            assertEquals("true", result[0][6])
+            result = sql """show table stats partition_test2"""
+            assertEquals("true", result[0][6])
+            assertEquals("6", result[0][0])
+        }
+        sql """DROP DATABASE IF EXISTS test_update_rows_and_partition_first_load"""
+    }
+}
+


### PR DESCRIPTION
Log one bdbje record for one load transaction. Reduce the log frequency and size of bdbje operation for load.

backport https://github.com/apache/doris/pull/31619

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

