### PR TITLE
[Fix](partial-update) Fix partial update fail when the datetime default value is 'current_time' #32926

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -65,6 +65,8 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
     _version = pschema.version();
     _is_partial_update = pschema.partial_update();
     _is_strict_mode = pschema.is_strict_mode();
+    _timestamp_ms = pschema.timestamp_ms();
+    _timezone = pschema.timezone();
 
     for (auto& col : pschema.partial_update_input_columns()) {
         _partial_update_input_columns.insert(col);
@@ -207,6 +209,8 @@ void OlapTableSchemaParam::to_protobuf(POlapTableSchemaParam* pschema) const {
     pschema->set_version(_version);
     pschema->set_partial_update(_is_partial_update);
     pschema->set_is_strict_mode(_is_strict_mode);
+    pschema->set_timestamp_ms(_timestamp_ms);
+    pschema->set_timezone(_timezone);
     for (auto col : _partial_update_input_columns) {
         *pschema->add_partial_update_input_columns() = col;
     }

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -88,6 +88,10 @@ public:
     std::set<std::string> partial_update_input_columns() const {
         return _partial_update_input_columns;
     }
+    void set_timestamp_ms(int64_t timestamp_ms) { _timestamp_ms = timestamp_ms; }
+    int64_t timestamp_ms() const { return _timestamp_ms; }
+    void set_timezone(std::string timezone) { _timezone = timezone; }
+    std::string timezone() const { return _timezone; }
     bool is_strict_mode() const { return _is_strict_mode; }
     std::string debug_string() const;
 
@@ -104,6 +108,8 @@ private:
     bool _is_partial_update = false;
     std::set<std::string> _partial_update_input_columns;
     bool _is_strict_mode = false;
+    int64_t _timestamp_ms = 0;
+    std::string _timezone;
 };
 
 using OlapTableIndexTablets = TOlapTableIndexTablets;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -651,7 +651,8 @@ void DeltaWriter::_build_current_tablet_schema(int64_t index_id,
     _partial_update_info = std::make_shared<PartialUpdateInfo>();
     _partial_update_info->init(*_tablet_schema, table_schema_param->is_partial_update(),
                                table_schema_param->partial_update_input_columns(),
-                               table_schema_param->is_strict_mode());
+                               table_schema_param->is_strict_mode(),
+                               table_schema_param->timestamp_ms(), table_schema_param->timezone());
 }
 
 void DeltaWriter::_request_slave_tablet_pull_rowset(PNodeInfo node_info) {

--- a/be/src/olap/partial_update_info.h
+++ b/be/src/olap/partial_update_info.h
@@ -23,9 +23,12 @@ namespace doris {
 
 struct PartialUpdateInfo {
     void init(const TabletSchema& tablet_schema, bool partial_update,
-              const std::set<string>& partial_update_cols, bool is_strict_mode) {
+              const std::set<string>& partial_update_cols, bool is_strict_mode,
+              int64_t timestamp_ms, const std::string& timezone) {
         is_partial_update = partial_update;
         partial_update_input_columns = partial_update_cols;
+        this->timestamp_ms = timestamp_ms;
+        this->timezone = timezone;
         missing_cids.clear();
         update_cids.clear();
         for (auto i = 0; i < tablet_schema.num_columns(); ++i) {
@@ -50,5 +53,7 @@ struct PartialUpdateInfo {
     // to generate a new row, only available in non-strict mode
     bool can_insert_new_rows_in_partial_update {true};
     bool is_strict_mode {false};
+    int64_t timestamp_ms {0};
+    std::string timezone;
 };
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -656,7 +656,7 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
                              to_lower(_tablet_schema->column(cids_missing[i]).default_value())
                                              .find(to_lower("CURRENT_TIMESTAMP")) !=
                                      std::string::npos)) {
-                    DateV2Value<DateTimeV2ValueType> dtv;
+                    vectorized::DateV2Value<vectorized::DateTimeV2ValueType> dtv;
                     dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
                                       _opts.rowset_ctx->partial_update_info->timezone);
                     default_value = dtv.debug_string();

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -54,6 +54,7 @@
 #include "util/faststring.h"
 #include "util/key_util.h"
 #include "vec/columns/column_nullable.h"
+#include "vec/columns/columns_number.h"
 #include "vec/common/schema_util.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
@@ -61,6 +62,7 @@
 #include "vec/io/reader_buffer.h"
 #include "vec/jsonb/serialize.h"
 #include "vec/olap/olap_data_convertor.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
 namespace segment_v2 {
@@ -648,7 +650,19 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
         for (auto i = 0; i < cids_missing.size(); ++i) {
             const auto& column = _tablet_schema->column(cids_missing[i]);
             if (column.has_default_value()) {
-                auto default_value = _tablet_schema->column(cids_missing[i]).default_value();
+                std::string default_value;
+                if (UNLIKELY(_tablet_schema->column(cids_missing[i]).type() ==
+                                     FieldType::OLAP_FIELD_TYPE_DATETIMEV2 &&
+                             to_lower(_tablet_schema->column(cids_missing[i]).default_value())
+                                             .find(to_lower("CURRENT_TIMESTAMP")) !=
+                                     std::string::npos)) {
+                    DateV2Value<DateTimeV2ValueType> dtv;
+                    dtv.from_unixtime(_opts.rowset_ctx->partial_update_info->timestamp_ms / 1000,
+                                      _opts.rowset_ctx->partial_update_info->timezone);
+                    default_value = dtv.debug_string();
+                } else {
+                    default_value = _tablet_schema->column(cids_missing[i]).default_value();
+                }
                 vectorized::ReadBuffer rb(const_cast<char*>(default_value.c_str()),
                                           default_value.size());
                 old_value_block.get_by_position(i).type->from_string(

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -983,6 +983,8 @@ Status VOlapTableSink::init(const TDataSink& t_sink) {
     _tuple_desc_id = table_sink.tuple_id;
     _schema.reset(new OlapTableSchemaParam());
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
+    _schema->set_timestamp_ms(_state->timestamp_ms());
+    _schema->set_timezone(_state->timezone());
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
     _nodes_info = _pool->add(new DorisNodesInfo(table_sink.nodes_info));
     if (table_sink.__isset.write_single_replica && table_sink.write_single_replica) {

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -983,8 +983,6 @@ Status VOlapTableSink::init(const TDataSink& t_sink) {
     _tuple_desc_id = table_sink.tuple_id;
     _schema.reset(new OlapTableSchemaParam());
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
-    _schema->set_timestamp_ms(_state->timestamp_ms());
-    _schema->set_timezone(_state->timezone());
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
     _nodes_info = _pool->add(new DorisNodesInfo(table_sink.nodes_info));
     if (table_sink.__isset.write_single_replica && table_sink.write_single_replica) {
@@ -1021,6 +1019,8 @@ Status VOlapTableSink::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(DataSink::prepare(state));
 
     _state = state;
+    _schema->set_timestamp_ms(_state->timestamp_ms());
+    _schema->set_timezone(_state->timezone());
 
     _sender_id = state->per_fragment_instance_idx();
     _num_senders = state->num_per_fragment_instances();

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -68,5 +68,7 @@ message POlapTableSchemaParam {
     optional bool partial_update = 7 [default = false];
     repeated string partial_update_input_columns = 8;
     optional bool is_strict_mode = 9 [default = false];
+    optional int64 timestamp_ms = 11 [default = 0];
+    optional string timezone = 12;
 };
 

--- a/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
+++ b/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
@@ -35,6 +35,9 @@
 3	"stranger"	500	\N	4321
 4	"foreigner"	600	\N	4321
 
+-- !select_timestamp --
+1
+
 -- !select_default --
 1	doris	200	123	1
 2	doris2	400	223	1
@@ -70,4 +73,7 @@
 2	doris2	2222	223	1
 3	"stranger"	500	\N	4321
 4	"foreigner"	600	\N	4321
+
+-- !select_timestamp --
+1
 

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -187,6 +187,25 @@ suite("test_primary_key_partial_update", "p0") {
 
             // drop drop
             sql """ DROP TABLE IF EXISTS ${tableName} """
+
+            sql """ CREATE TABLE ${tableName} (
+                        `name` VARCHAR(600) NULL,
+                        `userid` INT NOT NULL,
+                        `seq` BIGINT NOT NULL AUTO_INCREMENT(1),
+                        `ctime` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+                        `rtime` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+                        `corp_name` VARCHAR(600) NOT NULL
+                        ) ENGINE = OLAP UNIQUE KEY(`name`, `userid`) COMMENT 'OLAP' DISTRIBUTED BY HASH(`name`) BUCKETS 10 
+                        PROPERTIES ("replication_num" = "1",
+                                    "enable_unique_key_merge_on_write" = "true",
+                                    "store_row_column" = "${use_row_store}"); """
+
+            sql "set enable_unique_key_partial_update=true;" 
+            sql "set enable_insert_strict=false;"
+
+            sql "INSERT INTO ${tableName}(`name`, `userid`, `corp_name`) VALUES ('test1', 1234567, 'A');"
+
+            qt_select_timestamp "select count(*) from ${tableName} where `ctime` > \"1970-01-01\""
         }
     }
 }

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -191,9 +191,9 @@ suite("test_primary_key_partial_update", "p0") {
             sql """ CREATE TABLE ${tableName} (
                         `name` VARCHAR(600) NULL,
                         `userid` INT NOT NULL,
-                        `seq` BIGINT NOT NULL AUTO_INCREMENT(1),
+                        `seq` BIGINT NOT NULL DEFAULT "1",
                         `ctime` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
-                        `rtime` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+                        `rtime` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
                         `corp_name` VARCHAR(600) NOT NULL
                         ) ENGINE = OLAP UNIQUE KEY(`name`, `userid`) COMMENT 'OLAP' DISTRIBUTED BY HASH(`name`) BUCKETS 10 
                         PROPERTIES ("replication_num" = "1",


### PR DESCRIPTION


Problem:
When partially updating columns without specifying the auto-increment column, and the imported data contains new keys, an error stating the auto-increment column could not be found occurs.

Reason:
The logic for partial column updates does not account for new keys in auto-increment columns. Since auto-increment columns can be generated by the system, it's possible to omit this column data during import. However, partial column updates treat this as a regular column, expecting it to be nullable or have a default value for automatic filling, overlooking the fact that auto-increment columns can also be auto-filled. This oversight leads to the error.

Solution:
Incorporate a check for auto-increment columns into the partial column update logic, and include the logic for generating auto-increment column values in the process of completing partial updates.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

