### PR TITLE
[fix](meta) fix NPE when forward cmd to master FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -302,11 +302,6 @@ public class ConnectContext {
             mysqlChannel = new DummyMysqlChannel();
         }
         init();
-        sessionVariable = VariableMgr.newSessionVariable();
-        command = MysqlCommand.COM_SLEEP;
-        if (Config.use_fuzzy_session_variable) {
-            sessionVariable.initFuzzyModeVariables();
-        }
     }
 
     public boolean isTxnModel() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -301,6 +301,7 @@ public class ConnectContext {
         } else {
             mysqlChannel = new DummyMysqlChannel();
         }
+        init();
         sessionVariable = VariableMgr.newSessionVariable();
         command = MysqlCommand.COM_SLEEP;
         if (Config.use_fuzzy_session_variable) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

An error occurred when executing cmd which needs to be forwarded to master fe:
MySQL [(none)]> show frontends;
ERROR 1105 (HY000): TApplicationException, msg: org.apache.thrift.TApplicationException: Internal error processing forward

internal error:
Caused by: java.lang.NullPointerException
        at org.apache.doris.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:684)
        at org.apache.doris.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1096)
        ... 13 more


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

