### PR TITLE
[fix](memory) Fix thread context not initialized in MacOS

### DIFF
--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -147,7 +147,11 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     if (opts.use_page_cache && cache) {
         page_mem_tracker = cache->mem_tracker(opts.type);
     } else {
-        page_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
+        if (is_thread_context_init()) {
+            page_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
+        } else {
+            page_mem_tracker = ExecEnv::GetInstance()->orphan_mem_tracker();
+        }
     }
 
     // hold compressed page at first, reset to decompressed page later

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -38,7 +38,10 @@
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void Allocator<clear_memory_, mmap_populate, use_mmap>::sys_memory_check(size_t size) const {
-    if (doris::is_thread_context_init() && doris::thread_context()->skip_memory_check != 0) {
+    if (!doris::is_thread_context_init()) {
+        return;
+    }
+    if (doris::thread_context()->skip_memory_check != 0) {
         return;
     }
     if (doris::MemTrackerLimiter::sys_mem_exceed_limit_check(size)) {
@@ -132,10 +135,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::sys_memory_check(size_t 
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void Allocator<clear_memory_, mmap_populate, use_mmap>::memory_tracker_check(size_t size) const {
-    if (doris::is_thread_context_init() && doris::thread_context()->skip_memory_check != 0) {
+    if (!doris::is_thread_context_init()) {
         return;
     }
-    if (!doris::is_thread_context_init()) {
+    if (doris::thread_context()->skip_memory_check != 0) {
         return;
     }
     auto st = doris::thread_context()->thread_mem_tracker()->check_limit(size);


### PR DESCRIPTION
## Proposed changes

```
F20240319 20:27:21.981110 125873945 thread_context.h:269] __builtin_unreachableF20240319 20:0F0027:000F000319 21.000020:202427:03981154    19 thread_context.h:269] __builtin_unreachable26927:uiltin_unreachable21.981163 125873946 thread_context.h:269] __builtin_unreachableF20240319 20:27:21.981189 125873942 thread_context.h:269] __builtin_unreachableF20240319 20:27:21.981189 125873941 thread_context.h:269] __builtin_unreachable
*** Check failure stack trace: ***
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf83b4  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10abf43b8  google::LogMessageFatal::~LogMessageFatal()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x10099c198  doris::segment_v2::PageIO::read_and_decompress_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x100941014  doris::segment_v2::IndexedColumnReader::read_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x1009412e0  doris::segment_v2::IndexedColumnIterator::_read_data_page()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x100941718  doris::segment_v2::IndexedColumnIterator::seek_to_ordinal()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1009dcc1c  doris::segment_v2::ZoneMapIndexReader::_load()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1009dd540  _ZNSt3__117__call_once_proxyB7v160006INS_5tupleIJOZN5doris13DorisCallOnceINS2_6StatusEE4callIZNS2_10segment_v218ZoneMapIndexReader4loadEbbE3$_0EES4_T_EUlvE_EEEEEvPv
    @        0x188d9ca30  std::__1::__call_once()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1009dc99c  doris::segment_v2::ZoneMapIndexReader::load()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1008d8450  doris::segment_v2::ColumnReader::_get_filtered_pages()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1008d8314  doris::segment_v2::ColumnReader::get_row_ranges_by_zone_map()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1008df41c  doris::segment_v2::FileColumnIterator::get_row_ranges_by_zone_map()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1009b30cc  doris::segment_v2::SegmentIterator::_get_row_ranges_from_conditions()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x1009ae7f8  doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x1009ad544  doris::segment_v2::SegmentIterator::_lazy_init()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x1009bc45c  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x1009ba7b4  doris::segment_v2::SegmentIterator::next_batch()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10087a608  doris::BetaRowsetReader::next_block()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a521320  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a521558  doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a52346c  doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a51e3d8  doris::vectorized::VCollectIterator::build_heap()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a50ddf8  doris::vectorized::BlockReader::_init_collect_iter()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x10a50eadc  doris::vectorized::BlockReader::init()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x105b9cdf8  std::__1::__function::__func<>::operator()()
    @        0x105b9cdf8  std::__1::__function::__func<>::operator()()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x105b9cdf8  std::__1::__function::__func<>::operator()()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x105b8aa94  doris::vectorized::NewOlapScanner::open()
    @        0x100258958  doris::WorkThreadPool<>::work_thread()
    @        0x100258958  doris::WorkThreadPool<>::work_thread()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x100258958  doris::WorkThreadPool<>::work_thread()
    @        0x105b9b658  doris::vectorized::ScannerScheduler::_scanner_scan()
    @        0x105b9cdf8  std::__1::__function::__func<>::operator()()
    @        0x105b9cdf8  std::__1::__function::__func<>::operator()()
    @        0x10025902c  std::__1::__thread_proxy<>()
    @        0x188e72034  _pthread_start
    @        0x100258958  doris::WorkThreadPool<>::work_thread()
    @        0x10025902c  std::__1::__thread_proxy<>()
    @        0x188e72034  _pthread_start
*** Query id: 0-0 ***
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

