### PR TITLE
[Fix](executor)Fix regression test for test_active_queries/test_backend_active_tasks

### DIFF
--- a/regression-test/suites/query_p0/schema_table/test_active_queries.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_active_queries.groovy
@@ -17,7 +17,7 @@
 
 suite("test_active_queries") {
     def thread1 = new Thread({
-        while(true) {
+        for (int i = 0; i <= 300; i++) {
             // non-pipeline
             sql "set experimental_enable_pipeline_engine=false"
             sql "set experimental_enable_pipeline_x_engine=false"

--- a/regression-test/suites/query_p0/schema_table/test_backend_active_tasks.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_backend_active_tasks.groovy
@@ -17,7 +17,7 @@
 
 suite("test_backend_active_tasks") {
     def thread1 = new Thread({
-        while(true) {
+        for (int i = 0; i <= 300; i++) {
             // non-pipeline
             sql "set experimental_enable_pipeline_engine=false"
             sql "set experimental_enable_pipeline_x_engine=false"


### PR DESCRIPTION
## Proposed changes

Using ```while(true)``` in java daemon thread is too confused, to improve readability, use limited foreach.
