### PR TITLE
[Fix](Job)When jobname is the do keyword, parsing errors will occur when executing SQL.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateJobStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateJobStmtTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class CreateJobStmtTest {
 
@@ -74,5 +76,29 @@ public class CreateJobStmtTest {
         Assertions.assertThrows(AnalysisException.class, () -> {
             sqlParse(badSql);
         });
+    }
+
+    @Test
+    public void testParseExecuteSql() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = CreateJobStmt.class.getDeclaredMethod("parseExecuteSql", String.class, String.class, String.class);
+        method.setAccessible(true);
+        String executeSql = "insert into table.B select * from table.A ;";
+        String comment = "do do do do ";
+        String jobName = "do";
+        String doKeywordJobSql = "Create job " + jobName
+                + "on Scheduler every second comment " + comment + "\n"
+                + "do"
+                + executeSql;
+
+        String result = (String) method.invoke(null, doKeywordJobSql, jobName, comment);
+        Assertions.assertEquals(executeSql, result.trim());
+        executeSql = "insert into table.do select * from do.B ;";
+        comment = "do starts  end do \n \b \r ";
+        jobName = "do";
+        doKeywordJobSql = "Create job " + jobName
+                + "on Scheduler every second comment " + comment + "do\n"
+                + executeSql;
+        result = (String) method.invoke(null, doKeywordJobSql, jobName, comment);
+        Assertions.assertEquals(executeSql, result.trim());
     }
 }


### PR DESCRIPTION
## Proposed changes

The Insert statement lacks a corresponding toSql implementation. Therefore, we can only parse the corresponding execution statement from the original SQL. However, the original parsing method relies on the keyword index of "do" to determine the SQL execution position. When the JOB name is "do", this leads to an error where the execution SQL statement is extracted incorrectly. 

eg:
```
 CREATE JOB do ON SCHEDULE every 2 minute comment ' do'
DO insert into address  values  ('2023-07-19', 2, 1001);
```


To avoid this issue, we must first determine the positions of jobname and Comment before extracting the SQL position.

## Test

Add ut 



