### PR TITLE
[fix](iceberg) fix error when query iceberg table using date cast predicate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -643,6 +643,10 @@ public class DateLiteral extends LiteralExpr {
         return this.type.isDate() || this.type.isDateV2();
     }
 
+    public boolean isDateTimeType() {
+        return this.type.isDatetime() || this.type.isDatetimeV2();
+    }
+
     @Override
     public String getStringValue() {
         char[] dateTimeChars = new char[26]; // Enough to hold "YYYY-MM-DD HH:MM:SS.mmmmmm"

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -229,7 +229,7 @@ public class IcebergUtils {
             return boolLiteral.getValue();
         } else if (expr instanceof DateLiteral) {
             DateLiteral dateLiteral = (DateLiteral) expr;
-            if (dateLiteral.isDateType()) {
+            if (dateLiteral.isDateType() || dateLiteral.isDateTimeType()) {
                 return dateLiteral.getStringValue();
             } else {
                 return dateLiteral.unixTimestamp(TimeUtils.getTimeZone()) * MILLIS_TO_NANO_TIME;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

when runing tpch query Q3 Q5 Q10 Q11 Q18 Q19, an error occurs. Error msg: ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: Invalid value for conversion to type string: xxxx (java.lang.Long)
these query has same type predicate in where clause like this: o_orderdate >= date '1994-01-01'

error log:
```sql
java.lang.RuntimeException: Invalid value for conversion to type string: 809996400000000 (java.lang.Long)
        at org.apache.doris.common.security.authentication.HadoopUGI.ugiDoAs(HadoopUGI.java:114) ~[fe-common-1.2-SNAPSHOT.j
ar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.HiveMetaStoreClientHelper.ugiDoAs(HiveMetaStoreClientHelper.java:829) ~[doris-f
e.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.iceberg.source.IcebergScanNode.getSplits(IcebergScanNode.java:179) ~[doris-fe.jar:1.
2-SNAPSHOT]
        at org.apache.doris.datasource.FileQueryScanNode.createScanRangeLocations(FileQueryScanNode.java:271) ~[doris-fe.ja
r:1.2-SNAPSHOT]
        at org.apache.doris.datasource.FileQueryScanNode.doFinalize(FileQueryScanNode.java:226) ~[doris-fe.jar:1.2-SNAPSHOT
]
        at org.apache.doris.datasource.FileQueryScanNode.finalize(FileQueryScanNode.java:213) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:687) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.AggregationNode.finalize(AggregationNode.java:381) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.OriginalPlanner.createPlanFragments(OriginalPlanner.java:206) ~[doris-fe.jar:1.2-SNAPSH
OT]
        at org.apache.doris.planner.OriginalPlanner.plan(OriginalPlanner.java:100) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

