### PR TITLE
[fix](reader) wrong bytes_req size in CachedRemoteFileReader

### DIFF
--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -92,6 +92,7 @@ std::pair<size_t, size_t> CachedRemoteFileReader::_align_size(size_t offset,
 Status CachedRemoteFileReader::_read_from_cache(size_t offset, Slice result, size_t* bytes_read,
                                                 const IOContext* io_ctx) {
     size_t bytes_req = result.size;
+    bytes_req = std::min(bytes_req, size() - offset);
     ReadStatistics stats;
     auto [align_left, align_size] = _align_size(offset, bytes_req);
     CacheContext cache_context(io_ctx);


### PR DESCRIPTION
## Proposed changes

backport: #24277

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

