### PR TITLE
[bugfix](paimon)merge meta-inf/services for paimon FileIOLoader

### DIFF
--- a/fe/be-java-extensions/preload-extensions/src/main/resources/package-deps.xml
+++ b/fe/be-java-extensions/preload-extensions/src/main/resources/package-deps.xml
@@ -38,4 +38,11 @@ under the License.
             </unpackOptions>
         </dependencySet>
     </dependencySets>
+
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+
 </assembly>


### PR DESCRIPTION
## Proposed changes

We introduced paimon's oss and s3 packages, but did not register them in meta-info/service. As a result, when be used the s3  or oss interface, an error was reported and the class could not be found(`Could not find a file io implementation for scheme 's3' in the classpath.`).

FYI:
https://stackoverflow.com/questions/47310215/merging-meta-inf-services-files-with-maven-assembly-plugin
https://stackoverflow.com/questions/1607220/how-can-i-merge-resource-files-in-a-maven-assembly

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

