### PR TITLE
[fix](cloud-merge) Fix missing the whereColumn field

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -178,9 +178,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     }
 
     public void addMVIndex(long partitionId, MaterializedIndex mvIndex) {
-        if (mvIndex == null) {
-            LOG.info("lightman ?????????");
-        }
         this.partitionIdToRollupIndex.put(partitionId, mvIndex);
     }
 
@@ -203,7 +200,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     protected void createRollupReplica() throws AlterCancelException {
         Database db = Env.getCurrentInternalCatalog()
                 .getDbOrException(dbId, s -> new AlterCancelException("Database " + s + " does not exist"));
-        LOG.info("lightman1 add size {}", this.partitionIdToRollupIndex.size());
         // 1. create rollup replicas
         AgentBatchTask batchTask = new AgentBatchTask();
         // count total replica num
@@ -220,7 +216,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         } catch (MetaNotFoundException e) {
             throw new AlterCancelException(e.getMessage());
         }
-        LOG.info("lightman2 add size {}", this.partitionIdToRollupIndex.size());
         tbl.readLock();
         try {
             BinlogConfig binlogConfig = new BinlogConfig(tbl.getBinlogConfig());
@@ -279,7 +274,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         } finally {
             tbl.readUnlock();
         }
-        LOG.info("lightman3 add size {}", this.partitionIdToRollupIndex.size());
         if (!FeConstants.runningUnitTest) {
             // send all tasks and wait them finished
             AgentTaskQueue.addBatchTask(batchTask);
@@ -311,7 +305,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 throw new AlterCancelException("Create rollup replicas failed. Error: " + errMsg);
             }
         }
-        LOG.info("lightman4 add size {}", this.partitionIdToRollupIndex.size());
         // create all rollup replicas success.
         // add rollup index to catalog
         tbl.writeLockOrAlterCancelException();
@@ -354,10 +347,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         for (Partition partition : tbl.getPartitions()) {
             long partitionId = partition.getId();
             MaterializedIndex rollupIndex = this.partitionIdToRollupIndex.get(partitionId);
-            if (rollupIndex == null) {
-                LOG.warn("lightman partitionId {} size {}", partitionId,
-                        this.partitionIdToRollupIndex.size());
-            }
             Preconditions.checkNotNull(rollupIndex);
             Preconditions.checkState(rollupIndex.getState() == IndexState.SHADOW, rollupIndex.getState());
             partition.createRollupIndex(rollupIndex);
@@ -900,6 +889,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             throw new IOException("error happens when parsing create materialized view stmt: " + stmt, e);
         }
         setColumnsDefineExpr(stmt.getMVColumnItemList());
+        if (whereColumn != null) {
+            whereColumn.setDefineExpr(stmt.getWhereClause());
+        }
     }
 
     protected void onCreateRollupReplicaDone() throws AlterCancelException {}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1443,7 +1443,7 @@ public class SessionVariable implements Serializable, Writable {
     public boolean truncateCharOrVarcharColumns = false;
 
     @VariableMgr.VarAttr(name = ENABLE_MEMTABLE_ON_SINK_NODE, needForward = true)
-    public boolean enableMemtableOnSinkNode = false;
+    public boolean enableMemtableOnSinkNode = true;
 
     @VariableMgr.VarAttr(name = LOAD_STREAM_PER_NODE)
     public int loadStreamPerNode = 2;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

When replay the RollupJobV2 from store, the field `defineExpr` in `whereColumn` will be null so that when the jobState is JobState.PENDING and rerun it, the converted data will be wrong in new mv.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

