### PR TITLE
[Fix](bvar) Fix bloom filter bvar fault

### DIFF
--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -100,10 +100,10 @@ public:
     PrimaryKeyIndexReader() : _index_parsed(false), _bf_parsed(false) {}
 
     ~PrimaryKeyIndexReader() {
-        segment_v2::g_pk_total_bloom_filter_num << -_bf_num;
-        segment_v2::g_pk_total_bloom_filter_total_bytes << -_bf_bytes;
-        segment_v2::g_pk_read_bloom_filter_num << -_bf_num;
-        segment_v2::g_pk_read_bloom_filter_total_bytes << -_bf_bytes;
+        segment_v2::g_pk_total_bloom_filter_num << -static_cast<int64_t>(_bf_num);
+        segment_v2::g_pk_total_bloom_filter_total_bytes << -static_cast<int64_t>(_bf_bytes);
+        segment_v2::g_pk_read_bloom_filter_num << -static_cast<int64_t>(_bf_num);
+        segment_v2::g_pk_read_bloom_filter_total_bytes << -static_cast<int64_t>(_bf_bytes);
     }
 
     Status parse_index(io::FileReaderSPtr file_reader,

--- a/be/src/olap/rowset/segment_v2/bloom_filter.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter.h
@@ -27,26 +27,34 @@
 #include <memory>
 
 #include "common/status.h"
+#include "gutil/integral_types.h"
 #include "util/murmur_hash3.h"
 
 namespace doris {
 namespace segment_v2 {
 
-inline bvar::Adder<size_t> g_total_bloom_filter_num("doris_total_bloom_filter_num");
-inline bvar::Adder<size_t> g_read_bloom_filter_num("doris_read_bloom_filter_num");
-inline bvar::Adder<size_t> g_write_bloom_filter_num("doris_write_bloom_filter_num");
+inline bvar::Adder<int64_t> g_total_bloom_filter_num("doris_total_bloom_filter_num");
+inline bvar::Adder<int64_t> g_read_bloom_filter_num("doris_read_bloom_filter_num");
+inline bvar::Adder<int64_t> g_write_bloom_filter_num("doris_write_bloom_filter_num");
 
-inline bvar::Adder<size_t> g_total_bloom_filter_total_bytes("doris_total_bloom_filter_bytes");
-inline bvar::Adder<size_t> g_read_bloom_filter_total_bytes("doris_read_bloom_filter_bytes");
-inline bvar::Adder<size_t> g_write_bloom_filter_total_bytes("doris_write_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_total_bloom_filter_total_bytes("doris_total_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_read_bloom_filter_total_bytes("doris_read_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_write_bloom_filter_total_bytes("doris_write_bloom_filter_bytes");
 
-inline bvar::Adder<size_t> g_pk_total_bloom_filter_num("doris_pk_total_bloom_filter_num");
-inline bvar::Adder<size_t> g_pk_read_bloom_filter_num("doris_pk_read_bloom_filter_num");
-inline bvar::Adder<size_t> g_pk_write_bloom_filter_num("doris_pk_write_bloom_filter_num");
+inline bvar::Adder<int64_t> g_pk_total_bloom_filter_num("doris_pk_total_bloom_filter_num");
+inline bvar::Adder<int64_t> g_pk_read_bloom_filter_num("doris_pk_read_bloom_filter_num");
+inline bvar::Adder<int64_t> g_pk_write_bloom_filter_increase_num(
+        "doris_pk_write_bloom_filter_increase_num");
+inline bvar::Adder<int64_t> g_pk_write_bloom_filter_decrease_num(
+        "doris_pk_write_bloom_filter_decrease_num");
 
-inline bvar::Adder<size_t> g_pk_total_bloom_filter_total_bytes("doris_pk_total_bloom_filter_bytes");
-inline bvar::Adder<size_t> g_pk_read_bloom_filter_total_bytes("doris_pk_read_bloom_filter_bytes");
-inline bvar::Adder<size_t> g_pk_write_bloom_filter_total_bytes("doris_pk_write_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_pk_total_bloom_filter_total_bytes(
+        "doris_pk_total_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_pk_read_bloom_filter_total_bytes("doris_pk_read_bloom_filter_bytes");
+inline bvar::Adder<int64_t> g_pk_write_bloom_filter_increase_bytes(
+        "doris_pk_write_bloom_filter_increase_bytes");
+inline bvar::Adder<int64_t> g_pk_write_bloom_filter_decrease_bytes(
+        "doris_pk_write_bloom_filter_decrease_bytes");
 
 struct BloomFilterOptions {
     // false positive probability
@@ -79,13 +87,13 @@ public:
     virtual ~BloomFilter() {
         if (_data) {
             if (_is_write) {
-                g_write_bloom_filter_total_bytes << -_size;
+                g_write_bloom_filter_total_bytes << -static_cast<int64_t>(_size);
                 g_write_bloom_filter_num << -1;
             } else {
-                g_read_bloom_filter_total_bytes << -_size;
+                g_read_bloom_filter_total_bytes << -static_cast<int64_t>(_size);
                 g_read_bloom_filter_num << -1;
             }
-            g_total_bloom_filter_total_bytes << -_size;
+            g_total_bloom_filter_total_bytes << -static_cast<int64_t>(_size);
             delete[] _data;
         }
         g_total_bloom_filter_num << -1;

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -197,8 +197,8 @@ Status PrimaryKeyBloomFilterIndexWriterImpl::flush() {
     _bf_buffer_size += bf->size();
     g_pk_total_bloom_filter_num << 1;
     g_pk_total_bloom_filter_total_bytes << bf->size();
-    g_pk_write_bloom_filter_num << 1;
-    g_pk_write_bloom_filter_total_bytes << bf->size();
+    g_pk_write_bloom_filter_increase_num << 1;
+    g_pk_write_bloom_filter_increase_bytes << bf->size();
     _bfs.push_back(std::move(bf));
     _values.clear();
     _has_null = false;

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.h
@@ -79,9 +79,9 @@ public:
     ~PrimaryKeyBloomFilterIndexWriterImpl() override {
         for (auto& bf : _bfs) {
             g_pk_total_bloom_filter_num << -1;
-            g_pk_total_bloom_filter_total_bytes << -bf->size();
-            g_pk_write_bloom_filter_num << -1;
-            g_pk_write_bloom_filter_total_bytes << -bf->size();
+            g_pk_total_bloom_filter_total_bytes << -static_cast<int64_t>(bf->size());
+            g_pk_write_bloom_filter_decrease_num << 1;
+            g_pk_write_bloom_filter_decrease_bytes << bf->size();
         }
     };
 


### PR DESCRIPTION
The previous addition of `bvar` caused overflow issues due to incorrect type, and this PR fixes that problem.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

