### PR TITLE
[fix](jdbc catalog) fix jdbc-connector coredump as get env return nullptr

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -141,7 +141,7 @@ const std::string GetDorisJNIClasspathOption() {
             jvm_options[i] = {const_cast<char*>(options[i].c_str()), nullptr};
         }
 
-        JNIEnv* env;
+        JNIEnv* env = nullptr;
         JavaVMInitArgs vm_args;
         vm_args.version = JNI_VERSION_1_8;
         vm_args.options = jvm_options.get();
@@ -407,7 +407,7 @@ Status JniUtil::Init() {
     RETURN_IF_ERROR(LibJVMLoader::instance().load());
 
     // Get the JNIEnv* corresponding to current thread.
-    JNIEnv* env;
+    JNIEnv* env = nullptr;
     RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
 
     if (env == NULL) return Status::InternalError("Failed to get/create JVM");

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -52,9 +52,16 @@ public:
     static Status GetJNIEnv(JNIEnv** env) {
         if (tls_env_) {
             *env = tls_env_;
-            return Status::OK();
+        } else {
+            Status status = GetJNIEnvSlowPath(env);
+            if (!status.ok()) {
+                return status;
+            }
         }
-        return GetJNIEnvSlowPath(env);
+        if (*env == nullptr) {
+            return Status::RuntimeError("Failed to get JNIEnv: it is nullptr.");
+        }
+        return Status::OK();
     }
 
     static Status GetGlobalClassRef(JNIEnv* env, const char* class_str,

--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -60,7 +60,7 @@ public:
     AggregateJavaUdafData(int64_t num_args) { argument_size = num_args; }
 
     ~AggregateJavaUdafData() {
-        JNIEnv* env;
+        JNIEnv* env = nullptr;
         if (!JniUtil::GetJNIEnv(&env).ok()) {
             LOG(WARNING) << "Failed to get JNIEnv";
         }

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -83,8 +83,12 @@ Status JdbcConnector::close(Status /*unused*/) {
     if (_is_in_transaction) {
         RETURN_IF_ERROR(abort_trans());
     }
-    JNIEnv* env;
-    RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
+    JNIEnv* env = nullptr;
+    Status status = JniUtil::GetJNIEnv(&env);
+    if (!status.ok() || env == nullptr) {
+        LOG(WARNING) << "errors while get jni env " << status;
+        return status;
+    }
     env->DeleteGlobalRef(_executor_factory_clazz);
     env->DeleteGlobalRef(_executor_clazz);
     DELETE_BASIC_JAVA_CLAZZ_REF(object)

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -84,11 +84,7 @@ Status JdbcConnector::close(Status /*unused*/) {
         RETURN_IF_ERROR(abort_trans());
     }
     JNIEnv* env = nullptr;
-    Status status = JniUtil::GetJNIEnv(&env);
-    if (!status.ok() || env == nullptr) {
-        LOG(WARNING) << "errors while get jni env " << status;
-        return status;
-    }
+    RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
     env->DeleteGlobalRef(_executor_factory_clazz);
     env->DeleteGlobalRef(_executor_clazz);
     DELETE_BASIC_JAVA_CLAZZ_REF(object)


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
Call to AttachCurrentThread failed with error: -1
getJNIEnv: getGlobalJNIEnv failed
*** Query id: fcd93e45c5df4271-95179a8e8523a9df ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1710361477 (unix time) try "date -d @1710361477" if you are using GNU date ***
*** Current BE git commitID: 2f4401189a ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 90049 (TID 97639 OR 0x7f83b1cb9700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F8BCF8770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F8BCF87002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F8BD7C38090 in /lib/x86_64-linux-gnu/libc.so.6
 5# JNIEnv_::DeleteGlobalRef(_jobject*) at /usr/lib/jvm/java-8-openjdk-amd64/include/jni.h:848
 6# doris::vectorized::JdbcConnector::close(doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/vjdbc_connector.cpp:88
 7# doris::vectorized::NewJdbcScanner::close(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/scan/new_jdbc_scanner.cpp:207
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

