### PR TITLE
[fix](avro) avoid BE crash if avro scanner's dependency jars is mssing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -232,6 +232,7 @@ public abstract class ConnectProcessor {
                 // Parse sql failed, audit it and return
                 handleQueryException(e, convertedStmt, null, null);
                 return;
+            } catch (ParseEx)
             } catch (Exception e) {
                 // TODO: We should catch all exception here until we support all query syntax.
                 if (LOG.isDebugEnabled()) {

--- a/regression-test/suites/datatype_p0/bitmap/test_bitmap_int.groovy
+++ b/regression-test/suites/datatype_p0/bitmap/test_bitmap_int.groovy
@@ -68,7 +68,7 @@ suite("test_bitmap_int") {
 
     test {
         sql """SELECT case id_bitmap when 1 then 1 else 0 FROM test_bitmap;"""
-        exception "ParseException"
+        exception "Syntax error in line 1"
     }
 
     qt_sql64_4 """SELECT id_bitmap  FROM test_bitmap  WHERE id_bitmap is null LIMIT 20;"""

--- a/regression-test/suites/datatype_p0/nested_types/query/test_nestedtypes_insert_into_select.groovy
+++ b/regression-test/suites/datatype_p0/nested_types/query/test_nestedtypes_insert_into_select.groovy
@@ -52,6 +52,6 @@ suite("test_nestedtypes_insert_into_select", "p0") {
 
     test {
         sql "insert into ast values ('text' , [named_struct('a',1,'b','home'),named_struct('a',2,'b','work')]);"
-        exception "ParseException"
+        exception "Sql parser can't convert the result to array"
     }
 }

--- a/regression-test/suites/demo_p0/test_action.groovy
+++ b/regression-test/suites/demo_p0/test_action.groovy
@@ -19,7 +19,7 @@ suite("test_action") {
     test {
         sql "abcdefg"
         // check exception message contains
-        exception "ParseException"
+        exception "Syntax error in line 1"
     }
 
     test {

--- a/regression-test/suites/nereids_p0/insert_into_table/update_on_current_timestamp.groovy
+++ b/regression-test/suites/nereids_p0/insert_into_table/update_on_current_timestamp.groovy
@@ -190,6 +190,6 @@ suite("nereids_update_on_current_timestamp") {
                 k int,
                 `update_time` datetime(6) default current_timestamp(4) on update current_timestamp(3)) replace,
             ) AGGREGATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 properties("replication_num" = "1");"""
-        exception "ParseException"
+        exception "Syntax error in line 3"
     }
 }

--- a/regression-test/suites/query_p0/join/test_join2.groovy
+++ b/regression-test/suites/query_p0/join/test_join2.groovy
@@ -84,7 +84,7 @@ suite("test_join2", "query,p0,arrow_flight_sql") {
             FROM ${TBname1} NATURAL JOIN ${TBname2}
             ORDER BY 1,2,3,4,5,6;
         """
-        exception "ParseException"
+        exception "natural join is not supported"
     }
     
     qt_join4 """


### PR DESCRIPTION
## Proposed changes

1. Check the return value of avro reader's init_fetch_table_schema_reader()
2. Also fix a bug but the parse exception of Nereids may suppress the real exception from old planner
    It will result unable to see the real error msg.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

