### PR TITLE
[bugfix](hive)use `originHiveKeys` for hive partitionvalue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
@@ -234,6 +234,11 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     }
 
     public List<String> getPartitionValuesAsStringList() {
+        if (originHiveKeys.size() == keys.size()) {
+            // for hive, we need ues originHiveKeys
+            // because when a double 1.234 as partition column, it will save as '1.123000' for PartitionValue
+            return getPartitionValuesAsStringListForHive();
+        }
         return keys.stream().map(k -> k.getStringValue()).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Proposed changes

We will speed up reading the hive table by caching partition information. When the hive table partition information changes, we can refresh the cached partition information through `refresh table <hive-table>`. 
But we saved the partition value incorrectly, causing the cache to not be refreshed normally.

We should use partition value from `originHiveKeys`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

