### PR TITLE
[fix](Branch2.0) Catch error information after `hdfsCloseFile()`

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -64,7 +64,13 @@ Status HdfsFileWriter::close() {
         LOG(WARNING) << ss.str();
         return Status::InternalError(ss.str());
     }
-    hdfsCloseFile(_hdfs_fs->_fs_handle->hdfs_fs, _hdfs_file);
+    result = hdfsCloseFile(_hdfs_fs->_fs_handle->hdfs_fs, _hdfs_file);
+    if (result != 0) {
+        std::string _err_msg = hdfs_error();
+        return Status::InternalError(
+                "Write hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",
+                BackendOptions::get_localhost(), _fs_name, _path.string(), _err_msg);
+    }
     _hdfs_file = nullptr;
     return Status::OK();
 }

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -67,10 +67,10 @@ Status HdfsFileWriter::close() {
     result = hdfsCloseFile(_hdfs_fs->_fs_handle->hdfs_fs, _hdfs_file);
     _hdfs_file = nullptr;
     if (result != 0) {
-        std::string _err_msg = hdfs_error();
+        std::string err_msg = hdfs_error();
         return Status::InternalError(
                 "Write hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",
-                BackendOptions::get_localhost(), _fs_name, _path.string(), _err_msg);
+                BackendOptions::get_localhost(), _hdfs_fs->_fs_name, _path.string(), err_msg);
     }
     return Status::OK();
 }

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -65,13 +65,13 @@ Status HdfsFileWriter::close() {
         return Status::InternalError(ss.str());
     }
     result = hdfsCloseFile(_hdfs_fs->_fs_handle->hdfs_fs, _hdfs_file);
+    _hdfs_file = nullptr;
     if (result != 0) {
         std::string _err_msg = hdfs_error();
         return Status::InternalError(
                 "Write hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",
                 BackendOptions::get_localhost(), _fs_name, _path.string(), _err_msg);
     }
-    _hdfs_file = nullptr;
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

backport: #33195

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

