### PR TITLE
[Enhancement](compatible) display dateV2/datetimeV2/decimalv3 as date/datetime/decimal when show column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1130,7 +1130,31 @@ public class ShowExecutor {
                     continue;
                 }
                 final String columnName = col.getName();
-                final String columnType = col.getOriginType().toString().toLowerCase(Locale.ROOT);
+                String columnType;
+                if (col.getOriginType().isDatetimeV2()) {
+                    StringBuilder typeStr = new StringBuilder("DATETIME");
+                    if (((ScalarType) col.getOriginType()).getScalarScale() > 0) {
+                        typeStr.append("(").append(((ScalarType) col.getOriginType()).getScalarScale())
+                                .append(")");
+                    }
+                    columnType = typeStr.toString().toLowerCase(Locale.ROOT);
+                } else if (col.getOriginType().isDateV2()) {
+                    columnType = "date";
+                } else if (col.getOriginType().isDecimalV3()) {
+                    StringBuilder typeStr = new StringBuilder("DECIMAL");
+                    ScalarType sType = (ScalarType) col.getOriginType();
+                    int scale = sType.getScalarScale();
+                    int precision = sType.getScalarPrecision();
+                    // not default
+                    if (scale > 0 && precision != 9) {
+                        typeStr.append("(").append(precision).append(", ").append(scale)
+                                .append(")");
+                    }
+                    columnType = typeStr.toString().toLowerCase(Locale.ROOT);
+                } else {
+                    columnType = col.getOriginType().toString().toLowerCase(Locale.ROOT);
+                }
+
                 final String isAllowNull = col.isAllowNull() ? "YES" : "NO";
                 final String isKey = col.isKey() ? "YES" : "NO";
                 final String defaultValue = col.getDefaultValue();

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -90,8 +90,14 @@ public class ShowExecutorTest {
 
         Column column1 = new Column("col1", PrimitiveType.BIGINT);
         Column column2 = new Column("col2", PrimitiveType.DOUBLE);
+        Column column3 = new Column("col3", PrimitiveType.DATEV2);
+        Column column4 = new Column("col4", PrimitiveType.DATETIMEV2);
+        Column column5 = new Column("col5", PrimitiveType.DECIMALV2);
         column1.setIsKey(true);
         column2.setIsKey(true);
+        column3.setIsKey(false);
+        column4.setIsKey(false);
+        column5.setIsKey(false);
         // mock index 1
         MaterializedIndex index1 = new MaterializedIndex();
 
@@ -119,7 +125,7 @@ public class ShowExecutorTest {
 
                 table.getBaseSchema();
                 minTimes = 0;
-                result = Lists.newArrayList(column1, column2);
+                result = Lists.newArrayList(column1, column2, column3, column4, column5);
 
                 table.getKeysType();
                 minTimes = 0;
@@ -502,6 +508,15 @@ public class ShowExecutorTest {
         Assert.assertEquals("NO", resultSet.getString(2));
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("col2", resultSet.getString(0));
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("col3", resultSet.getString(0));
+        Assert.assertEquals("date", resultSet.getString(1));
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("col4", resultSet.getString(0));
+        Assert.assertEquals("datetime", resultSet.getString(1));
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("col5", resultSet.getString(0));
+        Assert.assertEquals("decimal(9, 0)", resultSet.getString(1));
         Assert.assertFalse(resultSet.next());
 
         // verbose
@@ -516,7 +531,7 @@ public class ShowExecutorTest {
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("col2", resultSet.getString(0));
         Assert.assertEquals("NO", resultSet.getString(3));
-        Assert.assertFalse(resultSet.next());
+        Assert.assertTrue(resultSet.next());
 
         // pattern
         stmt = new ShowColumnStmt(new TableName(internalCtl, "testDb", "testTable"), null, "%1", true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

There is column with type `date/datetime/decimal`when create table，but the column type returned from `SHOW FULL COLUMNS FROM xxx`is `dateV2/datetimeV2/decimalv3`. For example:

Create table:
```
CREATE TABLE `test_table` (
  `a` DATETIME NULL,
  `b` DATE NULL,
  `c` DECIMAL(5, 1) NULL,
  `d` INT NULL
) ENGINE=OLAP
DUPLICATE KEY(`a`, `b`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`a`) BUCKETS 4
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"storage_format" = "V2"
);
```

Show columns:
```
mysql> SHOW FULL COLUMNS FROM test_table;
+-------+-------------------+--------------+------+------+-----------+---------+--------------+--------------+
| Field | Type                    | Collation   | Null | Key  | Default   | Extra   | Privileges  | Comment |
+-------+-------------------+--------------+------+------+-----------+---------+--------------+--------------+
| a         | datetimev2(0)    |                       | YES  | YES  | NULL       |              |                        |                       |
| b         | datev2                   |                       | YES  | YES  | NULL      |              |                        |                       |
| c         | decimalv3(5, 1)  |                       | YES  | NO   | NULL      | NONE |                        |                       |
| d         | int                            |                       | YES  | NO   | NULL      | NONE |                        |                       |
+-------+-------------------+--------------+------+------+-----------+--------+---------------+--------------+
4 rows in set (0.00 sec)
```

It is necessary to display `dateV2/datetimeV2/decimalv3` as `date/datetime/decimal` in `ShowColumnStmt`. As follows：

```
mysql> SHOW FULL COLUMNS FROM test_table;
+-------+-------------------+--------------+------+------+-----------+---------+--------------+--------------+
| Field | Type                    | Collation   | Null | Key  | Default   | Extra   | Privileges  | Comment |
+-------+-------------------+--------------+------+------+-----------+---------+--------------+--------------+
| a     | datetime              |                       | YES  | YES  | NULL       |              |                        |                       |
| b     | date                        |                       | YES  | YES  | NULL      |              |                        |                       |
| c     | decimal(5, 1)       |                       | YES  | NO   | NULL      | NONE |                        |                       |
| d     | int                            |                       | YES  | NO   | NULL      | NONE |                        |                       |
+-------+-------------------+--------------+------+------+-----------+--------+---------------+--------------+
4 rows in set (0.00 sec)
```

Related PR：#18358
