### PR TITLE
[fix](schema change)support schema change operation between IPv4/IPv6 and VARCHAR/STRING/TEXT

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -617,6 +617,14 @@ public enum PrimitiveType {
         builder.put(TIMEV2, VARCHAR);
         builder.put(TIMEV2, STRING);
 
+        // IPV4
+        builder.put(IPV4, VARCHAR);
+        builder.put(IPV4, STRING);
+
+        // IPV6
+        builder.put(IPV6, VARCHAR);
+        builder.put(IPV6, STRING);
+
         implicitCastMap = builder.build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -96,8 +96,12 @@ public abstract class ColumnType {
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.DATEV2.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.STRING.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.IPV4.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.IPV6.ordinal()] = true;
 
         schemaChangeMatrix[PrimitiveType.STRING.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.STRING.ordinal()][PrimitiveType.IPV4.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.STRING.ordinal()][PrimitiveType.IPV6.ordinal()] = true;
 
         schemaChangeMatrix[PrimitiveType.JSONB.ordinal()][PrimitiveType.STRING.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.JSONB.ordinal()][PrimitiveType.VARCHAR.ordinal()] = true;
@@ -151,6 +155,12 @@ public abstract class ColumnType {
         schemaChangeMatrix[PrimitiveType.DATEV2.ordinal()][PrimitiveType.DATETIMEV2.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.DATETIMEV2.ordinal()][PrimitiveType.DATETIME.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.DATEV2.ordinal()][PrimitiveType.DATE.ordinal()] = true;
+
+        schemaChangeMatrix[PrimitiveType.IPV4.ordinal()][PrimitiveType.VARCHAR.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.IPV4.ordinal()][PrimitiveType.STRING.ordinal()] = true;
+
+        schemaChangeMatrix[PrimitiveType.IPV6.ordinal()][PrimitiveType.VARCHAR.ordinal()] = true;
+        schemaChangeMatrix[PrimitiveType.IPV6.ordinal()][PrimitiveType.STRING.ordinal()] = true;
 
         // we should support schema change between different precision
         schemaChangeMatrix[PrimitiveType.DATETIMEV2.ordinal()][PrimitiveType.DATETIMEV2.ordinal()] = true;

--- a/regression-test/data/datatype_p0/ip/test_ip_schema_change.out
+++ b/regression-test/data/datatype_p0/ip/test_ip_schema_change.out
@@ -1,0 +1,44 @@
+-- !sql1 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql2 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql3 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql4 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql5 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql6 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql7 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql8 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql9 --
+1	0.0.0.0	::
+2	127.0.0.1	2001:1b70:a1:610::b102:2
+3	255.255.255.255	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff

--- a/regression-test/suites/datatype_p0/ip/test_ip_schema_change.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_schema_change.groovy
@@ -1,0 +1,195 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_ip_schema_change") {
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_varchar` """
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_string` """
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_text` """
+
+    sql """ SET enable_nereids_planner=true """
+    sql """ SET enable_fallback_to_original_planner=false """
+
+    // test schema change between `ip` and `varchar`
+    sql """
+        CREATE TABLE `test_ip_schema_change_with_varchar` (
+            `id` INT,
+            `ip_v4` VARCHAR,
+            `ip_v6` VARCHAR
+        )
+        DUPLICATE KEY (`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """
+        INSERT INTO `test_ip_schema_change_with_varchar` VALUES
+        (1, '0.0.0.0', '::'),
+        (2, '127.0.0.1', '2001:1b70:a1:610::b102:2'),
+        (3, '255.255.255.255', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff');
+    """
+
+    qt_sql1 "SELECT * FROM `test_ip_schema_change_with_varchar` ORDER BY id"
+
+    String res = sql """ desc `test_ip_schema_change_with_varchar` """
+
+    assertTrue(res.contains("ip_v4, VARCHAR(65533)") && res.contains("ip_v6, VARCHAR(65533)"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_varchar` MODIFY COLUMN `ip_v4` IPV4"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_varchar` MODIFY COLUMN `ip_v6` IPV6"
+
+    sleep(5000)
+
+    qt_sql2 "SELECT * FROM `test_ip_schema_change_with_varchar` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_varchar` """
+
+    assertTrue(res.contains("ip_v4, IPV4") && res.contains("ip_v6, IPV6"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_varchar` MODIFY COLUMN `ip_v4` VARCHAR"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_varchar` MODIFY COLUMN `ip_v6` VARCHAR"
+
+    sleep(5000)
+
+    qt_sql3 "SELECT * FROM `test_ip_schema_change_with_varchar` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_varchar` """
+
+    assertTrue(res.contains("ip_v4, VARCHAR(65533)") && res.contains("ip_v6, VARCHAR(65533)"))
+
+    // test schema change between `ip` and `string`
+    sql """
+        CREATE TABLE `test_ip_schema_change_with_string` (
+            `id` INT,
+            `ip_v4` STRING,
+            `ip_v6` STRING
+        )
+        DUPLICATE KEY (`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """
+        INSERT INTO `test_ip_schema_change_with_string` VALUES
+        (1, '0.0.0.0', '::'),
+        (2, '127.0.0.1', '2001:1b70:a1:610::b102:2'),
+        (3, '255.255.255.255', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff');
+    """
+
+    qt_sql4 "SELECT * FROM `test_ip_schema_change_with_string` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_string` """
+
+    assertTrue(res.contains("ip_v4, TEXT") && res.contains("ip_v6, TEXT"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_string` MODIFY COLUMN `ip_v4` IPV4"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_string` MODIFY COLUMN `ip_v6` IPV6"
+
+    sleep(5000)
+
+    qt_sql5 "SELECT * FROM `test_ip_schema_change_with_string` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_string` """
+
+    assertTrue(res.contains("ip_v4, IPV4") && res.contains("ip_v6, IPV6"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_string` MODIFY COLUMN `ip_v4` STRING"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_string` MODIFY COLUMN `ip_v6` STRING"
+
+    sleep(5000)
+
+    qt_sql6 "SELECT * FROM `test_ip_schema_change_with_string` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_string` """
+
+    assertTrue(res.contains("ip_v4, TEXT") && res.contains("ip_v6, TEXT"))
+
+    // test schema change between `ip` and `text`
+    sql """
+        CREATE TABLE `test_ip_schema_change_with_text` (
+            `id` INT,
+            `ip_v4` TEXT,
+            `ip_v6` TEXT
+        )
+        DUPLICATE KEY (`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """
+        INSERT INTO `test_ip_schema_change_with_text` VALUES
+        (1, '0.0.0.0', '::'),
+        (2, '127.0.0.1', '2001:1b70:a1:610::b102:2'),
+        (3, '255.255.255.255', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff');
+    """
+
+    qt_sql7 "SELECT * FROM `test_ip_schema_change_with_text` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_text` """
+
+    assertTrue(res.contains("ip_v4, TEXT") && res.contains("ip_v6, TEXT"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_text` MODIFY COLUMN `ip_v4` IPV4"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_text` MODIFY COLUMN `ip_v6` IPV6"
+
+    sleep(5000)
+
+    qt_sql8 "SELECT * FROM `test_ip_schema_change_with_text` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_text` """
+
+    assertTrue(res.contains("ip_v4, IPV4") && res.contains("ip_v6, IPV6"))
+
+    sql "ALTER TABLE `test_ip_schema_change_with_text` MODIFY COLUMN `ip_v4` TEXT"
+
+    sleep(5000)
+
+    sql "ALTER TABLE `test_ip_schema_change_with_text` MODIFY COLUMN `ip_v6` TEXT"
+
+    sleep(5000)
+
+    qt_sql9 "SELECT * FROM `test_ip_schema_change_with_text` ORDER BY id"
+
+    res = sql """ desc `test_ip_schema_change_with_text` """
+
+    assertTrue(res.contains("ip_v4, TEXT") && res.contains("ip_v6, TEXT"))
+
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_varchar` """
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_string` """
+    sql """ DROP TABLE IF EXISTS `test_ip_schema_change_with_text` """
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Support schema change operations for IP and string types.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

