### PR TITLE
[docs](variant)group name optimization

### DIFF
--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/VARIANT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/VARIANT.md
@@ -296,7 +296,7 @@ mysql> SELECT
     ->     cast(repo['name'] as text) as repo_name, count() AS stars
     -> FROM github_events
     -> WHERE type = 'WatchEvent'
-    -> GROUP BY stars 
+    -> GROUP BY repo_name 
     -> ORDER BY stars DESC LIMIT 5;
 +--------------------------+-------+
 | repo_name                | stars |


### PR DESCRIPTION
## Proposed changes
1. SQL query syntax error
2. Change the group name stars to repo_name

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

