### PR TITLE
[fix](cloud) fix auto analyze triggering failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1066,6 +1066,55 @@ public class ConnectContext {
         this.cloudCluster = cluster;
     }
 
+    public void setCloudCluster() {
+        List<String> cloudClusterNames = ((CloudSystemInfoService) Env.getCurrentSystemInfo()).getCloudClusterNames();
+        // try set default cluster
+        String defaultCloudCluster = Env.getCurrentEnv().getAuth().getDefaultCloudCluster(getQualifiedUser());
+        if (!Strings.isNullOrEmpty(defaultCloudCluster)) {
+            // check cluster validity
+            if (cloudClusterNames.contains(defaultCloudCluster)) {
+                // valid
+                setCloudCluster(defaultCloudCluster);
+                LOG.info("use default cluster {}", defaultCloudCluster);
+                return;
+            } else {
+                // invalid
+                LOG.warn("default cluster {} current invalid, please change it", defaultCloudCluster);
+                getState().setError(ErrorCode.ERR_NO_CLUSTER_ERROR,
+                        "default cluster " + defaultCloudCluster + "current invalid, please change it");
+                return;
+            }
+        }
+
+        // get all available cluster of the user
+        for (String cloudClusterName : cloudClusterNames) {
+            if (Env.getCurrentEnv().getAuth().checkCloudPriv(getCurrentUserIdentity(),
+                    cloudClusterName, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
+                // find a cluster has more than one alive be
+                List<Backend> bes = ((CloudSystemInfoService) Env.getCurrentSystemInfo()).getBackendsByClusterName(
+                        cloudClusterName);
+                AtomicBoolean hasAliveBe = new AtomicBoolean(false);
+                bes.stream().filter(Backend::isAlive).findAny().ifPresent(backend -> {
+                    LOG.debug("get a clusterName {}, it's has more than one alive be {}", cloudClusterName, backend);
+                    hasAliveBe.set(true);
+                });
+                if (hasAliveBe.get()) {
+                    // set a cluster to context cloudCluster
+                    setCloudCluster(cloudClusterName);
+                    LOG.debug("set context cluster name {}", cloudClusterName);
+                    break;
+                }
+            }
+        }
+        if (Strings.isNullOrEmpty(this.cloudCluster)) {
+            LOG.warn("cant get a valid cluster for user {} to use", getCurrentUserIdentity());
+            getState().setError(ErrorCode.ERR_NO_CLUSTER_ERROR,
+                    "Cant get a Valid cluster for you to use, plz connect admin");
+            return;
+        }
+        LOG.info("finally set context cluster name {}", cloudCluster);
+    }
+
     /**
      * @return Returns an available cluster in the following order
      *         1 Use an explicitly specified cluster

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -140,7 +140,7 @@ public class StatisticsUtil {
         }
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
             if (Config.isCloudMode()) {
-                r.connectContext.setCloudCluster();
+                r.connectContext.getCloudCluster();
             }
             StmtExecutor stmtExecutor = new StmtExecutor(r.connectContext, sql);
             r.connectContext.setExecutor(stmtExecutor);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -139,6 +139,9 @@ public class StatisticsUtil {
             return Collections.emptyList();
         }
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            if (Config.isCloudMode()) {
+                r.connectContext.setCloudCluster();
+            }
             StmtExecutor stmtExecutor = new StmtExecutor(r.connectContext, sql);
             r.connectContext.setExecutor(stmtExecutor);
             return stmtExecutor.executeInternalQuery();
@@ -447,11 +450,25 @@ public class StatisticsUtil {
         } catch (Throwable t) {
             return false;
         }
-        for (OlapTable table : statsTbls) {
-            for (Partition partition : table.getPartitions()) {
-                if (partition.getBaseIndex().getTablets().stream()
-                        .anyMatch(t -> t.getNormalReplicaBackendIds().isEmpty())) {
-                    return false;
+        if (Config.isCloudMode()) {
+            try (AutoCloseConnectContext r = buildConnectContext()) {
+                r.connectContext.setCloudCluster();
+                for (OlapTable table : statsTbls) {
+                    for (Partition partition : table.getPartitions()) {
+                        if (partition.getBaseIndex().getTablets().stream()
+                                .anyMatch(t -> t.getNormalReplicaBackendIds().isEmpty())) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        } else {
+            for (OlapTable table : statsTbls) {
+                for (Partition partition : table.getPartitions()) {
+                    if (partition.getBaseIndex().getTablets().stream()
+                            .anyMatch(t -> t.getNormalReplicaBackendIds().isEmpty())) {
+                        return false;
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -452,7 +452,7 @@ public class StatisticsUtil {
         }
         if (Config.isCloudMode()) {
             try (AutoCloseConnectContext r = buildConnectContext()) {
-                r.connectContext.setCloudCluster();
+                r.connectContext.getCloudCluster();
                 for (OlapTable table : statsTbls) {
                     for (Partition partition : table.getPartitions()) {
                         if (partition.getBaseIndex().getTablets().stream()


### PR DESCRIPTION
StatisticsCollector only collect when replicas are normal. In cloud mode, this check needs getCloudCluster before execution. Otherwise, check will be a dead-end failure.

![image](https://github.com/apache/doris/assets/6492193/b2df5e5e-c06f-4713-a562-90066b898c29)


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

