### PR TITLE
[RuntimeFilter] (JDBC) jdbc scan node support IN/MIN_MAX runtime filter

### DIFF
--- a/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
@@ -20,13 +20,21 @@
 #include <fmt/format.h>
 #include <gen_cpp/PlanNodes_types.h>
 
+#include <boost/algorithm/string/join.hpp>
 #include <memory>
 #include <ostream>
+#include <sstream>
+#include <string>
 
 #include "common/logging.h"
 #include "common/object_pool.h"
+#include "exprs/hybrid_set.h"
 #include "runtime/runtime_state.h"
 #include "vec/exec/scan/new_jdbc_scanner.h"
+#include "vec/exprs/vcast_expr.h"
+#include "vec/exprs/vliteral.h"
+#include "vec/exprs/vruntimefilter_wrapper.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
 class DescriptorTbl;
@@ -71,5 +79,207 @@ Status NewJdbcScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
     RETURN_IF_ERROR(scanner->prepare(_state, _conjuncts));
     scanners->push_back(std::move(scanner));
     return Status::OK();
+}
+
+Status NewJdbcScanNode::_process_conjuncts() {
+    RETURN_IF_ERROR(VScanNode::_process_conjuncts());
+    if (_eos) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_process_rf_exprs());
+    return Status::OK();
+}
+
+Status NewJdbcScanNode::_process_rf_exprs() {
+    std::vector<std::string> filters;
+    for (auto expr : _rf_vexpr_set) {
+        if (typeid_cast<VRuntimeFilterWrapper*>(expr.get())) {
+            RETURN_IF_ERROR(_convert_rf_expr_to_sql_str(expr, filters));
+        }
+    }
+    if (!filters.empty()) {
+        const std::string filter_str = boost::join(filters, " AND ");
+        _append_rf_string(filter_str);
+    }
+    return Status::OK();
+}
+
+Status NewJdbcScanNode::_convert_rf_expr_to_sql_str(const vectorized::VExprSPtr& expr,
+                                                    std::vector<std::string>& filters) {
+    auto filter_impl = expr->get_impl();
+    auto node_type = expr->node_type();
+    auto op_code = expr->op();
+    if (node_type == TExprNodeType::IN_PRED) {
+        // in_predict includes only one SLOT_REF child
+        DCHECK(op_code == TExprOpcode::FILTER_IN && filter_impl->get_num_children() == 1);
+        auto hybrid_set = filter_impl->get_set_func();
+        auto slot_expr = filter_impl->get_child(0);
+        auto data_type = slot_expr->type().type;
+        if (slot_expr->node_type() == TExprNodeType::CAST_EXPR) {
+            data_type = dynamic_cast<const VCastExpr*>(slot_expr.get())
+                                ->get_target_type()
+                                ->get_type_as_type_descriptor()
+                                .type;
+            slot_expr = slot_expr->get_child(0);
+        }
+        if (slot_expr->node_type() != TExprNodeType::SLOT_REF) {
+            return Status::OK();
+        }
+        std::vector<std::string> in_strs;
+        if (hybrid_set) {
+            auto iter = hybrid_set->begin();
+            while (iter->has_next()) {
+                if (nullptr == iter->get_value()) {
+                    iter->next();
+                    continue;
+                }
+                std::string value_str = _convert_value_data(data_type, iter->get_value());
+                if (!value_str.empty()) {
+                    in_strs.push_back(value_str);
+                }
+                iter->next();
+            }
+
+            if (!in_strs.empty()) {
+                std::string in_pred_str = fmt::format("`{}` IN ({})", slot_expr->expr_name(),
+                                                      boost::join(in_strs, ", "));
+                filters.push_back(in_pred_str);
+            }
+        }
+    } else if (node_type == TExprNodeType::BINARY_PRED) {
+        DCHECK(filter_impl->get_num_children() == 2);
+        auto slot_expr = filter_impl->get_child(0);
+        auto data_type = slot_expr->type().type;
+        if (slot_expr->node_type() == TExprNodeType::CAST_EXPR) {
+            data_type = dynamic_cast<const VCastExpr*>(slot_expr.get())
+                                ->get_target_type()
+                                ->get_type_as_type_descriptor()
+                                .type;
+            slot_expr = slot_expr->get_child(0);
+        }
+        if (slot_expr->node_type() != TExprNodeType::SLOT_REF) {
+            return Status::OK();
+        }
+        auto literal = dynamic_cast<const vectorized::VLiteral*>(filter_impl->get_child(1).get());
+        const std::string value = (is_string_type(data_type) || is_date_type(data_type))
+                                          ? fmt::format("'{}'", literal->value())
+                                          : literal->value();
+        std::string min_max_pred_str;
+        switch (op_code) {
+        case TExprOpcode::LE:
+            min_max_pred_str = fmt::format("`{}`<={}", slot_expr->expr_name(), value);
+            filters.push_back(min_max_pred_str);
+            break;
+        case TExprOpcode::GE:
+            min_max_pred_str = fmt::format("`{}`>={}", slot_expr->expr_name(), value);
+            filters.push_back(min_max_pred_str);
+            break;
+        default:
+            LOG(WARNING) << "Invalid opcode for max_min_runtimefilter: " << op_code;
+            break;
+        }
+    }
+    return Status::OK();
+}
+
+std::string NewJdbcScanNode::_convert_value_data(PrimitiveType type, const void* value) {
+    std::string res;
+    switch (type) {
+    case TYPE_TINYINT: {
+        res = std::to_string(*reinterpret_cast<const int8_t*>(value));
+        break;
+    }
+    case TYPE_SMALLINT: {
+        res = std::to_string(*reinterpret_cast<const int16_t*>(value));
+        break;
+    }
+    case TYPE_INT: {
+        res = std::to_string(*reinterpret_cast<const int32_t*>(value));
+        break;
+    }
+    case TYPE_BIGINT: {
+        res = std::to_string(*reinterpret_cast<const int64_t*>(value));
+        break;
+    }
+    case TYPE_LARGEINT: {
+        res = LargeIntValue::to_string(*reinterpret_cast<const int128_t*>(value));
+        break;
+    }
+    case TYPE_FLOAT: {
+        res = std::to_string(*reinterpret_cast<const float*>(value));
+        break;
+    }
+    case TYPE_DOUBLE: {
+        res = std::to_string(*reinterpret_cast<const double*>(value));
+        break;
+    }
+    case TYPE_DECIMALV2: {
+        res = reinterpret_cast<const DecimalV2Value*>(value)->to_string();
+        break;
+    }
+    case TYPE_DECIMAL32: {
+        res = std::to_string(*reinterpret_cast<const int32_t*>(value));
+        break;
+    }
+    case TYPE_DECIMAL64: {
+        res = std::to_string(*reinterpret_cast<const int64_t*>(value));
+        break;
+    }
+    case TYPE_DECIMAL128I: {
+        res = LargeIntValue::to_string(*reinterpret_cast<const int128_t*>(value));
+        break;
+    }
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_STRING: {
+        const StringRef* min_string_value = reinterpret_cast<const StringRef*>(value);
+        // Wrapped in single quotation marks
+        res = fmt::format("'{}'", std::string(min_string_value->data, min_string_value->size));
+        break;
+    }
+    case TYPE_DATE:
+    case TYPE_DATETIME: {
+        char convert_buffer[64];
+        int len = reinterpret_cast<const VecDateTimeValue*>(value)->to_buffer(convert_buffer);
+        res = fmt::format("'{}'", std::string(convert_buffer, len));
+        break;
+    }
+    case TYPE_DATEV2: {
+        char convert_buffer[64];
+        int len = reinterpret_cast<const DateV2Value<DateV2ValueType>*>(value)->to_buffer(
+                convert_buffer);
+        res = fmt::format("'{}'", std::string(convert_buffer, len));
+        break;
+    }
+    case TYPE_DATETIMEV2: {
+        char convert_buffer[64];
+        int len = reinterpret_cast<const DateV2Value<DateTimeV2ValueType>*>(value)->to_buffer(
+                convert_buffer);
+        res = fmt::format("'{}'", std::string(convert_buffer, len));
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+    return res;
+}
+
+void NewJdbcScanNode::_append_rf_string(const std::string filter_str) {
+    const std::string where("WHERE");
+    bool has_where = false;
+    int pos = _query_string.find(where);
+    if (pos == std::string::npos) {
+        pos = _query_string.find(_table_name);
+    } else {
+        has_where = true;
+    }
+    DCHECK_NE(pos, std::string::npos);
+
+    if (has_where) {
+        _query_string.insert(pos + where.size(), fmt::format(" {} AND", filter_str));
+    } else {
+        _query_string.insert(pos + _table_name.size(), fmt::format(" {} {}", where, filter_str));
+    }
 }
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/new_jdbc_scan_node.h
+++ b/be/src/vec/exec/scan/new_jdbc_scan_node.h
@@ -45,6 +45,14 @@ public:
 protected:
     Status _init_profile() override;
     Status _init_scanners(std::list<VScannerSPtr>* scanners) override;
+    Status _process_conjuncts() override;
+
+private:
+    Status _process_rf_exprs();
+    Status _convert_rf_expr_to_sql_str(const vectorized::VExprSPtr& expr,
+                                       std::vector<std::string>& filters);
+    std::string _convert_value_data(PrimitiveType type, const void* value);
+    void _append_rf_string(std::string filter_str);
 
 private:
     std::string _table_name;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/source/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/source/JdbcScanNode.java
@@ -241,6 +241,10 @@ public class JdbcScanNode extends ExternalScanNode {
             Expr expr = convertConjunctsToAndCompoundPredicate(conjuncts);
             output.append(prefix).append("PREDICATES: ").append(expr.toSql()).append("\n");
         }
+        if (!runtimeFilters.isEmpty()) {
+            output.append(prefix).append("runtime filters: ");
+            output.append(getRuntimeFilterExplainString(false));
+        }
         return output.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
@@ -29,6 +29,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.util.BitUtil;
 import org.apache.doris.datasource.FileQueryScanNode;
+import org.apache.doris.datasource.jdbc.source.JdbcScanNode;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.thrift.TRuntimeFilterMode;
@@ -366,7 +367,8 @@ public final class RuntimeFilterGenerator {
      * 2. Only olap scan nodes are supported:
      */
     private void assignRuntimeFilters(ScanNode scanNode) {
-        if (!(scanNode instanceof OlapScanNode) && !(scanNode instanceof FileQueryScanNode)) {
+        if (!(scanNode instanceof OlapScanNode) && !(scanNode instanceof FileQueryScanNode)
+                && !(scanNode instanceof JdbcScanNode)) {
             return;
         }
         TupleId tid = scanNode.getTupleIds().get(0);

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_runtime_filter.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_runtime_filter.groovy
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_jdbc_runtime_filter", "p0,external,doris,external_docker,external_docker_doris") {
+    String jdbcUrl = context.config.jdbcUrl
+    String jdbcUser = context.config.jdbcUser
+    String jdbcPassword = context.config.jdbcPassword
+    String s3_endpoint = getS3Endpoint()
+    String bucket = getS3BucketName()
+    String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-java-8.0.25.jar"
+
+    String catalog_name = "doris_jdbc_catalog_test_runtime_filter";
+    String db_name = "regression_test_jdbc_runtime_filter";
+    String dorisTable = "doris_tbl";
+    String jdbcTable = "jdbc_tbl";
+
+    sql """create database if not exists ${db_name}; """
+
+    sql """use ${db_name}"""
+    sql  """ drop table if exists ${db_name}.${jdbcTable} """
+    sql  """ drop table if exists ${db_name}.${dorisTable} """
+     sql """
+          CREATE TABLE ${jdbcTable} (t1 INT) DISTRIBUTED BY HASH (t1) BUCKETS 2 PROPERTIES("replication_num" = "1");
+        """
+    sql """ INSERT INTO ${jdbcTable} VALUES (3), (4), (5); """
+    sql  """
+          CREATE TABLE ${dorisTable} (t2 INT) DISTRIBUTED BY HASH (t2) BUCKETS 2 PROPERTIES("replication_num" = "1");
+        """
+    sql """ INSERT INTO ${dorisTable} VALUES (1), (2), (3), (4); """
+
+    sql """drop catalog if exists ${catalog_name} """
+    sql """ CREATE CATALOG `${catalog_name}` PROPERTIES (
+        "user" = "${jdbcUser}",
+        "type" = "jdbc",
+        "password" = "${jdbcPassword}",
+        "jdbc_url" = "${jdbcUrl}",
+        "driver_url" = "${driver_url}",
+        "driver_class" = "com.mysql.cj.jdbc.Driver"
+        )"""
+
+    sql """ set enable_pipeline_x_engine=false; """
+    sql """ set runtime_filter_type="IN,MIN_MAX" """
+    sql """ set enable_nereids_planner=true """
+    sql """ set enable_fallback_to_original_planner=false """
+    sql """ set disable_join_reorder=true """
+    sql """ set enable_runtime_filter_prune=false """
+    explain {
+        sql(""" SELECT * FROM ${catalog_name}.${db_name}.${jdbcTable} tb1 JOIN ${dorisTable} tb2 where tb1.t1 = tb2.t2; """)
+        contains "runtime filters: RF000[in] <- t2"
+        contains "RF001[min_max] <- t2"
+        contains "runtime filters: RF000[in] -> t1"
+        contains "RF001[min_max] -> t1"
+    }
+
+    sql  """ drop table if exists ${db_name}.${dorisTable} """
+    sql  """ drop table if exists ${db_name}.${jdbcTable} """
+    sql """drop catalog if exists ${catalog_name} """
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
JDBC scan node can use runtime filter to filter data, 2 main changes:
1. Generating runtime filters for JDBC scan node if left table is a JDBC external table in join.
2. Converting IN and MIN_MAX runtime filters to query strings like `col in (v1, v2 . . .)` and `col >= min_v and col <= max_v`, then rebuilding `_query_string` for JDBCScanNode.  

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

