### PR TITLE
[fix](merge-cloud) MS return KV_TXN_CONFLICT_RETRY_TIMEOUT instead of KV_TXN_CONFLICT

### DIFF
--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -622,11 +622,14 @@ private:
 
             TEST_SYNC_POINT("MetaServiceProxy::call_impl:2");
             if (--retry_times < 0) {
+                // For KV_TXN_CONFLICT, we should return KV_TXN_CONFLICT_RETRY_EXCEEDED_MAX_TIMES,
+                // because BE will retries the KV_TXN_CONFLICT error.
                 resp->mutable_status()->set_code(
-                        code == MetaServiceCode::KV_TXN_STORE_COMMIT_RETRYABLE   ? KV_TXN_COMMIT_ERR
-                        : code == MetaServiceCode::KV_TXN_STORE_GET_RETRYABLE    ? KV_TXN_GET_ERR
-                        : code == MetaServiceCode::KV_TXN_STORE_CREATE_RETRYABLE ? KV_TXN_CREATE_ERR
-                                                                                 : code);
+                        code == MetaServiceCode::KV_TXN_STORE_COMMIT_RETRYABLE ? KV_TXN_COMMIT_ERR
+                        : code == MetaServiceCode::KV_TXN_STORE_GET_RETRYABLE  ? KV_TXN_GET_ERR
+                        : code == MetaServiceCode::KV_TXN_STORE_CREATE_RETRYABLE
+                                ? KV_TXN_CREATE_ERR
+                                : KV_TXN_CONFLICT_RETRY_EXCEEDED_MAX_TIMES);
                 return;
             }
 

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1220,6 +1220,9 @@ enum MetaServiceCode {
     // partial update
     ROWSET_META_NOT_FOUND = 9001;
 
+    // The meta service retries KV_TXN_CONFLICT error but is exceeded the max times.
+    KV_TXN_CONFLICT_RETRY_EXCEEDED_MAX_TIMES = 10001;
+
     UNDEFINED_ERR = 1000000;
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

For KV_TXN_CONFLICT, we should return KV_TXN_CONFLICT_RETRY_TIMEOUT, because BE will retries the KV_TXN_CONFLICT error.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

