### PR TITLE
[Fix](Outfiel) fix be core when the `open` method of `vfile_result_writer` failed

### DIFF
--- a/be/src/vec/sink/writer/vfile_result_writer.h
+++ b/be/src/vec/sink/writer/vfile_result_writer.h
@@ -60,7 +60,7 @@ public:
 
     Status write(Block& block) override;
 
-    Status close(Status s = Status::OK()) override;
+    Status close(Status exec_status) override;
 
     Status open(RuntimeState* state, RuntimeProfile* profile) override;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If the `open` method fails, we don't need to process things in the `close` method.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

