### PR TITLE
[Bug](min-max) store string data in MinMaxNumFunc to avoid use after free when cancel

### DIFF
--- a/be/src/exprs/minmax_predicate.h
+++ b/be/src/exprs/minmax_predicate.h
@@ -81,6 +81,7 @@ public:
                     _max = std::max(_max, column_string.get_data_at(i));
                 }
             }
+            store_string_ref();
         } else {
             const T* data = (T*)column->get_raw_data().data;
             for (size_t i = start; i < size; i++) {
@@ -109,6 +110,7 @@ public:
                     }
                 }
             }
+            store_string_ref();
         } else {
             const T* data = (T*)column->get_raw_data().data;
             for (size_t i = start; i < size; i++) {
@@ -171,9 +173,24 @@ public:
         return Status::OK();
     }
 
+    void store_string_ref() {
+        if constexpr (std::is_same_v<T, StringRef>) {
+            if constexpr (NeedMin) {
+                _stored_min = _min.to_string();
+                _min = StringRef(_stored_min);
+            }
+            if constexpr (NeedMax) {
+                _stored_max = _max.to_string();
+                _max = StringRef(_stored_max);
+            }
+        }
+    }
+
 protected:
     T _max = type_limit<T>::min();
     T _min = type_limit<T>::max();
+    std::string _stored_min;
+    std::string _stored_max;
 };
 
 template <class T>

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -490,8 +490,7 @@ public:
         case RuntimeFilterType::MIN_FILTER:
         case RuntimeFilterType::MAX_FILTER:
         case RuntimeFilterType::MINMAX_FILTER: {
-            RETURN_IF_ERROR(
-                    _context.minmax_func->merge(wrapper->_context.minmax_func.get(), _pool));
+            RETURN_IF_ERROR(_context.minmax_func->merge(wrapper->_context.minmax_func.get()));
             break;
         }
         case RuntimeFilterType::BLOOM_FILTER: {


### PR DESCRIPTION
## Proposed changes
store string data in MinMaxNumFunc to avoid use after free when cancel

```cpp
==812792==ERROR: AddressSanitizer: heap-use-after-free on address 0x60600ed02130 at pc 0x55b44689692d bp 0x7fef2f55deb0 sp 0x7fef2f55d678
READ of size 4 at 0x60600ed02130 thread T2361 (Pipe_normal [wo)
    #0 0x55b44689692c in __asan_memcpy (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x2610292c) (BuildId: dfb3a4f1336e35da)
    #1 0x55b4468f0ba4 in std::char_traits<char>::copy(char*, char const*, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/char_traits.h:409:33
    #2 0x55b4468f0a85 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_copy(char*, char const*, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:351:4
    #3 0x55b4468f0508 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_copy_chars(char*, char const*, char const*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:398:9
    #4 0x55b4468efe56 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:225:6
    #5 0x55b4468efc16 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct_aux<char const*>(char const*, char const*, std::__false_type) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:247:11
    #6 0x55b4468efb06 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<char const*>(char const*, char const*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:266:4
    #7 0x55b4469c0b3c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(char const*, unsigned long, std::allocator<char> const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:513:9
    #8 0x55b4469e3d76 in doris::StringRef::to_string[abi:cxx11]() const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/string_ref.h:200:44
    #9 0x55b463592586 in doris::Status doris::create_texpr_literal_node<(doris::PrimitiveType)10>(void const*, doris::TExprNode*, int, int) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exprs/vexpr.h:426:50
    #10 0x55b463574cad in doris::create_texpr_node_from(void const*, doris::PrimitiveType const&, int, int) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exprs/vexpr.cpp:140:9
    #11 0x55b44a0e8498 in doris::create_literal(doris::TypeDescriptor const&, void const*, std::shared_ptr<doris::vectorized::VExpr>&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:211:26
    #12 0x55b44a0f407c in doris::RuntimePredicateWrapper::get_push_exprs(std::__cxx11::list<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext>>>&, std::vector<std::shared_ptr<doris::vectorized::VRuntimeFilterWrapper>, std::allocator<std::shared_ptr<doris::vectorized::VRuntimeFilterWrapper>>>&, doris::TExpr const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:1799:9
    #13 0x55b44a0f1659 in doris::IRuntimeFilter::get_push_expr_ctxs(std::__cxx11::list<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext>>>&, std::vector<std::shared_ptr<doris::vectorized::VRuntimeFilterWrapper>, std::allocator<std::shared_ptr<doris::vectorized::VRuntimeFilterWrapper>>>&, bool) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:1097:9
    #14 0x55b4625bcc68 in doris::vectorized::RuntimeFilterConsumer::_acquire_runtime_filter() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exec/runtime_filter_consumer.cpp:96:13
    #15 0x55b479274163 in doris::pipeline::ScanLocalState<doris::pipeline::OlapScanLocalState>::open(doris::RuntimeState*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/scan_operator.cpp:159:5
    #16 0x55b47a471d2e in doris::pipeline::PipelineXTask::_open() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:193:36
    #17 0x55b47a47311d in doris::pipeline::PipelineXTask::execute(bool*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:241:23
    #18 0x55b47a4a832a in doris::pipeline::TaskScheduler::_do_work(unsigned long) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:339:32
    #19 0x55b47a4acb3c in doris::pipeline::TaskScheduler::start()::$_0::operator()() const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:218:9
    #20 0x55b47a4acab6 in void std::__invoke_impl<void, doris::pipeline::TaskScheduler::start()::$_0&>(std::__invoke_other, doris::pipeline::TaskScheduler::start()::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #21 0x55b47a4aca38 in std::enable_if<is_invocable_r_v<void, doris::pipeline::TaskScheduler::start()::$_0&>, void>::type std::__invoke_r<void, doris::pipeline::TaskScheduler::start()::$_0&>(doris::pipeline::TaskScheduler::start()::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #22 0x55b47a4ac86e in std::_Function_handler<void (), doris::pipeline::TaskScheduler::start()::$_0>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #23 0x55b446b18ca6 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #24 0x55b44ada2f8a in doris::FunctionRunnable::run() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:48:27
    #25 0x55b44ad8c55e in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:543:24
    #26 0x55b44adb80a5 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #27 0x55b44adb7f4e in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #28 0x55b44adb7ec6 in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #29 0x55b44adb7d5f in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::operator()<void>() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #30 0x55b44adb7c66 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #31 0x55b44adb7bd8 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #32 0x55b44adb779e in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #33 0x55b446b18ca6 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #34 0x55b44ad51273 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:498:5
    #35 0x7ff907ec0608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #36 0x7ff90816d132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x60600ed02130 is located 16 bytes inside of 64-byte region [0x60600ed02120,0x60600ed02160)
freed by thread T2366 (Pipe_normal [wo) here:
    #0 0x55b446897346 in free (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x26103346) (BuildId: dfb3a4f1336e35da)
    #1 0x55b4469eddd6 in Allocator<false, false, false>::free(void*, unsigned long) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.h:151:13
    #2 0x55b447407c0c in doris::vectorized::PODArrayBase<1ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::dealloc() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/pod_array.h:155:21
    #3 0x55b4474074a5 in doris::vectorized::PODArrayBase<1ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::~PODArrayBase() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/pod_array.h:272:23
    #4 0x55b44777cd14 in doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::~PODArray() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/pod_array_fwd.h:37:7
    #5 0x55b45d72e52c in doris::vectorized::ColumnString::~ColumnString() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_string.h:61:7
    #6 0x55b45d72e568 in doris::vectorized::ColumnString::~ColumnString() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_string.h:61:7
    #7 0x55b4469ee58e in COW<doris::vectorized::IColumn>::release_ref() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:99:13
    #8 0x55b446c13ccd in COW<doris::vectorized::IColumn>::intrusive_ptr<doris::vectorized::IColumn const>::~intrusive_ptr() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:133:47
    #9 0x55b446c13bf4 in COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>::~immutable_ptr() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:245:11
    #10 0x55b44779bc54 in COW<doris::vectorized::IColumn>::chameleon_ptr<doris::vectorized::IColumn>::~chameleon_ptr() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:321:11
    #11 0x55b45d637aa9 in doris::vectorized::ColumnNullable::~ColumnNullable() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_nullable.h:62:7
    #12 0x55b45d637ad8 in doris::vectorized::ColumnNullable::~ColumnNullable() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_nullable.h:62:7
    #13 0x55b4469ee58e in COW<doris::vectorized::IColumn>::release_ref() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:99:13
    #14 0x55b446c13ccd in COW<doris::vectorized::IColumn>::intrusive_ptr<doris::vectorized::IColumn const>::~intrusive_ptr() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:133:47
    #15 0x55b446c13bf4 in COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>::~immutable_ptr() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/cow.h:245:11
    #16 0x55b446c13bb2 in doris::vectorized::ColumnWithTypeAndName::~ColumnWithTypeAndName() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/core/column_with_type_and_name.h:46:8
    #17 0x55b446c13b76 in void std::destroy_at<doris::vectorized::ColumnWithTypeAndName>(doris::vectorized::ColumnWithTypeAndName*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #18 0x55b446c13b46 in void std::_Destroy<doris::vectorized::ColumnWithTypeAndName>(doris::vectorized::ColumnWithTypeAndName*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
    #19 0x55b446c13afa in void std::_Destroy_aux<false>::__destroy<doris::vectorized::ColumnWithTypeAndName*>(doris::vectorized::ColumnWithTypeAndName*, doris::vectorized::ColumnWithTypeAndName*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
    #20 0x55b446c13a9e in void std::_Destroy<doris::vectorized::ColumnWithTypeAndName*>(doris::vectorized::ColumnWithTypeAndName*, doris::vectorized::ColumnWithTypeAndName*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
    #21 0x55b446c13952 in void std::_Destroy<doris::vectorized::ColumnWithTypeAndName*, doris::vectorized::ColumnWithTypeAndName>(doris::vectorized::ColumnWithTypeAndName*, doris::vectorized::ColumnWithTypeAndName*, std::allocator<doris::vectorized::ColumnWithTypeAndName>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
    #22 0x55b446c12860 in std::vector<doris::vectorized::ColumnWithTypeAndName, std::allocator<doris::vectorized::ColumnWithTypeAndName>>::~vector() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
    #23 0x55b446c12774 in doris::vectorized::Block::~Block() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/core/block.h:92:22
    #24 0x55b44a314726 in void std::destroy_at<doris::vectorized::Block>(doris::vectorized::Block*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #25 0x55b44a3146f6 in void std::_Destroy<doris::vectorized::Block>(doris::vectorized::Block*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
    #26 0x55b44a3146aa in void std::_Destroy_aux<false>::__destroy<doris::vectorized::Block*>(doris::vectorized::Block*, doris::vectorized::Block*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
    #27 0x55b44a31464e in void std::_Destroy<doris::vectorized::Block*>(doris::vectorized::Block*, doris::vectorized::Block*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
    #28 0x55b44a314502 in void std::_Destroy<doris::vectorized::Block*, doris::vectorized::Block>(doris::vectorized::Block*, doris::vectorized::Block*, std::allocator<doris::vectorized::Block>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
    #29 0x55b44a313a00 in std::vector<doris::vectorized::Block, std::allocator<doris::vectorized::Block>>::~vector() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2

previously allocated by thread T2201 here:
    #0 0x55b4468975ee in malloc (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x261035ee) (BuildId: dfb3a4f1336e35da)

Thread T2361 (Pipe_normal [wo) created by T2340 here:
    #0 0x55b44687fcaa in pthread_create (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x260ebcaa) (BuildId: dfb3a4f1336e35da)
    #1 0x55b44ad4ffe1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:449:15
    #2 0x55b44ad9955e in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.h:56:16
    #3 0x55b44ad8993e in doris::ThreadPool::create_thread() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:611:12
    #4 0x55b44ad89400 in doris::ThreadPool::init() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:265:25
    #5 0x55b446c07c67 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.h:121:13
    #6 0x55b47a4a4a00 in doris::pipeline::TaskScheduler::start() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:209:5
    #7 0x55b44a6bec20 in doris::WorkloadGroup::upsert_task_scheduler(doris::WorkloadGroupInfo*, doris::ExecEnv*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/workload_group/workload_group.cpp:351:47
    #8 0x55b44a7eabd9 in doris::WorkloadGroupListener::handle_topic_info(std::vector<doris::TopicInfo, std::allocator<doris::TopicInfo>> const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/agent/workload_group_listener.cpp:54:13
    #9 0x55b44a7e2d5d in doris::TopicSubscriber::handle_topic_info(doris::TPublishTopicRequest const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/agent/topic_subscriber.cpp:46:35
    #10 0x55b44a797046 in doris::BackendService::publish_topic_info(doris::TPublishTopicResult&, doris::TPublishTopicRequest const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/backend_service.h:97:48
    #11 0x55b44afcb95a in doris::BackendServiceProcessor::process_publish_topic_info(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /home/zcp/repo_center/doris_branch-2.1/doris/gensrc/build/gen_cpp/BackendService.cpp:6690:13
    #12 0x55b44afaedf8 in doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int, void*) /home/zcp/repo_center/doris_branch-2.1/doris/gensrc/build/gen_cpp/BackendService.cpp:5492:3
    #13 0x55b44692fddb in apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/thrift/TDispatchProcessor.h:121:12
    #14 0x55b47adbcdb1 in apache::thrift::server::TConnectedClient::run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a628db1) (BuildId: dfb3a4f1336e35da)
    #15 0x55b47adbe03c in apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62a03c) (BuildId: dfb3a4f1336e35da)
    #16 0x55b47adc2eb5 in apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eeb5) (BuildId: dfb3a4f1336e35da)
    #17 0x55b47adc2d5b in void std::__invoke_impl<void, void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(std::__invoke_other, void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ed5b) (BuildId: dfb3a4f1336e35da)
    #18 0x55b47adc2cae in std::__invoke_result<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>::type std::__invoke<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ecae) (BuildId: dfb3a4f1336e35da)
    #19 0x55b47adc2c1e in void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ec1e) (BuildId: dfb3a4f1336e35da)
    #20 0x55b47adc2ba3 in std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::operator()() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eba3) (BuildId: dfb3a4f1336e35da)
    #21 0x55b47adc2b47 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>>::_M_run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eb47) (BuildId: dfb3a4f1336e35da)
    #22 0x55b47d6baa9f in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

Thread T2340 created by T1656 here:
    #0 0x55b44687fcaa in pthread_create (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x260ebcaa) (BuildId: dfb3a4f1336e35da)
    #1 0x55b47d6babc5 in __gthread_create /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x55b47d6babc5 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x55b47adc1554 in apache::thrift::concurrency::Thread::start() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62d554) (BuildId: dfb3a4f1336e35da)
    #4 0x55b47adbdd6c in apache::thrift::server::TThreadedServer::onClientConnected(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a629d6c) (BuildId: dfb3a4f1336e35da)
    #5 0x55b47adba1c2 in apache::thrift::server::TServerFramework::newlyConnectedClient(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a6261c2) (BuildId: dfb3a4f1336e35da)
    #6 0x55b47adb985d in apache::thrift::server::TServerFramework::serve() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62585d) (BuildId: dfb3a4f1336e35da)
    #7 0x55b47adbdad7 in apache::thrift::server::TThreadedServer::serve() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a629ad7) (BuildId: dfb3a4f1336e35da)
    #8 0x55b44adc950a in doris::ThriftServer::ThriftServerEventProcessor::supervise() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thrift_server.cpp:163:34
    #9 0x55b44addd455 in void std::__invoke_impl<void, void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>(std::__invoke_memfun_deref, void (doris::ThriftServer::ThriftServerEventProcessor::*&&)(), doris::ThriftServer::ThriftServerEventProcessor*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #10 0x55b44addd2fe in std::__invoke_result<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>::type std::__invoke<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>(void (doris::ThriftServer::ThriftServerEventProcessor::*&&)(), doris::ThriftServer::ThriftServerEventProcessor*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #11 0x55b44addd2c3 in void std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253:13
    #12 0x55b44addd276 in std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260:11
    #13 0x55b44addd07a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>>::_M_run() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211:13
    #14 0x55b47d6baa9f in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

Thread T1656 created by T0 here:
    #0 0x55b44687fcaa in pthread_create (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x260ebcaa) (BuildId: dfb3a4f1336e35da)
    #1 0x55b47d6babc5 in __gthread_create /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x55b47d6babc5 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x55b44adc8186 in doris::ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thrift_server.cpp:129:17
    #4 0x55b44adcdde0 in doris::ThriftServer::start() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thrift_server.cpp:378:5
    #5 0x55b4468db904 in main /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/doris_main.cpp:528:25
    #6 0x7ff908072082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

Thread T2366 (Pipe_normal [wo) created by T2340 here:
    #0 0x55b44687fcaa in pthread_create (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x260ebcaa) (BuildId: dfb3a4f1336e35da)
    #1 0x55b44ad4ffe1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:449:15
    #2 0x55b44ad9955e in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.h:56:16
    #3 0x55b44ad8993e in doris::ThreadPool::create_thread() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:611:12
    #4 0x55b44ad89400 in doris::ThreadPool::init() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.cpp:265:25
    #5 0x55b446c07c67 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/threadpool.h:121:13
    #6 0x55b47a4a4a00 in doris::pipeline::TaskScheduler::start() /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:209:5
    #7 0x55b44a6bec20 in doris::WorkloadGroup::upsert_task_scheduler(doris::WorkloadGroupInfo*, doris::ExecEnv*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/workload_group/workload_group.cpp:351:47
    #8 0x55b44a7eabd9 in doris::WorkloadGroupListener::handle_topic_info(std::vector<doris::TopicInfo, std::allocator<doris::TopicInfo>> const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/agent/workload_group_listener.cpp:54:13
    #9 0x55b44a7e2d5d in doris::TopicSubscriber::handle_topic_info(doris::TPublishTopicRequest const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/agent/topic_subscriber.cpp:46:35
    #10 0x55b44a797046 in doris::BackendService::publish_topic_info(doris::TPublishTopicResult&, doris::TPublishTopicRequest const&) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/backend_service.h:97:48
    #11 0x55b44afcb95a in doris::BackendServiceProcessor::process_publish_topic_info(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /home/zcp/repo_center/doris_branch-2.1/doris/gensrc/build/gen_cpp/BackendService.cpp:6690:13
    #12 0x55b44afaedf8 in doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int, void*) /home/zcp/repo_center/doris_branch-2.1/doris/gensrc/build/gen_cpp/BackendService.cpp:5492:3
    #13 0x55b44692fddb in apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/thrift/TDispatchProcessor.h:121:12
    #14 0x55b47adbcdb1 in apache::thrift::server::TConnectedClient::run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a628db1) (BuildId: dfb3a4f1336e35da)
    #15 0x55b47adbe03c in apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62a03c) (BuildId: dfb3a4f1336e35da)
    #16 0x55b47adc2eb5 in apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eeb5) (BuildId: dfb3a4f1336e35da)
    #17 0x55b47adc2d5b in void std::__invoke_impl<void, void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(std::__invoke_other, void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ed5b) (BuildId: dfb3a4f1336e35da)
    #18 0x55b47adc2cae in std::__invoke_result<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>::type std::__invoke<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ecae) (BuildId: dfb3a4f1336e35da)
    #19 0x55b47adc2c1e in void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62ec1e) (BuildId: dfb3a4f1336e35da)
    #20 0x55b47adc2ba3 in std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::operator()() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eba3) (BuildId: dfb3a4f1336e35da)
    #21 0x55b47adc2b47 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>>::_M_run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5a62eb47) (BuildId: dfb3a4f1336e35da)
    #22 0x55b47d6baa9f in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

Thread T2201 created by T0 here:
    #0 0x55b44687fcaa in pthread_create (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x260ebcaa) (BuildId: dfb3a4f1336e35da)
    #1 0x55b47bf61dee in bthread::TaskControl::add_workers(int) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b7cddee) (BuildId: dfb3a4f1336e35da)
    #2 0x55b47bf4ffdc in bthread_setconcurrency (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b7bbfdc) (BuildId: dfb3a4f1336e35da)
    #3 0x55b47c0cdce9 in brpc::Server::StartInternal(butil::EndPoint const&, brpc::PortRange const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b939ce9) (BuildId: dfb3a4f1336e35da)
    #4 0x55b47c0cfd39 in brpc::Server::Start(butil::EndPoint const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5b93bd39) (BuildId: dfb3a4f1336e35da)
    #5 0x55b44a810bb1 in doris::BRpcService::start(int, int) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/brpc_service.cpp:79:18
    #6 0x55b4468dbbee in main /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/doris_main.cpp:538:28
    #7 0x7ff908072082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

