### PR TITLE
[fix](es-catalog) Add support for IPv6 resolution in publish_address

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeInfo.java
@@ -74,7 +74,7 @@ public class EsNodeInfo {
                 // if network.publish_host is set to hostname like localhost,
                 // the publish_address contains hostname like "localhost/127.0.0.1:9200"
                 address = address.substring(address.lastIndexOf('/') + 1);
-                int pos = addrees.lastIndexOf(":");
+                int pos = address.lastIndexOf(":");
                 String host = address.substring(0, pos);
                 String port = address.substring(pos + 1);
                 this.publishAddress = new TNetworkAddress((httpSslEnabled ? "https://" : "") + host, Integer.parseInt(port));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeInfo.java
@@ -74,8 +74,10 @@ public class EsNodeInfo {
                 // if network.publish_host is set to hostname like localhost,
                 // the publish_address contains hostname like "localhost/127.0.0.1:9200"
                 address = address.substring(address.lastIndexOf('/') + 1);
-                String[] scratch = address.split(":");
-                this.publishAddress = new TNetworkAddress((httpSslEnabled ? "https://" : "") + scratch[0], Integer.parseInt(scratch[1]));
+                int pos = addrees.lastIndexOf(":");
+                String host = address.substring(0, pos);
+                String port = address.substring(pos + 1);
+                this.publishAddress = new TNetworkAddress((httpSslEnabled ? "https://" : "") + host, Integer.parseInt(port));
                 this.hasHttp = true;
             } else {
                 this.publishAddress = null;


### PR DESCRIPTION

This merge request primarily focuses on enhancing the parsing of IPv6 addresses within the publish_address function. The updated code now supports IPv6 addresses in the format [xxx::xxxx::::xxx]:1234

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

