### PR TITLE
[FE](memory) Update mariadb-java-client to 3.0.9 to avoid memory leak

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -322,7 +322,7 @@ under the License.
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
-        <mariadb-java-client.version>3.0.4</mariadb-java-client.version>
+        <mariadb-java-client.version>3.0.9</mariadb-java-client.version>
         <dlf-metastore-client-hive.version>0.2.14</dlf-metastore-client-hive.version>
         <hadoop.version>3.3.6</hadoop.version>
         <joda.version>2.8.1</joda.version>


### PR DESCRIPTION
This is a missing PR from master branch #30242

[fix](fe) Upgrade mariadb client version from 3.0.4 to 3.0.9 (#30242)

mariadb-java-client 3.0.4 has two serious problems:
* https://jira.mariadb.org/browse/CONJ-972
* https://jira.mariadb.org/browse/CONJ-973

Co-authored-by: Lei Zhang <27994433+SWJTU-ZhangLei@users.noreply.github.com>