### PR TITLE
[Fix](Planner) fix ifnull and nvl function with one parameters exception message anbugious

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1543,6 +1543,8 @@ public class FunctionCallExpr extends Expr {
 
         } else if (fnName.getFunction().equalsIgnoreCase("ifnull")
                 || fnName.getFunction().equalsIgnoreCase("nvl")) {
+            Preconditions.checkArgument(children != null && children.size() == 2,
+                    "The " + fnName + " function must have two params");
             Type[] childTypes = collectChildReturnTypes();
             Type assignmentCompatibleType = ScalarType.getAssignmentCompatibleType(childTypes[0], childTypes[1], true,
                     enableDecimal256);

--- a/regression-test/suites/nereids_function_p0/scalar_function/N.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/N.groovy
@@ -103,4 +103,18 @@ suite("nereids_scalar_fn_N") {
 	qt_sql_nvl_Varchar_Varchar_notnull "select nvl(kvchrs1, kvchrs1) from fn_test_not_nullable order by kvchrs1, kvchrs1"
 	qt_sql_nvl_String_String "select nvl(kstr, kstr) from fn_test order by kstr, kstr"
 	qt_sql_nvl_String_String_notnull "select nvl(kstr, kstr) from fn_test_not_nullable order by kstr, kstr"
+	test{
+		sql"""select ifnull(kstr) from fn_test"""
+		check {result, exception, startTime, endTime ->
+			assertTrue(exception != null)
+			logger.info(exception.message)
+		}
+	}
+	test{
+		sql"""select nvl(kstr) from fn_test"""
+		check {result, exception, startTime, endTime ->
+			assertTrue(exception != null)
+			logger.info(exception.message)
+		}
+	}
 }

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_ifnull.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_ifnull.groovy
@@ -17,6 +17,7 @@
 
 suite("test_ifnull") {
 	def tbName = "test_ifnull"
+	sql "set enable_nereids_planner=false"
 	sql "DROP TABLE IF EXISTS ${tbName};"
 	sql"""
 		CREATE TABLE IF NOT EXISTS ${tbName} (
@@ -34,6 +35,14 @@ suite("test_ifnull") {
 	"""
 
 	qt_sql "select id,t_decimal,test_double,ifnull(t_decimal,test_double) as if_dou,ifnull(test_double,t_decimal) as if_dei from test_ifnull;"
+
+	test{
+		sql"""select ifnull(kstr) from fn_test"""
+		check {result, exception, startTime, endTime ->
+			assertTrue(exception != null)
+			logger.info(exception.message)
+		}
+	}
 
 	sql "DROP TABLE ${tbName};"
 }

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_nvl.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_nvl.groovy
@@ -19,4 +19,12 @@ suite("test_nvl") {
     qt_select "select nvl(k6, \"false\") k from test_query_db.test order by k1"
     sql """set enable_nereids_planner=false;"""
     qt_select2 "select nvl(123456.134444454,0);"
+
+    test{
+        sql"""select nvl(k6) from test_query_db.test"""
+        check {result, exception, startTime, endTime ->
+            assertTrue(exception != null)
+            logger.info(exception.message)
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

When ifnull or nvl funtion have only one parameter, nereids planner would throw an exception and go back to 
original planner/ Original planner get secend parameter directly without check, so it return unexpected error message

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

