### PR TITLE
[feature](doris compose) Add no-detach mode && use java 17 image

### DIFF
--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -16,14 +16,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# choose a base image
-FROM openjdk:8u342-jdk
+#### START ARG ####
 
-ARG OUT_DIRECTORY=output
+# docker build cmd example:
+# docker build -f docker/runtime/doris-compose/Dockerfile -t <your-image-name>:<version> .
+
+# choose a base image
+ARG JDK_IMAGE=openjdk:17-jdk-slim
+#ARG JDK_IMAGE=openjdk:8u342-jdk
+
+#### END ARG ####
+
+FROM ${JDK_IMAGE}
+
+RUN <<EOF
+    if [ -d "/usr/local/openjdk-17" ]; then
+        ln -s /usr/local/openjdk-17  /usr/local/openjdk
+    else \
+        ln -s /usr/local/openjdk-8  /usr/local/openjdk
+    fi
+EOF
 
 # set environment variables
-ENV JAVA_HOME="/usr/local/openjdk-8/"
-ENV jacoco_version 0.8.8
+ENV JAVA_HOME="/usr/local/openjdk"
+ENV JACOCO_VERSION 0.8.8
 
 RUN mkdir -p /opt/apache-doris/coverage
 
@@ -31,17 +47,17 @@ RUN  sed -i s@/deb.debian.org/@/mirrors.aliyun.com/@g /etc/apt/sources.list
 RUN  apt-get clean
 
 RUN apt-get update && \
-    apt-get install -y default-mysql-client python lsof tzdata curl unzip patchelf jq && \
+    apt-get install -y default-mysql-client python lsof tzdata curl unzip patchelf jq procps && \
     ln -fs /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
     apt-get clean
 
-RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/$jacoco_version/jacoco-$jacoco_version.zip -o jacoco.zip && \
+RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/${JACOCO_VERSION}/jacoco-${JACOCO_VERSION}.zip -o jacoco.zip && \
     mkdir /jacoco && \
     unzip jacoco.zip -d /jacoco
 
 # cloud
-COPY ${OUT_DIRECTORY}/../cloud/CMakeLists.txt ${OUT_DIRECTORY}/../cloud/output* /opt/apache-doris/cloud/
+COPY cloud/CMakeLists.txt cloud/output* /opt/apache-doris/cloud/
 RUN <<EOF
     mkdir /opt/apache-doris/fdb
     if [ -d /opt/apache-doris/cloud/bin ]; then
@@ -50,7 +66,7 @@ RUN <<EOF
 EOF
 
 # fe and be
-COPY $OUT_DIRECTORY /opt/apache-doris/
+COPY output /opt/apache-doris/
 # in docker, run 'chmod 755 doris_be' first time cost 1min, remove it.
 RUN sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/be/bin/start_be.sh
 

--- a/docker/runtime/doris-compose/utils.py
+++ b/docker/runtime/doris-compose/utils.py
@@ -179,25 +179,37 @@ def is_dir_empty(dir):
     return False if os.listdir(dir) else True
 
 
-def exec_shell_command(command, ignore_errors=False):
+def exec_shell_command(command, ignore_errors=False, output_real_time=False):
     LOG.info("Exec command: {}".format(command))
     p = subprocess.Popen(command,
                          shell=True,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
-    out = p.communicate()[0].decode('utf-8')
+    out = ''
+    exitcode = None
+    if output_real_time:
+        while p.poll() is None:
+            s = p.stdout.readline().decode('utf-8')
+            if ENABLE_LOG and s.rstrip():
+                print(s.rstrip())
+            out += s
+        exitcode = p.wait()
+    else:
+        out = p.communicate()[0].decode('utf-8')
+        exitcode = p.returncode
+        if ENABLE_LOG and out:
+            print(out)
     if not ignore_errors:
-        assert p.returncode == 0, out
-    if ENABLE_LOG and out:
-        print(out)
-    return p.returncode, out
+        assert exitcode == 0, out
+    return exitcode, out
 
 
 def exec_docker_compose_command(compose_file,
                                 command,
                                 options=None,
                                 nodes=None,
-                                user_command=None):
+                                user_command=None,
+                                output_real_time=False):
     if nodes != None and not nodes:
         return 0, "Skip"
 
@@ -206,7 +218,7 @@ def exec_docker_compose_command(compose_file,
         " ".join([node.service_name() for node in nodes]) if nodes else "",
         user_command if user_command else "")
 
-    return exec_shell_command(compose_cmd)
+    return exec_shell_command(compose_cmd, output_real_time=output_real_time)
 
 
 def get_docker_subnets_prefix16():


### PR DESCRIPTION
1. Add no-detach mode, will can inspect container output error;
2. Use java 17 image;

no-detach mode can output container error log during start.

![123](https://github.com/apache/doris/assets/8347843/49226d24-f07f-45d2-bdfe-4fb08e05a838)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

