### PR TITLE
[enhancement](Nereids) refine and speedup analyzer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -98,12 +98,12 @@ public class FunctionRegistry {
                 String combinatorSuffix = AggCombinerFunctionBuilder.getCombinatorSuffix(name);
                 functionBuilders = name2InternalBuiltinBuilders.get(nestedName.toLowerCase());
                 if (functionBuilders != null) {
-                    List<FunctionBuilder> candidateBuilders = Lists.newArrayListWithCapacity(arguments.size());
+                    List<FunctionBuilder> candidateBuilders = Lists.newArrayListWithCapacity(functionBuilders.size());
                     for (FunctionBuilder functionBuilder : functionBuilders) {
-                        AggCombinerFunctionBuilder builder
+                        AggCombinerFunctionBuilder combinerBuilder
                                 = new AggCombinerFunctionBuilder(combinatorSuffix, functionBuilder);
-                        if (builder.canApply(arguments)) {
-                            candidateBuilders.add(functionBuilder);
+                        if (combinerBuilder.canApply(arguments)) {
+                            candidateBuilders.add(combinerBuilder);
                         }
                     }
                     functionBuilders = candidateBuilders;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -98,10 +98,15 @@ public class FunctionRegistry {
                 String combinatorSuffix = AggCombinerFunctionBuilder.getCombinatorSuffix(name);
                 functionBuilders = name2InternalBuiltinBuilders.get(nestedName.toLowerCase());
                 if (functionBuilders != null) {
-                    functionBuilders = functionBuilders.stream()
-                            .map(builder -> new AggCombinerFunctionBuilder(combinatorSuffix, builder))
-                            .filter(functionBuilder -> functionBuilder.canApply(arguments))
-                            .collect(Collectors.toList());
+                    List<FunctionBuilder> candidateBuilders = Lists.newArrayListWithCapacity(arguments.size());
+                    for (FunctionBuilder functionBuilder : functionBuilders) {
+                        AggCombinerFunctionBuilder builder
+                                = new AggCombinerFunctionBuilder(combinatorSuffix, functionBuilder);
+                        if (builder.canApply(arguments)) {
+                            candidateBuilders.add(functionBuilder);
+                        }
+                    }
+                    functionBuilders = candidateBuilders;
                 }
             }
         }
@@ -115,9 +120,12 @@ public class FunctionRegistry {
         }
 
         // check the arity and type
-        List<FunctionBuilder> candidateBuilders = functionBuilders.stream()
-                .filter(functionBuilder -> functionBuilder.canApply(arguments))
-                .collect(Collectors.toList());
+        List<FunctionBuilder> candidateBuilders = Lists.newArrayListWithCapacity(arguments.size());
+        for (FunctionBuilder functionBuilder : functionBuilders) {
+            if (functionBuilder.canApply(arguments)) {
+                candidateBuilders.add(functionBuilder);
+            }
+        }
         if (candidateBuilders.isEmpty()) {
             String candidateHints = getCandidateHint(name, functionBuilders);
             throw new AnalysisException("Can not found function '" + qualifiedName

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSignature.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.FollowToArgumentType;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -40,7 +41,7 @@ public class FunctionSignature {
     private FunctionSignature(DataType returnType, boolean hasVarArgs,
             List<? extends DataType> argumentsTypes) {
         this.returnType = Objects.requireNonNull(returnType, "returnType is not null");
-        this.argumentsTypes = ImmutableList.copyOf(
+        this.argumentsTypes = Utils.fastToImmutableList(
                 Objects.requireNonNull(argumentsTypes, "argumentsTypes is not null"));
         this.hasVarArgs = hasVarArgs;
         this.arity = argumentsTypes.size();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -71,6 +71,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -91,6 +93,7 @@ import javax.annotation.Nullable;
  * Context used in memo.
  */
 public class CascadesContext implements ScheduleContext {
+    private static final Logger LOG = LogManager.getLogger(CascadesContext.class);
 
     // in analyze/rewrite stage, the plan will storage in this field
     private Plan plan;
@@ -705,6 +708,12 @@ public class CascadesContext implements ScheduleContext {
             withPlanProcess(showPlanProcess, task);
         } else {
             task.run();
+        }
+    }
+
+    public void printPlanProcess() {
+        for (PlanProcess row : planProcesses) {
+            LOG.info("RULE: " + row.ruleName + "\nBEFORE:\n" + row.beforeShape + "\nafter:\n" + row.afterShape);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/ComplexDataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/ComplexDataType.java
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.analyzer;
+
+/** ComplexDataType */
+public interface ComplexDataType {
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/MappingSlot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/MappingSlot.java
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.analyzer;
+
+import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
+
+import java.util.List;
+
+/**
+ * MappingSlot.
+ * mapping slot to an expression, use to replace slot to this expression.
+ * this class only use in Scope, and **NEVER** appear in the expression tree
+ */
+public class MappingSlot extends Slot {
+    private final Slot slot;
+    private final Expression mappingExpression;
+
+    public MappingSlot(Slot slot, Expression mappingExpression) {
+        this.slot = slot;
+        this.mappingExpression = mappingExpression;
+    }
+
+    public Slot getRealSlot() {
+        return slot;
+    }
+
+    @Override
+    public List<String> getQualifier() {
+        return slot.getQualifier();
+    }
+
+    public Expression getMappingExpression() {
+        return mappingExpression;
+    }
+
+    @Override
+    public ExprId getExprId() {
+        return slot.getExprId();
+    }
+
+    @Override
+    public String getName() throws UnboundException {
+        return slot.getName();
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitSlot(this, context);
+    }
+
+    @Override
+    public boolean nullable() {
+        return slot.nullable();
+    }
+
+    @Override
+    public String toSql() {
+        return slot.toSql();
+    }
+
+    @Override
+    public String toString() {
+        return slot.toString();
+    }
+
+    @Override
+    public DataType getDataType() throws UnboundException {
+        return slot.getDataType();
+    }
+
+    @Override
+    public String getInternalName() {
+        return slot.getInternalName();
+    }
+
+    @Override
+    public Slot withName(String name) {
+        return this;
+    }
+
+    @Override
+    public Slot withNullable(boolean newNullable) {
+        return this;
+    }
+
+    @Override
+    public Slot withExprId(ExprId exprId) {
+        return this;
+    }
+
+    @Override
+    public Slot withQualifier(List<String> qualifier) {
+        return this;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/Scope.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/Scope.java
@@ -22,7 +22,8 @@ import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 
 import java.util.List;
@@ -62,14 +63,14 @@ public class Scope {
     private final List<Slot> slots;
     private final Optional<SubqueryExpr> ownerSubquery;
     private final Set<Slot> correlatedSlots;
-    private final Supplier<ArrayListMultimap<String, Slot>> nameToSlot;
+    private final Supplier<ListMultimap<String, Slot>> nameToSlot;
 
-    public Scope(List<Slot> slots) {
+    public Scope(List<? extends Slot> slots) {
         this(Optional.empty(), slots, Optional.empty());
     }
 
     /** Scope */
-    public Scope(Optional<Scope> outerScope, List<Slot> slots, Optional<SubqueryExpr> subqueryExpr) {
+    public Scope(Optional<Scope> outerScope, List<? extends Slot> slots, Optional<SubqueryExpr> subqueryExpr) {
         this.outerScope = Objects.requireNonNull(outerScope, "outerScope can not be null");
         this.slots = Utils.fastToImmutableList(Objects.requireNonNull(slots, "slots can not be null"));
         this.ownerSubquery = Objects.requireNonNull(subqueryExpr, "subqueryExpr can not be null");
@@ -93,12 +94,13 @@ public class Scope {
         return correlatedSlots;
     }
 
+    /** findSlotIgnoreCase */
     public List<Slot> findSlotIgnoreCase(String slotName) {
         return nameToSlot.get().get(slotName.toUpperCase(Locale.ROOT));
     }
 
-    private ArrayListMultimap<String, Slot> buildNameToSlot() {
-        ArrayListMultimap<String, Slot> map = ArrayListMultimap.create(slots.size(), 2);
+    private ListMultimap<String, Slot> buildNameToSlot() {
+        ListMultimap<String, Slot> map = LinkedListMultimap.create(slots.size());
         for (Slot slot : slots) {
             map.put(slot.getName().toUpperCase(Locale.ROOT), slot);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/Scope.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/Scope.java
@@ -19,14 +19,18 @@ package org.apache.doris.nereids.analyzer;
 
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.util.Utils;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Sets;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * The slot range required for expression analyze.
@@ -58,16 +62,19 @@ public class Scope {
     private final List<Slot> slots;
     private final Optional<SubqueryExpr> ownerSubquery;
     private final Set<Slot> correlatedSlots;
-
-    public Scope(Optional<Scope> outerScope, List<Slot> slots, Optional<SubqueryExpr> subqueryExpr) {
-        this.outerScope = outerScope;
-        this.slots = ImmutableList.copyOf(Objects.requireNonNull(slots, "slots can not be null"));
-        this.ownerSubquery = subqueryExpr;
-        this.correlatedSlots = Sets.newLinkedHashSet();
-    }
+    private final Supplier<ArrayListMultimap<String, Slot>> nameToSlot;
 
     public Scope(List<Slot> slots) {
         this(Optional.empty(), slots, Optional.empty());
+    }
+
+    /** Scope */
+    public Scope(Optional<Scope> outerScope, List<Slot> slots, Optional<SubqueryExpr> subqueryExpr) {
+        this.outerScope = Objects.requireNonNull(outerScope, "outerScope can not be null");
+        this.slots = Utils.fastToImmutableList(Objects.requireNonNull(slots, "slots can not be null"));
+        this.ownerSubquery = Objects.requireNonNull(subqueryExpr, "subqueryExpr can not be null");
+        this.correlatedSlots = Sets.newLinkedHashSet();
+        this.nameToSlot = Suppliers.memoize(this::buildNameToSlot);
     }
 
     public List<Slot> getSlots() {
@@ -84,5 +91,17 @@ public class Scope {
 
     public Set<Slot> getCorrelatedSlots() {
         return correlatedSlots;
+    }
+
+    public List<Slot> findSlotIgnoreCase(String slotName) {
+        return nameToSlot.get().get(slotName.toUpperCase(Locale.ROOT));
+    }
+
+    private ArrayListMultimap<String, Slot> buildNameToSlot() {
+        ArrayListMultimap<String, Slot> map = ArrayListMultimap.create(slots.size(), 2);
+        for (Slot slot : slots) {
+            map.put(slot.getName().toUpperCase(Locale.ROOT), slot);
+        }
+        return map;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteJob.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.jobs.rewrite;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.PlanProcess;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.JobType;
@@ -26,8 +27,6 @@ import org.apache.doris.nereids.minidump.NereidsTracer;
 import org.apache.doris.nereids.pattern.Pattern;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.trees.plans.Plan;
-
-import com.google.common.base.Preconditions;
 
 import java.util.List;
 
@@ -38,11 +37,9 @@ public abstract class PlanTreeRewriteJob extends Job {
         super(type, context);
     }
 
-    protected RewriteResult rewrite(Plan plan, List<Rule> rules, RewriteJobContext rewriteJobContext) {
-        // boolean traceEnable = isTraceEnable(context);
-        boolean isRewriteRoot = rewriteJobContext.isRewriteRoot();
+    protected final RewriteResult rewrite(Plan plan, List<Rule> rules, RewriteJobContext rewriteJobContext) {
         CascadesContext cascadesContext = context.getCascadesContext();
-        cascadesContext.setIsRewriteRoot(isRewriteRoot);
+        cascadesContext.setIsRewriteRoot(rewriteJobContext.isRewriteRoot());
 
         boolean showPlanProcess = cascadesContext.showPlanProcess();
         for (Rule rule : rules) {
@@ -52,8 +49,9 @@ public abstract class PlanTreeRewriteJob extends Job {
             Pattern<Plan> pattern = (Pattern<Plan>) rule.getPattern();
             if (pattern.matchPlanTree(plan)) {
                 List<Plan> newPlans = rule.transform(plan, cascadesContext);
-                Preconditions.checkState(newPlans.size() == 1,
-                        "Rewrite rule should generate one plan: " + rule.getRuleType());
+                if (newPlans.size() != 1) {
+                    throw new AnalysisException("Rewrite rule should generate one plan: " + rule.getRuleType());
+                }
                 Plan newPlan = newPlans.get(0);
                 if (!newPlan.deepEquals(plan)) {
                     // don't remove this comment, it can help us to trace some bug when developing.
@@ -78,13 +76,13 @@ public abstract class PlanTreeRewriteJob extends Job {
         return new RewriteResult(false, plan);
     }
 
-    protected Plan linkChildrenAndParent(Plan plan, RewriteJobContext rewriteJobContext) {
+    protected final Plan linkChildrenAndParent(Plan plan, RewriteJobContext rewriteJobContext) {
         Plan newPlan = linkChildren(plan, rewriteJobContext.childrenContext);
         rewriteJobContext.setResult(newPlan);
         return newPlan;
     }
 
-    protected Plan linkChildren(Plan plan, RewriteJobContext[] childrenContext) {
+    protected final Plan linkChildren(Plan plan, RewriteJobContext[] childrenContext) {
         boolean changed = false;
         Plan[] newChildren = new Plan[childrenContext.length];
         for (int i = 0; i < childrenContext.length; ++i) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AvgDistinctToSumDivCount.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AvgDistinctToSumDivCount.java
@@ -59,7 +59,7 @@ public class AvgDistinctToSumDivCount extends OneRewriteRuleFactory {
                             }));
                     if (!avgToSumDivCount.isEmpty()) {
                         List<NamedExpression> newOutput = agg.getOutputExpressions().stream()
-                                .map(expr -> (NamedExpression) ExpressionUtils.replace(expr, avgToSumDivCount))
+                                .map(expr -> ExpressionUtils.replaceNameExpression(expr, avgToSumDivCount))
                                 .collect(ImmutableList.toImmutableList());
                         return new LogicalAggregate<>(agg.getGroupByExpressions(), newOutput, agg.child());
                     } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotWithPaths.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotWithPaths.java
@@ -79,7 +79,7 @@ public class BindSlotWithPaths implements AnalysisRuleFactory {
                                 return ctx.root;
                             }
                             newProjectsExpr.addAll(newExprs);
-                            return new LogicalProject(newProjectsExpr, logicalOlapScan.withProjectPulledUp());
+                            return new LogicalProject<>(newProjectsExpr, logicalOlapScan.withProjectPulledUp());
                         }))
         );
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
@@ -128,13 +128,11 @@ public class CheckAnalysis implements AnalysisRuleFactory {
     }
 
     private void checkExpressionInputTypes(Plan plan) {
-        final Optional<TypeCheckResult> firstFailed = plan.getExpressions().stream()
-                .map(Expression::checkInputDataTypes)
-                .filter(TypeCheckResult::failed)
-                .findFirst();
-
-        if (firstFailed.isPresent()) {
-            throw new AnalysisException(firstFailed.get().getMessage());
+        for (Expression expression : plan.getExpressions()) {
+            TypeCheckResult firstFailed = expression.checkInputDataTypes();
+            if (firstFailed.failed()) {
+                throw new AnalysisException(firstFailed.getMessage());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHint.java
@@ -91,6 +91,7 @@ public class EliminateLogicalSelectHint extends OneRewriteRuleFactory {
             if (value.isPresent()) {
                 try {
                     VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(value.get())));
+                    context.invalidCache(key);
                 } catch (Throwable t) {
                     throw new AnalysisException("Can not set session variable '"
                         + key + "' = '" + value.get() + "'", t);
@@ -108,7 +109,6 @@ public class EliminateLogicalSelectHint extends OneRewriteRuleFactory {
             }
             throw new AnalysisException("The nereids is disabled in this sql, fallback to original planner");
         }
-        context.invalidCache(selectHint.getHintName());
     }
 
     private void extractLeading(SelectHintLeading selectHint, CascadesContext context,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -1,0 +1,809 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.analysis.ArithmeticExpr.Operator;
+import org.apache.doris.analysis.SetType;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.FunctionRegistry;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.util.Util;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.analyzer.Scope;
+import org.apache.doris.nereids.analyzer.UnboundAlias;
+import org.apache.doris.nereids.analyzer.UnboundFunction;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.analyzer.UnboundStar;
+import org.apache.doris.nereids.analyzer.UnboundVariable;
+import org.apache.doris.nereids.analyzer.UnboundVariable.VariableType;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
+import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
+import org.apache.doris.nereids.trees.expressions.BitNot;
+import org.apache.doris.nereids.trees.expressions.BoundStar;
+import org.apache.doris.nereids.trees.expressions.CaseWhen;
+import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
+import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
+import org.apache.doris.nereids.trees.expressions.Divide;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
+import org.apache.doris.nereids.trees.expressions.InSubquery;
+import org.apache.doris.nereids.trees.expressions.IntegralDivide;
+import org.apache.doris.nereids.trees.expressions.ListQuery;
+import org.apache.doris.nereids.trees.expressions.Match;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.TimestampArithmetic;
+import org.apache.doris.nereids.trees.expressions.Variable;
+import org.apache.doris.nereids.trees.expressions.WhenClause;
+import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
+import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.ElementAt;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.PushDownToProjectionFunction;
+import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInputTypes;
+import org.apache.doris.nereids.types.ArrayType;
+import org.apache.doris.nereids.types.BigIntType;
+import org.apache.doris.nereids.types.BooleanType;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.util.TypeCoercionUtils;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.qe.VariableVarConverters;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** ExpressionAnalyzer */
+public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext> {
+
+    /*
+    bounded={table.a, a}
+    unbound=a
+    if enableExactMatch, 'a' is bound to bounded 'a',
+    if not enableExactMatch, 'a' is ambiguous
+    in order to be compatible to original planner,
+    exact match mode is not enabled for having clause
+    but enabled for order by clause
+    TODO after remove original planner, always enable exact match mode.
+     */
+    private final boolean enableExactMatch;
+    private final boolean bindSlotInOuterScope;
+
+    public ExpressionAnalyzer(List<Scope> scopes, CascadesContext cascadesContext) {
+        this(scopes, cascadesContext, true, true);
+    }
+
+    public ExpressionAnalyzer(List<Scope> scopes, CascadesContext cascadesContext,
+            boolean enableExactMatch, boolean bindSlotInOuterScope) {
+        super(scopes, cascadesContext);
+        this.enableExactMatch = enableExactMatch;
+        this.bindSlotInOuterScope = bindSlotInOuterScope;
+    }
+
+    public Expression analyze(Expression expression, ExpressionRewriteContext context) {
+        return expression.accept(this, context);
+    }
+
+    @Override
+    public Expression visit(Expression expr, ExpressionRewriteContext context) {
+        expr = super.visit(expr, context);
+
+        expr.checkLegalityBeforeTypeCoercion();
+        // this cannot be removed, because some function already construct in parser.
+        if (expr instanceof ImplicitCastInputTypes) {
+            List<DataType> expectedInputTypes = ((ImplicitCastInputTypes) expr).expectedInputTypes();
+            if (!expectedInputTypes.isEmpty()) {
+                return TypeCoercionUtils.implicitCastInputTypes(expr, expectedInputTypes);
+            }
+        }
+        return expr;
+    }
+
+    /* ********************************************************************************************
+     * bind slot
+     * ******************************************************************************************** */
+    @Override
+    public Expression visitUnboundVariable(UnboundVariable unboundVariable, ExpressionRewriteContext context) {
+        String name = unboundVariable.getName();
+        SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+        Literal literal = null;
+        if (unboundVariable.getType() == VariableType.DEFAULT) {
+            literal = VariableMgr.getLiteral(sessionVariable, name, SetType.DEFAULT);
+        } else if (unboundVariable.getType() == VariableType.SESSION) {
+            literal = VariableMgr.getLiteral(sessionVariable, name, SetType.SESSION);
+        } else if (unboundVariable.getType() == VariableType.GLOBAL) {
+            literal = VariableMgr.getLiteral(sessionVariable, name, SetType.GLOBAL);
+        } else if (unboundVariable.getType() == VariableType.USER) {
+            literal = ConnectContext.get().getLiteralForUserVar(name);
+        }
+        if (literal == null) {
+            throw new AnalysisException("Unsupported system variable: " + unboundVariable.getName());
+        }
+        if (!Strings.isNullOrEmpty(name) && VariableVarConverters.hasConverter(name)) {
+            try {
+                Preconditions.checkArgument(literal instanceof IntegerLikeLiteral);
+                IntegerLikeLiteral integerLikeLiteral = (IntegerLikeLiteral) literal;
+                literal = new StringLiteral(VariableVarConverters.decode(name, integerLikeLiteral.getLongValue()));
+            } catch (DdlException e) {
+                throw new AnalysisException(e.getMessage());
+            }
+        }
+        return new Variable(unboundVariable.getName(), unboundVariable.getType(), literal);
+    }
+
+    @Override
+    public Expression visitUnboundAlias(UnboundAlias unboundAlias, ExpressionRewriteContext context) {
+        Expression child = unboundAlias.child().accept(this, context);
+        if (unboundAlias.getAlias().isPresent()) {
+            return new Alias(child, unboundAlias.getAlias().get());
+        } else if (child instanceof NamedExpression) {
+            return new Alias(child, ((NamedExpression) child).getName());
+        } else {
+            return new Alias(child);
+        }
+    }
+
+    @Override
+    public Slot visitUnboundSlot(UnboundSlot unboundSlot, ExpressionRewriteContext context) {
+        Optional<Scope> outerScope = getDefaultScope().getOuterScope();
+        Optional<List<Slot>> boundedOpt = Optional.of(
+                bindSlotByMultiScopes(unboundSlot, getScopes())
+        );
+        boolean foundInThisScope = !boundedOpt.get().isEmpty();
+        // Currently only looking for symbols on the previous level.
+        if (bindSlotInOuterScope && !foundInThisScope && outerScope.isPresent()) {
+            boundedOpt = Optional.of(bindSlot(unboundSlot, outerScope.get()));
+        }
+        List<Slot> bounded = boundedOpt.get();
+        switch (bounded.size()) {
+            case 0:
+                // just return, give a chance to bind on another slot.
+                // if unbound finally, check will throw exception
+                return unboundSlot;
+            case 1:
+                if (!foundInThisScope
+                        && !outerScope.get().getCorrelatedSlots().contains(bounded.get(0))) {
+                    outerScope.get().getCorrelatedSlots().add(bounded.get(0));
+                }
+                return bounded.get(0);
+            default:
+                if (enableExactMatch) {
+                    // select t1.k k, t2.k
+                    // from t1 join t2 order by k
+                    //
+                    // 't1.k k' is denoted by alias_k, its full name is 'k'
+                    // 'order by k' is denoted as order_k, it full name is 'k'
+                    // 't2.k' in select list, its full name is 't2.k'
+                    //
+                    // order_k can be bound on alias_k and t2.k
+                    // alias_k is exactly matched, since its full name is exactly match full name of order_k
+                    // t2.k is not exactly matched, since t2.k's full name is larger than order_k
+                    List<Slot> exactMatch = bounded.stream()
+                            .filter(bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
+                            .collect(Collectors.toList());
+                    if (exactMatch.size() == 1) {
+                        return exactMatch.get(0);
+                    }
+                }
+                throw new AnalysisException(String.format("%s is ambiguous: %s.",
+                        unboundSlot.toSql(),
+                        bounded.stream()
+                                .map(Slot::toString)
+                                .collect(Collectors.joining(", "))));
+        }
+    }
+
+    @Override
+    public Expression visitUnboundStar(UnboundStar unboundStar, ExpressionRewriteContext context) {
+        List<String> qualifier = unboundStar.getQualifier();
+        boolean showHidden = Util.showHiddenColumns();
+        List<Slot> slots = getDefaultScope().getSlots()
+                .stream()
+                .filter(slot -> !(slot instanceof SlotReference)
+                        || (((SlotReference) slot).isVisible()) || showHidden)
+                .filter(slot -> !(((SlotReference) slot).hasSubColPath()))
+                .collect(Collectors.toList());
+        switch (qualifier.size()) {
+            case 0: // select *
+                return new BoundStar(slots);
+            case 1: // select table.*
+            case 2: // select db.table.*
+            case 3: // select catalog.db.table.*
+                return bindQualifiedStar(qualifier, slots);
+            default:
+                throw new AnalysisException("Not supported qualifier: "
+                        + StringUtils.join(qualifier, "."));
+        }
+    }
+
+    /* ********************************************************************************************
+     * bind function
+     * ******************************************************************************************** */
+    @Override
+    public Expression visitUnboundFunction(UnboundFunction unboundFunction, ExpressionRewriteContext context) {
+        if (unboundFunction.isHighOrder()) {
+            unboundFunction = bindHighOrderFunction(unboundFunction, context);
+        } else {
+            unboundFunction = (UnboundFunction) rewriteChildren(this, unboundFunction, context);
+        }
+
+        // bind function
+        FunctionRegistry functionRegistry = Env.getCurrentEnv().getFunctionRegistry();
+        List<Object> arguments = unboundFunction.isDistinct()
+                ? ImmutableList.builderWithExpectedSize(unboundFunction.arity() + 1)
+                    .add(unboundFunction.isDistinct())
+                    .addAll(unboundFunction.getArguments())
+                    .build()
+                : (List) unboundFunction.getArguments();
+
+        if (StringUtils.isEmpty(unboundFunction.getDbName())) {
+            // we will change arithmetic function like add(), subtract(), bitnot()
+            // to the corresponding objects rather than BoundFunction.
+            ArithmeticFunctionBinder functionBinder = new ArithmeticFunctionBinder();
+            if (functionBinder.isBinaryArithmetic(unboundFunction.getName())) {
+                return functionBinder.bindBinaryArithmetic(unboundFunction.getName(), unboundFunction.children())
+                        .accept(this, context);
+            }
+        }
+
+        String functionName = unboundFunction.getName();
+        FunctionBuilder builder = functionRegistry.findFunctionBuilder(
+                unboundFunction.getDbName(), functionName, arguments);
+        if (builder instanceof AliasUdfBuilder) {
+            // we do type coercion in build function in alias function, so it's ok to return directly.
+            return builder.build(functionName, arguments);
+        } else {
+            Expression boundFunction = TypeCoercionUtils
+                    .processBoundFunction((BoundFunction) builder.build(functionName, arguments));
+            if (boundFunction instanceof Count
+                    && context.cascadesContext.getOuterScope().isPresent()
+                    && !context.cascadesContext.getOuterScope().get().getCorrelatedSlots()
+                    .isEmpty()) {
+                // consider sql: SELECT * FROM t1 WHERE t1.a <= (SELECT COUNT(t2.a) FROM t2 WHERE (t1.b = t2.b));
+                // when unnest correlated subquery, we create a left join node.
+                // outer query is left table and subquery is right one
+                // if there is no match, the row from right table is filled with nulls
+                // but COUNT function is always not nullable.
+                // so wrap COUNT with Nvl to ensure it's result is 0 instead of null to get the correct result
+                boundFunction = new Nvl(boundFunction, new BigIntLiteral(0));
+            }
+            return boundFunction;
+        }
+    }
+
+    @Override
+    public Expression visitBoundFunction(BoundFunction boundFunction, ExpressionRewriteContext context) {
+        boundFunction = (BoundFunction) super.visitBoundFunction(boundFunction, context);
+        return TypeCoercionUtils.processBoundFunction(boundFunction);
+    }
+
+    @Override
+    public Expression visitElementAt(ElementAt elementAt, ExpressionRewriteContext context) {
+        Expression boundFunction = visitBoundFunction(elementAt, context);
+        if (PushDownToProjectionFunction.validToPushDown(boundFunction)) {
+            if (ConnectContext.get() != null
+                    && ConnectContext.get().getSessionVariable() != null
+                    && !ConnectContext.get().getSessionVariable().isEnableRewriteElementAtToSlot()) {
+                return boundFunction;
+            }
+            Slot slot = elementAt.getInputSlots().stream().findFirst().get();
+            if (slot.hasUnbound()) {
+                slot = (Slot) super.visit(slot, context);
+            }
+            // rewrite to slot and bound this slot
+            return PushDownToProjectionFunction.rewriteToSlot(elementAt, (SlotReference) slot);
+        }
+        return boundFunction;
+    }
+
+    /**
+     * gets the method for calculating the time.
+     * e.g. YEARS_ADD、YEARS_SUB、DAYS_ADD 、DAYS_SUB
+     */
+    @Override
+    public Expression visitTimestampArithmetic(TimestampArithmetic arithmetic, ExpressionRewriteContext context) {
+        Expression left = arithmetic.left().accept(this, context);
+        Expression right = arithmetic.right().accept(this, context);
+
+        arithmetic = (TimestampArithmetic) arithmetic.withChildren(left, right);
+        // bind function
+        String funcOpName;
+        if (arithmetic.getFuncName() == null) {
+            // e.g. YEARS_ADD, MONTHS_SUB
+            funcOpName = String.format("%sS_%s", arithmetic.getTimeUnit(),
+                    (arithmetic.getOp() == Operator.ADD) ? "ADD" : "SUB");
+        } else {
+            funcOpName = arithmetic.getFuncName();
+        }
+        arithmetic = (TimestampArithmetic) arithmetic.withFuncName(funcOpName.toLowerCase(Locale.ROOT));
+
+        // type coercion
+        return TypeCoercionUtils.processTimestampArithmetic(arithmetic);
+    }
+
+    /* ********************************************************************************************
+     * type coercion
+     * ******************************************************************************************** */
+
+    @Override
+    public Expression visitBitNot(BitNot bitNot, ExpressionRewriteContext context) {
+        Expression child = bitNot.child().accept(this, context);
+        // type coercion
+        if (!(child.getDataType().isIntegralType() || child.getDataType().isBooleanType())) {
+            child = new Cast(child, BigIntType.INSTANCE);
+        }
+        return bitNot.withChildren(child);
+    }
+
+    @Override
+    public Expression visitDivide(Divide divide, ExpressionRewriteContext context) {
+        Expression left = divide.left().accept(this, context);
+        Expression right = divide.right().accept(this, context);
+        divide = (Divide) divide.withChildren(left, right);
+        // type coercion
+        return TypeCoercionUtils.processDivide(divide);
+    }
+
+    @Override
+    public Expression visitIntegralDivide(IntegralDivide integralDivide, ExpressionRewriteContext context) {
+        Expression left = integralDivide.left().accept(this, context);
+        Expression right = integralDivide.right().accept(this, context);
+        integralDivide = (IntegralDivide) integralDivide.withChildren(left, right);
+        // type coercion
+        return TypeCoercionUtils.processIntegralDivide(integralDivide);
+    }
+
+    @Override
+    public Expression visitBinaryArithmetic(BinaryArithmetic binaryArithmetic, ExpressionRewriteContext context) {
+        Expression left = binaryArithmetic.left().accept(this, context);
+        Expression right = binaryArithmetic.right().accept(this, context);
+        binaryArithmetic = (BinaryArithmetic) binaryArithmetic.withChildren(left, right);
+        return TypeCoercionUtils.processBinaryArithmetic(binaryArithmetic);
+    }
+
+    @Override
+    public Expression visitCompoundPredicate(CompoundPredicate compoundPredicate, ExpressionRewriteContext context) {
+        Expression left = compoundPredicate.left().accept(this, context);
+        Expression right = compoundPredicate.right().accept(this, context);
+        CompoundPredicate ret = (CompoundPredicate) compoundPredicate.withChildren(left, right);
+        return TypeCoercionUtils.processCompoundPredicate(ret);
+    }
+
+    @Override
+    public Expression visitNot(Not not, ExpressionRewriteContext context) {
+        // maybe is `not subquery`, we should bind it first
+        Expression expr = super.visitNot(not, context);
+
+        // expression is not subquery
+        if (expr instanceof Not) {
+            Expression child = not.child().accept(this, context);
+            Expression newChild = TypeCoercionUtils.castIfNotSameType(child, BooleanType.INSTANCE);
+            if (child != newChild) {
+                return expr.withChildren(newChild);
+            }
+        }
+        return expr;
+    }
+
+    @Override
+    public Expression visitComparisonPredicate(ComparisonPredicate cp, ExpressionRewriteContext context) {
+        Expression left = cp.left().accept(this, context);
+        Expression right = cp.right().accept(this, context);
+        cp = (ComparisonPredicate) cp.withChildren(left, right);
+        return TypeCoercionUtils.processComparisonPredicate(cp);
+    }
+
+    @Override
+    public Expression visitCaseWhen(CaseWhen caseWhen, ExpressionRewriteContext context) {
+        Builder<Expression> rewrittenChildren = ImmutableList.builderWithExpectedSize(caseWhen.arity());
+        for (Expression child : caseWhen.children()) {
+            rewrittenChildren.add(child.accept(this, context));
+        }
+        CaseWhen newCaseWhen = caseWhen.withChildren(rewrittenChildren.build());
+        newCaseWhen.checkLegalityBeforeTypeCoercion();
+        return TypeCoercionUtils.processCaseWhen(newCaseWhen);
+    }
+
+    @Override
+    public Expression visitWhenClause(WhenClause whenClause, ExpressionRewriteContext context) {
+        return whenClause.withChildren(TypeCoercionUtils.castIfNotSameType(
+                        whenClause.getOperand().accept(this, context), BooleanType.INSTANCE),
+                whenClause.getResult().accept(this, context));
+    }
+
+    @Override
+    public Expression visitInPredicate(InPredicate inPredicate, ExpressionRewriteContext context) {
+        List<Expression> rewrittenChildren = inPredicate.children().stream()
+                .map(e -> e.accept(this, context)).collect(Collectors.toList());
+        InPredicate newInPredicate = inPredicate.withChildren(rewrittenChildren);
+        return TypeCoercionUtils.processInPredicate(newInPredicate);
+    }
+
+    @Override
+    public Expression visitInSubquery(InSubquery inSubquery, ExpressionRewriteContext context) {
+        // analyze subquery
+        inSubquery = (InSubquery) super.visitInSubquery(inSubquery, context);
+
+        // compareExpr already analyze when invoke super.visitInSubquery
+        Expression newCompareExpr = inSubquery.getCompareExpr();
+        // but ListQuery does not analyze
+        Expression newListQuery = inSubquery.getListQuery().accept(this, context);
+
+        ComparisonPredicate afterTypeCoercion = (ComparisonPredicate) TypeCoercionUtils.processComparisonPredicate(
+                new EqualTo(newCompareExpr, newListQuery));
+        if (newListQuery.getDataType().isBitmapType()) {
+            if (!newCompareExpr.getDataType().isBigIntType()) {
+                newCompareExpr = new Cast(newCompareExpr, BigIntType.INSTANCE);
+            }
+        } else {
+            newCompareExpr = afterTypeCoercion.left();
+        }
+        return new InSubquery(newCompareExpr, (ListQuery) afterTypeCoercion.right(),
+                inSubquery.getCorrelateSlots(), ((ListQuery) afterTypeCoercion.right()).getTypeCoercionExpr(),
+                inSubquery.isNot());
+    }
+
+    @Override
+    public Expression visitMatch(Match match, ExpressionRewriteContext context) {
+        Expression left = match.left().accept(this, context);
+        Expression right = match.right().accept(this, context);
+        // check child type
+        if (!left.getDataType().isStringLikeType()
+                && !(left.getDataType() instanceof ArrayType
+                && ((ArrayType) left.getDataType()).getItemType().isStringLikeType())
+                && !left.getDataType().isVariantType()) {
+            throw new AnalysisException(String.format(
+                    "left operand '%s' part of predicate "
+                            + "'%s' should return type 'STRING', 'ARRAY<STRING> or VARIANT' but "
+                            + "returns type '%s'.",
+                    left.toSql(), match.toSql(), left.getDataType()));
+        }
+
+        if (!right.getDataType().isStringLikeType() && !right.getDataType().isNullType()) {
+            throw new AnalysisException(String.format(
+                    "right operand '%s' part of predicate " + "'%s' should return type 'STRING' but "
+                            + "returns type '%s'.",
+                    right.toSql(), match.toSql(), right.getDataType()));
+        }
+
+        if (left.getDataType().isVariantType()) {
+            left = new Cast(left, right.getDataType());
+        }
+        return match.withChildren(left, right);
+    }
+
+    @Override
+    public Expression visitCast(Cast cast, ExpressionRewriteContext context) {
+        cast = (Cast) super.visitCast(cast, context);
+        // NOTICE: just for compatibility with legacy planner.
+        if (cast.child().getDataType().isComplexType() || cast.getDataType().isComplexType()) {
+            TypeCoercionUtils.checkCanCastTo(cast.child().getDataType(), cast.getDataType());
+        }
+        return cast;
+    }
+
+    private BoundStar bindQualifiedStar(List<String> qualifierStar, List<Slot> boundSlots) {
+        // FIXME: compatible with previous behavior:
+        // https://github.com/apache/doris/pull/10415/files/3fe9cb0c3f805ab3a9678033b281b16ad93ec60a#r910239452
+        List<Slot> slots = boundSlots.stream().filter(boundSlot -> {
+            switch (qualifierStar.size()) {
+                // table.*
+                case 1:
+                    List<String> boundSlotQualifier = boundSlot.getQualifier();
+                    switch (boundSlotQualifier.size()) {
+                        // bound slot is `column` and no qualified
+                        case 0:
+                            return false;
+                        case 1: // bound slot is `table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0));
+                        case 2:// bound slot is `db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(1));
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(2));
+                        default:
+                            throw new AnalysisException("Not supported qualifier: "
+                                    + StringUtils.join(qualifierStar, "."));
+                    }
+                case 2: // db.table.*
+                    boundSlotQualifier = boundSlot.getQualifier();
+                    switch (boundSlotQualifier.size()) {
+                        // bound slot is `column` and no qualified
+                        case 0:
+                        case 1: // bound slot is `table`.`column`
+                            return false;
+                        case 2:// bound slot is `db`.`table`.`column`
+                            return compareDbName(qualifierStar.get(0), boundSlotQualifier.get(0))
+                                    && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(1));
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return compareDbName(qualifierStar.get(0), boundSlotQualifier.get(1))
+                                    && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(2));
+                        default:
+                            throw new AnalysisException("Not supported qualifier: "
+                                    + StringUtils.join(qualifierStar, ".") + ".*");
+                    }
+                case 3: // catalog.db.table.*
+                    boundSlotQualifier = boundSlot.getQualifier();
+                    switch (boundSlotQualifier.size()) {
+                        // bound slot is `column` and no qualified
+                        case 0:
+                        case 1: // bound slot is `table`.`column`
+                        case 2: // bound slot is `db`.`table`.`column`
+                            return false;
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0))
+                                    && compareDbName(qualifierStar.get(1), boundSlotQualifier.get(1))
+                                    && qualifierStar.get(2).equalsIgnoreCase(boundSlotQualifier.get(2));
+                        default:
+                            throw new AnalysisException("Not supported qualifier: "
+                                    + StringUtils.join(qualifierStar, ".") + ".*");
+                    }
+                default:
+                    throw new AnalysisException("Not supported name: "
+                            + StringUtils.join(qualifierStar, ".") + ".*");
+            }
+        }).collect(Collectors.toList());
+
+        if (slots.isEmpty()) {
+            throw new AnalysisException("unknown qualifier: " + StringUtils.join(qualifierStar, ".") + ".*");
+        }
+        return new BoundStar(slots);
+    }
+
+    private List<Slot> bindSlotByMultiScopes(UnboundSlot unboundSlot, List<Scope> scopes) {
+        for (Scope candidateScope : scopes) {
+            List<Slot> slots = bindSlot(unboundSlot, candidateScope);
+            if (!slots.isEmpty()) {
+                return slots;
+            }
+        }
+        return ImmutableList.of();
+    }
+
+    private List<Slot> bindSlot(UnboundSlot unboundSlot, Scope scope) {
+        // return scope.getSlots().stream().distinct().filter(boundSlot -> {
+        //     if (boundSlot instanceof SlotReference
+        //             && ((SlotReference) boundSlot).hasSubColPath()) {
+        //         // already bounded
+        //         return false;
+        //     }
+        //     List<String> nameParts = unboundSlot.getNameParts();
+        //     int qualifierSize = boundSlot.getQualifier().size();
+        //     int namePartsSize = nameParts.size();
+        //     if (namePartsSize > qualifierSize + 1) {
+        //         return false;
+        //     }
+        //     if (namePartsSize == 1) {
+        //         return nameParts.get(0).equalsIgnoreCase(boundSlot.getName());
+        //     }
+        //     if (namePartsSize == 2) {
+        //         String qualifierTableName = boundSlot.getQualifier().get(qualifierSize - 1);
+        //         return sameTableName(qualifierTableName, nameParts.get(0))
+        //                 && boundSlot.getName().equalsIgnoreCase(nameParts.get(1));
+        //     }
+        //     if (nameParts.size() == 3) {
+        //         String qualifierTableName = boundSlot.getQualifier().get(qualifierSize - 1);
+        //         String qualifierDbName = boundSlot.getQualifier().get(qualifierSize - 2);
+        //         return compareDbName(nameParts.get(0), qualifierDbName)
+        //                 && sameTableName(qualifierTableName, nameParts.get(1))
+        //                 && boundSlot.getName().equalsIgnoreCase(nameParts.get(2));
+        //     }
+        //     // catalog.db.table.column
+        //     if (nameParts.size() == 4) {
+        //         String qualifierTableName = boundSlot.getQualifier().get(qualifierSize - 1);
+        //         String qualifierDbName = boundSlot.getQualifier().get(qualifierSize - 2);
+        //         String qualifierCatalogName = boundSlot.getQualifier().get(qualifierSize - 3);
+        //         return qualifierCatalogName.equalsIgnoreCase(nameParts.get(0))
+        //                 && compareDbName(nameParts.get(1), qualifierDbName)
+        //                 && sameTableName(qualifierTableName, nameParts.get(2))
+        //                 && boundSlot.getName().equalsIgnoreCase(nameParts.get(3));
+        //     }
+        //     //TODO: handle name parts more than three.
+        //     throw new AnalysisException("Not supported name: "
+        //             + StringUtils.join(nameParts, "."));
+        // })
+        // .map(s -> s.withName(unboundSlot.getNameParts().get(unboundSlot.getNameParts().size() - 1)))
+        // .collect(Collectors.toList());
+        List<String> nameParts = unboundSlot.getNameParts();
+        int namePartSize = nameParts.size();
+        switch (namePartSize) {
+            // column
+            case 1: {
+                return bindSingleSlotByName(nameParts.get(0), scope);
+            }
+            // table.column
+            case 2: {
+                return bindSingleSlotByTable(nameParts.get(0), nameParts.get(1), scope);
+            }
+            // db.table.column
+            case 3: {
+                return bindSingleSlotByDb(nameParts.get(0), nameParts.get(1), nameParts.get(2), scope);
+            }
+            // catalog.db.table.column
+            case 4: {
+                return bindSingleSlotByCatalog(
+                        nameParts.get(0), nameParts.get(1), nameParts.get(2), nameParts.get(3), scope);
+            }
+            default: {
+                throw new AnalysisException("Not supported name: " + StringUtils.join(nameParts, "."));
+            }
+        }
+    }
+
+    public static boolean compareDbName(String boundedDbName, String unBoundDbName) {
+        return unBoundDbName.equalsIgnoreCase(boundedDbName);
+    }
+
+    public static boolean sameTableName(String boundSlot, String unboundSlot) {
+        if (GlobalVariable.lowerCaseTableNames != 1) {
+            return boundSlot.equals(unboundSlot);
+        } else {
+            return boundSlot.equalsIgnoreCase(unboundSlot);
+        }
+    }
+
+    private void checkBoundLambda(Expression lambdaFunction, List<String> argumentNames) {
+        lambdaFunction.foreachUp(e -> {
+            if (e instanceof UnboundSlot) {
+                UnboundSlot unboundSlot = (UnboundSlot) e;
+                throw new AnalysisException("Unknown lambda slot '"
+                        + unboundSlot.getNameParts().get(unboundSlot.getNameParts().size() - 1)
+                        + " in lambda arguments" + argumentNames);
+            }
+        });
+    }
+
+    private UnboundFunction bindHighOrderFunction(UnboundFunction unboundFunction, ExpressionRewriteContext context) {
+        int childrenSize = unboundFunction.children().size();
+        List<Expression> subChildren = new ArrayList<>();
+        for (int i = 1; i < childrenSize; i++) {
+            subChildren.add(unboundFunction.child(i).accept(this, context));
+        }
+
+        // bindLambdaFunction
+        Lambda lambda = (Lambda) unboundFunction.children().get(0);
+        Expression lambdaFunction = lambda.getLambdaFunction();
+        List<ArrayItemReference> arrayItemReferences = lambda.makeArguments(subChildren);
+
+        // 1.bindSlot
+        List<Slot> boundedSlots = arrayItemReferences.stream()
+                .map(ArrayItemReference::toSlot)
+                .collect(ImmutableList.toImmutableList());
+        lambdaFunction = new SlotBinder(new Scope(boundedSlots), context.cascadesContext,
+                true, false).bind(lambdaFunction);
+        checkBoundLambda(lambdaFunction, lambda.getLambdaArgumentNames());
+
+        // 2.bindFunction
+        lambdaFunction = lambdaFunction.accept(this, context);
+
+        Lambda lambdaClosure = lambda.withLambdaFunctionArguments(lambdaFunction, arrayItemReferences);
+
+        // We don't add the ArrayExpression in high order function at all
+        return unboundFunction.withChildren(ImmutableList.<Expression>builder()
+                .add(lambdaClosure)
+                .build());
+    }
+
+    private boolean shouldSlotBindBy(int namePartSize, Slot boundSlot) {
+        if (boundSlot instanceof SlotReference
+                && ((SlotReference) boundSlot).hasSubColPath()) {
+            // already bounded
+            return false;
+        }
+        if (namePartSize > boundSlot.getQualifier().size() + 1) {
+            return false;
+        }
+        return true;
+    }
+
+    private List<Slot> bindSingleSlotByName(String name, Scope scope) {
+        int namePartSize = 1;
+        Builder<Slot> usedSlots = ImmutableList.builderWithExpectedSize(1);
+        for (Slot boundSlot : scope.findSlotIgnoreCase(name)) {
+            if (!shouldSlotBindBy(namePartSize, boundSlot)) {
+                continue;
+            }
+            // set sql case as alias
+            usedSlots.add(boundSlot.withName(name));
+        }
+        return usedSlots.build();
+    }
+
+    private List<Slot> bindSingleSlotByTable(String table, String name, Scope scope) {
+        int namePartSize = 2;
+        Builder<Slot> usedSlots = ImmutableList.builderWithExpectedSize(1);
+        for (Slot boundSlot : scope.findSlotIgnoreCase(name)) {
+            if (!shouldSlotBindBy(namePartSize, boundSlot)) {
+                continue;
+            }
+            List<String> boundSlotQualifier = boundSlot.getQualifier();
+            String boundSlotTable = boundSlotQualifier.get(boundSlotQualifier.size() - 1);
+            if (!sameTableName(boundSlotTable, table)) {
+                continue;
+            }
+            // set sql case as alias
+            usedSlots.add(boundSlot.withName(name));
+        }
+        return usedSlots.build();
+    }
+
+    private List<Slot> bindSingleSlotByDb(String db, String table, String name, Scope scope) {
+        int namePartSize = 3;
+        Builder<Slot> usedSlots = ImmutableList.builderWithExpectedSize(1);
+        for (Slot boundSlot : scope.findSlotIgnoreCase(name)) {
+            if (!shouldSlotBindBy(namePartSize, boundSlot)) {
+                continue;
+            }
+            List<String> boundSlotQualifier = boundSlot.getQualifier();
+            String boundSlotDb = boundSlotQualifier.get(boundSlotQualifier.size() - 2);
+            String boundSlotTable = boundSlotQualifier.get(boundSlotQualifier.size() - 1);
+            if (!compareDbName(boundSlotDb, db) && !sameTableName(boundSlotTable, table)) {
+                continue;
+            }
+            // set sql case as alias
+            usedSlots.add(boundSlot.withName(name));
+        }
+        return usedSlots.build();
+    }
+
+    private List<Slot> bindSingleSlotByCatalog(String catalog, String db, String table, String name, Scope scope) {
+        int namePartSize = 4;
+        Builder<Slot> usedSlots = ImmutableList.builderWithExpectedSize(1);
+        for (Slot boundSlot : scope.findSlotIgnoreCase(name)) {
+            if (!shouldSlotBindBy(namePartSize, boundSlot)) {
+                continue;
+            }
+            List<String> boundSlotQualifier = boundSlot.getQualifier();
+            String boundSlotCatalog = boundSlotQualifier.get(boundSlotQualifier.size() - 3);
+            String boundSlotDb = boundSlotQualifier.get(boundSlotQualifier.size() - 2);
+            String boundSlotTable = boundSlotQualifier.get(boundSlotQualifier.size() - 1);
+            if (!boundSlotCatalog.equalsIgnoreCase(catalog)
+                    && !compareDbName(boundSlotDb, db)
+                    && !sameTableName(boundSlotTable, table)) {
+                continue;
+            }
+            // set sql case as alias
+            usedSlots.add(boundSlot.withName(name));
+        }
+        return usedSlots.build();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -631,9 +631,12 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
         if (candidates.size() == 1) {
             return candidates;
         }
-        return Utils.filterImmutableList(candidates, bound ->
+        List<Slot> extractSlots = Utils.filterImmutableList(candidates, bound ->
                 unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1
         );
+        // we should return origin candidates slots if extract slots is empty,
+        // and then throw an ambiguous exception
+        return !extractSlots.isEmpty() ? extractSlots : candidates;
     }
 
     /** bindSlotByScope */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -127,12 +127,12 @@ public class SlotBinder extends SubExprAnalyzer<CascadesContext> {
 
     @Override
     public Slot visitUnboundSlot(UnboundSlot unboundSlot, CascadesContext context) {
-        Optional<List<Slot>> boundedOpt = Optional.of(bindSlot(unboundSlot, getDefaultScope().getSlots()));
+        Optional<List<Slot>> boundedOpt = Optional.of(bindSlot(unboundSlot, getScope().getSlots()));
         boolean foundInThisScope = !boundedOpt.get().isEmpty();
         // Currently only looking for symbols on the previous level.
-        if (bindSlotInOuterScope && !foundInThisScope && getDefaultScope().getOuterScope().isPresent()) {
+        if (bindSlotInOuterScope && !foundInThisScope && getScope().getOuterScope().isPresent()) {
             boundedOpt = Optional.of(bindSlot(unboundSlot,
-                    getDefaultScope()
+                    getScope()
                             .getOuterScope()
                             .get()
                             .getSlots()));
@@ -145,8 +145,8 @@ public class SlotBinder extends SubExprAnalyzer<CascadesContext> {
                 return unboundSlot;
             case 1:
                 if (!foundInThisScope
-                        && !getDefaultScope().getOuterScope().get().getCorrelatedSlots().contains(bounded.get(0))) {
-                    getDefaultScope().getOuterScope().get().getCorrelatedSlots().add(bounded.get(0));
+                        && !getScope().getOuterScope().get().getCorrelatedSlots().contains(bounded.get(0))) {
+                    getScope().getOuterScope().get().getCorrelatedSlots().add(bounded.get(0));
                 }
                 return bounded.get(0);
             default:
@@ -180,7 +180,7 @@ public class SlotBinder extends SubExprAnalyzer<CascadesContext> {
     public Expression visitUnboundStar(UnboundStar unboundStar, CascadesContext context) {
         List<String> qualifier = unboundStar.getQualifier();
         boolean showHidden = Util.showHiddenColumns();
-        List<Slot> slots = getDefaultScope().getSlots()
+        List<Slot> slots = getScope().getSlots()
                 .stream()
                 .filter(slot -> !(slot instanceof SlotReference)
                         || (((SlotReference) slot).isVisible()) || showHidden)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 /**
  * SlotBinder is used to bind slot
  */
-public class SlotBinder extends SubExprAnalyzer {
+public class SlotBinder extends SubExprAnalyzer<CascadesContext> {
     /*
     bounded={table.a, a}
     unbound=a
@@ -127,12 +127,12 @@ public class SlotBinder extends SubExprAnalyzer {
 
     @Override
     public Slot visitUnboundSlot(UnboundSlot unboundSlot, CascadesContext context) {
-        Optional<List<Slot>> boundedOpt = Optional.of(bindSlot(unboundSlot, getScope().getSlots()));
+        Optional<List<Slot>> boundedOpt = Optional.of(bindSlot(unboundSlot, getDefaultScope().getSlots()));
         boolean foundInThisScope = !boundedOpt.get().isEmpty();
         // Currently only looking for symbols on the previous level.
-        if (bindSlotInOuterScope && !foundInThisScope && getScope().getOuterScope().isPresent()) {
+        if (bindSlotInOuterScope && !foundInThisScope && getDefaultScope().getOuterScope().isPresent()) {
             boundedOpt = Optional.of(bindSlot(unboundSlot,
-                    getScope()
+                    getDefaultScope()
                             .getOuterScope()
                             .get()
                             .getSlots()));
@@ -145,8 +145,8 @@ public class SlotBinder extends SubExprAnalyzer {
                 return unboundSlot;
             case 1:
                 if (!foundInThisScope
-                        && !getScope().getOuterScope().get().getCorrelatedSlots().contains(bounded.get(0))) {
-                    getScope().getOuterScope().get().getCorrelatedSlots().add(bounded.get(0));
+                        && !getDefaultScope().getOuterScope().get().getCorrelatedSlots().contains(bounded.get(0))) {
+                    getDefaultScope().getOuterScope().get().getCorrelatedSlots().add(bounded.get(0));
                 }
                 return bounded.get(0);
             default:
@@ -180,7 +180,7 @@ public class SlotBinder extends SubExprAnalyzer {
     public Expression visitUnboundStar(UnboundStar unboundStar, CascadesContext context) {
         List<String> qualifier = unboundStar.getQualifier();
         boolean showHidden = Util.showHiddenColumns();
-        List<Slot> slots = getScope().getSlots()
+        List<Slot> slots = getDefaultScope().getSlots()
                 .stream()
                 .filter(slot -> !(slot instanceof SlotReference)
                         || (((SlotReference) slot).isVisible()) || showHidden)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SubExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SubExprAnalyzer.java
@@ -49,19 +49,11 @@ import java.util.Optional;
  * Use the visitor to iterate sub expression.
  */
 class SubExprAnalyzer<T> extends DefaultExpressionRewriter<T> {
-    // some plan maybe bind slots in multi scopes in different priority
-    // example: sort(aggregate()), we try to bind sort.orderKey by Scope(aggregate.output)
-    //          if some orderKeys can not bind, we can try to bind sort.orderKey by
-    //          Scope(aggregate.child.output)
-    private final List<Scope> scopes;
+    private final Scope scope;
     private final CascadesContext cascadesContext;
 
     public SubExprAnalyzer(Scope scope, CascadesContext cascadesContext) {
-        this(ImmutableList.of(scope), cascadesContext);
-    }
-
-    public SubExprAnalyzer(List<Scope> scopes, CascadesContext cascadesContext) {
-        this.scopes = scopes;
+        this.scope = scope;
         this.cascadesContext = cascadesContext;
     }
 
@@ -174,17 +166,13 @@ class SubExprAnalyzer<T> extends DefaultExpressionRewriter<T> {
     }
 
     private Scope genScopeWithSubquery(SubqueryExpr expr) {
-        return new Scope(getDefaultScope().getOuterScope(),
-                getDefaultScope().getSlots(),
+        return new Scope(getScope().getOuterScope(),
+                getScope().getSlots(),
                 Optional.ofNullable(expr));
     }
 
-    public Scope getDefaultScope() {
-        return scopes.get(0);
-    }
-
-    public List<Scope> getScopes() {
-        return scopes;
+    public Scope getScope() {
+        return scope;
     }
 
     public CascadesContext getCascadesContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateSortUnderSubqueryOrView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateSortUnderSubqueryOrView.java
@@ -35,7 +35,7 @@ public class EliminateSortUnderSubqueryOrView implements RewriteRuleFactory {
                 logicalSubQueryAlias(logicalSort())
                         .then(subq -> subq.withChildren(subq.child().child(0)))
             ),
-            RuleType.ELIMINATE_ORDER_BY_UNDER_SUBQUERY.build(
+            RuleType.ELIMINATE_ORDER_BY_UNDER_VIEW.build(
                 logicalView(logicalSort())
                         .then(view -> view.withChildren(view.child().child(0)))
             )

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitDistinctThroughUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitDistinctThroughUnion.java
@@ -79,7 +79,7 @@ public class PushDownLimitDistinctThroughUnion implements RewriteRuleFactory {
                                         .map(expr -> ExpressionUtils.replace(expr, replaceMap))
                                         .collect(Collectors.toList());
                                 List<NamedExpression> newOutputs = agg.getOutputs().stream()
-                                        .map(expr -> ExpressionUtils.replace(expr, replaceMap))
+                                        .map(expr -> ExpressionUtils.replaceNameExpression(expr, replaceMap))
                                         .collect(Collectors.toList());
 
                                 LogicalAggregate<Plan> newAgg = new LogicalAggregate<>(newGroupBy, newOutputs, child);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectIntoUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectIntoUnion.java
@@ -62,7 +62,7 @@ public class PushProjectIntoUnion extends OneRewriteRuleFactory {
                     if (old instanceof SlotReference) {
                         newProjections.add(replaceRootMap.get(old));
                     } else {
-                        newProjections.add(ExpressionUtils.replace(old, replaceMap));
+                        newProjections.add(ExpressionUtils.replaceNameExpression(old, replaceMap));
                     }
                 }
                 newConstExprs.add(newProjections.build());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectThroughUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectThroughUnion.java
@@ -65,7 +65,7 @@ public class PushProjectThroughUnion extends OneRewriteRuleFactory {
                             replaceMap.put(union.getOutput().get(j), union.getRegularChildOutput(i).get(j));
                         }
                         List<NamedExpression> childProjections = project.getProjects().stream()
-                                .map(e -> (NamedExpression) ExpressionUtils.replace(e, replaceMap))
+                                .map(e -> (NamedExpression) ExpressionUtils.replaceNameExpression(e, replaceMap))
                                 .map(e -> {
                                     if (e instanceof Alias) {
                                         return new Alias(((Alias) e).child(), e.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
@@ -1572,7 +1572,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
             LogicalProject<? extends Plan> project,
             Map<Expression, Expression> projectMap) {
         return project.getProjects().stream()
-                .map(expr -> (NamedExpression) ExpressionUtils.replace(expr, projectMap))
+                .map(expr -> (NamedExpression) ExpressionUtils.replaceNameExpression(expr, projectMap))
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.nereids.trees;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.doris.nereids.util.Utils;
 
 import java.util.List;
 
@@ -34,11 +34,15 @@ public abstract class AbstractTreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>>
     // https://github.com/apache/doris/pull/9807#discussion_r884829067
 
     protected AbstractTreeNode(NODE_TYPE... children) {
-        this.children = ImmutableList.copyOf(children);
+        // NOTE: ImmutableList.copyOf has additional clone of the list, so here we
+        //       direct generate a ImmutableList
+        this.children = Utils.fastToImmutableList(children);
     }
 
     protected AbstractTreeNode(List<NODE_TYPE> children) {
-        this.children = ImmutableList.copyOf(children);
+        // NOTE: ImmutableList.copyOf has additional clone of the list, so here we
+        //       direct generate a ImmutableList
+        this.children = Utils.fastToImmutableList(children);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
@@ -46,7 +46,11 @@ public interface TreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>> {
     int arity();
 
     default NODE_TYPE withChildren(NODE_TYPE... children) {
-        return withChildren(ImmutableList.copyOf(children));
+        Builder<NODE_TYPE> list = ImmutableList.builderWithExpectedSize(children.length);
+        for (NODE_TYPE child : children) {
+            list.add(child);
+        }
+        return withChildren(list.build());
     }
 
     NODE_TYPE withChildren(List<NODE_TYPE> children);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.trees;
 
+import org.apache.doris.nereids.util.Utils;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
@@ -24,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -46,11 +49,7 @@ public interface TreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>> {
     int arity();
 
     default NODE_TYPE withChildren(NODE_TYPE... children) {
-        Builder<NODE_TYPE> list = ImmutableList.builderWithExpectedSize(children.length);
-        for (NODE_TYPE child : children) {
-            list.add(child);
-        }
-        return withChildren(list.build());
+        return withChildren(Utils.fastToImmutableList(children));
     }
 
     NODE_TYPE withChildren(List<NODE_TYPE> children);
@@ -176,6 +175,18 @@ public interface TreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>> {
         func.accept(this);
         for (NODE_TYPE child : children()) {
             child.foreach(func);
+        }
+    }
+
+    /** foreachBreath */
+    default void foreachBreath(Predicate<TreeNode<NODE_TYPE>> func) {
+        LinkedList<TreeNode<NODE_TYPE>> queue = new LinkedList<>();
+        queue.add(this);
+        while (!queue.isEmpty()) {
+            TreeNode<NODE_TYPE> current = queue.pollFirst();
+            if (!func.test(current)) {
+                queue.addAll(current.children());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -69,8 +69,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         int sumChildWidth = 0;
         for (int i = 0; i < children.length; ++i) {
             Expression child = children[i];
-            int childDepth = child.depth;
-            maxChildDepth = childDepth > maxChildDepth ? childDepth : maxChildDepth;
+            maxChildDepth = Math.max(child.depth, maxChildDepth);
             sumChildWidth += child.width;
         }
         this.depth = maxChildDepth + 1;
@@ -90,8 +89,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         int sumChildWidth = 0;
         for (int i = 0; i < children.size(); ++i) {
             Expression child = children.get(i);
-            int childDepth = child.depth;
-            maxChildDepth = childDepth > maxChildDepth ? childDepth : maxChildDepth;
+            maxChildDepth = Math.max(child.depth, maxChildDepth);
             sumChildWidth += child.width;
         }
         this.depth = maxChildDepth + 1;
@@ -130,8 +128,8 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
      */
     public TypeCheckResult checkInputDataTypes() {
         // check all of its children recursively.
-        for (Expression expression : this.children) {
-            TypeCheckResult childResult = expression.checkInputDataTypes();
+        for (Expression child : this.children) {
+            TypeCheckResult childResult = child.checkInputDataTypes();
             if (childResult.failed()) {
                 return childResult;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -39,7 +39,6 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
-import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Preconditions;
@@ -47,7 +46,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -67,36 +65,38 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
 
     protected Expression(Expression... children) {
         super(children);
-        depth = Arrays.stream(children)
-                .mapToInt(e -> e.depth)
-                .max().orElse(0) + 1;
-        width = Arrays.stream(children)
-                .mapToInt(e -> e.width)
-                .sum() + (children.length == 0 ? 1 : 0);
+        int maxChildDepth = 0;
+        int sumChildWidth = 0;
+        for (int i = 0; i < children.length; ++i) {
+            Expression child = children[i];
+            int childDepth = child.depth;
+            maxChildDepth = childDepth > maxChildDepth ? childDepth : maxChildDepth;
+            sumChildWidth += child.width;
+        }
+        this.depth = maxChildDepth + 1;
+        this.width = sumChildWidth + ((children.length == 0) ? 1 : 0);
+
         checkLimit();
         this.inferred = false;
     }
 
     protected Expression(List<Expression> children) {
-        super(children);
-        depth = children.stream()
-                .mapToInt(e -> e.depth)
-                .max().orElse(0) + 1;
-        width = children.stream()
-                .mapToInt(e -> e.width)
-                .sum() + (children.isEmpty() ? 1 : 0);
-        checkLimit();
-        this.inferred = false;
+        this(children, false);
     }
 
     protected Expression(List<Expression> children, boolean inferred) {
         super(children);
-        depth = children.stream()
-                .mapToInt(e -> e.depth)
-                .max().orElse(0) + 1;
-        width = children.stream()
-                .mapToInt(e -> e.width)
-                .sum() + (children.isEmpty() ? 1 : 0);
+        int maxChildDepth = 0;
+        int sumChildWidth = 0;
+        for (int i = 0; i < children.size(); ++i) {
+            Expression child = children.get(i);
+            int childDepth = child.depth;
+            maxChildDepth = childDepth > maxChildDepth ? childDepth : maxChildDepth;
+            sumChildWidth += child.width;
+        }
+        this.depth = maxChildDepth + 1;
+        this.width = sumChildWidth + ((children.isEmpty()) ? 1 : 0);
+
         checkLimit();
         this.inferred = inferred;
     }
@@ -180,21 +180,20 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     }
 
     private boolean checkPrimitiveInputDataTypesWithExpectType(DataType input, DataType expected) {
-        // These type will throw exception when invoke toCatalogDataType()
-        if (expected instanceof AnyDataType) {
-            return expected.acceptsType(input);
+        // support fast check the case: input=TinyIntType, expected=NumericType, for example: `1 + 1`.
+        // if no this check, there will have an exception when invoke NumericType.toCatalogDataType,
+        // when there has lots of expression, the exception become the bottleneck, because an exception
+        // need to record the whole StackFrame.
+        if (expected.acceptsType(input)) {
+            return true;
         }
+
         // TODO: complete the cast logic like FunctionCallExpr.analyzeImpl
-        boolean legacyCastCompatible = false;
         try {
-            legacyCastCompatible = input.toCatalogDataType().matchesType(expected.toCatalogDataType());
+            return input.toCatalogDataType().matchesType(expected.toCatalogDataType());
         } catch (Throwable t) {
-            // ignore.
-        }
-        if (!legacyCastCompatible && !expected.acceptsType(input)) {
             return false;
         }
-        return true;
     }
 
     private TypeCheckResult checkInputDataTypesWithExpectTypes(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.trees.plans.algebra.Relation;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
@@ -101,7 +102,8 @@ public class SlotReference extends Slot {
         this.exprId = exprId;
         this.name = name;
         this.dataType = dataType;
-        this.qualifier = ImmutableList.copyOf(Objects.requireNonNull(qualifier, "qualifier can not be null"));
+        this.qualifier = Utils.fastToImmutableList(
+                Objects.requireNonNull(qualifier, "qualifier can not be null"));
         this.nullable = nullable;
         this.table = table;
         this.column = column;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
@@ -38,9 +38,9 @@ import org.apache.doris.nereids.util.ResponsibilityChain;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -233,7 +233,7 @@ public class ComputeSignatureHelper {
     public static FunctionSignature implementAnyDataTypeWithOutIndex(
             FunctionSignature signature, List<Expression> arguments) {
         // collect all any data type with index
-        List<DataType> newArgTypes = Lists.newArrayList();
+        List<DataType> newArgTypes = Lists.newArrayListWithCapacity(arguments.size());
         for (int i = 0; i < arguments.size(); i++) {
             DataType sigType;
             if (i >= signature.argumentsTypes.size()) {
@@ -267,10 +267,19 @@ public class ComputeSignatureHelper {
             collectAnyDataType(sigType, expressionType, indexToArgumentTypes);
         }
         // if all any data type's expression is NULL, we should use follow to any data type to do type coercion
-        Set<Integer> allNullTypeIndex = indexToArgumentTypes.entrySet().stream()
-                .filter(entry -> entry.getValue().stream().allMatch(NullType.class::isInstance))
-                .map(Entry::getKey)
-                .collect(ImmutableSet.toImmutableSet());
+        Set<Integer> allNullTypeIndex = Sets.newHashSetWithExpectedSize(indexToArgumentTypes.size());
+        for (Entry<Integer, List<DataType>> entry : indexToArgumentTypes.entrySet()) {
+            boolean allIsNullType = true;
+            for (DataType dataType : entry.getValue()) {
+                if (!(dataType instanceof NullType)) {
+                    allIsNullType = false;
+                    break;
+                }
+            }
+            if (allIsNullType) {
+                allNullTypeIndex.add(entry.getKey());
+            }
+        }
         if (!allNullTypeIndex.isEmpty()) {
             for (int i = 0; i < arguments.size(); i++) {
                 DataType sigType;
@@ -297,7 +306,7 @@ public class ComputeSignatureHelper {
         }
 
         // replace any data type and follow to any data type with real data type
-        List<DataType> newArgTypes = Lists.newArrayList();
+        List<DataType> newArgTypes = Lists.newArrayListWithCapacity(signature.argumentsTypes.size());
         for (DataType sigType : signature.argumentsTypes) {
             newArgTypes.add(replaceAnyDataType(sigType, indexToCommonTypes));
         }
@@ -324,10 +333,18 @@ public class ComputeSignatureHelper {
         if (computeSignature instanceof ComputePrecision) {
             return ((ComputePrecision) computeSignature).computePrecision(signature);
         }
-        if (signature.argumentsTypes.stream().anyMatch(TypeCoercionUtils::hasDateTimeV2Type)) {
+
+        boolean hasDateTimeV2Type = false;
+        boolean hasDecimalV3Type = false;
+        for (DataType argumentsType : signature.argumentsTypes) {
+            hasDateTimeV2Type |= TypeCoercionUtils.hasDateTimeV2Type(argumentsType);
+            hasDecimalV3Type |= TypeCoercionUtils.hasDecimalV3Type(argumentsType);
+        }
+
+        if (hasDateTimeV2Type) {
             signature = defaultDateTimeV2PrecisionPromotion(signature, arguments);
         }
-        if (signature.argumentsTypes.stream().anyMatch(TypeCoercionUtils::hasDecimalV3Type)) {
+        if (hasDecimalV3Type) {
             // do decimal v3 precision
             signature = defaultDecimalV3PrecisionPromotion(signature, arguments);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExplicitlyCastableSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExplicitlyCastableSignature.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
@@ -48,6 +49,9 @@ public interface ExplicitlyCastableSignature extends ComputeSignature {
         }
         if (realType instanceof NullType) {
             return true;
+        }
+        if (signatureType instanceof ComplexDataType && !(realType instanceof ComplexDataType)) {
+            return false;
         }
         try {
             // TODO: copy canCastTo method to DataType

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/IdenticalSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/IdenticalSignature.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.types.coercion.FollowToAnyDataType;
@@ -43,6 +44,9 @@ public interface IdenticalSignature extends ComputeSignature {
             // TODO: copy matchesType to DataType
             // TODO: resolve AnyDataType invoke toCatalogDataType
             if (signatureType instanceof AnyDataType || signatureType instanceof FollowToAnyDataType) {
+                return false;
+            }
+            if (signatureType instanceof ComplexDataType && !(realType instanceof ComplexDataType)) {
                 return false;
             }
             return realType.toCatalogDataType().matchesType(signatureType.toCatalogDataType());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/NullOrIdenticalSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/NullOrIdenticalSignature.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
@@ -46,6 +47,9 @@ public interface NullOrIdenticalSignature extends ComputeSignature {
                 return true;
             }
             if (signatureType instanceof AnyDataType) {
+                return false;
+            }
+            if (signatureType instanceof ComplexDataType && !(realType instanceof ComplexDataType)) {
                 return false;
             }
             return realType.toCatalogDataType().matchesType(signatureType.toCatalogDataType());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultExpressionRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultExpressionRewriter.java
@@ -19,8 +19,8 @@ package org.apache.doris.nereids.trees.expressions.visitor;
 
 import org.apache.doris.nereids.trees.expressions.Expression;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 
 /**
  * Default implementation for expression rewriting, delegating to child expressions and rewrite current root
@@ -30,20 +30,42 @@ public abstract class DefaultExpressionRewriter<C> extends ExpressionVisitor<Exp
 
     @Override
     public Expression visit(Expression expr, C context) {
-        return rewrite(this, expr, context);
+        return rewriteChildren(this, expr, context);
     }
 
-    /** rewrite */
-    public static final <C> Expression rewrite(ExpressionVisitor<Expression, C> rewriter, Expression expr, C context) {
-        List<Expression> newChildren = new ArrayList<>(expr.arity());
-        boolean hasNewChildren = false;
-        for (Expression child : expr.children()) {
-            Expression newChild = child.accept(rewriter, context);
-            if (newChild != child) {
-                hasNewChildren = true;
+    /** rewriteChildren */
+    public static final <C> Expression rewriteChildren(
+            ExpressionVisitor<Expression, C> rewriter, Expression expr, C context) {
+        switch (expr.arity()) {
+            case 1: {
+                Expression originChild = expr.child(0);
+                Expression newChild = originChild.accept(rewriter, context);
+                return (originChild != newChild) ? expr.withChildren(ImmutableList.of(newChild)) : expr;
             }
-            newChildren.add(newChild);
+            case 2: {
+                Expression originLeft = expr.child(0);
+                Expression newLeft = originLeft.accept(rewriter, context);
+                Expression originRight = expr.child(1);
+                Expression newRight = originRight.accept(rewriter, context);
+                return (originLeft != newLeft || originRight != newRight)
+                        ? expr.withChildren(ImmutableList.of(newLeft, newRight))
+                        : expr;
+            }
+            case 0: {
+                return expr;
+            }
+            default: {
+                boolean hasNewChildren = false;
+                Builder<Expression> newChildren = ImmutableList.builderWithExpectedSize(expr.arity());
+                for (Expression child : expr.children()) {
+                    Expression newChild = child.accept(rewriter, context);
+                    if (newChild != child) {
+                        hasNewChildren = true;
+                    }
+                    newChildren.add(newChild);
+                }
+                return hasNewChildren ? expr.withChildren(newChildren.build()) : expr;
+            }
         }
-        return hasNewChildren ? expr.withChildren(newChildren) : expr;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
@@ -63,9 +63,9 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
             Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, CHILD_TYPE child) {
         super(PlanType.LOGICAL_GENERATE, groupExpression, logicalProperties, child);
-        this.generators = ImmutableList.copyOf(generators);
-        this.generatorOutput = ImmutableList.copyOf(generatorOutput);
-        this.expandColumnAlias = ImmutableList.copyOf(expandColumnAlias);
+        this.generators = Utils.fastToImmutableList(generators);
+        this.generatorOutput = Utils.fastToImmutableList(generatorOutput);
+        this.expandColumnAlias = Utils.fastToImmutableList(expandColumnAlias);
     }
 
     public List<Function> getGenerators() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -158,9 +158,9 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
         // Just use in withXXX method. Don't need check/copyOf()
         super(PlanType.LOGICAL_JOIN, groupExpression, logicalProperties, children);
         this.joinType = Objects.requireNonNull(joinType, "joinType can not be null");
-        this.hashJoinConjuncts = ImmutableList.copyOf(hashJoinConjuncts);
-        this.otherJoinConjuncts = ImmutableList.copyOf(otherJoinConjuncts);
-        this.markJoinConjuncts = ImmutableList.copyOf(markJoinConjuncts);
+        this.hashJoinConjuncts = Utils.fastToImmutableList(hashJoinConjuncts);
+        this.otherJoinConjuncts = Utils.fastToImmutableList(otherJoinConjuncts);
+        this.markJoinConjuncts = Utils.fastToImmutableList(markJoinConjuncts);
         this.hint = Objects.requireNonNull(hint, "hint can not be null");
         if (joinReorderContext != null) {
             this.joinReorderContext.copyFrom(joinReorderContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -95,7 +95,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         this.projects = projects.isEmpty()
                 ? ImmutableList.of(ExpressionUtils.selectMinimumColumn(child.get(0).getOutput()))
                 : projects;
-        this.excepts = ImmutableList.copyOf(excepts);
+        this.excepts = Utils.fastToImmutableList(excepts);
         this.isDistinct = isDistinct;
         this.canEliminate = canEliminate;
     }
@@ -173,7 +173,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     @Override
     public LogicalProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate, ImmutableList.copyOf(children));
+        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate, Utils.fastToImmutableList(children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -38,6 +38,7 @@ import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 import org.json.JSONObject;
 
@@ -119,9 +120,11 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public List<Slot> computeOutput() {
-        return projects.stream()
-                .map(NamedExpression::toSlot)
-                .collect(ImmutableList.toImmutableList());
+        Builder<Slot> slots = ImmutableList.builderWithExpectedSize(projects.size());
+        for (NamedExpression project : projects) {
+            slots.add(project.toSlot());
+        }
+        return slots.build();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -41,9 +41,7 @@ import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -115,8 +113,9 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
      * Generate new output for SetOperation.
      */
     public List<NamedExpression> buildNewOutputs() {
-        ImmutableList.Builder<NamedExpression> newOutputs = new Builder<>();
-        for (Slot slot : resetNullableForLeftOutputs()) {
+        List<Slot> slots = resetNullableForLeftOutputs();
+        ImmutableList.Builder<NamedExpression> newOutputs = ImmutableList.builderWithExpectedSize(slots.size());
+        for (Slot slot : slots) {
             newOutputs.add(new SlotReference(slot.toSql(), slot.getDataType(), slot.nullable()));
         }
         return newOutputs.build();
@@ -124,22 +123,28 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
 
     // If the right child is nullable, need to ensure that the left child is also nullable
     private List<Slot> resetNullableForLeftOutputs() {
-        List<Slot> resetNullableForLeftOutputs = new ArrayList<>();
-        for (int i = 0; i < child(1).getOutput().size(); ++i) {
+        int rightChildOutputSize = child(1).getOutput().size();
+        ImmutableList.Builder<Slot> resetNullableForLeftOutputs
+                = ImmutableList.builderWithExpectedSize(rightChildOutputSize);
+        for (int i = 0; i < rightChildOutputSize; ++i) {
             if (child(1).getOutput().get(i).nullable() && !child(0).getOutput().get(i).nullable()) {
                 resetNullableForLeftOutputs.add(child(0).getOutput().get(i).withNullable(true));
             } else {
                 resetNullableForLeftOutputs.add(child(0).getOutput().get(i));
             }
         }
-        return ImmutableList.copyOf(resetNullableForLeftOutputs);
+        return resetNullableForLeftOutputs.build();
     }
 
     private List<List<NamedExpression>> castCommonDataTypeOutputs() {
-        List<NamedExpression> newLeftOutputs = new ArrayList<>();
-        List<NamedExpression> newRightOutputs = new ArrayList<>();
+        int childOutputSize = child(0).getOutput().size();
+        ImmutableList.Builder<NamedExpression> newLeftOutputs = ImmutableList.builderWithExpectedSize(
+                childOutputSize);
+        ImmutableList.Builder<NamedExpression> newRightOutputs = ImmutableList.builderWithExpectedSize(
+                childOutputSize
+        );
         // Ensure that the output types of the left and right children are consistent and expand upward.
-        for (int i = 0; i < child(0).getOutput().size(); ++i) {
+        for (int i = 0; i < childOutputSize; ++i) {
             Slot left = child(0).getOutput().get(i);
             Slot right = child(1).getOutput().get(i);
             DataType compatibleType = getAssignmentCompatibleType(left.getDataType(), right.getDataType());
@@ -155,10 +160,7 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
             newRightOutputs.add((NamedExpression) newRight);
         }
 
-        List<List<NamedExpression>> resultExpressions = new ArrayList<>();
-        resultExpressions.add(newLeftOutputs);
-        resultExpressions.add(newRightOutputs);
-        return ImmutableList.copyOf(resultExpressions);
+        return ImmutableList.of(newLeftOutputs.build(), newRightOutputs.build());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
@@ -70,7 +70,7 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
             List<List<NamedExpression>> constantExprsList, boolean hasPushedFilter, List<Plan> children) {
         super(PlanType.LOGICAL_UNION, qualifier, outputs, childrenOutputs, children);
         this.hasPushedFilter = hasPushedFilter;
-        this.constantExprsList = ImmutableList.copyOf(
+        this.constantExprsList = Utils.fastToImmutableList(
                 Objects.requireNonNull(constantExprsList, "constantExprsList should not be null"));
     }
 
@@ -81,7 +81,7 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
         super(PlanType.LOGICAL_UNION, qualifier, outputs, childrenOutputs,
                 groupExpression, logicalProperties, children);
         this.hasPushedFilter = hasPushedFilter;
-        this.constantExprsList = ImmutableList.copyOf(
+        this.constantExprsList = Utils.fastToImmutableList(
                 Objects.requireNonNull(constantExprsList, "constantExprsList should not be null"));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.catalog.View;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.FdItem;
 import org.apache.doris.nereids.properties.FunctionalDependencies;
@@ -29,7 +30,6 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -46,7 +46,9 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
     public LogicalView(View view, BODY body) {
         super(PlanType.LOGICAL_VIEW, Optional.empty(), Optional.empty(), body);
         this.view = Objects.requireNonNull(view, "catalog can not be null");
-        Preconditions.checkArgument(body instanceof LogicalPlan);
+        if (!(body instanceof LogicalPlan)) {
+            throw new AnalysisException("Child of LogicalView should be LogicalPlan, but meet: " + body.getClass());
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/ArrayType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/ArrayType.java
@@ -18,13 +18,14 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 
 import java.util.Objects;
 
 /**
  * Array type in Nereids.
  */
-public class ArrayType extends DataType {
+public class ArrayType extends DataType implements ComplexDataType {
 
     public static final ArrayType SYSTEM_DEFAULT = new ArrayType(NullType.INSTANCE, true);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/MapType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/MapType.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 import org.apache.doris.nereids.annotation.Developing;
 
 import java.util.Objects;
@@ -26,7 +27,7 @@ import java.util.Objects;
  * Struct type in Nereids.
  */
 @Developing
-public class MapType extends DataType {
+public class MapType extends DataType implements ComplexDataType {
 
     public static final MapType SYSTEM_DEFAULT = new MapType();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StructType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StructType.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.analyzer.ComplexDataType;
 import org.apache.doris.nereids.annotation.Developing;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 
@@ -36,7 +37,7 @@ import java.util.stream.Collectors;
  * Struct type in Nereids.
  */
 @Developing
-public class StructType extends DataType {
+public class StructType extends DataType implements ComplexDataType {
 
     public static final StructType SYSTEM_DEFAULT = new StructType();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -68,6 +68,7 @@ import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -609,7 +610,7 @@ public class ExpressionUtils {
         return anyMatch(expressions, type::isInstance);
     }
 
-    public static <E> Set<E> collect(List<? extends Expression> expressions,
+    public static <E> Set<E> collect(Collection<? extends Expression> expressions,
             Predicate<TreeNode<Expression>> predicate) {
         return expressions.stream()
                 .flatMap(expr -> expr.<Set<E>>collect(predicate).stream())
@@ -649,7 +650,7 @@ public class ExpressionUtils {
                 .collect(Collectors.toSet());
     }
 
-    public static <E> List<E> collectAll(List<? extends Expression> expressions,
+    public static <E> List<E> collectAll(Collection<? extends Expression> expressions,
             Predicate<TreeNode<Expression>> predicate) {
         return expressions.stream()
                 .flatMap(expr -> expr.<Set<E>>collect(predicate).stream())
@@ -788,5 +789,18 @@ public class ExpressionUtils {
                 return inferred;
             }
         }, null);
+    }
+
+    /** distinctSlotByName */
+    public static List<Slot> distinctSlotByName(List<Slot> slots) {
+        Set<String> existSlotNames = new HashSet<>(slots.size() * 2);
+        Builder<Slot> distinctSlots = ImmutableList.builderWithExpectedSize(slots.size());
+        for (Slot slot : slots) {
+            String name = slot.getName();
+            if (existSlotNames.add(name)) {
+                distinctSlots.add(slot);
+            }
+        }
+        return distinctSlots.build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -45,6 +45,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -290,8 +291,11 @@ public class JoinUtils {
     }
 
     private static List<Slot> applyNullable(List<Slot> slots, boolean nullable) {
-        return slots.stream().map(o -> o.withNullable(nullable))
-                .collect(ImmutableList.toImmutableList());
+        Builder<Slot> newSlots = ImmutableList.builderWithExpectedSize(slots.size());
+        for (Slot slot : slots) {
+            newSlots.add(slot.withNullable(nullable));
+        }
+        return newSlots.build();
     }
 
     private static Map<Slot, Slot> mapPrimaryToForeign(ImmutableEqualSet<Slot> equivalenceSet,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -123,6 +124,23 @@ public class PlanUtils {
         ImmutableSet<TableIf> resultSet = tableSet.stream().map(e -> e.getTable())
                 .collect(ImmutableSet.toImmutableSet());
         return resultSet;
+    }
+
+    /** fastGetChildrenOutput */
+    public static List<Slot> fastGetChildrenOutputs(List<Plan> children) {
+        int outputNum = 0;
+        // child.output is cached by AbstractPlan.logicalProperties,
+        // we can compute output num without the overhead of re-compute output
+        for (Plan child : children) {
+            List<Slot> output = child.getOutput();
+            outputNum += output.size();
+        }
+        // generate output list only copy once and without resize the list
+        Builder<Slot> output = ImmutableList.builderWithExpectedSize(outputNum);
+        for (Plan child : children) {
+            output.addAll(child.getOutput());
+        }
+        return output.build();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -336,11 +337,30 @@ public class Utils {
                 // NOTE: ImmutableList.copyOf(list) has additional clone of the list, so here we
                 //       direct generate a ImmutableList
                 Builder<E> copyChildren = ImmutableList.builderWithExpectedSize(originList.size());
-                for (E child : originList) {
-                    copyChildren.add(child);
-                }
+                copyChildren.addAll(originList);
                 return copyChildren.build();
             }
         }
+    }
+
+    /** reverseImmutableList */
+    public static <E> ImmutableList<E> reverseImmutableList(List<? extends E> list) {
+        Builder<E> reverseList = ImmutableList.builderWithExpectedSize(list.size());
+        for (int i = list.size() - 1; i >= 0; i--) {
+            reverseList.add(list.get(i));
+        }
+        return reverseList.build();
+    }
+
+    /** filterImmutableList */
+    public static <E> ImmutableList<E> filterImmutableList(List<? extends E> list, Predicate<E> filter) {
+        Builder<E> newList = ImmutableList.builderWithExpectedSize(list.size());
+        for (int i = 0; i < list.size(); i++) {
+            E item = list.get(i);
+            if (filter.test(item)) {
+                newList.add(item);
+            }
+        }
+        return newList.build();
     }
 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -17,9 +17,12 @@
 
 package org.apache.doris.regression
 
+import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.core.OutputStreamAppender
 import com.google.common.collect.Lists
 import groovy.transform.CompileStatic
 import jodd.util.Wildcard
+import org.apache.doris.regression.logger.TeamcityServiceMessageEncoder
 import org.apache.doris.regression.suite.Suite
 import org.apache.doris.regression.suite.event.EventListener
 import org.apache.doris.regression.suite.GroovyFileSource
@@ -64,7 +67,13 @@ class RegressionTest {
         ch.qos.logback.classic.Logger loggerOfSuite =
                 LoggerFactory.getLogger(Suite.class) as ch.qos.logback.classic.Logger
         def context = loggerOfSuite.getLoggerContext()
-        context.getFrameworkPackages().add(IndyInterface.class.getPackage().getName())
+        def frameworkPackages = context.getFrameworkPackages()
+
+        // don't print this class name as the log class name
+        frameworkPackages.add(TeamcityServiceMessageEncoder.class.getPackage().getName())
+        frameworkPackages.add(IndyInterface.class.getPackage().getName())
+        frameworkPackages.add(OutputStreamAppender.class.getPackage().getName())
+        frameworkPackages.add(PatternLayout.class.getPackage().getName())
     }
 
     static void main(String[] args) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
@@ -141,7 +141,7 @@ class OutputUtils {
 
                     def res = checkCell(info, line, expectCell, realCell, dataType)
                     if(res != null) {
-                        res += "line ${line} mismatch\nExpectRow: ${expectRaw}\nRealRow: ${realRaw}";
+                        res += "\nline ${line} mismatch\nExpectRow: ${expectRaw}\nRealRow: ${realRaw}";
                         return res
                     }
                 }


### PR DESCRIPTION
## Proposed changes
1. check data type whether can applied should not throw exception when real data type is subclass of signature data type
2. merge `SlotBinder` and `FunctionBinder` to `ExpressionAnalyzer` to skip rewrite the whole expression tree multiple times.
3. `ExpressionAnalyzer.buildCustomSlotBinderAnalyzer()` provide more refined code to bind slot by different parts and different priority
4. the origin slot binder has O(n^2) complexity, this pr use `Scope.nameToSlot` to support O(n) bind
5. modify some `Collection.stream()` to `ImmutableXxx.builder()` to remove some method call which are difficult to inline by jvm in the hot path, e.g. `Expression.<init>` and `AbstractTreeNode.<init>`
6. modify some `ImmutableXxx.copyOf(xxx)` to `Utils.fastToImmutableList(xxx)` to skip addition copy of the array
7. set init size to `Immutable.builder()` to skip some useless resize
8. lazy compute and cache some heavy operations, like `Scope.nameToSlot` and `CaseWhen.computeDataTypesForCoercion()`
