### PR TITLE
[fix](nereids)NullSafeEqualToEqual rule only change to equal if both children are not nullable

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -175,7 +175,15 @@ Status HashJoinBuildSinkLocalState::_extract_join_column(
         vectorized::Block& block, vectorized::ColumnUInt8::MutablePtr& null_map,
         vectorized::ColumnRawPtrs& raw_ptrs, const std::vector<int>& res_col_ids) {
     auto& shared_state = *_shared_state;
+    auto& p = _parent->cast<HashJoinBuildSinkOperatorX>();
     for (size_t i = 0; i < shared_state.build_exprs_size; ++i) {
+        if (p._should_convert_to_nullable[i]) {
+            _key_columns_holder.emplace_back(
+                    vectorized::make_nullable(block.get_by_position(res_col_ids[i]).column));
+            raw_ptrs[i] = _key_columns_holder.back().get();
+            continue;
+        }
+
         if (shared_state.is_null_safe_eq_join[i]) {
             raw_ptrs[i] = block.get_by_position(res_col_ids[i]).column.get();
         } else {
@@ -411,7 +419,11 @@ Status HashJoinBuildSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* st
         const bool is_null_safe_equal = eq_join_conjunct.__isset.opcode &&
                                         eq_join_conjunct.opcode == TExprOpcode::EQ_FOR_NULL;
 
+        const bool should_convert_to_nullable = is_null_safe_equal &&
+                                                !eq_join_conjunct.right.nodes[0].is_nullable &&
+                                                eq_join_conjunct.left.nodes[0].is_nullable;
         _is_null_safe_eq_join.push_back(is_null_safe_equal);
+        _should_convert_to_nullable.emplace_back(should_convert_to_nullable);
 
         // if is null aware, build join column and probe join column both need dispose null value
         _store_null_in_hash_table.emplace_back(

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -90,6 +90,7 @@ protected:
 
     // build expr
     vectorized::VExprContextSPtrs _build_expr_ctxs;
+    std::vector<vectorized::ColumnPtr> _key_columns_holder;
 
     bool _should_build_hash_table = true;
     int64_t _build_side_mem_used = 0;
@@ -172,6 +173,8 @@ private:
 
     // mark the join column whether support null eq
     std::vector<bool> _is_null_safe_eq_join;
+
+    std::vector<bool> _should_convert_to_nullable;
 
     bool _is_broadcast_join = false;
     std::shared_ptr<vectorized::SharedHashTableController> _shared_hashtable_controller;

--- a/be/src/pipeline/exec/hashjoin_probe_operator.cpp
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.cpp
@@ -214,6 +214,7 @@ void HashJoinProbeLocalState::_prepare_probe_block() {
         column_type.column = remove_nullable(column_type.column);
         column_type.type = remove_nullable(column_type.type);
     }
+    _key_columns_holder.clear();
     _probe_block.clear_column_data(_parent->get_child()->row_desc().num_materialized_slots());
 }
 
@@ -374,7 +375,15 @@ Status HashJoinProbeLocalState::_extract_join_column(vectorized::Block& block,
                                                      vectorized::ColumnRawPtrs& raw_ptrs,
                                                      const std::vector<int>& res_col_ids) {
     auto& shared_state = *_shared_state;
+    auto& p = _parent->cast<HashJoinProbeOperatorX>();
     for (size_t i = 0; i < shared_state.build_exprs_size; ++i) {
+        if (p._should_convert_to_nullable[i]) {
+            _key_columns_holder.emplace_back(
+                    vectorized::make_nullable(block.get_by_position(res_col_ids[i]).column));
+            raw_ptrs[i] = _key_columns_holder.back().get();
+            continue;
+        }
+
         if (shared_state.is_null_safe_eq_join[i]) {
             raw_ptrs[i] = block.get_by_position(res_col_ids[i]).column.get();
         } else {
@@ -524,6 +533,18 @@ Status HashJoinProbeOperatorX::init(const TPlanNode& tnode, RuntimeState* state)
                 null_aware ||
                 (_probe_expr_ctxs.back()->root()->is_nullable() && probe_dispose_null);
         conjuncts_index++;
+        const bool is_null_safe_equal = eq_join_conjunct.__isset.opcode &&
+                                        eq_join_conjunct.opcode == TExprOpcode::EQ_FOR_NULL;
+
+        /// If it's right anti join,
+        /// we should convert the probe to nullable if the build side is nullable.
+        /// And if it is 'null safe equal',
+        /// we must make sure the build side and the probe side are both nullable or non-nullable.
+        const bool should_convert_to_nullable =
+                (is_null_safe_equal || _join_op == TJoinOp::RIGHT_ANTI_JOIN) &&
+                !eq_join_conjunct.left.nodes[0].is_nullable &&
+                eq_join_conjunct.right.nodes[0].is_nullable;
+        _should_convert_to_nullable.emplace_back(should_convert_to_nullable);
     }
     for (size_t i = 0; i < _probe_expr_ctxs.size(); ++i) {
         _probe_ignore_null |= !probe_not_ignore_null[i];

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -124,6 +124,8 @@ private:
 
     vectorized::VExprContextSPtrs _mark_join_conjuncts;
 
+    std::vector<vectorized::ColumnPtr> _key_columns_holder;
+
     // probe expr
     vectorized::VExprContextSPtrs _probe_expr_ctxs;
     std::vector<uint16_t> _probe_column_disguise_null;
@@ -193,6 +195,8 @@ private:
     // probe expr
     vectorized::VExprContextSPtrs _probe_expr_ctxs;
     bool _probe_ignore_null = false;
+
+    std::vector<bool> _should_convert_to_nullable;
 
     vectorized::DataTypes _right_table_data_types;
     vectorized::DataTypes _left_table_data_types;

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -281,9 +281,11 @@ private:
     // mark the build hash table whether it needs to store null value
     std::vector<bool> _store_null_in_hash_table;
 
+    std::vector<bool> _should_convert_build_side_to_nullable;
+    std::vector<bool> _should_convert_probe_side_to_nullable;
     // In right anti join, if the probe side is not nullable and the build side is nullable,
     // we need to convert the probe column to nullable.
-    std::vector<ColumnPtr> _temp_probe_nullable_columns;
+    std::vector<vectorized::ColumnPtr> _key_columns_holder;
 
     std::vector<uint16_t> _probe_column_disguise_null;
     std::vector<uint16_t> _probe_column_convert_to_null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqual.java
@@ -54,7 +54,7 @@ public class NullSafeEqualToEqual extends DefaultExpressionRewriter<ExpressionRe
             } else {
                 return BooleanLiteral.FALSE;
             }
-        } else if (!nullSafeEqual.left().nullable() || !nullSafeEqual.right().nullable()) {
+        } else if (!nullSafeEqual.left().nullable() && !nullSafeEqual.right().nullable()) {
             return new EqualTo(nullSafeEqual.left(), nullSafeEqual.right());
         }
         return nullSafeEqual;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqualTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqualTest.java
@@ -25,7 +25,6 @@ import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.types.StringType;
 
 import com.google.common.collect.ImmutableList;
@@ -49,21 +48,30 @@ class NullSafeEqualToEqualTest extends ExpressionRewriteTestHelper {
         assertRewrite(new NullSafeEqual(slot, NullLiteral.INSTANCE), BooleanLiteral.FALSE);
     }
 
-    // "A<=> "abc" to "A = "abc"
+    // "A(nullable)<=>B" not changed
+    @Test
+    void testNullSafeEqualNotChangedLeft() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(NullSafeEqualToEqual.INSTANCE));
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, true);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
+        assertRewrite(new NullSafeEqual(a, b), new NullSafeEqual(a, b));
+    }
+
+    // "A<=>B(nullable)" not changed
+    @Test
+    void testNullSafeEqualNotChangedRight() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(NullSafeEqualToEqual.INSTANCE));
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, true);
+        assertRewrite(new NullSafeEqual(a, b), new NullSafeEqual(a, b));
+    }
+
+    // "A<=>B" changed
     @Test
     void testNullSafeEqualToEqual() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(NullSafeEqualToEqual.INSTANCE));
-        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true);
-        StringLiteral str = new StringLiteral("abc");
-        assertRewrite(new NullSafeEqual(slot, str), new EqualTo(slot, str));
-    }
-
-    // "A<=>B" not changed
-    @Test
-    void testNullSafeEqualNotChanged() {
-        executor = new ExpressionRuleExecutor(ImmutableList.of(NullSafeEqualToEqual.INSTANCE));
-        SlotReference a = new SlotReference("a", StringType.INSTANCE, true);
-        SlotReference b = new SlotReference("b", StringType.INSTANCE, true);
-        assertRewrite(new NullSafeEqual(a, b), new NullSafeEqual(a, b));
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
+        assertRewrite(new NullSafeEqual(a, b), new EqualTo(a, b));
     }
 }

--- a/regression-test/suites/query_p0/join/test_half_join_nullable_build_side.groovy
+++ b/regression-test/suites/query_p0/join/test_half_join_nullable_build_side.groovy
@@ -16,8 +16,6 @@
 // under the License.
 
 suite("test_half_join_nullable_build_side", "query,p0") {
-    /// TODO: fix on pipelinex
-    sql " set ENABLE_PIPELINE_X_ENGINE = 0; "
     sql " set disable_join_reorder = 1; "
     sql " drop table if exists test_half_join_nullable_build_side_l; ";
     sql " drop table if exists test_half_join_nullable_build_side_l2; ";


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

