### PR TITLE
[fix](snapshot-loader) Fix be crash caused by deref end() iterator

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -338,7 +338,9 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             }
             // remove file which will be downloaded now.
             // this file will be added to local_files if it be downloaded successfully.
-            local_files.erase(find);
+            if (find != local_files.end()) {
+                local_files.erase(find);
+            }
             RETURN_IF_ERROR(_remote_fs->download(full_remote_file, full_local_file));
 
             // 3. check md5 of the downloaded file


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The standard said that the input parameter `pos` of std::vector::erase must be valid and dereferenceable, the `end()` iterator cannot be used as a value of `pos`. I did some tests and the crash only occurs when the vector is empty. Fortunately `local_files` is usually not empty.

The crash stack is:

```
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1710410771 (unix time) try "date -d @1710410771" if you are using GNU date ***
*** Current BE git commitID: 91efb6a43d ***
*** SIGSEGV address not mapped to object (@0xffffffffffffffe0) received by PID 114167 (TID 116733 OR 0x7fd55292c700) from PID 18446744073709551584; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo*, void*) in /mnt/disk1/caoliang/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/disk1/caoliang/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /mnt/disk1/caoliang/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 4# 0x00007FD981939B50 in /lib64/libc.so.6
 5# doris::SnapshotLoader::download(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::vector<long, std::allocator<long> >*) at /home/zcp/repo_center/doris_release/doris/be/src/runtime/snapshot_loader.cpp:344
 6# doris::download_callback(doris::StorageEngine&, doris::ExecEnv*, doris::TAgentTaskRequest const&) in /mnt/disk1/caoliang/doris/doris-2.1.0/apache-doris-2.1.0-rc10-bin-x64/be/lib/doris_be
 7# std::_Function_handler<void (), doris::TaskWorkerPool::submit_task(doris::TAgentTaskRequest const&)::$_0::operator()<doris::TAgentTaskRequest const&>(doris::TAgentTaskRequest const&) const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 8# doris::ThreadPool::dispatch_thread() in /mnt/disk1/caoliang/doris/doris-2.1.0/apache-doris-2.1.0-rc10-bin-x64/be/lib/doris_be
 9# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_release/doris/be/src/util/thread.cpp:499
10# start_thread in /lib64/libpthread.so.0
11# __clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

