### PR TITLE
[Enhancement](merge-on-write) Support  dynamic delete bitmap cache

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -803,7 +803,7 @@ DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
 // The default delete bitmap cache is set to 100MB,
 // which can be insufficient and cause performance issues when the amount of user data is large.
 // To mitigate the problem of an inadequate cache,
-// we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.
+// we will take the larger of 0.5% of the total memory and 100MB as the delete bitmap cache size.
 DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "0.5%");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -800,7 +800,11 @@ DEFINE_mInt32(jdbc_connection_pool_cache_clear_time_sec, "28800");
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
-DEFINE_Double(delete_bitmap_dynamic_agg_cache_capacity_percentage, "0.005");
+// The default delete bitmap cache is set to 100MB,
+// which can be insufficient and cause performance issues when the amount of user data is large.
+// To mitigate the problem of an inadequate cache,
+// we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.
+DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "0.5%");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 
 // reference https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#broker-version-compatibility

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -800,6 +800,7 @@ DEFINE_mInt32(jdbc_connection_pool_cache_clear_time_sec, "28800");
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
+DEFINE_Double(delete_bitmap_dynamic_agg_cache_capacity_percentage, "0.005");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 
 // reference https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#broker-version-compatibility

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -856,7 +856,7 @@ DECLARE_mInt32(jdbc_connection_pool_cache_clear_time_sec);
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DECLARE_Int64(delete_bitmap_agg_cache_capacity);
-DECLARE_Double(delete_bitmap_dynamic_agg_cache_capacity_percentage);
+DECLARE_String(delete_bitmap_dynamic_agg_cache_limit);
 DECLARE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec);
 
 // A common object cache depends on an Sharded LRU Cache.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -856,6 +856,7 @@ DECLARE_mInt32(jdbc_connection_pool_cache_clear_time_sec);
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DECLARE_Int64(delete_bitmap_agg_cache_capacity);
+DECLARE_Double(delete_bitmap_dynamic_agg_cache_capacity_percentage);
 DECLARE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec);
 
 // A common object cache depends on an Sharded LRU Cache.

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -42,6 +42,7 @@
 #include "olap/utils.h"
 #include "util/debug_points.h"
 #include "util/mem_info.h"
+#include "util/parse_util.h"
 #include "util/string_util.h"
 #include "util/time.h"
 #include "util/uid_util.h"
@@ -935,10 +936,13 @@ DeleteBitmap::DeleteBitmap(int64_t tablet_id) : _tablet_id(tablet_id) {
     // which can be insufficient and cause performance issues when the amount of user data is large.
     // To mitigate the problem of an inadequate cache,
     // we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.
-    int64_t mem =
-            config::delete_bitmap_dynamic_agg_cache_capacity_percentage * MemInfo::physical_mem();
-    _agg_cache.reset(new AggCache(mem > config::delete_bitmap_agg_cache_capacity
-                                          ? mem
+    bool is_percent = false;
+    int64_t delete_bitmap_agg_cache_cache_limit =
+            ParseUtil::parse_mem_spec(config::delete_bitmap_dynamic_agg_cache_limit,
+                                      MemInfo::mem_limit(), MemInfo::physical_mem(), &is_percent);
+    _agg_cache.reset(new AggCache(delete_bitmap_agg_cache_cache_limit >
+                                                  config::delete_bitmap_agg_cache_capacity
+                                          ? delete_bitmap_agg_cache_cache_limit
                                           : config::delete_bitmap_agg_cache_capacity));
 }
 

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -935,7 +935,8 @@ DeleteBitmap::DeleteBitmap(int64_t tablet_id) : _tablet_id(tablet_id) {
     // which can be insufficient and cause performance issues when the amount of user data is large.
     // To mitigate the problem of an inadequate cache,
     // we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.
-    int64_t mem = 0.05 * MemInfo::physical_mem();
+    int64_t mem =
+            config::delete_bitmap_dynamic_agg_cache_capacity_percentage * MemInfo::physical_mem();
     _agg_cache.reset(new AggCache(mem > config::delete_bitmap_agg_cache_capacity
                                           ? mem
                                           : config::delete_bitmap_agg_cache_capacity));

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -935,7 +935,7 @@ DeleteBitmap::DeleteBitmap(int64_t tablet_id) : _tablet_id(tablet_id) {
     // The default delete bitmap cache is set to 100MB,
     // which can be insufficient and cause performance issues when the amount of user data is large.
     // To mitigate the problem of an inadequate cache,
-    // we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.
+    // we will take the larger of 0.5% of the total memory and 100MB as the delete bitmap cache size.
     bool is_percent = false;
     int64_t delete_bitmap_agg_cache_cache_limit =
             ParseUtil::parse_mem_spec(config::delete_bitmap_dynamic_agg_cache_limit,


### PR DESCRIPTION
The default delete bitmap cache is set to 100MB, which can be insufficient and cause performance issues when the amount of user data is large. To mitigate the problem of an inadequate cache, we will take the larger of 5% of the total memory and 100MB as the delete bitmap cache size.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

