### PR TITLE
[fix](test) Fix cloud_p0/catalog_recycle_bin_p0/show.groovy failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1118,7 +1118,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
 
     @Override
     public Map<Long, List<Long>> getDbRunningTransInfo(long dbId) throws AnalysisException {
-        throw new AnalysisException(NOT_SUPPORTED_MSG);
+        return Maps.newHashMap();
     }
 
     @Override


### PR DESCRIPTION
* In cloud mode, `getDbRunningTransInfo` is not suppoted now, we just return a empty map instead of thrown exception

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

