### PR TITLE
[fix](Hudi-Utils) Change the Pid obtaining method

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
@@ -23,29 +23,19 @@ import org.apache.doris.common.security.authentication.HadoopUGI;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import sun.management.VMManagement;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 
 public class Utils {
     public static long getCurrentProcId() {
         try {
-            RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
-            Field jvmField = mxbean.getClass().getDeclaredField("jvm");
-            jvmField.setAccessible(true);
-            VMManagement management = (VMManagement) jvmField.get(mxbean);
-            Method method = management.getClass().getDeclaredMethod("getProcessId");
-            method.setAccessible(true);
-            return (long) (Integer) method.invoke(management);
+            return ManagementFactory.getRuntimeMXBean().getPid();
         } catch (Exception e) {
             throw new RuntimeException("Couldn't find PID of current JVM process.", e);
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Starting with JDK10, `RuntimeMXBean` provides `getPid()` method to help get the Pid, so it is no longer necessary to get it through reflection.

**Note:**
Do not merge into 2.1.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

