### PR TITLE
[bug](cloud) Use cached visible version when Fe replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
@@ -84,7 +84,7 @@ public class AddPartitionRecord {
             sb.append(")");
         }
         sb.append("(\"version_info\" = \"");
-        sb.append(partition.getVisibleVersion()).append("\"");
+        sb.append(partition.getCachedVisibleVersion()).append("\"");
         sb.append(");");
         this.sql = sb.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
@@ -161,6 +161,10 @@ public class Partition extends MetaObject implements Writable {
         this.setVisibleVersionAndTime(visibleVersion, visibleVersionTime);
     }
 
+    public long getCachedVisibleVersion() {
+        return visibleVersion;
+    }
+
     public long getVisibleVersion() {
         return visibleVersion;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -101,6 +101,11 @@ public class CloudPartition extends Partition {
     }
 
     @Override
+    public long getCachedVisibleVersion() {
+        return super.getVisibleVersion();
+    }
+
+    @Override
     public long getVisibleVersion() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("getVisibleVersion use CloudPartition {}", super.getName());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Use cached visible version which will be persisted in log so that we can avoid to send rpc in fe replay.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

