### PR TITLE
[enhancement](cloud) reduce rpc times in CloudGlobalTransactionMgr when calc delete bitmap for mow

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -559,10 +559,10 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             }
         });
         try {
-             List<Long> visibleVersion = CloudPartition.getSnapshotVisibleVersion(cloudPartitions);
-             for (int i = 0; i < visibleVersion.size(); i++) {
-                 long newVersion = visibleVersion.get(i) <= 0 ? 2 : visibleVersion.get(i) + 1;
-                 partitionToVersions.put(cloudPartitions.get(i).getId(), newVersion);
+            List<Long> visibleVersion = CloudPartition.getSnapshotVisibleVersion(cloudPartitions);
+            for (int i = 0; i < visibleVersion.size(); i++) {
+                long newVersion = visibleVersion.get(i) <= 0 ? 2 : visibleVersion.get(i) + 1;
+                partitionToVersions.put(cloudPartitions.get(i).getId(), newVersion);
             }
         } catch (RpcException e) {
             throw new RuntimeException("get version from meta service failed");

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -550,13 +550,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         Map<Long, Long> partitionToVersions = Maps.newHashMap();
         List<CloudPartition> cloudPartitions = Lists.newArrayList();
         partitionMap.forEach((key, value) -> {
-            if (value instanceof CloudPartition) {
-                cloudPartitions.add((CloudPartition) value);
-            } else {
-                long visibleVersion = value.getVisibleVersion();
-                long newVersion = visibleVersion <= 0 ? 2 : visibleVersion + 1;
-                partitionToVersions.put(key, newVersion);
-            }
+            cloudPartitions.add((CloudPartition) value);
         });
         try {
             List<Long> visibleVersion = CloudPartition.getSnapshotVisibleVersion(cloudPartitions);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Use batch mode to get partitions' visible versions to reduce rpc times

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

