### PR TITLE
[fix](tvf) Support fs.defaultFS with postfix '/'

### DIFF
--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -133,6 +133,11 @@ Path convert_path(const Path& path, const std::string& namenode) {
     Path real_path(path);
     if (path.string().find(namenode) != std::string::npos) {
         std::string real_path_str = path.string().substr(namenode.size());
+        if (!real_path_str.starts_with("/")) {
+            // The real path must starts with "/"
+            // Or the hadoop client will add a prefix like "/user/hadoop".
+            real_path_str = "/" + real_path_str;
+        }
         real_path = real_path_str;
     }
     return real_path;

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
@@ -147,7 +147,7 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
 
         qt_select_tvf1 """ select * from HDFS(
                         "uri" = "${outfile_url}0.parquet",
-                        "fs.defaultFS" = "${defaultFS_with_postfix}"
+                        "fs.defaultFS" = "${defaultFS_with_postfix}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "${format}");
                         """
@@ -186,7 +186,7 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
 
         qt_select_tvf2 """ select * from HDFS(
                         "uri" = "${outfile_url}0.parquet",
-                        "fs.defaultFS" = "${defaultFS}"
+                        "fs.defaultFS" = "${defaultFS}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "${format}");
                         """

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
@@ -41,6 +41,7 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
     def hdfsUserName = "doris"
     def format = "parquet"
     def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
+    def defaultFS_with_postfix = "hdfs://${externalEnvIp}:${hdfs_port}/"
     def outfile_path = "/user/doris/tmp_data"
     def uri = "${defaultFS}" + "${outfile_path}/exp_"
 
@@ -99,7 +100,6 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
             INTO OUTFILE "${uri}"
             FORMAT AS ${format}
             PROPERTIES (
-                "fs.defaultFS"="${defaultFS}",
                 "hadoop.username" = "${hdfsUserName}"
             );
         """
@@ -147,6 +147,7 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
 
         qt_select_tvf1 """ select * from HDFS(
                         "uri" = "${outfile_url}0.parquet",
+                        "fs.defaultFS" = "${defaultFS_with_postfix}"
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "${format}");
                         """
@@ -185,6 +186,7 @@ suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
 
         qt_select_tvf2 """ select * from HDFS(
                         "uri" = "${outfile_url}0.parquet",
+                        "fs.defaultFS" = "${defaultFS}"
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "${format}");
                         """


### PR DESCRIPTION
## Proposed changes

For HDFS tvf like:
```
select count(*) from hdfs(
"uri" = "hdfs://HDFS8000871/path/to/1.parquet",
"fs.defaultFS" = "hdfs://HDFS8000871/",
"format" = "parquet"
);
```

Before, if the `fs.defaultFS` is end with `/`, the query will fail with error like:
```
reason: RemoteException: File does not exist: /user/doris/path/to/1.parquet
```
You can see that is a wrong path with wrong prefix `/user/doris`
User need to set `fs.defaultFS` to `hdfs://HDFS8000871` to avoid this error.

This PR fix this issue

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

