### PR TITLE
[pipelineX](fix) Fix running tasks API core dump

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -378,15 +378,16 @@ std::string PipelineXTask::debug_string() {
                    "PipelineTask[this = {}, state = {}, dry run = {}, elapse time "
                    "= {}s], block dependency = {}, is running = {}\noperators: ",
                    (void*)this, get_state_name(_cur_state), _dry_run, elapsed,
-                   _blocked_dep ? _blocked_dep->debug_string() : "NULL", is_running());
+                   _blocked_dep && !_finished ? _blocked_dep->debug_string() : "NULL",
+                   is_running());
     for (size_t i = 0; i < _operators.size(); i++) {
-        fmt::format_to(
-                debug_string_buffer, "\n{}",
-                _opened ? _operators[i]->debug_string(_state, i) : _operators[i]->debug_string(i));
+        fmt::format_to(debug_string_buffer, "\n{}",
+                       _opened && !_finished ? _operators[i]->debug_string(_state, i)
+                                             : _operators[i]->debug_string(i));
     }
     fmt::format_to(debug_string_buffer, "\n{}",
-                   _opened ? _sink->debug_string(_state, _operators.size())
-                           : _sink->debug_string(_operators.size()));
+                   _opened && !_finished ? _sink->debug_string(_state, _operators.size())
+                                         : _sink->debug_string(_operators.size()));
     if (_finished) {
         return fmt::to_string(debug_string_buffer);
     }


### PR DESCRIPTION
## Proposed changes

==2168255==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x617003b9ee0c at pc 0x55cac64edddb bp 0x7f6824f48e30 sp 0x7f6824f48e28
READ of size 4 at 0x617003b9ee0c thread T2323 (EvHttpServer [w)
    #0 0x55cac64eddda in fmt::v7::detail::value<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>> fmt::v7::detail::make_arg<true, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>, (fmt::v7::detail::type)1, int, 0>(int const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1438:45
    #1 0x55caf9a2f696 in fmt::v7::format_arg_store<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, int const, int const, int const, int const, std::atomic<int>>::format_arg_store(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int const&, int const&, int const&, int const&, std::atomic<int> const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1587:15
    #2 0x55caf9a2f397 in fmt::v7::format_arg_store<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>, std::remove_reference<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>::type, std::remove_reference<int const&>::type, std::remove_reference<int const&>::type, std::remove_reference<int const&>::type, std::remove_reference<int const&>::type, std::remove_reference<std::atomic<int>&>::type> fmt::v7::make_args_checked<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, int const&, int const&, int const&, int const&, std::atomic<int>&, char [77], char>(char const (&) [77], std::remove_reference<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>::type const&, std::remove_reference<int const&>::type const&, std::remove_reference<int const&>::type const&, std::remove_reference<int const&>::type const&, std::remove_reference<int const&>::type const&, std::remove_reference<std::atomic<int>&>::type const&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/core.h:1626:10
    #3 0x55caf9a2c330 in fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>::iterator fmt::v7::format_to<char [77], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, int const&, int const&, int const&, int const&, std::atomic<int>&, 500ul, char>(fmt::v7::basic_memory_buffer<char, 500ul, std::allocator<char>>&, char const (&) [77], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&&, int const&, int const&, int const&, int const&, std::atomic<int>&) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/fmt/format.h:3820:23
    #4 0x55caf9b3a0d5 in doris::pipeline::LocalExchangeSourceLocalState::debug_string[abi:cxx11](int) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/local_exchange/local_exchange_source_operator.cpp:44:5
    #5 0x55caf992c73d in doris::pipeline::OperatorXBase::debug_string[abi:cxx11](doris::RuntimeState*, int) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/operator.cpp:104:51
    #6 0x55caf9e4e4f8 in doris::pipeline::PipelineXTask::debug_string[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:385:42
    #7 0x55caf9d83dcf in doris::pipeline::PipelineXFragmentContext::debug_string[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:1391:83
    #8 0x55cac9b9407e in doris::FragmentMgr::dump_pipeline_tasks[abi:cxx11]() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:768:82
    #9 0x55cacbaf37de in doris::PipelineTaskAction::handle(doris::HttpRequest*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/http/action/pipeline_task_action.cpp:38:69
    #10 0x55cacbbbb0d3 in doris::on_request(evhttp_request*, void*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/http/ev_http_server.cpp:68:25
    #11 0x55cafa7d2066  (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a10f066) (BuildId: bc1ed4d78455b26d)
    #12 0x55cafa7b23e0 in bufferevent_run_readcb_ (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a0ef3e0) (BuildId: bc1ed4d78455b26d)
    #13 0x55cafa7d4282  (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a111282) (BuildId: bc1ed4d78455b26d) 

0x617003b9ee0c is located 1156 bytes after 648-byte region [0x617003b9e700,0x617003b9e988)
freed by thread T1745 (brpc_heavy) here:
    #0 0x55cac6494d9d in operator delete(void*) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x25dd1d9d) (BuildId: bc1ed4d78455b26d)
    #1 0x55cafb99b7b4 in brpc::policy::HttpResponseSender::~HttpResponseSender() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b2d87b4) (BuildId: bc1ed4d78455b26d)
    #2 0x55cafb99f814 in brpc::policy::HttpResponseSenderAsDone::~HttpResponseSenderAsDone() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b2dc814) (BuildId: bc1ed4d78455b26d)
    #3 0x55cac9f08778 in doris::GetResultBatchCtx::on_data(std::unique_ptr<doris::TFetchDataResult, std::default_delete<doris::TFetchDataResult>> const&, long, bool) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/buffer_control_block.cpp:84:13
    #4 0x55cac9f0ac29 in doris::BufferControlBlock::get_batch(doris::GetResultBatchCtx*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/buffer_control_block.cpp:193:14
    #5 0x55cac9f0c892 in doris::PipBufferControlBlock::get_batch(doris::GetResultBatchCtx*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/buffer_control_block.cpp:284:25
    #6 0x55cac9eeed58 in doris::ResultBufferMgr::fetch_data(doris::PUniqueId const&, doris::GetResultBatchCtx*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/result_buffer_mgr.cpp:139:9
    #7 0x55caca3a84aa in doris::PInternalServiceImpl::fetch_data(google::protobuf::RpcController*, doris::PFetchDataRequest const*, doris::PFetchDataResult*, google::protobuf::Closure*)::$_0::operator()() const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/internal_service.cpp:612:34

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

