### PR TITLE
[fix](cloud) Fix missing disk and cpu report in cloud mode

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -205,6 +205,10 @@ void AgentServer::cloud_start_workers(CloudStorageEngine& engine, ExecEnv* exec_
     _report_workers.push_back(std::make_unique<ReportWorker>(
             "REPORT_TASK", _master_info, config::report_task_interval_seconds,
             [&master_info = _master_info] { report_task_callback(master_info); }));
+
+    _report_workers.push_back(std::make_unique<ReportWorker>(
+            "REPORT_DISK_STATE", _master_info, config::report_disk_state_interval_seconds,
+            [&engine, &master_info = _master_info] { report_disk_callback(engine, master_info); }));
 }
 
 // TODO(lingbin): each task in the batch may have it own status or FE must check and

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -178,6 +178,8 @@ void report_task_callback(const TMasterInfo& master_info);
 
 void report_disk_callback(StorageEngine& engine, const TMasterInfo& master_info);
 
+void report_disk_callback(CloudStorageEngine& engine, const TMasterInfo& master_info);
+
 void report_tablet_callback(StorageEngine& engine, const TMasterInfo& master_info);
 
 void calc_delete_bimtap_callback(CloudStorageEngine& engine, const TAgentTaskRequest& req);


### PR DESCRIPTION
Missing CPU reports may result in an incorrect PipelineExecutorSize (fixed to 1), affecting execution performance.

Reference code path of FE
```
getMinPipelineExecutorSize -> Backend.getPipelineExecutorSize 
public boolean updateCpuInfo(int cpuCores, int pipelineExecutorSize)
private static void cpuReport(long backendId, int cpuCores, int pipelineExecutorSize)
```