### PR TITLE
[fix](memory) Fix CloudEngineCalcDeleteBitmapTask handle() attach task in thread context

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -2004,6 +2004,7 @@ void calc_delete_bimtap_callback(CloudStorageEngine& engine, const TAgentTaskReq
     const auto& calc_delete_bitmap_req = req.calc_delete_bitmap_req;
     CloudEngineCalcDeleteBitmapTask engine_task(engine, calc_delete_bitmap_req, &error_tablet_ids,
                                                 &succ_tablet_ids);
+    SCOPED_ATTACH_TASK(engine_task.mem_tracker());
     status = engine_task.execute();
 
     TFinishTaskRequest finish_task_request;

--- a/be/src/cloud/cloud_delta_writer.cpp
+++ b/be/src/cloud/cloud_delta_writer.cpp
@@ -52,7 +52,8 @@ Status CloudDeltaWriter::batch_init(std::vector<CloudDeltaWriter*> writers) {
             if (writer->_is_init || writer->_is_cancelled) {
                 return Status::OK();
             }
-            return writer->init();
+            Status st = writer->init(); // included in SCOPED_ATTACH_TASK
+            return st;
         });
     }
 

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -17,6 +17,8 @@
 
 #include "cloud/cloud_engine_calc_delete_bitmap_task.h"
 
+#include <fmt/format.h>
+
 #include <memory>
 
 #include "cloud/cloud_meta_mgr.h"
@@ -29,6 +31,7 @@
 #include "olap/tablet_meta.h"
 #include "olap/txn_manager.h"
 #include "olap/utils.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 
 namespace doris {
 
@@ -38,7 +41,10 @@ CloudEngineCalcDeleteBitmapTask::CloudEngineCalcDeleteBitmapTask(
         : _engine(engine),
           _cal_delete_bitmap_req(cal_delete_bitmap_req),
           _error_tablet_ids(error_tablet_ids),
-          _succ_tablet_ids(succ_tablet_ids) {}
+          _succ_tablet_ids(succ_tablet_ids) {
+    _mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::SCHEMA_CHANGE,
+                                                    "CloudEngineCalcDeleteBitmapTask");
+}
 
 void CloudEngineCalcDeleteBitmapTask::add_error_tablet_id(int64_t tablet_id, const Status& err) {
     std::lock_guard<std::mutex> lck(_mutex);
@@ -126,9 +132,14 @@ CloudTabletCalcDeleteBitmapTask::CloudTabletCalcDeleteBitmapTask(
           _engine_calc_delete_bitmap_task(engine_task),
           _tablet(tablet),
           _transaction_id(transaction_id),
-          _version(version) {}
+          _version(version) {
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            fmt::format("CloudTabletCalcDeleteBitmapTask#_transaction_id={}", _transaction_id));
+}
 
 void CloudTabletCalcDeleteBitmapTask::handle() const {
+    SCOPED_ATTACH_TASK(_mem_tracker);
     RowsetSharedPtr rowset;
     DeleteBitmapPtr delete_bitmap;
     RowsetIdUnorderedSet rowset_ids;

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.h
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.h
@@ -28,6 +28,7 @@
 namespace doris {
 
 class CloudEngineCalcDeleteBitmapTask;
+class MemTrackerLimiter;
 
 class CloudTabletCalcDeleteBitmapTask {
 public:
@@ -46,6 +47,7 @@ private:
     std::shared_ptr<CloudTablet> _tablet;
     int64_t _transaction_id;
     int64_t _version;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };
 
 class CloudEngineCalcDeleteBitmapTask : public EngineTask {


### PR DESCRIPTION
## Proposed changes

1. Check failed: !doris::config::enable_memory_orphan_check || thread_mem_tracker()->label() != "Orphan"
```
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43803&logView=flowAware&focusLine=43803)   9# Allocator<false, false, false>::consume_memory(unsigned long) const in /home/work/unlimit_teamcity/TeamCity/Agents/20240329203858agent_172.16.0.233_1/work/60183217f6ee2a9c/output/be/lib/doris_be
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43804&logView=flowAware&focusLine=43804)  10# Allocator<false, false, false>::alloc_impl(unsigned long, unsigned long) at /root/doris/be/src/vec/common/allocator.h:101
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43805&logView=flowAware&focusLine=43805)  11# void doris::vectorized::PODArrayBase<1ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::realloc<>(unsigned long) at /root/doris/be/src/vec/common/pod_array.h:161
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43806&logView=flowAware&focusLine=43806)  12# doris::vectorized::ColumnString::insert_many_continuous_binary_data(char const*, unsigned int const*, unsigned long) at /root/doris/be/src/vec/columns/column_string.h:255
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43807&logView=flowAware&focusLine=43807)  13# doris::segment_v2::BinaryPlainPageDecoder<(doris::FieldType)17>::next_batch(unsigned long*, COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&) in /home/work/unlimit_teamcity/TeamCity/Agents/20240329203858agent_172.16.0.233_1/work/60183217f6ee2a9c/output/be/lib/doris_be
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43808&logView=flowAware&focusLine=43808)  14# doris::segment_v2::IndexedColumnIterator::next_batch(unsigned long*, COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&) at /root/doris/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp:288
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43809&logView=flowAware&focusLine=43809)  15# doris::segment_v2::BloomFilterIndexIterator::read_bloom_filter(unsigned int, std::unique_ptr<doris::segment_v2::BloomFilter, std::default_delete<doris::segment_v2::BloomFilter> >*) in /home/work/unlimit_teamcity/TeamCity/Agents/20240329203858agent_172.16.0.233_1/work/60183217f6ee2a9c/output/be/lib/doris_be
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43810&logView=flowAware&focusLine=43810)  16# doris::PrimaryKeyIndexReader::parse_bf(std::shared_ptr<doris::io::FileReader>, doris::segment_v2::PrimaryKeyIndexMetaPB const&) at /root/doris/be/src/olap/primary_key_index.cpp:111
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43811&logView=flowAware&focusLine=43811)  17# std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<doris::DorisCallOnce<doris::Status>::call<doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1}>(doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1})::{lambda()#1}>(std::once_flag&, doris::DorisCallOnce<doris::Status>::call<doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1}>(doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1})::{lambda()#1}&&)::{lambda()#1}>(doris::DorisCallOnce<doris::Status>::call<doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1}>(doris::segment_v2::Segment::_load_pk_bloom_filter()::$_0::operator()() const::{lambda()#1})::{lambda()#1}&)::{lambda()#1}::__invoke() at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/mutex:712
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43812&logView=flowAware&focusLine=43812)  18# __pthread_once_slow at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_once.c:118
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43813&logView=flowAware&focusLine=43813)  19# doris::segment_v2::Segment::_load_pk_bloom_filter() at /root/doris/be/src/olap/rowset/segment_v2/segment.cpp:289
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43814&logView=flowAware&focusLine=43814)  20# doris::segment_v2::Segment::load_pk_index_and_bf() in /home/work/unlimit_teamcity/TeamCity/Agents/20240329203858agent_172.16.0.233_1/work/60183217f6ee2a9c/output/be/lib/doris_be
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43815&logView=flowAware&focusLine=43815)  21# doris::BaseTablet::calc_segment_delete_bitmap(std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::RowsetWriter*) at /root/doris/be/src/olap/base_tablet.cpp:673
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43816&logView=flowAware&focusLine=43816)  22# doris::BaseTablet::calc_delete_bitmap(std::shared_ptr<doris::BaseTablet> const&, std::shared_ptr<doris::Rowset>, std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::CalcDeleteBitmapToken*, doris::RowsetWriter*) at /root/doris/be/src/olap/base_tablet.cpp:636
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43817&logView=flowAware&focusLine=43817)  23# doris::BaseTablet::update_delete_bitmap(std::shared_ptr<doris::BaseTablet> const&, doris::TabletTxnInfo const*, long, long) at /root/doris/be/src/olap/base_tablet.cpp:1211
[20:50:29 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/387916?buildTab=log&linesState=43818&logView=flowAware&focusLine=43818)  24# doris::CloudTabletCalcDeleteBitmapTask::handle() const at /root/doris/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp:153
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

