### PR TITLE
[fix](Cloud) Carry properties with storage vault

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -63,6 +63,13 @@ public class CreateStorageVaultStmt extends DdlStmt {
         return vaultType;
     }
 
+    public void setStorageVaultType(StorageVault.StorageVaultType type) throws UserException {
+        if (type == StorageVault.StorageVaultType.UNKNOWN) {
+            throw new AnalysisException("Unsupported Storage Vault type: " + type);
+        }
+        this.vaultType = type;
+    }
+
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
@@ -83,10 +90,7 @@ public class CreateStorageVaultStmt extends DdlStmt {
         if (type == null) {
             throw new AnalysisException("Storage Vault type can't be null");
         }
-        vaultType = StorageVault.StorageVaultType.fromString(type);
-        if (vaultType == StorageVault.StorageVaultType.UNKNOWN) {
-            throw new AnalysisException("Unsupported Storage Vault type: " + type);
-        }
+        setStorageVaultType(StorageVault.StorageVaultType.fromString(type));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -89,7 +89,6 @@ public class HdfsStorageVault extends StorageVault {
                     Cloud.HdfsVaultInfo.newBuilder();
         Cloud.HdfsBuildConf.Builder hdfsConfBuilder = Cloud.HdfsBuildConf.newBuilder();
         for (Map.Entry<String, String> property : properties.entrySet()) {
-            LOG.info("key is P{}, value is {}", property.getKey(), property.getValue());
             if (property.getKey().equalsIgnoreCase(HADOOP_FS_NAME)) {
                 hdfsConfBuilder.setFsName(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(VAULT_PATH_PREFIX)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -89,6 +89,7 @@ public class HdfsStorageVault extends StorageVault {
                     Cloud.HdfsVaultInfo.newBuilder();
         Cloud.HdfsBuildConf.Builder hdfsConfBuilder = Cloud.HdfsBuildConf.newBuilder();
         for (Map.Entry<String, String> property : properties.entrySet()) {
+            LOG.info("key is P{}, value is {}", property.getKey(), property.getValue());
             if (property.getKey().equalsIgnoreCase(HADOOP_FS_NAME)) {
                 hdfsConfBuilder.setFsName(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(VAULT_PATH_PREFIX)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -119,6 +119,7 @@ public abstract class StorageVault {
             default:
                 throw new DdlException("Unknown StorageVault type: " + type);
         }
+        vault.modifyProperties(stmt.getProperties());
 
         return vault;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.cloud.catalog;
 
-
+import org.apache.doris.analysis.CreateStorageVaultStmt;
 import org.apache.doris.catalog.HdfsStorageVault;
 import org.apache.doris.catalog.StorageVault;
 import org.apache.doris.catalog.StorageVaultMgr;
@@ -49,9 +49,10 @@ public class HdfsStorageVaultTest {
         Config.meta_service_endpoint = "127.0.0.1:20121";
     }
 
-    StorageVault createHdfsVault(String name, Map<String, String> properties) throws DdlException {
-        HdfsStorageVault vault = new HdfsStorageVault(name, false);
-        vault.modifyProperties(properties);
+    StorageVault createHdfsVault(String name, Map<String, String> properties) throws Exception {
+        CreateStorageVaultStmt stmt = new CreateStorageVaultStmt(false, name , properties);
+        stmt.setStorageVaultType(StorageVault.StorageVaultType.HDFS);
+        StorageVault vault = StorageVault.fromStmt(stmt);
         return vault;
     }
 
@@ -69,7 +70,11 @@ public class HdfsStorageVaultTest {
         };
         StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
                 "type", "hdfs",
-                "path", "abs/"));
+                "path", "abs/",
+                HdfsStorageVault.HADOOP_FS_NAME, "default"));
+        Map<String, String> properties = vault.getCopiedProperties();
+        // To check if the properties is carried correctly
+        Assertions.assertEquals(properties.get(HdfsStorageVault.HADOOP_FS_NAME), "default");
         mgr.createHdfsVault(vault);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -50,7 +50,7 @@ public class HdfsStorageVaultTest {
     }
 
     StorageVault createHdfsVault(String name, Map<String, String> properties) throws Exception {
-        CreateStorageVaultStmt stmt = new CreateStorageVaultStmt(false, name , properties);
+        CreateStorageVaultStmt stmt = new CreateStorageVaultStmt(false, name, properties);
         stmt.setStorageVaultType(StorageVault.StorageVaultType.HDFS);
         StorageVault vault = StorageVault.fromStmt(stmt);
         return vault;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
In #32681, the `StorageVault::fromStmt` function is changed to call `getStorageVaultInstance` function. But `getStorageVaultInstance` doesn't set the properties to storage vault.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

