### PR TITLE
[Fix](grace-exit) Fix threadpool hang on grace exit

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -671,6 +671,10 @@ void StorageEngine::stop() {
         _cold_data_compaction_thread_pool->shutdown();
     }
 
+    if (_cooldown_thread_pool) {
+        _cooldown_thread_pool->shutdown();
+    }
+
     _memtable_flush_executor.reset(nullptr);
     _calc_delete_bitmap_executor.reset(nullptr);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -181,7 +181,7 @@ WriteCooldownMetaExecutors::WriteCooldownMetaExecutors(size_t executor_nums)
     }
 }
 
-WriteCooldownMetaExecutors::~WriteCooldownMetaExecutors() {
+void WriteCooldownMetaExecutors::stop() {
     for (auto& pool_ptr : _executors) {
         if (pool_ptr) {
             pool_ptr->shutdown();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -168,30 +168,6 @@ void set_last_failure_time(Tablet* tablet, const Compaction& compaction, int64_t
 
 } // namespace
 
-struct WriteCooldownMetaExecutors {
-    WriteCooldownMetaExecutors(size_t executor_nums = 5);
-
-    static WriteCooldownMetaExecutors* get_instance() {
-        static WriteCooldownMetaExecutors instance;
-        return &instance;
-    }
-
-    void submit(TabletSharedPtr tablet);
-    size_t _get_executor_pos(int64_t tablet_id) const {
-        return std::hash<int64_t>()(tablet_id) % _executor_nums;
-    };
-    // Each executor is a mpsc to ensure uploads of the same tablet meta are not concurrent
-    // FIXME(AlexYue): Use mpsc instead of `ThreadPool` with 1 thread
-    // We use PriorityThreadPool since it would call status inside it's `shutdown` function.
-    // Consider one situation where the StackTraceCache's singleton is detructed before
-    // this WriteCooldownMetaExecutors's singleton, then invoking the status would also call
-    // StackTraceCache which would then result in heap use after free like #23834
-    std::vector<std::unique_ptr<PriorityThreadPool>> _executors;
-    std::unordered_set<int64_t> _pending_tablets;
-    std::mutex _latch;
-    size_t _executor_nums;
-};
-
 WriteCooldownMetaExecutors::WriteCooldownMetaExecutors(size_t executor_nums)
         : _executor_nums(executor_nums) {
     for (size_t i = 0; i < _executor_nums; i++) {
@@ -202,6 +178,14 @@ WriteCooldownMetaExecutors::WriteCooldownMetaExecutors(size_t executor_nums)
                                   .set_max_queue_size(std::numeric_limits<int>::max())
                                   .build(&pool));
         _executors.emplace_back(std::move(pool));
+    }
+}
+
+WriteCooldownMetaExecutors::~WriteCooldownMetaExecutors() {
+    for (auto& pool_ptr : _executors) {
+        if (pool_ptr) {
+            pool_ptr->shutdown();
+        }
     }
 }
 
@@ -1960,7 +1944,7 @@ Status check_version_continuity(const std::vector<RowsetMetaSharedPtr>& rs_metas
 // It's guaranteed the write cooldown meta task would be invoked at the end unless BE crashes
 // one tablet would at most have one async task to be done
 void Tablet::async_write_cooldown_meta(TabletSharedPtr tablet) {
-    WriteCooldownMetaExecutors::get_instance()->submit(std::move(tablet));
+    ExecEnv::GetInstance()->write_cooldown_meta_executors()->submit(std::move(tablet));
 }
 
 bool Tablet::update_cooldown_conf(int64_t cooldown_term, int64_t cooldown_replica_id) {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -24,9 +24,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <limits>
-#include <list>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <ostream>
@@ -34,7 +31,6 @@
 #include <shared_mutex>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -83,6 +79,27 @@ enum SortType : int;
 enum TabletStorageType { STORAGE_TYPE_LOCAL, STORAGE_TYPE_REMOTE, STORAGE_TYPE_REMOTE_AND_LOCAL };
 
 static inline constexpr auto TRACE_TABLET_LOCK_THRESHOLD = std::chrono::seconds(1);
+
+struct WriteCooldownMetaExecutors {
+    WriteCooldownMetaExecutors(size_t executor_nums = 5);
+
+    ~WriteCooldownMetaExecutors();
+
+    void submit(TabletSharedPtr tablet);
+    size_t _get_executor_pos(int64_t tablet_id) const {
+        return std::hash<int64_t>()(tablet_id) % _executor_nums;
+    };
+    // Each executor is a mpsc to ensure uploads of the same tablet meta are not concurrent
+    // FIXME(AlexYue): Use mpsc instead of `ThreadPool` with 1 thread
+    // We use PriorityThreadPool since it would call status inside it's `shutdown` function.
+    // Consider one situation where the StackTraceCache's singleton is detructed before
+    // this WriteCooldownMetaExecutors's singleton, then invoking the status would also call
+    // StackTraceCache which would then result in heap use after free like #23834
+    std::vector<std::unique_ptr<PriorityThreadPool>> _executors;
+    std::unordered_set<int64_t> _pending_tablets;
+    std::mutex _latch;
+    size_t _executor_nums;
+};
 
 class Tablet final : public BaseTablet {
 public:

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -83,7 +83,7 @@ static inline constexpr auto TRACE_TABLET_LOCK_THRESHOLD = std::chrono::seconds(
 struct WriteCooldownMetaExecutors {
     WriteCooldownMetaExecutors(size_t executor_nums = 5);
 
-    ~WriteCooldownMetaExecutors();
+    void stop();
 
     void submit(TabletSharedPtr tablet);
     size_t _get_executor_pos(int64_t tablet_id) const {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -30,7 +30,6 @@
 #include "olap/tablet_manager.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/frontend_info.h"
-#include "time.h"
 #include "util/debug_util.h"
 #include "util/time.h"
 #include "vec/sink/delta_writer_v2_pool.h"
@@ -47,6 +46,9 @@ ExecEnv::~ExecEnv() {
 #ifdef BE_TEST
 void ExecEnv::set_storage_engine(std::unique_ptr<BaseStorageEngine>&& engine) {
     _storage_engine = std::move(engine);
+}
+void ExecEnv::set_write_cooldown_meta_executors() {
+    _write_cooldown_meta_executors = std::make_unique<WriteCooldownMetaExecutors>();
 }
 #endif // BE_TEST
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -262,6 +262,7 @@ public:
     void set_dummy_lru_cache(std::shared_ptr<DummyLRUCache> dummy_lru_cache) {
         this->_dummy_lru_cache = dummy_lru_cache;
     }
+    void set_write_cooldown_meta_executors();
 
 #endif
     LoadStreamMapPool* load_stream_map_pool() { return _load_stream_map_pool.get(); }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -19,20 +19,16 @@
 
 #include <common/multi_version.h>
 
-#include <algorithm>
 #include <atomic>
-#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "common/status.h"
 #include "io/cache/fs_file_cache_storage.h"
 #include "olap/memtable_memory_limiter.h"
-#include "olap/olap_define.h"
 #include "olap/options.h"
 #include "olap/rowset/segment_v2/inverted_index_writer.h"
 #include "olap/tablet_fwd.h"
@@ -53,6 +49,7 @@ class BlockedTaskScheduler;
 struct RuntimeFilterTimerQueue;
 } // namespace pipeline
 class WorkloadGroupMgr;
+struct WriteCooldownMetaExecutors;
 namespace io {
 class FileCacheFactory;
 class FDCache;
@@ -232,6 +229,9 @@ public:
     MemTableMemoryLimiter* memtable_memory_limiter() { return _memtable_memory_limiter.get(); }
     WalManager* wal_mgr() { return _wal_manager.get(); }
     DNSCache* dns_cache() { return _dns_cache; }
+    WriteCooldownMetaExecutors* write_cooldown_meta_executors() {
+        return _write_cooldown_meta_executors.get();
+    }
 
 #ifdef BE_TEST
     void set_tmp_file_dir(std::unique_ptr<segment_v2::TmpFileDirs> tmp_file_dirs) {
@@ -397,6 +397,7 @@ private:
     std::unique_ptr<vectorized::DeltaWriterV2Pool> _delta_writer_v2_pool;
     std::shared_ptr<WalManager> _wal_manager;
     DNSCache* _dns_cache = nullptr;
+    std::unique_ptr<WriteCooldownMetaExecutors> _write_cooldown_meta_executors;
 
     std::mutex _frontends_lock;
     // ip:brpc_port -> frontend_indo

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -593,7 +593,7 @@ void ExecEnv::destroy() {
     _delta_writer_v2_pool.reset();
     _load_stream_map_pool.reset();
     _file_cache_open_fd_cache.reset();
-    _write_cooldown_meta_executors.reset();
+    SAFE_STOP(_write_cooldown_meta_executors);
 
     // StorageEngine must be destoried before _page_no_cache_mem_tracker.reset and _cache_manager destory
     // shouldn't use SAFE_STOP. otherwise will lead to twice stop.
@@ -655,6 +655,7 @@ void ExecEnv::destroy() {
     _s3_file_upload_thread_pool.reset(nullptr);
     _send_batch_thread_pool.reset(nullptr);
     _file_cache_open_fd_cache.reset(nullptr);
+    _write_cooldown_meta_executors.reset(nullptr);
 
     SAFE_DELETE(_broker_client_cache);
     SAFE_DELETE(_frontend_client_cache);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -26,12 +26,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "cloud/cloud_storage_engine.h"
@@ -40,11 +37,9 @@
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
-#include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_factory.h"
 #include "io/cache/fs_file_cache_storage.h"
 #include "io/fs/file_meta_cache.h"
-#include "io/fs/s3_file_bufferpool.h"
 #include "olap/memtable_memory_limiter.h"
 #include "olap/olap_define.h"
 #include "olap/options.h"
@@ -250,6 +245,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _file_cache_open_fd_cache = std::make_unique<io::FDCache>();
     _wal_manager = WalManager::create_shared(this, config::group_commit_wal_path);
     _dns_cache = new DNSCache();
+    _write_cooldown_meta_executors = std::make_unique<WriteCooldownMetaExecutors>();
     _spill_stream_mgr = new vectorized::SpillStreamManager(spill_store_paths);
     _backend_client_cache->init_metrics("backend");
     _frontend_client_cache->init_metrics("frontend");
@@ -597,6 +593,7 @@ void ExecEnv::destroy() {
     _delta_writer_v2_pool.reset();
     _load_stream_map_pool.reset();
     _file_cache_open_fd_cache.reset();
+    _write_cooldown_meta_executors.reset();
 
     // StorageEngine must be destoried before _page_no_cache_mem_tracker.reset and _cache_manager destory
     // shouldn't use SAFE_STOP. otherwise will lead to twice stop.

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -232,6 +232,7 @@ public:
         st = engine->open();
         EXPECT_TRUE(st.ok()) << st.to_string();
         ExecEnv* exec_env = doris::ExecEnv::GetInstance();
+        exec_env->set_write_cooldown_meta_executors(); // default cons
         exec_env->set_storage_engine(std::move(engine));
         exec_env->set_memtable_memory_limiter(new MemTableMemoryLimiter());
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

stack like:
```
Thread 641 (Thread 0x7f1d6e3ae700 (LWP 3912128) "WriteCooldownMe"):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x614009733320) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x614009733358, cond=0x6140097332f8) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x6140097332f8, mutex=0x614009733358) at pthread_cond_wait.c:647
#3  0x000056102fd56b0c in __gthread_cond_wait (__mutex=<optimized out>, __cond=<optimized out>) at /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:865
#4  std::__condvar::wait (__m=..., this=<optimized out>) at /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/std_mutex.h:155
#5  std::condition_variable::wait (this=<optimized out>, __lock=...) at ../../../../../libstdc++-v3/src/c++11/condition_variable.cc:41
#6  0x0000560ff926a0de in doris::BlockingPriorityQueue<doris::WorkThreadPool<true>::Task>::blocking_get (this=0x6140097332f0, out=0x7f1d69b0b020, timeout_ms=0) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/blocking_priority_queue.hpp:70
#7  0x0000560ff9264f19 in doris::WorkThreadPool<true>::work_thread (this=0x614009733240, thread_id=0) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:156
#8  0x0000560ff9267665 in std::__invoke_impl<void, void (doris::WorkThreadPool<true>::* const&)(int), doris::WorkThreadPool<true>*&, int&> (__f=@0x604042fb1c98: (void (doris::WorkThreadPool<true>::*)(doris::WorkThreadPool<true> * const, int)) 0x560ff9264d80 <doris::WorkThreadPool<true>::work_thread(int)>, __t=@0x604042fb1cb0: 0x614009733240, __args=@0x604042fb1ca8: 0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#9  0x0000560ff9267527 in std::__invoke<void (doris::WorkThreadPool<true>::* const&)(int), doris::WorkThreadPool<true>*&, int&> (__fn=@0x604042fb1c98: (void (doris::WorkThreadPool<true>::*)(doris::WorkThreadPool<true> * const, int)) 0x560ff9264d80 <doris::WorkThreadPool<true>::work_thread(int)>, __args=@0x604042fb1ca8: 0, __args=@0x604042fb1ca8: 0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#10 0x0000560ff92674e7 in std::_Mem_fn_base<void (doris::WorkThreadPool<true>::*)(int), true>::operator()<doris::WorkThreadPool<true>*&, int&> (this=0x604042fb1c98, __args=@0x604042fb1ca8: 0, __args=@0x604042fb1ca8: 0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:131
#11 0x0000560ff92674a7 in std::__invoke_impl<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)>&, doris::WorkThreadPool<true>*&, int&> (__f=..., __args=@0x604042fb1ca8: 0, __args=@0x604042fb1ca8: 0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#12 0x0000560ff92673a9 in std::__invoke_r<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)>&, doris::WorkThreadPool<true>*&, int&> (__fn=..., __args=@0x604042fb1ca8: 0, __args=@0x604042fb1ca8: 0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#13 0x0000560ff92672d6 in std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x604042fb1c98, __args=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
#14 0x0000560ff9267130 in std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>::operator()<>() (this=0x604042fb1c98) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
#15 0x0000560ff9267037 in std::__invoke_impl<void, std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>>(std::__invoke_other, std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>&&) (__f=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#16 0x0000560ff9266fd7 in std::__invoke<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>>(std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)>&&) (__fn=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#17 0x0000560ff9266f9f in std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x604042fb1c98) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253
#18 0x0000560ff9266f67 in std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)> > >::operator()() (this=0x604042fb1c98) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260
#19 0x0000560ff9266eab in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<true>::*)(int)> (doris::WorkThreadPool<true>*, int)> > > >::_M_run() (this=0x604042fb1c90) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211
#20 0x000056102fdc5aa0 in std::execute_native_thread_routine (__p=0x604042fb1c90) at ../../../../../libstdc++-v3/src/c++11/thread.cc:82
#21 0x00007f29ad6e9609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#22 0x00007f29ad996133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

