### PR TITLE
[fix](dns-cache) do not detach the refresh thread

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -597,7 +597,6 @@ void ExecEnv::destroy() {
     _delta_writer_v2_pool.reset();
     _load_stream_stub_pool.reset();
     _file_cache_open_fd_cache.reset();
-    SAFE_DELETE(_dns_cache);
 
     // StorageEngine must be destoried before _page_no_cache_mem_tracker.reset and _cache_manager destory
     // shouldn't use SAFE_STOP. otherwise will lead to twice stop.
@@ -688,6 +687,9 @@ void ExecEnv::destroy() {
 
     // We should free task scheduler finally because task queue / scheduler maybe used by pipelineX.
     SAFE_DELETE(_without_group_task_scheduler);
+
+    // dns cache is a global instance and need to be released at last
+    SAFE_DELETE(_dns_cache);
 
     _s_tracking_memory = false;
     LOG(INFO) << "Doris exec envorinment is destoried.";

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -24,7 +24,6 @@ namespace doris {
 
 DNSCache::DNSCache() {
     refresh_thread = std::thread(&DNSCache::_refresh_cache, this);
-    refresh_thread.detach();
 }
 
 DNSCache::~DNSCache() {


### PR DESCRIPTION
## Proposed changes

1. do not detach the refresh thread, or it can not be joined.
2. Released the dns cache at last when destroying the exec env, avoid other thread still using it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

