### PR TITLE
[fix](fe) Fix NPE in FrontendServiceImpl.loadTxnCommit if table is dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1507,7 +1507,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 status.addToErrorMsgs("transaction commit successfully, BUT data will be visible later");
             }
         } catch (UserException e) {
-            LOG.warn("failed to commit txn: {}: {}", request.getTxnId(), e.getMessage());
+            LOG.warn("failed to commit txn: {}", request.getTxnId(), e);
             status.setStatusCode(TStatusCode.ANALYSIS_ERROR);
             status.addToErrorMsgs(e.getMessage());
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1313,6 +1313,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     private List<Table> queryLoadCommitTables(TLoadTxnCommitRequest request, Database db) throws UserException {
         if (request.isSetTableId() && request.getTableId() > 0) {
             Table table = Env.getCurrentEnv().getInternalCatalog().getTableByTableId(request.getTableId());
+            if (table == null) {
+                throw new MetaNotFoundException("unknown table, table_id=" + request.getTableId());
+            }
             return Collections.singletonList(table);
         }
 


### PR DESCRIPTION
## Proposed changes

```
2024-03-01 17:05:52,204 WARN (thrift-server-pool-48|6275) [FrontendServiceImpl.loadTxnCommit():1511] catch unknown result.
java.lang.NullPointerException: null
	at org.apache.doris.common.util.MetaLockUtils.tryWriteLockTablesOrMetaException(MetaLockUtils.java:93) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.transaction.GlobalTransactionMgr.commitAndPublishTransaction(GlobalTransactionMgr.java:263) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommitImpl(FrontendServiceImpl.java:1554) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommit(FrontendServiceImpl.java:1501) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.GeneratedMethodAccessor18.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:59) ~[doris-fe.jar:1.2-SNAPSHOT]
	at com.sun.proxy.$Proxy33.loadTxnCommit(Unknown Source) ~[?:?]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3742) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3722) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
2024-03-01 17:05:52,389 WARN (thrift-server-pool-26|3108) [FrontendServiceImpl.loadTxnCommit():1511] catch unknown result.
java.lang.NullPointerException: null
	at org.apache.doris.common.util.MetaLockUtils.tryWriteLockTablesOrMetaException(MetaLockUtils.java:93) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.transaction.GlobalTransactionMgr.commitAndPublishTransaction(GlobalTransactionMgr.java:263) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommitImpl(FrontendServiceImpl.java:1554) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommit(FrontendServiceImpl.java:1501) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.GeneratedMethodAccessor18.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:59) ~[doris-fe.jar:1.2-SNAPSHOT]
	at com.sun.proxy.$Proxy33.loadTxnCommit(Unknown Source) ~[?:?]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3742) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3722) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

