### PR TITLE
[opt](routine-load) enhance auto resume to keep routine load stable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
@@ -35,6 +35,7 @@ public enum InternalErrorCode {
     TOO_MANY_FAILURE_ROWS_ERR(102),
     CREATE_TASKS_ERR(103),
     TASKS_ABORT_ERR(104),
+    CANNOT_RESUME_ERR(105),
 
     // for MoW table
     DELETE_BITMAP_LOCK_ERR(301);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1169,7 +1169,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                                         + " with reason: " + txnStatusChangeReasonString
                                         + " please check the jsonpaths";
                                 updateState(JobState.PAUSED,
-                                        new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg),
+                                        new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR, msg),
                                         false /* not replay */);
                                 return;
                             case OFFSET_OUT_OF_RANGE:
@@ -1182,14 +1182,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                                         + " using the Alter ROUTINE LOAD command to modify it,"
                                         + " and resume the job";
                                 updateState(JobState.PAUSED,
-                                        new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg),
+                                        new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR, msg),
                                         false /* not replay */);
                                 return;
                             case PAUSE:
                                 msg = "be " + taskBeId + " abort task "
                                         + "with reason: " + txnStatusChangeReasonString;
                                 updateState(JobState.PAUSED,
-                                        new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg),
+                                        new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR, msg),
                                         false /* not replay */);
                                 return;
                             default:

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
@@ -63,7 +63,10 @@ public class ScheduleRule {
                     jobRoutine.id, jobRoutine.firstResumeTimestamp, jobRoutine.autoResumeCount,
                     jobRoutine.pauseReason == null ? "null" : jobRoutine.pauseReason.getCode().name());
         }
-        if (jobRoutine.pauseReason != null && jobRoutine.pauseReason.getCode() == InternalErrorCode.REPLICA_FEW_ERR) {
+        if (jobRoutine.pauseReason != null
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR) {
             int dead = deadBeCount();
             if (dead > Config.max_tolerable_backend_down_num) {
                 if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1981,7 +1981,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             try {
                 RoutineLoadJob routineLoadJob = Env.getCurrentEnv().getRoutineLoadManager()
                         .getRoutineLoadJobByMultiLoadTaskTxnId(request.getTxnId());
-                routineLoadJob.updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.MANUAL_PAUSE_ERR,
+                routineLoadJob.updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR,
                             "failed to get stream load plan, " + exception.getMessage()), false);
             } catch (UserException e) {
                 LOG.warn("catch update routine load job error.", e);


### PR DESCRIPTION
## Proposed changes

Auto resume can solve some unstable factors and keep the routine load stable.

some unstable factors:
1. be restart or shutdown upgrade
2. RPC timeout
3. commit failed for unforeseen error.

Auto resume in these situations can avoid users manually resume job, improving the user experience.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

