### PR TITLE
[fix](jdbc catalog) Change Druid Pool dependency to version 1.2.5

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -251,7 +251,7 @@ under the License.
         <commons-io.version>2.7</commons-io.version>
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>5.8.2</junit.version>
-        <druid.version>1.2.11</druid.version>
+        <druid.version>1.2.5</druid.version>
         <clickhouse.version>0.4.6</clickhouse.version>
         <thrift.version>0.16.0</thrift.version>
         <tomcat-embed-core.version>8.5.86</tomcat-embed-core.version>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Since we depend on druid version 1.2.11, we will encounter the following warning when compiling, so we switch back to 1.2.5. However, please note that this version may have a connection leak problem when keepalive is turned on, so please use the keepalive function with caution
```
Caused by: org.apache.maven.model.building.ModelBuildingException: 2 problems were encountered while building the effective model for com.alibaba:druid:1.2.11
[ERROR] 'dependencies.dependency.systemPath' for com.sun:tools:jar must specify an absolute path but is ${project.basedir}/lib/openjdk-1.8-tools.jar @ line 645, column 16
[ERROR] 'dependencies.dependency.systemPath' for com.sun:jconsole:jar must specify an absolute path but is ${project.basedir}/lib/openjdk-1.8-jconsole.jar @ line 653, column 16
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

