### PR TITLE
[fix](grace-exit) Stop incorrectly of reportwork cause heap use after free

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -619,6 +619,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Be server stopped";
     brpc_service.reset(nullptr);
     LOG(INFO) << "Brpc service stopped";
+    service.reset();
+    LOG(INFO) << "Backend Service stopped";
     exec_env->destroy();
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
     LOG(INFO) << "Doris main exited.";


### PR DESCRIPTION
## Proposed changes

fix stop incorrectly of reportwork cause heap use after free. similar pr: https://github.com/apache/doris/pull/32205
```
==118151==ERROR: AddressSanitizer: heap-use-after-free on address 0x610000079a50 at pc 0x5587c545a0a8 bp 0x7f4450d4e1c0 sp 0x7f4450d4e1b8
READ of size 8 at 0x610000079a50 thread T1323 (REPORT_TASK-119)
    #0 0x5587c545a0a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187:28
    #1 0x5587c545a0a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::data() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:2319:16
    #2 0x5587c545a0a7 in std::hash<doris::TNetworkAddress>::operator()(doris::TNetworkAddress const&) const /root/doris/be/src/util/hash_util.hpp:379:55
    #3 0x5587c545a0a7 in std::__detail::_Hash_code_base<doris::TNetworkAddress, std::pair<doris::TNetworkAddress const, std::__cxx11::list<void*, std::allocator<void*> > >, std::__detail::_Select1st, std::hash<doris::TNetworkAddress>, std::__detail::_Mod_range_hashing,
std::__detail::_Default_ranged_hash, true>::_M_hash_code(doris::TNetworkAddress const&) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable_policy.h:1217:9
    #4 0x5587c545a0a7 in std::_Hashtable<doris::TNetworkAddress, std::pair<doris::TNetworkAddress const, std::__cxx11::list<void*, std::allocator<void*> > >, std::allocator<std::pair<doris::TNetworkAddress const, std::__cxx11::list<void*, std::allocator<void*> > > >, st
d::__detail::_Select1st, std::equal_to<doris::TNetworkAddress>, std::hash<doris::TNetworkAddress>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::find(do
ris::TNetworkAddress const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1570:34
    #5 0x5587c54560d4 in std::unordered_map<doris::TNetworkAddress, std::__cxx11::list<void*, std::allocator<void*> >, std::hash<doris::TNetworkAddress>, std::equal_to<doris::TNetworkAddress>, std::allocator<std::pair<doris::TNetworkAddress const, std::__cxx11::list<voi
d*, std::allocator<void*> > > > >::find(doris::TNetworkAddress const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unordered_map.h:869:21
    #6 0x5587c54560d4 in doris::ClientCacheHelper::_get_client_from_cache(doris::TNetworkAddress const&, void**) /root/doris/be/src/runtime/client_cache.cpp:44:38
    #7 0x5587c545685e in doris::ClientCacheHelper::get_client(doris::TNetworkAddress const&, std::function<doris::ThriftClientImpl* (doris::TNetworkAddress const&, void**)>&, void**, int) /root/doris/be/src/runtime/client_cache.cpp:61:5
    #8 0x5587c2f60591 in doris::ClientCache<doris::FrontendServiceClient>::get_client(doris::TNetworkAddress const&, doris::FrontendServiceClient**, int) /root/doris/be/src/runtime/client_cache.h:243:37
    #9 0x5587c2f60591 in doris::ClientConnection<doris::FrontendServiceClient>::ClientConnection(doris::ClientCache<doris::FrontendServiceClient>*, doris::TNetworkAddress const&, int, doris::Status*, int) /root/doris/be/src/runtime/client_cache.h:165:38
    #10 0x5587c2f5c955 in doris::MasterServerClient::report(doris::TReportRequest const&, doris::TMasterResult*) /root/doris/be/src/agent/utils.cpp:117:31
    #11 0x5587c2ef22c6 in doris::(anonymous namespace)::handle_report(doris::TReportRequest const&, doris::TMasterInfo const&, std::basic_string_view<char, std::char_traits<char> >) /root/doris/be/src/agent/task_worker_pool.cpp:355:53
    #12 0x5587c2ef1cbf in doris::report_task_callback(doris::TMasterInfo const&) /root/doris/be/src/agent/task_worker_pool.cpp:985:17
    #13 0x5587c2f26226 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #14 0x5587c2f26226 in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::TMasterInfo const&, int, std::function<void ()>)::$_0::operator()() const /root/doris/be/src/agent/task_worker_pool.cpp:67
1:13
    #15 0x5587c2f26226 in void std::__invoke_impl<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(std::__invoke_other, doris::ReportWo
rker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #16 0x5587c2f26226 in std::enable_if<is_invocable_r_v<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>, void>::type std::__invoke_r
<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(doris::ReportWorker::ReportWorker(std::__cxx11::basic_stri

0x610000079a50 is located 16 bytes inside of 192-byte region [0x610000079a40,0x610000079b00)
freed by thread T0 here:
    #0 0x5587c2e6780d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P1/Cluster0/be/lib/doris_be+0x133f680d) (BuildId: 77604ccbab68e052)
    #1 0x5587c54a3a00 in doris::ExecEnv::destroy() /root/doris/be/src/runtime/exec_env_init.cpp:669:5
    #2 0x5587c2e70158 in main /root/doris/be/src/service/doris_main.cpp:622:15
    #3 0x7f4ad5624082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

previously allocated by thread T0 here:
    #0 0x5587c2e66fad in operator new(unsigned long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P1/Cluster0/be/lib/doris_be+0x133f5fad) (BuildId: 77604ccbab68e052)
    #1 0x5587c5495539 in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /root/doris/be/src/runtime/exec_env_init.cpp:227:20
    #2 0x5587c549283d in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /root/doris/be/src/runtime/exec_env_init.cpp:147:17
    #3 0x5587c2e6d7ef in main /root/doris/be/src/service/doris_main.cpp:521:14
    #4 0x7f4ad5624082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

