### PR TITLE
[fix](fe plugin) change external audit loader plugin package name

### DIFF
--- a/fe_plugins/auditdemo/src/main/java/org/apache/doris/plugin/audit/AuditPluginDemo.java
+++ b/fe_plugins/auditdemo/src/main/java/org/apache/doris/plugin/audit/AuditPluginDemo.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.plugin.audit;
 
-import org.apache.doris.plugin.AuditEvent;
+import org.apache.doris.plugin.audit.AuditEvent;
 import org.apache.doris.plugin.AuditPlugin;
 import org.apache.doris.plugin.Plugin;
 import org.apache.doris.plugin.PluginContext;

--- a/fe_plugins/auditloader/src/main/assembly/plugin.properties
+++ b/fe_plugins/auditloader/src/main/assembly/plugin.properties
@@ -20,4 +20,4 @@ type=AUDIT
 description=load audit log to olap load, and user can view the statistic of queries
 version=1.0.0
 java.version=1.8.0
-classname=org.apache.doris.plugin.audit.AuditLoaderPlugin
+classname=org.apache.doris.plugin.audit.ext.AuditLoaderPlugin

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/AuditLoaderPlugin.java
@@ -46,6 +46,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/AuditLoaderPlugin.java
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.plugin.audit;
+package org.apache.doris.plugin.audit.ext;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.plugin.AuditEvent;
+import org.apache.doris.plugin.audit.AuditEvent;
 import org.apache.doris.plugin.AuditPlugin;
 import org.apache.doris.plugin.Plugin;
 import org.apache.doris.plugin.PluginContext;
@@ -46,7 +46,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/DorisStreamLoader.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/ext/DorisStreamLoader.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.plugin.audit;
+package org.apache.doris.plugin.audit.ext;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #32493

Change the `AuditEvent` import package name, and change the package name of the external 
audit loader plugin to make it still work after upgrading to version 2.1.0

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

