### PR TITLE
[Bug](resource) fix npe on Resource read from json

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
@@ -77,6 +77,10 @@ public class EsResource extends Resource {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
+    public EsResource() {
+        super();
+    }
+
     public EsResource(String name) {
         super(name, Resource.ResourceType.ES);
         properties = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HMSResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HMSResource.java
@@ -44,6 +44,10 @@ public class HMSResource extends Resource {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
+    public HMSResource() {
+        super();
+    }
+
     public HMSResource(String name) {
         super(name, ResourceType.HMS);
         this.properties = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -54,6 +54,10 @@ public class HdfsResource extends Resource {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
+    public HdfsResource() {
+        super();
+    }
+
     public HdfsResource(String name) {
         super(name, Resource.ResourceType.HDFS);
         properties = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcCatalogResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcCatalogResource.java
@@ -65,7 +65,6 @@ public class OdbcCatalogResource extends Resource {
     @SerializedName(value = "configs")
     private Map<String, String> configs;
 
-    // only for deep copy
     public OdbcCatalogResource() {
         super();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -111,6 +111,9 @@ public abstract class Resource implements Writable, GsonPostProcessable {
         lock.readLock().unlock();
     }
 
+    // https://programmerr47.medium.com/gson-unsafe-problem-d1ff29d4696f
+    // Resource subclass also MUST define default ctor, otherwise when reloading object from json
+    // some not serialized field (i.e. `lock`) will be `null`.
     public Resource() {
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -70,10 +70,9 @@ public class S3Resource extends Resource {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
-    // for Gson fromJson
-    // TODO(plat1ko): other Resource subclass also MUST define default ctor, otherwise when reloading object from json
-    //  some not serialized field (i.e. `lock`) will be `null`.
-    public S3Resource() {}
+    public S3Resource() {
+        super();
+    }
 
     public S3Resource(String name) {
         super(name, ResourceType.S3);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
@@ -117,6 +117,11 @@ public class SparkResource extends Resource {
     @SerializedName(value = "envConfigs")
     private Map<String, String> envConfigs;
 
+
+    public SparkResource() {
+        super();
+    }
+
     public SparkResource(String name) {
         this(name, Maps.newHashMap(), null, null, Maps.newHashMap(), Maps.newHashMap());
     }


### PR DESCRIPTION
## Proposed changes
```java
2024-03-01 17:09:01,469 WARN (agent-task-pool-0|157) [AgentBatchTask.run():186] task exec error. backend[10002]
java.lang.NullPointerException: null
	at org.apache.doris.catalog.Resource.readLock(Resource.java:107) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.task.PushStoragePolicyTask.lambda$toThrift$1(PushStoragePolicyTask.java:86) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.ArrayList.forEach(ArrayList.java:1249) ~[?:1.8.0_131]
	at org.apache.doris.task.PushStoragePolicyTask.toThrift(PushStoragePolicyTask.java:84) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.task.AgentBatchTask.toAgentTaskRequest(AgentBatchTask.java:370) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.task.AgentBatchTask.run(AgentBatchTask.java:169) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_131]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

