### PR TITLE
[fix](memory) Fix erase MemTrackerLimiter from tracker pool

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -159,18 +159,12 @@ void MemTrackerLimiter::refresh_global_counter() {
             {Type::GLOBAL, 0},     {Type::QUERY, 0},         {Type::LOAD, 0},
             {Type::COMPACTION, 0}, {Type::SCHEMA_CHANGE, 0}, {Type::OTHER, 0}};
     // always ExecEnv::ready(), because Daemon::_stop_background_threads_latch
-    for (unsigned i = 0; i < ExecEnv::GetInstance()->mem_tracker_limiter_pool.size(); ++i) {
-        TrackerLimiterGroup& group = ExecEnv::GetInstance()->mem_tracker_limiter_pool[i];
+    for (auto& group : ExecEnv::GetInstance()->mem_tracker_limiter_pool) {
         std::lock_guard<std::mutex> l(group.group_lock);
-        for (auto it = group.trackers.begin(); it != group.trackers.end();) {
-            auto tracker = (*it).lock();
-            if (tracker == nullptr) {
-                LOG(WARNING) << "abnormally invalid MemTrackerLimiter, env tracking memory: "
-                             << ExecEnv::tracking_memory() << ", group num: " << i;
-                it = group.trackers.erase(it);
-            } else {
+        for (auto trackerWptr : group.trackers) {
+            auto tracker = trackerWptr.lock();
+            if (tracker != nullptr) {
                 type_mem_sum[tracker->type()] += tracker->consumption();
-                ++it;
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

wrong usage of weak ptr in MemTrackerLimiter tracker pool
deleted code is redundant, MemTrackerLimiter destructor will erase it from the group.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

