### PR TITLE
[fix](ip) conversion of ipv4 or ipv6 to arrow type

### DIFF
--- a/be/src/vec/data_types/data_type_ipv4.h
+++ b/be/src/vec/data_types/data_type_ipv4.h
@@ -45,6 +45,9 @@ namespace doris::vectorized {
 class DataTypeIPv4 final : public DataTypeNumberBase<IPv4> {
 public:
     TypeIndex get_type_id() const override { return TypeIndex::IPv4; }
+    TypeDescriptor get_type_as_type_descriptor() const override {
+        return TypeDescriptor(TYPE_IPV4);
+    }
     const char* get_family_name() const override { return "IPv4"; }
     std::string do_get_name() const override { return "IPv4"; }
 

--- a/be/src/vec/data_types/data_type_ipv6.h
+++ b/be/src/vec/data_types/data_type_ipv6.h
@@ -45,6 +45,9 @@ namespace doris::vectorized {
 class DataTypeIPv6 final : public DataTypeNumberBase<IPv6> {
 public:
     TypeIndex get_type_id() const override { return TypeIndex::IPv6; }
+    TypeDescriptor get_type_as_type_descriptor() const override {
+        return TypeDescriptor(TYPE_IPV6);
+    }
     doris::FieldType get_storage_field_type() const override {
         return doris::FieldType::OLAP_FIELD_TYPE_IPV6;
     }


### PR DESCRIPTION
## Proposed changes
When utilizing the flink-connector-doris to read IPv6 addresses, we encounter the following errors: internal failure, with a status code of [INVALID_ARGUMENT] and an error message stating [([xxx.xxx.xxx.xxx](http://xxx.xxx.xxx.xxx/))[INVALID_ARGUMENT]Unknown primitive type(0) converted to Arrow type]. This issue arises due to the incompatible conversion between IPv6  datatype and arrow datatype.
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

