### PR TITLE
[opt](file-meta-cache) reduce file meta cache size and disable cache for some cases (#32340)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1051,9 +1051,10 @@ DEFINE_Bool(enable_feature_binlog, "false");
 // enable set in BitmapValue
 DEFINE_Bool(enable_set_in_bitmap_value, "false");
 
-DEFINE_Int64(max_hdfs_file_handle_cache_num, "20000");
+DEFINE_Int64(max_hdfs_file_handle_cache_num, "1000");
 DEFINE_Int32(max_hdfs_file_handle_cache_time_sec, "3600");
-DEFINE_Int64(max_external_file_meta_cache_num, "20000");
+DEFINE_Int64(max_external_file_meta_cache_num, "1000");
+
 // Apply delete pred in cumu compaction
 DEFINE_mBool(enable_delete_when_cumu_compaction, "false");
 

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -737,9 +737,8 @@ Status VFileScanner::_get_next_reader() {
             std::unique_ptr<ParquetReader> parquet_reader = ParquetReader::create_unique(
                     _profile, *_params, range, _state->query_options().batch_size, tz,
                     _io_ctx.get(), _state,
-                    config::max_external_file_meta_cache_num <= 0
-                            ? nullptr
-                            : ExecEnv::GetInstance()->file_meta_cache(),
+                    _shoudl_enable_file_meta_cache() ? ExecEnv::GetInstance()->file_meta_cache()
+                                                     : nullptr,
                     _state->query_options().enable_parquet_lazy_mat);
             {
                 SCOPED_TIMER(_open_reader_timer);

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -216,5 +216,14 @@ private:
         _counter.num_rows_unselected = 0;
         _counter.num_rows_filtered = 0;
     }
+
+    // enable the file meta cache only when
+    // 1. max_external_file_meta_cache_num is > 0
+    // 2. the file number is less than 1/3 of cache's capacibility
+    // Otherwise, the cache miss rate will be high
+    bool _shoudl_enable_file_meta_cache() {
+        return config::max_external_file_meta_cache_num > 0 &&
+               _ranges.size() < config::max_external_file_meta_cache_num / 3;
+    }
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
pick part of #32340

2. Reduce the default capability of file meta cache, from 20000 to 1000

    Also change the default capability of hdfs file handle cache, from 20000 to 1000

3. Change judgement of whether enable file meta cache when querying

    If the number of file need to be read is larger than the 1/3 of the file meta cache's capability, file meta cache
    will be disabled for this query. Because cache is useless if there are too many files.