### PR TITLE
[fix](cloud) Fix FE cannot work when restarting after schema change run in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1050,7 +1050,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         Partition partition = olapTable.getPartition(info.getPartitionId());
         MaterializedIndex materializedIndex = partition.getIndex(info.getIndexId());
         Tablet tablet = materializedIndex.getTablet(info.getTabletId());
-        Replica replica = tablet.getReplicaByBackendId(info.getBackendId());
+        Replica replica = tablet.getReplicaById(info.getReplicaId());
         Preconditions.checkNotNull(replica, info);
         replica.updateVersionInfo(info.getVersion(), info.getDataSize(), info.getRemoteDataSize(), info.getRowCount());
         replica.setBad(false);


### PR DESCRIPTION
```
2024-03-05 21:16:43,300 INFO (stateListener|110) [RollupJobV2.replayPendingJob():749] replay waiting txn rollup job: 30405
2024-03-05 21:16:43,300 INFO (stateListener|110) [MaterializedViewHandler.replayAlterJobV2():1114] set table's state to ROLLUP, table id: 29056, job id: 30405
2024-03-05 21:16:43,300 DEBUG (stateListener|110) [Env.replayJournal():2751] journal 21241 replayed.
2024-03-05 21:16:43,300 DEBUG (stateListener|110) [JournalObservable.notifyObservers():95] notify observers: journal: 21241, pos: 0, size: 0, obs: []
2024-03-05 21:16:43,300 DEBUG (stateListener|110) [JournalEntity.readFields():193] get opcode: 45
2024-03-05 21:16:43,300 DEBUG (stateListener|110) [EditLog.loadJournal():170] replay journal op code: 45
2024-03-05 21:16:43,301 DEBUG (stateListener|110) [InternalCatalog.unprotectUpdateReplica():1048] replay update a replica table id: 29056 partition id: 29050 index id: 30406 tablet id: 30505 backend id: 10002 replica id: 30506 version: 2 schema hash: -1 data size: 0 row count: 0 last failed version: -1 last success version: 2
2024-03-05 21:16:43,301 DEBUG (stateListener|110) [CloudReplica.getBackendId():143] connect context is null in getBackendId
2024-03-05 21:16:43,301 ERROR (stateListener|110) [EditLog.loadJournal():1226] Operation Type 45
java.lang.NullPointerException: table id: 29056 partition id: 29050 index id: 30406 tablet id: 30505 backend id: 10002 replica id: 30506 version: 2 schema hash: -1 data size: 0 row count: 0 last failed version: -1 last success version: 2
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:921) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.datasource.InternalCatalog.unprotectUpdateReplica(InternalCatalog.java:1054) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.InternalCatalog.replayUpdateReplica(InternalCatalog.java:1075) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.replayUpdateReplica(Env.java:3706) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:398) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.replayJournal(Env.java:2747) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.transferToMaster(Env.java:1459) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.access$1400(Env.java:319) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env$5.runOneCycle(Env.java:2638) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

