### PR TITLE
[improve](CI)Core modules require maintainer review

### DIFF
--- a/.github/workflows/pr-approve-status.yml
+++ b/.github/workflows/pr-approve-status.yml
@@ -20,41 +20,21 @@ name: Need_2_Approval
 on:
   pull_request_review:
     types: [submitted]
+
 jobs:
   Need_2_Approval:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          pr_num=${{ github.event.pull_request.number }}
-          echo $pr_num
-          if [ -z "$pr_num" ]; then
-              echo "PR number is not set"
-              exit 1
-          fi
-          response=$(curl -s  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "  "https://api.github.com/repos/apache/doris/pulls/${pr_num}/reviews?per_page=100")
-          # shellcheck disable=SC2207
-          reviewers=($(echo $response | jq -r '.[] | .user.login'))
-          # shellcheck disable=SC2207
-          statuses=($(echo $response | jq -r '.[] | .state'))
-          echo "${reviewers[@]}"
-          echo "${statuses[@]}"
-          approves=()
-          reviewers_unique=()
-          for ((i=${#reviewers[@]}-1;i>=0;i--)); do
-            if ! echo "${reviewers_unique[@]}" | grep -q -w "${reviewers[$i]}" && [ "${statuses[$i]}" != "COMMENTED" ]; then
-                  reviewers_unique+=( "${reviewers[$i]}" )
-                  if [ "${statuses[$i]}" == "APPROVED" ]; then
-                      approves+=( "${reviewers[$i]}" )
-                  fi
-              fi
-          done
-          echo "${approves[@]}"
-          if [ ${#approves[@]} -lt 2 ]; then
-              echo "PR ${pr_num} has not been approved by at least 2 reviewers"
-              # shellcheck disable=SC2242
-              exit 1
-          fi
-          echo "Thanks for your contribution to Doris."
-          exit 0
+      - name: Install Python dependencies
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.1.0'  # Adjust if needed
+      - name: Install fnmatch library
+        run: pip install fnmatch
+      - name: Run Python script
+        run: |
+          python tools/maintainers/check_reviews.py  ${{ github.event.pull_request.number }} ${{secrets.GITHUB_TOKEN}}
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-approve-status.yml
+++ b/.github/workflows/pr-approve-status.yml
@@ -38,6 +38,6 @@ jobs:
           pip install requests
       - name: Run Python script
         run: |
-          python tools/maintainers/check_reviews.py  ${{ github.event.pull_request.number }} ${{secrets.GITHUB_TOKEN}}
+          python tools/maintainers/check_review.py  ${{ github.event.pull_request.number }} ${{secrets.GITHUB_TOKEN}}
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-approve-status.yml
+++ b/.github/workflows/pr-approve-status.yml
@@ -19,7 +19,7 @@ name: Need_2_Approval
 
 on:
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
 
 jobs:
   Need_2_Approval:
@@ -31,8 +31,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'  # Adjust if needed
-      - name: Install fnmatch library
-        run: pip install fnmatch
+      - name: Install match library
+        run: |
+          pip install --upgrade pip 
+          pip install match
+          pip install requests
       - name: Run Python script
         run: |
           python tools/maintainers/check_reviews.py  ${{ github.event.pull_request.number }} ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-approve-status.yml
+++ b/.github/workflows/pr-approve-status.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Python dependencies
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.1.0'  # Adjust if needed
+          python-version: '3.10'  # Adjust if needed
       - name: Install fnmatch library
         run: pip install fnmatch
       - name: Run Python script

--- a/tools/maintainers/check_review.py
+++ b/tools/maintainers/check_review.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import requests
+import json
+import match
+import sys
+
+def check_review_pass(pr_num, maintainers_file, token):
+  """
+  Checks if all necessary files have been reviewed by maintainers.
+
+  Args:
+      pr_num (int): PR number.
+      maintainers_file (str): Path to maintainers.json.
+      token (str): GitHub token.
+
+  Returns:
+      bool: True if all files are reviewed, False otherwise.
+  """
+  headers = {'Authorization': f'{token}'}
+  
+  # Get PR review information and extract reviewers and statuses
+  response = requests.get(f"https://api.github.com/repos/apache/doris/pulls/{pr_num}/reviews?per_page=100", headers=headers)
+  reviews = response.json()
+  reviewers = [review['user']['login'] for review in reviews]
+  statuses = [review['state'] for review in reviews]
+
+  # Find approved reviewers
+  approves = [reviewer for reviewer, status in zip(reviewers, statuses) if status == 'APPROVED']
+
+  # Get list of changed files
+  response = requests.get(f"https://api.github.com/repos/apache/doris/pulls/{pr_num}/files", headers=headers)
+  file_changes = response.json()
+  file_change_names = [file['filename'] for file in file_changes]
+
+  # Read maintainers.json
+  with open(maintainers_file) as f:
+      data = json.load(f)
+  need_maintainers_review_path = [item['path'] for item in data['paths']]
+
+  # Check if each path's files have been reviewed by a maintainer
+  has_maintainer_review = True
+  for file in file_change_names:
+      path_found = False
+      for path_item in data['paths']:
+          path = path_item['path']
+          maintainers = path_item['maintainers']
+
+          if match.match(file, path):
+              path_found = True
+              if maintainers:
+                  if not any(maintainer in approves for maintainer in maintainers):
+                      has_maintainer_review = False
+                      break
+              else:
+                  continue
+
+      if not path_found:
+          continue
+          
+  if len(approves) < 2:
+      print("PR has not been approved by at least 2 reviewers")
+      exit(1)  
+
+  return has_maintainer_review
+
+if __name__ == "__main__":
+
+  pr_num = sys.argv[1]
+  token = sys.argv[2]
+  maintainers_file = 'tools/maintainers/maintainers.json'  # Adjust path if needed
+
+  if check_review_pass(pr_num, maintainers_file, token):
+      print("Thanks for your contribution to Doris.")
+  else:
+      print("PR has file changes that need to be reviewed by maintainers.")
+      exit(1)

--- a/tools/maintainers/check_review.py
+++ b/tools/maintainers/check_review.py
@@ -39,9 +39,13 @@ def check_review_pass(pr_num, maintainers_file, token):
   reviews = response.json()
   reviewers = [review['user']['login'] for review in reviews]
   statuses = [review['state'] for review in reviews]
+  print(reviewers)
+  print(statuses)
+  # Create a dictionary with the latest status for each reviewer
+  latest_statuses = {reviewer: status for reviewer, status in zip(reviewers, statuses)}
 
-  # Find approved reviewers
-  approves = [reviewer for reviewer, status in zip(reviewers, statuses) if status == 'APPROVED']
+  # Create a list of reviewers who have approved
+  approves = [reviewer for reviewer, status in latest_statuses.items() if status == 'APPROVED']
 
   # Get list of changed files
   response = requests.get(f"https://api.github.com/repos/apache/doris/pulls/{pr_num}/files", headers=headers)
@@ -72,10 +76,10 @@ def check_review_pass(pr_num, maintainers_file, token):
 
       if not path_found:
           continue
-          
+  print(approves)
   if len(approves) < 2:
       print("PR has not been approved by at least 2 reviewers")
-      exit(1)  
+      exit(1)
 
   return has_maintainer_review
 

--- a/tools/maintainers/maintainers.json
+++ b/tools/maintainers/maintainers.json
@@ -1,0 +1,12 @@
+{
+  "paths":[
+    {
+      "path":"be/src/io/*",
+       "maintainers": [
+         "platoneko", 
+         "gavinchou",
+         "dataroaring"
+       ]
+    }
+  ] 
+}


### PR DESCRIPTION
## Proposed changes

Configuration File Documentation
This configuration file is used to set maintainers for each path in a code repository. Only maintainers of a path can approve code changes under that path before they can be merged.

Configuration File Format

The configuration file is a JSON file that contains a paths array. Each element in the array represents a path and its list of maintainers.

Example

```
{
  "paths": [
    {
      "path": "docs/*",
      "maintainers": [
        "luzhijing",
        "morningman"
      ]
    }
  ]
}
```

Configurationの

paths: An array of objects that represent paths and their maintainers.
path: A string that represents the path that maintainers need to be set for. You can use the wildcard * to match multiple paths.
maintainers: An array of strings that represents the Github usernames  of the maintainers for the path.
Instructions

Add the configuration file to the root directory of your code repository.
In your code repository's settings, enable "Require pull request reviews before merging".
In your code repository's settings, set "Required approving reviewers" to the maintainers specified in the configuration file.

If a path does not have any maintainers set, then anyone can approve code changes under that path.


Suppose your code repository has the following file structure:

docs/
├── [index.md](http://index.md/)
└── [README.md](http://readme.md/)
And your configuration file is as follows:

```
{
  "paths": [
    {
      "path": "docs/*",
      "maintainers": [
        "luzhijing",
        "morningman"
      ]
    }
  ]
}
```

In this case, only Lu Zhijing and Morning Man can approve code changes under the docs/ directory.
Further Information

You can use multiple configuration files to set maintainers for different paths.
You can use GitHub Actions to automate the code review and merging process.
