### PR TITLE
[Chore](FE)Remove unused components

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -470,6 +470,12 @@ under the License.
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-jetty</artifactId>
                 <version>${spring.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>tomcat-embed-el</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -481,6 +487,10 @@ under the License.
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${spring.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-tomcat</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>validator</groupId>
                         <artifactId>hibernate-validator</artifactId>


### PR DESCRIPTION
The tomcat-embed-el dependency is primarily used for standardizing EL functionality, which we don't require in our application. Therefore, we can safely remove it.

