### PR TITLE
[Opt](func) reduce the useless mem alloc and const opt the concat code

### DIFF
--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -206,12 +206,10 @@ Status FunctionLikeBase::constant_regex_fn_scalar(LikeSearchState* state, const 
 
 Status FunctionLikeBase::regexp_fn_scalar(LikeSearchState* state, const StringRef& val,
                                           const StringRef& pattern, unsigned char* result) {
-    std::string re_pattern(pattern.data, pattern.size);
-
     RE2::Options opts;
     opts.set_never_nl(false);
     opts.set_dot_nl(true);
-    re2::RE2 re(re_pattern, opts);
+    re2::RE2 re(re2::StringPiece(pattern.data, pattern.size), opts);
     if (re.ok()) {
         *result = RE2::PartialMatch(re2::StringPiece(val.data, val.size), re);
     } else {


### PR DESCRIPTION
## Proposed changes

select a like concat(b, "%");

Before : 2s
After: 1.8s

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

