### PR TITLE
[Bug](top-n) do not get runtime predicate when predicate not initialized

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -152,6 +152,9 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
     if (read_options.use_topn_opt) {
         auto* query_ctx = read_options.runtime_state->get_query_ctx();
         for (int id : read_options.topn_filter_source_node_ids) {
+            if (!query_ctx->get_runtime_predicate(id).need_update()) {
+                continue;
+            }
             auto runtime_predicate = query_ctx->get_runtime_predicate(id).get_predicate();
 
             int32_t uid =

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -288,7 +288,7 @@ Status TabletReader::_init_params(const ReaderParams& read_params) {
     _reader_context.target_cast_type_for_variants = read_params.target_cast_type_for_variants;
 
     RETURN_IF_ERROR(_init_conditions_param(read_params));
-    _init_conditions_param_except_leafnode_of_andnode(read_params);
+    RETURN_IF_ERROR(_init_conditions_param_except_leafnode_of_andnode(read_params));
 
     Status res = _init_delete_condition(read_params);
     if (!res.ok()) {
@@ -558,7 +558,7 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     return Status::OK();
 }
 
-void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
+Status TabletReader::_init_conditions_param_except_leafnode_of_andnode(
         const ReaderParams& read_params) {
     for (const auto& condition : read_params.conditions_except_leafnode_of_andnode) {
         TCondition tmp_cond = condition;
@@ -578,9 +578,10 @@ void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
         for (int id : read_params.topn_filter_source_node_ids) {
             auto& runtime_predicate =
                     read_params.runtime_state->get_query_ctx()->get_runtime_predicate(id);
-            runtime_predicate.set_tablet_schema(_tablet_schema);
+            RETURN_IF_ERROR(runtime_predicate.set_tablet_schema(_tablet_schema));
         }
     }
+    return Status::OK();
 }
 
 ColumnPredicate* TabletReader::_parse_to_predicate(

--- a/be/src/olap/tablet_reader.h
+++ b/be/src/olap/tablet_reader.h
@@ -242,7 +242,7 @@ protected:
 
     Status _init_conditions_param(const ReaderParams& read_params);
 
-    void _init_conditions_param_except_leafnode_of_andnode(const ReaderParams& read_params);
+    Status _init_conditions_param_except_leafnode_of_andnode(const ReaderParams& read_params);
 
     ColumnPredicate* _parse_to_predicate(
             const std::pair<std::string, std::shared_ptr<BloomFilterFuncBase>>& bloom_filter);

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -56,15 +56,17 @@ public:
         return _inited && _tablet_schema;
     }
 
-    void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
+    Status set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
         // when sort node and scan node are not in the same backend, predicate will not be initialized
-        if (_tablet_schema || !_inited || !tablet_schema->have_column(_col_name)) {
-            return;
+        if (_tablet_schema || !_inited) {
+            return Status::OK();
         }
+        RETURN_IF_ERROR(tablet_schema->have_column(_col_name));
         _tablet_schema = tablet_schema;
         _predicate = SharedPredicate::create_shared(
                 _tablet_schema->field_index(_tablet_schema->column(_col_name).unique_id()));
+        return Status::OK();
     }
 
     std::shared_ptr<ColumnPredicate> get_predicate() {

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -59,12 +59,12 @@ public:
     void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
         // when sort node and scan node are not in the same backend, predicate will not be initialized
-        if (_tablet_schema || !_inited) {
+        if (_tablet_schema || !_inited || tablet_schema->have_column(_col_name)) {
             return;
         }
         _tablet_schema = tablet_schema;
         _predicate = SharedPredicate::create_shared(
-                tablet_schema->field_index(_tablet_schema->column(_col_name).unique_id()));
+                _tablet_schema->field_index(_tablet_schema->column(_col_name).unique_id()));
     }
 
     std::shared_ptr<ColumnPredicate> get_predicate() {

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -59,7 +59,7 @@ public:
     void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
         // when sort node and scan node are not in the same backend, predicate will not be initialized
-        if (_tablet_schema || !_inited || tablet_schema->have_column(_col_name)) {
+        if (_tablet_schema || !_inited || !tablet_schema->have_column(_col_name)) {
             return;
         }
         _tablet_schema = tablet_schema;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -106,10 +106,12 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
                 fragment_exec_params.runtime_filter_params);
     }
 
-    if (fragment_exec_params.__isset.topn_filter_source_node_ids) {
-        _query_ctx->init_runtime_predicates(fragment_exec_params.topn_filter_source_node_ids);
-    } else {
-        _query_ctx->init_runtime_predicates({0});
+    if (_query_ctx) {
+        if (fragment_exec_params.__isset.topn_filter_source_node_ids) {
+            _query_ctx->init_runtime_predicates(fragment_exec_params.topn_filter_source_node_ids);
+        } else {
+            _query_ctx->init_runtime_predicates({0});
+        }
     }
 }
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -25,6 +25,7 @@
 #include <gen_cpp/Types_types.h>
 #include <glog/logging.h>
 
+#include <memory>
 #include <string>
 
 #include "common/config.h"
@@ -98,13 +99,16 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
     Status status =
             init(fragment_exec_params.fragment_instance_id, query_options, query_globals, exec_env);
     DCHECK(status.ok());
-    _runtime_filter_mgr.reset(new RuntimeFilterMgr(fragment_exec_params.query_id,
-                                                   RuntimeFilterParamsContext::create(this)));
+    _runtime_filter_mgr = std::make_unique<RuntimeFilterMgr>(fragment_exec_params.query_id,
+                                                   RuntimeFilterParamsContext::create(this));
     if (fragment_exec_params.__isset.runtime_filter_params) {
         _query_ctx->runtime_filter_mgr()->set_runtime_filter_params(
                 fragment_exec_params.runtime_filter_params);
     }
-    if (_query_ctx) {
+
+    if (fragment_exec_params.__isset.topn_filter_source_node_ids) {
+        _query_ctx->init_runtime_predicates(fragment_exec_params.topn_filter_source_node_ids);
+    } else {
         _query_ctx->init_runtime_predicates({0});
     }
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -99,8 +99,8 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
     Status status =
             init(fragment_exec_params.fragment_instance_id, query_options, query_globals, exec_env);
     DCHECK(status.ok());
-    _runtime_filter_mgr = std::make_unique<RuntimeFilterMgr>(fragment_exec_params.query_id,
-                                                   RuntimeFilterParamsContext::create(this));
+    _runtime_filter_mgr = std::make_unique<RuntimeFilterMgr>(
+            fragment_exec_params.query_id, RuntimeFilterParamsContext::create(this));
     if (fragment_exec_params.__isset.runtime_filter_params) {
         _query_ctx->runtime_filter_mgr()->set_runtime_filter_params(
                 fragment_exec_params.runtime_filter_params);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -359,6 +359,7 @@ struct TPlanFragmentExecParams {
   // Used to merge and send runtime filter
   12: optional TRuntimeFilterParams runtime_filter_params
   13: optional bool group_commit // deprecated
+  14: optional list<i32> topn_filter_source_node_ids
 }
 
 // Global query parameters assigned by the coordinator.


### PR DESCRIPTION
## Proposed changes
1. do not get runtime predicate when predicate not initialized
```cpp
*** SIGSEGV address not mapped to object (@0x8) received by PID 1357919 (TID 1364208 OR 0x7fcb3b842700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007FD526E770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007FD526E7002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007FD52F188090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::ColumnPredicate::column_id() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/column_predicate.h:261
 6# doris::segment_v2::Segment::new_iterator(std::shared_ptr, doris::StorageReadOptions const&, std::unique_ptr >*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/segment_v2/segment.cpp:158
 7# doris::BetaRowsetReader::get_segment_iterators(doris::RowsetReaderContext*, std::vector >, std::allocator > > >*, bool) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_reader.cpp:263
 8# doris::BetaRowsetReader::_init_iterator() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_reader.cpp:294
 9# doris::BetaRowsetReader::_init_iterator_once()::$_0::operator()() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_reader.cpp:289

```
2. skip set schema when schema not have col_name
```cpp
F20240314 00:21:36.119753 4028038 tablet_schema.cpp:1219] Check failed: _field_name_to_index.contains(StringRef(field_name)) != 0 , field_name=O_ORDERKEY, f
ield_name_to_index=[N_COMMENT(3), N_REGIONKEY(2), N_NAME(1), N_NATIONKEY(0)]
```
3. add TPlanFragmentExecParams.topn_filter_source_node_ids
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

