### PR TITLE
[improve](load) try lock 30ms to get base_migration_lock in rowset builder

### DIFF
--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -166,10 +166,8 @@ Status RowsetBuilder::check_tablet_version_count() {
 }
 
 Status RowsetBuilder::prepare_txn() {
-    std::shared_lock base_migration_lock(tablet()->get_migration_lock(), std::try_to_lock);
-    if (!base_migration_lock.owns_lock()) {
-        base_migration_lock.try_lock_for(std::chrono::milliseconds(10));
-    }
+    std::shared_lock base_migration_lock(tablet()->get_migration_lock(), std::defer_lock);
+    base_migration_lock.try_lock_for(std::chrono::milliseconds(30));
     if (!base_migration_lock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>("try migration lock failed");
     }

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -167,8 +167,7 @@ Status RowsetBuilder::check_tablet_version_count() {
 
 Status RowsetBuilder::prepare_txn() {
     std::shared_lock base_migration_lock(tablet()->get_migration_lock(), std::defer_lock);
-    base_migration_lock.try_lock_for(std::chrono::milliseconds(30));
-    if (!base_migration_lock.owns_lock()) {
+    if (!base_migration_lock.try_lock_for(std::chrono::milliseconds(30))) {
         return Status::Error<TRY_LOCK_FAILED>("try migration lock failed");
     }
     std::lock_guard<std::mutex> push_lock(tablet()->get_push_lock());

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -167,10 +167,8 @@ Status RowsetBuilder::check_tablet_version_count() {
 
 Status RowsetBuilder::prepare_txn() {
     std::shared_lock base_migration_lock(tablet()->get_migration_lock(), std::try_to_lock);
-    // if try_lock failed, retry 3 times with 10ms interval
-    for (int retry_cnt = 0; !base_migration_lock.owns_lock() && retry_cnt < 3; retry_cnt++) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        base_migration_lock = std::shared_lock(tablet()->get_migration_lock(), std::try_to_lock);
+    if (!base_migration_lock.owns_lock()) {
+        base_migration_lock.try_lock_for(std::chrono::milliseconds(10));
     }
     if (!base_migration_lock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>("try migration lock failed");


### PR DESCRIPTION
## Proposed changes

Try lock for 30ms to get base_migration_lock in rowset builder, instead of failing immediately.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

