### PR TITLE
[bug](udaf) fix memory leak in the java udaf

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -278,8 +278,8 @@ public:
     }
 
     void create(AggregateDataPtr __restrict place) const override {
+        new (place) Data(argument_types.size());
         if (_first_created) {
-            new (place) Data(argument_types.size());
             Status status = Status::OK();
             SAFE_CREATE(RETURN_IF_STATUS_ERROR(status,
                                                this->data(place).init_udaf(_fn, _local_location)),
@@ -292,8 +292,6 @@ public:
             if (UNLIKELY(!status.ok())) {
                 throw doris::Exception(ErrorCode::INTERNAL_ERROR, status.to_string());
             }
-        } else {
-            new (place) Data(argument_types.size());
         }
     }
 
@@ -303,14 +301,12 @@ public:
             Status status = Status::OK();
             status = this->data(_exec_place).destroy();
             status = this->data(_exec_place).close_and_delete_object();
-            this->data(_exec_place).~Data();
             _first_created = true;
             if (UNLIKELY(!status.ok())) {
                 LOG(WARNING) << "Failed to destroy function: " << status.to_string();
             }
-        } else {
-            this->data(place).~Data();
         }
+        this->data(place).~Data();
     }
 
     String get_name() const override { return _fn.name.function_name; }


### PR DESCRIPTION
## Proposed changes
before:
if someone call destroy function with place,
when  place != _exec_place maybe do nothing , 
when  place == _exec_place, do destroy of all place,
as we not want call JNI every times, so will destroy all place at once.
but not call this->data(place).~Data(); this maybe not release the use memory of std::string serialize_data.



Issue Number: close #xxx


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

