### PR TITLE
[Fix](trino-connector) Disable JUL from printing logs to the console

### DIFF
--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.SimpleFormatter;
@@ -50,12 +52,14 @@ public class TrinoConnectorPluginLoader {
                         "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n");
                 java.util.logging.Logger logger = java.util.logging.Logger.getLogger("");
                 logger.setUseParentHandlers(false);
+                Arrays.stream(logger.getHandlers())
+                        .filter(handler -> handler instanceof ConsoleHandler)
+                        .forEach(handler -> handler.setLevel(Level.OFF));
                 FileHandler fileHandler = new FileHandler(EnvUtils.getDorisHome() + "/log/trinoconnector%g.log",
                         500000000, 10, true);
                 fileHandler.setLevel(Level.INFO);
                 fileHandler.setFormatter(new SimpleFormatter());
                 logger.addHandler(fileHandler);
-                java.util.logging.LogManager.getLogManager().addLogger(logger);
 
                 TypeOperators typeOperators = new TypeOperators();
                 featuresConfig = new FeaturesConfig();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Disable JUL from printing logs to the console, otherwise these logs will be printed to be.out

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

