### PR TITLE
[fix](nereids) planner should always gennerate bitmap runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -147,13 +147,7 @@ public class RuntimeFilterTranslator {
                 origFilter.setIsBroadcast(((HashJoinNode) node).getDistributionMode() == DistributionMode.BROADCAST);
             } else {
                 // nest loop join
-                if (filter.getType() == TRuntimeFilterType.BITMAP) {
-                    //bitmap rf requires isBroadCast=false, it always requires merge filter
-                    origFilter.setIsBroadcast(false);
-                } else {
-                    // min-max rf
-                    origFilter.setIsBroadcast(true);
-                }
+                origFilter.setIsBroadcast(true);
             }
             boolean isLocalTarget = scanNodeList.stream().allMatch(e ->
                     !(e instanceof CTEScanNode) && e.getFragmentId().equals(node.getFragmentId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -447,8 +447,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         }
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
 
-        if ((ctx.getSessionVariable().getRuntimeFilterType() & TRuntimeFilterType.BITMAP.getValue()) != 0
-                && !ctx.getSessionVariable().isIgnoreStorageDataDistribution()) {
+        if ((ctx.getSessionVariable().getRuntimeFilterType() & TRuntimeFilterType.BITMAP.getValue()) != 0) {
             generateBitMapRuntimeFilterForNLJ(join, ctx);
         }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

