### PR TITLE
[opt](iceberg) no need to check the name format of iceberg's database

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -24,11 +24,8 @@ import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.StructField;
 import org.apache.doris.catalog.StructType;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.DorisTypeVisitor;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
@@ -72,16 +69,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
 
     public List<String> listDatabaseNames() {
         return nsCatalog.listNamespaces().stream()
-                .map(e -> {
-                    String dbName = e.toString();
-                    try {
-                        FeNameFormat.checkDbName(dbName);
-                    } catch (AnalysisException ex) {
-                        Util.logAndThrowRuntimeException(LOG,
-                                String.format("Not a supported namespace name format: %s", dbName), ex);
-                    }
-                    return dbName;
-                })
+                .map(e -> e.toString())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Proposed changes

No need to check the name format of iceberg's database.
We should accept all databases.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

