### PR TITLE
[enhance](Cooldown) Skip cooldown if the tablet is dropped

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -214,6 +214,10 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
             VLOG_NOTICE << "tablet " << tablet_id << " is not cooldown replica";
             return;
         }
+        if (tablet->tablet_state() == TABLET_SHUTDOWN) [[unlikely]] {
+            LOG_INFO("tablet {} has been dropped, don't do cooldown", tablet_id);
+            return;
+        }
     }
     {
         // one tablet could at most have one cooldown task to be done


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Formerly the cooldown meta write task would continue doing no matter the tablet is dropped or not. It serves well under most circumstances, while it would end up with endless retrying if the corresponding storage policy is dropped neither. Which means the logic would be as follows:
```
1. Try to write cooldown meta
2. get the fs using the storage policy
3. can't not get the storage policy since it's dropped
4. repeat 1
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

