### PR TITLE
[enhancement](cloud) Only update table version when drop a non-empty partition

### DIFF
--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -638,7 +638,7 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
         if (need_update_table_version) {
             std::string ver_key =
                     table_version_key({instance_id, request->db_id(), request->table_id()});
-            txn->atomic_add(table_ver_key, 1);
+            txn->atomic_add(ver_key, 1);
             LOG_INFO("update table version").tag("ver_key", hex(ver_key));
         }
     }

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -599,12 +599,46 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
     }
     if (!need_commit) return;
 
-    // update table versions
+    // Update table version only when deleting non-empty partitions
     if (request->has_db_id()) {
-        std::string ver_key =
-                table_version_key({instance_id, request->db_id(), request->table_id()});
-        txn->atomic_add(ver_key, 1);
-        LOG_INFO("update table version").tag("ver_key", hex(ver_key));
+        bool needUpdateTableVersion = false;
+        for (auto part_id : request->partition_ids()) {
+            std::string partition_ver_key = partition_version_key({
+                instance_id, request->db_id(), request->table_id(), part_id});
+            std::string ver_val_str;
+            err = txn->get(partition_ver_key, &ver_val_str);
+            if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+                code = cast_as<ErrCategory::READ>(err);
+                ss << "failed to get partition version, table_id=" << request->table_id()
+                   << "partition_id=" << part_id << " key=" << hex(partition_ver_key);
+                msg = ss.str();
+                return;
+            }
+            int64_t part_version = -1;
+            if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+                // may be it is an empty partition
+                part_version = 1;
+            } else {
+                VersionPB pb;
+                if (!pb.ParseFromString(ver_val_str)) {
+                    code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+                    msg = "malformed partition version value";
+                    LOG_WARNING(msg).tag("partition_id", part_id);
+                    return;
+                }
+                part_version = pb.version();
+            }
+            if (part_version > 1) {
+                needUpdateTableVersion = true;
+                break;
+            }
+        }
+        if (needUpdateTableVersion) {
+            std::string ver_key =
+                    table_version_key({instance_id, request->db_id(), request->table_id()});
+            txn->atomic_add(table_ver_key, 1);
+            LOG_INFO("update table version").tag("ver_key", hex(ver_key));
+        }
     }
 
     err = txn->commit();

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -601,7 +601,7 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
 
     // Update table version only when deleting non-empty partitions
     if (request->has_db_id()) {
-        bool needUpdateTableVersion = false;
+        bool need_update_table_version = false;
         for (auto part_id : request->partition_ids()) {
             std::string partition_ver_key = partition_version_key({
                 instance_id, request->db_id(), request->table_id(), part_id});
@@ -631,11 +631,11 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
                 part_version = pb.version();
             }
             if (part_version > 1) {
-                needUpdateTableVersion = true;
+                need_update_table_version = true;
                 break;
             }
         }
-        if (needUpdateTableVersion) {
+        if (need_update_table_version) {
             std::string ver_key =
                     table_version_key({instance_id, request->db_id(), request->table_id()});
             txn->atomic_add(table_ver_key, 1);

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -612,6 +612,7 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
                 ss << "failed to get partition version, table_id=" << request->table_id()
                    << "partition_id=" << part_id << " key=" << hex(partition_ver_key);
                 msg = ss.str();
+                LOG_WARNING(msg);
                 return;
             }
             int64_t part_version = -1;

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -610,7 +610,8 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
             if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
                 code = cast_as<ErrCategory::READ>(err);
                 ss << "failed to get partition version, table_id=" << request->table_id()
-                   << "partition_id=" << part_id << " key=" << hex(partition_ver_key);
+                   << " partition_id=" << part_id << " key=" << hex(partition_ver_key)
+                   << " code=" << code;
                 msg = ss.str();
                 LOG_WARNING(msg);
                 return;

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -611,7 +611,7 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
                 code = cast_as<ErrCategory::READ>(err);
                 ss << "failed to get partition version, table_id=" << request->table_id()
                    << " partition_id=" << part_id << " key=" << hex(partition_ver_key)
-                   << " code=" << code;
+                   << " err=" << err;
                 msg = ss.str();
                 LOG_WARNING(msg);
                 return;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -38,7 +38,7 @@ import org.apache.doris.clone.TabletSchedCtx;
 import org.apache.doris.clone.TabletScheduler;
 import org.apache.doris.cloud.catalog.CloudPartition;
 import org.apache.doris.cloud.proto.Cloud;
-import org.apache.doris.cloud.qe.SnapshotProxy;
+import org.apache.doris.cloud.rpc.VersionHelper;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -2775,7 +2775,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf {
             throws RpcException {
         long startAt = System.nanoTime();
         try {
-            return SnapshotProxy.getVisibleVersion(req);
+            return VersionHelper.getVisibleVersion(req);
         } finally {
             SummaryProfile profile = getSummaryProfile();
             if (profile != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -22,7 +22,7 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.proto.Cloud.MetaServiceCode;
-import org.apache.doris.cloud.qe.SnapshotProxy;
+import org.apache.doris.cloud.rpc.VersionHelper;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
@@ -328,7 +328,7 @@ public class CloudPartition extends Partition {
             throws RpcException {
         long startAt = System.nanoTime();
         try {
-            return SnapshotProxy.getVisibleVersion(req);
+            return VersionHelper.getVisibleVersion(req);
         } finally {
             SummaryProfile profile = getSummaryProfile();
             if (profile != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/VersionHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/VersionHelper.java
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.cloud.qe;
+package org.apache.doris.cloud.rpc;
 
 import org.apache.doris.cloud.proto.Cloud;
-import org.apache.doris.cloud.rpc.MetaServiceProxy;
 import org.apache.doris.common.Config;
 import org.apache.doris.rpc.RpcException;
 
@@ -30,8 +29,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class SnapshotProxy {
-    private static final Logger LOG = LogManager.getLogger(SnapshotProxy.class);
+public class VersionHelper {
+    private static final Logger LOG = LogManager.getLogger(VersionHelper.class);
 
     public static Cloud.GetVersionResponse getVisibleVersion(Cloud.GetVersionRequest request) throws RpcException {
         int tryTimes = 0;

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -872,7 +872,7 @@ message IndexRequest {
     optional int64 table_id = 3;
     optional int64 expiration = 4;
     optional int64 db_id = 5;
-    optional bool is_new_table = 6;
+    optional bool is_new_table = 6; // For table version
 }
 
 message IndexResponse {

--- a/regression-test/suites/table_p0/test_table_version.groovy
+++ b/regression-test/suites/table_p0/test_table_version.groovy
@@ -49,7 +49,7 @@ suite("test_table_version") {
     assertEquals(2, visibleVersion);
 
     sql """
-        alter table ${tableNameNum} drop partition p201703_all;
+        alter table ${tableNameNum} drop partition p201703_all force;
         """
     visibleVersion = getTableVersion(dbId,tableNameNum);
     assertEquals(3, visibleVersion);


### PR DESCRIPTION
## Proposed changes

1.  fix regression test test-table-version. 
2. when dropping partition, only update table version when dropping a non-empty partition.
3. complete some unfinished work in #32738

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

