### PR TITLE
[feature](audit) support setting skip audit log user

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2595,6 +2595,13 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean checkpoint_after_check_compatibility = false;
 
+    @ConfField(description = {
+            "在这个列表中的用户的操作，不会被记录到审计日志中。多个用户之间用逗号分隔。",
+            "The operations of the users in this list will not be recorded in the audit log. "
+                    + "Multiple users are separated by commas."
+    })
+    public static String skip_audit_user_list = "";
+
     //==========================================================================
     //                    begin of cloud config
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
@@ -17,17 +17,21 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.plugin.AuditPlugin;
 import org.apache.doris.plugin.Plugin;
 import org.apache.doris.plugin.PluginInfo.PluginType;
 import org.apache.doris.plugin.PluginMgr;
 import org.apache.doris.plugin.audit.AuditEvent;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -49,14 +53,28 @@ public class AuditEventProcessor {
 
     private volatile boolean isStopped = false;
 
+    private Set<String> skipAuditUsers = Sets.newHashSet();
+
     public AuditEventProcessor(PluginMgr pluginMgr) {
         this.pluginMgr = pluginMgr;
     }
 
     public void start() {
+        initSkipAuditUsers();
         workerThread = new Thread(new Worker(), "AuditEventProcessor");
         workerThread.setDaemon(true);
         workerThread.start();
+    }
+
+    private void initSkipAuditUsers() {
+        if (Strings.isNullOrEmpty(Config.skip_audit_user_list)) {
+            return;
+        }
+        String[] users = Config.skip_audit_user_list.replaceAll(" ", "").split(",");
+        for (String user : users) {
+            skipAuditUsers.add(user);
+        }
+        LOG.info("skip audit users: {}", skipAuditUsers);
     }
 
     public void stop() {
@@ -71,6 +89,9 @@ public class AuditEventProcessor {
     }
 
     public void handleAuditEvent(AuditEvent auditEvent) {
+        if (skipAuditUsers.contains(auditEvent.user)) {
+            return;
+        }
         try {
             eventQueue.add(auditEvent);
         } catch (Exception e) {


### PR DESCRIPTION
## Proposed changes

Sometime we don't want to audit all users operation to audit log.
This PR offer a new FE config `skip_audit_users`.
Operations of users in this list will not be logged to audit log and audit table.

eg:

```
skip_audit_users=user1,user2
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

