### PR TITLE
[Fix](Nereids) fix leading with inner join and right join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
@@ -257,6 +257,12 @@ public class LeadingHint extends Hint {
     public boolean isConditionJoinTypeMatched(List<Expression> conditions, JoinType joinType) {
         for (Expression condition : conditions) {
             JoinType originalJoinType = conditionJoinType.get(condition);
+            if (originalJoinType == null) {
+                if (joinType.isOneSideOuterJoin() || joinType.isSemiJoin() || joinType.isAntiJoin()) {
+                    return false;
+                }
+                continue;
+            }
             if (originalJoinType.equals(joinType)
                     || originalJoinType.isOneSideOuterJoin() && joinType.isOneSideOuterJoin()
                     || originalJoinType.isSemiJoin() && joinType.isSemiJoin()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
@@ -44,6 +44,10 @@ import org.apache.doris.nereids.rules.analysis.ProjectToGlobalAggregate;
 import org.apache.doris.nereids.rules.analysis.ProjectWithDistinctToAggregate;
 import org.apache.doris.nereids.rules.analysis.ReplaceExpressionByChildOutput;
 import org.apache.doris.nereids.rules.analysis.SubqueryToApply;
+import org.apache.doris.nereids.rules.rewrite.EliminateOuterJoin;
+import org.apache.doris.nereids.rules.rewrite.InferAggNotNull;
+import org.apache.doris.nereids.rules.rewrite.InferFilterNotNull;
+import org.apache.doris.nereids.rules.rewrite.InferJoinNotNull;
 import org.apache.doris.nereids.rules.rewrite.MergeProjects;
 import org.apache.doris.nereids.rules.rewrite.SemiJoinCommute;
 import org.apache.doris.nereids.rules.rewrite.SimplifyAggGroupBy;
@@ -167,6 +171,12 @@ public class Analyzer extends AbstractBatchJobExecutor {
             topDown(new NormalizeAggregate()),
             topDown(new HavingToFilter()),
             bottomUp(new SemiJoinCommute()),
+            topDown(
+                new InferAggNotNull(),
+                new InferFilterNotNull(),
+                new InferJoinNotNull(),
+                new EliminateOuterJoin()
+            ),
             bottomUp(
                     new CollectSubQueryAlias(),
                     new CollectJoinConstraint()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
@@ -44,7 +44,6 @@ import org.apache.doris.nereids.rules.analysis.ProjectToGlobalAggregate;
 import org.apache.doris.nereids.rules.analysis.ProjectWithDistinctToAggregate;
 import org.apache.doris.nereids.rules.analysis.ReplaceExpressionByChildOutput;
 import org.apache.doris.nereids.rules.analysis.SubqueryToApply;
-import org.apache.doris.nereids.rules.rewrite.EliminateOuterJoin;
 import org.apache.doris.nereids.rules.rewrite.InferAggNotNull;
 import org.apache.doris.nereids.rules.rewrite.InferFilterNotNull;
 import org.apache.doris.nereids.rules.rewrite.InferJoinNotNull;
@@ -174,8 +173,7 @@ public class Analyzer extends AbstractBatchJobExecutor {
             topDown(
                 new InferAggNotNull(),
                 new InferFilterNotNull(),
-                new InferJoinNotNull(),
-                new EliminateOuterJoin()
+                new InferJoinNotNull()
             ),
             bottomUp(
                     new CollectSubQueryAlias(),

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -240,13 +240,114 @@ PhysicalResultSink
 --------NestedLoopJoin[RIGHT_OUTER_JOIN](t3.c3 > 500)
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------PhysicalProject
---------------NestedLoopJoin[LEFT_OUTER_JOIN](t1.c1 < 200)(t1.c1 > 500)
+--------------NestedLoopJoin[LEFT_OUTER_JOIN](t1.c1 > 500)
 ----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
+------------------filter((t1.c1 < 200))
+--------------------PhysicalOlapScan[t1]
 ----------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------PhysicalProject
 --------------------filter((t2.c2 > 500))
 ----------------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecGather]
+------------PhysicalProject
+--------------PhysicalOlapScan[t3]
+
+Hint log:
+Used: leading(t1 t2 t3 )
+UnUsed:
+SyntaxError:
+
+-- !select5_1 --
+4000
+
+-- !select5_2 --
+4000
+
+-- !select5_3 --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------NestedLoopJoin[LEFT_OUTER_JOIN]
+------------PhysicalProject
+--------------NestedLoopJoin[CROSS_JOIN]
+----------------PhysicalProject
+------------------filter((t1.c1 = t1.c11))
+--------------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecReplicated]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------PhysicalProject
+----------------filter((t3.c3 < 0))
+------------------PhysicalOlapScan[t3]
+
+-- !select5_4 --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------NestedLoopJoin[LEFT_OUTER_JOIN]
+------------PhysicalProject
+--------------NestedLoopJoin[CROSS_JOIN]
+----------------PhysicalProject
+------------------filter((t1.c1 = t1.c11))
+--------------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecReplicated]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------PhysicalProject
+----------------filter((t3.c3 < 0))
+------------------PhysicalOlapScan[t3]
+
+Hint log:
+Used: leading(t1 t2 t3 )
+UnUsed:
+SyntaxError:
+
+-- !select5_5 --
+1000
+
+-- !select5_6 --
+1000
+
+-- !select5_7 --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------NestedLoopJoin[LEFT_OUTER_JOIN](t3.c3 < 0)
+------------PhysicalProject
+--------------PhysicalOlapScan[t3]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------PhysicalProject
+----------------NestedLoopJoin[CROSS_JOIN]
+------------------PhysicalProject
+--------------------filter((t1.c1 = t1.c11))
+----------------------PhysicalOlapScan[t1]
+------------------PhysicalDistribute[DistributionSpecReplicated]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[t2]
+
+-- !select5_8 --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----hashAgg[LOCAL]
+------PhysicalProject
+--------NestedLoopJoin[RIGHT_OUTER_JOIN](t3.c3 < 0)
+----------PhysicalDistribute[DistributionSpecGather]
+------------PhysicalProject
+--------------NestedLoopJoin[CROSS_JOIN]
+----------------PhysicalProject
+------------------filter((t1.c1 = t1.c11))
+--------------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecReplicated]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[t2]
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------PhysicalProject
 --------------PhysicalOlapScan[t3]

--- a/regression-test/suites/nereids_p0/hint/fix_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/fix_leading.groovy
@@ -170,4 +170,16 @@ suite("fix_leading") {
     qt_select4_1 """select count(*) from t1 left join t2 on c1 > 500 and c2 >500 right join t3 on c3 > 500 and c1 < 200;"""
     qt_select4_2 """select /*+ leading(t1 t2 t3)*/ count(*) from t1 left join t2 on c1 > 500 and c2 >500 right join t3 on c3 > 500 and c1 < 200;"""
     qt_select4_3 """explain shape plan select /*+ leading(t1 t2 t3)*/ count(*) from t1 left join t2 on c1 > 500 and c2 >500 right join t3 on c3 > 500 and c1 < 200;"""
+
+    // fix inner join + left join with null rejection derive
+    qt_select5_1 """select count(*) from t1 join t2 on t1.c1 = t1.c11 left join t3 on t3.c3 < 0;"""
+    qt_select5_2 """select /*+ leading(t1 t2 t3) */ count(*) from t1 join t2 on t1.c1 = t1.c11 left join t3 on t3.c3 < 0;"""
+    qt_select5_3 """explain shape plan select count(*) from t1 join t2 on t1.c1 = t1.c11 left join t3 on t3.c3 < 0;"""
+    qt_select5_4 """explain shape plan select /*+ leading(t1 t2 t3) */ count(*) from t1 join t2 on t1.c1 = t1.c11 left join t3 on t3.c3 < 0;"""
+    qt_select5_5 """select count(*) from t1 join t2 on t1.c1 = t1.c11 right join t3 on t3.c3 < 0;"""
+    qt_select5_6 """select /*+ leading(t1 t2 t3) */ count(*) from t1 join t2 on t1.c1 = t1.c11 right join t3 on t3.c3 < 0;"""
+    qt_select5_7 """explain shape plan select count(*) from t1 join t2 on t1.c1 = t1.c11 right join t3 on t3.c3 < 0;"""
+    qt_select5_8 """explain shape plan select /*+ leading(t1 t2 t3) */ count(*) from t1 join t2 on t1.c1 = t1.c11 right join t3 on t3.c3 < 0;"""
+
+
 }


### PR DESCRIPTION
## Proposed changes

Problem:
when plan with inner join and right join, some predicate and join can derive some null reject column, leading could change these column to nullable
Solved:
before leading, we can do eliminate outer join first to avoid message lost

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

