### PR TITLE
[fix](partition) add log when tablet partition id eq 0

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -492,8 +492,8 @@ Status DataDir::load() {
     }
     if (rowset_partition_id_eq_0_num > config::ignore_invalid_partition_id_rowset_num) {
         LOG(FATAL) << fmt::format(
-                "roswet partition id eq 0 bigger than config {}, be exit, plz check be.INFO",
-                config::ignore_invalid_partition_id_rowset_num);
+                "roswet partition id eq 0 is {} bigger than config {}, be exit, plz check be.INFO",
+                rowset_partition_id_eq_0_num, config::ignore_invalid_partition_id_rowset_num);
         exit(-1);
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

加log，之前认为可以通过grep be中的log，得到异常tablet的个数。后面发现真遇到 grep 还是不直观，增加点log，增加可观测性，减少解决异常时间。

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

