### PR TITLE
[pipelineX](scanner) Fix scanner projection DCHECK failure

### DIFF
--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -174,6 +174,25 @@ Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Bl
     SCOPED_TIMER(exec_timer);
     SCOPED_TIMER(projection_timer);
 
+    auto insert_column_datas = [&](auto& to, vectorized::ColumnPtr& from, size_t rows) {
+        if (to->is_nullable() && !from->is_nullable()) {
+            if (!from->is_exclusive()) {
+                auto& null_column = reinterpret_cast<vectorized::ColumnNullable&>(*to);
+                null_column.get_nested_column().insert_range_from(*from, 0, rows);
+                null_column.get_null_map_column().get_data().resize_fill(rows, 0);
+            } else {
+                to = make_nullable(from, false)->assume_mutable();
+            }
+        } else {
+            if (!from->is_exclusive()) {
+                to->insert_range_from(*from, 0, rows);
+            } else {
+                to = from->assume_mutable();
+            }
+        }
+    };
+
+    using namespace vectorized;
     MutableBlock mutable_block =
             VectorizedUtils::build_mutable_mem_reuse_block(output_block, *_output_row_descriptor);
     auto rows = origin_block->rows();
@@ -183,9 +202,9 @@ Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Bl
 
         if (mutable_columns.size() != _projections.size()) {
             return Status::InternalError(
-                    "Logical error in scanner, output of projections {} mismatches with "
-                    "scanner output {}",
-                    _projections.size(), mutable_columns.size());
+                    "Logical error during processing {}, output of projections {} mismatches with "
+                    "exec node output {}",
+                    this->get_name(), _projections.size(), mutable_columns.size());
         }
 
         for (int i = 0; i < mutable_columns.size(); ++i) {
@@ -193,14 +212,7 @@ Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Bl
             RETURN_IF_ERROR(_projections[i]->execute(origin_block, &result_column_id));
             auto column_ptr = origin_block->get_by_position(result_column_id)
                                       .column->convert_to_full_column_if_const();
-            //TODO: this is a quick fix, we need a new function like "change_to_nullable" to do it
-            if (mutable_columns[i]->is_nullable() xor column_ptr->is_nullable()) {
-                DCHECK(mutable_columns[i]->is_nullable() && !column_ptr->is_nullable());
-                reinterpret_cast<ColumnNullable*>(mutable_columns[i].get())
-                        ->insert_range_from_not_nullable(*column_ptr, 0, rows);
-            } else {
-                mutable_columns[i]->insert_range_from(*column_ptr, 0, rows);
-            }
+            insert_column_datas(mutable_columns[i], column_ptr, rows);
         }
         DCHECK(mutable_block.rows() == rows);
         output_block->set_columns(std::move(mutable_columns));

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -174,7 +174,7 @@ Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Bl
     SCOPED_TIMER(exec_timer);
     SCOPED_TIMER(projection_timer);
 
-    auto insert_column_datas = [&](auto& to, vectorized::ColumnPtr& from, size_t rows) {
+    auto insert_column_data = [&](auto& to, vectorized::ColumnPtr& from, size_t rows) {
         if (to->is_nullable() && !from->is_nullable()) {
             if (!from->is_exclusive()) {
                 auto& null_column = reinterpret_cast<vectorized::ColumnNullable&>(*to);
@@ -212,7 +212,7 @@ Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Bl
             RETURN_IF_ERROR(_projections[i]->execute(origin_block, &result_column_id));
             auto column_ptr = origin_block->get_by_position(result_column_id)
                                       .column->convert_to_full_column_if_const();
-            insert_column_datas(mutable_columns[i], column_ptr, rows);
+            insert_column_data(mutable_columns[i], column_ptr, rows);
         }
         DCHECK(mutable_block.rows() == rows);
         output_block->set_columns(std::move(mutable_columns));


### PR DESCRIPTION
## Proposed changes

*** Query id: 96cf20fbb1594480-8d575b2d346c7771 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1711285486 (unix time) try "date -d @1711285486" if you are using GNU date ***
*** Current BE git commitID: 55ae41000f ***
*** SIGABRT unknown detail explain (@0x3bf2d8) received by PID 3928792 (TID 3929272 OR 0x7f3037ae5700) from PID 3928792; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F3331B2A090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x00005594A734D41D in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 5# 0x00005594A733FB7A in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 9# doris::vectorized::VScanner::_do_projections(doris::vectorized::Block*, doris::vectorized::Block*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
10# doris::vectorized::VScanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/scan/vscanner.cpp:82
11# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr, std::shared_ptr) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:267
12# doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_2::operator()() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:169
13# void std::__invoke_impl, std::shared_ptr)::$_2&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_2&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
14# std::enable_if, std::shared_ptr)::$_2&>, void>::type std::__invoke_r, std::shared_ptr)::$_2&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_2&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
15# std::_Function_handler, std::shared_ptr)::$_2>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
16# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
17# doris::WorkThreadPool::work_thread(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:158
18# void std::__invoke_impl::* const&)(int), doris::WorkThreadPool*&, int&>(std::__invoke_memfun_deref, void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
19# std::__invoke_result::* const&)(int), doris::WorkThreadPool*&, int&>::type std::__invoke::* const&)(int), doris::WorkThreadPool*&, int&>(void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
20# decltype (std::__invoke((*this)._M_pmf, std::forward*&>({parm#1}), std::forward({parm#1}))) std::_Mem_fn_base::*)(int), true>::operator()*&, int&>(doris::WorkThreadPool*&, int&) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:131
21# void std::__invoke_impl::*)(int)>&, doris::WorkThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
22# std::enable_if::*)(int)>&, doris::WorkThreadPool*&, int&>, void>::type std::__invoke_r::*)(int)>&, doris::WorkThreadPool*&, int&>(std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
23# void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
24# void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::operator()<>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
25# void std::__invoke_impl::*)(int)> (doris::WorkThreadPool*, int)>>(std::__invoke_other, std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
26# std::__invoke_result::*)(int)> (doris::WorkThreadPool*, int)>>::type std::__invoke::*)(int)> (doris::WorkThreadPool*, int)>>(std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
27# void std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253
28# std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)> > >::operator()() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260
29# std::thread::_State_impl::*)(int)> (doris::WorkThreadPool*, int)> > > >::_M_run() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211
30# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
31# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
32# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

