### PR TITLE
(cloud-merge) Fix filecache coredump because the fileWriterMapKey is not unique

### DIFF
--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -89,7 +89,13 @@ private:
     using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
     struct FileWriterMapKeyHash {
         std::size_t operator()(const FileWriterMapKey& w) const {
-            return UInt128Hash()(w.first.value_) + w.second;
+            char* v1 = (char*)&w.first.value_;
+            char* v2 = (char*)&w.second;
+            char buf[24];
+            memcpy(buf, v1, 16);
+            memcpy(buf+16, v2, 8);
+            std::string_view str(buf, 24);
+            return std::hash<std::string_view>{}(str);
         }
     };
 

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -93,9 +93,10 @@ private:
             char* v2 = (char*)&w.second;
             char buf[24];
             memcpy(buf, v1, 16);
-            memcpy(buf+16, v2, 8);
+            memcpy(buf + 16, v2, 8);
             std::string_view str(buf, 24);
-            return std::hash<std::string_view>{}(str);
+            return std::hash<std::string_view> {}(str);
+        }
         }
     };
 

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -86,12 +86,19 @@ private:
 
     void load_cache_info_into_memory(BlockFileCache* _mgr) const;
 
+    using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
+    struct FileWriterMapKeyHash {
+        std::size_t operator()(const FileWriterMapKey& w) const {
+            return UInt128Hash()(w.first.value_) + w.second;
+        }
+    };
+
     std::string _cache_base_path;
     std::thread _cache_background_load_thread;
     const std::shared_ptr<LocalFileSystem>& fs = global_local_filesystem();
     // TODO(Lchangliang): use a more efficient data structure
     std::mutex _mtx;
-    std::unordered_map<UInt128Wrapper, FileWriterPtr, KeyHash> _key_to_writer;
+    std::unordered_map<FileWriterMapKey, FileWriterPtr, FileWriterMapKeyHash> _key_to_writer;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -97,7 +97,6 @@ private:
             std::string_view str(buf, 24);
             return std::hash<std::string_view> {}(str);
         }
-        }
     };
 
     std::string _cache_base_path;


### PR DESCRIPTION
## Proposed changes

Followup #30039

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

