### PR TITLE
[enhancement](Nereids) Optimize expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlots.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlots.java
@@ -66,7 +66,7 @@ public class FillUpMissingSlots implements AnalysisRuleFactory {
                                 .flatMap(Set::stream)
                                 .filter(s -> !projectOutputSet.contains(s))
                                 .collect(Collectors.toSet());
-                        if (notExistedInProject.size() == 0) {
+                        if (notExistedInProject.isEmpty()) {
                             return null;
                         }
                         List<NamedExpression> projects = ImmutableList.<NamedExpression>builder()
@@ -128,7 +128,7 @@ public class FillUpMissingSlots implements AnalysisRuleFactory {
                                 .flatMap(Set::stream)
                                 .filter(s -> !childOutput.contains(s))
                                 .collect(Collectors.toSet());
-                        if (notExistedInProject.size() == 0) {
+                        if (notExistedInProject.isEmpty()) {
                             return null;
                         }
                         LogicalProject<?> project = sort.child().child();
@@ -165,7 +165,7 @@ public class FillUpMissingSlots implements AnalysisRuleFactory {
                                 .flatMap(Set::stream)
                                 .filter(s -> !projectOutputSet.contains(s))
                                 .collect(Collectors.toSet());
-                        if (notExistedInProject.size() == 0) {
+                        if (notExistedInProject.isEmpty()) {
                             return null;
                         }
                         List<NamedExpression> projects = ImmutableList.<NamedExpression>builder()
@@ -189,7 +189,7 @@ public class FillUpMissingSlots implements AnalysisRuleFactory {
             outputExpressions = aggregate.getOutputExpressions();
             groupByExpressions = aggregate.getGroupByExpressions();
             outputSubstitutionMap = outputExpressions.stream().filter(Alias.class::isInstance)
-                    .collect(Collectors.toMap(alias -> alias.toSlot(), alias -> alias.child(0),
+                    .collect(Collectors.toMap(NamedExpression::toSlot, alias -> alias.child(0),
                             (k1, k2) -> k1));
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
@@ -37,12 +37,11 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
-import org.apache.doris.nereids.util.PlanUtils;
+import org.apache.doris.nereids.util.PlanUtils.CollectNonWindowedAggFuncs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import java.util.HashSet;
@@ -144,8 +143,7 @@ public class NormalizeAggregate implements RewriteRuleFactory, NormalizeToSlot {
 
         // collect all trival-agg
         List<NamedExpression> aggregateOutput = aggregate.getOutputExpressions();
-        List<AggregateFunction> aggFuncs = Lists.newArrayList();
-        aggregateOutput.forEach(o -> o.accept(PlanUtils.CollectNonWindowedAggFuncs.INSTANCE, aggFuncs));
+        List<AggregateFunction> aggFuncs = CollectNonWindowedAggFuncs.collect(aggregateOutput);
 
         // split non-distinct agg child as two part
         // TRUE part 1: need push down itself, if it contains subqury or window expression

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
@@ -39,11 +39,10 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
 import org.apache.doris.nereids.util.ExpressionUtils;
-import org.apache.doris.nereids.util.PlanUtils;
+import org.apache.doris.nereids.util.PlanUtils.CollectNonWindowedAggFuncs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
@@ -174,9 +173,7 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
                 .flatMap(function -> function.getArguments().stream())
                 .collect(ImmutableSet.toImmutableSet());
 
-        List<AggregateFunction> aggregateFunctions = Lists.newArrayList();
-        repeat.getOutputExpressions().forEach(
-                o -> o.accept(PlanUtils.CollectNonWindowedAggFuncs.INSTANCE, aggregateFunctions));
+        List<AggregateFunction> aggregateFunctions = CollectNonWindowedAggFuncs.collect(repeat.getOutputExpressions());
 
         ImmutableSet<Expression> argumentsOfAggregateFunction = aggregateFunctions.stream()
                 .flatMap(function -> function.getArguments().stream().map(arg -> {
@@ -271,9 +268,8 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
             @NotNull LogicalAggregate<Plan> aggregate) {
         LogicalRepeat<Plan> repeat = (LogicalRepeat<Plan>) aggregate.child();
 
-        List<AggregateFunction> aggregateFunctions = Lists.newArrayList();
-        aggregate.getOutputExpressions().forEach(
-                o -> o.accept(PlanUtils.CollectNonWindowedAggFuncs.INSTANCE, aggregateFunctions));
+        List<AggregateFunction> aggregateFunctions =
+                CollectNonWindowedAggFuncs.collect(aggregate.getOutputExpressions());
         Set<Slot> aggUsedSlots = aggregateFunctions.stream()
                 .flatMap(e -> e.<Set<SlotReference>>collect(SlotReference.class::isInstance).stream())
                 .collect(ImmutableSet.toImmutableSet());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/TreeNode.java
@@ -144,9 +144,7 @@ public interface TreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>> {
         boolean changed = false;
         for (NODE_TYPE child : children()) {
             NODE_TYPE newChild = child.rewriteUp(rewriteFunction);
-            if (child != newChild) {
-                changed = true;
-            }
+            changed |= child != newChild;
             newChildren.add(newChild);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -121,7 +121,7 @@ public class Alias extends NamedExpression implements UnaryExpression {
 
     @Override
     public String toSql() {
-        return child().toSql() + " AS `" + name + "`";
+        return child().toSql() + " AS `" + name.get() + "`";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Any.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Any.java
@@ -74,4 +74,8 @@ public class Any extends Expression implements LeafExpression {
     public boolean deepEquals(TreeNode<?> that) {
         return true;
     }
+
+    protected boolean supportCompareWidthAndDepth() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
@@ -147,7 +147,7 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
 
         @Override
         public ArrayItemSlot withExprId(ExprId exprId) {
-            return new ArrayItemSlot(exprId, name, dataType, nullable);
+            return new ArrayItemSlot(exprId, name.get(), dataType, nullable);
         }
 
         @Override
@@ -157,7 +157,7 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
 
         @Override
         public SlotReference withNullable(boolean newNullable) {
-            return new ArrayItemSlot(exprId, name, dataType, nullable);
+            return new ArrayItemSlot(exprId, name.get(), dataType, nullable);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryOperator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryOperator.java
@@ -68,16 +68,4 @@ public abstract class BinaryOperator extends Expression implements BinaryExpress
     public int hashCode() {
         return Objects.hash(symbol, left(), right());
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        BinaryOperator other = (BinaryOperator) o;
-        return Objects.equals(left(), other.left()) && Objects.equals(right(), other.right());
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -47,7 +47,6 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -336,7 +335,25 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
             return false;
         }
         Expression that = (Expression) o;
-        return Objects.equals(children(), that.children());
+        if (this.width != that.width || this.depth != that.depth || arity() != that.arity() || !extraEquals(that)) {
+            return false;
+        }
+        return equalsChildren(that);
+    }
+
+    protected boolean equalsChildren(Expression that) {
+        List<Expression> children = children();
+        List<Expression> thatChildren = that.children();
+        for (int i = 0; i < children.size(); i++) {
+            if (!children.get(i).equals(thatChildren.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean extraEquals(Expression that) {
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
@@ -71,7 +71,7 @@ public class MarkJoinSlotReference extends SlotReference {
 
     @Override
     public MarkJoinSlotReference withExprId(ExprId exprId) {
-        return new MarkJoinSlotReference(exprId, name, existsHasAgg);
+        return new MarkJoinSlotReference(exprId, name.get(), existsHasAgg);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -201,7 +201,7 @@ public class SlotReference extends Slot {
         if (qualifier.isEmpty()) {
             return name.get();
         } else {
-            return qualifier.get(qualifier.size() - 1) + "." + name;
+            return qualifier.get(qualifier.size() - 1) + "." + name.get();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
@@ -124,13 +124,13 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
         if (this.nullable == newNullable) {
             return this;
         }
-        return new VirtualSlotReference(exprId, name, dataType, newNullable, qualifier,
+        return new VirtualSlotReference(exprId, name.get(), dataType, newNullable, qualifier,
                 originExpression, computeLongValueMethod);
     }
 
     @Override
     public VirtualSlotReference withQualifier(List<String> qualifier) {
-        return new VirtualSlotReference(exprId, name, dataType, nullable, qualifier,
+        return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
                 originExpression, computeLongValueMethod);
     }
 
@@ -142,7 +142,7 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
 
     @Override
     public VirtualSlotReference withExprId(ExprId exprId) {
-        return new VirtualSlotReference(exprId, name, dataType, nullable, qualifier,
+        return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
                 originExpression, computeLongValueMethod);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WhenClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WhenClause.java
@@ -90,21 +90,6 @@ public class WhenClause extends Expression implements BinaryExpression, ExpectsI
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        WhenClause other = (WhenClause) o;
-        return Objects.equals(left(), other.left()) && Objects.equals(right(), other.right());
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(left(), right());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
@@ -131,7 +131,7 @@ public class WindowExpression extends Expression {
 
     @Override
     public WindowExpression withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() >= 1);
+        Preconditions.checkArgument(!children.isEmpty());
         int index = 0;
         Expression func = children.get(index);
         index += 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BoundFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BoundFunction.java
@@ -85,11 +85,16 @@ public abstract class BoundFunction extends Function implements ComputeSignature
 
     @Override
     public String toSql() throws UnboundException {
-        String args = children()
-                .stream()
-                .map(Expression::toSql)
-                .collect(Collectors.joining(", "));
-        return name + "(" + args + ")";
+        StringBuilder sql = new StringBuilder(name).append("(");
+        int arity = arity();
+        for (int i = 0; i < arity; i++) {
+            Expression arg = child(i);
+            sql.append(arg.toSql());
+            if (i + 1 < arity) {
+                sql.append(", ");
+            }
+        }
+        return sql.append(")").toString();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BoundFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BoundFunction.java
@@ -74,15 +74,8 @@ public abstract class BoundFunction extends Function implements ComputeSignature
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        BoundFunction that = (BoundFunction) o;
-        return Objects.equals(name, that.name) && Objects.equals(children, that.children);
+    protected boolean extraEquals(Expression that) {
+        return Objects.equals(name, ((BoundFunction) that).name);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -75,8 +75,8 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
         this.type = Objects.requireNonNull(type, "type can not be null");
         this.groupExpression = Objects.requireNonNull(groupExpression, "groupExpression can not be null");
         Objects.requireNonNull(optLogicalProperties, "logicalProperties can not be null");
-        this.logicalPropertiesSupplier = Suppliers.memoize(() -> optLogicalProperties.orElseGet(
-                this::computeLogicalProperties));
+        this.logicalPropertiesSupplier = Suppliers.memoize(() ->
+                optLogicalProperties.orElseGet(this::computeLogicalProperties));
         this.statistics = statistics;
         this.id = StatementScopeIdGenerator.newObjectId();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -166,8 +166,14 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
 
     @Override
     public LogicalProperties computeLogicalProperties() {
-        boolean hasUnboundChild = children.stream()
-                .anyMatch(child -> !child.bound());
+        boolean hasUnboundChild = false;
+        for (Plan child : children) {
+            if (!child.bound()) {
+                hasUnboundChild = true;
+                break;
+            }
+        }
+
         if (hasUnboundChild || hasUnboundExpression()) {
             return UnboundLogicalProperties.INSTANCE;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -61,8 +61,14 @@ public interface Plan extends TreeNode<Plan> {
         return !(getLogicalProperties() instanceof UnboundLogicalProperties);
     }
 
+    /** hasUnboundExpression */
     default boolean hasUnboundExpression() {
-        return getExpressions().stream().anyMatch(Expression::hasUnbound);
+        for (Expression expression : getExpressions()) {
+            if (expression.hasUnbound()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     default boolean containsSlots(ImmutableSet<Slot> slots) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -645,9 +645,11 @@ public class ExpressionUtils {
 
     public static <E> Set<E> mutableCollect(List<? extends Expression> expressions,
             Predicate<TreeNode<Expression>> predicate) {
-        return expressions.stream()
-                .flatMap(expr -> expr.<Set<E>>collect(predicate).stream())
-                .collect(Collectors.toSet());
+        Set<E> set = new HashSet<>();
+        for (Expression expr : expressions) {
+            set.addAll(expr.collect(predicate));
+        }
+        return set;
     }
 
     public static <E> List<E> collectAll(Collection<? extends Expression> expressions,
@@ -717,9 +719,11 @@ public class ExpressionUtils {
      * Get input slot set from list of expressions.
      */
     public static Set<Slot> getInputSlotSet(Collection<? extends Expression> exprs) {
-        return exprs.stream()
-                .flatMap(expr -> expr.getInputSlots().stream())
-                .collect(ImmutableSet.toImmutableSet());
+        Set<Slot> set = new HashSet<>();
+        for (Expression expr : exprs) {
+            set.addAll(expr.getInputSlots());
+        }
+        return set;
     }
 
     public static boolean checkTypeSkipCast(Expression expression, Class<? extends Expression> cls) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
-import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
@@ -152,7 +151,7 @@ public class PlanUtils {
     /**
      * collect non_window_agg_func
      */
-    public static class CollectNonWindowedAggFuncs extends DefaultExpressionVisitor<Void, List<AggregateFunction>> {
+    public static class CollectNonWindowedAggFuncs {
         public static List<AggregateFunction> collect(Collection<? extends Expression> expressions) {
             List<AggregateFunction> aggFunctions = Lists.newArrayList();
             for (Expression expression : expressions) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
@@ -529,7 +529,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         Alias minXX = new Alias(new ExprId(5), new Min(xx.toSlot()), "min(xx)");
         PlanChecker.from(connectContext).analyze(sql).printlnTree().matches(logicalProject(
                 logicalSort(logicalProject(logicalAggregate(logicalProject(logicalOlapScan())
-                        .when(FieldChecker.check("projects", Lists.newArrayList(xx, a2, a1))))))
+                        .when(FieldChecker.check("projects", Lists.newArrayList(xx, a1, a2))))))
                                 .when(FieldChecker.check("orderKeys",
                                         ImmutableList
                                                 .of(new OrderKey(minXX.toSlot(), true, true)))))


### PR DESCRIPTION
## Proposed changes

1. optimize expression comparison by
  a) flatter method call stack
  b) short circuit: if some simple field not equals, then return, and not compare to the big field, like `Alias.name`
2. lazy compute `Alias.name` which is computed by `toSql`. Now `Alias.toSlot()` will not generate long name immediately
3. cache `Expresssion.inputSlots`, it can save time when invoke this method multiple times
4.  always compute `Expression.unbound`, it can avoid traverse the big expression tree

this pr can save about 200ms when submit some long sqls