### PR TITLE
[enhance](S3) Print the oss request id for each error s3 request

### DIFF
--- a/be/src/io/fs/err_utils.cpp
+++ b/be/src/io/fs/err_utils.cpp
@@ -115,16 +115,17 @@ Status s3fs_error(const Aws::S3::S3Error& err, std::string_view msg) {
     using namespace Aws::Http;
     switch (err.GetResponseCode()) {
     case HttpResponseCode::NOT_FOUND:
-        return Status::Error<NOT_FOUND, false>("{}: {} {} type={}", msg, err.GetExceptionName(),
-                                               err.GetMessage(), err.GetErrorType());
+        return Status::Error<NOT_FOUND, false>("{}: {} {} type={}, request_id={}", msg,
+                                               err.GetExceptionName(), err.GetMessage(),
+                                               err.GetErrorType(), err.GetRequestId());
     case HttpResponseCode::FORBIDDEN:
-        return Status::Error<PERMISSION_DENIED, false>("{}: {} {} type={}", msg,
+        return Status::Error<PERMISSION_DENIED, false>("{}: {} {} type={}, request_id={}", msg,
                                                        err.GetExceptionName(), err.GetMessage(),
-                                                       err.GetErrorType());
+                                                       err.GetErrorType(), err.GetRequestId());
     default:
         return Status::Error<ErrorCode::INTERNAL_ERROR, false>(
-                "{}: {} {} code={} type={}", msg, err.GetExceptionName(), err.GetMessage(),
-                err.GetResponseCode(), err.GetErrorType());
+                "{}: {} {} code={} type={}, request_id={}", msg, err.GetExceptionName(),
+                err.GetMessage(), err.GetResponseCode(), err.GetErrorType(), err.GetRequestId());
     }
 }
 

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -53,6 +53,7 @@ public:
 
 private:
     Status _abort();
+    [[nodiscard]] std::string _dump_completed_part() const;
     void _wait_until_finish(std::string_view task_name);
     Status _complete();
     Status _create_multi_upload_request();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Sometimes users may need to use the request ID to consult the cloud service provider about a specific S3 operation's request logs, so it is necessary to provide the request ID.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

