### PR TITLE
[enhancement](Nereids): support more condition Date/DateTime Literal

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -34,6 +34,13 @@ class DateTimeLiteralTest {
     }
 
     @Test
+    void mysqlStrangeCase() {
+        new DateTimeV2Literal("0-08-01 13:21:03");
+        new DateTimeV2Literal("0001-01-01: 00:01:01.001");
+        new DateTimeV2Literal("2021?01?01 00.00.00");
+    }
+
+    @Test
     void testBasic() {
         Consumer<DateTimeV2Literal> assertFunc = (datetime) -> {
             Assertions.assertEquals(2022, datetime.year);


### PR DESCRIPTION
## Proposed changes

support

```
        new DateTimeV2Literal("0-08-01 13:21:03");
        new DateTimeV2Literal("0001-01-01: 00:01:01.001");
        new DateTimeV2Literal("2021?01?01 00.00.00");
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

