### PR TITLE
[Bug] Error occurred while passing status up

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -319,10 +319,10 @@ public:
     Status seek_to_position_in_page(size_t pos) override {
         DCHECK(_parsed) << "Must call init()";
         if (PREDICT_FALSE(_num_elements == 0)) {
+            // num_element is not increased when there is a NULL value in the table,
+            // but data is not empty and should not return error here
             DCHECK_EQ(0, pos);
-            return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("invalid pos");
         }
-
         DCHECK_LE(pos, _num_elements);
         _cur_index = pos;
         return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -367,7 +367,7 @@ public:
     bool is_all_dict_encoding() const override { return _is_all_dict_encoding; }
 
 private:
-    void _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page) const;
+    Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page) const;
     Status _load_next_page(bool* eos);
     Status _read_data_page(const OrdinalPageIndexIterator& iter);
     Status _read_dict_data();


### PR DESCRIPTION
## Proposed changes

Issue Number: #31892

<!--Describe your changes.-->

## Further comments

When querying a table with only NULL values, the function seek_to_position_in_page will misjudge and pass status upward, as shown in Figure, where data is not empty, but num_element is 0
![截图 2024-03-23 20-04-57.png](https://img2.imgtp.com/2024/03/23/3nm1nG8Y.png)

