### PR TITLE
[fix] (doc)Fix invalid link on benchmark tool page

### DIFF
--- a/docs/en/community/developer-guide/benchmark-tool.md
+++ b/docs/en/community/developer-guide/benchmark-tool.md
@@ -33,7 +33,7 @@ It can be used to test the performance of some parts of the BE storage layer (fo
 
 ## Compilation
 
-1. To ensure that the environment has been able to successfully compile the Doris ontology, you can refer to [Installation and deployment](/docs/install/source-install/compilation).
+1. To ensure that the environment has been able to successfully compile the Doris ontology, you can refer to [Installation and deployment](/docs/install/source-install/compilation-general).
 
 2. Execute`run-be-ut.sh`
 

--- a/docs/zh-CN/community/developer-guide/benchmark-tool.md
+++ b/docs/zh-CN/community/developer-guide/benchmark-tool.md
@@ -33,7 +33,7 @@ under the License.
 
 ## 编译
 
-1. 确保环境已经能顺利编译Doris本体,可以参考[编译与部署](/docs/install/source-install/compilation)。
+1. 确保环境已经能顺利编译Doris本体,可以参考[编译与部署](/docs/install/source-install/compilation-general)。
 
 2. 运行目录下的`run-be-ut.sh`
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #31918

<!--Describe your changes.-->
Modify link  '/docs/install/source-install/compilation' to '/docs/install/source-install/compilation-general'
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

