### PR TITLE
[fix](memory) Fix Allocator cancel pipelinex query

### DIFF
--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -25,12 +25,11 @@
 namespace doris {
 
 void ThreadMemTrackerMgr::attach_limiter_tracker(
-        const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
-        const TUniqueId& fragment_instance_id) {
+        const std::shared_ptr<MemTrackerLimiter>& mem_tracker, const TUniqueId& query_id) {
     DCHECK(mem_tracker);
     CHECK(init());
     flush_untracked_mem();
-    _fragment_instance_id = fragment_instance_id;
+    _query_id = query_id;
     _limiter_tracker = mem_tracker;
     _limiter_tracker_raw = mem_tracker.get();
     _wait_gc = true;
@@ -40,15 +39,15 @@ void ThreadMemTrackerMgr::detach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& old_mem_tracker) {
     CHECK(init());
     flush_untracked_mem();
-    _fragment_instance_id = TUniqueId();
+    _query_id = TUniqueId();
     _limiter_tracker = old_mem_tracker;
     _limiter_tracker_raw = old_mem_tracker.get();
     _wait_gc = false;
 }
 
-void ThreadMemTrackerMgr::cancel_instance(const std::string& exceed_msg) {
-    ExecEnv::GetInstance()->fragment_mgr()->cancel_instance(
-            _fragment_instance_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, exceed_msg);
+void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {
+    ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
+            _query_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, exceed_msg);
 }
 
 } // namespace doris

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -24,18 +24,17 @@ namespace doris {
 class MemTracker;
 
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
-                       const TUniqueId& task_id, const TUniqueId& fragment_instance_id) {
+                       const TUniqueId& task_id) {
     ThreadLocalHandle::create_thread_local_if_not_exits();
     signal::set_signal_task_id(task_id);
-    thread_context()->attach_task(task_id, fragment_instance_id, mem_tracker);
+    thread_context()->attach_task(task_id, mem_tracker);
 }
 
 AttachTask::AttachTask(RuntimeState* runtime_state) {
     ThreadLocalHandle::create_thread_local_if_not_exits();
     signal::set_signal_task_id(runtime_state->query_id());
     signal::set_signal_is_nereids(runtime_state->is_nereids());
-    thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
-                                  runtime_state->query_mem_tracker());
+    thread_context()->attach_task(runtime_state->query_id(), runtime_state->query_mem_tracker());
 }
 
 AttachTask::~AttachTask() {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -110,7 +110,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::sys_memory_check(size_t 
                             "Query:{} canceled asyn, after waiting for memory {}ms, {}.",
                             print_id(doris::thread_context()->task_id()), wait_milliseconds,
                             err_msg);
-                    doris::thread_context()->thread_mem_tracker_mgr->cancel_instance(err_msg);
+                    doris::thread_context()->thread_mem_tracker_mgr->cancel_query(err_msg);
                 } else {
                     LOG(INFO) << fmt::format(
                             "Query:{} throw exception, after waiting for memory {}ms, {}.",
@@ -148,7 +148,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::memory_tracker_check(siz
             if (!doris::enable_thread_catch_bad_alloc) {
                 LOG(INFO) << fmt::format("query/load:{} canceled asyn, {}.",
                                          print_id(doris::thread_context()->task_id()), err_msg);
-                doris::thread_context()->thread_mem_tracker_mgr->cancel_instance(err_msg);
+                doris::thread_context()->thread_mem_tracker_mgr->cancel_query(err_msg);
             } else {
                 LOG(INFO) << fmt::format("query/load:{} throw exception, {}.",
                                          print_id(doris::thread_context()->task_id()), err_msg);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -425,7 +425,7 @@ Status VDataStreamRecvr::create_merger(const VExprContextSPtrs& ordering_expr,
 
 Status VDataStreamRecvr::add_block(const PBlock& pblock, int sender_id, int be_number,
                                    int64_t packet_seq, ::google::protobuf::Closure** done) {
-    SCOPED_ATTACH_TASK_WITH_ID(_query_mem_tracker, _query_id, _fragment_instance_id);
+    SCOPED_ATTACH_TASK_WITH_ID(_query_mem_tracker, _query_id);
     int use_sender_id = _is_merging ? sender_id : 0;
     return _sender_queues[use_sender_id]->add_block(pblock, be_number, packet_seq, done);
 }


### PR DESCRIPTION
## Proposed changes

When memory exceed limit, Allocator cancel query instead of cancel fragment instance,
because pipelinex not have instance.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

