### PR TITLE
[fix](jdbc catalog) Change Druid Pool dependency to version 1.2.11

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -251,7 +251,7 @@ under the License.
         <commons-io.version>2.7</commons-io.version>
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>5.8.2</junit.version>
-        <druid.version>1.2.20</druid.version>
+        <druid.version>1.2.11</druid.version>
         <clickhouse.version>0.4.6</clickhouse.version>
         <thrift.version>0.16.0</thrift.version>
         <tomcat-embed-core.version>8.5.86</tomcat-embed-core.version>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In PR #30588, we upgraded the Druid Pool dependency to version 1.2.20 to address potential connection pool state anomalies when KeepAlive is set to true. However, since version 1.2.12, Druid Pool introduced a default 10-second socketTime timeout, which can cause the jdbc catalog to easily timeout during large queries. Therefore, this PR downgrades the Druid Pool dependency back to 1.2.11, which has resolved most of the KeepAlive issues without including the default socketTime timeout setting.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

