### PR TITLE
[Fix](trino-connector) fix hive split info of trino-connector catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalCatalog.java
@@ -71,16 +71,17 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.Identity;
 import io.trino.spi.transaction.IsolationLevel;
+import io.trino.spi.type.TimeZoneKey;
 import io.trino.sql.gen.JoinCompiler;
 import io.trino.sql.planner.OptimizerConfig;
 import io.trino.testing.TestingAccessControlManager;
-import io.trino.testing.TestingSession;
 import io.trino.transaction.NoOpTransactionManager;
 import io.trino.type.InternalTypeManager;
 import io.trino.util.EmbedVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -101,6 +102,7 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
 
     private CatalogHandle trinoCatalogHandle;
     private Connector connector;
+    private ConnectorName connectorName;
     private Session trinoSession;
 
     public TrinoConnectorExternalCatalog(long catalogId, String name, String resource,
@@ -138,7 +140,7 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
                 .setSource("test")
                 .setCatalog("catalog")
                 .setSchema("schema")
-                .setTimeZoneKey(TestingSession.DEFAULT_TIME_ZONE_KEY)
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(ZoneId.systemDefault().toString()))
                 .setLocale(Locale.ENGLISH)
                 .setClientCapabilities(Arrays.stream(ClientCapabilities.values()).map(Enum::name)
                         .collect(ImmutableSet.toImmutableSet()))
@@ -196,7 +198,7 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
                     deprecatedConnectorName, connectorNameString);
         }
 
-        ConnectorName connectorName = new ConnectorName(connectorNameString);
+        this.connectorName = new ConnectorName(connectorNameString);
 
         // 2. create CatalogFactory
         LazyCatalogFactory catalogFactory = new LazyCatalogFactory();
@@ -298,6 +300,10 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
 
     public Connector getConnector() {
         return connector;
+    }
+
+    public ConnectorName getConnectorName() {
+        return connectorName;
     }
 
     public CatalogHandle getTrinoCatalogHandle() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
@@ -131,7 +131,7 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         List<Split> splits = Lists.newArrayList();
         while (!splitSource.isFinished()) {
             for (io.trino.metadata.Split split : getNextSplitBatch(splitSource)) {
-                splits.add(new TrinoConnectorSplit(split.getConnectorSplit()));
+                splits.add(new TrinoConnectorSplit(split.getConnectorSplit(), source.getConnectorName()));
             }
         }
         return splits;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSource.java
@@ -24,6 +24,7 @@ import org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalTable;
 import org.apache.doris.thrift.TFileAttributes;
 
 import io.trino.Session;
+import io.trino.connector.ConnectorName;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorTableHandle;
@@ -36,6 +37,7 @@ public class TrinoConnectorSource {
     private final CatalogHandle catalogHandle;
     private final Session trinoSession;
     private final Connector connector;
+    private final ConnectorName connectorName;
     private ConnectorTransactionHandle connectorTransactionHandle;
     private final ConnectorTableHandle trinoConnectorExtTableHandle;
 
@@ -47,6 +49,7 @@ public class TrinoConnectorSource {
         this.trinoConnectorExtTableHandle = table.getConnectorTableHandle();
         this.trinoSession = trinoConnectorExternalCatalog.getTrinoSession();
         this.connector = ((TrinoConnectorExternalCatalog) table.getCatalog()).getConnector();
+        this.connectorName = ((TrinoConnectorExternalCatalog) table.getCatalog()).getConnectorName();
     }
 
     public TupleDescriptor getDesc() {
@@ -79,6 +82,10 @@ public class TrinoConnectorSource {
 
     public Connector getConnector() {
         return connector;
+    }
+
+    public ConnectorName getConnectorName() {
+        return connectorName;
     }
 
     public void setConnectorTransactionHandle(ConnectorTransactionHandle connectorTransactionHandle) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSplit.java
@@ -74,7 +74,7 @@ public class TrinoConnectorSplit extends FileSplit {
                 initHiveSplitInfo();
                 break;
             default:
-                LOG.warn("Unknow connector name: " + connectorName);
+                LOG.debug("Unknow connector name: " + connectorName);
                 return;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSplit.java
@@ -20,17 +20,29 @@ package org.apache.doris.datasource.trinoconnector.source;
 import org.apache.doris.datasource.FileSplit;
 import org.apache.doris.datasource.TableFormatType;
 
+import io.trino.connector.ConnectorName;
+import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import org.apache.hadoop.fs.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class TrinoConnectorSplit extends FileSplit {
+    private static final Logger LOG = LogManager.getLogger(TrinoConnectorSplit.class);
     private ConnectorSplit connectorSplit;
     private TableFormatType tableFormatType;
+    private final ConnectorName connectorName;
 
-    public TrinoConnectorSplit(ConnectorSplit connectorSplit) {
+    public TrinoConnectorSplit(ConnectorSplit connectorSplit, ConnectorName connectorName) {
         super(new Path("dummyPath"), 0, 0, 0, null, null);
         this.connectorSplit = connectorSplit;
         this.tableFormatType = TableFormatType.TRINO_CONNECTOR;
+        this.connectorName = connectorName;
+        initSplitInfo();
     }
 
     public ConnectorSplit getSplit() {
@@ -49,4 +61,34 @@ public class TrinoConnectorSplit extends FileSplit {
         this.tableFormatType = tableFormatType;
     }
 
+    private void initSplitInfo() {
+        // set hosts
+        List<HostAddress> addresses = connectorSplit.getAddresses();
+        this.hosts = new String[addresses.size()];
+        for (int i = 0; i < addresses.size(); i++) {
+            hosts[i] = addresses.get(0).getHostText();
+        }
+
+        switch (connectorName.toString()) {
+            case "hive":
+                initHiveSplitInfo();
+                break;
+            default:
+                LOG.warn("Unknow connector name: " + connectorName);
+                return;
+        }
+    }
+
+    private void initHiveSplitInfo() {
+        Object info = connectorSplit.getInfo();
+        if (info instanceof Map) {
+            Map<String, Object> splitInfo = (Map<String, Object>) info;
+            path = new Path((String) splitInfo.getOrDefault("path", "dummyPath"));
+            start = (long) splitInfo.getOrDefault("start", 0);
+            length = (long) splitInfo.getOrDefault("length", 0);
+            fileLength  = (long) splitInfo.getOrDefault("estimatedFileSize", 0);
+            partitionValues = new ArrayList<>();
+            partitionValues.add((String) splitInfo.getOrDefault("partitionName", ""));
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Before, the ScanNode of trino-Connector did not display the split information.

Now get the corresponding split information through the trino connector API

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

