### PR TITLE
[fix](arrow-flight) Fix arrow flight sql compatible with JDK 17 and upgrade arrow 15.0.2

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -620,8 +620,6 @@ int main(int argc, char** argv) {
     brpc_service.reset(nullptr);
     LOG(INFO) << "Brpc service stopped";
     service.reset();
-    LOG(INFO) << "Backend Service stopped";
-    exec_env->destroy();
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
     LOG(INFO) << "Doris main exited.";
     return 0;

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -619,6 +619,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Be server stopped";
     brpc_service.reset(nullptr);
     LOG(INFO) << "Brpc service stopped";
+    service.reset();
+    LOG(INFO) << "Backend Service stopped";
     exec_env->destroy();
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
     LOG(INFO) << "Doris main exited.";

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -619,7 +619,7 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Be server stopped";
     brpc_service.reset(nullptr);
     LOG(INFO) << "Brpc service stopped";
-    service.reset();
+    exec_env->destroy();
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
     LOG(INFO) << "Doris main exited.";
     return 0;

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -206,6 +206,13 @@ under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
     </build>
     <modules>
         <module>fe-common</module>
@@ -305,7 +312,7 @@ under the License.
         <iceberg.version>1.4.3</iceberg.version>
         <maxcompute.version>0.45.2-public</maxcompute.version>
         <avro.version>1.11.3</avro.version>
-        <arrow.version>15.0.0</arrow.version>
+        <arrow.version>15.0.2</arrow.version>
         <!-- hudi -->
         <hudi.version>0.14.1</hudi.version>
         <presto.hadoop.version>2.7.4-11</presto.hadoop.version>

--- a/regression-test/framework/pom.xml
+++ b/regression-test/framework/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <antlr.version>4.9.3</antlr.version>
         <hadoop.version>2.8.0</hadoop.version>
         <aws-java-sdk-s3.version>1.11.95</aws-java-sdk-s3.version>
-        <arrow.version>15.0.0</arrow.version>
+        <arrow.version>15.0.2</arrow.version>
     </properties>
     <build>
         <plugins>

--- a/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_in_expr", "query,arrow_flight_sql") {
+suite("test_in_expr", "query") { // "arrow_flight_sql", groovy not support print arrow array type, throw IndexOutOfBoundsException.
     def nullTableName = "in_expr_test_null"
     def notNullTableName = "in_expr_test_not_null"
 

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
@@ -14,7 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_window_fn", "arrow_flight_sql") {
+suite("test_window_fn") {
+    // "arrow_flight_sql", groovy use flight sql connection to execute query `SUM(MAX(c1) OVER (PARTITION BY))` report error:
+    // `AGGREGATE clause must not contain analytic expressions`, but no problem in Java execute it with `jdbc::arrow-flight-sql`.
     def tbName1 = "empsalary"
     def tbName2 = "tenk1"
     sql """ DROP TABLE IF EXISTS ${tbName1} """

--- a/regression-test/suites/query_p0/test_two_phase_read_with_having.groovy
+++ b/regression-test/suites/query_p0/test_two_phase_read_with_having.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_two_phase_read_with_having", "arrow_flight_sql") {
+suite("test_two_phase_read_with_having") { // "arrow_flight_sql" not support two phase read
 
     sql """ set enable_partition_topn = 1; """
     sql """ set topn_opt_limit_threshold = 1024; """

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -209,6 +209,7 @@ fi
     -Dfile.encoding="UTF-8" \
     -Dlogback.configurationFile="${LOG_CONFIG_FILE}" \
     ${JAVA_OPTS:+${JAVA_OPTS}} \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
     -jar ${RUN_JAR:+${RUN_JAR}} \
     -cf "${CONFIG_FILE}" \
     ${REGRESSION_OPTIONS_PREFIX:+${REGRESSION_OPTIONS_PREFIX}} "$@"

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -200,6 +200,7 @@ fi
 
 echo "===== Run Regression Test ====="
 
+# if use jdk17, add java option "--add-opens=java.base/java.nio=ALL-UNNAMED"
 if [[ "${TEAMCITY}" -eq 1 ]]; then
     JAVA_OPTS="${JAVA_OPTS} -DstdoutAppenderType=teamcity -Xmx2048m"
 fi
@@ -209,7 +210,6 @@ fi
     -Dfile.encoding="UTF-8" \
     -Dlogback.configurationFile="${LOG_CONFIG_FILE}" \
     ${JAVA_OPTS:+${JAVA_OPTS}} \
-    --add-opens=java.base/java.nio=ALL-UNNAMED \
     -jar ${RUN_JAR:+${RUN_JAR}} \
     -cf "${CONFIG_FILE}" \
     ${REGRESSION_OPTIONS_PREFIX:+${REGRESSION_OPTIONS_PREFIX}} "$@"


### PR DESCRIPTION
## Proposed changes

1. `--add-opens=java.base/java.nio=ALL-UNNAMED`, see: https://arrow.apache.org/docs/java/install.html#java-compatibility
2. groovy use flight sql connection to execute query `SUM(MAX(c1) OVER (PARTITION BY))` report error: `AGGREGATE clause must not contain analytic expressions`, but no problem in Java execute it with `jdbc::arrow-flight-sql`.
3. groovy not support print arrow array type, throw IndexOutOfBoundsException.
4. "arrow_flight_sql" not support two phase read

./run-regression-test.sh --run --clean -g arrow_flight_sql

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

