### PR TITLE
[fix](compile) Fix links failure when use gcc to compile

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <chrono> // IWYU pragma: keep
+#include <mutex>
 
 #include "common/config.h"
 #include "common/logging.h"
@@ -1507,5 +1508,7 @@ Status BlockFileCache::clear_file_cache_directly() {
             .tag("use_time", static_cast<int64_t>(use_time.count()));
     return Status::OK();
 }
-
+template void BlockFileCache::remove(FileBlockSPtr file_block,
+                                     std::lock_guard<std::mutex>& cache_lock,
+                                     std::lock_guard<std::mutex>& block_lock);
 } // namespace doris::io

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -29,10 +29,8 @@
 namespace doris::io {
 
 template <class Lock>
-concept IsXLock = requires {
-    std::same_as<Lock, std::lock_guard<std::mutex>> ||
-            std::same_as<Lock, std::unique_lock<std::mutex>>;
-};
+concept IsXLock = std::same_as<Lock, std::lock_guard<std::mutex>> ||
+                  std::same_as<Lock, std::unique_lock<std::mutex>>;
 
 class FSFileCacheStorage;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This is because the iso standard didn't specified whether or not implicitly instantiated symbols must be exported

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

