### PR TITLE
[feature](rf) add filter info profile when rf run as expr 

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -230,7 +230,8 @@ public:
     PrimitiveType column_type() const;
 
     Status get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
-                              std::vector<vectorized::VExprSPtr>& push_exprs, bool is_late_arrival);
+                              std::vector<vectorized::VRuntimeFilterPtr>& push_exprs,
+                              bool is_late_arrival);
 
     bool is_broadcast_join() const { return _is_broadcast_join; }
 

--- a/be/src/vec/exec/runtime_filter_consumer.h
+++ b/be/src/vec/exec/runtime_filter_consumer.h
@@ -46,7 +46,7 @@ protected:
     // Get all arrived runtime filters at Open phase.
     Status _acquire_runtime_filter();
     // Append late-arrival runtime filters to the vconjunct_ctx.
-    Status _append_rf_into_conjuncts(const VExprSPtrs& vexprs);
+    Status _append_rf_into_conjuncts(const std::vector<vectorized::VRuntimeFilterPtr>& vexprs);
 
     void _init_profile(RuntimeProfile* profile);
 
@@ -54,9 +54,9 @@ protected:
 
     // For runtime filters
     struct RuntimeFilterContext {
-        RuntimeFilterContext(IRuntimeFilter* rf) : apply_mark(false), runtime_filter(rf) {}
+        RuntimeFilterContext(IRuntimeFilter* rf) : runtime_filter(rf) {}
         // set to true if this runtime filter is already applied to vconjunct_ctx_ptr
-        bool apply_mark;
+        bool apply_mark = false;
         IRuntimeFilter* runtime_filter = nullptr;
     };
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -763,8 +763,8 @@ void NewOlapScanNode::add_filter_info(int id, const PredicateFilterInfo& update_
     filter_name += std::to_string(id);
     std::string info_str;
     info_str += "type = " + type_to_string(static_cast<PredicateType>(info.type)) + ", ";
-    info_str += "input = " + std::to_string(info.input_row) + ", ";
-    info_str += "filtered = " + std::to_string(info.filtered_row);
+    info_str += "predicate input = " + std::to_string(info.input_row) + ", ";
+    info_str += "predicate filtered = " + std::to_string(info.filtered_row);
     info_str = "[" + info_str + "]";
 
     // add info

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -20,9 +20,12 @@
 #include <fmt/format.h>
 #include <stddef.h>
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 
+#include "util/defer_op.h"
+#include "util/runtime_profile.h"
 #include "util/simd/bits.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
@@ -84,7 +87,19 @@ Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* 
         *result_column_id = num_columns_without_result;
         return Status::OK();
     } else {
-        _scan_rows += block->rows();
+        int64_t input_rows = 0, filter_rows = 0;
+        Defer statistic_filter_info {[&]() {
+            if (_expr_filtered_rows_counter) {
+                COUNTER_UPDATE(_expr_filtered_rows_counter, filter_rows);
+            }
+            if (_expr_input_rows_counter) {
+                COUNTER_UPDATE(_expr_input_rows_counter, input_rows);
+            }
+            if (_always_true_counter) {
+                COUNTER_SET(_always_true_counter, (int64_t)_always_true);
+            }
+        }};
+        input_rows += block->rows();
 
         if (_getting_const_col) {
             _impl->set_getting_const_col(true);
@@ -99,28 +114,29 @@ Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* 
         if (is_column_const(*result_column.column)) {
             auto* constant_val = const_cast<char*>(result_column.column->get_data_at(0).data);
             if (constant_val == nullptr || !*reinterpret_cast<bool*>(constant_val)) {
-                _filtered_rows += block->rows();
+                filter_rows += block->rows();
             }
         } else if (const auto* nullable =
                            check_and_get_column<ColumnNullable>(*result_column.column)) {
             data = ((ColumnVector<UInt8>*)nullable->get_nested_column_ptr().get())
                            ->get_data()
                            .data();
-            _filtered_rows += doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(data),
-                                                          nullable->get_null_map_data().data(),
-                                                          block->rows());
+            filter_rows += doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(data),
+                                                       nullable->get_null_map_data().data(),
+                                                       block->rows());
         } else if (const auto* res_col =
                            check_and_get_column<ColumnVector<UInt8>>(*result_column.column)) {
             data = const_cast<uint8_t*>(res_col->get_data().data());
-            _filtered_rows += doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(data),
-                                                          block->rows());
+            filter_rows += doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(data),
+                                                       block->rows());
         } else {
             return Status::InternalError(
                     "Invalid type for runtime filters!, and _expr_name is: {}. _data_type is: {}. "
                     "result_column_id is: {}. block structure: {}.",
                     _expr_name, _data_type->get_name(), *result_column_id, block->dump_structure());
         }
-
+        _filtered_rows += filter_rows;
+        _scan_rows += input_rows;
         calculate_filter(VRuntimeFilterWrapper::EXPECTED_FILTER_RATE, _filtered_rows, _scan_rows,
                          _has_calculate_filter, _always_true);
         return Status::OK();


### PR DESCRIPTION
## Proposed changes
Currently, RF can be used in expr or predicates. Previously, the profile was added in predicates; now, add it in expr as well.


```
                    RuntimeFilter:  (id  =  2,  type  =  minmax):
                          -  Info:  [IsPushDown  =  true,  RuntimeFilterState  =  READY,  IgnoredMsg  =  ,  HasRemoteTarget  =  true,  HasLocalTarget  =  false]
                          -  EffectTime:  7  ms
                          -  UpdateTime:  0  ms
                          -  MergeTime:  0  ms
                          -  RealRuntimeFilterType:  minmax
                          -  always_true:  0
                          -  expr_filtered_rows:  509
                          -  expr_input_rows:  50.441K  (50441)

```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

