### PR TITLE
[bugfx](Cloud) Add refresh hdfs vault logic && check whether latest fs is nullptr

### DIFF
--- a/be/src/cloud/cloud_delete_task.cpp
+++ b/be/src/cloud/cloud_delete_task.cpp
@@ -62,6 +62,9 @@ Status CloudDeleteTask::execute(CloudStorageEngine& engine, const TPushReq& requ
     load_id.set_hi(0);
     load_id.set_lo(0);
     RowsetWriterContext context;
+    if (engine.latest_fs() == nullptr) [[unlikely]] {
+        return Status::IOError("Invalid latest fs");
+    }
     context.fs = engine.latest_fs();
     context.txn_id = request.transaction_id;
     context.load_id = load_id;

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -70,6 +70,9 @@ Status CloudRowsetBuilder::init() {
     // TODO(AlexYue): use the passed resource id to retrive the corresponding
     // fs to pass to the RowsetWriterContext
     if (_req.storage_vault_id.empty()) {
+        if (_engine.latest_fs() == nullptr) [[unlikely]] {
+            return Status::IOError("Invalid latest fs");
+        }
         context.fs = _engine.latest_fs();
     } else {
         // TODO(ByteYue): What if the corresponding fs does not exists temporarily?

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -251,9 +251,9 @@ Status CloudSchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParam
         context.segments_overlap = rs_reader->rowset()->rowset_meta()->segments_overlap();
         context.tablet_schema = _new_tablet->tablet_schema();
         context.newest_write_timestamp = rs_reader->newest_write_timestamp();
-        if (engine.latest_fs() == nullptr) [[unlikely]] {
-        return Status::IOError("Invalid latest fs");
-    }
+        if (_cloud_storage_engine.latest_fs() == nullptr) [[unlikely]] {
+            return Status::IOError("Invalid latest fs");
+        }
         context.fs = _cloud_storage_engine.latest_fs();
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         auto rowset_writer = DORIS_TRY(_new_tablet->create_rowset_writer(context, false));

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -251,6 +251,9 @@ Status CloudSchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParam
         context.segments_overlap = rs_reader->rowset()->rowset_meta()->segments_overlap();
         context.tablet_schema = _new_tablet->tablet_schema();
         context.newest_write_timestamp = rs_reader->newest_write_timestamp();
+        if (engine.latest_fs() == nullptr) [[unlikely]] {
+        return Status::IOError("Invalid latest fs");
+    }
         context.fs = _cloud_storage_engine.latest_fs();
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         auto rowset_writer = DORIS_TRY(_new_tablet->create_rowset_writer(context, false));

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -98,7 +98,8 @@ struct VaultCreateFSVisitor {
 };
 
 struct RefreshFSVaultVisitor {
-    RefreshFSVaultVisitor(std::string_view id, io::FileSystemSPtr fs) : id(id), fs(std::move(fs)) {}
+    RefreshFSVaultVisitor(const std::string& id, io::FileSystemSPtr fs)
+            : id(id), fs(std::move(fs)) {}
 
     Status operator()(const S3Conf& s3_conf) const {
         DCHECK_EQ(fs->type(), io::FileSystemType::S3) << id;
@@ -111,12 +112,16 @@ struct RefreshFSVaultVisitor {
         return st;
     }
 
-    Status operator()(const cloud::HdfsVaultInfo& vault_info) const {
-        // TODO(ByteYue): Implmente the hdfs fs refresh logic
-        return Status::OK();
+    Status operator()(const cloud::HdfsVaultInfo& vault) const {
+        auto hdfs_params = io::to_hdfs_params(vault);
+        auto hdfs_fs =
+                DORIS_TRY(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, id, nullptr,
+                                                     vault.has_prefix() ? vault.prefix() : ""));
+        auto hdfs = std::static_pointer_cast<io::HdfsFileSystem>(hdfs_fs);
+        put_storage_resource(id, {std::move(hdfs), 0});
     }
 
-    std::string_view id;
+    const std::string& id;
     io::FileSystemSPtr fs;
 };
 
@@ -260,7 +265,8 @@ void CloudStorageEngine::_refresh_storage_vault_info_thread_callback() {
             }
         }
 
-        if (auto& id = std::get<0>(vault_infos.back()); latest_fs()->id() != id) {
+        if (auto& id = std::get<0>(vault_infos.back());
+            latest_fs() == nullptr || latest_fs()->id() != id) {
             set_latest_fs(get_filesystem(id));
         }
     }

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -119,6 +119,7 @@ struct RefreshFSVaultVisitor {
                                                      vault.has_prefix() ? vault.prefix() : ""));
         auto hdfs = std::static_pointer_cast<io::HdfsFileSystem>(hdfs_fs);
         put_storage_resource(id, {std::move(hdfs), 0});
+        return Status::OK();
     }
 
     const std::string& id;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -1060,6 +1060,9 @@ Status CloudCompactionMixin::modify_rowsets() {
 }
 
 Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext& ctx) {
+    if (_engine.latest_fs() == nullptr) [[unlikely]] {
+        return Status::IOError("Invalid latest fs");
+    }
     ctx.fs = _engine.latest_fs();
     ctx.txn_id = boost::uuids::hash_value(UUIDGenerator::instance()->next_uuid()) &
                  std::numeric_limits<int64_t>::max(); // MUST be positive


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
The latest fs logic would be replaced in #32910. This pr mainly prevents the nullptr coredump by accessing latest fs.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

