### PR TITLE
[fix](merge-iterator) fix NOT_IMPLEMENTED_ERROR when read next block view

### DIFF
--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -422,9 +422,9 @@ Status VUnionIterator::current_block_row_locations(std::vector<RowLocation>* loc
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
                                        uint64_t* merged_rows) {
-    if (inputs.size() == 1) {
-        return std::move(inputs[0]);
-    }
+    // when the size of inputs is 1, we also need to use VMergeIterator, because the
+    // next_block_view function only be implemented in VMergeIterator. The reason why
+    // the size of inputs is 1 is that the segment was filtered out by zone map or others.
     return std::make_unique<VMergeIterator>(std::move(inputs), sequence_id_idx, is_unique,
                                             is_reverse, merged_rows);
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

W0327 06:03:44.308210  6588 beta_rowset_reader.cpp:350] failed to read next block view: [NOT_IMPLEMENTED_ERROR]to be implemented


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

