### PR TITLE
[fix](hdfs-writer) Catch error information after `hdfsCloseFile()`

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -62,9 +62,9 @@ Status HdfsFileWriter::close() {
         return Status::InternalError(ss.str());
     }
 
-    int res = hdfsCloseFile(_hdfs_handler->hdfs_fs, _hdfs_file);
+    result = hdfsCloseFile(_hdfs_handler->hdfs_fs, _hdfs_file);
     _hdfs_file = nullptr;
-    if (res != 0) {
+    if (result != 0) {
         std::string err_msg = hdfs_error();
         return Status::InternalError(
                 "Write hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -62,8 +62,14 @@ Status HdfsFileWriter::close() {
         return Status::InternalError(ss.str());
     }
 
-    hdfsCloseFile(_hdfs_handler->hdfs_fs, _hdfs_file);
+    int res = hdfsCloseFile(_hdfs_handler->hdfs_fs, _hdfs_file);
     _hdfs_file = nullptr;
+    if (res != 0) {
+        std::string err_msg = hdfs_error();
+        return Status::InternalError(
+                "Write hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",
+                BackendOptions::get_localhost(), _fs_name, _path.string(), err_msg);
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

