### PR TITLE
[improvement](jdbc catalog) support sqlserver timestamp type read

### DIFF
--- a/docker/thirdparties/docker-compose/sqlserver/init/03-create-table.sql
+++ b/docker/thirdparties/docker-compose/sqlserver/init/03-create-table.sql
@@ -134,3 +134,7 @@ CREATE TABLE dbo.all_type (
     bit_value bit NULL
 );
 
+CREATE TABLE dbo.test_timestamp (
+id_col int PRIMARY KEY NOT NULL,
+timestamp_col timestamp NULL
+);

--- a/docker/thirdparties/docker-compose/sqlserver/init/04-insert.sql
+++ b/docker/thirdparties/docker-compose/sqlserver/init/04-insert.sql
@@ -97,3 +97,5 @@ Insert into dbo.all_type values
 0
 ),
 (2,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+
+insert into dbo.test_timestamp(id_col) values(1);

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SQLServerJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SQLServerJdbcExecutor.java
@@ -93,6 +93,8 @@ public class SQLServerJdbcExecutor extends BaseJdbcExecutor {
                 return createConverter(input -> {
                     if (input instanceof java.sql.Time) {
                         return timeToString((java.sql.Time) input);
+                    } else if (input instanceof byte[]) {
+                        return sqlserverByteArrayToHexString((byte[]) input);
                     } else {
                         return input.toString();
                     }
@@ -100,5 +102,17 @@ public class SQLServerJdbcExecutor extends BaseJdbcExecutor {
             default:
                 return null;
         }
+    }
+
+    private String sqlserverByteArrayToHexString(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder("0x");
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xFF & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
@@ -82,6 +82,7 @@ public class JdbcSQLServerClient extends JdbcClient {
             case "time":
             case "datetimeoffset":
             case "uniqueidentifier":
+            case "timestamp":
                 return ScalarType.createStringType();
             case "image":
             case "binary":

--- a/regression-test/data/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.out
@@ -107,6 +107,13 @@ bit_value	BOOLEAN	Yes	false	\N	NONE
 1	doris	18	0	1	1	123.123	123.123	123.123	12345678901234567890123456789012345678	12345678901234567890123456789012345678	1234567890123456789012345678.0123456789	1234567890123456789012345678.0123456789	Make Doris Great!   	Make Doris Great!	Make Doris Great!	Make Doris Great!   	Make Doris Great!	Make Doris Great!	2023-01-17	16:49:05.123	2023-01-17T16:49:05	2023-01-17T16:49:05.123456	2023-01-17T16:49	2023-01-17 16:49:05 +08:00	Make Doris Great!	Make Doris Great!	922337203685477.5807	214748.3647	false
 2	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
 
+-- !desc_timestamp --
+id_col	INT	No	true	\N	
+timestamp_col	TEXT	Yes	true	\N	
+
+-- !query_timestamp --
+1
+
 -- !sql --
 INFORMATION_SCHEMA
 db_accessadmin

--- a/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
@@ -84,6 +84,9 @@ suite("test_sqlserver_jdbc_catalog", "p0,external,sqlserver,external_docker,exte
             order_qt_ctas """ create table internal.${internal_db_name}.ctas_all_type PROPERTIES("replication_num" = "1") as select * from all_type; """
             qt_desc_query_ctas """ desc internal.${internal_db_name}.ctas_all_type; """
             order_qt_query_ctas """ select * from internal.${internal_db_name}.ctas_all_type order by id; """
+            order_qt_desc_timestamp """desc dbo.test_timestamp; """
+            order_qt_query_timestamp """select count(timestamp_col) from dbo.test_timestamp; """
+
 
             sql """ drop catalog if exists ${catalog_name} """
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In previous versions, we encountered an issue where SQL Server's timestamp type did not have a direct mapping in Doris. As SQL Server’s timestamp is actually a binary type rather than a real timestamp, and since Doris does not have a binary type to map SQL Server's timestamp, this caused SQL Server's timestamp fields to be recognized as an unsupported type in Doris. This issue would throw an exception when queries involved these fields. Considering that many users utilize the timestamp type in SQL Server, we have made improvements in this PR. We now map SQL Server's timestamp type to the String type in Doris, displaying the binary data in hexadecimal format. Please note that the converted data does not carry meaningful information; the primary goal is to prevent query failures due to unsupported field types, thereby ensuring smooth query execution.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

