### PR TITLE
[fix](meta) fix NullPointerException error when forwarding cmd to master fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/ProxyMysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/ProxyMysqlChannel.java
@@ -26,6 +26,9 @@ import java.util.List;
  * An interceptor for proxy query, keeping all packets to be sent to master mysql channel.
  */
 public class ProxyMysqlChannel extends MysqlChannel {
+    public ProxyMysqlChannel() {
+        this.serializer = MysqlSerializer.newInstance();
+    }
 
     private final List<ByteBuffer> proxyResultBuffer = Lists.newArrayList();
 


### PR DESCRIPTION
```sql
Internal error processing forward
java.lang.reflect.UndeclaredThrowableException
        at com.sun.proxy.$Proxy37.forward(Unknown Source)
        at org.apache.doris.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:3132)
        at org.apache.doris.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:3112)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:59)
        ... 9 more
Caused by: java.lang.NullPointerException
        at org.apache.doris.qe.ConnectProcessor.getResultPacket(ConnectProcessor.java:629)
        at org.apache.doris.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:813)
        at org.apache.doris.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1096)
        ... 14 more
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

