### PR TITLE
[expr](fix) Not to throw exception when close failed

### DIFF
--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -542,9 +542,9 @@ void VExpr::close_function_context(VExprContext* context, FunctionContext::Funct
     if (_fn_context_index != -1) {
         FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
         // close failed will make system unstable. dont swallow it.
-        THROW_IF_ERROR(function->close(fn_ctx, FunctionContext::THREAD_LOCAL));
+        static_cast<void>(function->close(fn_ctx, FunctionContext::THREAD_LOCAL));
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
-            THROW_IF_ERROR(function->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL));
+            static_cast<void>(function->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL));
         }
     }
 }

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -541,7 +541,7 @@ void VExpr::close_function_context(VExprContext* context, FunctionContext::Funct
                                    const FunctionBasePtr& function) const {
     if (_fn_context_index != -1) {
         FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
-        // close failed will make system unstable. dont swallow it.
+        // `close_function_context` is called in VExprContext's destructor so do not throw exceptions here.
         static_cast<void>(function->close(fn_ctx, FunctionContext::THREAD_LOCAL));
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
             static_cast<void>(function->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL));

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -42,7 +42,11 @@ VExprContext::~VExprContext() {
     if (!_prepared || !_opened) {
         return;
     }
-    close();
+    try {
+        close();
+    } catch (const Exception& e) {
+        LOG(WARNING) << "Exception occurs when expr context deconstruct: " << e.to_string();
+    }
 }
 
 Status VExprContext::execute(vectorized::Block* block, int* result_column_id) {


### PR DESCRIPTION
## Proposed changes

*** Query id: c9f84ca8622241d5-b525bbbed62b6655 ***
12:51:06   *** is nereids: 1 ***
12:51:06   *** tablet id: 0 ***
12:51:06   *** Aborted at 1710477445 (unix time) try "date -d @1710477445" if you are using GNU date ***
12:51:06   *** Current BE git commitID: 7e2fc3c ***
12:51:06   *** SIGABRT unknown detail explain (@0x187ad) received by PID 100269 (TID 102225 OR 0x7f1109f62700) from PID 100269; stack trace: ***
12:51:06    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
12:51:06    1# 0x00007F19D09D7090 in /lib/x86_64-linux-gnu/libc.so.6
12:51:06    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
12:51:06    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
12:51:06    4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
12:51:06    5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
12:51:06    6# 0x000055EC9D7A9EA1 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06    7# 0x000055EC6F0BA2EE in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06    8# 0x000055EC855AD391 at /root/doris/be/src/vec/exprs/vexpr_context.cpp:45
12:51:06    9# doris::pipeline::PipelineXLocalStateBase::~PipelineXLocalStateBase() at /root/doris/be/src/pipeline/pipeline_x/operator.h:54
12:51:06   10# doris::pipeline::ScanLocalState<doris::pipeline::OlapScanLocalState>::~ScanLocalState() at /root/doris/be/src/pipeline/exec/scan_operator.h:138
12:51:06   11# doris::pipeline::OlapScanLocalState::~OlapScanLocalState() at /root/doris/be/src/pipeline/exec/olap_scan_operator.h:41
12:51:06   12# doris::RuntimeState::~RuntimeState() at /root/doris/be/src/runtime/runtime_state.cpp:260
12:51:06   13# doris::pipeline::PipelineXFragmentContext::~PipelineXFragmentContext() at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:119
12:51:06   14# doris::pipeline::ExchangeSinkBuffer<doris::pipeline::ExchangeSinkLocalState>::_send_rpc(long)::{lambda(long const&, bool const&, doris::PTransmitDataResult const&, long const&)#2}::operator()(long const&, bool const&, doris::PTransmitDataResult const&, long const&) const at /root/doris/be/src/pipeline/exec/exchange_sink_buffer.cpp:392
12:51:06   15# doris::pipeline::ExchangeSendCallback<doris::PTransmitDataResult>::call() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   16# doris::AutoReleaseClosure<doris::PTransmitDataParams, doris::pipeline::ExchangeSendCallback<doris::PTransmitDataResult> >::Run() at /root/doris/be/src/util/ref_count_closure.h:91
12:51:06   17# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   18# brpc::Controller::OnVersionedRPCReturned(brpc::Controller::CompletionInfo const&, bool, int) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   19# brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   20# brpc::ProcessInputMessage(void*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   21# bthread::TaskGroup::task_runner(long) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:51:06   22# bthread_make_fcontext in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

