### PR TITLE
[Fix](core) Fix wal mgr heap use after free when stop doris

### DIFF
--- a/be/src/olap/wal/wal_manager.cpp
+++ b/be/src/olap/wal/wal_manager.cpp
@@ -474,6 +474,9 @@ Status WalManager::update_wal_dir_estimated_wal_bytes(const std::string& wal_dir
 }
 
 Status WalManager::_update_wal_dir_info_thread() {
+    while (!ExecEnv::ready()) {
+        sleep(1);
+    }
     while (!_stop.load()) {
         static_cast<void>(_wal_dirs_info->update_all_wal_dir_limit());
         static_cast<void>(_wal_dirs_info->update_all_wal_dir_used());

--- a/be/src/olap/wal/wal_manager.cpp
+++ b/be/src/olap/wal/wal_manager.cpp
@@ -475,7 +475,8 @@ Status WalManager::update_wal_dir_estimated_wal_bytes(const std::string& wal_dir
 
 Status WalManager::_update_wal_dir_info_thread() {
     while (!ExecEnv::ready()) {
-        sleep(1);
+        LOG(INFO) << "Sleep 1s to wait storage engine init.";
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
     while (!_stop.load()) {
         static_cast<void>(_wal_dirs_info->update_all_wal_dir_limit());


### PR DESCRIPTION
Problem: When the process stops, there is a heap use after free error with the WAL manager.

Reason: During the startup process, if the storage engine does not initialize successfully and the main program directly returns 0, the WAL manager, which was created during initialization and started a thread to periodically check disk space, will encounter an issue. When the program exits and returns 0, local variables are destroyed first before the thread is properly terminated. If the thread attempts to access those local variables at this point, it leads to a heap use after free error.

Solution: Ensure that the thread for periodically checking disk space is only started after the storage engine has been successfully initialized.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

