### PR TITLE
[pipelineX](local exchange) Fix potential timeout problem

### DIFF
--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.cpp
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.cpp
@@ -40,13 +40,25 @@ Status LocalExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
     return Status::OK();
 }
 
+Status LocalExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
+    if (_closed) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(Base::close(state, exec_status));
+    if (!_release_count) {
+        _shared_state->sub_running_sink_operators();
+    }
+    return Status::OK();
+}
+
 std::string LocalExchangeSinkLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer,
-                   "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}",
+                   "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}, "
+                   "_running_sink_operators: {}, _release_count: {}",
                    Base::debug_string(indentation_level), _channel_id, _exchanger->_num_partitions,
                    _exchanger->_num_senders, _exchanger->_num_sources,
-                   _exchanger->_running_sink_operators);
+                   _exchanger->_running_sink_operators, _release_count);
     return fmt::to_string(debug_string_buffer);
 }
 
@@ -59,6 +71,7 @@ Status LocalExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
 
     if (eos) {
         local_state._shared_state->sub_running_sink_operators();
+        local_state._release_count = true;
     }
 
     return Status::OK();

--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.cpp
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.cpp
@@ -45,8 +45,8 @@ Status LocalExchangeSinkLocalState::close(RuntimeState* state, Status exec_statu
         return Status::OK();
     }
     RETURN_IF_ERROR(Base::close(state, exec_status));
-    if (!_release_count) {
-        _shared_state->sub_running_sink_operators();
+    if (exec_status.ok()) {
+        DCHECK(_release_count) << "Do not finish correctly! " << debug_string(0);
     }
     return Status::OK();
 }

--- a/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.h
+++ b/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.h
@@ -37,6 +37,7 @@ public:
     ~LocalExchangeSinkLocalState() override = default;
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
+    Status close(RuntimeState* state, Status exec_status) override;
     std::string debug_string(int indentation_level) const override;
 
 private:
@@ -58,6 +59,7 @@ private:
 
     // Used by random passthrough exchanger
     int _channel_id = 0;
+    bool _release_count = false;
 };
 
 // A single 32-bit division on a recent x64 processor has a throughput of one instruction every six cycles with a latency of 26 cycles.


### PR DESCRIPTION
## Proposed changes

If pipeline task is cancelled, `eos` will be never to pass to sink operator. So local exchange will be never scheduled

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

