### PR TITLE
[statistic](cloud) Support force full analysis to sample

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2259,6 +2259,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int cpu_resource_limit_per_analyze_task = 1;
 
+    @ConfField(mutable = true)
+    public static boolean force_sample_analyze = false; // avoid full analyze for performance reason
+
     @ConfField(mutable = true, description = {
             "Export任务允许的最大分区数量",
             "The maximum number of partitions allowed by Export job"})

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
@@ -123,6 +123,10 @@ public class AnalyzeProperties {
         return Integer.parseInt(properties.get(PROPERTY_SAMPLE_ROWS));
     }
 
+    public void setSampleRows(long sampleRows) {
+        properties.put(PROPERTY_SAMPLE_ROWS, String.valueOf(sampleRows));
+    }
+
     public int getNumBuckets() {
         if (!properties.containsKey(PROPERTY_NUM_BUCKETS)) {
             return 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -144,6 +144,9 @@ public class AnalysisManager implements Writable {
         if (!StatisticsUtil.statsTblAvailable() && !FeConstants.runningUnitTest) {
             throw new DdlException("Stats table not available, please make sure your cluster status is normal");
         }
+        if (Config.force_sample_analyze) {
+            analyzeStmt.checkAndSetSample();
+        }
         if (analyzeStmt instanceof AnalyzeDBStmt) {
             createAnalysisJobs((AnalyzeDBStmt) analyzeStmt, proxy);
         } else if (analyzeStmt instanceof AnalyzeTblStmt) {


### PR DESCRIPTION
Full analysis may take a lot of time due to lack of file cache in cloud mode, which may lead to analysis timeout when we run regression test.

We can force sample analysis for the analysis statements such as `analyze table $table with sync` to get rid of analysis timeout.

fe.conf `force_sample_analyze = true;`, it is `false` by default

Co-authored-by: zhengyu <freeman.zhang1992@gmail.com>