### PR TITLE
[enhancement](random-bucket) random tabletindex when there is no cached value in memory

### DIFF
--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -198,7 +198,7 @@ Status UnionSourceOperatorX::get_next_const(RuntimeState* state, vectorized::Blo
     auto& _const_expr_list_idx = local_state._const_expr_list_idx;
     vectorized::MutableBlock mblock =
             vectorized::VectorizedUtils::build_mutable_mem_reuse_block(block, _row_descriptor);
-    for (; _const_expr_list_idx < _const_expr_lists.size() && mblock.rows() <= state->batch_size();
+    for (; _const_expr_list_idx < _const_expr_lists.size() && mblock.rows() < state->batch_size();
          ++_const_expr_list_idx) {
         vectorized::Block tmp_block;
         tmp_block.insert({vectorized::ColumnUInt8::create(1),

--- a/be/src/vec/exec/vunion_node.cpp
+++ b/be/src/vec/exec/vunion_node.cpp
@@ -161,7 +161,7 @@ Status VUnionNode::get_next_materialized(RuntimeState* state, Block* block) {
     MutableBlock mblock = VectorizedUtils::build_mutable_mem_reuse_block(block, _row_descriptor);
 
     Block child_block;
-    while (has_more_materialized() && mblock.rows() <= state->batch_size()) {
+    while (has_more_materialized() && mblock.rows() < state->batch_size()) {
         // The loop runs until we are either done iterating over the children that require
         // materialization, or the row batch is at capacity.
         DCHECK(!is_child_passthrough(_child_idx));


### PR DESCRIPTION
1. In cloud mode, get visible version is a rpc to metaservice, while loads would get visible version for all partitions.
2. VunionNode should follow batch size.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

