### PR TITLE
[feature](cloud) Add one http action for Meta Service to drop storage vault

### DIFF
--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -209,6 +209,7 @@ static HttpResponse process_alter_obj_store_info(MetaServiceImpl* service, brpc:
     static std::unordered_map<std::string_view, AlterObjStoreInfoRequest::Operation> operations {
             {"add_obj_info", AlterObjStoreInfoRequest::ADD_OBJ_INFO},
             {"legacy_update_ak_sk", AlterObjStoreInfoRequest::LEGACY_UPDATE_AK_SK},
+            {"drop_hdfs_vault", AlterObjStoreInfoRequest::DROP_HDFS_INFO}
     };
 
     auto& path = ctrl->http_request().unresolved_path();
@@ -443,6 +444,8 @@ void MetaServiceImpl::http(::google::protobuf::RpcController* controller,
             {"v1/add_obj_info", process_alter_obj_store_info},
             {"v1/legacy_update_ak_sk", process_alter_obj_store_info},
             {"v1/update_ak_sk", process_update_ak_sk},
+            {"show_storage_vaults", process_storage_vault},
+            {"drop_hdfs_vault", process_alter_obj_store_info},
             // for tools
             {"decode_key", process_decode_key},
             {"encode_key", process_encode_key},

--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -444,7 +444,7 @@ void MetaServiceImpl::http(::google::protobuf::RpcController* controller,
             {"v1/add_obj_info", process_alter_obj_store_info},
             {"v1/legacy_update_ak_sk", process_alter_obj_store_info},
             {"v1/update_ak_sk", process_update_ak_sk},
-            {"show_storage_vaults", process_storage_vault},
+            {"show_storage_vaults", process_get_obj_store_info},
             {"drop_hdfs_vault", process_alter_obj_store_info},
             // for tools
             {"decode_key", process_decode_key},

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -245,10 +245,8 @@ void MetaServiceImpl::get_obj_store_info(google::protobuf::RpcController* contro
 
     // Iterate all the resources to return to the rpc caller
     if (!instance.resource_ids().empty()) {
-        std::string storage_vault_start =
-                storage_vault_key({instance_id, *instance.resource_ids().begin()});
-        std::string storage_vault_end = storage_vault_key(
-                {instance_id, instance.resource_ids().at(instance.resource_ids().size() - 1)});
+        std::string storage_vault_start = storage_vault_key({instance_id, ""});
+        std::string storage_vault_end = storage_vault_key({instance_id, "\xff"});
         std::unique_ptr<RangeGetIterator> it;
         do {
             TxnErrorCode err = txn->get(storage_vault_start, storage_vault_end, &it);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

We can get the whole storage vault and obj info message using `get_obj_info` action of Meta Service. Similarly, we add one http action to drop the storage cault.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

