### PR TITLE
[opt](file-meta-cache) reduce file meta cache size and disable cache for some cases

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -814,8 +814,6 @@ DEFINE_mInt32(jdbc_connection_pool_cache_clear_time_sec, "28800");
 DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 
-DEFINE_mInt32(common_obj_lru_cache_stale_sweep_time_sec, "900");
-
 // s3 config
 DEFINE_mInt32(max_remote_storage_count, "10");
 
@@ -1070,9 +1068,10 @@ DEFINE_Bool(enable_feature_binlog, "false");
 // enable set in BitmapValue
 DEFINE_Bool(enable_set_in_bitmap_value, "false");
 
-DEFINE_Int64(max_hdfs_file_handle_cache_num, "20000");
+DEFINE_Int64(max_hdfs_file_handle_cache_num, "1000");
 DEFINE_Int32(max_hdfs_file_handle_cache_time_sec, "3600");
-DEFINE_Int64(max_external_file_meta_cache_num, "20000");
+DEFINE_Int64(max_external_file_meta_cache_num, "1000");
+DEFINE_mInt32(common_obj_lru_cache_stale_sweep_time_sec, "900");
 // Apply delete pred in cumu compaction
 DEFINE_mBool(enable_delete_when_cumu_compaction, "false");
 

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -45,4 +45,11 @@ void ObjLRUCache::erase(const ObjKey& key) {
     }
 }
 
+bool ObjLRUCache::exceed_prune_limit() {
+    // just return true to prune all cached obj.
+    // Because ObjLRUCache is counted with number, not memory.
+    // Simple prune all
+    return true;
+}
+
 } // namespace doris

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -103,6 +103,8 @@ public:
 
     void erase(const ObjKey& key);
 
+    bool exceed_prune_limit() override;
+
 private:
     bool _enabled;
 };

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -814,9 +814,8 @@ Status VFileScanner::_get_next_reader() {
             std::unique_ptr<ParquetReader> parquet_reader = ParquetReader::create_unique(
                     _profile, *_params, range, _state->query_options().batch_size, tz,
                     _io_ctx.get(), _state,
-                    config::max_external_file_meta_cache_num <= 0
-                            ? nullptr
-                            : ExecEnv::GetInstance()->file_meta_cache(),
+                    _shoudl_enable_file_meta_cache() ? ExecEnv::GetInstance()->file_meta_cache()
+                                                     : nullptr,
                     _state->query_options().enable_parquet_lazy_mat);
             {
                 SCOPED_TIMER(_open_reader_timer);

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -232,5 +232,14 @@ private:
             return _local_state->get_push_down_count();
         }
     }
+
+    // enable the file meta cache only when
+    // 1. max_external_file_meta_cache_num is > 0
+    // 2. the file number is less than 1/3 of cache's capacibility
+    // Otherwise, the cache miss rate will be high
+    bool _shoudl_enable_file_meta_cache() {
+        return config::max_external_file_meta_cache_num > 0 &&
+               _ranges.size() < config::max_external_file_meta_cache_num / 3;
+    }
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

File meta cache on BE is used to cache the meta for external table's file such as parquet footer.
This cache is counted by number, not memory consumption.
So if the cache object is big(eg, a large parquet footer), the total memory consumption of this cache
will be large and causing OOM.

This PR mainly changes:

1. Add a new method `exceed_prune_limit()` for `CachePolicy`
    For `ObjLRUCache`, it always return true so that the minor of full gc on BE will prune the cache each time.

2. Reduce the default capability of file meta cache, from 20000 to 1000

    Also change the default capability of hdfs file handle cache, from 20000 to 1000

3. Change judgement of whether enable file meta cache when querying

    If the number of file need to be read is larger than the 1/3 of the file meta cache's capability, file meta cache
    will be disabled for this query. Because cache is useless if there are too many files.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

