### PR TITLE
[fix](group commit) group commit may heap-use-after-free if execute plan failed

### DIFF
--- a/be/src/runtime/group_commit_mgr.h
+++ b/be/src/runtime/group_commit_mgr.h
@@ -134,8 +134,7 @@ public:
                                 std::shared_ptr<LoadBlockQueue>& load_block_queue);
 
 private:
-    Status _create_group_commit_load(std::shared_ptr<LoadBlockQueue>& load_block_queue,
-                                     int be_exe_version);
+    Status _create_group_commit_load(int be_exe_version);
     Status _exec_plan_fragment(int64_t db_id, int64_t table_id, const std::string& label,
                                int64_t txn_id, bool is_pipeline,
                                const TExecPlanFragmentParams& params,


### PR DESCRIPTION
## Proposed changes

```
=================================================================
==12641==ERROR: AddressSanitizer: heap-use-after-free on address 0x613005be1d30 at pc 0x563e94a010fa bp 0x7f3b94edc550 sp 0x7f3b94edc548
WRITE of size 8 at 0x613005be1d30 thread T9324 (GroupCommitThre)
    #0 0x563e94a010f9 in std::enable_if<__and_<std::__not_<std::__is_tuple_like<doris::LoadBlockQueue*>>, std::is_move_constructible<doris::LoadBlockQueue*>, std::is_move_assignable<doris::LoadBlockQueue*>>::value, void>::type std::swap<doris::LoadBlockQueue*>(doris::LoadBlockQueue*&, doris::LoadBlockQueue*&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/move.h:206:11
    #1 0x563e94a010f9 in std::__shared_ptr<doris::LoadBlockQueue, (__gnu_cxx::_Lock_policy)2>::swap(std::__shared_ptr<doris::LoadBlockQueue, (__gnu_cxx::_Lock_policy)2>&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1311:2
    #2 0x563e94a010f9 in std::__shared_ptr<doris::LoadBlockQueue, (__gnu_cxx::_Lock_policy)2>::reset() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1267:24
    #3 0x563e94a010f9 in doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0::operator()() const /root/doris/be/src/runtime/group_commit_mgr.cpp:214:17
    #4 0x563e94a010f9 in void std::__invoke_impl<void, doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0&>(std::__invoke_other, doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #5 0x563e94a010f9 in std::enable_if<is_invocable_r_v<void, doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0&>, void>::type std::__invoke_r<void, doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0&>(doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #6 0x563e94a010f9 in std::_Function_handler<void (), doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int)::$_0>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #7 0x563e950b65bc in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #8 0x563e950942e8 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #9 0x563e950942e8 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #10 0x7f46fb719608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #11 0x7f46fb9c6132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

