### PR TITLE
[Fix](partial-update) Fix partial update fail when the datetime default value is 'current_time'

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -121,6 +121,8 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
     if (_is_partial_update) {
         _auto_increment_column = pschema.auto_increment_column();
     }
+    _timestamp_ms = pschema.timestamp_ms();
+    _timezone = pschema.timezone();
 
     for (const auto& col : pschema.partial_update_input_columns()) {
         _partial_update_input_columns.insert(col);
@@ -255,6 +257,8 @@ void OlapTableSchemaParam::to_protobuf(POlapTableSchemaParam* pschema) const {
     pschema->set_partial_update(_is_partial_update);
     pschema->set_is_strict_mode(_is_strict_mode);
     pschema->set_auto_increment_column(_auto_increment_column);
+    pschema->set_timestamp_ms(_timestamp_ms);
+    pschema->set_timezone(_timezone);
     for (auto col : _partial_update_input_columns) {
         *pschema->add_partial_update_input_columns() = col;
     }

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -93,6 +93,10 @@ public:
         return _partial_update_input_columns;
     }
     std::string auto_increment_coulumn() const { return _auto_increment_column; }
+    void set_timestamp_ms(int64_t timestamp_ms) { _timestamp_ms = timestamp_ms; }
+    int64_t timestamp_ms() const { return _timestamp_ms; }
+    void set_timezone(std::string timezone) { _timezone = timezone; }
+    std::string timezone() const { return _timezone; }
     bool is_strict_mode() const { return _is_strict_mode; }
     std::string debug_string() const;
 
@@ -109,6 +113,8 @@ private:
     std::set<std::string> _partial_update_input_columns;
     bool _is_strict_mode = false;
     std::string _auto_increment_column;
+    int64_t _timestamp_ms = 0;
+    std::string _timezone;
 };
 
 using OlapTableIndexTablets = TOlapTableIndexTablets;

--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -243,7 +243,8 @@ void DeltaWriterV2::_build_current_tablet_schema(int64_t index_id,
     _partial_update_info = std::make_shared<PartialUpdateInfo>();
     _partial_update_info->init(*_tablet_schema, table_schema_param->is_partial_update(),
                                table_schema_param->partial_update_input_columns(),
-                               table_schema_param->is_strict_mode());
+                               table_schema_param->is_strict_mode(),
+                               table_schema_param->timestamp_ms(), table_schema_param->timezone());
 }
 
 } // namespace doris

--- a/be/src/olap/partial_update_info.h
+++ b/be/src/olap/partial_update_info.h
@@ -23,9 +23,12 @@ namespace doris {
 
 struct PartialUpdateInfo {
     void init(const TabletSchema& tablet_schema, bool partial_update,
-              const std::set<string>& partial_update_cols, bool is_strict_mode) {
+              const std::set<string>& partial_update_cols, bool is_strict_mode,
+              int64_t timestamp_ms, const std::string& timezone) {
         is_partial_update = partial_update;
         partial_update_input_columns = partial_update_cols;
+        this->timestamp_ms = timestamp_ms;
+        this->timezone = timezone;
         missing_cids.clear();
         update_cids.clear();
         for (auto i = 0; i < tablet_schema.num_columns(); ++i) {
@@ -51,5 +54,7 @@ struct PartialUpdateInfo {
     // to generate a new row, only available in non-strict mode
     bool can_insert_new_rows_in_partial_update {true};
     bool is_strict_mode {false};
+    int64_t timestamp_ms {0};
+    std::string timezone;
 };
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -698,8 +698,9 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
                 std::string default_value;
                 if (UNLIKELY(_tablet_schema->column(cids_missing[i]).type() ==
                                      FieldType::OLAP_FIELD_TYPE_DATETIMEV2 &&
-                             to_lower(_tablet_schema->column(cids_missing[i]).default_value()) ==
-                                     to_lower("CURRENT_TIMESTAMP"))) {
+                             to_lower(_tablet_schema->column(cids_missing[i]).default_value())
+                                             .find(to_lower("CURRENT_TIMESTAMP")) !=
+                                     std::string::npos)) {
                     DateV2Value<DateTimeV2ValueType> dtv;
                     dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
                                       _opts.rowset_ctx->partial_update_info->timezone);

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -698,9 +698,8 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
                 std::string default_value;
                 if (UNLIKELY(_tablet_schema->column(cids_missing[i]).type() ==
                                      FieldType::OLAP_FIELD_TYPE_DATETIMEV2 &&
-                             _tablet_schema->column(cids_missing[i])
-                                             .default_value()
-                                             .find("CURRENT_TIMESTAMP") != std::string::npos)) {
+                             to_lower(_tablet_schema->column(cids_missing[i]).default_value()) ==
+                                     to_lower("CURRENT_TIMESTAMP"))) {
                     DateV2Value<DateTimeV2ValueType> dtv;
                     dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
                                       _opts.rowset_ctx->partial_update_info->timezone);

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -626,8 +626,9 @@ Status VerticalSegmentWriter::_fill_missing_columns(
                 std::string default_value;
                 if (UNLIKELY(_tablet_schema->column(missing_cids[i]).type() ==
                                      FieldType::OLAP_FIELD_TYPE_DATETIMEV2 &&
-                             to_lower(_tablet_schema->column(missing_cids[i]).default_value()) ==
-                                     to_lower("CURRENT_TIMESTAMP"))) {
+                             to_lower(_tablet_schema->column(missing_cids[i]).default_value())
+                                             .find(to_lower("CURRENT_TIMESTAMP")) !=
+                                     std::string::npos)) {
                     DateV2Value<DateTimeV2ValueType> dtv;
                     dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
                                       _opts.rowset_ctx->partial_update_info->timezone);

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -626,9 +626,8 @@ Status VerticalSegmentWriter::_fill_missing_columns(
                 std::string default_value;
                 if (UNLIKELY(_tablet_schema->column(missing_cids[i]).type() ==
                                      FieldType::OLAP_FIELD_TYPE_DATETIMEV2 &&
-                             _tablet_schema->column(missing_cids[i])
-                                             .default_value()
-                                             .find("CURRENT_TIMESTAMP") != std::string::npos)) {
+                             to_lower(_tablet_schema->column(missing_cids[i]).default_value()) ==
+                                     to_lower("CURRENT_TIMESTAMP"))) {
                     DateV2Value<DateTimeV2ValueType> dtv;
                     dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
                                       _opts.rowset_ctx->partial_update_info->timezone);

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -380,7 +380,8 @@ void BaseRowsetBuilder::_build_current_tablet_schema(int64_t index_id,
     _partial_update_info = std::make_shared<PartialUpdateInfo>();
     _partial_update_info->init(*_tablet_schema, table_schema_param->is_partial_update(),
                                table_schema_param->partial_update_input_columns(),
-                               table_schema_param->is_strict_mode());
+                               table_schema_param->is_strict_mode(),
+                               table_schema_param->timestamp_ms(), table_schema_param->timezone());
 }
 
 } // namespace doris

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1136,6 +1136,8 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
     _write_file_cache = table_sink.write_file_cache;
     _schema.reset(new OlapTableSchemaParam());
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
+    _schema->set_timestamp_ms(state->timestamp_ms());
+    _schema->set_timezone(state->timezone());
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
     _nodes_info = _pool->add(new DorisNodesInfo(table_sink.nodes_info));
     if (table_sink.__isset.write_single_replica && table_sink.write_single_replica) {

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -153,6 +153,8 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
     _write_file_cache = table_sink.write_file_cache;
     _schema.reset(new OlapTableSchemaParam());
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
+    _schema->set_timestamp_ms(state->timestamp_ms());
+    _schema->set_timezone(state->timezone());
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
     _nodes_info = _pool->add(new DorisNodesInfo(table_sink.nodes_info));
 

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -70,5 +70,7 @@ message POlapTableSchemaParam {
     repeated string partial_update_input_columns = 8;
     optional bool is_strict_mode = 9 [default = false];
     optional string auto_increment_column = 10;
+    optional int64 timestamp_ms = 11 [default = 0];
+    optional string timezone = 12;
 };
 

--- a/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
+++ b/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
@@ -35,6 +35,9 @@
 3	"stranger"	500	\N	4321
 4	"foreigner"	600	\N	4321
 
+-- !select_timestamp --
+1
+
 -- !select_default --
 1	doris	200	123	1
 2	doris2	400	223	1
@@ -70,4 +73,7 @@
 2	doris2	2222	223	1
 3	"stranger"	500	\N	4321
 4	"foreigner"	600	\N	4321
+
+-- !select_timestamp --
+1
 

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -187,6 +187,25 @@ suite("test_primary_key_partial_update", "p0") {
 
             // drop drop
             sql """ DROP TABLE IF EXISTS ${tableName} """
+
+            sql """ CREATE TABLE ${tableName} (
+                        `name` VARCHAR(600) NULL,
+                        `userid` INT NOT NULL,
+                        `seq` BIGINT NOT NULL AUTO_INCREMENT(1),
+                        `ctime` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+                        `rtime` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+                        `corp_name` VARCHAR(600) NOT NULL
+                        ) ENGINE = OLAP UNIQUE KEY(`name`, `userid`) COMMENT 'OLAP' DISTRIBUTED BY HASH(`name`) BUCKETS 10 
+                        PROPERTIES ("replication_num" = "1",
+                                    "enable_unique_key_merge_on_write" = "true",
+                                    "store_row_column" = "${use_row_store}"); """
+
+            sql "set enable_unique_key_partial_update=true;" 
+            sql "set enable_insert_strict=false;"
+
+            sql "INSERT INTO ${tableName}(`name`, `userid`, `corp_name`) VALUES ('test1', 1234567, 'A');"
+
+            qt_select_timestamp "select count(*) from ${tableName} where `ctime` > \"1970-01-01\""
         }
     }
 }


### PR DESCRIPTION
Problem: When importing data that includes datetime with a default value of current time for partial column updates, the import fails.

Reason: Partial column updates do not handle the logic for datetime default values.

Solution: During partial column updates, when the default value is set to current time, read the current time from the runtime state and write it into the data.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

