### PR TITLE
[bugfix](use after free) should not set finish depdency any more if task ctx lock failed

### DIFF
--- a/be/src/vec/sink/writer/async_result_writer.cpp
+++ b/be/src/vec/sink/writer/async_result_writer.cpp
@@ -101,7 +101,6 @@ Status AsyncResultWriter::start_writer(RuntimeState* state, RuntimeProfile* prof
         RETURN_IF_ERROR(pool_ptr->submit_func([this, state, profile, task_ctx]() {
             auto task_lock = task_ctx.lock();
             if (task_lock == nullptr) {
-                _set_ready_to_finish();
                 return;
             }
             this->process_block(state, profile);
@@ -111,7 +110,6 @@ Status AsyncResultWriter::start_writer(RuntimeState* state, RuntimeProfile* prof
                 [this, state, profile, task_ctx]() {
                     auto task_lock = task_ctx.lock();
                     if (task_lock == nullptr) {
-                        _set_ready_to_finish();
                         return;
                     }
                     this->process_block(state, profile);


### PR DESCRIPTION
## Proposed changes

If task ctx lock failed, it means the runtime state or fragment context is deconstruted.
And it also means the operator and exec node is deconstruted, then if we want to set set finish dependency, it will core because of use after free.

Only in PipelineX

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

