### PR TITLE
[fix](Cloud) Only set vault name if it's not null nor empty and check it in Meta Service

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -498,7 +498,7 @@ void MetaServiceImpl::create_tablets(::google::protobuf::RpcController* controll
         return;
     }
     RPC_RATE_LIMIT(create_tablets)
-    if (request->has_storage_vault_name()) {
+    if (request->has_storage_vault_name() && !request->storage_vault_name().empty()) {
         InstanceInfoPB instance;
         std::unique_ptr<Transaction> txn0;
         TxnErrorCode err = txn_kv_->create_txn(&txn0);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -120,6 +120,10 @@ public class CloudInternalCatalog extends InternalCatalog {
 
         final String storageVaultName = tbl.getTableProperty().getStorageVauldName();
         boolean storageVaultIdSet = false;
+        // We don't need to set the vault name if the table has no property
+        if (storageVaultName == null || storageVaultName.isEmpty()) {
+            storageVaultIdSet = true;
+        }
 
         // short totalReplicaNum = replicaAlloc.getTotalReplicaNum();
         for (Map.Entry<Long, MaterializedIndex> entry : indexMap.entrySet()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The vault name should only be set if the table has one no-null and no empty vault name property.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

