### PR TITLE
[fix](jdbc catalog) fix get doris column info when lower case

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -252,7 +252,7 @@ public abstract class JdbcClient {
                     remoteTablesNames.add(rs.getString("TABLE_NAME"));
                 }
             } catch (SQLException e) {
-                throw new JdbcClientException("failed to get all tables for remote database %s", e, remoteDbName);
+                throw new JdbcClientException("failed to get all tables for remote database: `%s`", e, remoteDbName);
             }
         });
         return filterTableNames(remoteDbName, remoteTablesNames);
@@ -313,8 +313,8 @@ public abstract class JdbcClient {
                 tableSchema.add(field);
             }
         } catch (SQLException e) {
-            throw new JdbcClientException("failed to get jdbc columns info for table %.%s: %s",
-                    e, localDbName, localTableName, Util.getRootCauseMessage(e));
+            throw new JdbcClientException("failed to get jdbc columns info for remote table `%s.%s`: %s",
+                    remoteDbName, remoteTableName, Util.getRootCauseMessage(e));
         } finally {
             close(rs, conn);
         }
@@ -415,8 +415,8 @@ public abstract class JdbcClient {
         return jdbcLowerCaseMetaMatching.setDatabaseNameMapping(filteredDatabaseNames);
     }
 
-    protected List<String> filterTableNames(String remoteDbName, List<String> localTableNames) {
-        return jdbcLowerCaseMetaMatching.setTableNameMapping(remoteDbName, localTableNames);
+    protected List<String> filterTableNames(String remoteDbName, List<String> remoteTableNames) {
+        return jdbcLowerCaseMetaMatching.setTableNameMapping(remoteDbName, remoteTableNames);
     }
 
     protected List<Column> filterColumnName(String remoteDbName, String remoteTableName, List<Column> remoteColumns) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When using MySQL JDBC Catalog to connect to Doris, we should use remoteDbName and remoteTableName to obtain column info instead of localname. This bug may be triggered when the current Doris FE configuration lower_case_table_name = 1 or the catalog properties lower_case_meta_name = true

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

