### PR TITLE
[BugFix](Iceberg Catalog) Fix iceberg catalog of  hms and hadoop not support iceberg properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
@@ -42,7 +42,7 @@ public class IcebergHMSExternalCatalog extends IcebergExternalCatalog {
         HiveCatalog hiveCatalog = new org.apache.iceberg.hive.HiveCatalog();
         hiveCatalog.setConf(getConfiguration());
         // initialize hive catalog
-        Map<String, String> catalogProperties = new HashMap<>();
+        Map<String, String> catalogProperties = catalogProperty.getProperties();
         String metastoreUris = catalogProperty.getOrDefault(HMSProperties.HIVE_METASTORE_URIS, "");
         catalogProperties.put(CatalogProperties.URI, metastoreUris);
         hiveCatalog.initialize(icebergCatalogType, catalogProperties);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
@@ -24,7 +24,6 @@ import org.apache.doris.datasource.property.constants.HMSProperties;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.hive.HiveCatalog;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class IcebergHMSExternalCatalog extends IcebergExternalCatalog {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
@@ -56,8 +56,8 @@ public class IcebergHadoopExternalCatalog extends IcebergExternalCatalog {
         HadoopCatalog hadoopCatalog = new HadoopCatalog();
         Configuration conf = getConfiguration();
         initS3Param(conf);
-        // initialize hive catalog
-        Map<String, String> catalogProperties = new HashMap<>();
+        // initialize hadoop catalog
+        Map<String, String> catalogProperties = catalogProperty.getProperties();
         String warehouse = catalogProperty.getHadoopProperties().get(CatalogProperties.WAREHOUSE_LOCATION);
         hadoopCatalog.setConf(conf);
         catalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class IcebergHadoopExternalCatalog extends IcebergExternalCatalog {


### PR DESCRIPTION
## Proposed changes

when use use iceberg catalog with hms or hadoop type, we can not set the iceberg properties like "io.manifest.cache-enabled" to enable manifest cache in iceberg.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

