### PR TITLE
[pipelineX](refactor) Wait for 2-phase execution before opening

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -225,6 +225,10 @@ Status PipelineXTask::execute(bool* eos) {
         }
     }};
     *eos = false;
+    if (has_dependency()) {
+        set_state(PipelineTaskState::BLOCKED_FOR_DEPENDENCY);
+        return Status::OK();
+    }
     // The status must be runnable
     if (!_opened) {
         {
@@ -234,10 +238,6 @@ Status PipelineXTask::execute(bool* eos) {
                 return Status::OK();
             }
             RETURN_IF_ERROR(st);
-        }
-        if (has_dependency()) {
-            set_state(PipelineTaskState::BLOCKED_FOR_DEPENDENCY);
-            return Status::OK();
         }
         if (!source_can_read()) {
             set_state(PipelineTaskState::BLOCKED_FOR_SOURCE);


### PR DESCRIPTION
## Proposed changes

Now we do opening without waiting for 2nd rpc triggering. This will cause unknown risks.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

