### PR TITLE
[Fix](Export) fix variable name of code

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -372,7 +372,7 @@ public class ExportStmt extends StatementBase {
             }
             this.dataConsistency = ExportJob.CONSISTENT_PARTITION;
         } else {
-            this.dataConsistency = ExportJob.CONSISTENT_ALL;
+            this.dataConsistency = ExportJob.CONSISTENT_NONE;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -109,7 +109,7 @@ public class ExportJob implements Writable {
 
     private static final int MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT = Config.maximum_tablets_of_outfile_in_export;
 
-    public static final String CONSISTENT_ALL = "all";
+    public static final String CONSISTENT_NONE = "none";
     public static final String CONSISTENT_PARTITION = "partition";
 
     @SerializedName("id")

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -320,7 +320,7 @@ public class ExportCommand extends Command implements ForwardWithSync {
             }
             exportJob.setDataConsistency(ExportJob.CONSISTENT_PARTITION);
         } else {
-            exportJob.setDataConsistency(ExportJob.CONSISTENT_ALL);
+            exportJob.setDataConsistency(ExportJob.CONSISTENT_NONE);
         }
 
         // Must copy session variable, because session variable may be changed during export job running.


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

related: #31290

Because the name of this property is `data consistence` , `none` means data consistency is not guaranteed.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

