### PR TITLE
[improvement](inverted index)Avoid parsing ignore_above in add_values…

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -466,6 +466,7 @@ Status CompactionMixin::do_inverted_index_compaction() {
                     _tablet->table_id());
             DCHECK(false) << err_msg;
             LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
         }
     }
 


### PR DESCRIPTION
… and return error status when rowid_conversion is failed.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

