### PR TITLE
[fix](mysql) Fix Connection Attributes Parsing Logic for Compatibility

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlAuthPacket.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlAuthPacket.java
@@ -104,8 +104,9 @@ public class MysqlAuthPacket extends MysqlPacket {
         // attribute map, no use now.
         if (buffer.remaining() > 0 && capability.isConnectAttrs()) {
             connectAttributes = Maps.newHashMap();
-            long numPair = MysqlProto.readVInt(buffer);
-            for (long i = 0; i < numPair; ++i) {
+            long attrsLength = MysqlProto.readVInt(buffer);
+            long initialPosition = buffer.position();
+            while (buffer.position() - initialPosition < attrsLength) {
                 String key = new String(MysqlProto.readLenEncodedString(buffer));
                 String value = new String(MysqlProto.readLenEncodedString(buffer));
                 connectAttributes.put(key, value);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #31857

This PR addresses compatibility issues with the latest version of the MySQL Python Connector. The previous implementation failed to correctly handle connection attributes (`conn_attrs`), leading to handshake failures. By adjusting the logic for reading connection attribute data to ensure we do not exceed the actual length of the attribute section when parsing key-value pairs, we have resolved the compatibility issue. This change allows our custom MySQL protocol implementation to correctly parse connection requests from the new version of the Connector.

Thanks to @liujiwen-up for helping with this

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

