### PR TITLE
[chore](build) delete palo_be soft link

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -731,12 +731,6 @@ EOF
         cp -r -p "${DORIS_HOME}/be/output/lib/fs_benchmark_tool" "${DORIS_OUTPUT}/be/lib"/
     fi
 
-    # make a soft link palo_be point to doris_be, for forward compatibility
-    cd "${DORIS_OUTPUT}/be/lib"
-    rm -f palo_be
-    ln -s doris_be palo_be
-    cd -
-
     if [[ "${BUILD_META_TOOL}" = "ON" ]]; then
         cp -r -p "${DORIS_HOME}/be/output/lib/meta_tool" "${DORIS_OUTPUT}/be/lib"/
     fi


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Since the bin that started be no longer supports palo_be after several versions of updates, the palo_be soft link in the build script is deleted.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

