### PR TITLE
[improve](function) add error msg if exceeded maximum default value in repeat function

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -32,6 +32,7 @@
 #include <ostream>
 #include <random>
 #include <sstream>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -1439,6 +1440,14 @@ public:
     static FunctionPtr create() { return std::make_shared<FunctionStringRepeat>(); }
     String get_name() const override { return name; }
     size_t get_number_of_arguments() const override { return 2; }
+    std::string error_msg(int default_value, int repeat_value) const {
+        auto error_msg = fmt::format(
+                "The second parameter of repeat function exceeded maximum default value, "
+                "default_value is {}, and now input is {} . you could try change default value "
+                "greater than value eg: set repeat_max_num = {}.",
+                default_value, repeat_value, repeat_value + 10);
+        return error_msg;
+    }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
         return make_nullable(std::make_shared<DataTypeString>());
@@ -1456,17 +1465,20 @@ public:
 
         if (auto* col1 = check_and_get_column<ColumnString>(*argument_ptr[0])) {
             if (auto* col2 = check_and_get_column<ColumnInt32>(*argument_ptr[1])) {
-                vector_vector(col1->get_chars(), col1->get_offsets(), col2->get_data(),
-                              res->get_chars(), res->get_offsets(), null_map->get_data(),
-                              context->state()->repeat_max_num());
+                RETURN_IF_ERROR(vector_vector(col1->get_chars(), col1->get_offsets(),
+                                              col2->get_data(), res->get_chars(),
+                                              res->get_offsets(), null_map->get_data(),
+                                              context->state()->repeat_max_num()));
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
                 return Status::OK();
             } else if (auto* col2_const = check_and_get_column<ColumnConst>(*argument_ptr[1])) {
                 DCHECK(check_and_get_column<ColumnInt32>(col2_const->get_data_column()));
-                int repeat = 0;
-                repeat = std::min<int>(col2_const->get_int(0), context->state()->repeat_max_num());
-
+                int repeat = col2_const->get_int(0);
+                if (repeat > context->state()->repeat_max_num()) {
+                    return Status::InvalidArgument(
+                            error_msg(context->state()->repeat_max_num(), repeat));
+                }
                 if (repeat <= 0) {
                     null_map->get_data().resize_fill(input_rows_count, 0);
                     res->insert_many_defaults(input_rows_count);
@@ -1484,10 +1496,10 @@ public:
                                     argument_ptr[0]->get_name(), argument_ptr[1]->get_name());
     }
 
-    void vector_vector(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
-                       const ColumnInt32::Container& repeats, ColumnString::Chars& res_data,
-                       ColumnString::Offsets& res_offsets, ColumnUInt8::Container& null_map,
-                       const int repeat_max_num) const {
+    Status vector_vector(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
+                         const ColumnInt32::Container& repeats, ColumnString::Chars& res_data,
+                         ColumnString::Offsets& res_offsets, ColumnUInt8::Container& null_map,
+                         const int repeat_max_num) const {
         size_t input_row_size = offsets.size();
 
         fmt::memory_buffer buffer;
@@ -1497,8 +1509,10 @@ public:
             buffer.clear();
             const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
             size_t size = offsets[i] - offsets[i - 1];
-            int repeat = 0;
-            repeat = std::min<int>(repeats[i], repeat_max_num);
+            int repeat = repeats[i];
+            if (repeat > repeat_max_num) {
+                return Status::InvalidArgument(error_msg(repeat_max_num, repeat));
+            }
 
             if (repeat <= 0) {
                 StringOP::push_empty_string(i, res_data, res_offsets);
@@ -1512,6 +1526,7 @@ public:
                                             res_data, res_offsets);
             }
         }
+        return Status::OK();
     }
 
     // TODO: 1. use pmr::vector<char> replace fmt_buffer may speed up the code

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -174,15 +174,20 @@ TEST(function_string_test, function_string_repeat_test) {
     std::string func_name = "repeat";
     InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
-    DataSet data_set = {
-            {{std::string("a"), 3}, std::string("aaa")},
-            {{std::string("hel lo"), 2}, std::string("hel lohel lo")},
-            {{std::string("hello word"), -1}, std::string("")},
-            {{std::string(""), 1}, std::string("")},
-            {{std::string("a"), 1073741825}, std::string("aaaaaaaaaa")}, // ut repeat max num 10
-            {{std::string("HELLO,!^%"), 2}, std::string("HELLO,!^%HELLO,!^%")},
-            {{std::string("你"), 2}, std::string("你你")}};
+    DataSet data_set = {{{std::string("a"), 3}, std::string("aaa")},
+                        {{std::string("hel lo"), 2}, std::string("hel lohel lo")},
+                        {{std::string("hello word"), -1}, std::string("")},
+                        {{std::string(""), 1}, std::string("")},
+                        {{std::string("HELLO,!^%"), 2}, std::string("HELLO,!^%HELLO,!^%")},
+                        {{std::string("你"), 2}, std::string("你你")}};
     static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    {
+        DataSet data_set = {{{std::string("a"), 1073741825},
+                             std::string("aaaaaaaaaa")}}; // ut repeat max num 10
+        Status st = check_function<DataTypeString, true>(func_name, input_types, data_set, true);
+        EXPECT_NE(Status::OK(), st);
+    }
 }
 
 TEST(function_string_test, function_string_reverse_test) {

--- a/regression-test/suites/datatype_p0/string/test_string_basic.groovy
+++ b/regression-test/suites/datatype_p0/string/test_string_basic.groovy
@@ -129,11 +129,9 @@ suite("test_string_basic") {
          (2, repeat("test1111", 131072))
         """
     order_qt_select_str_tb "select k1, md5(v1), length(v1) from ${tbName}"
-    try {
-        sql """ SELECT repeat("test1111", 131073 + 100); """
-    } catch (Exception ex) {
-        log.info(ex.getMessage());
-        assertTrue(ex.getMessage().contains("repeat function exceeded maximum default value"))
+    test {
+        sql """SELECT repeat("test1111", 131073 + 100);"""
+        exception "repeat function exceeded maximum default value"
     }
     sql """drop table if exists test_string_cmp;"""
 

--- a/regression-test/suites/datatype_p0/string/test_string_basic.groovy
+++ b/regression-test/suites/datatype_p0/string/test_string_basic.groovy
@@ -129,7 +129,12 @@ suite("test_string_basic") {
          (2, repeat("test1111", 131072))
         """
     order_qt_select_str_tb "select k1, md5(v1), length(v1) from ${tbName}"
-
+    try {
+        sql """ SELECT repeat("test1111", 131073 + 100); """
+    } catch (Exception ex) {
+        log.info(ex.getMessage());
+        assertTrue(ex.getMessage().contains("repeat function exceeded maximum default value"))
+    }
     sql """drop table if exists test_string_cmp;"""
 
     sql """

--- a/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
+++ b/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
@@ -27,7 +27,9 @@ suite("max_msg_size_of_result_receiver") {
         ENGINE=OLAP DISTRIBUTED BY HASH(id)
         PROPERTIES("replication_num"="1")
     """
-
+    sql """
+        set repeat_max_num = 1000*1000*105;
+    """
     sql """
         INSERT INTO ${table_name} VALUES (104, repeat("a", ${MESSAGE_SIZE_BASE * 104}))
     """

--- a/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
+++ b/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
@@ -27,15 +27,14 @@ suite("max_msg_size_of_result_receiver") {
         ENGINE=OLAP DISTRIBUTED BY HASH(id)
         PROPERTIES("replication_num"="1")
     """
+    sql """set repeat_max_num=100000;"""
+    sql """set max_msg_size_of_result_receiver=90000;""" // so the test of repeat("a", 80000) could pass, and repeat("a", 100000) will be failed
     sql """
-        set repeat_max_num = 1000*1000*105;
-    """
-    sql """
-        INSERT INTO ${table_name} VALUES (104, repeat("a", ${MESSAGE_SIZE_BASE * 104}))
+        INSERT INTO ${table_name} VALUES (104, repeat("a", 80000))
     """
 
     sql """
-        INSERT INTO ${table_name} VALUES (105, repeat("a", ${MESSAGE_SIZE_BASE * 105}))
+        INSERT INTO ${table_name} VALUES (105, repeat("a", 100000))
     """
 
     def with_exception = false
@@ -49,6 +48,7 @@ suite("max_msg_size_of_result_receiver") {
     try {
         sql "SELECT * FROM ${table_name} WHERE id = 105"
     } catch (Exception e) {
+        log.info("error msg: " + e.getMessage())
         assertTrue(e.getMessage().contains('MaxMessageSize reached, try increase max_msg_size_of_result_receiver'))
     }
 

--- a/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
+++ b/regression-test/suites/variable_p0/max_msg_size_of_result_receiver.groovy
@@ -45,11 +45,9 @@ suite("max_msg_size_of_result_receiver") {
     }
     assertEquals(with_exception, false)
     
-    try {
-        sql "SELECT * FROM ${table_name} WHERE id = 105"
-    } catch (Exception e) {
-        log.info("error msg: " + e.getMessage())
-        assertTrue(e.getMessage().contains('MaxMessageSize reached, try increase max_msg_size_of_result_receiver'))
+    test {
+        sql """SELECT * FROM ${table_name} WHERE id = 105;"""
+        exception "MaxMessageSize reached, try increase max_msg_size_of_result_receiver"
     }
 
     try {


### PR DESCRIPTION
add some error msg from repeat function, so the user could know the count is greater than default value.
```
mysql [test_query_qa]>set repeat_max_num = 5;
Query OK, 0 rows affected (0.01 sec)

mysql [test_query_qa]>select repeat(k6,10) from baseall where k1 = 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[CANCELLED]The second parameter of repeat function exceeded maximum default value, default_value is 5, and now input is 10 . you could try change default value greater than value by: set repeat_max_num = 20.
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

