### PR TITLE
[Fix](hive-writer) Fix correct num when hive writing data to an unpartitioned table if size large than `hive_sink_max_file_size`.

### DIFF
--- a/be/src/vec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/vec/sink/writer/vhive_table_writer.cpp
@@ -76,7 +76,6 @@ Status VHiveTableWriter::write(vectorized::Block& block) {
                     writer = _create_partition_writer(block, -1);
                     _partitions_to_writers.insert({"", writer});
                     RETURN_IF_ERROR(writer->open(_state, _profile));
-                    RETURN_IF_ERROR(writer->write(block));
                 } catch (doris::Exception& e) {
                     return e.to_status();
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: #31442

[Fix] (hive-writer) Fix correct num when hive writing data to an unpartitioned table if size large than hive_sink_max_file_size.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

