### PR TITLE
[fix](Nereids) IGNORE_STORAGE_DATA_DISTRIBUTION should not block generating filter for nested loop join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -315,6 +315,11 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         if (join.getJoinType() != JoinType.LEFT_SEMI_JOIN && join.getJoinType() != JoinType.CROSS_JOIN) {
             return;
         }
+        if (ctx.getSessionVariable().isIgnoreStorageDataDistribution()) {
+            // BITMAP filter is not supported to merge. So we disable this kind of runtime filter
+            // if IgnoreStorageDataDistribution is enabled.
+            return;
+        }
         List<Slot> leftSlots = join.left().getOutput();
         List<Slot> rightSlots = join.right().getOutput();
         List<Expression> bitmapRuntimeFilterConditions = JoinUtils.extractBitmapRuntimeFilterConditions(leftSlots,
@@ -446,11 +451,6 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
             return join;
         }
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        if (ctx.getSessionVariable().isIgnoreStorageDataDistribution()) {
-            // BITMAP filter is not supported to merge. So we disable this kind of runtime filter
-            // if IgnoreStorageDataDistribution is enabled.
-            return join;
-        }
 
         if ((ctx.getSessionVariable().getRuntimeFilterType() & TRuntimeFilterType.BITMAP.getValue()) != 0) {
             generateBitMapRuntimeFilterForNLJ(join, ctx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -315,11 +315,6 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         if (join.getJoinType() != JoinType.LEFT_SEMI_JOIN && join.getJoinType() != JoinType.CROSS_JOIN) {
             return;
         }
-        if (ctx.getSessionVariable().isIgnoreStorageDataDistribution()) {
-            // BITMAP filter is not supported to merge. So we disable this kind of runtime filter
-            // if IgnoreStorageDataDistribution is enabled.
-            return;
-        }
         List<Slot> leftSlots = join.left().getOutput();
         List<Slot> rightSlots = join.right().getOutput();
         List<Expression> bitmapRuntimeFilterConditions = JoinUtils.extractBitmapRuntimeFilterConditions(leftSlots,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

