### PR TITLE
[Improvement](executor)Add BypassWorkloadGroup to pass query queue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -619,7 +619,7 @@ public class Coordinator implements CoordInterface {
         if (context != null) {
             if (Config.enable_workload_group) {
                 this.setTWorkloadGroups(context.getEnv().getWorkloadGroupMgr().getWorkloadGroup(context));
-                if (Config.enable_query_queue) {
+                if (Config.enable_query_queue && !context.getSessionVariable().getBypassWorkloadGroup()) {
                     queryQueue = context.getEnv().getWorkloadGroupMgr().getWorkloadGroupQueryQueue(context);
                     if (queryQueue == null) {
                         // This logic is actually useless, because when could not find query queue, it will

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -539,6 +539,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String MAX_MSG_SIZE_OF_RESULT_RECEIVER = "max_msg_size_of_result_receiver";
 
+    public static final String BYPASS_WORKLOAD_GROUP = "bypass_workload_group";
+
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
             SKIP_DELETE_BITMAP,
@@ -654,6 +656,11 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = WORKLOAD_VARIABLE, needForward = true)
     public String workloadGroup = "";
+
+    @VariableMgr.VarAttr(name = BYPASS_WORKLOAD_GROUP, needForward = true, description = {
+            "查询是否绕开WorkloadGroup的限制，目前仅支持绕开查询排队的逻辑",
+            "whether bypass workload group's limitation, currently only support bypass query queue"})
+    public boolean bypassWorkloadGroup = false;
 
     @VariableMgr.VarAttr(name = RESOURCE_VARIABLE)
     public String resourceGroup = "";
@@ -2226,6 +2233,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setWorkloadGroup(String workloadGroup) {
         this.workloadGroup = workloadGroup;
+    }
+
+    public boolean getBypassWorkloadGroup() {
+        return this.bypassWorkloadGroup;
     }
 
     public String getResourceGroup() {

--- a/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
+++ b/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
@@ -31,6 +31,7 @@ suite("test_crud_wlg") {
     sql "drop workload group if exists tag1_mem_wg1;"
     sql "drop workload group if exists tag1_mem_wg2;"
     sql "drop workload group if exists tag1_mem_wg3;"
+    sql "drop workload group if exists bypass_group;"
 
     sql """
         CREATE TABLE IF NOT EXISTS `${table_name}` (
@@ -516,6 +517,17 @@ suite("test_crud_wlg") {
 
     qt_show_wg_tag "select name,MEMORY_LIMIT,CPU_HARD_LIMIT,TAG from information_schema.workload_groups where name in('tag1_wg1','tag1_wg2','tag2_wg1','tag1_wg3','tag1_mem_wg1','tag1_mem_wg2','tag1_mem_wg3') order by tag,name;"
 
+    // test bypass
+    sql "create workload group if not exists bypass_group properties (  'max_concurrency'='0','max_queue_size'='0','queue_timeout'='0');"
+    sql "set workload_group=bypass_group;"
+    test {
+        sql "select count(1) from information_schema.active_queries;"
+        exception "query waiting queue is full"
+    }
+
+    sql "set bypass_workload_group = true;"
+    sql "select count(1) from information_schema.active_queries;"
+
     sql "drop workload group tag1_wg1;"
     sql "drop workload group tag1_wg2;"
     sql "drop workload group if exists tag2_wg1;"
@@ -523,5 +535,6 @@ suite("test_crud_wlg") {
     sql "drop workload group tag1_mem_wg1;"
     sql "drop workload group tag1_mem_wg2;"
     sql "drop workload group tag1_mem_wg3;"
+    sql "drop workload group bypass_group;"
 
 }


### PR DESCRIPTION
## Proposed changes

Add a session variable ```bypass_workload_group```, when set ```bypass_workload_group=true```,  query can bypass workload group's limit and run.
Currently only support bypass queue queue.
