### PR TITLE
[partitionsort](fix) Fix DCHECK failure

### DIFF
--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -141,8 +141,6 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
             local_state._value_places[i]->create_or_reset_sorter_state();
             auto sorter = std::move(local_state._value_places[i]->_partition_topn_sorter);
 
-            DCHECK(_child_x->row_desc().num_materialized_slots() ==
-                   local_state._value_places[i]->_blocks.back()->columns());
             //get blocks from every partition, and sorter get those data.
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));

--- a/be/src/vec/exec/vpartition_sort_node.cpp
+++ b/be/src/vec/exec/vpartition_sort_node.cpp
@@ -263,8 +263,6 @@ Status VPartitionSortNode::sink(RuntimeState* state, vectorized::Block* input_bl
             _value_places[i]->create_or_reset_sorter_state();
             auto sorter = std::ref(_value_places[i]->_partition_topn_sorter);
 
-            DCHECK(child(0)->row_desc().num_materialized_slots() ==
-                   _value_places[i]->_blocks.back()->columns());
             //get blocks from every partition, and sorter get those data.
             for (const auto& block : _value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter.get()->append_block(block.get()));


### PR DESCRIPTION
## Proposed changes

In partition sort operator, blocks vector in value place will be clear after a batch data. If we sink data with eos after this clear, DCHECK will cause a illegal memory access to empty vector.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

