### PR TITLE
[opt](iceberg) no need to check the name format of iceberg's database #32977

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -210,7 +210,7 @@ public class InternalCatalog implements CatalogIf<Database> {
     @Getter
     private transient EsRepository esRepository = new EsRepository();
     @Getter
-    private IcebergTableCreationRecordMgr icebergTableCreationRecordMgr = new IcebergTableCreationRecordMgr();
+    private transient IcebergTableCreationRecordMgr icebergTableCreationRecordMgr = new IcebergTableCreationRecordMgr();
 
     public InternalCatalog() {
         // create internal databases

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -18,9 +18,6 @@
 package org.apache.doris.datasource.iceberg;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.FeNameFormat;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.SessionContext;
@@ -75,16 +72,7 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
 
     protected List<String> listDatabaseNames() {
         return nsCatalog.listNamespaces().stream()
-            .map(e -> {
-                String dbName = e.toString();
-                try {
-                    FeNameFormat.checkDbName(dbName);
-                } catch (AnalysisException ex) {
-                    Util.logAndThrowRuntimeException(LOG,
-                            String.format("Not a supported namespace name format: %s", dbName), ex);
-                }
-                return dbName;
-            })
+            .map(e -> e.toString())
             .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRepository.java
@@ -42,9 +42,9 @@ public class EsRepository extends MasterDaemon {
 
     private static final Logger LOG = LogManager.getLogger(EsRepository.class);
 
-    private Map<Long, EsTable> esTables;
+    private transient Map<Long, EsTable> esTables;
 
-    private Map<Long, EsRestClient> esClients;
+    private transient Map<Long, EsRestClient> esClients;
 
     public EsRepository() {
         super("es repository", Config.es_state_sync_interval_second * 1000);


### PR DESCRIPTION
bp #32977

Also fix some gson serde issue like:
```
XXX declares multiple JSON fields named runnable.
```