### PR TITLE
[feature](pipeline) avoid unnecessary copying during projection.

### DIFF
--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -209,42 +209,16 @@ Status OperatorXBase::do_projections(RuntimeState* state, vectorized::Block* ori
     }
 
     DCHECK_EQ(rows, input_block.rows());
-    auto insert_column_datas = [&](auto& to, vectorized::ColumnPtr& from, size_t rows) {
-        if (to->is_nullable() && !from->is_nullable()) {
-            if (_keep_origin || !from->is_exclusive()) {
-                auto& null_column = reinterpret_cast<vectorized::ColumnNullable&>(*to);
-                null_column.get_nested_column().insert_range_from(*from, 0, rows);
-                null_column.get_null_map_column().get_data().resize_fill(rows, 0);
-            } else {
-                to = make_nullable(from, false)->assume_mutable();
-            }
-        } else {
-            if (_keep_origin || !from->is_exclusive()) {
-                to->insert_range_from(*from, 0, rows);
-            } else {
-                to = from->assume_mutable();
-            }
-        }
-    };
+    vectorized::VectorizedUtils::build_output_block_mem_reuse(output_block,
+                                                              *_output_row_descriptor);
 
-    using namespace vectorized;
-    vectorized::MutableBlock mutable_block =
-            vectorized::VectorizedUtils::build_mutable_mem_reuse_block(output_block,
-                                                                       *_output_row_descriptor);
-    if (rows != 0) {
-        auto& mutable_columns = mutable_block.mutable_columns();
-        DCHECK(mutable_columns.size() == local_state->_projections.size());
-        for (int i = 0; i < mutable_columns.size(); ++i) {
-            auto result_column_id = -1;
-            RETURN_IF_ERROR(local_state->_projections[i]->execute(&input_block, &result_column_id));
-            auto column_ptr = input_block.get_by_position(result_column_id)
-                                      .column->convert_to_full_column_if_const();
-            insert_column_datas(mutable_columns[i], column_ptr, rows);
-        }
-        DCHECK(mutable_block.rows() == rows);
-        output_block->set_columns(std::move(mutable_columns));
+    DCHECK(output_block->columns() == local_state->_projections.size());
+    result_column_ids.resize(local_state->_projections.size());
+    for (int i = 0; i < local_state->_projections.size(); ++i) {
+        RETURN_IF_ERROR(local_state->_projections[i]->execute(&input_block, &result_column_ids[i]));
     }
-
+    output_block->build_output_block_after_projects(input_block, *origin_block, result_column_ids);
+    DCHECK(output_block->rows() == rows);
     return Status::OK();
 }
 

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -100,7 +100,8 @@ ColumnArray::ColumnArray(MutableColumnPtr&& nested_column, MutableColumnPtr&& of
 
         /// This will also prevent possible overflow in offset.
         if (data->size() != last_offset) {
-            LOG(FATAL) << "offsets_column has data inconsistent with nested_column";
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "offsets_column has data inconsistent with key_column");
         }
     }
 

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -175,6 +175,10 @@ public:
 
     ColumnPtr convert_to_full_column_if_const() const override;
 
+    bool is_exclusive() const override {
+        return IColumn::is_exclusive() && data->is_exclusive() && offsets->is_exclusive();
+    }
+
     /** More efficient methods of manipulation */
     IColumn& get_data() { return *data; }
     const IColumn& get_data() const { return *data; }

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -58,10 +58,12 @@ ColumnMap::ColumnMap(MutableColumnPtr&& keys, MutableColumnPtr&& values, Mutable
 
         /// This will also prevent possible overflow in offset.
         if (keys_column->size() != last_offset) {
-            LOG(FATAL) << "offsets_column has data inconsistent with key_column";
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "offsets_column has data inconsistent with key_column");
         }
         if (values_column->size() != last_offset) {
-            LOG(FATAL) << "offsets_column has data inconsistent with value_column";
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "offsets_column has data inconsistent with key_column");
         }
     }
 }

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -91,6 +91,11 @@ public:
         offsets_column->clear();
     }
 
+    bool is_exclusive() const override {
+        return IColumn::is_exclusive() && keys_column->is_exclusive() &&
+               values_column->is_exclusive() && offsets_column;
+    }
+
     ColumnPtr convert_to_full_column_if_const() const override;
 
     MutableColumnPtr clone_resized(size_t size) const override;

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -93,7 +93,7 @@ public:
 
     bool is_exclusive() const override {
         return IColumn::is_exclusive() && keys_column->is_exclusive() &&
-               values_column->is_exclusive() && offsets_column;
+               values_column->is_exclusive() && offsets_column->is_exclusive();
     }
 
     ColumnPtr convert_to_full_column_if_const() const override;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -256,6 +256,7 @@ public:
     bool is_column_string() const override { return get_nested_column().is_column_string(); }
     bool is_column_array() const override { return get_nested_column().is_column_array(); }
     bool is_column_map() const override { return get_nested_column().is_column_map(); }
+    bool is_variant() const override { return get_nested_column().is_variant(); }
     bool is_column_struct() const override { return get_nested_column().is_column_struct(); }
     bool is_fixed_and_contiguous() const override { return false; }
     bool values_have_fixed_size() const override { return nested_column->values_have_fixed_size(); }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -782,6 +782,10 @@ void Block::build_output_block_after_projects(Block& input_block, Block& origin_
         if (column_cnt[col_id] > 1) {
             return {intput_column_ptr, false};
         }
+        // For complex types like "variant," direct swapping can easily lead to issues.
+        if (intput_column_ptr->is_variant()) {
+            return {intput_column_ptr, false};
+        }
         // When this column ID appears for the last time,
         // it needs to be checked whether this column comes from the origin block or is in the input block.
         for (int i = 0; i < origin_block.columns(); i++) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -686,11 +686,12 @@ void Block::clear() {
 }
 
 std::string Block::print_use_count() {
-    std::stringstream ss;
+    fmt::memory_buffer buf;
     for (auto& d : data) {
-        ss << ", [" << d.name << ", " << d.column->use_count() << ", " << d.column.get() << "]";
+        fmt::format_to(buf, ", [{}, {}, {}]", d.name, d.column->use_count(),
+                       fmt::ptr(d.column.get()));
     }
-    return ss.str();
+    return fmt::to_string(buf);
 }
 
 void Block::clear_column_data(int column_size) noexcept {
@@ -763,7 +764,7 @@ void Block::build_output_block_after_projects(Block& input_block, Block& origin_
         };
         if (is_column_const(*origin_column)) {
             auto column_ptr = origin_column->convert_to_full_column_if_const();
-            insert_column(to, column_ptr, rows, false);
+            insert_column(to, column_ptr, rows, true);
         } else {
             insert_column(to, origin_column, rows, use_swap);
         }

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -237,6 +237,13 @@ public:
     // Shuffle columns in place based on the result_column_ids
     void shuffle_columns(const std::vector<int>& result_column_ids);
 
+    // This function is used to construct the projected output block.
+    // The origin block is the original input, and the input block contains intermediate results computed during projection.
+    // The function will use swap as much as possible, rather than direct copying.
+    // If a result column id is unique, swap directly.
+    // If there are multiple identical result column id, swap one and copy the rest.
+    void build_output_block_after_projects(Block& input_block, Block& origin_block,
+                                           const std::vector<int>& result_column_ids);
     // Default column size = -1 means clear all column in block
     // Else clear column [0, column_size) delete column [column_size, data.size)
     void clear_column_data(int column_size = -1) noexcept;

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -42,6 +42,12 @@ public:
         }
         return MutableBlock::build_mutable_block(block);
     }
+    static void build_output_block_mem_reuse(Block* block, const RowDescriptor& row_desc) {
+        if (!block->mem_reuse()) {
+            MutableBlock tmp(VectorizedUtils::create_columns_with_type_and_name(row_desc));
+            block->swap(tmp.to_block());
+        }
+    }
     static MutableBlock build_mutable_mem_reuse_block(Block* block, const Block& other) {
         if (!block->mem_reuse()) {
             MutableBlock tmp(other.clone_empty());


### PR DESCRIPTION
## Proposed changes
If a result column id is unique, swap directly.
If there are multiple identical result column id, swap one and copy the rest.

before
```
OLAP_SCAN_OPERATOR  (id=0.  table  name  =  lineitem(lineitem)):
                                    -  BlocksProduced:  sum  194.216K  (194216),  avg  38.843K  (38843),  max  48.653K  (48653),  min  10.724K  (10724)
                                    -  CloseTime:  avg  6.763ms,  max  12.937ms,  min  0ns
                                    -  ExecTime:  avg  1s23ms,  max  1s303ms,  min  277.730ms
                                    -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                        -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                    -  OpenTime:  avg  4.419ms,  max  6.479ms,  min  2.899ms
                                    -  ProjectionTime:  avg  903.742ms,  max  1s149ms,  min  247.347ms
                                    -  RowsProduced:  sum  787.405897M  (787405897),  avg  157.481179M  (157481179),  max  197.206057M  (197206057),  min  43.521018M  (43521018)
                                    -  RuntimeFilterInfo:  sum  ,  avg  ,  max  ,  min  
                                    -  WaitForDependency[OLAP_SCAN_OPERATOR_DEPENDENCY]Time:  avg  1.76ms,  max  2.945ms,  min  0ns
```

now
```
 OLAP_SCAN_OPERATOR  (id=0.  table  name  =  lineitem(lineitem)):
                                    -  BlocksProduced:  sum  198.75K  (198750),  avg  39.75K  (39750),  max  48.653K  (48653),  min  21.542K  (21542)
                                    -  CloseTime:  avg  8.106ms,  max  15.835ms,  min  0ns
                                    -  ExecTime:  avg  180.862ms,  max  227.702ms,  min  95.371ms
                                    -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                        -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                    -  OpenTime:  avg  5.692ms,  max  6.603ms,  min  4.609ms
                                    -  ProjectionTime:  avg  52.289ms,  max  64.535ms,  min  30.375ms
                                    -  RowsProduced:  sum  805.805177M  (805805177),  avg  161.161035M  (161161035),  max  197.206057M  (197206057),  min  87.392577M  (87392577)
                                    -  RuntimeFilterInfo:  sum  ,  avg  ,  max  ,  min  
                                    -  WaitForDependency[OLAP_SCAN_OPERATOR_DEPENDENCY]Time:
```


For this type of projection with many references, there is a significant performance improvement.
Because it avoids creating copies.

```
 0:VOlapScanNode(258)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|      TABLE: tpch_sf100.lineitem(lineitem), PREAGGREGATION: ON                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|      PREDICATES: (l_shipdate[#0] <= '1998-09-02')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|      partitions=1/1 (lineitem), tablets=768/768, tabletList=866164,866166,866168 ...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|      cardinality=600037902, avgRowSize=0.0, numNodes=1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|      pushAggOp=NONE                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|      final projections: l_returnflag[#9], l_linestatus[#10], l_quantity[#5], l_extendedprice[#6], l_discount[#7], l_tax[#8]                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|      final project output tuple id: 1         
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

