### PR TITLE
[improvement](storage) support glibc <2.21 for system call eventfd

### DIFF
--- a/be/src/glibc-compatibility/musl/eventfd.c
+++ b/be/src/glibc-compatibility/musl/eventfd.c
@@ -2,8 +2,16 @@
 #include <unistd.h>
 #include <errno.h>
 #include "syscall.h"
+#include <features.h>
 
+
+
+
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 21)
 int eventfd(unsigned int count, int flags)
+#else
+int eventfd(int count, int flags)
+#endif
 {
 	int r = __syscall(SYS_eventfd2, count, flags);
 #ifdef SYS_eventfd


### PR DESCRIPTION
## Proposed changes
support lower version eventfd function

The definition of function event in be/src/glibc-compatibility/musl/eventfd.c currently only supports >=glibc2.21 declarations.
It does not support lower version declarations. Modify the eventfd.c code to also support <glibc2.21 declarations.

