### PR TITLE
[opt](conf) modify the default fe be config file

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -19,15 +19,13 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 
 PPROF_TMPDIR="$DORIS_HOME/log/"
 
-JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xloggc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+# For jdk 8
+JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xloggc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
 
-# For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc*:$DORIS_HOME/log/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
 
-# For jdk 17+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
-
-# since 1.2, the JAVA_HOME need to be set to run BE process.
+# Set your own JAVA_HOME
 # JAVA_HOME=/path/to/jdk/
 
 # https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
@@ -51,7 +49,6 @@ enable_https = false
 ssl_certificate_path = "$DORIS_HOME/conf/cert.pem"
 # path of private key in PEM format.
 ssl_private_key_path = "$DORIS_HOME/conf/key.pem"
-
 
 # Choose one if there are more than one ip except loopback address. 
 # Note that there should at most one ip match this list.
@@ -82,7 +79,6 @@ ssl_private_key_path = "$DORIS_HOME/conf/key.pem"
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = *
 # log_buffer_level = -1
-# palo_cgroups 
 
 # aws sdk log level
 #    Off = 0,

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -26,20 +26,14 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # the output dir of stderr and stdout 
 LOG_DIR = ${DORIS_HOME}/log
 
-# CMS JAVA OPTS
-# JAVA_OPTS="-Dsun.security.krb5.debug=true -Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE"
+# For jdk 8
+JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
 
-# G1 JAVA OPTS
-JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -Dlog4j2.formatMsgNoLookups=true"
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M"
 
-# For jdk 9+, this JAVA_OPTS_FOR_JDK_9 will be used as default CMS JVM options
-# JAVA_OPTS_FOR_JDK_9="-Dsun.security.krb5.debug=true -Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time"
-
-# For jdk 9+, this JAVA_OPTS_FOR_JDK_9 will be used as default G1 JVM options
-JAVA_OPTS_FOR_JDK_9="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time -Dlog4j2.formatMsgNoLookups=true"
-
-# For jdk 17+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time"
+# Set your own JAVA_HOME
+# JAVA_HOME=/path/to/jdk/
 
 ##
 ## the lowercase properties are read by main program.

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -15,67 +15,43 @@
 # specific language governing permissions and limitations
 # under the License.
 
+CUR_DATE=`date +%Y%m%d-%H%M%S`
+
 PPROF_TMPDIR="$DORIS_HOME/log/"
 
-# For jdk 17+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives --add-opens=java.base/java.net=ALL-UNNAMED"
+# For jdk 8
+JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xloggc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc*:$DORIS_HOME/log/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
+
+# Set your own JAVA_HOME
+# JAVA_HOME=/path/to/jdk/
+
+# https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
+# https://jemalloc.net/jemalloc.3.html
+JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:15000,dirty_decay_ms:15000,oversize_threshold:0,prof:false,lg_prof_interval:32,lg_prof_sample:19,prof_gdump:false,prof_accum:false,prof_leak:false,prof_final:false"
+JEMALLOC_PROF_PRFIX=""
 
 # INFO, WARNING, ERROR, FATAL
 sys_log_level = INFO
 
-# ports for admin, web, heartbeat service
 be_port = 9161
 webserver_port = 8141
 heartbeat_service_port = 9151
 brpc_port = 8161
 arrow_flight_sql_port = 8181
 
-mem_limit = 90%
-disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180
-rowbatch_align_tuple_offset=true
 
-buffer_pool_limit = 2%
-storage_page_cache_limit = 0%
-disable_storage_page_cache = true
-chunk_reserved_bytes_limit = 134217728
-# Choose one if there are more than one ip except loopback address.
-# Note that there should at most one ip match this list.
-# If no ip match this rule, will choose one randomly.
-# use CIDR format, e.g. 10.10.10.0/24
-# Default value is empty.
-# priority_networks = 10.10.10.0/24;192.168.0.0/16
-
-# data root path, separate by ';'
-# you can specify the storage medium of each root path, HDD or SSD
-# you can add capacity limit at the end of each root path, seperate by ','
-# eg:
-# /home/disk2/doris, capacity limit is disk capacity, HDD(default)
-#
-# you also can specify the properties by setting '<property>:<value>', seperate by ','
-# property 'medium' has a higher priority than the extension of path
-#
-# Default value is ${DORIS_HOME}/storage, you should create it by hand.
-
-# Advanced configurations
-# sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_mode = SIZE-MB-1024
-# sys_log_roll_num = 10
-# sys_log_verbose_modules = *
 log_buffer_level = -1
 enable_stream_load_record = true
-# palo_cgroups
-#storage_root_path=/mnt/hdd01/doris.SSD/NON_VEC_RELEASE;/mnt/hdd01/doris.HDD/NON_VEC_RELEASE;/mnt/hdd02/doris.SSD/NON_VEC_RELEASE;/mnt/hdd02/doris.HDD/NON_VEC_RELEASE;/mnt/hdd03/doris.SSD/NON_VEC_RELEASE;/mnt/hdd03/doris.HDD/NON_VEC_RELEASE;/mnt/hdd04/doris.SSD/NON_VEC_RELEASE;/mnt/hdd04/doris.HDD/NON_VEC_RELEASE;/mnt/hdd05/doris.SSD/NON_VEC_RELEASE;/mnt/hdd05/doris.HDD/NON_VEC_RELEASE;/mnt/hdd06/doris.SSD/NON_VEC_RELEASE;/mnt/hdd06/doris.HDD/NON_VEC_RELEASE;
-
 storage_root_path=/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster1
 disable_auto_compaction=true
-tablet_map_shard_size=256
 priority_networks=172.19.0.0/24
-fragment_pool_thread_num_max=5000
 enable_fuzzy_mode=true
 max_depth_of_expr_tree=200
-enable_set_in_bitmap_value=true
 enable_feature_binlog=true
 max_sys_mem_available_low_water_mark_bytes=69206016
 user_files_secure_path=/

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -21,58 +21,21 @@
 ## see fe/src/org/apache/doris/common/Config.java
 #####################################################################
 
-# the output dir of stderr and stdout
+CUR_DATE=`date +%Y%m%d-%H%M%S`
+
+# the output dir of stderr and stdout 
 LOG_DIR = ${DORIS_HOME}/log
 
-DATE = `date +%Y%m%d-%H%M%S`
-# JAVA_OPTS="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5050"
-# G1 JAVA OPTS
-JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -Dlog4j2.formatMsgNoLookups=true"
+# For jdk 8
+JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
 
-# For jdk 9+, this JAVA_OPTS will be used as default JVM options
-# JAVA_OPTS_FOR_JDK_9="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
-JAVA_OPTS_FOR_JDK_9="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -Dlog4j2.formatMsgNoLookups=true"
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M"
 
-# For jdk 17+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time"
-
-##
-## the lowercase properties are read by main program.
-##
-
-# INFO, WARN, ERROR, FATAL
 sys_log_level = INFO
-
+sys_log_mode = NORMAL
 arrow_flight_sql_port = 8080
-
-# store metadata, must be created before start FE.
-# Default value is ${DORIS_HOME}/doris-meta
-# meta_dir = ${DORIS_HOME}/doris-meta
-
-disable_decimalv2 = false
-disable_datev1 = false
 catalog_trash_expire_second=1
-# Choose one if there are more than one ip except loopback address.
-# Note that there should at most one ip match this list.
-# If no ip match this rule, will choose one randomly.
-# use CIDR format, e.g. 10.10.10.0/24
-# Default value is empty.
-# priority_networks = 10.10.10.0/24;192.168.0.0/16
-
-# Advanced configurations
-# log_roll_size_mb = 1024
-# sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_num = 10
-# sys_log_verbose_modules = org.apache.doris
-# audit_log_dir = ${DORIS_HOME}/log
-# audit_log_modules = slow_query, query
-# audit_log_roll_num = 10
-# meta_delay_toleration_second = 10
-# qe_max_connection = 1024
-# qe_query_timeout_second = 300
-# qe_slow_log_ms = 5000
-#
-
 #enable ssl for test
 enable_ssl = true
 
@@ -82,8 +45,6 @@ remote_fragment_exec_timeout_ms=60000
 fuzzy_test_type=p0
 use_fuzzy_session_variable=true
 
-enable_map_type=true
-enable_struct_type=true
 enable_feature_binlog=true
 
 enable_debug_points=true
@@ -93,7 +54,6 @@ enable_mtmv = true
 
 dynamic_partition_check_interval_seconds=3
 
-enable_full_auto_analyze=true
 desired_max_waiting_jobs=200
 
 # make checkpoint more frequent
@@ -113,4 +73,3 @@ publish_topic_info_interval_ms = 1000
 
 master_sync_policy = WRITE_NO_SYNC
 replica_sync_policy = WRITE_NO_SYNC
-

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -71,5 +71,8 @@ enable_job_schedule_second_for_test = true
 enable_workload_group = true
 publish_topic_info_interval_ms = 1000
 
+disable_decimalv2 = false
+disable_datev1 = false
+
 master_sync_policy = WRITE_NO_SYNC
 replica_sync_policy = WRITE_NO_SYNC

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -15,60 +15,46 @@
 # specific language governing permissions and limitations
 # under the License.
 
+CUR_DATE=`date +%Y%m%d-%H%M%S`
+
 PPROF_TMPDIR="$DORIS_HOME/log/"
+
+# For jdk 8
+JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xloggc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc*:$DORIS_HOME/log/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED"
+
+# Set your own JAVA_HOME
+# JAVA_HOME=/path/to/jdk/
+
+# https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
+# https://jemalloc.net/jemalloc.3.html
+JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:15000,dirty_decay_ms:15000,oversize_threshold:0,prof:false,lg_prof_interval:32,lg_prof_sample:19,prof_gdump:false,prof_accum:false,prof_leak:false,prof_final:false"
+JEMALLOC_PROF_PRFIX=""
 
 # INFO, WARNING, ERROR, FATAL
 sys_log_level = INFO
-sys_log_verbose_modules = vrow_distribution
 
-# ports for admin, web, heartbeat service 
 be_port = 9162
 webserver_port = 8142
 heartbeat_service_port = 9152
 brpc_port = 8162
+arrow_flight_sql_port = 8182
 
-mem_limit = 90%
-disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180
-rowbatch_align_tuple_offset=true
 
-buffer_pool_limit = 2%
-storage_page_cache_limit = 0%
-disable_storage_page_cache = true
-chunk_reserved_bytes_limit = 134217728
-# Choose one if there are more than one ip except loopback address. 
-# Note that there should at most one ip match this list.
-# If no ip match this rule, will choose one randomly.
-# use CIDR format, e.g. 10.10.10.0/24
-# Default value is empty.
-# priority_networks = 10.10.10.0/24;192.168.0.0/16
-priority_networks=172.19.0.0/24
-
-# data root path, separate by ';'
-# you can specify the storage medium of each root path, HDD or SSD
-# you can add capacity limit at the end of each root path, seperate by ','
-# eg:
-# /home/disk2/doris, capacity limit is disk capacity, HDD(default)
-# 
-# you also can specify the properties by setting '<property>:<value>', seperate by ','
-# property 'medium' has a higher priority than the extension of path
-#
-# Default value is ${DORIS_HOME}/storage, you should create it by hand.
-
-# Advanced configurations
-# sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_mode = SIZE-MB-1024
-# sys_log_roll_num = 10
-# sys_log_verbose_modules = *
-# log_buffer_level = -1
+log_buffer_level = -1
 enable_stream_load_record = true
-# palo_cgroups 
-
+storage_root_path=/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster1
 disable_auto_compaction=true
-tablet_map_shard_size=256
-fragment_pool_thread_num_max=5000
+priority_networks=172.19.0.0/24
 enable_fuzzy_mode=true
-enable_set_in_bitmap_value=true
+max_depth_of_expr_tree=200
 enable_feature_binlog=true
 max_sys_mem_available_low_water_mark_bytes=69206016
+user_files_secure_path=/
+enable_debug_points=true
+# debug scanner context dead loop
+enable_debug_log_timeout_secs=0

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -21,57 +21,21 @@
 ## see fe/src/org/apache/doris/common/Config.java
 #####################################################################
 
-# the output dir of stderr and stdout
+CUR_DATE=`date +%Y%m%d-%H%M%S`
+
+# the output dir of stderr and stdout 
 LOG_DIR = ${DORIS_HOME}/log
 
-DATE = `date +%Y%m%d-%H%M%S`
-# JAVA_OPTS="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
-JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -Dlog4j2.formatMsgNoLookups=true"
+# For jdk 8
+JAVA_OPTS="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
 
-# For jdk 9+, this JAVA_OPTS will be used as default JVM options
-# JAVA_OPTS_FOR_JDK_9="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
-JAVA_OPTS_FOR_JDK_9="-Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/fe.jmap -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -Xloggc:$DORIS_HOME/log/fe.gc.log.$CUR_DATE -Dlog4j2.formatMsgNoLookups=true"
+# For jdk 17, this JAVA_OPTS will be used as default JVM options
+JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M"
 
-# For jdk 17+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_17="-Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$DORIS_HOME/log/ -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$CUR_DATE:time"
-
-##
-## the lowercase properties are read by main program.
-##
-
-# INFO, WARN, ERROR, FATAL
 sys_log_level = INFO
-sys_log_verbose_modules=org.apache.doris.service.FrontendServiceImpl
-
-# store metadata, must be created before start FE.
-# Default value is ${DORIS_HOME}/doris-meta
-# meta_dir = ${DORIS_HOME}/doris-meta
-
-disable_decimalv2 = false
-disable_datev1 = false
+sys_log_mode = NORMAL
+arrow_flight_sql_port = 8080
 catalog_trash_expire_second=1
-# Choose one if there are more than one ip except loopback address.
-# Note that there should at most one ip match this list.
-# If no ip match this rule, will choose one randomly.
-# use CIDR format, e.g. 10.10.10.0/24
-# Default value is empty.
-# priority_networks = 10.10.10.0/24;192.168.0.0/16
-priority_networks=172.19.0.0/24
-
-# Advanced configurations
-# log_roll_size_mb = 1024
-# sys_log_dir = ${DORIS_HOME}/log
-# sys_log_roll_num = 10
-# sys_log_verbose_modules = org.apache.doris
-# audit_log_dir = ${DORIS_HOME}/log
-# audit_log_modules = slow_query, query
-# audit_log_roll_num = 10
-# meta_delay_toleration_second = 10
-# qe_max_connection = 1024
-# qe_query_timeout_second = 300
-# qe_slow_log_ms = 5000
-#
-
 #enable ssl for test
 enable_ssl = true
 
@@ -81,17 +45,34 @@ remote_fragment_exec_timeout_ms=60000
 fuzzy_test_type=p1
 use_fuzzy_session_variable=true
 
+enable_feature_binlog=true
+
+enable_debug_points=true
+
 # enable mtmv
 enable_mtmv = true
 
-# enable auto collect statistics
-enable_auto_collect_statistics=true
-auto_check_statistics_in_sec=60
-
 dynamic_partition_check_interval_seconds=3
 
-enable_feature_binlog=true
+desired_max_waiting_jobs=200
+
+# make checkpoint more frequent
+edit_log_roll_num = 1000
+
+# make job/label clean more frequent
+history_job_keep_max_second = 300
+streaming_label_keep_max_second = 300
+label_keep_max_second = 300
+
+# job test configurations
+#allows the creation of jobs with an interval of second
+enable_job_schedule_second_for_test = true
+
+enable_workload_group = true
+publish_topic_info_interval_ms = 1000
+
+master_sync_policy = WRITE_NO_SYNC
+replica_sync_policy = WRITE_NO_SYNC
 
 auth_token = 5ff161c3-2c08-4079-b108-26c8850b6598
-
 sys_log_verbose_modules = org.apache.doris.persist.EditLog,org.apache.doris.journal.bdbje.BDBJEJournal

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -74,5 +74,8 @@ publish_topic_info_interval_ms = 1000
 master_sync_policy = WRITE_NO_SYNC
 replica_sync_policy = WRITE_NO_SYNC
 
+disable_decimalv2 = false
+disable_datev1 = false
+
 auth_token = 5ff161c3-2c08-4079-b108-26c8850b6598
 sys_log_verbose_modules = org.apache.doris.persist.EditLog,org.apache.doris.journal.bdbje.BDBJEJournal


### PR DESCRIPTION
## Proposed changes

Refine the default fe.conf and be.conf

1. Modify the default jvm opt, only leave jvm opt for jdk8 and jdk17, remove jdk9 and jdk11.
2. Add gc log config, the rollnum and the log size
3. Modify the config file for pipeline p0 and p1

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

