### PR TITLE
[fix](pipelineX) _local_channel_dependency is null in non pipelineX

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -487,7 +487,7 @@ void VDataStreamRecvr::cancel_stream(Status exec_status) {
 
 void VDataStreamRecvr::SenderQueue::update_blocks_memory_usage(int64_t size) {
     _recvr->update_blocks_memory_usage(size);
-    if (_recvr->exceeds_limit(0)) {
+    if (_local_channel_dependency && _recvr->exceeds_limit(0)) {
         _local_channel_dependency->block();
     }
 }


### PR DESCRIPTION
## Proposed changes

odd pr test https://github.com/apache/doris/pull/32055

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

