### PR TITLE
[fix](spark load)Init the array to avoid hidden columns __DORIS_DELETE_SIGN__  being polluted by old memory in spark load #32971

### DIFF
--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -237,7 +237,7 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
             }
 
             // 3. Init Row
-            std::unique_ptr<uint8_t[]> tuple_buf(new uint8_t[schema->schema_size()]);
+            std::unique_ptr<uint8_t[]> tuple_buf(new uint8_t[schema->schema_size()]());
             ContiguousRow row(schema.get(), tuple_buf.get());
 
             // 4. Read data from broker and write into SegmentGroup of cur_tablet


### PR DESCRIPTION
…_DELETE_SIGN__  being polluted by old memory in spark load

## Proposed changes

Issue Number: close #32971 

Init the array to avoid hidden columns __DORIS_DELETE_SIGN__  being polluted by old memory
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

