### PR TITLE
[branch-2.0][opt](information_schema) Add DEFAULT_ENCRYPTION column to schemata table

### DIFF
--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -40,6 +40,7 @@ std::vector<SchemaScanner::ColumnDesc> SchemaSchemataScanner::_s_columns = {
         {"DEFAULT_CHARACTER_SET_NAME", TYPE_VARCHAR, sizeof(StringRef), false},
         {"DEFAULT_COLLATION_NAME", TYPE_VARCHAR, sizeof(StringRef), false},
         {"SQL_PATH", TYPE_VARCHAR, sizeof(StringRef), true},
+        {"DEFAULT_ENCRYPTION", TYPE_VARCHAR, sizeof(StringRef), true},
 };
 
 SchemaSchemataScanner::SchemaSchemataScanner()
@@ -145,6 +146,16 @@ Status SchemaSchemataScanner::_fill_block_impl(vectorized::Block* block) {
     }
     // SQL_PATH
     { fill_dest_column_for_range(block, 4, null_datas); }
+
+    // DEFAULT_ENCRYPTION
+    {
+        std::string src = "NO";
+        StringRef str = StringRef(src.c_str(), src.size());
+        for (int i = 0; i < dbs_num; ++i) {
+            datas[i] = &str;
+        }
+        RETURN_IF_ERROR(fill_dest_column_for_range(block, 5, datas));
+    }
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -147,7 +147,8 @@ public class SchemaTable extends Table {
                             .column("SCHEMA_NAME", ScalarType.createVarchar(32))
                             .column("DEFAULT_CHARACTER_SET_NAME", ScalarType.createVarchar(32))
                             .column("DEFAULT_COLLATION_NAME", ScalarType.createVarchar(32))
-                            .column("SQL_PATH", ScalarType.createVarchar(512)).build()))
+                            .column("SQL_PATH", ScalarType.createVarchar(512))
+                            .column("DEFAULT_ENCRYPTION", ScalarType.createVarchar(3)).build()))
             .put("session_variables",
                     new SchemaTable(SystemIdGenerator.getNextId(), "session_variables", TableType.SCHEMA,
                             builder().column("VARIABLE_NAME", ScalarType.createVarchar(64))


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

pick (#32501)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

