### PR TITLE
[bugfix]json_length() BE crash fix

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -1080,7 +1080,8 @@ struct JsonbLengthUtil {
         MutableColumnPtr res = return_type->create_column();
 
         for (size_t i = 0; i < input_rows_count; ++i) {
-            if (jsonb_data_column->is_null_at(i) || path_column->is_null_at(i)) {
+            if (jsonb_data_column->is_null_at(i) || path_column->is_null_at(i) ||
+                (jsonb_data_column->get_data_at(i).size == 0)) {
                 null_map->get_data()[i] = 1;
                 res->insert_data(nullptr, 0);
                 continue;
@@ -1100,7 +1101,7 @@ struct JsonbLengthUtil {
             // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
             JsonbDocument* doc = JsonbDocument::createDocument(jsonb_value.data, jsonb_value.size);
             JsonbValue* value = doc->getValue()->findValue(path, nullptr);
-            if (UNLIKELY(jsonb_value.size == 0 || !value)) {
+            if (UNLIKELY(!value)) {
                 null_map->get_data()[i] = 1;
                 res->insert_data(nullptr, 0);
                 continue;

--- a/regression-test/data/jsonb_p0/test_jsonb_load_and_function.out
+++ b/regression-test/data/jsonb_p0/test_jsonb_load_and_function.out
@@ -7494,6 +7494,9 @@ false
 -- !sql_json_length --
 2
 
+-- !sql_json_length --
+\N
+
 -- !select_length --
 1	\N	\N
 2	null	1

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
@@ -552,6 +552,7 @@ suite("test_jsonb_load_and_function", "p0") {
     qt_sql_json_length """SELECT json_length('{"k1":"v31","k2":300}')"""
     qt_sql_json_length """SELECT json_length('{"a.b.c":{"k1.a1":"v31", "k2": 300},"a":"niu"}')"""
     qt_sql_json_length """SELECT json_length('{"a":{"k1.a1":"v31", "k2": 300},"b":"niu"}','\$.a')"""
+    qt_sql_json_length """SELECT json_length('abc','\$.k1')"""
 
     qt_select_length """SELECT id, j, json_length(j) FROM ${testTable} ORDER BY id"""
     qt_select_length """SELECT id, j, json_length(j, '\$[1]') FROM ${testTable} ORDER BY id"""


### PR DESCRIPTION
## Proposed changes

Issue Number: close #32124 

MySQL [(none)]> select json_length('abc','$.k1');
+------------------------------------------+
| json_length('abc', '$.k1') |
+------------------------------------------+
|                                     NULL |
+------------------------------------------+
1 row in set (0.109 sec)

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

