### PR TITLE
[fix](pipeline) fix check failed in StatefulOperator

### DIFF
--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -130,6 +130,9 @@ public:
         _origin_block.clear_column_data(_row_descriptor.num_materialized_slots());
     }
 
+    // Force clear _origin_block, currently only used in StatefulOperator.
+    void force_clear_origin_block() { _origin_block.clear(); }
+
     // Emit data, both need impl with method: sink
     // Eg: Aggregation, Sort, Scan
     [[nodiscard]] virtual Status pull(RuntimeState* state, vectorized::Block* output_block,

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -430,7 +430,10 @@ public:
             RETURN_IF_ERROR(node->get_next_after_projects(
                     state, block, &eos,
                     std::bind(&ExecNode::pull, node, std::placeholders::_1, std::placeholders::_2,
-                              std::placeholders::_3)));
+                              std::placeholders::_3),
+                    false));
+            // The old code always had clear_data set to true, so here we are changing it to pull first and then clear.
+            node->force_clear_origin_block();
             if (eos) {
                 source_state = SourceState::FINISHED;
             } else if (!node->need_more_input_data()) {


### PR DESCRIPTION
## Proposed changes

fix
```
F20240324 11:48:03.674883 55270 block.cpp:703] Check failed: d.column->use_count() == 1 (2 vs. 1)  , [k1, 2], [k2, 2]
*** Check failure stack trace: ***
    @     0x55df632ea216  google::LogMessageFatal::~LogMessageFatal()
    @     0x55df4a348f3c  doris::vectorized::Block::clear_column_data()
    @     0x55df618c09b1  doris::pipeline::StatefulOperator<>::get_block()
    @     0x55df62a721cf  doris::pipeline::PipelineTask::execute()
    @     0x55df62f89be7  doris::pipeline::TaskScheduler::_do_work()
    @     0x55df3a704b4d  doris::ThreadPool::dispatch_thread()
    @     0x55df3a6e26c9  doris::Thread::supervise_thread()
    @     0x7f9e03460609  start_thread
```


In the StatefulOperator, there is code like this:
```
Status NestLoopJoinProbeOperator::prepare(doris::RuntimeState* state) {
    // just for speed up, the way is dangerous
    _child_block = _node->get_left_block();
    return StatefulOperator::prepare(state);
}
```
This will lead to a failure in the check because both _origin_block in the exec node of the old pipeline and _child_block in the StatefulOperator will simultaneously hold the same column.
Here's the modification: previously, we would clear _origin_block and then pull, but here we are switching to pulling first and then clearing _origin_block.



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

