### PR TITLE
[fix](load) fix npe on loadTxn2PCImpl

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1526,9 +1526,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         DatabaseTransactionMgr dbTransactionMgr = Env.getCurrentGlobalTransactionMgr()
                 .getDatabaseTransactionMgr(database.getId());
         TransactionState transactionState = dbTransactionMgr.getTransactionState(request.getTxnId());
-        LOG.debug("txn {} has multi table {}", request.getTxnId(), transactionState.getTableIdList());
         if (transactionState == null) {
             throw new UserException("transaction [" + request.getTxnId() + "] not found");
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("txn {} has multi table {}", request.getTxnId(), transactionState.getTableIdList());
         }
         List<Long> tableIdList = transactionState.getTableIdList();
         String txnOperation = request.getOperation().trim();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

This code has been refactored  and the problem has been fixed on master branch.

2024-02-21 17:08:32,822 WARN (thrift-server-pool-19|2010) [FrontendServiceImpl.loadTxn2PC():1494] catch unknown result.
java.lang.NullPointerException: null
 at org.apache.doris.service.FrontendServiceImpl.loadTxn2PCImpl(FrontendServiceImpl.java:1525) ~[doris-fe.jar:1.2-SNAPSHOT]
 at org.apache.doris.service.FrontendServiceImpl.loadTxn2PC(FrontendServiceImpl.java:1488) ~[doris-fe.jar:1.2-SNAPSHOT]
 at sun.reflect.GeneratedMethodAccessor29.invoke(Unknown Source) ~[?:?]
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_241]
 at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_241]
 at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:59) ~[doris-fe.jar:1.2-SNAPSHOT]
 at com.sun.proxy.$Proxy36.loadTxn2PC(Unknown Source) ~[?:?]

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

