### PR TITLE
[fix](pipeline) fix check failed in StatefulOperator

### DIFF
--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -86,7 +86,12 @@ Status JoinProbeLocalState<SharedStateArg, Derived>::_build_output_block(
         // In previous versions, the join node had a separate set of project structures,
         // and you could see a 'todo' in the Thrift definition.
         //  Here, we have refactored it, but considering upgrade compatibility, we still need to retain the old code.
-        *output_block = *origin_block;
+        if (!output_block->mem_reuse()) {
+            vectorized::MutableBlock tmp(
+                    vectorized::VectorizedUtils::create_columns_with_type_and_name(p.row_desc()));
+            output_block->swap(tmp.to_block());
+        }
+        output_block->swap(*origin_block);
         return Status::OK();
     }
     SCOPED_TIMER(_build_output_block_timer);

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -184,7 +184,11 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
         // In previous versions, the join node had a separate set of project structures,
         // and you could see a 'todo' in the Thrift definition.
         //  Here, we have refactored it, but considering upgrade compatibility, we still need to retain the old code.
-        *output_block = *origin_block;
+        if (!output_block->mem_reuse()) {
+            MutableBlock tmp(VectorizedUtils::create_columns_with_type_and_name(row_desc()));
+            output_block->swap(tmp.to_block());
+        }
+        output_block->swap(*origin_block);
         return Status::OK();
     }
     auto is_mem_reuse = output_block->mem_reuse();


### PR DESCRIPTION
## Proposed changes

fix
```
F20240324 11:48:03.674883 55270 block.cpp:703] Check failed: d.column->use_count() == 1 (2 vs. 1)  , [k1, 2], [k2, 2]
*** Check failure stack trace: ***
    @     0x55df632ea216  google::LogMessageFatal::~LogMessageFatal()
    @     0x55df4a348f3c  doris::vectorized::Block::clear_column_data()
    @     0x55df618c09b1  doris::pipeline::StatefulOperator<>::get_block()
    @     0x55df62a721cf  doris::pipeline::PipelineTask::execute()
    @     0x55df62f89be7  doris::pipeline::TaskScheduler::_do_work()
    @     0x55df3a704b4d  doris::ThreadPool::dispatch_thread()
    @     0x55df3a6e26c9  doris::Thread::supervise_thread()
    @     0x7f9e03460609  start_thread
```

error pr
https://github.com/apache/doris/pull/32439

error code

```
    if (!Base::_projections.empty()) {
        *output_block = *origin_block;
```

This will lead to a failure in the check because both _origin_block in the exec node of the pipeline and _child_block in the StatefulOperator will simultaneously hold the same column.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

