### PR TITLE
[Bug] Stop incorrectly of reportwork cause heap use after free

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -259,4 +259,10 @@ void AgentServer::publish_cluster_state(TAgentResult& t_agent_result,
     status.to_thrift(&t_agent_result.status);
 }
 
+void AgentServer::stop_report_workers() {
+    for (auto& work : _report_workers) {
+        work->stop();
+    }
+}
+
 } // namespace doris

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -60,6 +60,8 @@ public:
 
     TopicSubscriber* get_topic_subscriber() { return _topic_subscriber.get(); }
 
+    void stop_report_workers();
+
 private:
     // Reference to the ExecEnv::_master_info
     const TMasterInfo& _master_info;

--- a/be/src/cloud/cloud_backend_service.cpp
+++ b/be/src/cloud/cloud_backend_service.cpp
@@ -28,8 +28,8 @@ CloudBackendService::CloudBackendService(CloudStorageEngine& engine, ExecEnv* ex
 CloudBackendService::~CloudBackendService() = default;
 
 Status CloudBackendService::create_service(CloudStorageEngine& engine, ExecEnv* exec_env, int port,
-                                           std::unique_ptr<ThriftServer>* server) {
-    auto service = std::make_shared<CloudBackendService>(engine, exec_env);
+                                           std::unique_ptr<ThriftServer>* server,
+                                           std::shared_ptr<doris::CloudBackendService> service) {
     service->_agent_server->cloud_start_workers(engine, exec_env);
     // TODO: do we want a BoostThreadFactory?
     // TODO: we want separate thread factories here, so that fe requests can't starve

--- a/be/src/cloud/cloud_backend_service.h
+++ b/be/src/cloud/cloud_backend_service.h
@@ -26,7 +26,8 @@ class CloudStorageEngine;
 class CloudBackendService final : public BaseBackendService {
 public:
     static Status create_service(CloudStorageEngine& engine, ExecEnv* exec_env, int port,
-                                 std::unique_ptr<ThriftServer>* server);
+                                 std::unique_ptr<ThriftServer>* server,
+                                 std::shared_ptr<doris::CloudBackendService> service);
 
     CloudBackendService(CloudStorageEngine& engine, ExecEnv* exec_env);
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -374,8 +374,8 @@ BackendService::BackendService(StorageEngine& engine, ExecEnv* exec_env)
 BackendService::~BackendService() = default;
 
 Status BackendService::create_service(StorageEngine& engine, ExecEnv* exec_env, int port,
-                                      std::unique_ptr<ThriftServer>* server) {
-    auto service = std::make_shared<BackendService>(engine, exec_env);
+                                      std::unique_ptr<ThriftServer>* server,
+                                      std::shared_ptr<doris::BackendService> service) {
     service->_agent_server->start_workers(engine, exec_env);
     // TODO: do we want a BoostThreadFactory?
     // TODO: we want separate thread factories here, so that fe requests can't starve

--- a/be/src/service/backend_service.h
+++ b/be/src/service/backend_service.h
@@ -156,6 +156,8 @@ public:
     void warm_up_tablets(TWarmUpTabletsResponse& response,
                          const TWarmUpTabletsRequest& request) override;
 
+    void stop_works() { _agent_server->stop_report_workers(); }
+
 protected:
     Status start_plan_fragment_execution(const TExecPlanFragmentParams& exec_params);
 
@@ -169,7 +171,8 @@ class BackendService final : public BaseBackendService {
 public:
     // NOTE: now we do not support multiple backend in one process
     static Status create_service(StorageEngine& engine, ExecEnv* exec_env, int port,
-                                 std::unique_ptr<ThriftServer>* server);
+                                 std::unique_ptr<ThriftServer>* server,
+                                 std::shared_ptr<doris::BackendService> service);
 
     BackendService(StorageEngine& engine, ExecEnv* exec_env);
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -34,8 +34,11 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <functional>
+#include <memory>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -498,40 +501,44 @@ int main(int argc, char** argv) {
     doris::ThriftRpcHelper::setup(exec_env);
     // 1. thrift server with be_port
     std::unique_ptr<doris::ThriftServer> be_server;
+    std::shared_ptr<doris::BaseBackendService> service;
+    std::function<void(Status&, std::string_view)> stop_work_if_error = [&](Status& status,
+                                                                            std::string_view msg) {
+        if (!status.ok()) {
+            std::cerr << msg << '\n';
+            service->stop_works();
+            exit(-1);
+        }
+    };
 
     if (doris::config::is_cloud_mode()) {
+        service = std::make_shared<doris::CloudBackendService>(
+                exec_env->storage_engine().to_cloud(), exec_env);
         EXIT_IF_ERROR(doris::CloudBackendService::create_service(
-                exec_env->storage_engine().to_cloud(), exec_env, doris::config::be_port,
-                &be_server));
+                exec_env->storage_engine().to_cloud(), exec_env, doris::config::be_port, &be_server,
+                std::dynamic_pointer_cast<doris::CloudBackendService>(service)));
     } else {
-        EXIT_IF_ERROR(doris::BackendService::create_service(exec_env->storage_engine().to_local(),
-                                                            exec_env, doris::config::be_port,
-                                                            &be_server));
+        service = std::make_shared<doris::BackendService>(exec_env->storage_engine().to_local(),
+                                                          exec_env);
+        EXIT_IF_ERROR(doris::BackendService::create_service(
+                exec_env->storage_engine().to_local(), exec_env, doris::config::be_port, &be_server,
+                std::dynamic_pointer_cast<doris::BackendService>(service)));
     }
 
     status = be_server->start();
-    if (!status.ok()) {
-        std::cerr << "Doris BE server did not start correctly, exiting\n";
-        exit(-1);
-    }
+    stop_work_if_error(status, "Doris BE server did not start correctly, exiting");
 
     // 2. bprc service
     std::unique_ptr<doris::BRpcService> brpc_service =
             std::make_unique<doris::BRpcService>(exec_env);
     status = brpc_service->start(doris::config::brpc_port, doris::config::brpc_num_threads);
-    if (!status.ok()) {
-        std::cerr << "BRPC service did not start correctly, exiting\n";
-        exit(-1);
-    }
+    stop_work_if_error(status, "BRPC service did not start correctly, exiting");
 
     // 3. http service
     std::unique_ptr<doris::HttpService> http_service = std::make_unique<doris::HttpService>(
             exec_env, doris::config::webserver_port, doris::config::webserver_num_workers);
     status = http_service->start();
-    if (!status.ok()) {
-        std::cerr << "Doris Be http service did not start correctly, exiting\n";
-        exit(-1);
-    }
+    stop_work_if_error(status, "Doris Be http service did not start correctly, exiting");
 
     // 4. heart beat server
     doris::TMasterInfo* master_info = exec_env->master_info();
@@ -540,17 +547,11 @@ int main(int argc, char** argv) {
             exec_env, doris::config::heartbeat_service_port, &heartbeat_thrift_server,
             doris::config::heartbeat_service_thread_count, master_info);
 
-    if (!heartbeat_status.ok()) {
-        std::cerr << "Heartbeat services did not start correctly, exiting";
-        exit(-1);
-    }
+    stop_work_if_error(heartbeat_status, "Heartbeat services did not start correctly, exiting");
 
     status = heartbeat_thrift_server->start();
-    if (!status.ok()) {
-        std::cerr << "Doris BE HeartBeat Service did not start correctly, exiting: " << status
-                  << '\n';
-        exit(-1);
-    }
+    stop_work_if_error(status, "Doris BE HeartBeat Service did not start correctly, exiting: " +
+                                       status.to_string());
 
     // 5. arrow flight service
     std::shared_ptr<doris::flight::FlightSqlServer> flight_server =
@@ -560,11 +561,8 @@ int main(int argc, char** argv) {
     // 6. start daemon thread to do clean or gc jobs
     doris::Daemon daemon;
     daemon.start();
-    if (!status.ok()) {
-        std::cerr << "Arrow Flight Service did not start correctly, exiting, " << status.to_string()
-                  << '\n';
-        exit(-1);
-    }
+    stop_work_if_error(
+            status, "Arrow Flight Service did not start correctly, exiting, " + status.to_string());
 
     while (!doris::k_doris_exit) {
 #if defined(LEAK_SANITIZER)

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -168,7 +168,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         try {
             BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
         } catch (UserException e) {
-            throw new AnalysisException("parse file failed, path = " + path, e);
+            throw new AnalysisException("parse file failed, path = " + path + ", reason: " + e);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When a port conflict occurs, an incorrect exit is caused

## Further comments
```
=================================================================
==1511173==ERROR: AddressSanitizer: heap-use-after-free on address 0x51000004e270 at pc 0x5641a1a823f9 bp 0x7f7381ab57b0 sp 0x7f7381ab57a8
READ of size 4 at 0x51000004e270 thread T1220 (REPORT_TASK-151)
    #0 0x5641a1a823f8 in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0::operator()() const /home/yixuan/doris/be/src/agent/task_worker_pool.cpp:587:45
    #1 0x5641a1a81fb4 in void std::__invoke_impl<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(std::__invoke_other, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /home/yixuan/ldb_tool/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #2 0x5641a1a81f54 in std::enable_if<is_invocable_r_v<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>, void>::type std::__invoke_r<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /home/yixuan/ldb_tool/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #3 0x5641a1a81d4c in std::_Function_handler<void (), doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0>::_M_invoke(std::_Any_data const&) /home/yixuan/ldb_tool/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #4 0x56419f523ce2 in std::function<void ()>::operator()() const /home/yixuan/ldb_tool/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #5 0x5641a2d6495b in doris::Thread::supervise_thread(void*) /home/yixuan/doris/be/src/util/thread.cpp:498:5
    #6 0x56419f357e0a in asan_thread_start(void*) crtstuff.c
    #7 0x7f79c49cd608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #8 0x7f79c4c7a132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x51000004e270 is located 48 bytes inside of 192-byte region [0x51000004e240,0x51000004e300)
freed by thread T0 here:
    #0 0x56419f39743d in operator delete(void*) (/home/yixuan/doris/output/be/lib/doris_be+0x2165943d) (BuildId: d7c9d2a3e104bf3f)
    #1 0x5641a3627301 in doris::TMasterInfo::~TMasterInfo() /home/yixuan/doris/gensrc/build/gen_cpp/HeartbeatService_types.cpp:133:38
    #2 0x5641a2234057 in doris::ExecEnv::destroy() /home/yixuan/doris/be/src/runtime/exec_env_init.cpp:637:5
    #3 0x5641a2211848 in doris::ExecEnv::~ExecEnv() /home/yixuan/doris/be/src/runtime/exec_env.cpp:44:5
    #4 0x7f79c4ba18a6 in __run_exit_handlers /build/glibc-SzIz7B/glibc-2.31/stdlib/exit.c:108:8

previously allocated by thread T0 here:
    #0 0x56419f396bdd in operator new(unsigned long) (/home/yixuan/doris/output/be/lib/doris_be+0x21658bdd) (BuildId: d7c9d2a3e104bf3f)
    #1 0x5641a2227e1e in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) /home/yixuan/doris/be/src/runtime/exec_env_init.cpp:214:20
    #2 0x5641a222612f in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) /home/yixuan/doris/be/src/runtime/exec_env_init.cpp:143:17
    #3 0x56419f39eb4a in main /home/yixuan/doris/be/src/service/doris_main.cpp:488:14
    #4 0x7f79c4b7f082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

Thread T1220 (REPORT_TASK-151) created by T0 here:
    #0 0x56419f33fcad in pthread_create (/home/yixuan/doris/output/be/lib/doris_be+0x21601cad) (BuildId: d7c9d2a3e104bf3f)
    #1 0x5641a2d6389f in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /home/yixuan/doris/be/src/util/thread.cpp:449:15
    #2 0x5641a1a56ebd in doris::Status doris::Thread::create<doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0 const&, scoped_refptr<doris::Thread>*) /home/yixuan/doris/be/src/util/thread.h:50:16
    #3 0x5641a1a568ae in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>) /home/yixuan/doris/be/src/agent/task_worker_pool.cpp:598:15
    #4 0x5641a290b69b in std::__detail::_MakeUniq<doris::ReportWorker>::__single_object std::make_unique<doris::ReportWorker, char const (&) [12], doris::TMasterInfo const&, int&, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_18>(char const (&) [12], doris::TMasterInfo const&, int&, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_18&&) /home/yixuan/ldb_tool/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_ptr.h:1070:34
    #5 0x5641a29073b4 in doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*) /home/yixuan/doris/be/src/agent/agent_server.cpp:180:31
    #6 0x5641a28d40c9 in doris::BackendService::create_service(doris::StorageEngine&, doris::ExecEnv*, int, std::unique_ptr<doris::ThriftServer, std::default_delete<doris::ThriftServer>>*) /home/yixuan/doris/be/src/service/backend_service.cpp:379:29
    #7 0x56419f39f121 in main /home/yixuan/doris/be/src/service/doris_main.cpp:504:9
    #8 0x7f79c4b7f082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
```

