### PR TITLE
[Fix](group commit) Do not forward to master when enable group commit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -373,6 +373,11 @@ public class StmtExecutor {
             return false;
         }
 
+        // group commit doesn't need to forward to master
+        if (context.getSessionVariable().isEnableInsertGroupCommit()) {
+            return false;
+        }
+
         // this is a query stmt, but this non-master FE can not read, forward it to master
         if (isQuery() && !Env.getCurrentEnv().isMaster()
                 && (!Env.getCurrentEnv().canRead() || debugForwardAllQueries())) {


### PR DESCRIPTION
Problem: With group commit enabled, connecting to a non-master node and inserting data through subqueries like 'insert into test select 6;' results in the data being inserted in regular insert mode rather than group commit mode.

Reason: An insert into statement with a subquery is forwarded to the master node, and group commit, being a session variable, is not forwarded during this process. This results in the final insert being in the normal insert into mode.

Solution: Make the group commit setting a forwardable variable.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

