### PR TITLE
[fix](arrow-flight) Fix reach limit of connections error

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2341,10 +2341,16 @@ public class Config extends ConfigBase {
     })
     public static int autobucket_min_buckets = 1;
 
-    @ConfField(description = {"Arrow Flight Server中所有用户token的缓存上限，超过后LRU淘汰，默认值为2000",
+    @ConfField(description = {"Arrow Flight Server中所有用户token的缓存上限，超过后LRU淘汰，默认值为512, "
+            + "并强制限制小于 qe_max_connection/2, 避免`Reach limit of connections`, "
+            + "因为arrow flight sql是无状态的协议，连接通常不会主动断开，"
+            + "bearer token 从 cache 淘汰的同时会 unregister Connection.",
             "The cache limit of all user tokens in Arrow Flight Server. which will be eliminated by"
-            + "LRU rules after exceeding the limit, the default value is 2000."})
-    public static int arrow_flight_token_cache_size = 2000;
+            + "LRU rules after exceeding the limit, the default value is 512, the mandatory limit is "
+            + "less than qe_max_connection/2 to avoid `Reach limit of connections`, "
+            + "because arrow flight sql is a stateless protocol, the connection is usually not actively "
+            + "disconnected, bearer token is evict from the cache will unregister ConnectContext."})
+    public static int arrow_flight_token_cache_size = 512;
 
     @ConfField(description = {"Arrow Flight Server中用户token的存活时间，自上次写入后过期时间，单位分钟，默认值为4320，即3天",
             "The alive time of the user token in Arrow Flight Server, expire after write, unit minutes,"

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/auth2/FlightBearerTokenAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/auth2/FlightBearerTokenAuthenticator.java
@@ -86,7 +86,7 @@ public class FlightBearerTokenAuthenticator implements CallHeaderAuthenticator {
             return createAuthResultWithBearerToken(token);
         } catch (IllegalArgumentException e) {
             LOG.error("Bearer token validation failed.", e);
-            throw CallStatus.UNAUTHENTICATED.toRuntimeException();
+            throw CallStatus.UNAUTHENTICATED.withCause(e).withDescription(e.getMessage()).toRuntimeException();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsWithTokenManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsWithTokenManager.java
@@ -47,42 +47,36 @@ public class FlightSessionsWithTokenManager implements FlightSessionsManager {
             ConnectContext connectContext = ExecuteEnv.getInstance().getScheduler().getContext(peerIdentity);
             if (null == connectContext) {
                 connectContext = createConnectContext(peerIdentity);
-                if (null == connectContext) {
-                    flightTokenManager.invalidateToken(peerIdentity);
-                    String err = "UserSession expire after access, need reauthorize.";
-                    LOG.error(err);
-                    throw CallStatus.UNAUTHENTICATED.withDescription(err).toRuntimeException();
-                }
                 return connectContext;
             }
             return connectContext;
         } catch (Exception e) {
-            LOG.warn("getConnectContext failed, " + e.getMessage(), e);
+            LOG.warn("get ConnectContext failed, " + e.getMessage(), e);
             throw CallStatus.INTERNAL.withDescription(Util.getRootCauseMessage(e)).withCause(e).toRuntimeException();
         }
     }
 
     @Override
     public ConnectContext createConnectContext(String peerIdentity) {
-        try {
-            final FlightTokenDetails flightTokenDetails = flightTokenManager.validateToken(peerIdentity);
-            if (flightTokenDetails.getCreatedSession()) {
-                return null;
-            }
-            flightTokenDetails.setCreatedSession(true);
-            ConnectContext connectContext = FlightSessionsManager.buildConnectContext(peerIdentity,
-                    flightTokenDetails.getUserIdentity(), flightTokenDetails.getRemoteIp());
-            connectContext.setConnectionId(nextConnectionId.getAndAdd(1));
-            connectContext.resetLoginTime();
-            if (!ExecuteEnv.getInstance().getScheduler().registerConnection(connectContext)) {
-                connectContext.getState()
-                        .setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, "Reach limit of connections");
-                throw CallStatus.UNAUTHENTICATED.withDescription("Reach limit of connections").toRuntimeException();
-            }
-            return connectContext;
-        } catch (IllegalArgumentException e) {
-            LOG.error("Bearer token validation failed.", e);
-            throw CallStatus.UNAUTHENTICATED.toRuntimeException();
+        final FlightTokenDetails flightTokenDetails = flightTokenManager.validateToken(peerIdentity);
+        if (flightTokenDetails.getCreatedSession()) {
+            flightTokenManager.invalidateToken(peerIdentity);
+            throw new IllegalArgumentException("UserSession expire after access, try reconnect, bearer token: "
+                    + peerIdentity + ", a peerIdentity(bearer token) can only create a ConnectContext once. "
+                    + "if ConnectContext is deleted without operation for a long time, it needs to be reconnected "
+                    + "(at the same time obtain a new bearer token).");
         }
+        flightTokenDetails.setCreatedSession(true);
+        ConnectContext connectContext = FlightSessionsManager.buildConnectContext(peerIdentity,
+                flightTokenDetails.getUserIdentity(), flightTokenDetails.getRemoteIp());
+        connectContext.setConnectionId(nextConnectionId.getAndAdd(1));
+        connectContext.resetLoginTime();
+        if (!ExecuteEnv.getInstance().getScheduler().registerConnection(connectContext)) {
+            String err = "Reach limit of connections, increase `qe_max_connection` in fe.conf, or decrease "
+                    + "`arrow_flight_token_cache_size` to evict unused bearer tokens and it connections faster";
+            connectContext.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, err);
+            throw new IllegalArgumentException(err);
+        }
+        return connectContext;
     }
 }


### PR DESCRIPTION
## Proposed changes

1. Fix `Reach limit of connections` error
in fe.conf , `arrow_flight_token_cache_size` is mandatory less than `qe_max_connection/2`. arrow flight sql is a stateless protocol, connection is usually not actively disconnected, bearer token is evict from the cache will unregister ConnectContext.

2. Fix ConnectContext.command not be reset to COM_SLEEP in time, this will result in frequent kill connection after query timeout.

3. Fix bearer token evict log and exception.

TODO: use arrow flight session: https://mail.google.com/mail/u/0/#inbox/FMfcgzGxRdxBLQLTcvvtRpqsvmhrHpdH

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

