### PR TITLE
[Improvement](runtime-filter) support sync join node build side's size to init bloom runtime filter

### DIFF
--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -108,7 +108,9 @@ public:
 
     Status init_with_fixed_length() { return init_with_fixed_length(_bloom_filter_length); }
 
-    Status init_with_cardinality(const size_t build_bf_cardinality, int id = 0) {
+    bool get_build_bf_cardinality() const { return _build_bf_exactly; }
+
+    Status init_with_cardinality(const size_t build_bf_cardinality) {
         if (_build_bf_exactly) {
             // Use the same algorithm as org.apache.doris.planner.RuntimeFilter#calculateFilterSize
             constexpr double fpp = 0.05;
@@ -195,10 +197,7 @@ public:
         *len = _bloom_filter->size();
     }
 
-    bool contain_null() const {
-        DCHECK(_bloom_filter);
-        return _bloom_filter->contain_null();
-    }
+    bool contain_null() const { return _bloom_filter->contain_null(); }
 
     void set_contain_null_and_null_aware() { _bloom_filter->set_contain_null_and_null_aware(); }
 

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -197,7 +197,10 @@ public:
         *len = _bloom_filter->size();
     }
 
-    bool contain_null() const { return _bloom_filter->contain_null(); }
+    bool contain_null() const {
+        DCHECK(_bloom_filter);
+        return _bloom_filter->contain_null();
+    }
 
     void set_contain_null_and_null_aware() { _bloom_filter->set_contain_null_and_null_aware(); }
 

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1036,7 +1036,7 @@ Status IRuntimeFilter::send_filter_size(uint64_t local_filter_size) {
         } else {
             if (_has_local_target) {
                 for (auto* filter : local_merge_filters->filters) {
-                    filter->set_global_size(local_merge_filters->local_merged_size);
+                    filter->set_synced_size(local_merge_filters->local_merged_size);
                 }
                 return Status::OK();
             } else {
@@ -1044,7 +1044,7 @@ Status IRuntimeFilter::send_filter_size(uint64_t local_filter_size) {
             }
         }
     } else if (_has_local_target) {
-        set_global_size(local_filter_size);
+        set_synced_size(local_filter_size);
         return Status::OK();
     }
 
@@ -1285,9 +1285,9 @@ void IRuntimeFilter::set_dependency(pipeline::CountedFinishDependency* dependenc
     CHECK(_dependency);
 }
 
-void IRuntimeFilter::set_global_size(uint64_t global_size) {
+void IRuntimeFilter::set_synced_size(uint64_t global_size) {
     CHECK(_dependency);
-    _global_size = global_size;
+    _synced_size = global_size;
     _dependency->sub();
 }
 

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1288,7 +1288,6 @@ void IRuntimeFilter::set_dependency(pipeline::CountedFinishDependency* dependenc
 void IRuntimeFilter::set_global_size(uint64_t global_size) {
     CHECK(_dependency);
     _global_size = global_size;
-    _isset_global_size = true;
     _dependency->sub();
 }
 

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -290,9 +290,9 @@ public:
             : _pool(pool),
               _column_return_type(column_type),
               _filter_type(type),
+              _context(new RuntimeFilterContext()),
               _filter_id(filter_id),
-              _build_bf_exactly(build_bf_exactly),
-              _context(new RuntimeFilterContext()) {}
+              _build_bf_exactly(build_bf_exactly) {}
 
     // init runtime filter wrapper
     // alloc memory to init runtime filter function

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -291,9 +291,8 @@ public:
               _column_return_type(column_type),
               _filter_type(type),
               _filter_id(filter_id),
-              _build_bf_exactly(build_bf_exactly) {
-        _context = std::make_shared<RuntimeFilterContext>();
-    }
+              _build_bf_exactly(build_bf_exactly),
+              _context(new RuntimeFilterContext()) {}
 
     // init runtime filter wrapper
     // alloc memory to init runtime filter function

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -291,7 +291,9 @@ public:
               _column_return_type(column_type),
               _filter_type(type),
               _filter_id(filter_id),
-              _build_bf_exactly(build_bf_exactly) {}
+              _build_bf_exactly(build_bf_exactly) {
+        _context = std::make_shared<RuntimeFilterContext>();
+    }
 
     // init runtime filter wrapper
     // alloc memory to init runtime filter function
@@ -299,37 +301,36 @@ public:
         _max_in_num = params->max_in_num;
         switch (_filter_type) {
         case RuntimeFilterType::IN_FILTER: {
-            _context.hybrid_set.reset(create_set(_column_return_type));
-            _context.hybrid_set->set_null_aware(params->null_aware);
+            _context->hybrid_set.reset(create_set(_column_return_type));
+            _context->hybrid_set->set_null_aware(params->null_aware);
             break;
         }
         // Only use in nested loop join not need set null aware
         case RuntimeFilterType::MIN_FILTER:
         case RuntimeFilterType::MAX_FILTER: {
-            _context.minmax_func.reset(create_minmax_filter(_column_return_type));
+            _context->minmax_func.reset(create_minmax_filter(_column_return_type));
             break;
         }
         case RuntimeFilterType::MINMAX_FILTER: {
-            _context.minmax_func.reset(create_minmax_filter(_column_return_type));
-            _context.minmax_func->set_null_aware(params->null_aware);
+            _context->minmax_func.reset(create_minmax_filter(_column_return_type));
+            _context->minmax_func->set_null_aware(params->null_aware);
             break;
         }
         case RuntimeFilterType::BLOOM_FILTER: {
-            _is_bloomfilter = true;
-            _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type));
-            _context.bloom_filter_func->init_params(params);
+            _context->bloom_filter_func.reset(create_bloom_filter(_column_return_type));
+            _context->bloom_filter_func->init_params(params);
             return Status::OK();
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
-            _context.hybrid_set.reset(create_set(_column_return_type));
-            _context.hybrid_set->set_null_aware(params->null_aware);
-            _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type));
-            _context.bloom_filter_func->init_params(params);
+            _context->hybrid_set.reset(create_set(_column_return_type));
+            _context->hybrid_set->set_null_aware(params->null_aware);
+            _context->bloom_filter_func.reset(create_bloom_filter(_column_return_type));
+            _context->bloom_filter_func->init_params(params);
             return Status::OK();
         }
         case RuntimeFilterType::BITMAP_FILTER: {
-            _context.bitmap_filter_func.reset(create_bitmap_filter(_column_return_type));
-            _context.bitmap_filter_func->set_not_in(params->bitmap_filter_not_in);
+            _context->bitmap_filter_func.reset(create_bitmap_filter(_column_return_type));
+            _context->bitmap_filter_func->set_not_in(params->bitmap_filter_not_in);
             return Status::OK();
         }
         default:
@@ -342,61 +343,66 @@ public:
         CHECK(_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER)
                 << "Can not change to bloom filter because of runtime filter type is "
                 << IRuntimeFilter::to_string(_filter_type);
-        _is_bloomfilter = true;
-        BloomFilterFuncBase* bf = _context.bloom_filter_func.get();
+        BloomFilterFuncBase* bf = _context->bloom_filter_func.get();
         if (need_init_bf) {
             // BloomFilter may be not init
             RETURN_IF_ERROR(bf->init_with_fixed_length());
             insert_to_bloom_filter(bf);
         }
         // release in filter
-        _context.hybrid_set.reset();
+        _context->hybrid_set.reset();
         return Status::OK();
     }
 
     Status init_bloom_filter(const size_t build_bf_cardinality) {
         DCHECK(_filter_type == RuntimeFilterType::BLOOM_FILTER ||
                _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
-        return _context.bloom_filter_func->init_with_cardinality(build_bf_cardinality);
+        return _context->bloom_filter_func->init_with_cardinality(build_bf_cardinality);
+    }
+
+    bool get_build_bf_cardinality() const {
+        DCHECK(_filter_type == RuntimeFilterType::BLOOM_FILTER ||
+               _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
+        return _context->bloom_filter_func->get_build_bf_cardinality();
     }
 
     void insert_to_bloom_filter(BloomFilterFuncBase* bloom_filter) const {
-        if (_context.hybrid_set->size() > 0) {
-            auto* it = _context.hybrid_set->begin();
+        if (_context->hybrid_set->size() > 0) {
+            auto* it = _context->hybrid_set->begin();
             while (it->has_next()) {
                 bloom_filter->insert(it->get_value());
                 it->next();
             }
         }
-        if (_context.hybrid_set->contain_null()) {
+        if (_context->hybrid_set->contain_null()) {
             bloom_filter->set_contain_null_and_null_aware();
         }
     }
 
-    BloomFilterFuncBase* get_bloomfilter() const { return _context.bloom_filter_func.get(); }
+    BloomFilterFuncBase* get_bloomfilter() const { return _context->bloom_filter_func.get(); }
 
     void insert_fixed_len(const vectorized::ColumnPtr& column, size_t start) {
         DCHECK(!is_ignored());
         switch (_filter_type) {
         case RuntimeFilterType::IN_FILTER: {
-            _context.hybrid_set->insert_fixed_len(column, start);
+            _context->hybrid_set->insert_fixed_len(column, start);
             break;
         }
         case RuntimeFilterType::MIN_FILTER:
         case RuntimeFilterType::MAX_FILTER:
         case RuntimeFilterType::MINMAX_FILTER: {
-            _context.minmax_func->insert_fixed_len(column, start);
+            _context->minmax_func->insert_fixed_len(column, start);
             break;
         }
         case RuntimeFilterType::BLOOM_FILTER: {
-            _context.bloom_filter_func->insert_fixed_len(column, start);
+            _context->bloom_filter_func->insert_fixed_len(column, start);
             break;
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
-            if (_is_bloomfilter) {
-                _context.bloom_filter_func->insert_fixed_len(column, start);
+            if (is_bloomfilter()) {
+                _context->bloom_filter_func->insert_fixed_len(column, start);
             } else {
-                _context.hybrid_set->insert_fixed_len(column, start);
+                _context->hybrid_set->insert_fixed_len(column, start);
             }
             break;
         }
@@ -434,23 +440,21 @@ public:
                 bitmaps.push_back(&(col->get_data()[i]));
             }
         }
-        _context.bitmap_filter_func->insert_many(bitmaps);
+        _context->bitmap_filter_func->insert_many(bitmaps);
     }
 
     RuntimeFilterType get_real_type() const {
-        auto real_filter_type = _filter_type;
-        if (real_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-            real_filter_type = _is_bloomfilter ? RuntimeFilterType::BLOOM_FILTER
-                                               : RuntimeFilterType::IN_FILTER;
+        if (_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
+            if (_context->hybrid_set) {
+                return RuntimeFilterType::IN_FILTER;
+            }
+            return RuntimeFilterType::BLOOM_FILTER;
         }
-        return real_filter_type;
+        return _filter_type;
     }
 
     size_t get_bloom_filter_size() const {
-        if (_is_bloomfilter) {
-            return _context.bloom_filter_func->get_size();
-        }
-        return 0;
+        return _context->bloom_filter_func ? _context->bloom_filter_func->get_size() : 0;
     }
 
     Status get_push_exprs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
@@ -458,6 +462,11 @@ public:
                           const TExpr& probe_expr);
 
     Status merge(const RuntimePredicateWrapper* wrapper) {
+        if (is_ignored() || wrapper->is_ignored()) {
+            _context->ignored = true;
+            return Status::OK();
+        }
+
         bool can_not_merge_in_or_bloom =
                 _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
                 (wrapper->_filter_type != RuntimeFilterType::IN_FILTER &&
@@ -475,70 +484,56 @@ public:
         switch (_filter_type) {
         case RuntimeFilterType::IN_FILTER: {
             // try insert set
-            _context.hybrid_set->insert(wrapper->_context.hybrid_set.get());
-            if (_max_in_num >= 0 && _context.hybrid_set->size() >= _max_in_num) {
-                _ignored_msg = fmt::format(
-                        " ignore merge runtime filter(in filter id {})"
-                        "because: in_num({}) >= max_in_num({})",
-                        _filter_id, _context.hybrid_set->size(), _max_in_num);
-                _ignored = true;
+            _context->hybrid_set->insert(wrapper->_context->hybrid_set.get());
+            if (_max_in_num >= 0 && _context->hybrid_set->size() >= _max_in_num) {
+                _context->ignored = true;
                 // release in filter
-                _context.hybrid_set.reset();
+                _context->hybrid_set.reset();
             }
             break;
         }
         case RuntimeFilterType::MIN_FILTER:
         case RuntimeFilterType::MAX_FILTER:
         case RuntimeFilterType::MINMAX_FILTER: {
-            RETURN_IF_ERROR(_context.minmax_func->merge(wrapper->_context.minmax_func.get()));
+            RETURN_IF_ERROR(_context->minmax_func->merge(wrapper->_context->minmax_func.get()));
             break;
         }
         case RuntimeFilterType::BLOOM_FILTER: {
             RETURN_IF_ERROR(
-                    _context.bloom_filter_func->merge(wrapper->_context.bloom_filter_func.get()));
+                    _context->bloom_filter_func->merge(wrapper->_context->bloom_filter_func.get()));
             break;
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
-            auto real_filter_type = _is_bloomfilter ? RuntimeFilterType::BLOOM_FILTER
-                                                    : RuntimeFilterType::IN_FILTER;
+            auto real_filter_type = get_real_type();
 
             auto other_filter_type = wrapper->_filter_type;
             if (other_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-                other_filter_type = wrapper->_is_bloomfilter ? RuntimeFilterType::BLOOM_FILTER
-                                                             : RuntimeFilterType::IN_FILTER;
+                other_filter_type = wrapper->get_real_type();
             }
 
             if (real_filter_type == RuntimeFilterType::IN_FILTER) {
                 if (other_filter_type == RuntimeFilterType::IN_FILTER) { // in merge in
-                    CHECK(!wrapper->_ignored)
-                            << " can not ignore merge runtime filter(in filter id "
-                            << wrapper->_filter_id << ") when used IN_OR_BLOOM_FILTER, ignore msg: "
-                            << wrapper->ignored_msg();
-                    _context.hybrid_set->insert(wrapper->_context.hybrid_set.get());
-                    if (_max_in_num >= 0 && _context.hybrid_set->size() >= _max_in_num) {
+                    _context->hybrid_set->insert(wrapper->_context->hybrid_set.get());
+                    if (_max_in_num >= 0 && _context->hybrid_set->size() >= _max_in_num) {
                         VLOG_DEBUG << " change runtime filter to bloom filter(id=" << _filter_id
-                                   << ") because: in_num(" << _context.hybrid_set->size()
+                                   << ") because: in_num(" << _context->hybrid_set->size()
                                    << ") >= max_in_num(" << _max_in_num << ")";
                         RETURN_IF_ERROR(change_to_bloom_filter(true));
                     }
                 } else {
                     VLOG_DEBUG << " change runtime filter to bloom filter(id=" << _filter_id
                                << ") because: already exist a bloom filter";
-                    RETURN_IF_ERROR(change_to_bloom_filter(!_build_bf_exactly));
-                    RETURN_IF_ERROR(_context.bloom_filter_func->merge(
-                            wrapper->_context.bloom_filter_func.get()));
+                    RETURN_IF_ERROR(change_to_bloom_filter(false));
+                    RETURN_IF_ERROR(_context->bloom_filter_func->merge(
+                            wrapper->_context->bloom_filter_func.get()));
                 }
             } else {
                 if (other_filter_type == RuntimeFilterType::IN_FILTER) { // bloom filter merge in
-                    CHECK(!wrapper->_ignored)
-                            << " can not ignore merge runtime filter(in filter id "
-                            << wrapper->_filter_id << ") when used IN_OR_BLOOM_FILTER, ignore msg: "
-                            << wrapper->ignored_msg();
-                    wrapper->insert_to_bloom_filter(_context.bloom_filter_func.get());
+                    wrapper->insert_to_bloom_filter(_context->bloom_filter_func.get());
                     // bloom filter merge bloom filter
                 } else {
-                    RETURN_IF_ERROR(_context.bloom_filter_func->merge(
-                            wrapper->_context.bloom_filter_func.get()));
+                    RETURN_IF_ERROR(_context->bloom_filter_func->merge(
+                            wrapper->_context->bloom_filter_func.get()));
                 }
             }
             break;
@@ -550,19 +545,11 @@ public:
     }
 
     Status assign(const PInFilter* in_filter, bool contain_null) {
-        if (in_filter->has_ignored_msg()) {
-            VLOG_DEBUG << "Ignore in filter(id=" << _filter_id
-                       << ") because: " << in_filter->ignored_msg();
-            _ignored = true;
-            _ignored_msg = in_filter->ignored_msg();
-            return Status::OK();
-        }
-
         PrimitiveType type = to_primitive_type(in_filter->column_type());
-        _context.hybrid_set.reset(create_set(type));
+        _context->hybrid_set.reset(create_set(type));
         if (contain_null) {
-            _context.hybrid_set->set_null_aware(true);
-            _context.hybrid_set->insert((const void*)nullptr);
+            _context->hybrid_set->set_null_aware(true);
+            _context->hybrid_set->insert((const void*)nullptr);
         }
 
         switch (type) {
@@ -735,14 +722,13 @@ public:
     // assign this filter by protobuf
     Status assign(const PBloomFilter* bloom_filter, butil::IOBufAsZeroCopyInputStream* data,
                   bool contain_null) {
-        _is_bloomfilter = true;
         // we won't use this class to insert or find any data
         // so any type is ok
-        _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type == INVALID_TYPE
-                                                                     ? PrimitiveType::TYPE_INT
-                                                                     : _column_return_type));
-        RETURN_IF_ERROR(_context.bloom_filter_func->assign(data, bloom_filter->filter_length(),
-                                                           contain_null));
+        _context->bloom_filter_func.reset(create_bloom_filter(_column_return_type == INVALID_TYPE
+                                                                      ? PrimitiveType::TYPE_INT
+                                                                      : _column_return_type));
+        RETURN_IF_ERROR(_context->bloom_filter_func->assign(data, bloom_filter->filter_length(),
+                                                            contain_null));
         return Status::OK();
     }
 
@@ -750,38 +736,38 @@ public:
     // assign this filter by protobuf
     Status assign(const PMinMaxFilter* minmax_filter, bool contain_null) {
         PrimitiveType type = to_primitive_type(minmax_filter->column_type());
-        _context.minmax_func.reset(create_minmax_filter(type));
+        _context->minmax_func.reset(create_minmax_filter(type));
 
         if (contain_null) {
-            _context.minmax_func->set_null_aware(true);
-            _context.minmax_func->set_contain_null();
+            _context->minmax_func->set_null_aware(true);
+            _context->minmax_func->set_contain_null();
         }
 
         switch (type) {
         case TYPE_BOOLEAN: {
             bool min_val = minmax_filter->min_val().boolval();
             bool max_val = minmax_filter->max_val().boolval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_TINYINT: {
             int8_t min_val = static_cast<int8_t>(minmax_filter->min_val().intval());
             int8_t max_val = static_cast<int8_t>(minmax_filter->max_val().intval());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_SMALLINT: {
             int16_t min_val = static_cast<int16_t>(minmax_filter->min_val().intval());
             int16_t max_val = static_cast<int16_t>(minmax_filter->max_val().intval());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_INT: {
             int32_t min_val = minmax_filter->min_val().intval();
             int32_t max_val = minmax_filter->max_val().intval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_BIGINT: {
             int64_t min_val = minmax_filter->min_val().longval();
             int64_t max_val = minmax_filter->max_val().longval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_LARGEINT: {
             auto min_string_val = minmax_filter->min_val().stringval();
@@ -793,27 +779,27 @@ public:
             int128_t max_val = StringParser::string_to_int<int128_t>(
                     max_string_val.c_str(), max_string_val.length(), &result);
             DCHECK(result == StringParser::PARSE_SUCCESS);
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_FLOAT: {
             float min_val = static_cast<float>(minmax_filter->min_val().doubleval());
             float max_val = static_cast<float>(minmax_filter->max_val().doubleval());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DOUBLE: {
             double min_val = static_cast<double>(minmax_filter->min_val().doubleval());
             double max_val = static_cast<double>(minmax_filter->max_val().doubleval());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DATEV2: {
             int32_t min_val = minmax_filter->min_val().intval();
             int32_t max_val = minmax_filter->max_val().intval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DATETIMEV2: {
             int64_t min_val = minmax_filter->min_val().longval();
             int64_t max_val = minmax_filter->max_val().longval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DATETIME:
         case TYPE_DATE: {
@@ -823,24 +809,24 @@ public:
             VecDateTimeValue max_val;
             min_val.from_date_str(min_val_ref.c_str(), min_val_ref.length());
             max_val.from_date_str(max_val_ref.c_str(), max_val_ref.length());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DECIMALV2: {
             auto& min_val_ref = minmax_filter->min_val().stringval();
             auto& max_val_ref = minmax_filter->max_val().stringval();
             DecimalV2Value min_val(min_val_ref);
             DecimalV2Value max_val(max_val_ref);
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DECIMAL32: {
             int32_t min_val = minmax_filter->min_val().intval();
             int32_t max_val = minmax_filter->max_val().intval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DECIMAL64: {
             int64_t min_val = minmax_filter->min_val().longval();
             int64_t max_val = minmax_filter->max_val().longval();
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DECIMAL128I: {
             auto min_string_val = minmax_filter->min_val().stringval();
@@ -852,7 +838,7 @@ public:
             int128_t max_val = StringParser::string_to_int<int128_t>(
                     max_string_val.c_str(), max_string_val.length(), &result);
             DCHECK(result == StringParser::PARSE_SUCCESS);
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_DECIMAL256: {
             auto min_string_val = minmax_filter->min_val().stringval();
@@ -864,7 +850,7 @@ public:
             auto max_val = StringParser::string_to_int<wide::Int256>(
                     max_string_val.c_str(), max_string_val.length(), &result);
             DCHECK(result == StringParser::PARSE_SUCCESS);
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         case TYPE_VARCHAR:
         case TYPE_CHAR:
@@ -875,7 +861,7 @@ public:
             auto max_val_ptr = _pool->add(new std::string(max_val_ref));
             StringRef min_val(min_val_ptr->c_str(), min_val_ptr->length());
             StringRef max_val(max_val_ptr->c_str(), max_val_ptr->length());
-            return _context.minmax_func->assign(&min_val, &max_val);
+            return _context->minmax_func->assign(&min_val, &max_val);
         }
         default:
             DCHECK(false) << "unknown type";
@@ -884,65 +870,67 @@ public:
         return Status::InvalidArgument("not support!");
     }
 
-    HybridSetBase::IteratorBase* get_in_filter_iterator() { return _context.hybrid_set->begin(); }
+    HybridSetBase::IteratorBase* get_in_filter_iterator() { return _context->hybrid_set->begin(); }
 
     void get_bloom_filter_desc(char** data, int* filter_length) {
-        _context.bloom_filter_func->get_data(data, filter_length);
+        _context->bloom_filter_func->get_data(data, filter_length);
     }
 
     void get_minmax_filter_desc(void** min_data, void** max_data) {
-        *min_data = _context.minmax_func->get_min();
-        *max_data = _context.minmax_func->get_max();
+        *min_data = _context->minmax_func->get_min();
+        *max_data = _context->minmax_func->get_max();
     }
 
     PrimitiveType column_type() { return _column_return_type; }
 
-    bool is_bloomfilter() const { return _is_bloomfilter; }
+    bool is_bloomfilter() const { return get_real_type() == RuntimeFilterType::BLOOM_FILTER; }
 
     bool contain_null() const {
-        if (_is_bloomfilter) {
-            return _context.bloom_filter_func->contain_null();
+        if (is_bloomfilter()) {
+            return _context->bloom_filter_func->contain_null();
         }
-        if (_context.hybrid_set) {
+        if (_context->hybrid_set) {
             DCHECK(get_real_type() == RuntimeFilterType::IN_FILTER);
-            return _context.hybrid_set->contain_null();
+            return _context->hybrid_set->contain_null();
         }
-        if (_context.minmax_func) {
-            return _context.minmax_func->contain_null();
+        if (_context->minmax_func) {
+            return _context->minmax_func->contain_null();
         }
         return false;
     }
 
-    bool is_ignored() const { return _ignored; }
+    bool is_ignored() const { return _context->ignored; }
 
-    const std::string& ignored_msg() const { return _ignored_msg; }
+    void set_ignored() { _context->ignored = true; }
 
     void batch_assign(const PInFilter* filter,
                       void (*assign_func)(std::shared_ptr<HybridSetBase>& _hybrid_set,
                                           PColumnValue&, ObjectPool*)) {
         for (int i = 0; i < filter->values_size(); ++i) {
             PColumnValue column = filter->values(i);
-            assign_func(_context.hybrid_set, column, _pool);
+            assign_func(_context->hybrid_set, column, _pool);
         }
     }
 
-    size_t get_in_filter_size() const { return _context.hybrid_set->size(); }
+    size_t get_in_filter_size() const {
+        return _context->hybrid_set ? _context->hybrid_set->size() : 0;
+    }
 
     std::shared_ptr<BitmapFilterFuncBase> get_bitmap_filter() const {
-        return _context.bitmap_filter_func;
+        return _context->bitmap_filter_func;
     }
 
     friend class IRuntimeFilter;
 
     void set_filter_id(int id) {
-        if (_context.bloom_filter_func) {
-            _context.bloom_filter_func->set_filter_id(id);
+        if (_context->bloom_filter_func) {
+            _context->bloom_filter_func->set_filter_id(id);
         }
-        if (_context.bitmap_filter_func) {
-            _context.bitmap_filter_func->set_filter_id(id);
+        if (_context->bitmap_filter_func) {
+            _context->bitmap_filter_func->set_filter_id(id);
         }
-        if (_context.hybrid_set) {
-            _context.hybrid_set->set_filter_id(id);
+        if (_context->hybrid_set) {
+            _context->hybrid_set->set_filter_id(id);
         }
     }
 
@@ -954,10 +942,7 @@ private:
     RuntimeFilterType _filter_type;
     int32_t _max_in_num = -1;
 
-    vectorized::SharedRuntimeFilterContext _context;
-    bool _is_bloomfilter = false;
-    bool _ignored = false;
-    std::string _ignored_msg;
+    SharedRuntimeFilterContext _context;
     uint32_t _filter_id;
     bool _build_bf_exactly;
 };
@@ -968,11 +953,10 @@ Status IRuntimeFilter::create(RuntimeFilterParamsContext* state, ObjectPool* poo
                               bool build_bf_exactly, bool need_local_merge) {
     *res = pool->add(new IRuntimeFilter(state, pool, desc, need_local_merge));
     (*res)->set_role(role);
-    return (*res)->init_with_desc(desc, query_options, node_id,
-                                  need_local_merge ? false : build_bf_exactly);
+    return (*res)->init_with_desc(desc, query_options, node_id, build_bf_exactly);
 }
 
-vectorized::SharedRuntimeFilterContext& IRuntimeFilter::get_shared_context_ref() {
+SharedRuntimeFilterContext& IRuntimeFilter::get_shared_context_ref() {
     return _wrapper->_context;
 }
 
@@ -983,6 +967,7 @@ void IRuntimeFilter::insert_batch(const vectorized::ColumnPtr column, size_t sta
 
 Status IRuntimeFilter::publish(bool publish_local) {
     DCHECK(is_producer());
+
     auto send_to_remote = [&](IRuntimeFilter* filter) {
         TNetworkAddress addr;
         DCHECK(_state != nullptr);
@@ -994,7 +979,7 @@ Status IRuntimeFilter::publish(bool publish_local) {
         RETURN_IF_ERROR(_state->runtime_filter_mgr->get_consume_filters(_filter_id, filters));
         DCHECK(!filters.empty());
         // push down
-        for (auto filter : filters) {
+        for (auto* filter : filters) {
             filter->_wrapper = wrapper;
             filter->update_runtime_filter_type_to_profile();
             filter->signal();
@@ -1036,14 +1021,75 @@ Status IRuntimeFilter::publish(bool publish_local) {
     return Status::OK();
 }
 
+Status IRuntimeFilter::send_filter_size(uint64_t local_filter_size) {
+    DCHECK(is_producer());
+
+    if (_need_local_merge) {
+        LocalMergeFilters* local_merge_filters = nullptr;
+        RETURN_IF_ERROR(_state->runtime_filter_mgr->get_local_merge_producer_filters(
+                _filter_id, &local_merge_filters));
+        std::lock_guard l(*local_merge_filters->lock);
+        local_merge_filters->merge_size_times--;
+        local_merge_filters->local_merged_size += local_filter_size;
+        if (local_merge_filters->merge_size_times) {
+            return Status::OK();
+        } else {
+            if (_has_local_target) {
+                for (auto* filter : local_merge_filters->filters) {
+                    filter->set_global_size(local_merge_filters->local_merged_size);
+                }
+                return Status::OK();
+            } else {
+                local_filter_size = local_merge_filters->local_merged_size;
+            }
+        }
+    } else if (_has_local_target) {
+        set_global_size(local_filter_size);
+        return Status::OK();
+    }
+
+    TNetworkAddress addr;
+    DCHECK(_state != nullptr);
+    RETURN_IF_ERROR(_state->runtime_filter_mgr->get_merge_addr(&addr));
+    std::shared_ptr<PBackendService_Stub> stub(
+            _state->exec_env->brpc_internal_client_cache()->get_client(addr));
+    if (!stub) {
+        std::string msg =
+                fmt::format("Get rpc stub failed, host={},  port=", addr.hostname, addr.port);
+        return Status::InternalError(msg);
+    }
+
+    auto request = std::make_shared<PSendFilterSizeRequest>();
+    auto callback = DummyBrpcCallback<PSendFilterSizeResponse>::create_shared();
+    auto closure =
+            AutoReleaseClosure<PSendFilterSizeRequest,
+                               DummyBrpcCallback<PSendFilterSizeResponse>>::create_unique(request,
+                                                                                          callback);
+    auto* pquery_id = request->mutable_query_id();
+    pquery_id->set_hi(_state->query_id.hi());
+    pquery_id->set_lo(_state->query_id.lo());
+
+    auto* source_addr = request->mutable_source_addr();
+    source_addr->set_hostname(BackendOptions::get_local_backend().host);
+    source_addr->set_port(BackendOptions::get_local_backend().brpc_port);
+
+    request->set_filter_size(local_filter_size);
+    request->set_filter_id(_filter_id);
+    callback->cntl_->set_timeout_ms(wait_time_ms());
+
+    stub->send_filter_size(closure->cntl_.get(), closure->request_.get(), closure->response_.get(),
+                           closure.get());
+    closure.release();
+    return Status::OK();
+}
+
 Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr, bool opt_remote_rf) {
     DCHECK(is_producer());
     std::shared_ptr<PBackendService_Stub> stub(
             _state->exec_env->brpc_internal_client_cache()->get_client(*addr));
     if (!stub) {
-        std::string msg =
-                fmt::format("Get rpc stub failed, host={},  port=", addr->hostname, addr->port);
-        return Status::InternalError(msg);
+        return Status::InternalError(
+                fmt::format("Get rpc stub failed, host={},  port=", addr->hostname, addr->port));
     }
 
     auto merge_filter_request = std::make_shared<PMergeFilterRequest>();
@@ -1054,11 +1100,11 @@ Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr, bool opt_remo
     void* data = nullptr;
     int len = 0;
 
-    auto pquery_id = merge_filter_request->mutable_query_id();
+    auto* pquery_id = merge_filter_request->mutable_query_id();
     pquery_id->set_hi(_state->query_id.hi());
     pquery_id->set_lo(_state->query_id.lo());
 
-    auto pfragment_instance_id = merge_filter_request->mutable_fragment_instance_id();
+    auto* pfragment_instance_id = merge_filter_request->mutable_fragment_instance_id();
     pfragment_instance_id->set_hi(BackendOptions::get_local_backend().id);
     pfragment_instance_id->set_lo((int64_t)this);
 
@@ -1069,21 +1115,23 @@ Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr, bool opt_remo
     merge_filter_request->set_column_type(to_proto(column_type));
     merge_filter_callback->cntl_->set_timeout_ms(wait_time_ms());
 
-    Status serialize_status = serialize(merge_filter_request.get(), &data, &len);
-    if (serialize_status.ok()) {
-        VLOG_NOTICE << "Producer:" << merge_filter_request->ShortDebugString() << addr->hostname
-                    << ":" << addr->port;
-        if (len > 0) {
-            DCHECK(data != nullptr);
-            merge_filter_callback->cntl_->request_attachment().append(data, len);
-        }
-
-        stub->merge_filter(merge_filter_closure->cntl_.get(), merge_filter_closure->request_.get(),
-                           merge_filter_closure->response_.get(), merge_filter_closure.get());
-        // the closure will be released by brpc during closure->Run.
-        merge_filter_closure.release();
+    if (get_ignored()) {
+        merge_filter_request->set_filter_type(PFilterType::UNKNOW_FILTER);
+        merge_filter_request->set_ignored(true);
+    } else {
+        RETURN_IF_ERROR(serialize(merge_filter_request.get(), &data, &len));
     }
-    return serialize_status;
+
+    if (len > 0) {
+        DCHECK(data != nullptr);
+        merge_filter_callback->cntl_->request_attachment().append(data, len);
+    }
+
+    stub->merge_filter(merge_filter_closure->cntl_.get(), merge_filter_closure->request_.get(),
+                       merge_filter_closure->response_.get(), merge_filter_closure.get());
+    // the closure will be released by brpc during closure->Run.
+    merge_filter_closure.release();
+    return Status::OK();
 }
 
 Status IRuntimeFilter::get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
@@ -1231,17 +1279,32 @@ void IRuntimeFilter::set_filter_timer(std::shared_ptr<pipeline::RuntimeFilterTim
     _filter_timer.push_back(timer);
 }
 
-void IRuntimeFilter::set_ignored(const std::string& msg) {
-    _wrapper->_ignored = true;
-    _wrapper->_ignored_msg = msg;
+void IRuntimeFilter::set_dependency(pipeline::CountedFinishDependency* dependency) {
+    _dependency = dependency;
+    _dependency->add();
+    CHECK(_dependency);
+}
+
+void IRuntimeFilter::set_global_size(uint64_t global_size) {
+    CHECK(_dependency);
+    _global_size = global_size;
+    _isset_global_size = true;
+    _dependency->sub();
+}
+
+void IRuntimeFilter::set_ignored() {
+    _wrapper->_context->ignored = true;
+}
+
+bool IRuntimeFilter::get_ignored() {
+    return _wrapper->is_ignored();
 }
 
 std::string IRuntimeFilter::_format_status() const {
     return fmt::format(
-            "[IsPushDown = {}, RuntimeFilterState = {}, IgnoredMsg = {}, HasRemoteTarget = {}, "
+            "[IsPushDown = {}, RuntimeFilterState = {}, HasRemoteTarget = {}, "
             "HasLocalTarget = {}]",
-            _is_push_down, _get_explain_state_string(), _wrapper->ignored_msg(), _has_remote_target,
-            _has_local_target);
+            _is_push_down, _get_explain_state_string(), _has_remote_target, _has_local_target);
 }
 
 BloomFilterFuncBase* IRuntimeFilter::get_bloomfilter() const {
@@ -1271,10 +1334,15 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     // 1. Only 1 join key
     // 2. Do not have remote target (e.g. do not need to merge), or broadcast join
     // 3. Bloom filter
-    params.build_bf_exactly = build_bf_exactly && (!_has_remote_target || _is_broadcast_join) &&
-                              (_runtime_filter_type == RuntimeFilterType::BLOOM_FILTER ||
-                               _runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
+    params.build_bf_exactly =
+            build_bf_exactly && (_runtime_filter_type == RuntimeFilterType::BLOOM_FILTER ||
+                                 _runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
+
     params.bloom_filter_size_calculated_by_ndv = desc->bloom_filter_size_calculated_by_ndv;
+
+    if (!desc->__isset.sync_filter_size || !desc->sync_filter_size) {
+        params.build_bf_exactly &= (!_has_remote_target || _is_broadcast_join);
+    }
 
     if (desc->__isset.bloom_filter_size_bytes) {
         params.bloom_filter_size = desc->bloom_filter_size_bytes;
@@ -1341,6 +1409,12 @@ Status IRuntimeFilter::create_wrapper(const UpdateRuntimeFilterParamsV2* param,
     PrimitiveType column_type = param->column_type;
     *wrapper = param->pool->add(new RuntimePredicateWrapper(
             param->pool, column_type, get_type(filter_type), param->request->filter_id()));
+
+    if (param->request->has_ignored() && param->request->ignored()) {
+        (*wrapper)->set_ignored();
+        return Status::OK();
+    }
+
     switch (filter_type) {
     case PFilterType::IN_FILTER: {
         DCHECK(param->request->has_in_filter());
@@ -1382,8 +1456,14 @@ Status IRuntimeFilter::_create_wrapper(const T* param, ObjectPool* pool,
     if (param->request->has_column_type()) {
         column_type = to_primitive_type(param->request->column_type());
     }
-    wrapper->reset(new RuntimePredicateWrapper(pool, column_type, get_type(filter_type),
-                                               param->request->filter_id()));
+    *wrapper = std::make_unique<RuntimePredicateWrapper>(pool, column_type, get_type(filter_type),
+                                                         param->request->filter_id());
+
+    if (param->request->has_ignored() && param->request->ignored()) {
+        (*wrapper)->set_ignored();
+        return Status::OK();
+    }
+
     switch (filter_type) {
     case PFilterType::IN_FILTER: {
         DCHECK(param->request->has_in_filter());
@@ -1420,12 +1500,7 @@ void IRuntimeFilter::update_runtime_filter_type_to_profile() {
 }
 
 Status IRuntimeFilter::merge_from(const RuntimePredicateWrapper* wrapper) {
-    if (wrapper->is_ignored()) {
-        set_ignored(wrapper->ignored_msg());
-    } else if (!_wrapper->is_ignored()) {
-        return _wrapper->merge(wrapper);
-    }
-    return Status::OK();
+    return _wrapper->merge(wrapper);
 }
 
 template <typename T>
@@ -1441,11 +1516,7 @@ void batch_copy(PInFilter* filter, HybridSetBase::IteratorBase* it,
 
 template <class T>
 Status IRuntimeFilter::serialize_impl(T* request, void** data, int* len) {
-    auto real_runtime_filter_type = _runtime_filter_type;
-    if (real_runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-        real_runtime_filter_type = _wrapper->is_bloomfilter() ? RuntimeFilterType::BLOOM_FILTER
-                                                              : RuntimeFilterType::IN_FILTER;
-    }
+    auto real_runtime_filter_type = _wrapper->get_real_type();
 
     request->set_filter_type(get_type(real_runtime_filter_type));
     request->set_contain_null(_wrapper->contain_null());
@@ -1472,11 +1543,6 @@ Status IRuntimeFilter::serialize_impl(T* request, void** data, int* len) {
 void IRuntimeFilter::to_protobuf(PInFilter* filter) {
     auto column_type = _wrapper->column_type();
     filter->set_column_type(to_proto(column_type));
-
-    if (_wrapper->is_ignored()) {
-        filter->set_ignored_msg(_wrapper->ignored_msg());
-        return;
-    }
 
     auto it = _wrapper->get_in_filter_iterator();
     DCHECK(it != nullptr);
@@ -1719,16 +1785,21 @@ void IRuntimeFilter::to_protobuf(PMinMaxFilter* filter) {
     }
 }
 
-bool IRuntimeFilter::is_bloomfilter() {
-    return _wrapper->is_bloomfilter();
+RuntimeFilterType IRuntimeFilter::get_real_type() {
+    return _wrapper->get_real_type();
+}
+
+bool IRuntimeFilter::need_sync_filter_size() {
+    return (type() == RuntimeFilterType::IN_OR_BLOOM_FILTER ||
+            type() == RuntimeFilterType::BLOOM_FILTER) &&
+           _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
 }
 
 Status IRuntimeFilter::update_filter(const UpdateRuntimeFilterParams* param) {
     _profile->add_info_string("MergeTime", std::to_string(param->request->merge_time()) + " ms");
 
-    if (param->request->has_in_filter() && param->request->in_filter().has_ignored_msg()) {
-        const PInFilter in_filter = param->request->in_filter();
-        set_ignored(in_filter.ignored_msg());
+    if (param->request->has_ignored() && param->request->ignored()) {
+        set_ignored();
     } else {
         std::unique_ptr<RuntimePredicateWrapper> wrapper;
         RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(param, _pool, &wrapper));
@@ -1752,7 +1823,7 @@ void IRuntimeFilter::update_filter(RuntimePredicateWrapper* wrapper, int64_t mer
     }
     _wrapper = wrapper;
     update_runtime_filter_type_to_profile();
-    this->signal();
+    signal();
 }
 
 Status RuntimePredicateWrapper::get_push_exprs(
@@ -1783,7 +1854,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         node.in_predicate.__set_is_not_in(false);
         node.__set_opcode(TExprOpcode::FILTER_IN);
         node.__set_is_nullable(false);
-        auto in_pred = vectorized::VDirectInPredicate::create_shared(node, _context.hybrid_set);
+        auto in_pred = vectorized::VDirectInPredicate::create_shared(node, _context->hybrid_set);
         in_pred->add_child(probe_ctx->root());
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, in_pred, null_aware);
         container.push_back(wrapper);
@@ -1796,7 +1867,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         RETURN_IF_ERROR(create_vbin_predicate(probe_ctx->root()->type(), TExprOpcode::GE, min_pred,
                                               &min_pred_node));
         vectorized::VExprSPtr min_literal;
-        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context.minmax_func->get_min(),
+        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context->minmax_func->get_min(),
                                        min_literal));
         min_pred->add_child(probe_ctx->root());
         min_pred->add_child(min_literal);
@@ -1811,7 +1882,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         RETURN_IF_ERROR(create_vbin_predicate(probe_ctx->root()->type(), TExprOpcode::LE, max_pred,
                                               &max_pred_node));
         vectorized::VExprSPtr max_literal;
-        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context.minmax_func->get_max(),
+        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context->minmax_func->get_max(),
                                        max_literal));
         max_pred->add_child(probe_ctx->root());
         max_pred->add_child(max_literal);
@@ -1826,7 +1897,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         RETURN_IF_ERROR(create_vbin_predicate(probe_ctx->root()->type(), TExprOpcode::LE, max_pred,
                                               &max_pred_node, null_aware));
         vectorized::VExprSPtr max_literal;
-        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context.minmax_func->get_max(),
+        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context->minmax_func->get_max(),
                                        max_literal));
         max_pred->add_child(probe_ctx->root());
         max_pred->add_child(max_literal);
@@ -1844,7 +1915,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
                                               min_pred, &min_pred_node, null_aware));
         vectorized::VExprSPtr min_literal;
         RETURN_IF_ERROR(create_literal(new_probe_ctx->root()->type(),
-                                       _context.minmax_func->get_min(), min_literal));
+                                       _context->minmax_func->get_min(), min_literal));
         min_pred->add_child(new_probe_ctx->root());
         min_pred->add_child(min_literal);
         container.push_back(vectorized::VRuntimeFilterWrapper::create_shared(min_pred_node,
@@ -1861,7 +1932,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         node.__set_opcode(TExprOpcode::RT_FILTER);
         node.__set_is_nullable(false);
         auto bloom_pred = vectorized::VBloomPredicate::create_shared(node);
-        bloom_pred->set_filter(_context.bloom_filter_func);
+        bloom_pred->set_filter(_context->bloom_filter_func);
         bloom_pred->add_child(probe_ctx->root());
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, bloom_pred);
         container.push_back(wrapper);
@@ -1877,7 +1948,7 @@ Status RuntimePredicateWrapper::get_push_exprs(
         node.__set_opcode(TExprOpcode::RT_FILTER);
         node.__set_is_nullable(false);
         auto bitmap_pred = vectorized::VBitmapPredicate::create_shared(node);
-        bitmap_pred->set_filter(_context.bitmap_filter_func);
+        bitmap_pred->set_filter(_context->bitmap_filter_func);
         bitmap_pred->add_child(probe_ctx->root());
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, bitmap_pred);
         container.push_back(wrapper);

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -362,13 +362,13 @@ public:
 
     void set_filter_timer(std::shared_ptr<pipeline::RuntimeFilterTimer>);
 
-    void set_global_size(uint64_t global_size);
+    void set_synced_size(uint64_t global_size);
 
     void set_dependency(pipeline::CountedFinishDependency* dependency);
 
-    int64_t get_global_size() const { return _global_size; }
+    int64_t get_synced_size() const { return _synced_size; }
 
-    bool isset_global_size() const { return _global_size != -1; }
+    bool isset_synced_size() const { return _synced_size != -1; }
 
 protected:
     // serialize _wrapper to protobuf
@@ -452,7 +452,7 @@ protected:
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
-    int64_t _global_size = -1;
+    int64_t _synced_size = -1;
     pipeline::CountedFinishDependency* _dependency = nullptr;
 };
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -366,9 +366,9 @@ public:
 
     void set_dependency(pipeline::CountedFinishDependency* dependency);
 
-    uint64_t get_global_size() const { return _global_size; }
+    int64_t get_global_size() const { return _global_size; }
 
-    bool isset_global_size() const { return _isset_global_size; }
+    bool isset_global_size() const { return _global_size != -1; }
 
 protected:
     // serialize _wrapper to protobuf
@@ -452,8 +452,7 @@ protected:
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
-    uint64_t _global_size = 0;
-    bool _isset_global_size = false;
+    int64_t _global_size = -1;
     pipeline::CountedFinishDependency* _dependency = nullptr;
 };
 

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -51,6 +51,8 @@ public:
                 runtime_filter->set_dependency(dependency);
             }
         }
+
+        // send_filter_size may call dependency->sub(), so we call set_dependency firstly for all rf to avoid dependency set_ready repeatedly
         for (auto* runtime_filter : _runtime_filters) {
             if (runtime_filter->need_sync_filter_size()) {
                 RETURN_IF_ERROR(runtime_filter->send_filter_size(hash_table_size));

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -34,130 +34,73 @@ class VRuntimeFilterSlots {
 public:
     VRuntimeFilterSlots(
             const std::vector<std::shared_ptr<vectorized::VExprContext>>& build_expr_ctxs,
-            const std::vector<IRuntimeFilter*>& runtime_filters, bool need_local_merge = false)
-            : _build_expr_context(build_expr_ctxs),
-              _runtime_filters(runtime_filters),
-              _need_local_merge(need_local_merge) {}
-
-    Status init(RuntimeState* state, int64_t hash_table_size) {
-        // runtime filter effect strategy
-        // 1. we will ignore IN filter when hash_table_size is too big
-        // 2. we will ignore BLOOM filter and MinMax filter when hash_table_size
-        // is too small and IN filter has effect
-        std::map<int, bool> has_in_filter;
-
-        auto ignore_local_filter = [&](int filter_id) {
-            auto runtime_filter_mgr = _need_local_merge ? state->global_runtime_filter_mgr()
-                                                        : state->local_runtime_filter_mgr();
-
-            std::vector<IRuntimeFilter*> filters;
-            RETURN_IF_ERROR(runtime_filter_mgr->get_consume_filters(filter_id, filters));
-            if (filters.empty()) {
-                throw Exception(ErrorCode::INTERNAL_ERROR, "filters empty, filter_id={}",
-                                filter_id);
-            }
-            for (auto* filter : filters) {
-                filter->set_ignored("");
-                filter->signal();
-            }
-            return Status::OK();
-        };
-
-        auto ignore_remote_filter = [](IRuntimeFilter* runtime_filter, std::string& msg) {
-            runtime_filter->set_ignored(msg);
-            RETURN_IF_ERROR(runtime_filter->publish());
-            return Status::OK();
-        };
-
-        // ordered vector: IN, IN_OR_BLOOM, others.
-        // so we can ignore other filter if IN Predicate exists.
-        auto compare_desc = [](IRuntimeFilter* d1, IRuntimeFilter* d2) {
-            if (d1->type() == d2->type()) {
-                return false;
-            } else if (d1->type() == RuntimeFilterType::IN_FILTER) {
-                return true;
-            } else if (d2->type() == RuntimeFilterType::IN_FILTER) {
-                return false;
-            } else if (d1->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-                return true;
-            } else if (d2->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-                return false;
-            } else {
-                return d1->type() < d2->type();
-            }
-        };
-        std::sort(_runtime_filters.begin(), _runtime_filters.end(), compare_desc);
-
-        // do not create 'in filter' when hash_table size over limit
-        const auto max_in_num = state->runtime_filter_max_in_num();
-        const bool over_max_in_num = (hash_table_size >= max_in_num);
-
+            const std::vector<IRuntimeFilter*>& runtime_filters)
+            : _build_expr_context(build_expr_ctxs), _runtime_filters(runtime_filters) {
         for (auto* runtime_filter : _runtime_filters) {
-            if (runtime_filter->expr_order() < 0 ||
-                runtime_filter->expr_order() >= _build_expr_context.size()) {
-                return Status::InternalError(
-                        "runtime_filter meet invalid expr_order, expr_order={}, "
-                        "_build_expr_context.size={}",
-                        runtime_filter->expr_order(), _build_expr_context.size());
-            }
-
-            bool is_in_filter = (runtime_filter->type() == RuntimeFilterType::IN_FILTER);
-
-            if (over_max_in_num &&
-                runtime_filter->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-                RETURN_IF_ERROR(runtime_filter->change_to_bloom_filter());
-            }
-
-            if (runtime_filter->is_bloomfilter()) {
-                RETURN_IF_ERROR(runtime_filter->init_bloom_filter(hash_table_size));
-            }
-
-            // Note:
-            // In the case that exist *remote target* and in filter and other filter,
-            // we must merge other filter whatever in filter is over the max num in current node,
-            // because:
-            // case 1: (in filter >= max num) in current node, so in filter will be ignored,
-            //         and then other filter can be used
-            // case 2: (in filter < max num) in current node, we don't know whether the in filter
-            //         will be ignored in merge node, so we must transfer other filter to merge node
-            if (!runtime_filter->has_remote_target()) {
-                bool exists_in_filter = has_in_filter[runtime_filter->expr_order()];
-                if (is_in_filter && over_max_in_num) {
-                    VLOG_DEBUG << "fragment instance " << print_id(state->fragment_instance_id())
-                               << " ignore runtime filter(in filter id "
-                               << runtime_filter->filter_id() << ") because: in_num("
-                               << hash_table_size << ") >= max_in_num(" << max_in_num << ")";
-                    RETURN_IF_ERROR(ignore_local_filter(runtime_filter->filter_id()));
-                    continue;
-                } else if (!is_in_filter && exists_in_filter) {
-                    // do not create 'bloom filter' and 'minmax filter' when 'in filter' has created
-                    // because in filter is exactly filter, so it is enough to filter data
-                    VLOG_DEBUG << "fragment instance " << print_id(state->fragment_instance_id())
-                               << " ignore runtime filter("
-                               << IRuntimeFilter::to_string(runtime_filter->type()) << " id "
-                               << runtime_filter->filter_id()
-                               << ") because: already exists in filter";
-                    RETURN_IF_ERROR(ignore_local_filter(runtime_filter->filter_id()));
-                    continue;
-                }
-            } else if (is_in_filter && over_max_in_num) {
-                std::string msg = fmt::format(
-                        "fragment instance {} ignore runtime filter(in filter id {}) because: "
-                        "in_num({}) >= max_in_num({})",
-                        print_id(state->fragment_instance_id()), runtime_filter->filter_id(),
-                        hash_table_size, max_in_num);
-                RETURN_IF_ERROR(ignore_remote_filter(runtime_filter, msg));
-                continue;
-            }
-
-            if ((runtime_filter->type() == RuntimeFilterType::IN_FILTER) ||
-                (runtime_filter->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
-                 !over_max_in_num)) {
-                has_in_filter[runtime_filter->expr_order()] = true;
-            }
             _runtime_filters_map[runtime_filter->expr_order()].push_back(runtime_filter);
         }
+    }
 
+    Status send_filter_size(RuntimeState* state, uint64_t hash_table_size, bool publish_local,
+                            pipeline::CountedFinishDependency* dependency) {
+        if (_runtime_filters.empty() || publish_local) {
+            return Status::OK();
+        }
+        for (auto* runtime_filter : _runtime_filters) {
+            if (runtime_filter->need_sync_filter_size()) {
+                runtime_filter->set_dependency(dependency);
+            }
+        }
+        for (auto* runtime_filter : _runtime_filters) {
+            if (runtime_filter->need_sync_filter_size()) {
+                RETURN_IF_ERROR(runtime_filter->send_filter_size(hash_table_size));
+            }
+        }
+        return Status::OK();
+    }
+
+    static uint64_t get_real_size(IRuntimeFilter* runtime_filter, uint64_t hash_table_size) {
+        return runtime_filter->isset_global_size() ? runtime_filter->get_global_size()
+                                                   : hash_table_size;
+    }
+
+    Status ignore_filters(RuntimeState* state, uint64_t hash_table_size) {
+        // process ignore duplicate IN_FILTER
+        std::unordered_set<int> has_in_filter;
+        for (auto* filter : _runtime_filters) {
+            if (filter->get_real_type() != RuntimeFilterType::IN_FILTER) {
+                continue;
+            }
+            if (has_in_filter.contains(filter->expr_order())) {
+                filter->set_ignored();
+                continue;
+            }
+            has_in_filter.insert(filter->expr_order());
+        }
+
+        // process ignore filter when it has IN_FILTER on same expr, and init bloom filter size
+        for (auto* filter : _runtime_filters) {
+            if (filter->get_real_type() == RuntimeFilterType::IN_FILTER ||
+                !has_in_filter.contains(filter->expr_order())) {
+                continue;
+            }
+            filter->set_ignored();
+        }
+        return Status::OK();
+    }
+
+    Status init_filters(RuntimeState* state, uint64_t hash_table_size) {
+        // process IN_OR_BLOOM_FILTER's real type
+        for (auto* filter : _runtime_filters) {
+            if (filter->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
+                get_real_size(filter, hash_table_size) > state->runtime_filter_max_in_num()) {
+                RETURN_IF_ERROR(filter->change_to_bloom_filter());
+            }
+
+            if (filter->get_real_type() == RuntimeFilterType::BLOOM_FILTER) {
+                RETURN_IF_ERROR(filter->init_bloom_filter(get_real_size(filter, hash_table_size)));
+            }
+        }
         return Status::OK();
     }
 
@@ -171,6 +114,9 @@ public:
             int result_column_id = _build_expr_context[i]->get_last_result_column_id();
             const auto& column = block->get_by_position(result_column_id).column;
             for (auto* filter : iter->second) {
+                if (filter->get_ignored()) {
+                    continue;
+                }
                 filter->insert_batch(column, 1);
             }
         }
@@ -213,7 +159,6 @@ public:
 private:
     const std::vector<std::shared_ptr<vectorized::VExprContext>>& _build_expr_context;
     std::vector<IRuntimeFilter*> _runtime_filters;
-    const bool _need_local_merge = false;
     // prob_contition index -> [IRuntimeFilter]
     std::map<int, std::list<IRuntimeFilter*>> _runtime_filters_map;
 };

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -39,7 +39,11 @@ Overload(Callables&&... callables) -> Overload<Callables...>;
 
 HashJoinBuildSinkLocalState::HashJoinBuildSinkLocalState(DataSinkOperatorXBase* parent,
                                                          RuntimeState* state)
-        : JoinBuildSinkLocalState(parent, state) {}
+        : JoinBuildSinkLocalState(parent, state) {
+    _finish_dependency = std::make_shared<CountedFinishDependency>(
+            parent->operator_id(), parent->node_id(), parent->get_name() + "_FINISH_DEPENDENCY",
+            state->get_query_ctx());
+}
 
 Status HashJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) {
     RETURN_IF_ERROR(JoinBuildSinkLocalState::init(state, info));
@@ -72,8 +76,10 @@ Status HashJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
     }
     if (!_should_build_hash_table) {
         _dependency->block();
+        _finish_dependency->block();
         p._shared_hashtable_controller->append_dependency(p.node_id(),
-                                                          _dependency->shared_from_this());
+                                                          _dependency->shared_from_this(),
+                                                          _finish_dependency->shared_from_this());
     }
 
     _build_blocks_memory_usage =
@@ -102,6 +108,9 @@ Status HashJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
                 _build_expr_ctxs.size() == 1));
     }
 
+    _runtime_filter_slots =
+            std::make_shared<VRuntimeFilterSlots>(_build_expr_ctxs, runtime_filters());
+
     return Status::OK();
 }
 
@@ -109,6 +118,40 @@ Status HashJoinBuildSinkLocalState::open(RuntimeState* state) {
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_open_timer);
     RETURN_IF_ERROR(JoinBuildSinkLocalState::open(state));
+    return Status::OK();
+}
+
+Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_status) {
+    auto p = _parent->cast<HashJoinBuildSinkOperatorX>();
+    Defer defer {[&]() {
+        if (_should_build_hash_table && p._shared_hashtable_controller) {
+            p._shared_hashtable_controller->signal_finish(p.node_id());
+        }
+    }};
+
+    if (!_runtime_filter_slots || _runtime_filters.empty()) {
+        return Status::OK();
+    }
+    auto* block = _shared_state->build_block.get();
+    uint64_t hash_table_size = block ? block->rows() : 0;
+    {
+        SCOPED_TIMER(_runtime_filter_init_timer);
+        RETURN_IF_ERROR(_runtime_filter_slots->init_filters(state, hash_table_size));
+        RETURN_IF_ERROR(_runtime_filter_slots->ignore_filters(state, hash_table_size));
+    }
+    if (_should_build_hash_table) {
+        if (hash_table_size > 1) {
+            SCOPED_TIMER(_runtime_filter_compute_timer);
+            _runtime_filter_slots->insert(block);
+        }
+        {
+            SCOPED_TIMER(_publish_runtime_filter_timer);
+            RETURN_IF_ERROR(_runtime_filter_slots->publish());
+        }
+    } else {
+        SCOPED_TIMER(_publish_runtime_filter_timer);
+        RETURN_IF_ERROR(_runtime_filter_slots->publish(true));
+    }
     return Status::OK();
 }
 
@@ -444,6 +487,7 @@ Status HashJoinBuildSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* st
                 is_null_safe_equal ||
                 (_build_expr_ctxs.back()->root()->is_nullable() && build_stores_null));
     }
+
     return Status::OK();
 }
 
@@ -501,9 +545,9 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
 
         const bool need_local_merge =
                 local_state._parent->cast<HashJoinBuildSinkOperatorX>()._need_local_merge;
-        RETURN_IF_ERROR(vectorized::process_runtime_filter_build(
-                state, local_state._shared_state->build_block.get(), &local_state,
-                need_local_merge));
+        RETURN_IF_ERROR(local_state._runtime_filter_slots->send_filter_size(
+                state, local_state._shared_state->build_block->rows(), need_local_merge,
+                (CountedFinishDependency*)(local_state._finish_dependency.get())));
         RETURN_IF_ERROR(
                 local_state.process_build_block(state, (*local_state._shared_state->build_block)));
         if (_shared_hashtable_controller) {
@@ -514,13 +558,10 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                     local_state._shared_state->hash_table_variants;
             _shared_hash_table_context->short_circuit_for_null_in_probe_side =
                     local_state._shared_state->_has_null_in_build_side;
-            if (local_state._runtime_filter_slots) {
-                local_state._runtime_filter_slots->copy_to_shared_context(
-                        _shared_hash_table_context);
-            }
             _shared_hash_table_context->block = local_state._shared_state->build_block;
             _shared_hash_table_context->build_indexes_null =
                     local_state._shared_state->build_indexes_null;
+            local_state._runtime_filter_slots->copy_to_shared_context(_shared_hash_table_context);
             _shared_hashtable_controller->signal(node_id());
         }
     } else if (!local_state._should_build_hash_table) {
@@ -531,6 +572,9 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         if (!_shared_hash_table_context->status.ok()) {
             return _shared_hash_table_context->status;
         }
+
+        RETURN_IF_ERROR(local_state._runtime_filter_slots->copy_from_shared_context(
+                _shared_hash_table_context));
 
         local_state.profile()->add_info_string(
                 "SharedHashTableFrom",
@@ -553,36 +597,6 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         local_state._shared_state->build_block = _shared_hash_table_context->block;
         local_state._shared_state->build_indexes_null =
                 _shared_hash_table_context->build_indexes_null;
-        const bool need_local_merge =
-                local_state._parent->cast<HashJoinBuildSinkOperatorX>()._need_local_merge;
-
-        if (!_shared_hash_table_context->runtime_filters.empty()) {
-            auto ret = std::visit(
-                    Overload {
-                            [&](std::monostate&) -> Status {
-                                LOG(FATAL) << "FATAL: uninited hash table";
-                                __builtin_unreachable();
-                            },
-                            [&](auto&& arg) -> Status {
-                                if (local_state._runtime_filters.empty()) {
-                                    return Status::OK();
-                                }
-                                local_state._runtime_filter_slots =
-                                        std::make_shared<VRuntimeFilterSlots>(
-                                                _build_expr_ctxs, local_state._runtime_filters,
-                                                need_local_merge);
-
-                                RETURN_IF_ERROR(local_state._runtime_filter_slots->init(
-                                        state, arg.hash_table->size()));
-                                RETURN_IF_ERROR(
-                                        local_state._runtime_filter_slots->copy_from_shared_context(
-                                                _shared_hash_table_context));
-                                RETURN_IF_ERROR(local_state._runtime_filter_slots->publish(true));
-                                return Status::OK();
-                            }},
-                    *local_state._shared_state->hash_table_variants);
-            RETURN_IF_ERROR(ret);
-        }
     }
 
     if (eos) {

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -70,6 +70,10 @@ public:
         _profile->add_info_string("HashTableFilledBuckets", info);
     }
 
+    Dependency* finishdependency() override { return _finish_dependency.get(); }
+
+    Status close(RuntimeState* state, Status exec_status) override;
+
 protected:
     void _hash_table_init(RuntimeState* state);
     void _set_build_ignore_flag(vectorized::Block& block, const std::vector<int>& res_col_ids);
@@ -83,10 +87,6 @@ protected:
     friend class HashJoinBuildSinkOperatorX;
     template <class HashTableContext, typename Parent>
     friend struct vectorized::ProcessHashTableBuild;
-    template <typename Parent>
-    friend Status vectorized::process_runtime_filter_build(RuntimeState* state,
-                                                           vectorized::Block* block, Parent* parent,
-                                                           bool is_global);
 
     // build expr
     vectorized::VExprContextSPtrs _build_expr_ctxs;
@@ -107,6 +107,7 @@ protected:
      */
     bool _build_side_ignore_null = false;
     std::vector<int> _build_col_ids;
+    std::shared_ptr<Dependency> _finish_dependency;
 
     RuntimeProfile::Counter* _build_table_timer = nullptr;
     RuntimeProfile::Counter* _build_expr_call_timer = nullptr;

--- a/be/src/pipeline/exec/join_build_sink_operator.cpp
+++ b/be/src/pipeline/exec/join_build_sink_operator.cpp
@@ -40,7 +40,8 @@ Status JoinBuildSinkLocalState<SharedStateArg, Derived>::init(RuntimeState* stat
                                               "PublishRuntimeFilterTime");
     _runtime_filter_compute_timer = ADD_TIMER(PipelineXSinkLocalState<SharedStateArg>::profile(),
                                               "RuntimeFilterComputeTime");
-
+    _runtime_filter_init_timer =
+            ADD_TIMER(PipelineXSinkLocalState<SharedStateArg>::profile(), "RuntimeFilterInitTime");
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/join_build_sink_operator.h
+++ b/be/src/pipeline/exec/join_build_sink_operator.h
@@ -44,6 +44,7 @@ protected:
     RuntimeProfile::Counter* _build_rows_counter = nullptr;
     RuntimeProfile::Counter* _publish_runtime_filter_timer = nullptr;
     RuntimeProfile::Counter* _runtime_filter_compute_timer = nullptr;
+    RuntimeProfile::Counter* _runtime_filter_init_timer = nullptr;
     std::vector<IRuntimeFilter*> _runtime_filters;
 };
 

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -334,7 +334,6 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::VScannerSPtr>* s
                 RETURN_IF_ERROR(olap_scanner->prepare(state(), _conjuncts));
                 olap_scanner->set_compound_filters(_compound_filters);
             }
-            LOG(INFO) << "parallel scanners count: " << scanners->size();
             return Status::OK();
         }
     }

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -112,6 +112,16 @@ std::string Dependency::debug_string(int indentation_level) {
     return fmt::to_string(debug_string_buffer);
 }
 
+std::string CountedFinishDependency::debug_string(int indentation_level) {
+    fmt::memory_buffer debug_string_buffer;
+    fmt::format_to(
+            debug_string_buffer,
+            "{}{}: id={}, block task = {}, ready={}, _always_ready={}, is cancelled={}, count={}",
+            std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(), _ready,
+            _always_ready, _is_cancelled(), _counter);
+    return fmt::to_string(debug_string_buffer);
+}
+
 std::string RuntimeFilterDependency::debug_string(int indentation_level) {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer,

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1443,7 +1443,7 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
                 runtime_filter_mgr = pip_context->get_query_ctx()->runtime_filter_mgr();
                 pool = &pip_context->get_query_ctx()->obj_pool;
                 query_thread_context = {pip_context->get_query_ctx()->query_id(),
-                                    pip_context->get_query_ctx()->query_mem_tracker};
+                                        pip_context->get_query_ctx()->query_mem_tracker};
             } else {
                 auto iter = _fragment_instance_map.find(tfragment_instance_id);
                 if (iter == _fragment_instance_map.end()) {
@@ -1455,7 +1455,7 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
                 runtime_filter_mgr = fragment_executor->get_query_ctx()->runtime_filter_mgr();
                 pool = &fragment_executor->get_query_ctx()->obj_pool;
                 query_thread_context = {fragment_executor->get_query_ctx()->query_id(),
-                                    fragment_executor->get_query_ctx()->query_mem_tracker};
+                                        fragment_executor->get_query_ctx()->query_mem_tracker};
             }
             break;
         }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1419,76 +1419,110 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
     bool is_pipeline = request->has_is_pipeline() && request->is_pipeline();
     int64_t start_apply = MonotonicMillis();
 
+    std::shared_ptr<PlanFragmentExecutor> fragment_executor;
+    std::shared_ptr<pipeline::PipelineFragmentContext> pip_context;
+    QueryThreadContext query_thread_context;
+
+    RuntimeFilterMgr* runtime_filter_mgr = nullptr;
+    ObjectPool* pool = nullptr;
+
     const auto& fragment_instance_ids = request->fragment_instance_ids();
-    if (!fragment_instance_ids.empty()) {
-        UniqueId fragment_instance_id = fragment_instance_ids[0];
-        TUniqueId tfragment_instance_id = fragment_instance_id.to_thrift();
+    {
+        std::unique_lock<std::mutex> lock(_lock);
+        for (UniqueId fragment_instance_id : fragment_instance_ids) {
+            TUniqueId tfragment_instance_id = fragment_instance_id.to_thrift();
 
-        std::shared_ptr<PlanFragmentExecutor> fragment_executor;
-        std::shared_ptr<pipeline::PipelineFragmentContext> pip_context;
-        QueryThreadContext query_thread_context;
+            if (is_pipeline) {
+                auto iter = _pipeline_map.find(tfragment_instance_id);
+                if (iter == _pipeline_map.end()) {
+                    continue;
+                }
+                pip_context = iter->second;
 
-        RuntimeFilterMgr* runtime_filter_mgr = nullptr;
-        ObjectPool* pool = nullptr;
-        if (is_pipeline) {
-            std::unique_lock<std::mutex> lock(_lock);
-            auto iter = _pipeline_map.find(tfragment_instance_id);
-            if (iter == _pipeline_map.end()) {
-                VLOG_CRITICAL << "unknown.... fragment-id:" << fragment_instance_id;
-                return Status::InvalidArgument("fragment-id: {}", fragment_instance_id.to_string());
-            }
-            pip_context = iter->second;
-
-            DCHECK(pip_context != nullptr);
-            runtime_filter_mgr = pip_context->get_query_ctx()->runtime_filter_mgr();
-            pool = &pip_context->get_query_ctx()->obj_pool;
-            query_thread_context = {pip_context->get_query_ctx()->query_id(),
+                DCHECK(pip_context != nullptr);
+                runtime_filter_mgr = pip_context->get_query_ctx()->runtime_filter_mgr();
+                pool = &pip_context->get_query_ctx()->obj_pool;
+                query_thread_context = {pip_context->get_query_ctx()->query_id(),
                                     pip_context->get_query_ctx()->query_mem_tracker};
-        } else {
-            std::unique_lock<std::mutex> lock(_lock);
-            auto iter = _fragment_instance_map.find(tfragment_instance_id);
-            if (iter == _fragment_instance_map.end()) {
-                VLOG_CRITICAL << "unknown.... fragment instance id:"
-                              << print_id(tfragment_instance_id);
-                return Status::InvalidArgument("fragment instance id: {}",
-                                               print_id(tfragment_instance_id));
-            }
-            fragment_executor = iter->second;
+            } else {
+                auto iter = _fragment_instance_map.find(tfragment_instance_id);
+                if (iter == _fragment_instance_map.end()) {
+                    continue;
+                }
+                fragment_executor = iter->second;
 
-            DCHECK(fragment_executor != nullptr);
-            runtime_filter_mgr = fragment_executor->get_query_ctx()->runtime_filter_mgr();
-            pool = &fragment_executor->get_query_ctx()->obj_pool;
-            query_thread_context = {fragment_executor->get_query_ctx()->query_id(),
+                DCHECK(fragment_executor != nullptr);
+                runtime_filter_mgr = fragment_executor->get_query_ctx()->runtime_filter_mgr();
+                pool = &fragment_executor->get_query_ctx()->obj_pool;
+                query_thread_context = {fragment_executor->get_query_ctx()->query_id(),
                                     fragment_executor->get_query_ctx()->query_mem_tracker};
-        }
-
-        SCOPED_ATTACH_TASK(query_thread_context);
-
-        // 1. get the target filters
-        std::vector<IRuntimeFilter*> filters;
-        RETURN_IF_ERROR(runtime_filter_mgr->get_consume_filters(request->filter_id(), filters));
-
-        // 2. create the filter wrapper to replace or ignore the target filters
-        if (request->has_in_filter() && request->in_filter().has_ignored_msg()) {
-            const auto& in_filter = request->in_filter();
-
-            std::ranges::for_each(filters, [&in_filter](auto& filter) {
-                filter->set_ignored(in_filter.ignored_msg());
-                filter->signal();
-            });
-        } else if (!filters.empty()) {
-            UpdateRuntimeFilterParamsV2 params {request, attach_data, pool,
-                                                filters[0]->column_type()};
-            RuntimePredicateWrapper* filter_wrapper = nullptr;
-            RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(&params, &filter_wrapper));
-
-            std::ranges::for_each(filters, [&](auto& filter) {
-                filter->update_filter(filter_wrapper, request->merge_time(), start_apply);
-            });
+            }
+            break;
         }
     }
 
+    if (runtime_filter_mgr == nullptr) {
+        // all instance finished
+        return Status::OK();
+    }
+
+    SCOPED_ATTACH_TASK(query_thread_context);
+    // 1. get the target filters
+    std::vector<IRuntimeFilter*> filters;
+    RETURN_IF_ERROR(runtime_filter_mgr->get_consume_filters(request->filter_id(), filters));
+
+    // 2. create the filter wrapper to replace or ignore the target filters
+    if (!filters.empty()) {
+        UpdateRuntimeFilterParamsV2 params {request, attach_data, pool, filters[0]->column_type()};
+        RuntimePredicateWrapper* filter_wrapper = nullptr;
+        RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(&params, &filter_wrapper));
+
+        std::ranges::for_each(filters, [&](auto& filter) {
+            filter->update_filter(filter_wrapper, request->merge_time(), start_apply);
+        });
+    }
+
     return Status::OK();
+}
+
+Status FragmentMgr::send_filter_size(const PSendFilterSizeRequest* request) {
+    UniqueId queryid = request->query_id();
+    std::shared_ptr<RuntimeFilterMergeControllerEntity> filter_controller;
+    RETURN_IF_ERROR(_runtimefilter_controller.acquire(queryid, &filter_controller));
+
+    std::shared_ptr<QueryContext> query_ctx;
+    {
+        TUniqueId query_id;
+        query_id.__set_hi(queryid.hi);
+        query_id.__set_lo(queryid.lo);
+        std::lock_guard<std::mutex> lock(_lock);
+        auto iter = _query_ctx_map.find(query_id);
+        if (iter == _query_ctx_map.end()) {
+            return Status::InvalidArgument("query-id: {}", queryid.to_string());
+        }
+
+        query_ctx = iter->second;
+    }
+    auto merge_status = filter_controller->send_filter_size(request);
+    return merge_status;
+}
+
+Status FragmentMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
+    UniqueId queryid = request->query_id();
+    std::shared_ptr<QueryContext> query_ctx;
+    {
+        TUniqueId query_id;
+        query_id.__set_hi(queryid.hi);
+        query_id.__set_lo(queryid.lo);
+        std::lock_guard<std::mutex> lock(_lock);
+        auto iter = _query_ctx_map.find(query_id);
+        if (iter == _query_ctx_map.end()) {
+            return Status::InvalidArgument("query-id: {}", queryid.to_string());
+        }
+
+        query_ctx = iter->second;
+    }
+    return query_ctx->runtime_filter_mgr()->sync_filter_size(request);
 }
 
 Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
@@ -1515,7 +1549,6 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
     }
     SCOPED_ATTACH_TASK_WITH_ID(query_ctx->query_mem_tracker, query_ctx->query_id());
     auto merge_status = filter_controller->merge(request, attach_data, opt_remote_rf);
-    DCHECK(merge_status.ok());
     return merge_status;
 }
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -132,6 +132,10 @@ public:
     Status merge_filter(const PMergeFilterRequest* request,
                         butil::IOBufAsZeroCopyInputStream* attach_data);
 
+    Status send_filter_size(const PSendFilterSizeRequest* request);
+
+    Status sync_filter_size(const PSyncFilterSizeRequest* request);
+
     std::string to_http_path(const std::string& file_name);
 
     void coordinator_callback(const ReportStatusRequest& req);

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -362,7 +362,7 @@ Status RuntimeFilterMergeControllerEntity::send_filter_size(const PSendFilterSiz
 Status RuntimeFilterMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
     auto* filter = try_get_product_filter(request->filter_id());
     if (filter) {
-        filter->set_global_size(request->filter_size());
+        filter->set_synced_size(request->filter_size());
         return Status::OK();
     }
 
@@ -370,7 +370,7 @@ Status RuntimeFilterMgr::sync_filter_size(const PSyncFilterSizeRequest* request)
     RETURN_IF_ERROR(get_local_merge_producer_filters(request->filter_id(), &local_merge_filters));
     // first filter size merged filter
     for (size_t i = 1; i < local_merge_filters->filters.size(); i++) {
-        local_merge_filters->filters[i]->set_global_size(request->filter_size());
+        local_merge_filters->filters[i]->set_synced_size(request->filter_size());
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -20,8 +20,10 @@
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/Types_types.h>
+#include <gen_cpp/internal_service.pb.h>
 #include <stdint.h>
 
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <memory>
@@ -30,6 +32,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "common/object_pool.h"
@@ -57,6 +60,8 @@ class ExecEnv;
 struct LocalMergeFilters {
     std::unique_ptr<std::mutex> lock = std::make_unique<std::mutex>();
     int merge_time = 0;
+    int merge_size_times = 0;
+    uint64_t local_merged_size = 0;
     std::vector<IRuntimeFilter*> filters;
 };
 
@@ -81,6 +86,15 @@ public:
 
     Status get_consume_filters(const int filter_id, std::vector<IRuntimeFilter*>& consumer_filters);
 
+    IRuntimeFilter* try_get_product_filter(const int filter_id) {
+        std::lock_guard<std::mutex> l(_lock);
+        auto iter = _producer_map.find(filter_id);
+        if (iter == _producer_map.end()) {
+            return nullptr;
+        }
+        return iter->second;
+    }
+
     // register filter
     Status register_consumer_filter(const TRuntimeFilterDesc& desc, const TQueryOptions& options,
                                     int node_id, IRuntimeFilter** consumer_filter,
@@ -104,6 +118,8 @@ public:
     void set_runtime_filter_params(const TRuntimeFilterParams& runtime_filter_params);
 
     Status get_merge_addr(TNetworkAddress* addr);
+
+    Status sync_filter_size(const PSyncFilterSizeRequest* request);
 
 private:
     struct ConsumerFilterHolder {
@@ -146,16 +162,20 @@ public:
     Status merge(const PMergeFilterRequest* request, butil::IOBufAsZeroCopyInputStream* attach_data,
                  bool opt_remote_rf);
 
+    Status send_filter_size(const PSendFilterSizeRequest* request);
+
     UniqueId query_id() const { return _query_id; }
 
     struct RuntimeFilterCntlVal {
         int64_t merge_time;
         int producer_size;
+        uint64_t global_size;
         TRuntimeFilterDesc runtime_filter_desc;
         std::vector<doris::TRuntimeFilterTargetParams> target_info;
         std::vector<doris::TRuntimeFilterTargetParamsV2> targetv2_info;
         IRuntimeFilter* filter = nullptr;
-        std::unordered_set<UniqueId> arrive_id; // fragment_instance_id ?
+        std::unordered_set<UniqueId> arrive_id;
+        std::vector<PNetworkAddress> source_addrs;
         std::shared_ptr<ObjectPool> pool;
     };
 
@@ -174,8 +194,14 @@ private:
     // protect _filter_map
     std::shared_mutex _filter_map_mutex;
     std::shared_ptr<MemTracker> _mem_tracker;
-    using CntlValwithLock =
-            std::pair<std::shared_ptr<RuntimeFilterCntlVal>, std::unique_ptr<std::mutex>>;
+
+    struct CntlValwithLock {
+        std::shared_ptr<RuntimeFilterCntlVal> cnt_val;
+        std::unique_ptr<std::mutex> mutex;
+        CntlValwithLock(std::shared_ptr<RuntimeFilterCntlVal> input_cnt_val)
+                : cnt_val(std::move(input_cnt_val)), mutex(std::make_unique<std::mutex>()) {}
+    };
+
     std::map<int, CntlValwithLock> _filter_map;
     RuntimeFilterParamsContext* _state = nullptr;
 };

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -75,6 +75,7 @@ TBackend BackendOptions::get_local_backend() {
     _backend.__set_host(_s_localhost);
     _backend.__set_be_port(config::be_port);
     _backend.__set_http_port(config::webserver_port);
+    _backend.__set_brpc_port(config::brpc_port);
     return _backend;
 }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1179,9 +1179,36 @@ void PInternalService::merge_filter(::google::protobuf::RpcController* controlle
         auto attachment = static_cast<brpc::Controller*>(controller)->request_attachment();
         butil::IOBufAsZeroCopyInputStream zero_copy_input_stream(attachment);
         Status st = _exec_env->fragment_mgr()->merge_filter(request, &zero_copy_input_stream);
-        if (!st.ok()) {
-            LOG(WARNING) << "merge meet error" << st.to_string();
-        }
+        st.to_protobuf(response->mutable_status());
+    });
+    if (!ret) {
+        offer_failed(response, done, _light_work_pool);
+        return;
+    }
+}
+
+void PInternalService::send_filter_size(::google::protobuf::RpcController* controller,
+                                        const ::doris::PSendFilterSizeRequest* request,
+                                        ::doris::PSendFilterSizeResponse* response,
+                                        ::google::protobuf::Closure* done) {
+    bool ret = _light_work_pool.try_offer([this, request, response, done]() {
+        brpc::ClosureGuard closure_guard(done);
+        Status st = _exec_env->fragment_mgr()->send_filter_size(request);
+        st.to_protobuf(response->mutable_status());
+    });
+    if (!ret) {
+        offer_failed(response, done, _light_work_pool);
+        return;
+    }
+}
+
+void PInternalService::sync_filter_size(::google::protobuf::RpcController* controller,
+                                        const ::doris::PSyncFilterSizeRequest* request,
+                                        ::doris::PSyncFilterSizeResponse* response,
+                                        ::google::protobuf::Closure* done) {
+    bool ret = _light_work_pool.try_offer([this, request, response, done]() {
+        brpc::ClosureGuard closure_guard(done);
+        Status st = _exec_env->fragment_mgr()->sync_filter_size(request);
         st.to_protobuf(response->mutable_status());
     });
     if (!ret) {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -148,6 +148,16 @@ public:
                       ::doris::PMergeFilterResponse* response,
                       ::google::protobuf::Closure* done) override;
 
+    void send_filter_size(::google::protobuf::RpcController* controller,
+                          const ::doris::PSendFilterSizeRequest* request,
+                          ::doris::PSendFilterSizeResponse* response,
+                          ::google::protobuf::Closure* done) override;
+
+    void sync_filter_size(::google::protobuf::RpcController* controller,
+                          const ::doris::PSyncFilterSizeRequest* request,
+                          ::doris::PSyncFilterSizeResponse* response,
+                          ::google::protobuf::Closure* done) override;
+
     void apply_filter(::google::protobuf::RpcController* controller,
                       const ::doris::PPublishFilterRequest* request,
                       ::doris::PPublishFilterResponse* response,

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -77,6 +77,10 @@ public:
     }
 #endif
 
+    std::shared_ptr<T> get_client(const PNetworkAddress& paddr) {
+        return get_client(paddr.hostname(), paddr.port());
+    }
+
     std::shared_ptr<T> get_client(const std::string& host, int port) {
         std::string realhost;
         realhost = host;

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -78,10 +78,11 @@ Status process_runtime_filter_build(RuntimeState* state, Block* block, Parent* p
     if (parent->runtime_filters().empty()) {
         return Status::OK();
     }
-    parent->_runtime_filter_slots = std::make_shared<VRuntimeFilterSlots>(
-            parent->_build_expr_ctxs, parent->runtime_filters(), is_global);
-
-    RETURN_IF_ERROR(parent->_runtime_filter_slots->init(state, block->rows()));
+    {
+        SCOPED_TIMER(parent->_runtime_filter_init_timer);
+        RETURN_IF_ERROR(parent->_runtime_filter_slots->init_filters(state, block->rows()));
+        RETURN_IF_ERROR(parent->_runtime_filter_slots->ignore_filters(state, block->rows()));
+    }
 
     if (!parent->_runtime_filter_slots->empty() && block->rows() > 1) {
         SCOPED_TIMER(parent->_runtime_filter_compute_timer);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -78,13 +78,14 @@ Status process_runtime_filter_build(RuntimeState* state, Block* block, Parent* p
     if (parent->runtime_filters().empty()) {
         return Status::OK();
     }
+    uint64_t rows = block->rows();
     {
         SCOPED_TIMER(parent->_runtime_filter_init_timer);
-        RETURN_IF_ERROR(parent->_runtime_filter_slots->init_filters(state, block->rows()));
-        RETURN_IF_ERROR(parent->_runtime_filter_slots->ignore_filters(state, block->rows()));
+        RETURN_IF_ERROR(parent->_runtime_filter_slots->init_filters(state, rows));
+        RETURN_IF_ERROR(parent->_runtime_filter_slots->ignore_filters(state));
     }
 
-    if (!parent->_runtime_filter_slots->empty() && block->rows() > 1) {
+    if (!parent->_runtime_filter_slots->empty() && rows > 1) {
         SCOPED_TIMER(parent->_runtime_filter_compute_timer);
         parent->_runtime_filter_slots->insert(block);
     }

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -144,6 +144,7 @@ Status VJoinNodeBase::prepare(RuntimeState* state) {
 
     _publish_runtime_filter_timer = ADD_TIMER(runtime_profile(), "PublishRuntimeFilterTime");
     _runtime_filter_compute_timer = ADD_TIMER(runtime_profile(), "RunmtimeFilterComputeTime");
+    _runtime_filter_init_timer = ADD_TIMER(runtime_profile(), "RunmtimeFilterInitTime");
 
     return Status::OK();
 }

--- a/be/src/vec/exec/join/vjoin_node_base.h
+++ b/be/src/vec/exec/join/vjoin_node_base.h
@@ -152,6 +152,7 @@ protected:
     RuntimeProfile::Counter* _probe_rows_counter = nullptr;
     RuntimeProfile::Counter* _publish_runtime_filter_timer = nullptr;
     RuntimeProfile::Counter* _runtime_filter_compute_timer = nullptr;
+    RuntimeProfile::Counter* _runtime_filter_init_timer = nullptr;
     RuntimeProfile::Counter* _join_filter_timer = nullptr;
     RuntimeProfile::Counter* _build_output_block_timer = nullptr;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -239,6 +239,10 @@ public final class RuntimeFilter {
                 tFilter.setNullAware(false);
             }
         }
+        tFilter.setSyncFilterSize(
+                ConnectContext.get() != null && ConnectContext.get().getSessionVariable().getEnablePipelineXEngine()
+                        && ConnectContext.get().getSessionVariable().getEnablePipelineEngine()
+                        && ConnectContext.get().getSessionVariable().enableSyncRuntimeFilterSize());
         return tFilter;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -185,6 +185,8 @@ public class SessionVariable implements Serializable, Writable {
     // if the right table is greater than this value in the hash join,  we will ignore IN filter
     public static final String RUNTIME_FILTER_MAX_IN_NUM = "runtime_filter_max_in_num";
 
+    public static final String ENABLE_SYNC_RUNTIME_FILTER_SIZE = "enable_sync_runtime_filter_size";
+
     public static final String BE_NUMBER_FOR_TEST = "be_number_for_test";
 
     // max ms to wait transaction publish finish when exec insert stmt.
@@ -992,6 +994,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MAX_IN_NUM, needForward = true)
     private int runtimeFilterMaxInNum = 1024;
+
+    @VariableMgr.VarAttr(name = ENABLE_SYNC_RUNTIME_FILTER_SIZE, needForward = true)
+    private boolean enableSyncRuntimeFilterSize = true;
 
     @VariableMgr.VarAttr(name = USE_RF_DEFAULT)
     public boolean useRuntimeFilterDefaultSize = false;
@@ -3470,6 +3475,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnablePipelineXEngine() {
         return enablePipelineXEngine;
+    }
+
+    public boolean enableSyncRuntimeFilterSize() {
+        return enableSyncRuntimeFilterSize;
     }
 
     public static boolean enablePipelineEngine() {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -526,6 +526,27 @@ enum PFilterType {
     MAX_FILTER = 6;
 };
 
+message PSendFilterSizeRequest {
+    required int32 filter_id = 1;
+    required PUniqueId query_id = 2;
+    required PNetworkAddress source_addr = 3;
+    required uint64 filter_size = 4;
+};
+
+message PSendFilterSizeResponse {
+    required PStatus status = 1;
+};
+
+message PSyncFilterSizeRequest {
+    required int32 filter_id = 1;
+    required PUniqueId query_id = 2;
+    required uint64 filter_size = 3;
+};
+
+message PSyncFilterSizeResponse {
+    required PStatus status = 1;
+};
+
 message PMergeFilterRequest {
     required int32 filter_id = 1;
     required PUniqueId query_id = 2;
@@ -538,6 +559,7 @@ message PMergeFilterRequest {
     optional bool opt_remote_rf = 9;
     optional PColumnType column_type = 10;
     optional bool contain_null = 11;
+    optional bool ignored = 12;
 };
 
 message PMergeFilterResponse {
@@ -557,6 +579,7 @@ message PPublishFilterRequest {
     optional int64 merge_time = 9;
     optional PColumnType column_type = 10;
     optional bool contain_null = 11;
+    optional bool ignored = 12;
 };
 
 message PPublishFilterRequestV2 {
@@ -570,6 +593,7 @@ message PPublishFilterRequestV2 {
     optional bool is_pipeline = 8;
     optional int64 merge_time = 9;
     optional bool contain_null = 10;
+    optional bool ignored = 11;
 };
 
 message PPublishFilterResponse {
@@ -916,6 +940,8 @@ service PBackendService {
     rpc commit(PCommitRequest) returns (PCommitResult);
     rpc rollback(PRollbackRequest) returns (PRollbackResult);
     rpc merge_filter(PMergeFilterRequest) returns (PMergeFilterResponse);
+    rpc send_filter_size(PSendFilterSizeRequest) returns (PSendFilterSizeResponse);
+    rpc sync_filter_size(PSyncFilterSizeRequest) returns (PSyncFilterSizeResponse);
     rpc apply_filter(PPublishFilterRequest) returns (PPublishFilterResponse);
     rpc apply_filterv2(PPublishFilterRequestV2) returns (PPublishFilterResponse);
     rpc fold_constant_expr(PConstantExprRequest) returns (PConstantExprResult);

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -234,3 +234,8 @@ enum PPlanFragmentCancelReason {
     CALL_RPC_ERROR = 5;
     MEMORY_LIMIT_EXCEED = 6;
 }
+
+message PNetworkAddress {
+    required string hostname = 1;
+    required int32 port = 2;
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1216,6 +1216,8 @@ struct TRuntimeFilterDesc {
  
   // true, if join type is null aware like <=>. rf should dispose the case
   15: optional bool null_aware;
+
+  16: optional bool sync_filter_size;
 }
 
 


### PR DESCRIPTION
## Proposed changes
support sync join node build side's size to init bloom runtime filter


**tpch with no stats**
![HQQqTbyE44](https://github.com/apache/doris/assets/7939630/cace31cc-ac6e-43ac-ba4e-91eeff2fd165)

**tpcds with stats**
![cMHwKYIWxG](https://github.com/apache/doris/assets/7939630/c699fcbb-721a-41a0-bb6e-a4063175f350)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

