### PR TITLE
[fix](cast) return error when numerical cast out-of-range

### DIFF
--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -432,6 +432,15 @@ struct ConvertImpl {
                     block.get_by_position(result).column =
                             ColumnNullable::create(std::move(col_to), std::move(col_null_map_to));
                     return Status::OK();
+                } else if constexpr (IsDataTypeNumber<FromDataType> &&
+                                     IsDataTypeNumber<ToDataType>) {
+                    for (size_t i = 0; i < size; ++i) {
+                        if (vec_from[i] < min_result || vec_from[i] > max_result) {
+                            return Status::RuntimeError("{}({}) out of range", col_to->get_name(),
+                                                        vec_from[i]);
+                        }
+                        vec_to[i] = static_cast<ToFieldType>(vec_from[i]);
+                    }
                 } else {
                     for (size_t i = 0; i < size; ++i) {
                         vec_to[i] = static_cast<ToFieldType>(vec_from[i]);

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1560,6 +1560,11 @@ struct ConvertThroughParsing {
                 parsed = try_parse_impl<ToDataType, void*, FromDataType>(
                         vec_to[i], read_buffer, context->state()->timezone_obj());
             }
+            bool parse_success = parsed && is_all_read(read_buffer);
+            if (string_size > 0 && !parse_success) {
+                std::string_view raw{reinterpret_cast<const char *>(&(*chars)[current_offset]), string_size};
+                return Status::RuntimeError("failed to parse '{}' as {}", raw, col_to->get_name());
+            }
             (*vec_null_map_to)[i] = !parsed || !is_all_read(read_buffer);
             current_offset = next_offset;
         }


### PR DESCRIPTION
## Proposed changes

Return an error when numerical cast result is out-of-range.

Before:
![image](https://github.com/apache/doris/assets/5821159/c3cc34d8-3f68-45ff-8db5-a5cd80eec90d)

After:
<img width="823" alt="image" src="https://github.com/apache/doris/assets/5821159/db7ba4d2-ee20-465b-88e9-71e08b0dbc8b">

Note: [MySQL no restrictive modes](https://dev.mysql.com/doc/refman/8.0/en/out-of-range-and-overflow.html) is not supported.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

