### PR TITLE
[fix](Nereids) json_object can't be odd parameters, need even parameters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonObject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonObject.java
@@ -49,6 +49,9 @@ public class JsonObject extends ScalarFunction
 
     @Override
     public void checkLegalityBeforeTypeCoercion() {
+        if ((arity() & 1) == 1) {
+            throw new AnalysisException("json_object can't be odd parameters, need even parameters: " + this.toSql());
+        }
         for (int i = 0; i < arity(); i++) {
             if ((i & 1) == 0 && getArgumentType(i).isNullType()) {
                 throw new AnalysisException("json_object key can't be NULL: " + this.toSql());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #31766

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

