### PR TITLE
[Performance](exec) Support runtime filter in <=> join [BE part]

### DIFF
--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -32,7 +32,9 @@ public:
         return doris::segment_v2::BloomFilter::optimal_bit_num(expect_num, fpp) / 8;
     }
 
-    static BloomFilterAdaptor* create() { return new BloomFilterAdaptor(); }
+    static BloomFilterAdaptor* create(bool null_aware) {
+        return new BloomFilterAdaptor(null_aware);
+    }
 
     Status merge(BloomFilterAdaptor* other) { return _bloom_filter->merge(*other->_bloom_filter); }
 
@@ -87,6 +89,8 @@ public:
 
     void set_build_bf_exactly(bool build_bf_exactly) { _build_bf_exactly = build_bf_exactly; }
 
+    void set_null_aware(bool null_aware) { _null_aware = null_aware; }
+
     Status init_with_fixed_length() { return init_with_fixed_length(_bloom_filter_length); }
 
     Status init_with_cardinality(const size_t build_bf_cardinality) {
@@ -116,7 +120,7 @@ public:
         DCHECK(bloom_filter_length >= 0);
         DCHECK_EQ((bloom_filter_length & (bloom_filter_length - 1)), 0);
         _bloom_filter_alloced = bloom_filter_length;
-        _bloom_filter.reset(BloomFilterAdaptor::create());
+        _bloom_filter.reset(BloomFilterAdaptor::create(_null_aware));
         RETURN_IF_ERROR(_bloom_filter->init(bloom_filter_length));
         _inited = true;
         return Status::OK();
@@ -162,7 +166,7 @@ public:
 
     Status assign(butil::IOBufAsZeroCopyInputStream* data, const size_t data_size) {
         if (_bloom_filter == nullptr) {
-            _bloom_filter.reset(BloomFilterAdaptor::create());
+            _bloom_filter.reset(BloomFilterAdaptor::create(_null_aware));
         }
 
         _bloom_filter_alloced = data_size;
@@ -201,6 +205,7 @@ protected:
     std::mutex _lock;
     int64_t _bloom_filter_length;
     bool _build_bf_exactly = false;
+    bool _null_aware = false;
 };
 
 template <typename T, bool need_trim = false>

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -311,6 +311,7 @@ public:
             _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type));
             _context.bloom_filter_func->set_length(params->bloom_filter_size);
             _context.bloom_filter_func->set_build_bf_exactly(params->build_bf_exactly);
+            _context.bloom_filter_func->set_null_aware(params->null_aware);
             return Status::OK();
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
@@ -318,6 +319,7 @@ public:
             _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type));
             _context.bloom_filter_func->set_length(params->bloom_filter_size);
             _context.bloom_filter_func->set_build_bf_exactly(params->build_bf_exactly);
+            _context.bloom_filter_func->set_null_aware(params->null_aware);
             return Status::OK();
         }
         case RuntimeFilterType::BITMAP_FILTER: {
@@ -1228,6 +1230,9 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
                                _runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
     if (desc->__isset.bloom_filter_size_bytes) {
         params.bloom_filter_size = desc->bloom_filter_size_bytes;
+    }
+    if (desc->__isset.null_aware) {
+        params.null_aware = desc->null_aware;
     }
     if (_runtime_filter_type == RuntimeFilterType::BITMAP_FILTER) {
         if (!build_ctx->root()->type().is_bitmap_type()) {

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -131,6 +131,7 @@ struct RuntimeFilterParams {
     int32_t filter_id;
     bool bitmap_filter_not_in;
     bool build_bf_exactly;
+    bool null_aware = false;
 };
 struct FilterFuncBase {
 public:

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1188,6 +1188,9 @@ struct TRuntimeFilterDesc {
   // if bloom_filter_size_calculated_by_ndv=false, BE could calculate filter size according to the actural row count, and 
   // ignore bloom_filter_size_bytes
   14: optional bool bloom_filter_size_calculated_by_ndv;
+ 
+  // true, if join type is null aware like <=>. rf should dispose the case
+  15: optional bool null_aware;
 }
 
 

--- a/regression-test/data/query_p0/join/test_join.out
+++ b/regression-test/data/query_p0/join/test_join.out
@@ -2595,6 +2595,357 @@ false	true	true	false	false
 5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
 5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
 
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !left_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !right_join --
+1	\N	null	\N	\N	8.9	1	\N	null	\N	\N	8.9
+1	\N	null	\N	\N	8.9	2	\N	2	\N	\N	8.9
+1	\N	null	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+1	\N	null	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+2	\N	2	\N	\N	8.9	2	\N	2	\N	\N	8.9
+2	\N	2	\N	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+2	\N	2	\N	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	3	\N	null	2019-09-09	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !hash_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	1	\N	null	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	2	\N	2	\N	\N	8.9
+\N	\N	\N	\N	\N	\N	3	\N	null	2019-09-09	\N	8.9
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+
+-- !cross_join --
+\N	\N	\N	\N	\N	\N	5	\N	null	\N	2019-09-09T00:00	8.9
+2	\N	2	\N	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	1	\N	null	\N	\N	8.9
+3	\N	null	2019-09-09	\N	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	1	\N	null	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	2	\N	2	\N	\N	8.9
+5	\N	null	\N	2019-09-09T00:00	8.9	3	\N	null	2019-09-09	\N	8.9
+
 -- !join_null_value1 --
 
 -- !join_null_value2 --

--- a/regression-test/suites/query_p0/join/test_join.groovy
+++ b/regression-test/suites/query_p0/join/test_join.groovy
@@ -1160,6 +1160,25 @@ suite("test_join", "query,p0") {
         qt_cross_join"""select * from ${null_table_1} a right join ${null_table_1} b on  a.k${index}<=>b.k${index} and a.k1 > b.k1
             order by a.k1, b.k1"""
     }
+    
+    // test null <=> runtime filter
+    sql"set enable_runtime_filter_prune = false"
+    for (index in range(1, 7)) {
+        qt_left_join"""select * from ${null_table_1} a join ${null_table_1} b on  a.k${index}<=>b.k${index} 
+            order by a.k1, b.k1"""
+        qt_left_join"""select * from ${null_table_1} a left join ${null_table_1} b on  a.k${index}<=>b.k${index} 
+            order by a.k1, b.k1"""
+        qt_right_join"""select * from ${null_table_1} a right join ${null_table_1} b on  a.k${index}<=>b.k${index}
+            order by a.k1, b.k1"""
+        qt_hash_join"""select * from ${null_table_1} a right join ${null_table_1} b on  a.k${index}<=>b.k${index} and a.k2=b.k2
+            order by a.k1, b.k1"""
+        qt_cross_join"""select * from ${null_table_1} a right join ${null_table_1} b on  a.k${index}<=>b.k${index} and a.k2 !=b.k2
+            order by a.k1, b.k1"""
+        qt_cross_join"""select * from ${null_table_1} a right join ${null_table_1} b on  a.k${index}<=>b.k${index} and a.k1 > b.k1
+            order by a.k1, b.k1"""
+    }
+    sql"set enable_runtime_filter_prune = true"
+    
     //  windows
     def res97 = sql"""select * from (select k1, k2, sum(k2) over (partition by k1) as ss from ${null_table_2})a
        left join ${null_table_1} b on  a.k2=b.k2 and a.k1 >b.k1 order by a.k1, b.k1"""


### PR DESCRIPTION
## Proposed changes

Support runtime filter in <=> join [BE part]

before: 
```
select a.k3, b.k3 from baseall a, bigtable b where a.k3 <=> b.k3;

6.93s
```
after:
```
select a.k3, b.k3 from baseall a, bigtable b where a.k3 <=> b.k3;

0.36s
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

