### PR TITLE
[fix](path-gc) Fix pending rowset guard check failure when ordered data compaction failed

### DIFF
--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -147,6 +147,7 @@ private:
 
     void construct_skip_inverted_index(RowsetWriterContext& ctx);
 
+    // Return true if do ordered data compaction successfully
     bool handle_ordered_data_compaction();
 
     Status do_compact_ordered_rowsets();

--- a/be/src/olap/rowset/pending_rowset_helper.h
+++ b/be/src/olap/rowset/pending_rowset_helper.h
@@ -35,21 +35,13 @@ public:
     PendingRowsetGuard(const PendingRowsetGuard&) = delete;
     PendingRowsetGuard& operator=(const PendingRowsetGuard&) = delete;
 
-    PendingRowsetGuard(PendingRowsetGuard&& other) noexcept {
-        CHECK(!_pending_rowset_set ||
-              (_rowset_id == other._rowset_id && _pending_rowset_set == other._pending_rowset_set));
-        _rowset_id = other._rowset_id;
-        _pending_rowset_set = other._pending_rowset_set;
-        other._pending_rowset_set = nullptr;
-    }
-    PendingRowsetGuard& operator=(PendingRowsetGuard&& other) noexcept {
-        CHECK(!_pending_rowset_set ||
-              (_rowset_id == other._rowset_id && _pending_rowset_set == other._pending_rowset_set));
-        _rowset_id = other._rowset_id;
-        _pending_rowset_set = other._pending_rowset_set;
-        other._pending_rowset_set = nullptr;
-        return *this;
-    }
+    PendingRowsetGuard(PendingRowsetGuard&& other) noexcept;
+    PendingRowsetGuard& operator=(PendingRowsetGuard&& other) noexcept;
+
+    // Remove guarded rowset id from `PendingRowsetSet` if it's initialized and reset the guard to
+    // uninitialized state. This be used to manually release the pending rowset, ensure that the
+    // guarded rowset is indeed no longer in use.
+    void drop();
 
 private:
     friend class PendingRowsetSet;


### PR DESCRIPTION


## Proposed changes

Fix pending rowset guard check failure when ordered data compaction failed

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

