### PR TITLE
[Bug](runtime-filter) set need_local_merge to false when rf is broadcast

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1255,6 +1255,7 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     DCHECK(node_id >= 0 || (node_id == -1 && !is_consumer()));
 
     _is_broadcast_join = desc->is_broadcast_join;
+    _need_local_merge &= !_is_broadcast_join;
     _has_local_target = desc->has_local_targets;
     _has_remote_target = desc->has_remote_targets;
     _expr_order = desc->expr_order;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -434,7 +434,7 @@ protected:
     bool _opt_remote_rf;
     // `_need_local_merge` indicates whether this runtime filter is global on this BE.
     // All runtime filters should be merged on each BE before push_to_remote or publish.
-    const bool _need_local_merge = false;
+    bool _need_local_merge = false;
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 };

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
@@ -46,7 +46,7 @@ Status NestedLoopJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkSta
                 p._runtime_filter_descs[i], p._need_local_merge, &_runtime_filters[i], false));
         if (!_runtime_filters[i]->is_broadcast_join()) {
             return Status::InternalError(
-                    "runtime filter({}) on NestedLoopJoin should be set to is_broadcast_join,",
+                    "runtime filter({}) on NestedLoopJoin should be set to is_broadcast_join",
                     _runtime_filters[i]->get_name());
         }
     }


### PR DESCRIPTION
## Proposed changes
set need_local_merge to false when rf is broadcast
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

