### PR TITLE
[enhancement](util) print if using nereids planner when be coredump

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -54,6 +54,7 @@ namespace doris::signal {
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
 inline thread_local int64_t tablet_id = 0;
+inline thread_local bool is_nereids = false;
 
 namespace {
 
@@ -243,6 +244,9 @@ void DumpTimeInfo() {
     formatter.AppendUint64(query_id_hi, 16);
     formatter.AppendString("-");
     formatter.AppendUint64(query_id_lo, 16);
+    formatter.AppendString(" ***\n");
+    formatter.AppendString("*** is nereids: ");
+    formatter.AppendUint64(is_nereids, 10);
     formatter.AppendString(" ***\n");
     formatter.AppendString("*** tablet id: ");
     formatter.AppendUint64(tablet_id, 10);
@@ -434,6 +438,10 @@ inline void set_signal_task_id(PUniqueId tid) {
 inline void set_signal_task_id(TUniqueId tid) {
     query_id_hi = tid.hi;
     query_id_lo = tid.lo;
+}
+
+inline void set_signal_is_nereids(bool is_nereids_arg) {
+    is_nereids = is_nereids_arg;
 }
 
 inline void InstallFailureSignalHandler() {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -587,7 +587,7 @@ void FragmentMgr::remove_pipeline_context(
 
 template <typename Params>
 Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline,
-                                   std::shared_ptr<QueryContext>& query_ctx) {
+                                   bool nereids, std::shared_ptr<QueryContext>& query_ctx) {
     if (params.is_simplified_param) {
         // Get common components from _query_ctx_map
         std::lock_guard<std::mutex> lock(_lock);
@@ -611,8 +611,9 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
 
         // This may be a first fragment request of the query.
         // Create the query fragments context.
-        query_ctx = QueryContext::create_shared(query_id, params.fragment_num_on_host, _exec_env,
-                                                params.query_options, params.coord, pipeline);
+        query_ctx =
+                QueryContext::create_shared(query_id, params.fragment_num_on_host, _exec_env,
+                                            params.query_options, params.coord, pipeline, nereids);
         RETURN_IF_ERROR(DescriptorTbl::create(&(query_ctx->obj_pool), params.desc_tbl,
                                               &(query_ctx->desc_tbl)));
         // set file scan range params
@@ -687,8 +688,9 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
     std::shared_ptr<QueryContext> query_ctx;
     bool pipeline_engine_enabled = params.query_options.__isset.enable_pipeline_engine &&
                                    params.query_options.enable_pipeline_engine;
-    RETURN_IF_ERROR(
-            _get_query_ctx(params, params.params.query_id, pipeline_engine_enabled, query_ctx));
+
+    RETURN_IF_ERROR(_get_query_ctx(params, params.params.query_id, pipeline_engine_enabled,
+                                   params.is_nereids, query_ctx));
     {
         // Need lock here, because it will modify fragment ids and std::vector may resize and reallocate
         // memory, but query_is_canncelled will traverse the vector, it will core.
@@ -780,7 +782,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
              << apache::thrift::ThriftDebugString(params.query_options).c_str();
 
     std::shared_ptr<QueryContext> query_ctx;
-    RETURN_IF_ERROR(_get_query_ctx(params, params.query_id, true, query_ctx));
+    RETURN_IF_ERROR(_get_query_ctx(params, params.query_id, true, params.is_nereids, query_ctx));
 
     const bool enable_pipeline_x = params.query_options.__isset.enable_pipeline_x_engine &&
                                    params.query_options.enable_pipeline_x_engine;

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -178,7 +178,7 @@ private:
                                                     QueryContext* query_ctx);
 
     template <typename Params>
-    Status _get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline,
+    Status _get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline, bool is_nereids,
                           std::shared_ptr<QueryContext>& query_ctx);
 
     // This is input params

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -178,7 +178,7 @@ private:
                                                     QueryContext* query_ctx);
 
     template <typename Params>
-    Status _get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline, bool is_nereids,
+    Status _get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline,
                           std::shared_ptr<QueryContext>& query_ctx);
 
     // This is input params

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -38,12 +38,13 @@ public:
 
 QueryContext::QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* exec_env,
                            const TQueryOptions& query_options, TNetworkAddress coord_addr,
-                           bool is_pipeline)
+                           bool is_pipeline, bool is_nereids)
         : fragment_num(total_fragment_num),
           timeout_second(-1),
           _query_id(query_id),
           _exec_env(exec_env),
           _is_pipeline(is_pipeline),
+          _is_nereids(is_nereids),
           _query_options(query_options) {
     this->coord_addr = coord_addr;
     _start_time = VecDateTimeValue::local_time();

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -70,7 +70,8 @@ class QueryContext {
 
 public:
     QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* exec_env,
-                 const TQueryOptions& query_options, TNetworkAddress coord_addr, bool is_pipeline);
+                 const TQueryOptions& query_options, TNetworkAddress coord_addr, bool is_pipeline,
+                 bool is_nereids);
 
     ~QueryContext();
 
@@ -235,6 +236,8 @@ public:
         _merge_controller_handler = handler;
     }
 
+    bool is_nereids() const { return _is_nereids; }
+
     DescriptorTbl* desc_tbl = nullptr;
     bool set_rsc_info = false;
     std::string user;
@@ -269,6 +272,7 @@ private:
     VecDateTimeValue _start_time;
     int64_t _bytes_limit = 0;
     bool _is_pipeline = false;
+    bool _is_nereids = false;
 
     // A token used to submit olap scanner to the "_limited_scan_thread_pool",
     // This thread pool token is created from "_limited_scan_thread_pool" from exec env.

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -533,4 +533,8 @@ Status RuntimeState::register_consumer_runtime_filter(const doris::TRuntimeFilte
                                                                     consumer_filter, false, false);
     }
 }
+
+bool RuntimeState::is_nereids() const {
+    return _query_ctx->is_nereids();
+}
 } // end namespace doris

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -579,6 +579,7 @@ public:
     Status register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                             bool need_local_merge, int node_id,
                                             doris::IRuntimeFilter** producer_filter);
+    bool is_nereids() const;
 
 private:
     Status create_error_log_file();

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -33,6 +33,7 @@ AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
 AttachTask::AttachTask(RuntimeState* runtime_state) {
     ThreadLocalHandle::create_thread_local_if_not_exits();
     signal::set_signal_task_id(runtime_state->query_id());
+    signal::set_signal_is_nereids(runtime_state->is_nereids());
     thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
                                   runtime_state->query_mem_tracker());
 }


### PR DESCRIPTION
## Proposed changes

```
*** Query id: 9b6b7e6d2cab4374-b8a74b413939f0cb ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1709879366 (unix time) try "date -d @1709879366" if you are using GNU date ***
*** Current BE git commitID: dd08ec9dd7 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 2746553 (TID 2753310 OR 0x72aec33ad700) from PID 0; stack trace: ***
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

