### PR TITLE
[fix](memory) Fix CloudDeltaWriter init attach task in thread context

### DIFF
--- a/be/src/cloud/cloud_delta_writer.cpp
+++ b/be/src/cloud/cloud_delta_writer.cpp
@@ -29,6 +29,7 @@ CloudDeltaWriter::CloudDeltaWriter(CloudStorageEngine& engine, const WriteReques
                                    RuntimeProfile* profile, const UniqueId& load_id)
         : BaseDeltaWriter(req, profile, load_id), _engine(engine) {
     _rowset_builder = std::make_unique<CloudRowsetBuilder>(engine, req, profile);
+    _query_thread_context.init();
 }
 
 CloudDeltaWriter::~CloudDeltaWriter() = default;
@@ -46,7 +47,7 @@ Status CloudDeltaWriter::batch_init(std::vector<CloudDeltaWriter*> writers) {
         }
 
         tasks.emplace_back([writer] {
-            ThreadLocalHandle::create_thread_local_if_not_exits();
+            SCOPED_ATTACH_TASK(writer->query_thread_context());
             std::lock_guard<bthread::Mutex> lock(writer->_mtx);
             if (writer->_is_init || writer->_is_cancelled) {
                 return Status::OK();

--- a/be/src/cloud/cloud_delta_writer.h
+++ b/be/src/cloud/cloud_delta_writer.h
@@ -53,12 +53,15 @@ public:
 
     Status set_txn_related_delete_bitmap();
 
+    QueryThreadContext query_thread_context() { return _query_thread_context; }
+
 private:
     // Convert `_rowset_builder` from `BaseRowsetBuilder` to `CloudRowsetBuilder`
     CloudRowsetBuilder* rowset_builder();
 
     bthread::Mutex _mtx;
     CloudStorageEngine& _engine;
+    QueryThreadContext _query_thread_context;
 };
 
 } // namespace doris

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -43,7 +43,6 @@ namespace doris {
 
 class FlushToken;
 class MemTable;
-class MemTracker;
 class StorageEngine;
 class TupleDescriptor;
 class SlotDescriptor;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -75,7 +75,6 @@
 #include "olap/tablet_meta_manager.h"
 #include "olap/task/engine_task.h"
 #include "olap/txn_manager.h"
-#include "runtime/memory/mem_tracker.h"
 #include "runtime/stream_load/stream_load_recorder.h"
 #include "util/doris_metrics.h"
 #include "util/metrics.h"

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -60,7 +60,6 @@ class BaseCompaction;
 class CumulativeCompaction;
 class SingleReplicaCompaction;
 class CumulativeCompactionPolicy;
-class MemTracker;
 class StreamLoadRecorder;
 class TCloneReq;
 class TCreateTabletReq;


### PR DESCRIPTION
## Proposed changes

1. Check failed: !doris::config::enable_memory_orphan_check || doris::thread_context()->thread_mem_tracker()->label() != "Orphan"
```
9# doris::MemTable::MemTable(long, doris::TabletSchema const*, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const*, doris::TupleDescriptor*, bool, doris::PartialUpdateInfo*, std::shared_ptr<doris::MemTracker> const&, std::shared_ptr<doris::MemTracker> const&) at /root/doris/be/src/olap/memtable.cpp:69
[16:40:35 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387577?buildTab=log&linesState=26285&logView=flowAware&focusLine=26285)  10# doris::MemTableWriter::_reset_mem_table() at /root/doris/be/src/olap/memtable_writer.cpp:217
[16:40:35 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387577?buildTab=log&linesState=26286&logView=flowAware&focusLine=26286)  11# doris::MemTableWriter::init(std::shared_ptr<doris::RowsetWriter>, std::shared_ptr<doris::TabletSchema>, std::shared_ptr<doris::PartialUpdateInfo>, doris::ThreadPool*, bool) in /home/work/unlimit_teamcity/TeamCity/Agents/20240329151037agent_172.16.0.157_1/work/60183217f6ee2a9c/output/be/lib/doris_be
[16:40:35 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387577?buildTab=log&linesState=26287&logView=flowAware&focusLine=26287)  12# doris::BaseDeltaWriter::init() at /root/doris/be/src/olap/delta_writer.cpp:106
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

