### PR TITLE
[fix](load) fix load channel may memory leak

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -916,7 +916,7 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
     _close_time_ms = UnixMillis() - _close_time_ms;
 
     if (_cancelled || state->is_cancelled()) {
-        _cancel_with_msg(state->cancel_reason());
+        cancel(state->cancel_reason());
     }
 
     if (_add_batches_finished) {


### PR DESCRIPTION
## Proposed changes

load channel resource can not be recycled, causing memory leak.
![img_v3_028p_4dd85cd7-62c3-4798-a25c-d4d05a6b2fdg](https://github.com/apache/doris/assets/77738092/f92711d2-dec4-4a4d-88ee-60cddfb5db8c)

Bug would be happened in follow corn case:
- use group commit and fragment open fail.
- load empty file with fail.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

