### PR TITLE
[log](pipeline)add more log in scan localstate

### DIFF
--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -140,7 +140,7 @@ class ScanLocalState : public ScanLocalStateBase {
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
-    std::string debug_string(int indentation_level) const override;
+    std::string debug_string(int indentation_level) const final;
 
     bool ready_to_read() override;
 


### PR DESCRIPTION
## Proposed changes

error log

```
PipelineTask[this = 0x61901570a780, state = BLOCKED_FOR_SOURCE, dry run = false, elapse time = 599.986904548s], block dependency = OLAP_SCAN_OPERATOR_DEPENDENCY: id=4, block task = 1, ready=false, _always_ready=false, is cancelled=false, is running = false
operators: 
OLAP_SCAN_OPERATOR: id=4, parallel_tasks=1, _eos = false
  DATA_STREAM_SINK_OPERATOR: id=5, Sink Buffer: (_should_stop = false, _busy_channels = 0)
Read Dependency Information: 
```
parallel_tasks=1, _eos = false with out _scanner_ctx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

