### PR TITLE
[fix](s3 client)add default ca cert list for s3 client to avoid problem:'curlCode:77'

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1199,6 +1199,12 @@ DEFINE_mInt32(max_s3_client_retry, "10");
 
 DEFINE_String(trino_connector_plugin_dir, "${DORIS_HOME}/connectors");
 
+// ca_cert_file is in this path by default, Normally no modification is required
+// ca cert default path is different from different OS
+DEFINE_mString(ca_cert_file_paths,
+               "/etc/pki/tls/certs/ca-bundle.crt;/etc/ssl/certs/ca-certificates.crt;"
+               "/etc/ssl/ca-bundle.pem");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1277,6 +1277,9 @@ DECLARE_String(tmp_file_dir);
 // the directory for storing the trino-connector plugins.
 DECLARE_String(trino_connector_plugin_dir);
 
+// the file paths(one or more) of CA cert, splite using ";" aws s3 lib use it to init s3client
+DECLARE_mString(ca_cert_file_paths);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -138,10 +138,12 @@ public:
 
 private:
     S3ClientFactory();
+    static std::string get_valid_ca_cert_path();
 
     Aws::SDKOptions _aws_options;
     std::mutex _lock;
     std::unordered_map<uint64_t, std::shared_ptr<Aws::S3::S3Client>> _cache;
+    std::string _ca_cert_file_path;
 };
 
 } // end namespace doris


### PR DESCRIPTION

## Proposed changes

Issue Number: #23163

<!--Describe your changes.-->
add a be config field: ca_cert_file_paths , this is a default ca cart file list for different OS
And selects a valid file for initialization of the s3 client
if All ca cert file path is invalid ，s3 client will no set this config and use s3‘s default config
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

