### PR TITLE
[fix](fe rest api) When the query plan contains Chinese characters, the query/profile API results in garbled text

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -109,7 +109,8 @@ public class HttpUtils {
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
         CloseableHttpClient client = HttpClientBuilder.create().build();
-        return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
+        return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity(), 
+				StandardCharsets.UTF_8));
     }
 
     static String parseResponse(String response) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #32016

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

