### PR TITLE
[fix](core) Fix buffer overflow in debug print

### DIFF
--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp
@@ -40,13 +40,13 @@ Status LocalExchangeSourceLocalState::init(RuntimeState* state, LocalStateInfo& 
 }
 
 std::string LocalExchangeSourceLocalState::debug_string(int indentation_level) const {
-    fmt::memory_buffer debug_string_buffer;
-    fmt::format_to(debug_string_buffer,
-                   "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}",
-                   Base::debug_string(indentation_level), _channel_id, _exchanger->_num_partitions,
-                   _exchanger->_num_senders, _exchanger->_num_sources,
-                   _exchanger->_running_sink_operators);
-    return fmt::to_string(debug_string_buffer);
+    std::string debug_string;
+    debug_string = fmt::format(
+            "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}",
+            Base::debug_string(indentation_level), _channel_id, _exchanger->_num_partitions,
+            _exchanger->_num_senders, _exchanger->_num_sources,
+            _exchanger->_running_sink_operators);
+    return debug_string;
 }
 
 Status LocalExchangeSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* block,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This is because `fmt::memory_buffer` is limited in size by default
```
==2168255==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x617003b9ee0c at pc 0x55cac64edddb bp 0x7f6824f48e30 sp 0x7f6824f48e28
READ of size 4 at 0x617003b9ee0c thread T2323 (EvHttpServer [w)
    #0 0x55cac64eddda in fmt::v7::detail::value, char>> fmt::v7::detail::make_arg, char>, (fmt::v7::detail::type)1, int, 0>(int const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1438:45
    #1 0x55caf9a2f696 in fmt::v7::format_arg_store, char>, std::__cxx11::basic_string, std::allocator>, int const, int const, int const, int const, std::atomic>::format_arg_store(std::__cxx11::basic_string, std::allocator> const&, int const&, int const&, int const&, int const&, std::atomic const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1587:15
    #2 0x55caf9a2f397 in fmt::v7::format_arg_store, char>, std::remove_reference, std::allocator>>::type, std::remove_reference::type, std::remove_reference::type, std::remove_reference::type, std::remove_reference::type, std::remove_reference&>::type> fmt::v7::make_args_checked, std::allocator>, int const&, int const&, int const&, int const&, std::atomic&, char [77], char>(char const (&) [77], std::remove_reference, std::allocator>>::type const&, std::remove_reference::type const&, std::remove_reference::type const&, std::remove_reference::type const&, std::remove_reference::type const&, std::remove_reference&>::type const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1626:10
    #3 0x55caf9a2c330 in fmt::v7::basic_format_context, char>::iterator fmt::v7::format_to, std::allocator>, int const&, int const&, int const&, int const&, std::atomic&, 500ul, char>(fmt::v7::basic_memory_buffer>&, char const (&) [77], std::__cxx11::basic_string, std::allocator>&&, int const&, int const&, int const&, int const&, std::atomic&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/format.h:3820:23
    #4 0x55caf9b3a0d5 in doris::pipeline::LocalExchangeSourceLocalState::debug_string[abi:cxx11](int) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp:44:5
    #5 0x55caf992c73d in doris::pipeline::OperatorXBase::debug_string[abi:cxx11](doris::RuntimeState*, int) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/operator.cpp:104:51
    #6 0x55caf9e4e4f8 in doris::pipeline::PipelineXTask::debug_string[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:385:42
    #7 0x55caf9d83dcf in doris::pipeline::PipelineXFragmentContext::debug_string[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:1391:83
    #8 0x55cac9b9407e in doris::FragmentMgr::dump_pipeline_tasks[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:768:82
    #9 0x55cacbaf37de in doris::PipelineTaskAction::handle(doris::HttpRequest*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/http/action/pipeline_task_action.cpp:38:69
    #10 0x55cacbbbb0d3 in doris::on_request(evhttp_request*, void*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/http/ev_http_server.cpp:68:25
    #11 0x55cafa7d2066  (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a10f066) (BuildId: bc1ed4d78455b26d)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

