### PR TITLE
[fix](mtmv)partition limit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionItem.java
@@ -75,7 +75,7 @@ public class RangePartitionItem extends PartitionItem {
         }
         // If the upper limit of the partition range meets the requirements, this partition needs to be retained
         return !isDefaultPartition() && MTMVUtil.getExprTimeSec(partitionKey.getKeys().get(pos), dateFormatOptional)
-                >= nowTruncSubSec;
+                > nowTruncSubSec;
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when base table has three partitions
```
[("2024-03-26"),("2024-03-27")),
[("2024-03-27"),("2024-03-28")),
[("2024-03-28"),("2024-03-29"))
```
current time is 2024-03-28 xx:xx:xx
when mtmv set 'partition_sync_limit'='1'
mtmv should have only one partition 
```
[("2024-03-28"),("2024-03-29"))
```

but current have two
```
[("2024-03-27"),("2024-03-28")),
[("2024-03-28"),("2024-03-29"))
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

