### PR TITLE
[Fix](point query) avoid nullptr in _block_pool

### DIFF
--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -100,12 +100,14 @@ std::unique_ptr<vectorized::Block> Reusable::get_block() {
 
 void Reusable::return_block(std::unique_ptr<vectorized::Block>& block) {
     std::lock_guard lock(_block_mutex);
-    if (_block_pool.size() > s_preallocted_blocks_num) {
+    if (block == nullptr) {
         return;
     }
     block->clear_column_data();
     _block_pool.push_back(std::move(block));
-    _block_pool.resize(s_preallocted_blocks_num);
+    if (_block_pool.size() > s_preallocted_blocks_num) {
+        _block_pool.resize(s_preallocted_blocks_num);
+    }
 }
 
 int64_t Reusable::mem_size() const {


### PR DESCRIPTION
`resize` will make nullptrs in _block_pool if _block_pool.size() < s_preallocted_blocks_num

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

