### PR TITLE
[fix](memory) Fix erase invalid MemTrackerLimiter from tracker pool

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -161,10 +161,14 @@ void MemTrackerLimiter::refresh_global_counter() {
     // always ExecEnv::ready(), because Daemon::_stop_background_threads_latch
     for (auto& group : ExecEnv::GetInstance()->mem_tracker_limiter_pool) {
         std::lock_guard<std::mutex> l(group.group_lock);
-        for (auto trackerWptr : group.trackers) {
-            auto tracker = trackerWptr.lock();
-            CHECK(tracker != nullptr);
-            type_mem_sum[tracker->type()] += tracker->consumption();
+        for (auto it = group.trackers.begin(); it != group.trackers.end();) {
+            auto tracker = (*it).lock();
+            if (tracker == nullptr) {
+                it = group.trackers.erase(it);
+            } else {
+                type_mem_sum[tracker->type()] += tracker->consumption();
+                ++it;
+            }
         }
     }
     for (auto it : type_mem_sum) {
@@ -223,9 +227,10 @@ void MemTrackerLimiter::make_type_snapshots(std::vector<MemTracker::Snapshot>* s
                 ExecEnv::GetInstance()->mem_tracker_limiter_pool[0].group_lock);
         for (auto trackerWptr : ExecEnv::GetInstance()->mem_tracker_limiter_pool[0].trackers) {
             auto tracker = trackerWptr.lock();
-            CHECK(tracker != nullptr);
-            (*snapshots).emplace_back(tracker->make_snapshot());
-            MemTracker::make_group_snapshot(snapshots, tracker->group_num(), tracker->label());
+            if (tracker != nullptr) {
+                (*snapshots).emplace_back(tracker->make_snapshot());
+                MemTracker::make_group_snapshot(snapshots, tracker->group_num(), tracker->label());
+            }
         }
     } else {
         for (unsigned i = 1; i < ExecEnv::GetInstance()->mem_tracker_limiter_pool.size(); ++i) {
@@ -233,8 +238,7 @@ void MemTrackerLimiter::make_type_snapshots(std::vector<MemTracker::Snapshot>* s
                     ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].group_lock);
             for (auto trackerWptr : ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].trackers) {
                 auto tracker = trackerWptr.lock();
-                CHECK(tracker != nullptr);
-                if (tracker->type() == type) {
+                if (tracker != nullptr && tracker->type() == type) {
                     (*snapshots).emplace_back(tracker->make_snapshot());
                     MemTracker::make_group_snapshot(snapshots, tracker->group_num(),
                                                     tracker->label());
@@ -253,8 +257,9 @@ void MemTrackerLimiter::make_top_consumption_snapshots(std::vector<MemTracker::S
                 ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].group_lock);
         for (auto trackerWptr : ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].trackers) {
             auto tracker = trackerWptr.lock();
-            CHECK(tracker != nullptr);
-            max_pq.emplace(tracker->make_snapshot());
+            if (tracker != nullptr) {
+                max_pq.emplace(tracker->make_snapshot());
+            }
         }
     }
 
@@ -286,8 +291,7 @@ std::string MemTrackerLimiter::type_detail_usage(const std::string& msg, Type ty
                 ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].group_lock);
         for (auto trackerWptr : ExecEnv::GetInstance()->mem_tracker_limiter_pool[i].trackers) {
             auto tracker = trackerWptr.lock();
-            CHECK(tracker != nullptr);
-            if (tracker->type() == type) {
+            if (tracker != nullptr && tracker->type() == type) {
                 detail += "\n    " + MemTrackerLimiter::log_usage(tracker->make_snapshot());
             }
         }
@@ -468,8 +472,7 @@ int64_t MemTrackerLimiter::free_top_memory_query(
             std::lock_guard<std::mutex> l(tracker_groups[i].group_lock);
             for (auto trackerWptr : tracker_groups[i].trackers) {
                 auto tracker = trackerWptr.lock();
-                CHECK(tracker != nullptr);
-                if (tracker->type() == type) {
+                if (tracker != nullptr && tracker->type() == type) {
                     seek_num++;
                     if (tracker->is_query_cancelled()) {
                         canceling_task.push_back(fmt::format("{}:{} Bytes", tracker->label(),
@@ -593,8 +596,7 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(
             std::lock_guard<std::mutex> l(tracker_groups[i].group_lock);
             for (auto trackerWptr : tracker_groups[i].trackers) {
                 auto tracker = trackerWptr.lock();
-                CHECK(tracker != nullptr);
-                if (tracker->type() == type) {
+                if (tracker != nullptr && tracker->type() == type) {
                     seek_num++;
                     // 32M small query does not cancel
                     if (tracker->consumption() <= 33554432 ||

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -160,7 +160,7 @@ void MemTrackerLimiter::refresh_global_counter() {
             {Type::COMPACTION, 0}, {Type::SCHEMA_CHANGE, 0}, {Type::OTHER, 0}};
     // always ExecEnv::ready(), because Daemon::_stop_background_threads_latch
     for (unsigned i = 0; i < ExecEnv::GetInstance()->mem_tracker_limiter_pool.size(); ++i) {
-        auto group = ExecEnv::GetInstance()->mem_tracker_limiter_pool[i];
+        TrackerLimiterGroup& group = ExecEnv::GetInstance()->mem_tracker_limiter_pool[i];
         std::lock_guard<std::mutex> l(group.group_lock);
         for (auto it = group.trackers.begin(); it != group.trackers.end();) {
             auto tracker = (*it).lock();

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -46,6 +46,9 @@ class RuntimeProfile;
 constexpr auto MEM_TRACKER_GROUP_NUM = 1000;
 
 struct TrackerLimiterGroup {
+    // Note! in order to enable ExecEnv::mem_tracker_limiter_pool support resize,
+    // the copy construction of TrackerLimiterGroup is disabled.
+    // so cannot copy TrackerLimiterGroup anywhere, should use reference.
     TrackerLimiterGroup() = default;
     TrackerLimiterGroup(TrackerLimiterGroup&&) noexcept {}
     TrackerLimiterGroup(const TrackerLimiterGroup&) {}


### PR DESCRIPTION
## Proposed changes

Bug introduced by https://github.com/apache/doris/pull/32039

```
F20240330 22:37:15.508097 61876 mem_tracker_limiter.cpp:596] Check failed: tracker != nullptr

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
 1# 0x00007FE2CE248090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x0000559E053C857D in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 5# google::LogMessage::SendToLog() in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 6# google::LogMessage::Flush() in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 7# google::LogMessageFatal::~LogMessageFatal() in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 8# doris::MemTrackerLimiter::free_top_overcommit_query(long, doris::MemTrackerLimiter::Type, std::vector<doris::TrackerLimiterGroup, std::allocator<doris::TrackerLimiterGroup> >&, std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, doris::RuntimeProfile*, doris::MemTrackerLimiter::GCType) in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 9# doris::MemTrackerLimiter::free_top_overcommit_query(long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::RuntimeProfile*, doris::MemTrackerLimiter::Type) at /root/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:547
10# doris::MemInfo::process_minor_gc() at /root/doris/be/src/util/mem_info.cpp:162
11# doris::Daemon::memory_gc_thread() in /home/work/unlimit_teamcity/TeamCity/Agents/20240330193530agent_172.16.0.76_1/work/60183217f6ee2a9c/output/be/lib/doris_be
12# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

