### PR TITLE
[bug](fold) fix fold constant rule can't handle variable expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -100,7 +100,8 @@ public class FoldConstantsRule implements ExprRewriteRule {
         // children should have been folded at this point.
         for (Expr child : expr.getChildren()) {
             if (!child.isLiteral() && !(child instanceof CastExpr) && !((child instanceof FunctionCallExpr
-                    || child instanceof ArithmeticExpr || child instanceof TimestampArithmeticExpr))) {
+                    || child instanceof ArithmeticExpr || child instanceof TimestampArithmeticExpr
+                    || child instanceof VariableExpr))) {
                 return expr;
             }
         }

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -446,4 +446,41 @@ suite("test_delete") {
     """
     sql "set experimental_enable_nereids_planner = false;"
     sql "delete from test3 where statistic_date >= date_sub('2024-01-16',INTERVAL 1 day);"
+
+    sql "drop table if exists bi_acti_per_period_plan"
+    sql """
+            CREATE TABLE `bi_acti_per_period_plan` (
+            `proj_id` bigint(20) NULL,
+            `proj_name` varchar(400) NULL,
+            `proj_start_date` datetime NULL,
+            `proj_end_date` datetime NULL,
+            `last_data_date` datetime NULL,
+            `data_date` datetime NULL,
+            `data_batch_num` datetime NULL,
+            `la_sum_base_proj_id` varchar(200) NULL,
+            `sum_base_proj_id` varchar(200) NULL,
+            `today_date` datetime NULL,
+            `count` bigint(20) NULL,
+            `count_type` varchar(50) NULL,
+            `bl_count` bigint(20) NULL
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`proj_id`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`proj_id`) BUCKETS 10
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "is_being_synced" = "false",
+            "storage_format" = "V2",
+            "light_schema_change" = "true",
+            "disable_auto_compaction" = "false",
+            "enable_single_replica_compaction" = "false"
+            ); 
+    """
+    sql """
+            INSERT INTO bi_acti_per_period_plan (proj_id,proj_name,proj_start_date,proj_end_date,last_data_date,data_date,data_batch_num,la_sum_base_proj_id,sum_base_proj_id,today_date,count,count_type,bl_count) VALUES
+            (4508,'建筑工程项目A','2023-05-30 00:00:00','2024-03-07 00:00:00','2023-06-01 00:00:00','2023-08-15 00:00:00','2024-01-31 00:00:00','4509','4509','2023-08-27 00:00:00',5,'plan',4);
+    """
+    sql "set experimental_enable_nereids_planner = false;"
+    sql "set @data_batch_num='2024-01-31 00:00:00';"
+    sql "delete  from bi_acti_per_period_plan where data_batch_num =@data_batch_num; "
 }


### PR DESCRIPTION
## Proposed changes
in old planner of fold constant rule not handle variable expression.
it will report error eg:
```
SQL 错误 [1105] [HY000]: errCode = 2, detailMessage = errCode = 2, detailMessage = Right expr of binary predicate should be value, predicate: `column_h ` = CAST(@ column_h AS DATETIMEV2(0)), right expr type:DATETIMEV2(0)
```

some steps to reproduce the case:

```
CREATE TABLE `tets_table` (
  `column_a` bigint(20) NULL,
  `column_b` varchar(400) NULL,
  `column_c` datetime NULL,
  `column_d` datetime NULL,
  `column_e` datetime NULL,
  `column_f` datetime NULL,
  `column_h` datetime NULL,
  `column_i` varchar(200) NULL,
  `column_j` varchar(200) NULL,
  `column_k` datetime NULL,
  `column_l` bigint(20) NULL,
  `column_m` varchar(50) NULL,
  `column_n` bigint(20) NULL
) ENGINE=OLAP
DUPLICATE KEY(`column_a`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`column_a`) BUCKETS 10
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"is_being_synced" = "false",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
);


INSERT INTO tets_table (column_a,column_b,column_c,column_d,column_e,column_f,column_h,column_i,column_j,column_k,column_l,column_m,column_n) VALUES
  (4508,'AAAA','2023-05-30 00:00:00','2024-03-07 00:00:00','2023-06-01 00:00:00','2023-08-15 00:00:00','2024-01-31 00:00:00','4509','4509','2023-08-27 00:00:00',5,'plan',4);

 
set @column_h='2024-01-31 00:00:00';

delete  from tets_table where column_h =@column_h; 
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

