### PR TITLE
[fix](timeout) query timeout was not correctly set

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -52,6 +52,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.plsql.Exec;
 import org.apache.doris.plsql.executor.PlSqlOperation;
 import org.apache.doris.plugin.audit.AuditEvent.AuditEventBuilder;
+import org.apache.doris.proto.Types;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.service.arrowflight.results.FlightSqlChannel;
 import org.apache.doris.statistics.ColumnStatistic;
@@ -885,6 +886,24 @@ public class ConnectContext {
         cancelQuery();
     }
 
+    // kill operation with no protect by timeout.
+    private void killByTimeout(boolean killConnection) {
+        LOG.warn("kill query from {}, kill mysql connection: {} reason time out", getRemoteHostPortString(),
+                killConnection);
+
+        if (killConnection) {
+            isKilled = true;
+            // Close channel to break connection with client
+            closeChannel();
+        }
+        // Now, cancel running query.
+        // cancelQuery by time out
+        StmtExecutor executorRef = executor;
+        if (executorRef != null) {
+            executorRef.cancel(Types.PPlanFragmentCancelReason.TIMEOUT);
+        }
+    }
+
     public void cancelQuery() {
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
@@ -925,7 +944,7 @@ public class ConnectContext {
         }
 
         if (killFlag) {
-            kill(killConnection);
+            killByTimeout(killConnection);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1301,7 +1301,7 @@ public class Coordinator implements CoordInterface {
         resultBatch = receiver.getNext(status);
         if (!status.ok()) {
             LOG.warn("Query {} coordinator get next fail, {}, need cancel.",
-                    DebugUtil.printId(queryId), status.toString());
+                    DebugUtil.printId(queryId), status.getErrorMsg());
         }
 
         updateStatus(status);
@@ -1440,7 +1440,8 @@ public class Coordinator implements CoordInterface {
             } else {
                 queryStatus.setStatus(Status.CANCELLED);
             }
-            LOG.warn("Cancel execution of query {}, this is a outside invoke", DebugUtil.printId(queryId));
+            LOG.warn("Cancel execution of query {}, this is a outside invoke, cancelReason {}",
+                    DebugUtil.printId(queryId), cancelReason.toString());
             cancelInternal(cancelReason);
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1335,6 +1335,20 @@ public class StmtExecutor {
         }
     }
 
+    // Because this is called by other thread
+    public void cancel(Types.PPlanFragmentCancelReason cancelReason) {
+        Coordinator coordRef = coord;
+        if (coordRef != null) {
+            coordRef.cancel(cancelReason);
+        }
+        if (mysqlLoadId != null) {
+            Env.getCurrentEnv().getLoadManager().getMysqlLoadManager().cancelMySqlLoad(mysqlLoadId);
+        }
+        if (parsedStmt instanceof AnalyzeTblStmt || parsedStmt instanceof AnalyzeDBStmt) {
+            Env.getCurrentEnv().getAnalysisManager().cancelSyncTask(context);
+        }
+    }
+
     // Handle kill statement.
     private void handleKill() throws DdlException {
         KillStmt killStmt = (KillStmt) parsedStmt;


### PR DESCRIPTION
## Proposed changes

In the past, in ConnectContext's checkTimeout, if a timeout occurred and cancel was not passed PPlanFragmentCancelReason, it resulted in being set to Types.PPlanFragmentCancelReason.USER_CANCEL.


```java
    public void cancel() {
        cancel(Types.PPlanFragmentCancelReason.USER_CANCEL);
    }
```

```
2024-03-29 13:11:11,683 WARN (connect-scheduler-check-timer-0|103) [ConnectContext.checkTimeout():921] kill query timeout, remote: 172.30.0.32:50876, query timeout: 600000
2024-03-29 13:11:11,683 WARN (connect-scheduler-check-timer-0|103) [ConnectContext.kill():877] kill query from 172.30.0.32:50876, kill mysql connection: false
2024-03-29 13:10:39,686 WARN (connect-scheduler-check-timer-0|103) [Coordinator.cancel():1443] Cancel execution of query a82b68a3a1bc44b9-b4bc0254ac412006, this is a outside invoke
2024-03-29 13:10:39,698 WARN (mysql-nio-pool-67|868) [ResultReceiver.getNext():102] Query a82b68a3a1bc44b9-b4bc0254ac412006 get result timeout, get result duration 599 ms
2024-03-29 13:10:39,698 WARN (mysql-nio-pool-67|868) [ResultReceiver.updateCancelReason():194] Query a82b68a3a1bc44b9-b4bc0254ac412006 already has cancel reason: USER_CANCEL, new reason fetch data timeout will be ignored

```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

