### PR TITLE
[FIX](inverted_index) fix inverted index write array with _doc is empty

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -400,9 +400,12 @@ public:
                         _doc->add(*new_field);
                     }
                 }
-                RETURN_IF_ERROR(add_document());
-                _doc->clear();
-                _CLDELETE(ts);
+                if (!_doc->getFields()->empty()) {
+                    // if this array is null, we just ignore to write inverted index
+                    RETURN_IF_ERROR(add_document());
+                    _doc->clear();
+                    _CLDELETE(ts);
+                }
                 _rid++;
             }
         } else if constexpr (field_is_numeric_type(field_type)) {


### PR DESCRIPTION
## Proposed changes
when a array in single row is null or array has all null elements , the _doc param may has empty field, in this situation if we also call add_document,  inverted index will call process_document() make sure field with inverted , but field is cleared, and _doc is empty which will make heap use after free, so we should avoid this situation happen!
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

