### PR TITLE
[fix](load) skip cancel rpc if stub is not initialized

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -852,6 +852,10 @@ void VNodeChannel::cancel(const std::string& cancel_msg) {
     // But do we need brpc::StartCancel(call_id)?
     _cancel_with_msg(cancel_msg);
 
+    if (_stub == nullptr) {
+        return;
+    }
+
     PTabletWriterCancelRequest request;
     request.set_allocated_id(&_parent->_load_id);
     request.set_index_id(_index_channel->_index_id);


### PR DESCRIPTION
## Proposed changes

Fix coredump in VNodeChannel::cancel

```
*** Query id: b94d185960dc7990-4cc55561c7aef297 ***
*** tablet id: 0 ***
*** Aborted at 1711443908 (unix time) try "date -d @1711443908" if you are using GNU date ***
*** Current BE git commitID: d75ba6ef4e ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 22808 (TID 25126 OR 0xfff9d72d8010) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /data/software/jdk1.8.0_401/jre/lib/aarch64/server/libjvm.so
 2# JVM_handle_linux_signal in /data/software/jdk1.8.0_401/jre/lib/aarch64/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /data/software/jdk1.8.0_401/jre/lib/aarch64/server/libjvm.so
 4# 0x0000FFFFA4BE066C in 
 5# doris::stream_load::VNodeChannel::cancel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /home/zcp/repo_center/doris_release/doris/be/src/vec/sink/vtablet_sink.cpp:871
 6# std::_Function_handler<void (std::shared_ptr<doris::stream_load::VNodeChannel> const&), doris::stream_load::VOlapTableSink::_cancel_all_channel(doris::Status)::$_0>::_M_invoke(std::_Any_data const&, std::shared_ptr<doris::stream_load::VNodeChannel> const&) at /usr/local/bin/ldb-toolchain/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 7# doris::stream_load::VOlapTableSink::_cancel_all_channel(doris::Status) at /home/zcp/repo_center/doris_release/doris/be/src/vec/sink/vtablet_sink.cpp:1467
 8# doris::stream_load::VOlapTableSink::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_release/doris/be/src/vec/sink/vtablet_sink.cpp:1535
 9# doris::PlanFragmentExecutor::close() at /home/zcp/repo_center/doris_release/doris/be/src/runtime/plan_fragment_executor.cpp:522
10# doris::PlanFragmentExecutor::~PlanFragmentExecutor() at /home/zcp/repo_center/doris_release/doris/be/src/runtime/plan_fragment_executor.cpp:95
11# doris::FragmentExecState::~FragmentExecState() at /home/zcp/repo_center/doris_release/doris/be/src/runtime/fragment_mgr.cpp:112
12# std::_Sp_counted_ptr<doris::FragmentExecState*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /usr/local/bin/ldb-toolchain/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348
13# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /home/zcp/repo_center/doris_release/doris/be/src/runtime/fragment_mgr.cpp:864
14# doris::StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<doris::StreamLoadContext>) at /home/zcp/repo_center/doris_release/doris/be/src/runtime/stream_load/stream_load_executor.cpp:75
15# doris::StreamLoadAction::_process_put(doris::HttpRequest*, std::shared_ptr<doris::StreamLoadContext>) at /home/zcp/repo_center/doris_release/doris/be/src/http/action/stream_load.cpp:620
16# doris::StreamLoadAction::_on_header(doris::HttpRequest*, std::shared_ptr<doris::StreamLoadContext>) at /home/zcp/repo_center/doris_release/doris/be/src/http/action/stream_load.cpp:318
17# doris::StreamLoadAction::on_header(doris::HttpRequest*) at /home/zcp/repo_center/doris_release/doris/be/src/http/action/stream_load.cpp:193
18# doris::EvHttpServer::on_header(evhttp_request*) at /home/zcp/repo_center/doris_release/doris/be/src/http/ev_http_server.cpp:255
19# 0x0000AAAAF5E2D334 in /data/software/doris206/be/lib/doris_be
20# bufferevent_run_readcb_ in /data/software/doris206/be/lib/doris_be
21# 0x0000AAAAF5E31544 in /data/software/doris206/be/lib/doris_be
22# 0x0000AAAAF5E1941C in /data/software/doris206/be/lib/doris_be
23# 0x0000AAAAF5E19B90 in /data/software/doris206/be/lib/doris_be
24# 0x0000AAAAF5E1C0DC in /data/software/doris206/be/lib/doris_be
25# std::_Function_handler<void (), doris::EvHttpServer::start()::$_0>::_M_invoke(std::_Any_data const&) at /usr/local/bin/ldb-toolchain/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
26# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_release/doris/be/src/util/threadpool.cpp:541
27# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_release/doris/be/src/util/thread.cpp:499
28# start_thread in /lib64/libpthread.so.0
29# thread_start in /lib64/libc.so.6 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

