### PR TITLE
[pipelineX](scanner) Use the actual instances num when ignore data distribution

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -76,7 +76,8 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
     _max_thread_num = _state->num_scanner_threads() > 0
                               ? _state->num_scanner_threads()
                               : config::doris_scanner_thread_pool_thread_num /
-                                        state->query_parallel_instance_num();
+                                        (_local_state ? num_parallel_instances
+                                                      : state->query_parallel_instance_num());
     _max_thread_num *= num_parallel_instances;
     _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
     _max_thread_num = std::min(_max_thread_num, (int32_t)scanners.size());


### PR DESCRIPTION
## Proposed changes

Create clickbench table with 48buckets and use 92 cores machine, Q29 is accelerated from 11s+ to 1.8s+

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

