### PR TITLE
[Exception](Json functions) throw Exception when using escaped_list_separator

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/exception.h"
 #include "common/logging.h"
 
 namespace doris {
@@ -213,10 +214,14 @@ void JsonFunctions::parse_json_paths(const std::string& path_string,
     //    '$.text#abc.xyz'  ->  [$, text#abc, xyz]
     //    '$."text.abc".xyz'  ->  [$, text.abc, xyz]
     //    '$."text.abc"[1].xyz'  ->  [$, text.abc[1], xyz]
-    boost::tokenizer<boost::escaped_list_separator<char>> tok(
-            path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
-    std::vector<std::string> paths(tok.begin(), tok.end());
-    get_parsed_paths(paths, parsed_paths);
+    try {
+        boost::tokenizer<boost::escaped_list_separator<char>> tok(
+                path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
+        std::vector<std::string> paths(tok.begin(), tok.end());
+        get_parsed_paths(paths, parsed_paths);
+    } catch (const boost::escaped_list_error& err) {
+        throw doris::Exception(ErrorCode::INVALID_JSON_PATH, "meet error {}", err.what());
+    }
 }
 
 void JsonFunctions::get_parsed_paths(const std::vector<std::string>& path_exprs,

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -32,6 +32,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "common/exception.h"
+#include "common/status.h"
+
 namespace doris {
 
 inline std::string to_lower(const std::string& input) {
@@ -135,8 +138,12 @@ using StringCaseUnorderedMap =
 
 template <typename T>
 auto get_json_token(T& path_string) {
-    return boost::tokenizer<boost::escaped_list_separator<char>>(
-            path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
+    try {
+        return boost::tokenizer<boost::escaped_list_separator<char>>(
+                path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
+    } catch (const boost::escaped_list_error& err) {
+        throw doris::Exception(ErrorCode::INVALID_JSON_PATH, "meet error {}", err.what());
+    }
 }
 
 #ifdef USE_LIBCPP


### PR DESCRIPTION
…eparator

since it could throw boost::escaped_list_error when meet invalid json path

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

