### PR TITLE
[fix](backup) clear snapshot info for cancelled backup job to reduce log size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -859,6 +859,7 @@ public class BackupJob extends AbstractJob {
         }
 
         releaseSnapshots();
+        snapshotInfos.clear();
 
         BackupJobState curState = state;
         finishedTime = System.currentTimeMillis();


### PR DESCRIPTION
Cherry-pick #32604