### PR TITLE
[Fix](push down) Push down min max can not execute on unique MoR table value column

### DIFF
--- a/regression-test/data/nereids_p0/explain/test_pushdown_explain.out
+++ b/regression-test/data/nereids_p0/explain/test_pushdown_explain.out
@@ -74,9 +74,6 @@ asd
 -- !select_10 --
 qwe
 
--- !select_11 --
-cc
-
 -- !select_12 --
 zzz
 
@@ -97,9 +94,6 @@ asd
 
 -- !select_16 --
 qdf
-
--- !select_17 --
-ll
 
 -- !select_18 --
 zzz

--- a/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
+++ b/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
@@ -177,7 +177,6 @@ suite("test_pushdown_explain") {
     qt_select_8 "select max(user_id) from table_unique;"
     qt_select_9 "select min(username) from table_unique;"
     qt_select_10 "select max(username) from table_unique;"
-    qt_select_11 "select min(val) from table_unique;"
     qt_select_12 "select max(val) from table_unique;"
 
     sql """
@@ -188,7 +187,6 @@ suite("test_pushdown_explain") {
     qt_select_14 "select max(user_id) from table_unique;"
     qt_select_15 "select min(username) from table_unique;"
     qt_select_16 "select max(username) from table_unique;"
-    qt_select_17 "select min(val) from table_unique;"
     qt_select_18 "select max(val) from table_unique;"
 
 


### PR DESCRIPTION
Push down min max can not execute on unique merge on read (MOR) table value column, so we delete min max push down on MOR value column case.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

