### PR TITLE
[fix](s3-load) fix s3 load profile incomplete when enable profile is true

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -146,6 +146,7 @@ public class LoadLoadingTask extends LoadTask {
                 planner.getFragments(), planner.getScanNodes(), planner.getTimezone(), loadZeroTolerance);
         if (this.jobProfile != null) {
             this.jobProfile.setExecutionProfile(curCoordinator.getExecutionProfile());
+            curCoordinator.getQueryOptions().setEnableProfile(true);
         }
         curCoordinator.setQueryType(TQueryType.LOAD);
         curCoordinator.setExecMemoryLimit(execMemLimit);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -856,7 +856,7 @@ public class Coordinator implements CoordInterface {
                 }
                 waitRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send execution start");
             }
-            if (context != null && context.getSessionVariable().enableProfile()) {
+            if (this.queryOptions.isEnableProfile()) {
                 attachInstanceProfileToFragmentProfile();
             }
         } finally {
@@ -1002,7 +1002,7 @@ public class Coordinator implements CoordInterface {
                 }
                 waitPipelineRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send execution start");
             }
-            if (context != null && context.getSessionVariable().enableProfile()) {
+            if (this.queryOptions.isEnableProfile()) {
                 attachInstanceProfileToFragmentProfile();
             }
         } finally {


### PR DESCRIPTION
## Proposed changes

S3 load profile is loss important data when set enable profile is true.
![mRmQwfcGXV](https://github.com/apache/doris/assets/77738092/cc4c0ce1-fd56-4886-8997-c5b0572af93b)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

