### PR TITLE
[fix](kill_sql) support force cancel sql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1482,15 +1482,22 @@ public class StmtExecutor {
             }
             return;
         }
-        Coordinator coordRef = coord;
-        if (coordRef != null) {
-            coordRef.cancel();
-        }
         if (mysqlLoadId != null) {
             Env.getCurrentEnv().getLoadManager().getMysqlLoadManager().cancelMySqlLoad(mysqlLoadId);
         }
         if (parsedStmt instanceof AnalyzeTblStmt || parsedStmt instanceof AnalyzeDBStmt) {
             Env.getCurrentEnv().getAnalysisManager().cancelSyncTask(context);
+        }
+
+        Coordinator coordRef = coord;
+        if (coordRef != null) {
+            coordRef.cancel();
+        } else {
+            // force cancel, for scenerios when above strategies does not work, like sql error in analyze period
+            if (context != null) {
+                context.cleanup();
+                context = null;
+            }
         }
     }
 


### PR DESCRIPTION
In some scenarios, cancel query does not work, no matter auto cancel or manually cancel.
One case is when an error occurs during analyzing a sql.
<img width="312" alt="image" src="https://github.com/apache/doris/assets/28004179/683c1a6b-fc0c-4eb6-ab91-32a4e269d592">


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

