### PR TITLE
[fix](memory) Fix MemTableWriter flush_async attach task in thread context

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -70,6 +70,7 @@ Status MemTableWriter::init(std::shared_ptr<RowsetWriter> rowset_writer,
     _tablet_schema = tablet_schema;
     _unique_key_mow = unique_key_mow;
     _partial_update_info = partial_update_info;
+    _query_thread_context.init();
 
     _reset_mem_table();
 
@@ -150,6 +151,7 @@ Status MemTableWriter::_flush_memtable_async() {
 
 Status MemTableWriter::flush_async() {
     std::lock_guard<std::mutex> l(_lock);
+    SCOPED_ATTACH_TASK(_query_thread_context);
     if (!_is_init || _is_closed) {
         // This writer is uninitialized or closed before flushing, do nothing.
         // We return OK instead of NOT_INITIALIZED or ALREADY_CLOSED.

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -136,6 +136,7 @@ private:
     SpinLock _mem_table_tracker_lock;
     SpinLock _mem_table_ptr_lock;
     std::atomic<uint32_t> _mem_table_num = 1;
+    QueryThreadContext _query_thread_context;
 
     std::mutex _lock;
 


### PR DESCRIPTION
## Proposed changes

Bug introduced by #32039

thread_context.h:292] __builtin_unreachable
```
10# doris::QueryThreadContext::init() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/thread_context.h:306
11# doris::MemTable::MemTable(long, doris::TabletSchema const*, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const*, doris::TupleDescriptor*, bool, doris::PartialUpdateInfo*, std::shared_ptr<doris::MemTracker> const&, std::shared_ptr<doris::MemTracker> const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable.cpp:69
12# doris::MemTableWriter::_reset_mem_table() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_writer.cpp:217
13# doris::MemTableWriter::flush_async() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_writer.cpp:171
14# doris::MemTableMemoryLimiter::_flush_memtable(std::weak_ptr<doris::MemTableWriter>, long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:193
15# doris::MemTableMemoryLimiter::_flush_active_memtables(long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:165
16# doris::MemTableMemoryLimiter::handle_memtable_flush() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:146
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

