### PR TITLE
[enhance](Cache) Control whether writing into file cache for query and load

### DIFF
--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -106,17 +106,6 @@ Status CachedRemoteFileReader::_read_from_cache(size_t offset, Slice result, siz
     size_t bytes_req = result.size;
     bytes_req = std::min(bytes_req, size() - offset);
     ReadStatistics stats;
-    // session variable chooses to close file cache for this query
-    if (!io_ctx->read_file_cache) {
-        SCOPED_RAW_TIMER(&stats.remote_read_timer);
-        RETURN_IF_ERROR(_remote_file_reader->read_at(offset, result, bytes_read, io_ctx));
-        DorisMetrics::instance()->s3_bytes_read_total->increment(*bytes_read);
-        if (io_ctx->file_cache_stats) {
-            stats.bytes_read += bytes_req;
-            _update_state(stats, io_ctx->file_cache_stats);
-        }
-        return Status::OK();
-    }
     auto [align_left, align_size] = _align_size(offset, bytes_req);
     CacheContext cache_context(io_ctx);
     FileBlocksHolder holder = _cache->get_or_set(_cache_key, align_left, align_size, cache_context);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -232,6 +232,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         _read_options.io_ctx.query_id = &_read_context->runtime_state->query_id();
         _read_options.io_ctx.read_file_cache =
                 _read_context->runtime_state->query_options().enable_file_cache;
+        _read_options.io_ctx.is_disposable =
+                _read_context->runtime_state->query_options().disable_file_cache;
     }
 
     // load segments

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -207,8 +207,11 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
     }
     auto path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, segment_id);
     io::FileReaderOptions reader_options {
-            .cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
-                                                    : io::FileCachePolicy::NO_CACHE,
+            .cache_type =
+                    _context.write_file_cache
+                            ? (config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
+                                                         : io::FileCachePolicy::NO_CACHE)
+                            : io::FileCachePolicy::NO_CACHE,
             .is_doris_table = true};
     auto s = segment_v2::Segment::open(fs, path, segment_id, rowset_id(), _context.tablet_schema,
                                        reader_options, &segment);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The former implementation would never try to read from cache even though the data might already lie inside local storage. This pr makes it only read the data which does not exist on local cache.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

