### PR TITLE
[Improve](build-script)Add be-extension-ignore to ignore avro-scanner when building release packages

### DIFF
--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -145,7 +145,7 @@ echo "JAR:  ${OUTPUT_EXT}"
 
 sh build.sh --clean &&
     USE_AVX2="${_USE_AVX2}" sh build.sh &&
-    USE_AVX2="${_USE_AVX2}" sh build.sh --be --meta-tool
+    USE_AVX2="${_USE_AVX2}" sh build.sh --be --meta-tool --be-extension-ignore avro-scanner
 
 echo "Begin to pack"
 rm -rf "${OUTPUT}"

--- a/build.sh
+++ b/build.sh
@@ -492,9 +492,9 @@ if [[ "${BUILD_BE_JAVA_EXTENSIONS}" -eq 1 ]]; then
 
     # If the BE_EXTENSION_IGNORE variable is not empty, remove the modules that need to be ignored from FE_MODULES
     if [[ -n "${BE_EXTENSION_IGNORE}" ]]; then
-        IFS=',' read -r -a ignore_modules <<< "${BE_EXTENSION_IGNORE}"
+        IFS=',' read -r -a ignore_modules <<<"${BE_EXTENSION_IGNORE}"
         for module in "${ignore_modules[@]}"; do
-            modules=("${modules[@]/be-java-extensions\/${module}}")
+            modules=("${modules[@]/be-java-extensions\/${module}/}")
         done
     fi
 fi
@@ -779,7 +779,7 @@ EOF
     extensions_modules+=("preload-extensions")
 
     if [[ -n "${BE_EXTENSION_IGNORE}" ]]; then
-        IFS=',' read -r -a ignore_modules <<< "${BE_EXTENSION_IGNORE}"
+        IFS=',' read -r -a ignore_modules <<<"${BE_EXTENSION_IGNORE}"
         new_modules=()
         for module in "${extensions_modules[@]}"; do
             module=${module// /}


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

