### PR TITLE
[fix](partial-update) Fix dcheck failure in CloudTablet::create_transient_rowset_writer

### DIFF
--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -1162,16 +1162,16 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, const Tablet
     RowsetSharedPtr rowset = txn_info->rowset;
     int64_t cur_version = rowset->start_version();
 
-    auto rowset_writer = DORIS_TRY(self->create_transient_rowset_writer(
-            *rowset, txn_info->partial_update_info, txn_expiration));
-
+    std::unique_ptr<RowsetWriter> transient_rs_writer;
     DeleteBitmapPtr delete_bitmap = txn_info->delete_bitmap;
-    // Partial update might generate new segments when there is conflicts while publish, and mark
-    // the same key in original segments as delete.
-    // When the new segment flush fails or the rowset build fails, the deletion marker for the
-    // duplicate key of the original segment should not remain in `txn_info->delete_bitmap`,
-    // so we need to make a copy of `txn_info->delete_bitmap` and make changes on it.
     if (txn_info->partial_update_info && txn_info->partial_update_info->is_partial_update) {
+        transient_rs_writer = DORIS_TRY(self->create_transient_rowset_writer(
+                *rowset, txn_info->partial_update_info, txn_expiration));
+        // Partial update might generate new segments when there is conflicts while publish, and mark
+        // the same key in original segments as delete.
+        // When the new segment flush fails or the rowset build fails, the deletion marker for the
+        // duplicate key of the original segment should not remain in `txn_info->delete_bitmap`,
+        // so we need to make a copy of `txn_info->delete_bitmap` and make changes on it.
         delete_bitmap = std::make_shared<DeleteBitmap>(*(txn_info->delete_bitmap));
     }
 
@@ -1209,12 +1209,13 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, const Tablet
     // Otherwise, it will be submitted to the thread pool for calculation.
     if (segments.size() <= 1) {
         RETURN_IF_ERROR(calc_delete_bitmap(self, rowset, segments, specified_rowsets, delete_bitmap,
-                                           cur_version - 1, nullptr, rowset_writer.get()));
+                                           cur_version - 1, nullptr, transient_rs_writer.get()));
 
     } else {
         auto token = self->calc_delete_bitmap_executor()->create_token();
         RETURN_IF_ERROR(calc_delete_bitmap(self, rowset, segments, specified_rowsets, delete_bitmap,
-                                           cur_version - 1, token.get(), rowset_writer.get()));
+                                           cur_version - 1, token.get(),
+                                           transient_rs_writer.get()));
         RETURN_IF_ERROR(token->wait());
     }
 
@@ -1247,7 +1248,7 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, const Tablet
         self->_remove_sentinel_mark_from_delete_bitmap(delete_bitmap);
     }
 
-    if (txn_info->partial_update_info && txn_info->partial_update_info->is_partial_update) {
+    if (transient_rs_writer) {
         DBUG_EXECUTE_IF("Tablet.update_delete_bitmap.partial_update_write_rowset_fail", {
             if (rand() % 100 < (100 * dp->param("percent", 0.5))) {
                 LOG_WARNING("Tablet.update_delete_bitmap.partial_update_write_rowset random failed")
@@ -1257,17 +1258,17 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, const Tablet
             }
         });
         // build rowset writer and merge transient rowset
-        RETURN_IF_ERROR(rowset_writer->flush());
+        RETURN_IF_ERROR(transient_rs_writer->flush());
         RowsetSharedPtr transient_rowset;
-        RETURN_IF_ERROR(rowset_writer->build(transient_rowset));
+        RETURN_IF_ERROR(transient_rs_writer->build(transient_rowset));
         rowset->rowset_meta()->merge_rowset_meta(*transient_rowset->rowset_meta());
 
         // erase segment cache cause we will add a segment to rowset
         SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
     }
 
-    RETURN_IF_ERROR(self->save_delete_bitmap(txn_info, txn_id, delete_bitmap, rowset_writer.get(),
-                                             cur_rowset_ids));
+    RETURN_IF_ERROR(self->save_delete_bitmap(txn_info, txn_id, delete_bitmap,
+                                             transient_rs_writer.get(), cur_rowset_ids));
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Fix dcheck failure in CloudTablet::create_transient_rowset_writer

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

