### PR TITLE
[fix](jdbc catalog) Fix the wrong method used in loadColumnNames of JdbcIdentifierMapping

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcIdentifierMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcIdentifierMapping.java
@@ -40,6 +40,6 @@ public class JdbcIdentifierMapping extends IdentifierMapping {
 
     @Override
     protected void loadColumnNames(String localDbName, String localTableName) {
-        jdbcClient.getJdbcColumnsInfo(localDbName, localTableName);
+        jdbcClient.getColumnsFromJdbc(localDbName, localTableName);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/mapping/IdentifierMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/mapping/IdentifierMapping.java
@@ -208,8 +208,7 @@ public abstract class IdentifierMapping {
                 || localColumnToRemoteColumn.get(remoteDbName).isEmpty()
                 || !localColumnToRemoteColumn.get(remoteDbName).containsKey(remoteTableName)
                 || localColumnToRemoteColumn.get(remoteDbName).get(remoteTableName) == null
-                || localColumnToRemoteColumn.get(
-                remoteDbName).get(remoteTableName).isEmpty()) {
+                || localColumnToRemoteColumn.get(remoteDbName).get(remoteTableName).isEmpty()) {
             loadColumnNamesIfNeeded(localDbName, localTableName);
         }
         return localColumnToRemoteColumn.get(remoteDbName).get(remoteTableName);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the loadColumnNames method of JdbcIdentifierMapping, a method with the functionality to populate the localColumnToRemoteColumn map must be called

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

