### PR TITLE
[fix](function) fixed the get_json_string function

### DIFF
--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "exprs/json_functions.h"
+#include "vec/io/io_helper.h"
 #ifdef __AVX2__
 #include "util/jsonb_parser_simd.h"
 #else
@@ -350,7 +351,7 @@ struct GetJsonString {
             rapidjson::Value* root = nullptr;
 
             root = get_json_object<JSON_FUN_STRING>(json_string, path_string, &document);
-            const int max_string_len = (l_size <= 65535) ? 65535 : (l_size + 1);
+            const int max_string_len = DEFAULT_MAX_JSON_SIZE;
 
             if (root == nullptr || root->IsNull()) {
                 StringOP::push_null_string(i, res_data, res_offsets, null_map);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`When using get_json_string function. The length of the string to be parsed will be truncated if it exceeds 65535. The data is incomplete. optimization made in 1.2`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

