### PR TITLE
[Fix](schema change) Fix schema change fault when add complex type column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -926,7 +926,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
-            if (newColumn.getAggregationType() != AggregateType.NONE) {
+            if (newColumn.getAggregationType() != null) {
                 throw new DdlException(
                         "Can not assign aggregation method" + " on column in Unique data model table: " + newColName);
             }
@@ -938,7 +938,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else {
-            if (newColumn.getAggregationType() != AggregateType.NONE) {
+            if (newColumn.getAggregationType() != null) {
                 throw new DdlException(
                         "Can not assign aggregation method" + " on column in Duplicate data model table: "
                                 + newColName);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -926,7 +926,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
-            if (newColumn.getAggregationType() != null) {
+            if (newColumn.getAggregationType() != AggregateType.NONE) {
                 throw new DdlException(
                         "Can not assign aggregation method" + " on column in Unique data model table: " + newColName);
             }
@@ -938,7 +938,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else {
-            if (newColumn.getAggregationType() != null) {
+            if (newColumn.getAggregationType() != AggregateType.NONE) {
                 throw new DdlException(
                         "Can not assign aggregation method" + " on column in Duplicate data model table: "
                                 + newColName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -18,13 +18,11 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
-import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
@@ -82,20 +80,9 @@ public class AddColumnClause extends AlterTableClause {
                     && columnDef.getAggregateType() == null) {
                 columnDef.setIsKey(true);
             }
-        }
-
-        OlapTable table = (OlapTable) Env.getCurrentInternalCatalog().getDbOrDdlException(this.tableName.getDb())
-                .getTableOrDdlException(tableName.getTbl(),
-                        TableType.OLAP);
-        if (table.getKeysType() != KeysType.AGG_KEYS) {
-            AggregateType type = AggregateType.REPLACE;
-            if (table.getKeysType() == KeysType.DUP_KEYS) {
-                type = AggregateType.NONE;
+            if (table instanceof OlapTable) {
+                columnDef.setKeysType(((OlapTable) table).getKeysType());
             }
-            if (table.getKeysType() == KeysType.UNIQUE_KEYS && table.getEnableUniqueKeyMergeOnWrite()) {
-                type = AggregateType.NONE;
-            }
-            columnDef.setAggregateType(type);
         }
 
         columnDef.analyze(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -320,16 +320,16 @@ public class ColumnDef {
         }
 
         // disable Bitmap Hll type in keys, values without aggregate function.
-        if (keysType == null || keysType == KeysType.AGG_KEYS) {
-            if (type.isBitmapType() || type.isHllType() || type.isQuantileStateType()) {
-                if (isKey) {
-                    throw new AnalysisException("Key column can not set complex type:" + name);
-                }
+        if (type.isBitmapType() || type.isHllType() || type.isQuantileStateType()) {
+            if (isKey) {
+                throw new AnalysisException("Key column can not set complex type:" + name);
+            }
+            if (keysType == null || keysType == KeysType.AGG_KEYS) {
                 if (aggregateType == null) {
                     throw new AnalysisException("complex type have to use aggregate function: " + name);
                 }
-                isAllowNull = false;
             }
+            isAllowNull = false;
         }
 
         // A column is a key column if and only if isKey is true.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -75,7 +75,11 @@ public class ModifyColumnClause extends AlterTableClause {
                     && columnDef.getAggregateType() == null) {
                 columnDef.setIsKey(true);
             }
+            if (table instanceof OlapTable) {
+                columnDef.setKeysType(((OlapTable) table).getKeysType());
+            }
         }
+
         columnDef.analyze(true);
         if (colPos != null) {
             colPos.analyze();

--- a/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
@@ -203,6 +203,13 @@ suite("test_schema_change_duplicate", "p0") {
     'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', 10086) """
 
     sql """ alter table ${tableName3} drop column v14 """
+    
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
 
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {

--- a/regression-test/suites/schema_change_p0/test_schema_change_unique.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_unique.groovy
@@ -204,6 +204,14 @@ suite("test_schema_change_unique", "p0") {
 
     sql """ alter table ${tableName3} drop column v14 """
 
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
+
+
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {
         assertEquals(2, row[1]);

--- a/regression-test/suites/schema_change_p0/test_schema_change_unique_mow.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_unique_mow.groovy
@@ -205,6 +205,13 @@ suite("test_schema_change_unique_mow", "p0") {
 
     sql """ alter table ${tableName3} drop column v14 """
 
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
+
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {
         assertEquals(2, row[1]);


### PR DESCRIPTION
Problem: An error is encountered when executing a schema change on a unique table to add a column with a complex type, such as bitmap, as documented in https://github.com/apache/doris/issues/31365

Reason: The error arises because the schema change logic erroneously applies an aggregation check for new columns across all table types, demanding an explicit aggregation type declaration. However, unique and duplicate tables inherently assume default aggregation types for newly added columns, leading to this misstep.

Solution: The schema change process for introducing new columns needs to distinguish between table types accurately. For unique and duplicate tables, it should automatically assign the appropriate aggregation type, which, for the purpose of smooth integration with subsequent processes, should be set to NONE.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

