### PR TITLE
[branch-2.0][fix](broker) fix broker writer close issue

### DIFF
--- a/be/src/io/fs/broker_file_writer.cpp
+++ b/be/src/io/fs/broker_file_writer.cpp
@@ -75,7 +75,7 @@ inline const std::string& client_id(ExecEnv* env, const TNetworkAddress& addr) {
 #endif
 
 Status BrokerFileWriter::close() {
-    if (_closed) {
+    if (_closed || !_opened) {
         return Status::OK();
     }
     _closed = true;

--- a/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
@@ -63,7 +63,7 @@ PID_DIR="$(
 )"
 export PID_DIR
 
-export JAVA_OPTS="-Xmx1024m -Dfile.encoding=UTF-8"
+export JAVA_OPTS="-Xmx1024m -Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true"
 export BROKER_LOG_DIR="${BROKER_HOME}/log"
 # java
 if [[ -z "${JAVA_HOME}" ]]; then


### PR DESCRIPTION
the broker writer may be closed even it is not opened yet.
If the broker writer is not opened, the fd is empty, the close will fail.
So check the open status of broker writer before closing it.

Also add kerberos debug options for broker process.