### PR TITLE
[fix](merge-cloud) Fix CloudPartition.getVisibleVersion return value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
@@ -44,6 +44,7 @@ import java.util.Objects;
 public class Partition extends MetaObject implements Writable {
     private static final Logger LOG = LogManager.getLogger(Partition.class);
 
+    // Every partition starts from version 1, version 1 has no data
     public static final long PARTITION_INIT_VERSION = 1L;
 
     public enum PartitionState {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

The return value of Partition.getVisibleVersion is 1 if the partition is empty, this PR unifies the behaviors between Partition and CloudPartition.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

