### PR TITLE
[Fix](auto-inc) Fix partial update auto inc unique table case failure

### DIFF
--- a/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
+++ b/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
@@ -116,16 +116,18 @@ Carter	500	9994
 Beata	700	9996
 Nereids	900	9998
 
--- !partial_update_value --
-Bob	100	1
-Alice	200	2
-Tom	300	3
-Test	400	4
-Carter	500	5
-Smith	600	6
-Beata	700	7
-Doris	800	8
-Nereids	900	9
+-- !partial_update_value1 --
+Bob	100
+Alice	200
+Tom	300
+Test	400
+Carter	500
+Smith	600
+Beata	700
+Doris	800
+Nereids	900
+
+-- !partial_update_value2 --
 
 -- !partial_update_value --
 Bob	9990	1

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
@@ -279,7 +279,8 @@ suite("test_unique_table_auto_inc") {
         time 10000 // limit inflight 10s
     }
     sql "sync"
-    qt_partial_update_value "select * from ${table7} order by id;"
+    qt_partial_update_value1 "select name, value from ${table7} order by value;"
+    qt_partial_update_value2 "select id, count(*) from ${table7} group by id having count(*) > 1;"
 
     streamLoad {
         table "${table7}"


### PR DESCRIPTION
The issue introduced by the recently added auto-increment column works fine on a single node but may result in discontinuous auto-increment IDs when running on a cluster. This PR has been modified to check for the uniqueness of the auto-increment column values instead of checking for equality to a fixed value.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

