### PR TITLE
[regression-test](test) remove dropping un-related table

### DIFF
--- a/regression-test/suites/nereids_rules_p0/grouping_sets/test_grouping_sets_combination.groovy
+++ b/regression-test/suites/nereids_rules_p0/grouping_sets/test_grouping_sets_combination.groovy
@@ -30,26 +30,6 @@ suite("test_grouping_sets_combination") {
         insert into mal_test1 values(2,1,3),(1,1,2),(3,5,6),(6,null,6),(4,5,6);
      """
 
-    sql "drop table if exists test_window_table2"
-
-    sql """
-        create table test_window_table2
-         (
-             a varchar(100) null,
-             b decimalv3(18,10) null,
-             c int,
-         ) ENGINE=OLAP
-         DUPLICATE KEY(a)
-         DISTRIBUTED BY HASH(a) BUCKETS 1
-         PROPERTIES (
-         "replication_allocation" = "tag.location.default: 1"
-         );
-    """
-
-    sql """
-        insert into test_window_table2 values("1", 1, 1),("1", 1, 2),("1", 2, 1),("1", 2, 2),("2", 11, 1),("2", 11, 2),("2", 12, 1),("2", 12, 2);
-    """
-
 
     sql """drop table if exists test_sql;"""
     sql """


### PR DESCRIPTION
## Proposed changes
"window_agg_grouping_sets " uses table test_window_table2, which sometimes dropped by test_grouping_sets_combination.groovy


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

