### PR TITLE
[fix](group commit) Fix group commit connect to observer fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -663,6 +663,13 @@ public class StmtExecutor {
                                 + Env.getCurrentEnv().getSelfNode().getHost() + ") and failed to execute"
                                 + " because Master FE is not ready. You may need to check FE's status"));
                     }
+                    if (context.getSessionVariable().isEnableInsertGroupCommit()) {
+                        // FIXME: Group commit insert does not need to forward to master
+                        //  Nereids does not support group commit, so we can not judge if should forward
+                        //  Here throw an exception to fallback to legacy planner and let legacy judge if should forward
+                        //  After Nereids support group commit, we can remove this exception
+                        throw new NereidsException(new UserException("Nereids does not support group commit insert"));
+                    }
                     forwardToMaster();
                     if (masterOpExecutor != null && masterOpExecutor.getQueryId() != null) {
                         context.setQueryId(masterOpExecutor.getQueryId());


### PR DESCRIPTION
## Proposed changes

1. Group commit insert does not need to forward to master
2. Nereids does not support group commit, so we can not judge if should forward
3. Here throw an exception to fallback to legacy planner and let legacy judge if should forward
4. After Nereids support group commit, we can remove this exception

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

