### PR TITLE
[fix](compatibility) should enable windown funnel mode from 2.0

### DIFF
--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -60,8 +60,9 @@ private:
  *    e. add repeat_max_num in repeat function
  * 3: start from doris 2.0 (by some mistakes)
  *    a. aggregation function do not serialize bitmap to string.
+ *    b. support window funnel mode.
  * 4: start from doris 2.1
- *    a. support window funnel mode from 2.0
+ *    a. ignore this line, window funnel mode should be enabled from 2.0.
  *    b. array contains/position/countequal function return nullable in less situations.
  *    c. cleared old version of Version 2.
  *    d. unix_timestamp function support timestamp with float for datetimev2, and change nullable mode.

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -270,8 +270,8 @@ public:
 
     void create(AggregateDataPtr __restrict place) const override {
         auto data = new (place) WindowFunnelState<DateValueType, NativeType>();
-        /// support window funnel mode from 2.1. See `BeExecVersionManager::max_be_exec_version`
-        data->enable_mode = version >= USE_NEW_SERDE;
+        /// support window funnel mode from 2.0. See `BeExecVersionManager::max_be_exec_version`
+        data->enable_mode = version >= 3;
     }
 
     String get_name() const override { return "window_funnel"; }


### PR DESCRIPTION
## Proposed changes

Issue imported by #32162
The window funnel mode was enabled from 2.0.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

