### PR TITLE
[Bug](materialized-view) do not check key/value column when index is dup or mow

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1777,13 +1777,13 @@ Status SegmentIterator::_read_columns(const std::vector<ColumnId>& column_ids,
     return Status::OK();
 }
 
-void SegmentIterator::_init_current_block(
+Status SegmentIterator::_init_current_block(
         vectorized::Block* block, std::vector<vectorized::MutableColumnPtr>& current_columns) {
     block->clear_column_data(_schema->num_column_ids());
 
     for (size_t i = 0; i < _schema->num_column_ids(); i++) {
         auto cid = _schema->column_id(i);
-        auto column_desc = _schema->column(cid);
+        const auto* column_desc = _schema->column(cid);
         if (!_is_pred_column[cid] &&
             !_segment->same_with_storage_type(
                     cid, *_schema, _opts.io_ctx.reader_type != ReaderType::READER_QUERY)) {
@@ -1803,6 +1803,11 @@ void SegmentIterator::_init_current_block(
             // the column in block must clear() here to insert new data
             if (_is_pred_column[cid] ||
                 i >= block->columns()) { //todo(wb) maybe we can release it after output block
+                if (current_columns[cid].get() == nullptr) {
+                    return Status::InternalError(
+                            "SegmentIterator meet invalid column, id={}, name={}", cid,
+                            _schema->column(cid)->name());
+                }
                 current_columns[cid]->clear();
             } else { // non-predicate column
                 current_columns[cid] = std::move(*block->get_by_position(i).column).mutate();
@@ -1816,6 +1821,7 @@ void SegmentIterator::_init_current_block(
             }
         }
     }
+    return Status::OK();
 }
 
 void SegmentIterator::_output_non_pred_columns(vectorized::Block* block) {
@@ -2207,7 +2213,7 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             }
         }
     }
-    _init_current_block(block, _current_return_columns);
+    RETURN_IF_ERROR(_init_current_block(block, _current_return_columns));
     _converted_column_ids.assign(_schema->columns().size(), 0);
 
     _current_batch_rows_read = 0;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -218,7 +218,7 @@ private:
                                                 bool set_block_rowid);
     void _replace_version_col(size_t num_rows);
     Status _init_current_block(vectorized::Block* block,
-                             std::vector<vectorized::MutableColumnPtr>& non_pred_vector);
+                               std::vector<vectorized::MutableColumnPtr>& non_pred_vector);
     uint16_t _evaluate_vectorization_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);
     uint16_t _evaluate_short_circuit_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);
     void _output_non_pred_columns(vectorized::Block* block);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -217,7 +217,7 @@ private:
     [[nodiscard]] Status _read_columns_by_index(uint32_t nrows_read_limit, uint32_t& nrows_read,
                                                 bool set_block_rowid);
     void _replace_version_col(size_t num_rows);
-    void _init_current_block(vectorized::Block* block,
+    Status _init_current_block(vectorized::Block* block,
                              std::vector<vectorized::MutableColumnPtr>& non_pred_vector);
     uint16_t _evaluate_vectorization_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);
     uint16_t _evaluate_short_circuit_predicate(uint16_t* sel_rowid_idx, uint16_t selected_size);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -126,12 +126,6 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return keysType;
     }
 
-    public boolean isDupKeysOrMergeOnWrite() {
-        // temporarily assume mv index is not mow because mow table not support create mv now
-        return getKeysType() == KeysType.DUP_KEYS;
-    }
-
-
     public void setKeysType(KeysType keysType) {
         this.keysType = keysType;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -126,6 +126,12 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return keysType;
     }
 
+    public boolean isDupKeysOrMergeOnWrite() {
+        // temporarily assume mv index is not mow because mow table not support create mv now
+        return getKeysType() == KeysType.DUP_KEYS;
+    }
+
+
     public void setKeysType(KeysType keysType) {
         this.keysType = keysType;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -375,7 +375,11 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
         if (isNullLiteral()) {
             return false;
         }
-        if (dataType.isSmallIntType() || dataType.isTinyIntType() || dataType.isIntegerType()) {
+        if (dataType.isTinyIntType()) {
+            return getValue().equals((byte) 0);
+        } else if (dataType.isSmallIntType()) {
+            return getValue().equals((short) 0);
+        } else if (dataType.isIntegerType()) {
             return getValue().equals(0);
         } else if (dataType.isBigIntType()) {
             return getValue().equals(0L);

--- a/regression-test/data/mv_p0/test_dup_mv_plus/test_dup_mv_plus.out
+++ b/regression-test/data/mv_p0/test_dup_mv_plus/test_dup_mv_plus.out
@@ -37,9 +37,9 @@
 
 -- !select_group_mv_add --
 -4
+3
 1
 2
--3
 
 -- !select_group_mv_not --
 -3

--- a/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
@@ -18,9 +18,6 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("mv_ssb_q_1_1") {
-
-    sql """set enable_nereids_planner=false"""
-
     sql """ DROP TABLE IF EXISTS lineorder_flat; """
 
     sql """

--- a/regression-test/suites/mv_p0/ssb/q_4_1/q_4_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_4_1/q_4_1.groovy
@@ -18,9 +18,6 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("mv_ssb_q_4_1") {
-
-    sql """set enable_nereids_planner=false"""
-
     sql """ DROP TABLE IF EXISTS lineorder_flat; """
 
     sql """

--- a/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
@@ -18,10 +18,6 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("test_dup_mv_plus") {
-
-    // because nereids cannot support rollup correctly forbid it temporary
-    sql """set enable_nereids_planner=false"""
-
     sql """ DROP TABLE IF EXISTS d_table; """
 
     sql """
@@ -59,10 +55,10 @@ suite ("test_dup_mv_plus") {
     qt_select_mv_sub "select k2+1 from d_table order by k1;"
 
     explain {
-        sql("select k2+1-1 from d_table order by k1;")
+        sql("select k2+1 from d_table order by k1+1-1;")
         contains "(k12p)"
     }
-    qt_select_mv_sub_add "select k2+1-1 from d_table order by k1;"
+    qt_select_mv_sub_add "select k2+1-1 from d_table order by k1+1-1;"
 
     explain {
         sql("select sum(k2+1) from d_table group by k1 order by k1;")
@@ -77,10 +73,10 @@ suite ("test_dup_mv_plus") {
     qt_select_group_mv "select sum(k1) from d_table group by k2+1 order by k2+1;"
 
     explain {
-        sql("select sum(k2+1-1) from d_table group by k1 order by k1;")
+        sql("select sum(k1+1-1) from d_table group by k2+1 order by k2+1;")
         contains "(k12p)"
     }
-    qt_select_group_mv_add "select sum(k2+1-1) from d_table group by k1 order by k1;"
+    qt_select_group_mv_add "select sum(k1+1-1) from d_table group by k2+1 order by k2+1;"
 
     explain {
         sql("select sum(k2) from d_table group by k3;")

--- a/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
@@ -56,7 +56,6 @@ suite ("testProjectionMV1") {
     }
     qt_select_mv "select empid, deptno from emps order by empid;"
 
-    sql """set enable_nereids_planner=false""" // need fix it on nereids
     explain {
         sql("select empid, sum(deptno) from emps group by empid order by empid;")
         contains "(emps_mv)"


### PR DESCRIPTION
## Proposed changes
1. do not check key/value column when index is dup or mow
2. enable nereids on some mv case
3. fix wrong implementation of iszero
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

