### PR TITLE
[fix](hive) fix spelling mistakes for "separatorChar" for 2.0

### DIFF
--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_table.hql
@@ -1803,6 +1803,6 @@ create table employee_gz(name string,salary string)
 row format serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
 with serdeproperties 
 ('quoteChar'='\"'
-,'seperatorChar'=',');
+,'separatorChar'=',');
 
 insert into employee_gz values ('a', '1.1'), ('b', '2.2');

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
@@ -78,7 +78,7 @@ public class HiveScanNode extends FileQueryScanNode {
     public static final String DEFAULT_FIELD_DELIMITER = "\1"; // "\x01"
     public static final String PROP_LINE_DELIMITER = "line.delim";
     public static final String DEFAULT_LINE_DELIMITER = "\n";
-    public static final String PROP_SEPERATOR_CHAR = "seperatorChar";
+    public static final String PROP_SEPARATOR_CHAR = "separatorChar";
     public static final String PROP_QUOTA_CHAR = "quoteChar";
 
 
@@ -369,8 +369,8 @@ public class HiveScanNode extends FileQueryScanNode {
         java.util.Map<String, String> delimiter = hmsTable.getRemoteTable().getSd().getSerdeInfo().getParameters();
         if (delimiter.containsKey(PROP_FIELD_DELIMITER)) {
             textParams.setColumnSeparator(delimiter.get(PROP_FIELD_DELIMITER));
-        } else if (delimiter.containsKey(PROP_SEPERATOR_CHAR)) {
-            textParams.setColumnSeparator(delimiter.get(PROP_SEPERATOR_CHAR));
+        } else if (delimiter.containsKey(PROP_SEPARATOR_CHAR)) {
+            textParams.setColumnSeparator(delimiter.get(PROP_SEPARATOR_CHAR));
         } else {
             textParams.setColumnSeparator(DEFAULT_FIELD_DELIMITER);
         }


### PR DESCRIPTION
## Proposed changes

mirror: #32061

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

