### PR TITLE
[fix](memory) Fix LRU cache deleter and memory tracking

### DIFF
--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -179,8 +179,8 @@ Result<std::shared_ptr<CloudTablet>> CloudTabletMgr::get_tablet(int64_t tablet_i
                 return nullptr;
             }
 
-            auto* handle = _cache->insert(key, value.release(), 1, CachePriority::NORMAL,
-                                          sizeof(CloudTablet));
+            auto* handle = _cache->insert(key, value.release(), 1, sizeof(CloudTablet),
+                                          CachePriority::NORMAL);
             auto ret = std::shared_ptr<CloudTablet>(
                     tablet.get(), [this, handle](...) { _cache->release(handle); });
             _tablet_map->put(std::move(tablet));

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -148,7 +148,9 @@ Result<std::shared_ptr<CloudTablet>> CloudTabletMgr::get_tablet(int64_t tablet_i
     class Value : public LRUCacheValueBase {
     public:
         Value(const std::shared_ptr<CloudTablet>& tablet, TabletMap& tablet_map)
-                : tablet(tablet), tablet_map(tablet_map) {}
+                : LRUCacheValueBase(CachePolicy::CacheType::CLOUD_TABLET_CACHE),
+                  tablet(tablet),
+                  tablet_map(tablet_map) {}
         ~Value() override { tablet_map.erase(tablet.get()); }
 
         // FIXME(plat1ko): The ownership of tablet seems to belong to 'TabletMap', while `Value`

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -69,17 +69,16 @@ Status CloudTxnDeleteBitmapCache::get_tablet_txn_info(
     }
     std::string key_str = fmt::format("{}/{}", transaction_id, tablet_id);
     CacheKey key(key_str);
-    Cache::Handle* handle = cache()->lookup(key);
+    Cache::Handle* handle = lookup(key);
 
     DeleteBitmapCacheValue* val =
-            handle == nullptr ? nullptr
-                              : reinterpret_cast<DeleteBitmapCacheValue*>(cache()->value(handle));
+            handle == nullptr ? nullptr : reinterpret_cast<DeleteBitmapCacheValue*>(value(handle));
     if (val) {
         *delete_bitmap = val->delete_bitmap;
         *rowset_ids = val->rowset_ids;
         // must call release handle to reduce the reference count,
         // otherwise there will be memory leak
-        cache()->release(handle);
+        release(handle);
     } else {
         LOG_INFO("cache missed when get delete bitmap")
                 .tag("txn_id", transaction_id)
@@ -111,17 +110,14 @@ void CloudTxnDeleteBitmapCache::set_tablet_txn_info(
     CacheKey key(key_str);
 
     auto val = new DeleteBitmapCacheValue(delete_bitmap, rowset_ids);
-    auto deleter = [](const CacheKey&, void* value) {
-        delete (DeleteBitmapCacheValue*)value; // Just delete to reclaim
-    };
     size_t charge = sizeof(DeleteBitmapCacheValue);
     for (auto& [k, v] : val->delete_bitmap->delete_bitmap) {
         charge += v.getSizeInBytes();
     }
-    auto handle = cache()->insert(key, val, charge, deleter, CachePriority::NORMAL);
+    auto* handle = insert(key, val, charge, CachePriority::NORMAL);
     // must call release handle to reduce the reference count,
     // otherwise there will be memory leak
-    cache()->release(handle);
+    release(handle);
     LOG_INFO("set txn related delete bitmap")
             .tag("txn_id", transaction_id)
             .tag("expiration", txn_expiration)
@@ -137,17 +133,14 @@ void CloudTxnDeleteBitmapCache::update_tablet_txn_info(TTransactionId transactio
     CacheKey key(key_str);
 
     auto val = new DeleteBitmapCacheValue(delete_bitmap, rowset_ids);
-    auto deleter = [](const CacheKey&, void* value) {
-        delete (DeleteBitmapCacheValue*)value; // Just delete to reclaim
-    };
     size_t charge = sizeof(DeleteBitmapCacheValue);
     for (auto& [k, v] : val->delete_bitmap->delete_bitmap) {
         charge += v.getSizeInBytes();
     }
-    auto handle = cache()->insert(key, val, charge, deleter, CachePriority::NORMAL);
+    auto* handle = insert(key, val, charge, CachePriority::NORMAL);
     // must call release handle to reduce the reference count,
     // otherwise there will be memory leak
-    cache()->release(handle);
+    release(handle);
     LOG_INFO("update txn related delete bitmap")
             .tag("txn_id", transaction_id)
             .tag("tablt_id", tablet_id)
@@ -174,7 +167,7 @@ void CloudTxnDeleteBitmapCache::remove_expired_tablet_txn_info() {
             std::string key_str = std::to_string(txn_iter->first.txn_id) + "/" +
                                   std::to_string(txn_iter->first.tablet_id); // Cache key container
             CacheKey cache_key(key_str);
-            cache()->erase(cache_key);
+            erase(cache_key);
             _txn_map.erase(iter->second);
         }
         _expiration_txn.erase(iter);

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -114,7 +114,7 @@ void CloudTxnDeleteBitmapCache::set_tablet_txn_info(
     for (auto& [k, v] : val->delete_bitmap->delete_bitmap) {
         charge += v.getSizeInBytes();
     }
-    auto* handle = insert(key, val, charge, CachePriority::NORMAL);
+    auto* handle = insert(key, val, charge, charge, CachePriority::NORMAL);
     // must call release handle to reduce the reference count,
     // otherwise there will be memory leak
     release(handle);
@@ -137,7 +137,7 @@ void CloudTxnDeleteBitmapCache::update_tablet_txn_info(TTransactionId transactio
     for (auto& [k, v] : val->delete_bitmap->delete_bitmap) {
         charge += v.getSizeInBytes();
     }
-    auto* handle = insert(key, val, charge, CachePriority::NORMAL);
+    auto* handle = insert(key, val, charge, charge, CachePriority::NORMAL);
     // must call release handle to reduce the reference count,
     // otherwise there will be memory leak
     release(handle);

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.h
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.h
@@ -56,7 +56,8 @@ public:
 private:
     void _clean_thread_callback();
 
-    struct DeleteBitmapCacheValue {
+    class DeleteBitmapCacheValue : public LRUCacheValueBase {
+    public:
         DeleteBitmapPtr delete_bitmap;
         // records rowsets calc in commit txn
         RowsetIdUnorderedSet rowset_ids;

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.h
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.h
@@ -63,7 +63,9 @@ private:
         RowsetIdUnorderedSet rowset_ids;
 
         DeleteBitmapCacheValue(DeleteBitmapPtr delete_bitmap_, const RowsetIdUnorderedSet& ids_)
-                : delete_bitmap(std::move(delete_bitmap_)), rowset_ids(ids_) {}
+                : LRUCacheValueBase(CachePolicy::CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE),
+                  delete_bitmap(std::move(delete_bitmap_)),
+                  rowset_ids(ids_) {}
     };
 
     struct TxnKey {

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -603,11 +603,6 @@ void* ShardedLRUCache::value(Handle* handle) {
     return reinterpret_cast<LRUHandle*>(handle)->value;
 }
 
-Slice ShardedLRUCache::value_slice(Handle* handle) {
-    auto* lru_handle = reinterpret_cast<LRUHandle*>(handle);
-    return Slice((char*)lru_handle->value, lru_handle->charge);
-}
-
 uint64_t ShardedLRUCache::new_id() {
     return _last_id.fetch_add(1, std::memory_order_relaxed);
 }
@@ -686,11 +681,6 @@ void DummyLRUCache::release(Cache::Handle* handle) {
 
 void* DummyLRUCache::value(Handle* handle) {
     return reinterpret_cast<LRUHandle*>(handle)->value;
-}
-
-Slice DummyLRUCache::value_slice(Handle* handle) {
-    auto* lru_handle = reinterpret_cast<LRUHandle*>(handle);
-    return Slice((char*)lru_handle->value, lru_handle->charge);
 }
 
 } // namespace doris

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "gutil/bits.h"
-#include "runtime/thread_context.h"
 #include "util/doris_metrics.h"
 #include "util/time.h"
 
@@ -350,34 +349,23 @@ bool LRUCache::_check_element_count_limit() {
 }
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
-                                void (*deleter)(const CacheKey& key, void* value),
-                                MemTrackerLimiter* tracker, CachePriority priority, size_t bytes) {
+                                CachePriority priority) {
     size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
-    LRUHandle* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
+    auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
     e->value = value;
-    e->deleter = deleter;
     e->charge = charge;
     e->key_length = key.size();
     // if LRUCacheType::NUMBER, charge not add handle_size,
     // because charge at this time is no longer the memory size, but an weight.
     e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : charge);
-    DCHECK(_type == LRUCacheType::SIZE || bytes != -1) << " _type " << _type;
-    // if LRUCacheType::NUMBER and bytes equals 0, such as some caches cannot accurately track memory size.
-    // cache mem tracker value divided by handle_size(106) will get the number of cache entries.
-    e->bytes = (_type == LRUCacheType::SIZE ? handle_size + charge : handle_size + bytes);
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.
     e->next = e->prev = nullptr;
     e->in_cache = true;
     e->priority = priority;
-    e->mem_tracker = tracker;
     e->type = _type;
     memcpy(e->key_data, key.data(), key.size());
     e->last_visit_time = UnixMillis();
-    // The memory of the parameter value should be recorded in the tls mem tracker,
-    // transfer the memory ownership of the value to ShardedLRUCache::_mem_tracker.
-    THREAD_MEM_TRACKER_TRANSFER_TO(e->bytes, tracker);
-    DorisMetrics::instance()->lru_cache_memory_bytes->increment(e->bytes);
     LRUHandle* to_remove_head = nullptr;
     {
         std::lock_guard l(_mutex);
@@ -464,7 +452,7 @@ PrunedInfo LRUCache::prune() {
     int64_t pruned_size = 0;
     while (to_remove_head != nullptr) {
         ++pruned_count;
-        pruned_size += to_remove_head->bytes;
+        pruned_size += to_remove_head->total_size;
         LRUHandle* next = to_remove_head->next;
         to_remove_head->free();
         to_remove_head = next;
@@ -506,7 +494,7 @@ PrunedInfo LRUCache::prune_if(CachePrunePredicate pred, bool lazy_mode) {
     int64_t pruned_size = 0;
     while (to_remove_head != nullptr) {
         ++pruned_count;
-        pruned_size += to_remove_head->bytes;
+        pruned_size += to_remove_head->total_size;
         LRUHandle* next = to_remove_head->next;
         to_remove_head->free();
         to_remove_head = next;
@@ -534,9 +522,6 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
           _shards(nullptr),
           _last_id(1),
           _total_capacity(total_capacity) {
-    _mem_tracker = std::make_unique<MemTrackerLimiter>(
-            MemTrackerLimiter::Type::GLOBAL,
-            fmt::format("{}[{}]", name, lru_cache_type_string(type)));
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;
@@ -594,11 +579,9 @@ ShardedLRUCache::~ShardedLRUCache() {
 }
 
 Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t charge,
-                                       void (*deleter)(const CacheKey& key, void* value),
-                                       CachePriority priority, size_t bytes) {
+                                       CachePriority priority) {
     const uint32_t hash = _hash_slice(key);
-    return _shards[_shard(hash)]->insert(key, hash, value, charge, deleter, _mem_tracker.get(),
-                                         priority, bytes);
+    return _shards[_shard(hash)]->insert(key, hash, value, charge, priority);
 }
 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
@@ -621,7 +604,7 @@ void* ShardedLRUCache::value(Handle* handle) {
 }
 
 Slice ShardedLRUCache::value_slice(Handle* handle) {
-    auto lru_handle = reinterpret_cast<LRUHandle*>(handle);
+    auto* lru_handle = reinterpret_cast<LRUHandle*>(handle);
     return Slice((char*)lru_handle->value, lru_handle->charge);
 }
 
@@ -647,10 +630,6 @@ PrunedInfo ShardedLRUCache::prune_if(CachePrunePredicate pred, bool lazy_mode) {
         pruned_info.pruned_size += info.pruned_size;
     }
     return pruned_info;
-}
-
-int64_t ShardedLRUCache::mem_consumption() {
-    return _mem_tracker->consumption();
 }
 
 int64_t ShardedLRUCache::get_usage() {
@@ -683,16 +662,13 @@ void ShardedLRUCache::update_cache_metrics() const {
 }
 
 Cache::Handle* DummyLRUCache::insert(const CacheKey& key, void* value, size_t charge,
-                                     void (*deleter)(const CacheKey& key, void* value),
-                                     CachePriority priority, size_t bytes) {
+                                     CachePriority priority) {
     size_t handle_size = sizeof(LRUHandle);
     auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
     e->value = value;
-    e->deleter = deleter;
     e->charge = charge;
     e->key_length = 0;
     e->total_size = 0;
-    e->bytes = 0;
     e->hash = 0;
     e->refs = 1; // only one for the returned handle
     e->next = e->prev = nullptr;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -23,7 +23,6 @@
 #include "runtime/memory/lru_cache_value_base.h"
 #include "util/doris_metrics.h"
 #include "util/metrics.h"
-#include "util/slice.h"
 
 namespace doris {
 
@@ -201,10 +200,6 @@ public:
     // REQUIRES: handle must not have been released yet.
     // REQUIRES: handle must have been returned by a method on *this.
     virtual void* value(Handle* handle) = 0;
-
-    // Return the value in Slice format encapsulated in the given handle
-    // returned by a successful lookup()
-    virtual Slice value_slice(Handle* handle) = 0;
 
     // If the cache contains entry for key, erase it.  Note that the
     // underlying entry will be kept around until all existing handles
@@ -403,7 +398,6 @@ public:
     virtual void release(Handle* handle) override;
     virtual void erase(const CacheKey& key) override;
     virtual void* value(Handle* handle) override;
-    Slice value_slice(Handle* handle) override;
     virtual uint64_t new_id() override;
     PrunedInfo prune() override;
     PrunedInfo prune_if(CachePrunePredicate pred, bool lazy_mode = false) override;
@@ -460,7 +454,6 @@ public:
     void release(Handle* handle) override;
     void erase(const CacheKey& key) override {};
     void* value(Handle* handle) override;
-    Slice value_slice(Handle* handle) override;
     uint64_t new_id() override { return 0; };
     PrunedInfo prune() override { return {0, 0}; };
     PrunedInfo prune_if(CachePrunePredicate pred, bool lazy_mode = false) override {

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <butil/macros.h>
+#include <bvar/bvar.h>
 #include <glog/logging.h>
 #include <gtest/gtest_prod.h>
 #include <stdint.h>

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -19,8 +19,7 @@
 #include <string>
 #include <utility>
 
-#include "runtime/memory/mem_tracker_limiter.h"
-#include "runtime/thread_context.h"
+#include "runtime/memory/lru_cache_value_base.h"
 #include "util/doris_metrics.h"
 #include "util/metrics.h"
 #include "util/slice.h"
@@ -182,8 +181,7 @@ public:
     // When the inserted entry is no longer needed, the key and
     // value will be passed to "deleter".
     virtual Handle* insert(const CacheKey& key, void* value, size_t charge,
-                           void (*deleter)(const CacheKey& key, void* value),
-                           CachePriority priority = CachePriority::NORMAL, size_t bytes = -1) = 0;
+                           CachePriority priority = CachePriority::NORMAL) = 0;
 
     // If the cache has no mapping for "key", returns nullptr.
     //
@@ -231,8 +229,6 @@ public:
     // may hold lock for a long time to execute predicate.
     virtual PrunedInfo prune_if(CachePrunePredicate pred, bool lazy_mode = false) { return {0, 0}; }
 
-    virtual int64_t mem_consumption() = 0;
-
     virtual int64_t get_usage() = 0;
 
     virtual size_t get_total_capacity() = 0;
@@ -243,21 +239,20 @@ private:
 
 // An entry is a variable length heap-allocated structure.  Entries
 // are kept in a circular doubly linked list ordered by access time.
+// Note: member variables can only be POD types and raw pointer,
+// cannot be class objects or smart pointers, because LRUHandle will be created using malloc.
 struct LRUHandle {
     void* value = nullptr;
-    void (*deleter)(const CacheKey&, void* value);
     struct LRUHandle* next_hash = nullptr; // next entry in hash table
     struct LRUHandle* next = nullptr;      // next entry in lru list
     struct LRUHandle* prev = nullptr;      // previous entry in lru list
     size_t charge;
     size_t key_length;
     size_t total_size; // Entry charge, used to limit cache capacity, LRUCacheType::SIZE including key length.
-    size_t bytes;  // Used by LRUCacheType::NUMBER, LRUCacheType::SIZE equal to total_size.
     bool in_cache; // Whether entry is in the cache.
     uint32_t refs;
     uint32_t hash; // Hash of key(); used for fast sharding and comparisons
     CachePriority priority = CachePriority::NORMAL;
-    MemTrackerLimiter* mem_tracker;
     LRUCacheType type;
     int64_t last_visit_time; // Save the last visit time of this cache entry.
     char key_data[1];        // Beginning of key
@@ -274,10 +269,8 @@ struct LRUHandle {
     }
 
     void free() {
-        (*deleter)(key(), value);
-        if (bytes != 0) { // DummyLRUCache bytes always equal to 0
-            THREAD_MEM_TRACKER_TRANSFER_FROM(bytes, mem_tracker);
-            DorisMetrics::instance()->lru_cache_memory_bytes->increment(-bytes);
+        if (value != nullptr) { // value allows null pointer.
+            delete (LRUCacheValueBase*)value;
         }
         ::free(this);
     }
@@ -346,9 +339,7 @@ public:
     // Like Cache methods, but with an extra "hash" parameter.
     // Must call release on the returned handle pointer.
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
-                          void (*deleter)(const CacheKey& key, void* value),
-                          MemTrackerLimiter* tracker,
-                          CachePriority priority = CachePriority::NORMAL, size_t bytes = -1);
+                          CachePriority priority = CachePriority::NORMAL);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
     void release(Cache::Handle* handle);
     void erase(const CacheKey& key, uint32_t hash);
@@ -406,9 +397,7 @@ class ShardedLRUCache : public Cache {
 public:
     virtual ~ShardedLRUCache();
     virtual Handle* insert(const CacheKey& key, void* value, size_t charge,
-                           void (*deleter)(const CacheKey& key, void* value),
-                           CachePriority priority = CachePriority::NORMAL,
-                           size_t bytes = -1) override;
+                           CachePriority priority = CachePriority::NORMAL) override;
     virtual Handle* lookup(const CacheKey& key) override;
     virtual void release(Handle* handle) override;
     virtual void erase(const CacheKey& key) override;
@@ -417,7 +406,6 @@ public:
     virtual uint64_t new_id() override;
     PrunedInfo prune() override;
     PrunedInfo prune_if(CachePrunePredicate pred, bool lazy_mode = false) override;
-    int64_t mem_consumption() override;
     int64_t get_usage() override;
     size_t get_total_capacity() override { return _total_capacity; };
 
@@ -434,17 +422,6 @@ private:
 
     void update_cache_metrics() const;
 
-    static std::string lru_cache_type_string(LRUCacheType type) {
-        switch (type) {
-        case LRUCacheType::SIZE:
-            return "size";
-        case LRUCacheType::NUMBER:
-            return "number";
-        default:
-            LOG(FATAL) << "not match type of lru cache:" << static_cast<int>(type);
-        }
-    }
-
 private:
     static uint32_t _hash_slice(const CacheKey& s);
     uint32_t _shard(uint32_t hash) {
@@ -458,7 +435,6 @@ private:
     std::atomic<uint64_t> _last_id;
     size_t _total_capacity;
 
-    std::unique_ptr<MemTrackerLimiter> _mem_tracker;
     std::shared_ptr<MetricEntity> _entity;
     IntGauge* cache_capacity = nullptr;
     IntGauge* cache_usage = nullptr;
@@ -478,8 +454,7 @@ class DummyLRUCache : public Cache {
 public:
     // Must call release on the returned handle pointer.
     Handle* insert(const CacheKey& key, void* value, size_t charge,
-                   void (*deleter)(const CacheKey& key, void* value),
-                   CachePriority priority = CachePriority::NORMAL, size_t bytes = -1) override;
+                   CachePriority priority = CachePriority::NORMAL) override;
     Handle* lookup(const CacheKey& key) override { return nullptr; };
     void release(Handle* handle) override;
     void erase(const CacheKey& key) override {};
@@ -490,7 +465,6 @@ public:
     PrunedInfo prune_if(CachePrunePredicate pred, bool lazy_mode = false) override {
         return {0, 0};
     };
-    int64_t mem_consumption() override { return 0; };
     int64_t get_usage() override { return 0; };
     size_t get_total_capacity() override { return 0; };
 };

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -70,7 +70,7 @@ void StoragePageCache::insert(const CacheKey& key, DataPage* data, PageCacheHand
     }
 
     auto* cache = _get_page_cache(page_type);
-    auto* lru_handle = cache->insert_no_tracking(key.encode(), data, data->capacity(), priority);
+    auto* lru_handle = cache->insert(key.encode(), data, data->capacity(), 0, priority);
     *handle = PageCacheHandle(cache, lru_handle);
 }
 

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -28,9 +28,8 @@ StoragePageCache* StoragePageCache::create_global_cache(size_t capacity,
                                                         int32_t index_cache_percentage,
                                                         int64_t pk_index_cache_capacity,
                                                         uint32_t num_shards) {
-    StoragePageCache* res = new StoragePageCache(capacity, index_cache_percentage,
-                                                 pk_index_cache_capacity, num_shards);
-    return res;
+    return new StoragePageCache(capacity, index_cache_percentage, pk_index_cache_capacity,
+                                num_shards);
 }
 
 StoragePageCache::StoragePageCache(size_t capacity, int32_t index_cache_percentage,
@@ -54,8 +53,8 @@ StoragePageCache::StoragePageCache(size_t capacity, int32_t index_cache_percenta
 
 bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle,
                               segment_v2::PageTypePB page_type) {
-    auto cache = _get_page_cache(page_type);
-    auto lru_handle = cache->lookup(key.encode());
+    auto* cache = _get_page_cache(page_type);
+    auto* lru_handle = cache->lookup(key.encode());
     if (lru_handle == nullptr) {
         return false;
     }
@@ -65,18 +64,13 @@ bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle,
 
 void StoragePageCache::insert(const CacheKey& key, DataPage* data, PageCacheHandle* handle,
                               segment_v2::PageTypePB page_type, bool in_memory) {
-    auto deleter = [](const doris::CacheKey& key, void* value) {
-        DataPage* cache_value = (DataPage*)value;
-        delete cache_value;
-    };
-
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {
         priority = CachePriority::DURABLE;
     }
 
-    auto cache = _get_page_cache(page_type);
-    auto lru_handle = cache->insert(key.encode(), data, data->capacity(), deleter, priority);
+    auto* cache = _get_page_cache(page_type);
+    auto* lru_handle = cache->insert_no_tracking(key.encode(), data, data->capacity(), priority);
     *handle = PageCacheHandle(cache, lru_handle);
 }
 

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -40,7 +40,7 @@ class PageCacheHandle;
 template <typename TAllocator>
 class PageBase : private TAllocator, public LRUCacheValueBase {
 public:
-    PageBase() : _data(nullptr), _size(0), _capacity(0) {}
+    PageBase() = default;
 
     PageBase(size_t b, const std::shared_ptr<MemTrackerLimiter>& mem_tracker)
             : _size(b), _capacity(b), _mem_tracker(mem_tracker) {
@@ -71,7 +71,7 @@ public:
 private:
     char* _data = nullptr;
     // Effective size, smaller than capacity, such as data page remove checksum suffix.
-    size_t _size;
+    size_t _size = 0;
     size_t _capacity = 0;
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -43,7 +43,7 @@ public:
     PageBase() = default;
 
     PageBase(size_t b, const std::shared_ptr<MemTrackerLimiter>& mem_tracker)
-            : _size(b), _capacity(b), _mem_tracker(mem_tracker) {
+            : LRUCacheValueBase(mem_tracker), _size(b), _capacity(b) {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
         _data = reinterpret_cast<char*>(TAllocator::alloc(_capacity, ALLOCATOR_ALIGNMENT_16));
     }
@@ -73,7 +73,6 @@ private:
     // Effective size, smaller than capacity, such as data page remove checksum suffix.
     size_t _size = 0;
     size_t _capacity = 0;
-    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };
 
 using DataPage = PageBase<Allocator<false>>;

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -28,6 +28,7 @@
 
 #include "olap/lru_cache.h"
 #include "runtime/memory/lru_cache_policy.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "util/slice.h"
 #include "vec/common/allocator.h"
 #include "vec/common/allocator_fwd.h"
@@ -37,20 +38,23 @@ namespace doris {
 class PageCacheHandle;
 
 template <typename TAllocator>
-class PageBase : private TAllocator {
+class PageBase : private TAllocator, public LRUCacheValueBase {
 public:
     PageBase() : _data(nullptr), _size(0), _capacity(0) {}
 
-    PageBase(size_t b) : _size(b), _capacity(b) {
+    PageBase(size_t b, const std::shared_ptr<MemTrackerLimiter>& mem_tracker)
+            : _size(b), _capacity(b), _mem_tracker(mem_tracker) {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
         _data = reinterpret_cast<char*>(TAllocator::alloc(_capacity, ALLOCATOR_ALIGNMENT_16));
     }
 
     PageBase(const PageBase&) = delete;
     PageBase& operator=(const PageBase&) = delete;
 
-    ~PageBase() {
+    ~PageBase() override {
         if (_data != nullptr) {
             DCHECK(_capacity != 0 && _size != 0);
+            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
             TAllocator::free(_data, _capacity);
         }
     }
@@ -69,6 +73,7 @@ private:
     // Effective size, smaller than capacity, such as data page remove checksum suffix.
     size_t _size;
     size_t _capacity = 0;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };
 
 using DataPage = PageBase<Allocator<false>>;
@@ -157,6 +162,10 @@ public:
     void insert(const CacheKey& key, DataPage* data, PageCacheHandle* handle,
                 segment_v2::PageTypePB page_type, bool in_memory = false);
 
+    std::shared_ptr<MemTrackerLimiter> mem_tracker(segment_v2::PageTypePB page_type) {
+        return _get_page_cache(page_type)->mem_tracker();
+    }
+
 private:
     StoragePageCache();
 
@@ -168,16 +177,16 @@ private:
     // delete bitmap in unique key with mow
     std::unique_ptr<PKIndexPageCache> _pk_index_page_cache;
 
-    Cache* _get_page_cache(segment_v2::PageTypePB page_type) {
+    LRUCachePolicy* _get_page_cache(segment_v2::PageTypePB page_type) {
         switch (page_type) {
         case segment_v2::DATA_PAGE: {
-            return _data_page_cache->cache();
+            return _data_page_cache.get();
         }
         case segment_v2::INDEX_PAGE: {
-            return _index_page_cache->cache();
+            return _index_page_cache.get();
         }
         case segment_v2::PRIMARY_KEY_INDEX_PAGE: {
-            return _pk_index_page_cache->cache();
+            return _pk_index_page_cache.get();
         }
         default:
             LOG(FATAL) << "get error type page cache";
@@ -192,8 +201,9 @@ private:
 // class will release the cache entry when it is destroyed.
 class PageCacheHandle {
 public:
-    PageCacheHandle() {}
-    PageCacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
+    PageCacheHandle() = default;
+    PageCacheHandle(LRUCachePolicy* cache, Cache::Handle* handle)
+            : _cache(cache), _handle(handle) {}
     ~PageCacheHandle() {
         if (_handle != nullptr) {
             _cache->release(_handle);
@@ -212,14 +222,14 @@ public:
         return *this;
     }
 
-    Cache* cache() const { return _cache; }
+    LRUCachePolicy* cache() const { return _cache; }
     Slice data() const {
-        DataPage* cache_value = (DataPage*)_cache->value(_handle);
-        return Slice(cache_value->data(), cache_value->size());
+        auto* cache_value = (DataPage*)_cache->value(_handle);
+        return {cache_value->data(), cache_value->size()};
     }
 
 private:
-    Cache* _cache = nullptr;
+    LRUCachePolicy* _cache = nullptr;
     Cache::Handle* _handle = nullptr;
 
     // Don't allow copy and assign

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
@@ -38,8 +38,8 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
      * @param size_of_tail including size of footer and null map
      * @return Status
      */
-    virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice,
-                          size_t size_of_tail) override {
+    Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
+                  const std::shared_ptr<MemTrackerLimiter>& mem_tracker) override {
         size_t num_elements, compressed_size, num_element_after_padding;
         int size_of_element;
 
@@ -66,7 +66,8 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
         Slice decoded_slice;
         decoded_slice.size = size_of_dict_header + BITSHUFFLE_PAGE_HEADER_SIZE +
                              num_element_after_padding * size_of_element + size_of_tail;
-        std::unique_ptr<DataPage> decoded_page = std::make_unique<DataPage>(decoded_slice.size);
+        std::unique_ptr<DataPage> decoded_page =
+                std::make_unique<DataPage>(decoded_slice.size, mem_tracker);
         decoded_slice.data = decoded_page->data();
 
         if constexpr (USED_IN_DICT_ENCODING) {

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -42,8 +42,8 @@ enum EncodingTypePB : int;
 // For better performance, some encodings (like BitShuffle) need to be decoded before being added to the PageCache.
 class DataPagePreDecoder {
 public:
-    virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice,
-                          size_t size_of_tail) = 0;
+    virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
+                          const std::shared_ptr<MemTrackerLimiter>& mem_tracker) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -112,8 +112,8 @@ void InvertedIndexSearcherCache::insert(const InvertedIndexSearcherCache::CacheK
 
 Cache::Handle* InvertedIndexSearcherCache::_insert(const InvertedIndexSearcherCache::CacheKey& key,
                                                    CacheValue* value) {
-    Cache::Handle* lru_handle =
-            _policy->insert(key.index_file_path, value, value->size, CachePriority::NORMAL);
+    Cache::Handle* lru_handle = _policy->insert(key.index_file_path, value, value->size,
+                                                value->size, CachePriority::NORMAL);
     return lru_handle;
 }
 
@@ -139,7 +139,8 @@ void InvertedIndexQueryCache::insert(const CacheKey& key, std::shared_ptr<roarin
     }
 
     auto* lru_handle = LRUCachePolicy::insert(key.encode(), (void*)cache_value_ptr.release(),
-                                              bitmap->getSizeInBytes(), CachePriority::NORMAL);
+                                              bitmap->getSizeInBytes(), bitmap->getSizeInBytes(),
+                                              CachePriority::NORMAL);
     *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -81,7 +81,8 @@ public:
 
     // The cache value of index_searcher lru cache.
     // Holding an opened index_searcher.
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
         IndexSearcherPtr index_searcher;
         size_t size = 0;
         int64_t last_visit_time;
@@ -119,7 +120,7 @@ public:
     // function `erase` called after compaction remove segment
     Status erase(const std::string& index_file_path);
 
-    void release(Cache::Handle* handle) { _policy->cache()->release(handle); }
+    void release(Cache::Handle* handle) { _policy->release(handle); }
 
     int64_t mem_consumption();
 
@@ -162,7 +163,7 @@ using IndexCacheValuePtr = std::unique_ptr<InvertedIndexSearcherCache::CacheValu
 class InvertedIndexCacheHandle {
 public:
     InvertedIndexCacheHandle() = default;
-    InvertedIndexCacheHandle(Cache* cache, Cache::Handle* handle)
+    InvertedIndexCacheHandle(LRUCachePolicy* cache, Cache::Handle* handle)
             : _cache(cache), _handle(handle) {}
 
     ~InvertedIndexCacheHandle() {
@@ -197,7 +198,7 @@ public:
     }
 
 private:
-    Cache* _cache = nullptr;
+    LRUCachePolicy* _cache = nullptr;
     Cache::Handle* _handle = nullptr;
 
     // Don't allow copy and assign
@@ -232,7 +233,8 @@ public:
         }
     };
 
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
         std::shared_ptr<roaring::Roaring> bitmap;
     };
 
@@ -267,7 +269,7 @@ class InvertedIndexQueryCacheHandle {
 public:
     InvertedIndexQueryCacheHandle() = default;
 
-    InvertedIndexQueryCacheHandle(Cache* cache, Cache::Handle* handle)
+    InvertedIndexQueryCacheHandle(LRUCachePolicy* cache, Cache::Handle* handle)
             : _cache(cache), _handle(handle) {}
 
     ~InvertedIndexQueryCacheHandle() {
@@ -288,7 +290,7 @@ public:
         return *this;
     }
 
-    Cache* cache() const { return _cache; }
+    LRUCachePolicy* cache() const { return _cache; }
     Slice data() const { return _cache->value_slice(_handle); }
 
     std::shared_ptr<roaring::Roaring> get_bitmap() const {
@@ -299,7 +301,7 @@ public:
     }
 
 private:
-    Cache* _cache = nullptr;
+    LRUCachePolicy* _cache = nullptr;
     Cache::Handle* _handle = nullptr;
 
     // Don't allow copy and assign

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -89,7 +89,8 @@ public:
 
         CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::INVERTEDINDEX_SEARCHER_CACHE) {}
         explicit CacheValue(IndexSearcherPtr searcher, size_t mem_size, int64_t visit_time)
-                : index_searcher(std::move(searcher)) {
+                : LRUCacheValueBase(CachePolicy::CacheType::INVERTEDINDEX_SEARCHER_CACHE),
+                  index_searcher(std::move(searcher)) {
             size = mem_size;
             last_visit_time = visit_time;
         }

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -87,7 +87,7 @@ public:
         size_t size = 0;
         int64_t last_visit_time;
 
-        CacheValue() = default;
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::INVERTEDINDEX_SEARCHER_CACHE) {}
         explicit CacheValue(IndexSearcherPtr searcher, size_t mem_size, int64_t visit_time)
                 : index_searcher(std::move(searcher)) {
             size = mem_size;
@@ -235,6 +235,8 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::INVERTEDINDEX_QUERY_CACHE) {}
+
         std::shared_ptr<roaring::Roaring> bitmap;
     };
 
@@ -291,7 +293,6 @@ public:
     }
 
     LRUCachePolicy* cache() const { return _cache; }
-    Slice data() const { return _cache->value_slice(_handle); }
 
     std::shared_ptr<roaring::Roaring> get_bitmap() const {
         if (!_cache) {

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -95,7 +95,7 @@ public:
             value->schema = schema;
         }
 
-        auto lru_handle = insert(key, value, 1, CachePriority::NORMAL, schema->mem_size());
+        auto lru_handle = insert(key, value, 1, schema->mem_size(), CachePriority::NORMAL);
         release(lru_handle);
     }
 

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -104,6 +104,8 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::SCHEMA_CACHE) {}
+
         Type type;
         // either tablet_schema or schema
         TabletSchemaSPtr tablet_schema = nullptr;

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -65,10 +65,10 @@ public:
         if (!instance() || schema_key.empty()) {
             return {};
         }
-        auto lru_handle = cache()->lookup(schema_key);
+        auto* lru_handle = lookup(schema_key);
         if (lru_handle) {
-            Defer release([cache = cache(), lru_handle] { cache->release(lru_handle); });
-            auto value = (CacheValue*)cache()->value(lru_handle);
+            Defer release([cache = this, lru_handle] { cache->release(lru_handle); });
+            auto* value = (CacheValue*)LRUCachePolicy::value(lru_handle);
             VLOG_DEBUG << "use cache schema";
             if constexpr (std::is_same_v<SchemaType, TabletSchemaSPtr>) {
                 return value->tablet_schema;
@@ -86,7 +86,7 @@ public:
         if (!instance() || key.empty()) {
             return;
         }
-        CacheValue* value = new CacheValue;
+        auto* value = new CacheValue;
         if constexpr (std::is_same_v<SchemaType, TabletSchemaSPtr>) {
             value->type = Type::TABLET_SCHEMA;
             value->tablet_schema = schema;
@@ -94,19 +94,16 @@ public:
             value->type = Type::SCHEMA;
             value->schema = schema;
         }
-        auto deleter = [](const doris::CacheKey& key, void* value) {
-            CacheValue* cache_value = (CacheValue*)value;
-            delete cache_value;
-        };
-        auto lru_handle =
-                cache()->insert(key, value, 1, deleter, CachePriority::NORMAL, schema->mem_size());
-        cache()->release(lru_handle);
+
+        auto lru_handle = insert(key, value, 1, CachePriority::NORMAL, schema->mem_size());
+        release(lru_handle);
     }
 
     // Try to prune the cache if expired.
     Status prune();
 
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
         Type type;
         // either tablet_schema or schema
         TabletSchemaSPtr tablet_schema = nullptr;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -39,8 +39,8 @@ bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle*
 
 void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::CacheValue& value,
                           SegmentCacheHandle* handle) {
-    auto* lru_handle = LRUCachePolicy::insert(key.encode(), &value, 1, CachePriority::NORMAL,
-                                              value.segment->meta_mem_usage());
+    auto* lru_handle = LRUCachePolicy::insert(
+            key.encode(), &value, 1, value.segment->meta_mem_usage(), CachePriority::NORMAL);
     handle->push_segment(this, lru_handle);
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -72,7 +72,10 @@ public:
 
     // The cache value of segment lru cache.
     // Holding all opened segments of a rowset.
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
+        ~CacheValue() override { segment.reset(); }
+
         segment_v2::SegmentSharedPtr segment;
     };
 
@@ -131,7 +134,7 @@ public:
     SegmentCacheHandle() = default;
     ~SegmentCacheHandle() = default;
 
-    void push_segment(Cache* cache, Cache::Handle* handle) {
+    void push_segment(LRUCachePolicy* cache, Cache::Handle* handle) {
         segments.push_back(((SegmentCache::CacheValue*)cache->value(handle))->segment);
         cache->release(handle);
     }

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -74,6 +74,7 @@ public:
     // Holding all opened segments of a rowset.
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::SEGMENT_CACHE) {}
         ~CacheValue() override { segment.reset(); }
 
         segment_v2::SegmentSharedPtr segment;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1501,7 +1501,7 @@ void CreateTabletIdxCache::set_index(const std::string& key, int next_idx) {
     assert(next_idx >= 0);
     auto* value = new CacheValue;
     value->idx = next_idx;
-    auto* lru_handle = insert(key, value, 1, CachePriority::NORMAL, sizeof(int));
+    auto* lru_handle = insert(key, value, 1, sizeof(int), CachePriority::NORMAL);
     release(lru_handle);
 }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1487,10 +1487,10 @@ void StorageEngine::_decrease_low_priority_task_nums(DataDir* dir) {
 }
 
 int CreateTabletIdxCache::get_index(const std::string& key) {
-    auto lru_handle = cache()->lookup(key);
+    auto* lru_handle = lookup(key);
     if (lru_handle) {
-        Defer release([cache = cache(), lru_handle] { cache->release(lru_handle); });
-        auto value = (CacheValue*)cache()->value(lru_handle);
+        Defer release([cache = this, lru_handle] { cache->release(lru_handle); });
+        auto* value = (CacheValue*)LRUCachePolicy::value(lru_handle);
         VLOG_DEBUG << "use create tablet idx cache key=" << key << " value=" << value->idx;
         return value->idx;
     }
@@ -1499,14 +1499,10 @@ int CreateTabletIdxCache::get_index(const std::string& key) {
 
 void CreateTabletIdxCache::set_index(const std::string& key, int next_idx) {
     assert(next_idx >= 0);
-    CacheValue* value = new CacheValue;
+    auto* value = new CacheValue;
     value->idx = next_idx;
-    auto deleter = [](const doris::CacheKey& key, void* value) {
-        CacheValue* cache_value = (CacheValue*)value;
-        delete cache_value;
-    };
-    auto lru_handle = cache()->insert(key, value, 1, deleter, CachePriority::NORMAL, sizeof(int));
-    cache()->release(lru_handle);
+    auto* lru_handle = insert(key, value, 1, CachePriority::NORMAL, sizeof(int));
+    release(lru_handle);
 }
 
 } // namespace doris

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -529,6 +529,8 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::CREATE_TABLET_RR_IDX_CACHE) {}
+
         int idx = 0;
     };
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -527,7 +527,8 @@ public:
 
     void set_index(const std::string& key, int next_idx);
 
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
         int idx = 0;
     };
 

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1108,11 +1108,8 @@ std::shared_ptr<roaring::Roaring> DeleteBitmap::get_agg(const BitmapKey& bmk) co
                 val->bitmap |= bm;
             }
         }
-        static auto deleter = [](const CacheKey& key, void* value) {
-            delete (AggCache::Value*)value; // Just delete to reclaim
-        };
         size_t charge = val->bitmap.getSizeInBytes() + sizeof(AggCache::Value);
-        handle = _agg_cache->repr()->insert(key, val, charge, deleter, CachePriority::NORMAL);
+        handle = _agg_cache->repr()->insert(key, val, charge, CachePriority::NORMAL);
     }
 
     // It is natural for the cache to reclaim the underlying memory

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1109,7 +1109,7 @@ std::shared_ptr<roaring::Roaring> DeleteBitmap::get_agg(const BitmapKey& bmk) co
             }
         }
         size_t charge = val->bitmap.getSizeInBytes() + sizeof(AggCache::Value);
-        handle = _agg_cache->repr()->insert(key, val, charge, CachePriority::NORMAL);
+        handle = _agg_cache->repr()->insert(key, val, charge, charge, CachePriority::NORMAL);
     }
 
     // It is natural for the cache to reclaim the underlying memory

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -502,7 +502,8 @@ public:
 
     class AggCache {
     public:
-        struct Value {
+        class Value : public LRUCacheValueBase {
+        public:
             roaring::Roaring bitmap;
         };
 
@@ -517,7 +518,7 @@ public:
             }
         }
 
-        static Cache* repr() { return s_repr.load(std::memory_order_acquire)->cache(); }
+        static LRUCachePolicy* repr() { return s_repr.load(std::memory_order_acquire); }
         static std::atomic<AggCachePolicy*> s_repr;
     };
 

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -504,6 +504,8 @@ public:
     public:
         class Value : public LRUCacheValueBase {
         public:
+            Value() : LRUCacheValueBase(CachePolicy::CacheType::DELETE_BITMAP_AGG_CACHE) {}
+
             roaring::Roaring bitmap;
         };
 

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -28,10 +28,10 @@ bvar::Adder<int64_t> g_tablet_schema_cache_columns_count("tablet_schema_cache_co
 namespace doris {
 
 std::pair<Cache::Handle*, TabletSchemaSPtr> TabletSchemaCache::insert(const std::string& key) {
-    auto* lru_handle = cache()->lookup(key);
+    auto* lru_handle = lookup(key);
     TabletSchemaSPtr tablet_schema_ptr;
     if (lru_handle) {
-        auto* value = (CacheValue*)cache()->value(lru_handle);
+        auto* value = (CacheValue*)LRUCachePolicy::value(lru_handle);
         tablet_schema_ptr = value->tablet_schema;
     } else {
         auto* value = new CacheValue;
@@ -40,14 +40,8 @@ std::pair<Cache::Handle*, TabletSchemaSPtr> TabletSchemaCache::insert(const std:
         pb.ParseFromString(key);
         tablet_schema_ptr->init_from_pb(pb);
         value->tablet_schema = tablet_schema_ptr;
-        auto deleter = [](const doris::CacheKey& key, void* value) {
-            auto* cache_value = (CacheValue*)value;
-            g_tablet_schema_cache_count << -1;
-            g_tablet_schema_cache_columns_count << -cache_value->tablet_schema->num_columns();
-            delete cache_value;
-        };
-        lru_handle = cache()->insert(key, value, tablet_schema_ptr->num_columns(), deleter,
-                                     CachePriority::NORMAL, 0);
+        lru_handle = LRUCachePolicy::insert(key, value, tablet_schema_ptr->num_columns(),
+                                            CachePriority::NORMAL, 0);
         g_tablet_schema_cache_count << 1;
         g_tablet_schema_cache_columns_count << tablet_schema_ptr->num_columns();
     }
@@ -56,7 +50,12 @@ std::pair<Cache::Handle*, TabletSchemaSPtr> TabletSchemaCache::insert(const std:
 }
 
 void TabletSchemaCache::release(Cache::Handle* lru_handle) {
-    cache()->release(lru_handle);
+    LRUCachePolicy::release(lru_handle);
+}
+
+TabletSchemaCache::CacheValue::~CacheValue() {
+    g_tablet_schema_cache_count << -1;
+    g_tablet_schema_cache_columns_count << -tablet_schema->num_columns();
 }
 
 } // namespace doris

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -40,8 +40,8 @@ std::pair<Cache::Handle*, TabletSchemaSPtr> TabletSchemaCache::insert(const std:
         pb.ParseFromString(key);
         tablet_schema_ptr->init_from_pb(pb);
         value->tablet_schema = tablet_schema_ptr;
-        lru_handle = LRUCachePolicy::insert(key, value, tablet_schema_ptr->num_columns(),
-                                            CachePriority::NORMAL, 0);
+        lru_handle = LRUCachePolicy::insert(key, value, tablet_schema_ptr->num_columns(), 0,
+                                            CachePriority::NORMAL);
         g_tablet_schema_cache_count << 1;
         g_tablet_schema_cache_columns_count << tablet_schema_ptr->num_columns();
     }

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -43,7 +43,10 @@ public:
     void release(Cache::Handle*);
 
 private:
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
+        ~CacheValue() override;
+
         TabletSchemaSPtr tablet_schema;
     };
 };

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -45,6 +45,7 @@ public:
 private:
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::TABLET_SCHEMA_CACHE) {}
         ~CacheValue() override;
 
         TabletSchemaSPtr tablet_schema;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -881,8 +881,8 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
     auto* value = new CacheValue;
     value->value = new int64_t;
     *value->value = txn_id;
-    auto* handle = _tablet_version_cache->insert(cache_key, value, 1, CachePriority::NORMAL,
-                                                 sizeof(txn_id));
+    auto* handle = _tablet_version_cache->insert(cache_key, value, 1, sizeof(txn_id),
+                                                 CachePriority::NORMAL);
     _tablet_version_cache->release(handle);
 }
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -863,12 +863,12 @@ int64_t TxnManager::get_txn_by_tablet_version(int64_t tablet_id, int64_t version
     memcpy(key + sizeof(int64_t), &version, sizeof(int64_t));
     CacheKey cache_key((const char*)&key, sizeof(key));
 
-    auto* handle = _tablet_version_cache->cache()->lookup(cache_key);
+    auto* handle = _tablet_version_cache->lookup(cache_key);
     if (handle == nullptr) {
         return -1;
     }
-    int64_t res = *(int64_t*)_tablet_version_cache->cache()->value(handle);
-    _tablet_version_cache->cache()->release(handle);
+    int64_t res = *(int64_t*)_tablet_version_cache->value(handle);
+    _tablet_version_cache->release(handle);
     return res;
 }
 
@@ -878,16 +878,12 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
     memcpy(key + sizeof(int64_t), &version, sizeof(int64_t));
     CacheKey cache_key((const char*)&key, sizeof(key));
 
-    int64_t* value = new int64_t;
-    *value = txn_id;
-    auto deleter = [](const doris::CacheKey& key, void* value) {
-        int64_t* cache_value = (int64_t*)value;
-        delete cache_value;
-    };
-
-    auto* handle = _tablet_version_cache->cache()->insert(cache_key, value, 1, deleter,
-                                                          CachePriority::NORMAL, sizeof(txn_id));
-    _tablet_version_cache->cache()->release(handle);
+    auto* value = new CacheValue;
+    value->value = new int64_t;
+    *value->value = txn_id;
+    auto* handle = _tablet_version_cache->insert(cache_key, value, 1, CachePriority::NORMAL,
+                                                 sizeof(txn_id));
+    _tablet_version_cache->release(handle);
 }
 
 TxnState TxnManager::get_txn_state(TPartitionId partition_id, TTransactionId transaction_id,

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -867,7 +867,7 @@ int64_t TxnManager::get_txn_by_tablet_version(int64_t tablet_id, int64_t version
     if (handle == nullptr) {
         return -1;
     }
-    int64_t res = *(int64_t*)_tablet_version_cache->value(handle);
+    int64_t res = *(int64_t*)((CacheValue*)_tablet_version_cache->value(handle))->value;
     _tablet_version_cache->release(handle);
     return res;
 }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -879,8 +879,7 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
     CacheKey cache_key((const char*)&key, sizeof(key));
 
     auto* value = new CacheValue;
-    value->value = new int64_t;
-    *value->value = txn_id;
+    value->value = txn_id;
     auto* handle = _tablet_version_cache->insert(cache_key, value, 1, sizeof(txn_id),
                                                  CachePriority::NORMAL);
     _tablet_version_cache->release(handle);

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -867,7 +867,7 @@ int64_t TxnManager::get_txn_by_tablet_version(int64_t tablet_id, int64_t version
     if (handle == nullptr) {
         return -1;
     }
-    int64_t res = *(int64_t*)((CacheValue*)_tablet_version_cache->value(handle))->value;
+    int64_t res = ((CacheValue*)_tablet_version_cache->value(handle))->value;
     _tablet_version_cache->release(handle);
     return res;
 }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -129,9 +129,8 @@ public:
     class CacheValue : public LRUCacheValueBase {
     public:
         CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::TABLET_VERSION_CACHE) {}
-        ~CacheValue() override { delete value; }
 
-        int64_t* value;
+        int64_t value;
     };
 
     // add a txn to manager

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -126,6 +126,11 @@ public:
         delete[] _txn_tablet_delta_writer_map_locks;
     }
 
+    class CacheValue : public LRUCacheValueBase {
+    public:
+        int64_t* value;
+    };
+
     // add a txn to manager
     // partition id is useful in publish version stage because version is associated with partition
     Status prepare_txn(TPartitionId partition_id, const Tablet& tablet,

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -128,6 +128,9 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::TABLET_VERSION_CACHE) {}
+        ~CacheValue() override { delete value; }
+
         int64_t* value;
     };
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -114,8 +114,6 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
     return Status::OK();
 }
 
-static void dummy_deleter(const CacheKey& key, void* value) {}
-
 Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                                          const UniqueId& load_id,
                                          const PTabletWriterAddBlockRequest& request) {
@@ -123,10 +121,10 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
     std::lock_guard<std::mutex> l(_lock);
     auto it = _load_channels.find(load_id);
     if (it == _load_channels.end()) {
-        auto handle = _last_success_channels->cache()->lookup(load_id.to_string());
+        auto* handle = _last_success_channels->lookup(load_id.to_string());
         // success only when eos be true
         if (handle != nullptr) {
-            _last_success_channels->cache()->release(handle);
+            _last_success_channels->release(handle);
             if (request.has_eos() && request.eos()) {
                 is_eof = true;
                 return Status::OK();
@@ -182,9 +180,8 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
         if (_load_channels.find(load_id) != _load_channels.end()) {
             _load_channels.erase(load_id);
         }
-        auto handle = _last_success_channels->cache()->insert(load_id.to_string(), nullptr, 1,
-                                                              dummy_deleter);
-        _last_success_channels->cache()->release(handle);
+        auto* handle = _last_success_channels->insert(load_id.to_string(), nullptr, 1);
+        _last_success_channels->release(handle);
     }
     VLOG_CRITICAL << "removed load channel " << load_id;
 }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -180,7 +180,7 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
         if (_load_channels.find(load_id) != _load_channels.end()) {
             _load_channels.erase(load_id);
         }
-        auto* handle = _last_success_channels->insert(load_id.to_string(), nullptr, 1);
+        auto* handle = _last_success_channels->insert(load_id.to_string(), nullptr, 1, 1);
         _last_success_channels->release(handle);
     }
     VLOG_CRITICAL << "removed load channel " << load_id;

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -27,7 +27,7 @@ int64_t CacheManager::for_each_cache_prune_stale_wrap(
     int64_t freed_size = 0;
     std::lock_guard<std::mutex> l(_caches_lock);
     for (const auto& pair : _caches) {
-        auto* cache_policy = pair->second;
+        auto* cache_policy = pair.second;
         if (!cache_policy->enable_prune()) {
             continue;
         }

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -26,7 +26,8 @@ int64_t CacheManager::for_each_cache_prune_stale_wrap(
         std::function<void(CachePolicy* cache_policy)> func, RuntimeProfile* profile) {
     int64_t freed_size = 0;
     std::lock_guard<std::mutex> l(_caches_lock);
-    for (auto* cache_policy : _caches) {
+    for (const auto& pair : _caches) {
+        auto* cache_policy = pair->second;
         if (!cache_policy->enable_prune()) {
             continue;
         }
@@ -57,11 +58,7 @@ int64_t CacheManager::for_each_cache_prune_all(RuntimeProfile* profile) {
 
 void CacheManager::clear_once(CachePolicy::CacheType type) {
     std::lock_guard<std::mutex> l(_caches_lock);
-    for (auto* cache_policy : _caches) {
-        if (cache_policy->type() == type) {
-            cache_policy->prune_all(true); // will print log
-        }
-    }
+    _caches[type]->prune_all(true); // will print log
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -23,12 +23,12 @@ namespace doris {
 
 CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune)
         : _type(type), _stale_sweep_time_s(stale_sweep_time_s), _enable_prune(enable_prune) {
-    _it = CacheManager::instance()->register_cache(this);
+    CacheManager::instance()->register_cache(this);
     init_profile();
 }
 
 CachePolicy::~CachePolicy() {
-    CacheManager::instance()->unregister_cache(_it);
+    CacheManager::instance()->unregister_cache(_type);
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
@@ -99,6 +100,8 @@ public:
     virtual void prune_all(bool force) = 0;
 
     CacheType type() { return _type; }
+    std::shared_ptr<MemTrackerLimiter> mem_tracker() { return _mem_tracker; }
+    int64_t mem_consumption() { return _mem_tracker->consumption(); }
     bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 
@@ -114,7 +117,8 @@ protected:
     }
 
     CacheType _type;
-    std::list<CachePolicy*>::iterator _it;
+
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 
     std::unique_ptr<RuntimeProfile> _profile;
     RuntimeProfile::Counter* _prune_stale_number_counter = nullptr;

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -116,6 +116,10 @@ protected:
         _cost_timer = ADD_TIMER(_profile, "CostTime");
     }
 
+    void init_mem_tracker(const std::string& name) {
+        _mem_tracker = std::make_shared<MemTrackerLimiter>(MemTrackerLimiter::Type::GLOBAL, name);
+    }
+
     CacheType _type;
 
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -19,8 +19,13 @@
 
 #include <fmt/format.h>
 
+#include <memory>
+
 #include "olap/lru_cache.h"
 #include "runtime/memory/cache_policy.h"
+#include "runtime/memory/lru_cache_value_base.h"
+#include "runtime/thread_context.h"
+#include "util/doris_metrics.h"
 #include "util/time.h"
 
 namespace doris {
@@ -32,7 +37,7 @@ public:
                    uint32_t stale_sweep_time_s, uint32_t num_shards = DEFAULT_LRU_CACHE_NUM_SHARDS,
                    uint32_t element_count_capacity = DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY,
                    bool enable_prune = true)
-            : CachePolicy(type, stale_sweep_time_s, enable_prune) {
+            : CachePolicy(type, stale_sweep_time_s, enable_prune), _lru_cache_type(lru_cache_type) {
         if (check_capacity(capacity, num_shards)) {
             _cache = std::shared_ptr<ShardedLRUCache>(
                     new ShardedLRUCache(type_string(type), capacity, lru_cache_type, num_shards,
@@ -41,6 +46,7 @@ public:
             CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
+        _init_mem_tracker();
     }
 
     LRUCachePolicy(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
@@ -48,7 +54,7 @@ public:
                    uint32_t element_count_capacity,
                    CacheValueTimeExtractor cache_value_time_extractor,
                    bool cache_value_check_timestamp, bool enable_prune = true)
-            : CachePolicy(type, stale_sweep_time_s, enable_prune) {
+            : CachePolicy(type, stale_sweep_time_s, enable_prune), _lru_cache_type(lru_cache_type) {
         if (check_capacity(capacity, num_shards)) {
             _cache = std::shared_ptr<ShardedLRUCache>(
                     new ShardedLRUCache(type_string(type), capacity, lru_cache_type, num_shards,
@@ -58,7 +64,10 @@ public:
             CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
+        _init_mem_tracker();
     }
+
+    ~LRUCachePolicy() override = default;
 
     bool check_capacity(size_t capacity, uint32_t num_shards) {
         if (capacity < num_shards) {
@@ -72,7 +81,48 @@ public:
         return true;
     }
 
-    ~LRUCachePolicy() override = default;
+    static std::string lru_cache_type_string(LRUCacheType type) {
+        switch (type) {
+        case LRUCacheType::SIZE:
+            return "size";
+        case LRUCacheType::NUMBER:
+            return "number";
+        default:
+            LOG(FATAL) << "not match type of lru cache:" << static_cast<int>(type);
+        }
+    }
+
+    std::shared_ptr<MemTrackerLimiter> mem_tracker() { return _mem_tracker; }
+
+    Cache::Handle* insert(const CacheKey& key, void* value, size_t charge,
+                          CachePriority priority = CachePriority::NORMAL, size_t bytes = -1) {
+        return _insert(true, key, value, charge, priority, bytes);
+    }
+
+    Cache::Handle* insert_no_tracking(const CacheKey& key, void* value, size_t charge,
+                                      CachePriority priority = CachePriority::NORMAL,
+                                      size_t bytes = -1) {
+        return _insert(false, key, value, charge, priority, bytes);
+    }
+
+    Cache::Handle* lookup(const CacheKey& key) { return _cache->lookup(key); }
+
+    void release(Cache::Handle* handle) { _cache->release(handle); }
+
+    void* value(Cache::Handle* handle) { return _cache->value(handle); }
+
+    Slice value_slice(Cache::Handle* handle) {
+        return _cache->value_slice(handle);
+        ;
+    }
+
+    void erase(const CacheKey& key) { _cache->erase(key); }
+
+    int64_t mem_consumption() { return _mem_tracker->consumption(); }
+
+    int64_t get_usage() { return _cache->get_usage(); }
+
+    size_t get_total_capacity() { return _cache->get_total_capacity(); }
 
     // Try to prune the cache if expired.
     void prune_stale() override {
@@ -81,7 +131,7 @@ public:
         if (_stale_sweep_time_s <= 0 && _cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
             return;
         }
-        if (_cache->mem_consumption() > CACHE_MIN_FREE_SIZE) {
+        if (mem_consumption() > CACHE_MIN_FREE_SIZE) {
             COUNTER_SET(_cost_timer, (int64_t)0);
             SCOPED_TIMER(_cost_timer);
             const int64_t curtime = UnixMillis();
@@ -91,7 +141,7 @@ public:
             };
 
             LOG(INFO) << fmt::format("[MemoryGC] {} prune stale start, consumption {}",
-                                     type_string(_type), _cache->mem_consumption());
+                                     type_string(_type), mem_consumption());
             // Prune cache in lazy mode to save cpu and minimize the time holding write lock
             PrunedInfo pruned_info = _cache->prune_if(pred, true);
             COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
@@ -105,7 +155,7 @@ public:
             LOG(INFO) << fmt::format(
                     "[MemoryGC] {} not need prune stale, consumption {} less than "
                     "CACHE_MIN_FREE_SIZE {}",
-                    type_string(_type), _cache->mem_consumption(), CACHE_MIN_FREE_SIZE);
+                    type_string(_type), mem_consumption(), CACHE_MIN_FREE_SIZE);
         }
     }
 
@@ -115,12 +165,11 @@ public:
         if (_cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
             return;
         }
-        if ((force && _cache->mem_consumption() != 0) ||
-            _cache->mem_consumption() > CACHE_MIN_FREE_SIZE) {
+        if ((force && mem_consumption() != 0) || mem_consumption() > CACHE_MIN_FREE_SIZE) {
             COUNTER_SET(_cost_timer, (int64_t)0);
             SCOPED_TIMER(_cost_timer);
             LOG(INFO) << fmt::format("[MemoryGC] {} prune all start, consumption {}",
-                                     type_string(_type), _cache->mem_consumption());
+                                     type_string(_type), mem_consumption());
             PrunedInfo pruned_info = _cache->prune();
             COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
             COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
@@ -133,16 +182,47 @@ public:
             LOG(INFO) << fmt::format(
                     "[MemoryGC] {} not need prune all, force is {}, consumption {}, "
                     "CACHE_MIN_FREE_SIZE {}",
-                    type_string(_type), force, _cache->mem_consumption(), CACHE_MIN_FREE_SIZE);
+                    type_string(_type), force, mem_consumption(), CACHE_MIN_FREE_SIZE);
         }
+    }
+
+private:
+    void _init_mem_tracker() {
+        _mem_tracker = std::make_shared<MemTrackerLimiter>(
+                MemTrackerLimiter::Type::GLOBAL,
+                fmt::format("{}[{}]", type_string(_type), lru_cache_type_string(_lru_cache_type)));
+    }
+
+    // LRUCacheType::SIZE equal to total_size.
+    size_t _get_bytes_with_handle(const CacheKey& key, size_t charge, size_t bytes) {
+        size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
+        DCHECK(_lru_cache_type == LRUCacheType::SIZE || bytes != -1)
+                << " _type " << type_string(_type);
+        // if LRUCacheType::NUMBER and bytes equals 0, such as some caches cannot accurately track memory size.
+        // cache mem tracker value and _usage divided by handle_size(106) will get the number of cache entries.
+        return _lru_cache_type == LRUCacheType::SIZE ? handle_size + charge : handle_size + bytes;
+    }
+
+    Cache::Handle* _insert(bool need_tracking, const CacheKey& key, void* value, size_t charge,
+                           CachePriority priority = CachePriority::NORMAL, size_t bytes = -1) {
+        size_t bytes_with_handle = _get_bytes_with_handle(key, charge, bytes);
+        if (need_tracking) {
+            _mem_tracker->cache_consume(bytes_with_handle);
+        }
+        DorisMetrics::instance()->lru_cache_memory_bytes->increment(bytes_with_handle);
+        if (value != nullptr) {
+            ((LRUCacheValueBase*)value)
+                    ->bind_release_memory_callback(bytes_with_handle,
+                                                   need_tracking ? _mem_tracker : nullptr);
+        }
+        return _cache->insert(key, value, charge, priority);
     }
 
     // if check_capacity failed, will return dummy lru cache,
     // compatible with ShardedLRUCache usage, but will not actually cache.
-    Cache* cache() const { return _cache.get(); }
-
-private:
     std::shared_ptr<Cache> _cache;
+    LRUCacheType _lru_cache_type;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };
 
 } // namespace doris

--- a/be/src/runtime/memory/lru_cache_value_base.h
+++ b/be/src/runtime/memory/lru_cache_value_base.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "runtime/memory/mem_tracker_limiter.h"
+#include "util/doris_metrics.h"
+
+namespace doris {
+
+// Base of the lru cache value.
+class LRUCacheValueBase {
+public:
+    LRUCacheValueBase() = default;
+
+    virtual ~LRUCacheValueBase() {
+        if (bytes_with_handle != 0) { // DummyLRUCache bytes always equal to 0
+            if (mem_tracker != nullptr) {
+                // value not alloc use Allocator
+                mem_tracker->cache_consume(-bytes_with_handle);
+            }
+            DorisMetrics::instance()->lru_cache_memory_bytes->increment(-bytes_with_handle);
+        }
+    }
+
+    void bind_release_memory_callback(size_t bytes_with_handle,
+                                      const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
+        this->bytes_with_handle = bytes_with_handle;
+        this->mem_tracker = mem_tracker;
+    }
+
+private:
+    size_t bytes_with_handle = 0;
+    std::shared_ptr<MemTrackerLimiter> mem_tracker;
+};
+
+} // namespace doris

--- a/be/src/runtime/memory/lru_cache_value_base.h
+++ b/be/src/runtime/memory/lru_cache_value_base.h
@@ -25,6 +25,7 @@ namespace doris {
 // Base of the lru cache value.
 class LRUCacheValueBase {
 public:
+    LRUCacheValueBase() = delete;
     LRUCacheValueBase(CachePolicy::CacheType type) {
         _mem_tracker = CacheManager::instance()->get_cache(type)->mem_tracker();
     }

--- a/be/src/runtime/memory/lru_cache_value_base.h
+++ b/be/src/runtime/memory/lru_cache_value_base.h
@@ -37,15 +37,14 @@ public:
         }
     }
 
-    void bind_release_memory_callback(size_t bytes_with_handle,
-                                      const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
+    void bind_memory_tracking(size_t bytes_with_handle, MemTrackerLimiter* mem_tracker) {
         this->bytes_with_handle = bytes_with_handle;
         this->mem_tracker = mem_tracker;
     }
 
 private:
     size_t bytes_with_handle = 0;
-    std::shared_ptr<MemTrackerLimiter> mem_tracker;
+    MemTrackerLimiter* mem_tracker = nullptr;
 };
 
 } // namespace doris

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -149,8 +149,8 @@ void RowCache::insert(const RowCacheKey& key, const Slice& value) {
     auto* row_cache_value = new RowCacheValue;
     row_cache_value->cache_value = cache_value;
     const std::string& encoded_key = key.encode();
-    auto* handle =
-            LRUCachePolicy::insert(encoded_key, row_cache_value, value.size, CachePriority::NORMAL);
+    auto* handle = LRUCachePolicy::insert(encoded_key, row_cache_value, value.size, value.size,
+                                          CachePriority::NORMAL);
     // handle will released
     auto tmp = CacheHandle {this, handle};
 }

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -129,6 +129,7 @@ public:
 
     class RowCacheValue : public LRUCacheValueBase {
     public:
+        RowCacheValue() : LRUCacheValueBase(CachePolicy::CacheType::POINT_QUERY_ROW_CACHE) {}
         ~RowCacheValue() override { free(cache_value); }
         char* cache_value;
     };
@@ -161,7 +162,6 @@ public:
         bool valid() { return _cache != nullptr && _handle != nullptr; }
 
         LRUCachePolicy* cache() const { return _cache; }
-        Slice data() const { return _cache->value_slice(_handle); }
 
     private:
         LRUCachePolicy* _cache = nullptr;
@@ -244,6 +244,8 @@ private:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE) {}
+
         std::shared_ptr<Reusable> item;
     };
 };

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -226,7 +226,8 @@ private:
         LOG(INFO) << "Add item mem size " << item->mem_size()
                   << ", cache_capacity: " << get_total_capacity()
                   << ", cache_usage: " << get_usage() << ", mem_consum: " << mem_consumption();
-        auto* lru_handle = insert(key, value, item->mem_size(), CachePriority::NORMAL);
+        auto* lru_handle =
+                insert(key, value, item->mem_size(), item->mem_size(), CachePriority::NORMAL);
         release(lru_handle);
     }
 

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -162,6 +162,10 @@ public:
         bool valid() { return _cache != nullptr && _handle != nullptr; }
 
         LRUCachePolicy* cache() const { return _cache; }
+        Slice data() const {
+            return {(char*)((RowCacheValue*)_cache->value(_handle))->cache_value,
+                    reinterpret_cast<LRUHandle*>(_handle)->charge};
+        }
 
     private:
         LRUCachePolicy* _cache = nullptr;

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -127,13 +127,20 @@ public:
         }
     };
 
+    class RowCacheValue : public LRUCacheValueBase {
+    public:
+        ~RowCacheValue() override { free(cache_value); }
+        char* cache_value;
+    };
+
     // A handle for RowCache entry. This class make it easy to handle
     // Cache entry. Users don't need to release the obtained cache entry. This
     // class will release the cache entry when it is destroyed.
     class CacheHandle {
     public:
         CacheHandle() = default;
-        CacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
+        CacheHandle(LRUCachePolicy* cache, Cache::Handle* handle)
+                : _cache(cache), _handle(handle) {}
         ~CacheHandle() {
             if (_handle != nullptr) {
                 _cache->release(_handle);
@@ -153,11 +160,11 @@ public:
 
         bool valid() { return _cache != nullptr && _handle != nullptr; }
 
-        Cache* cache() const { return _cache; }
+        LRUCachePolicy* cache() const { return _cache; }
         Slice data() const { return _cache->value_slice(_handle); }
 
     private:
-        Cache* _cache = nullptr;
+        LRUCachePolicy* _cache = nullptr;
         Cache::Handle* _handle = nullptr;
 
         // Don't allow copy and assign
@@ -206,7 +213,7 @@ private:
                              LRUCacheType::SIZE, config::tablet_lookup_cache_stale_sweep_time_sec) {
     }
 
-    std::string encode_key(__int128_t cache_id) {
+    static std::string encode_key(__int128_t cache_id) {
         fmt::memory_buffer buffer;
         fmt::format_to(buffer, "{}", cache_id);
         return std::string(buffer.data(), buffer.size());
@@ -214,33 +221,28 @@ private:
 
     void add(__int128_t cache_id, std::shared_ptr<Reusable> item) {
         std::string key = encode_key(cache_id);
-        CacheValue* value = new CacheValue;
+        auto* value = new CacheValue;
         value->item = item;
-        auto deleter = [](const doris::CacheKey& key, void* value) {
-            CacheValue* cache_value = (CacheValue*)value;
-            delete cache_value;
-        };
         LOG(INFO) << "Add item mem size " << item->mem_size()
-                  << ", cache_capacity: " << cache()->get_total_capacity()
-                  << ", cache_usage: " << cache()->get_usage()
-                  << ", mem_consum: " << cache()->mem_consumption();
-        auto lru_handle =
-                cache()->insert(key, value, item->mem_size(), deleter, CachePriority::NORMAL);
-        cache()->release(lru_handle);
+                  << ", cache_capacity: " << get_total_capacity()
+                  << ", cache_usage: " << get_usage() << ", mem_consum: " << mem_consumption();
+        auto* lru_handle = insert(key, value, item->mem_size(), CachePriority::NORMAL);
+        release(lru_handle);
     }
 
     std::shared_ptr<Reusable> get(__int128_t cache_id) {
         std::string key = encode_key(cache_id);
-        auto lru_handle = cache()->lookup(key);
+        auto* lru_handle = lookup(key);
         if (lru_handle) {
-            Defer release([cache = cache(), lru_handle] { cache->release(lru_handle); });
-            auto value = (CacheValue*)cache()->value(lru_handle);
+            Defer release([cache = this, lru_handle] { cache->release(lru_handle); });
+            auto* value = (CacheValue*)(LRUCachePolicy::value(lru_handle));
             return value->item;
         }
         return nullptr;
     }
 
-    struct CacheValue {
+    class CacheValue : public LRUCacheValueBase {
+    public:
         std::shared_ptr<Reusable> item;
     };
 };

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -156,8 +156,6 @@ DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_memory_total_byte, MetricUni
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_sql_total_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_partition_total_count, MetricUnit::NOUNIT);
 
-DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(lru_cache_memory_bytes, MetricUnit::BYTES);
-
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(upload_total_byte, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(upload_rowset_count, MetricUnit::ROWSETS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(upload_fail_count, MetricUnit::ROWSETS);
@@ -276,8 +274,6 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_memory_total_byte);
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_sql_total_count);
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_partition_total_count);
-
-    INT_GAUGE_METRIC_REGISTER(_server_metric_entity, lru_cache_memory_bytes);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, local_file_reader_total);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, s3_file_reader_total);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -190,8 +190,6 @@ public:
     UIntGauge* query_cache_sql_total_count = nullptr;
     UIntGauge* query_cache_partition_total_count = nullptr;
 
-    IntGauge* lru_cache_memory_bytes = nullptr;
-
     UIntGauge* scanner_thread_pool_queue_size = nullptr;
     UIntGauge* add_batch_task_queue_size = nullptr;
     UIntGauge* send_batch_thread_pool_thread_num = nullptr;

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -30,18 +30,18 @@ bool ObjLRUCache::lookup(const ObjKey& key, CacheHandle* handle) {
     if (!_enabled) {
         return false;
     }
-    auto lru_handle = cache()->lookup(key.key);
+    auto* lru_handle = LRUCachePolicy::lookup(key.key);
     if (!lru_handle) {
         // cache miss
         return false;
     }
-    *handle = CacheHandle(cache(), lru_handle);
+    *handle = CacheHandle(this, lru_handle);
     return true;
 }
 
 void ObjLRUCache::erase(const ObjKey& key) {
     if (_enabled) {
-        cache()->erase(key.key);
+        LRUCachePolicy::erase(key.key);
     }
 }
 

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -33,10 +33,20 @@ public:
         std::string key;
     };
 
+    template <typename T>
+    class ObjValue : public LRUCacheValueBase {
+    public:
+        ObjValue(const T* value) : value(value) {}
+        ~ObjValue() override { delete value; }
+
+        const T* value;
+    };
+
     class CacheHandle {
     public:
         CacheHandle() = default;
-        CacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
+        CacheHandle(LRUCachePolicy* cache, Cache::Handle* handle)
+                : _cache(cache), _handle(handle) {}
         ~CacheHandle() {
             if (_handle != nullptr) {
                 _cache->release(_handle);
@@ -56,11 +66,11 @@ public:
 
         bool valid() { return _cache != nullptr && _handle != nullptr; }
 
-        Cache* cache() const { return _cache; }
+        LRUCachePolicy* cache() const { return _cache; }
         void* data() const { return _cache->value(_handle); }
 
     private:
-        Cache* _cache = nullptr;
+        LRUCachePolicy* _cache = nullptr;
         Cache::Handle* _handle = nullptr;
 
         // Don't allow copy and assign
@@ -73,21 +83,12 @@ public:
 
     template <typename T>
     void insert(const ObjKey& key, const T* value, CacheHandle* cache_handle) {
-        auto deleter = [](const doris::CacheKey& key, void* value) {
-            T* v = (T*)value;
-            delete v;
-        };
-        insert(key, value, cache_handle, deleter);
-    }
-
-    template <typename T>
-    void insert(const ObjKey& key, const T* value, CacheHandle* cache_handle,
-                void (*deleter)(const CacheKey& key, void* value)) {
         if (_enabled) {
             const std::string& encoded_key = key.key;
-            auto handle = cache()->insert(encoded_key, (void*)value, 1, deleter,
-                                          CachePriority::NORMAL, sizeof(T));
-            *cache_handle = CacheHandle {cache(), handle};
+            auto* obj_value = new ObjValue<T>(value);
+            auto* handle = LRUCachePolicy::insert(encoded_key, obj_value, 1, CachePriority::NORMAL,
+                                                  sizeof(T));
+            *cache_handle = CacheHandle {this, handle};
         } else {
             cache_handle = nullptr;
         }

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -38,7 +38,10 @@ public:
     public:
         ObjValue(const T* value)
                 : LRUCacheValueBase(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE), value(value) {}
-        ~ObjValue() override { delete value; }
+        ~ObjValue() override {
+            T* v = (T*)value;
+            delete v;
+        }
 
         const T* value;
     };
@@ -68,7 +71,8 @@ public:
         bool valid() { return _cache != nullptr && _handle != nullptr; }
 
         LRUCachePolicy* cache() const { return _cache; }
-        void* data() const { return _cache->value(_handle); }
+        template <typename T>
+        void* data() const { return (void*)((ObjValue<T>*)_cache->value(_handle))->value; }
 
     private:
         LRUCachePolicy* _cache = nullptr;

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -72,7 +72,9 @@ public:
 
         LRUCachePolicy* cache() const { return _cache; }
         template <typename T>
-        void* data() const { return (void*)((ObjValue<T>*)_cache->value(_handle))->value; }
+        void* data() const {
+            return (void*)((ObjValue<T>*)_cache->value(_handle))->value;
+        }
 
     private:
         LRUCachePolicy* _cache = nullptr;

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -86,8 +86,8 @@ public:
         if (_enabled) {
             const std::string& encoded_key = key.key;
             auto* obj_value = new ObjValue<T>(value);
-            auto* handle = LRUCachePolicy::insert(encoded_key, obj_value, 1, CachePriority::NORMAL,
-                                                  sizeof(T));
+            auto* handle = LRUCachePolicy::insert(encoded_key, obj_value, 1, sizeof(T),
+                                                  CachePriority::NORMAL);
             *cache_handle = CacheHandle {this, handle};
         } else {
             cache_handle = nullptr;

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -36,7 +36,8 @@ public:
     template <typename T>
     class ObjValue : public LRUCacheValueBase {
     public:
-        ObjValue(const T* value) : value(value) {}
+        ObjValue(const T* value)
+                : LRUCacheValueBase(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE), value(value) {}
         ~ObjValue() override { delete value; }
 
         const T* value;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -263,7 +263,7 @@ Status ParquetReader::_open_file() {
                 _column_statistics.meta_read_calls += 1;
             }
 
-            _file_metadata = (FileMetaData*)_meta_cache_handle.data();
+            _file_metadata = (FileMetaData*)_meta_cache_handle.data<FileMetaData>();
         }
 
         if (_file_metadata == nullptr) {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -71,7 +71,8 @@ public:
 
     class CacheValueWithKey : public LRUCacheValueBase {
     public:
-        CacheValueWithKey(int key, void* value) : key(key), value(value) {}
+        CacheValueWithKey(int key, void* value)
+                : LRUCacheValueBase(CachePolicy::CacheType::FOR_UT), key(key), value(value) {}
         ~CacheValueWithKey() override {
             _s_current->_deleted_keys.push_back(key);
             _s_current->_deleted_values.push_back(DecodeValue(value));
@@ -83,7 +84,7 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue(void* value) : value(value) {}
+        CacheValue(void* value) : LRUCacheValueBase(CachePolicy::CacheType::FOR_UT), value(value) {}
         ~CacheValue() override = default;
 
         void* value;

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -92,7 +92,7 @@ public:
 
     ~CacheTest() override { delete _cache; }
 
-    Cache* cache() const { return _cache->cache(); }
+    LRUCachePolicy* cache() const { return _cache; }
 
     int Lookup(int key) const {
         std::string result;

--- a/be/test/olap/page_cache_test.cpp
+++ b/be/test/olap/page_cache_test.cpp
@@ -28,12 +28,17 @@ static int kNumShards = StoragePageCache::kDefaultNumShards;
 
 class StoragePageCacheTest : public testing::Test {
 public:
-    StoragePageCacheTest() {}
-    virtual ~StoragePageCacheTest() {}
+    StoragePageCacheTest() {
+        mem_tracker = std::make_shared<MemTrackerLimiter>(MemTrackerLimiter::Type::GLOBAL,
+                                                          "StoragePageCacheTest");
+    }
+    ~StoragePageCacheTest() override = default;
+
+    std::shared_ptr<MemTrackerLimiter> mem_tracker;
 };
 
 // All cache space is allocated to data pages
-TEST(StoragePageCacheTest, data_page_only) {
+TEST_F(StoragePageCacheTest, data_page_only) {
     StoragePageCache cache(kNumShards * 2048, 0, 0, kNumShards);
 
     StoragePageCache::CacheKey key("abc", 0, 0);
@@ -44,7 +49,7 @@ TEST(StoragePageCacheTest, data_page_only) {
     {
         // insert normal page
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(key, data, &handle, page_type, false);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -57,7 +62,7 @@ TEST(StoragePageCacheTest, data_page_only) {
     {
         // insert in_memory page
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(memory_key, data, &handle, page_type, true);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -70,7 +75,7 @@ TEST(StoragePageCacheTest, data_page_only) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(key, data, &handle, page_type, false);
     }
 
@@ -99,7 +104,7 @@ TEST(StoragePageCacheTest, data_page_only) {
 }
 
 // All cache space is allocated to index pages
-TEST(StoragePageCacheTest, index_page_only) {
+TEST_F(StoragePageCacheTest, index_page_only) {
     StoragePageCache cache(kNumShards * 2048, 100, 0, kNumShards);
 
     StoragePageCache::CacheKey key("abc", 0, 0);
@@ -110,7 +115,7 @@ TEST(StoragePageCacheTest, index_page_only) {
     {
         // insert normal page
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(key, data, &handle, page_type, false);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -123,7 +128,7 @@ TEST(StoragePageCacheTest, index_page_only) {
     {
         // insert in_memory page
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(memory_key, data, &handle, page_type, true);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -136,7 +141,7 @@ TEST(StoragePageCacheTest, index_page_only) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        DataPage* data = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
         cache.insert(key, data, &handle, page_type, false);
     }
 
@@ -165,7 +170,7 @@ TEST(StoragePageCacheTest, index_page_only) {
 }
 
 // Cache space is allocated by index_page_cache_ratio
-TEST(StoragePageCacheTest, mixed_pages) {
+TEST_F(StoragePageCacheTest, mixed_pages) {
     StoragePageCache cache(kNumShards * 2048, 10, 0, kNumShards);
 
     StoragePageCache::CacheKey data_key("data", 0, 0);
@@ -179,8 +184,8 @@ TEST(StoragePageCacheTest, mixed_pages) {
     {
         // insert both normal pages
         PageCacheHandle data_handle, index_handle;
-        DataPage* data = new DataPage(1024);
-        DataPage* index = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
+        auto* index = new DataPage(1024, mem_tracker);
         cache.insert(data_key, data, &data_handle, page_type_data, false);
         cache.insert(index_key, index, &index_handle, page_type_index, false);
 
@@ -198,8 +203,8 @@ TEST(StoragePageCacheTest, mixed_pages) {
     {
         // insert both in_memory pages
         PageCacheHandle data_handle, index_handle;
-        DataPage* data = new DataPage(1024);
-        DataPage* index = new DataPage(1024);
+        auto* data = new DataPage(1024, mem_tracker);
+        auto* index = new DataPage(1024, mem_tracker);
         cache.insert(data_key_mem, data, &data_handle, page_type_data, true);
         cache.insert(index_key_mem, index, &index_handle, page_type_index, true);
 
@@ -216,8 +221,8 @@ TEST(StoragePageCacheTest, mixed_pages) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024);
-        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024);
+        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, mem_tracker);
+        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, mem_tracker);
         cache.insert(key, data.release(), &handle, page_type_data, false);
         cache.insert(key, index.release(), &handle, page_type_index, false);
     }
@@ -237,8 +242,8 @@ TEST(StoragePageCacheTest, mixed_pages) {
         PageCacheHandle data_handle, index_handle;
         StoragePageCache::CacheKey miss_key_data("data_miss", 0, 1);
         StoragePageCache::CacheKey miss_key_index("index_miss", 0, 1);
-        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024);
-        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024);
+        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, mem_tracker);
+        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, mem_tracker);
         cache.insert(miss_key_data, data.release(), &data_handle, page_type_data, false);
         cache.insert(miss_key_index, index.release(), &index_handle, page_type_index, false);
 


### PR DESCRIPTION
## Proposed changes

In order to add common code to the value deleter of LRU cache, let all lru cache values inherit from LRUCacheValueBase class and tracking memory in destructor.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

