### PR TITLE
[pipelineX](streaming agg) Fix wrong columns produced by streaming agg

### DIFF
--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -449,7 +449,8 @@ Status StatefulOperatorX<LocalStateType>::get_block(RuntimeState* state, vectori
                                                     bool* eos) {
     auto& local_state = get_local_state(state);
     if (need_more_input_data(state)) {
-        local_state._child_block->clear_column_data();
+        local_state._child_block->clear_column_data(
+                OperatorX<LocalStateType>::_child_x->row_desc().num_materialized_slots());
         RETURN_IF_ERROR(OperatorX<LocalStateType>::_child_x->get_block_after_projects(
                 state, local_state._child_block.get(), &local_state._child_eos));
         *eos = local_state._child_eos;

--- a/regression-test/data/query_p0/join/test_join.out
+++ b/regression-test/data/query_p0/join/test_join.out
@@ -3240,3 +3240,6 @@ false	true	true	false	false
 
 -- !test --
 
+-- !sql --
+1
+

--- a/regression-test/data/query_p0/join/test_join.out
+++ b/regression-test/data/query_p0/join/test_join.out
@@ -3241,5 +3241,5 @@ false	true	true	false	false
 -- !test --
 
 -- !sql --
-1
+4
 

--- a/regression-test/suites/query_p0/join/test_join.groovy
+++ b/regression-test/suites/query_p0/join/test_join.groovy
@@ -1294,4 +1294,45 @@ suite("test_join", "query,p0") {
     sql """INSERT INTO t0 (c0) VALUES (true);"""
     sql """INSERT INTO t0 (c0) VALUES (false);"""
     qt_test """SELECT t1.c0 FROM  t1 RIGHT JOIN t0 ON true WHERE  (abs(1)=0) GROUP BY  t1.c0;"""
+
+    sql """ DROP TABLE IF EXISTS tbl2; """
+    sql """ DROP TABLE IF EXISTS tbl1; """
+    sql """ CREATE TABLE tbl1 (
+            data_dt DATE NULL COMMENT '数据日期',
+            engineer VARCHAR(100) NULL COMMENT '工程师'
+            ) ENGINE=OLAP
+            UNIQUE KEY(data_dt, engineer)
+            PARTITION BY RANGE(data_dt)
+            (
+              FROM ('2022-11-05') TO ('2024-03-20') INTERVAL 1 DAY
+            )
+            DISTRIBUTED BY HASH(data_dt) BUCKETS 10
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "group_commit_interval_ms" = "10000",
+            "group_commit_data_bytes" = "134217728"
+            ); """
+    sql """ CREATE TABLE tbl2 (
+            data_dt DATE NULL COMMENT '数据日期'
+            ) ENGINE=OLAP
+            UNIQUE KEY(data_dt)
+            PARTITION BY RANGE(data_dt)
+            (
+              FROM ('2022-11-05') TO ('2024-03-20') INTERVAL 1 DAY
+            )
+            DISTRIBUTED BY HASH(data_dt) BUCKETS 10
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "min_load_replica_num" = "-1",
+            "is_being_synced" = "false",
+            "storage_format" = "V2",
+            "group_commit_interval_ms" = "10000",
+            "group_commit_data_bytes" = "134217728"
+            ); """
+
+    sql """ insert into tbl1 values('2023-01-01', 'engineer1'),('2023-01-01', 'engineer1'),('2023-01-02', 'engineer1'),('2023-01-02', 'engineer1'); """
+    sql """ insert into tbl2 values('2023-01-01'); """
+    qt_sql """ select /*+SET_VAR(batch_size=1, enable_nereids_planner=false)*/ count(DISTINCT dcqewrt.engineer)  as active_person_count from tbl1 dcqewrt left join [broadcast] tbl2 dd on dd.data_dt = dcqewrt.data_dt; """
+    sql """ DROP TABLE IF EXISTS tbl2; """
+    sql """ DROP TABLE IF EXISTS tbl1; """
 }

--- a/regression-test/suites/query_p0/join/test_join.groovy
+++ b/regression-test/suites/query_p0/join/test_join.groovy
@@ -1330,7 +1330,7 @@ suite("test_join", "query,p0") {
             "group_commit_data_bytes" = "134217728"
             ); """
 
-    sql """ insert into tbl1 values('2023-01-01', 'engineer1'),('2023-01-01', 'engineer1'),('2023-01-02', 'engineer1'),('2023-01-02', 'engineer1'); """
+    sql """ insert into tbl1 values('2023-01-01', 'engineer1'),('2023-01-01', 'engineer2'),('2023-01-02', 'engineer3'),('2023-01-02', 'enginee4'); """
     sql """ insert into tbl2 values('2023-01-01'); """
     qt_sql """ select /*+SET_VAR(batch_size=1, enable_nereids_planner=false)*/ count(DISTINCT dcqewrt.engineer)  as active_person_count from tbl1 dcqewrt left join [broadcast] tbl2 dd on dd.data_dt = dcqewrt.data_dt; """
     sql """ DROP TABLE IF EXISTS tbl2; """


### PR DESCRIPTION
## Proposed changes

*** tablet id: 0 ***
*** Aborted at 1710666968 (unix time) try "date -d @1710666968" if you are using GNU date ***
*** Current BE git commitID: 91efb6a ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 22964 (TID 24870 OR 0x7ff55cac8700) from PID 0; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:417
1# os::Linux::chained_handler(int, siginfo_t*, void*) in /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
3# signalHandler(int, siginfo_t*, void*) in /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
4# 0x00007FF60EC1B400 in /lib64/libc.so.6
5# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_release/doris/be/src/vec/exprs/vexpr_context.cpp:50
6# doris::pipeline::JoinProbeLocalState<doris::pipeline::HashJoinSharedState, doris::pipeline::HashJoinProbeLocalState>::_build_output_block(doris::vectorized::Block*, doris::vectorized::Block*, bool) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/join_probe_operator.cpp:127
7# doris::pipeline::HashJoinProbeLocalState::filter_data_and_build_output(doris::RuntimeState*, doris::vectorized::Block*, bool*, doris::vectorized::Block*, bool) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/hashjoin_probe_operator.cpp:433
8# doris::pipeline::HashJoinProbeOperatorX::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) const at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/hashjoin_probe_operator.cpp:364
9# doris::pipeline::StatefulOperatorXdoris::pipeline::HashJoinProbeLocalState::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/operator.cpp:459
10# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/operator.cpp:210
11# doris::pipeline::StatefulOperatorXdoris::pipeline::DistinctStreamingAggLocalState::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/operator.cpp:444
12# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/operator.cpp:210
13# doris::pipeline::PipelineXTask::execute(bool*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:274
14# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/task_scheduler.cpp:334
15# doris::ThreadPool::dispatch_thread() in /opt/software/doris_be/lib/doris_be
16# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_release/doris/be/src/util/thread.cpp:499
17# start_thread in /lib64/libpthread.so.0
18# clone in /lib64/libc.so.6
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

