### PR TITLE
[fix](compaction) fix single replica compaction input rowsets

### DIFF
--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -239,7 +239,6 @@ bool SingleReplicaCompaction::_find_rowset_to_fetch(const std::vector<Version>& 
     if (find) {
         //  4. reset input rowsets
         _input_rowsets.clear();
-        std::vector<RowsetSharedPtr> candidate_rowsets;
         tablet()->traverse_rowsets([this, &proper_version](const auto& rs) {
             // only need rowset in proper_version
             if (rs->is_local() && rs->start_version() >= proper_version->first &&

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -241,9 +241,8 @@ bool SingleReplicaCompaction::_find_rowset_to_fetch(const std::vector<Version>& 
     if (find) {
         //  4. reset input rowsets
         _input_rowsets.clear();
-        Tablet* tablet = static_cast<Tablet*>(_tablet.get());
         std::vector<RowsetSharedPtr> candidate_rowsets;
-        tablet->traverse_rowsets([&candidate_rowsets, &proper_version](const auto& rs) {
+        tablet()->traverse_rowsets([&candidate_rowsets, &proper_version](const auto& rs) {
             // only need rowset in proper_version
             if (rs->is_local() && rs->end_version() >= proper_version->first &&
                 rs->start_version() <= proper_version->second) {

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -249,6 +249,16 @@ bool SingleReplicaCompaction::_find_rowset_to_fetch(const std::vector<Version>& 
         std::sort(_input_rowsets.begin(), _input_rowsets.end(), Rowset::comparator);
         DCHECK_EQ(_input_rowsets.front()->start_version(), proper_version->first);
         DCHECK_EQ(_input_rowsets.back()->end_version(), proper_version->second);
+        if (_input_rowsets.front()->start_version() != proper_version->first ||
+            _input_rowsets.back()->end_version() != proper_version->second) {
+            LOG(WARNING) << fmt::format(
+                    "single compaction input rowsets error, tablet_id={}, input rowset = {}-{}, "
+                    "remote rowset = {}-{}",
+                    tablet()->tablet_id(), _input_rowsets.front()->start_version(),
+                    _input_rowsets.back()->end_version(), proper_version->first,
+                    proper_version->second);
+            return false;
+        }
         for (auto& rowset : _input_rowsets) {
             _input_rowsets_size += rowset->data_disk_size();
             _input_row_num += rowset->num_rows();

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -240,11 +240,11 @@ bool SingleReplicaCompaction::_find_rowset_to_fetch(const std::vector<Version>& 
         //  4. reset input rowsets
         _input_rowsets.clear();
         std::vector<RowsetSharedPtr> candidate_rowsets;
-        tablet()->traverse_rowsets([&_input_rowsets, &proper_version](const auto& rs) {
+        tablet()->traverse_rowsets([this, &proper_version](const auto& rs) {
             // only need rowset in proper_version
             if (rs->is_local() && rs->start_version() >= proper_version->first &&
                 rs->end_version() <= proper_version->second) {
-                _input_rowsets.emplace_back(rs);
+                this->_input_rowsets.emplace_back(rs);
             }
         });
         std::sort(_input_rowsets.begin(), _input_rowsets.end(), Rowset::comparator);

--- a/be/src/olap/single_replica_compaction.h
+++ b/be/src/olap/single_replica_compaction.h
@@ -48,7 +48,7 @@ protected:
 private:
     Status _do_single_replica_compaction();
     Status _do_single_replica_compaction_impl();
-    bool _find_rowset_to_fetch(const std::vector<Version>& peer_versions, Version* peer_version);
+    bool _find_rowset_to_fetch(const std::vector<Version>& peer_versions, Version* proper_version);
     Status _get_rowset_verisons_from_peer(const TReplicaInfo& addr,
                                           std::vector<Version>* peer_versions);
     Status _fetch_rowset(const TReplicaInfo& addr, const std::string& token,

--- a/be/src/olap/single_replica_compaction.h
+++ b/be/src/olap/single_replica_compaction.h
@@ -38,7 +38,6 @@ public:
     Status execute_compact() override;
 
 protected:
-    Status pick_rowsets_to_compact();
     std::string_view compaction_name() const override { return "single replica compaction"; }
     ReaderType compaction_type() const override {
         return (_compaction_type == CompactionType::CUMULATIVE_COMPACTION)

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1100,20 +1100,6 @@ std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_cumulative_compac
     return candidate_rowsets;
 }
 
-std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_single_replica_compaction() {
-    std::vector<RowsetSharedPtr> candidate_rowsets;
-    {
-        std::shared_lock rlock(_meta_lock);
-        for (const auto& [version, rs] : _rs_version_map) {
-            if (rs->is_local()) {
-                candidate_rowsets.push_back(rs);
-            }
-        }
-    }
-    std::sort(candidate_rowsets.begin(), candidate_rowsets.end(), Rowset::comparator);
-    return candidate_rowsets;
-}
-
 std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_base_compaction() {
     std::vector<RowsetSharedPtr> candidate_rowsets;
     {
@@ -1130,7 +1116,15 @@ std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_base_compaction()
 }
 
 std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_full_compaction() {
-    return pick_candidate_rowsets_to_single_replica_compaction();
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    traverse_rowsets([&candidate_rowsets](const auto& rs) {
+        // Do full compaction on all local rowsets.
+        if (rs->is_local()) {
+            candidate_rowsets.emplace_back(rs);
+        }
+    });
+    std::sort(candidate_rowsets.begin(), candidate_rowsets.end(), Rowset::comparator);
+    return candidate_rowsets;
 }
 
 std::vector<RowsetSharedPtr> Tablet::pick_first_consecutive_empty_rowsets(int limit) {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -246,7 +246,6 @@ public:
     std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_build_inverted_index(
             const std::set<int32_t>& alter_index_uids, bool is_drop_op);
 
-    std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_single_replica_compaction();
     std::vector<Version> get_all_versions();
 
     std::vector<RowsetSharedPtr> pick_first_consecutive_empty_rowsets(int limit);

--- a/be/test/olap/single_compaction_test.cpp
+++ b/be/test/olap/single_compaction_test.cpp
@@ -1,0 +1,132 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_common.pb.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/stringprintf.h"
+#include "olap/data_dir.h"
+#include "olap/olap_common.h"
+#include "olap/options.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_meta.h"
+#include "olap/single_replica_compaction.h"
+#include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/utils.h"
+namespace doris {
+namespace vectorized {
+
+static StorageEngine* engine_ref = nullptr;
+
+class SingleCompactionTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const std::string dir_path = "ut_dir/path_gc_test";
+        _engine = new StorageEngine({});
+        _data_dir = new DataDir(*_engine, dir_path);
+        engine_ref = _engine;
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id) {
+        auto tablet_meta = std::make_shared<TabletMeta>();
+        tablet_meta->_tablet_id = tablet_id;
+        (void)tablet_meta->set_partition_id(10000);
+        tablet_meta->set_tablet_uid({tablet_id, 0});
+        tablet_meta->set_shard_id(tablet_id % 4);
+        tablet_meta->_schema_hash = tablet_id;
+        return std::make_shared<Tablet>(*_engine, std::move(tablet_meta), data_dir);
+    }
+    RowsetSharedPtr create_rowset(TabletSharedPtr tablet, int64_t start, int64 end) {
+        auto rowset_meta = std::make_shared<RowsetMeta>();
+        Version version(start, end);
+        rowset_meta->set_version(version);
+        rowset_meta->set_tablet_id(tablet->tablet_id());
+        rowset_meta->set_tablet_uid(tablet->tablet_uid());
+        rowset_meta->set_rowset_id(_engine->next_rowset_id());
+        return std::make_shared<BetaRowset>(tablet->tablet_schema(), tablet->tablet_path(),
+                                            std::move(rowset_meta));
+    }
+    void TearDown() override {
+        delete _engine;
+        delete _data_dir;
+    }
+
+private:
+    StorageEngine* _engine;
+    DataDir* _data_dir;
+};
+
+TEST_F(SingleCompactionTest, test_input_rowset) {
+    TabletSharedPtr tablet = create_tablet(10000);
+
+    SingleReplicaCompaction single_compaction(engine_ref, tablet,
+                                              CompactionType::CUMULATIVE_COMPACTION);
+
+    // load 30 rowsets
+    for (int i = 1; i <= 30; ++i) {
+        auto rs = create_rowset(tablet, i, i);
+        auto st = tablet->add_inc_rowset(rs);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    // prepare pick input rowsets, but now no picked
+    single_compaction.prepare_compact();
+
+    // load 2 rowsets
+    for (int i = 31; i <= 32; i++) {
+        auto rs = create_rowset(tablet, i, i);
+        auto st = tablet->add_inc_rowset(rs);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    // create peer compacted rowset
+    auto v1 = Version(1, 32);
+    auto v2 = Version(33, 38);
+    std::vetcor<Version> peer_version {v1, v2};
+    Version proper_version;
+    bool find = single_compaction._find_rowset_to_fetch(peer_version, &proper_version);
+    EXPECT_EQ(find, true);
+    EXPECT_EQ(single_compaction._input_rowsets_size, 32);
+    EXPECT_EQ(single_compaction._input_rowsets.front()->start_version(),
+              single_compaction._output_rowset->start_version())
+    EXPECT_EQ(single_compaction._input_rowsets.back()->end_version(),
+              single_compaction._output_rowset->end_version())
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/test/olap/single_compaction_test.cpp
+++ b/be/test/olap/single_compaction_test.cpp
@@ -16,11 +16,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/logging.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
-#include <stdint.h>
-#include <unistd.h>
 
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Single replica compaction does not require picking input rowsets.
Input rowsets depend on the fetched  rowset.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

