### PR TITLE
[Feature](vectorization) Add string `INSERT` function

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -514,7 +514,7 @@ void MemInfo::init() {
     bool is_percent = true;
     _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
-    _s_soft_mem_limit = _s_mem_limit * config::soft_mem_limit_frac;
+    _s_soft_mem_limit = int64_t(_s_mem_limit * config::soft_mem_limit_frac);
     _s_soft_mem_limit_str = PrettyPrinter::print(_s_soft_mem_limit, TUnit::BYTES);
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -1131,6 +1131,7 @@ void register_function_string(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionMaskPartial<false>>();
     factory.register_function<FunctionSubReplace<SubReplaceThreeImpl>>();
     factory.register_function<FunctionSubReplace<SubReplaceFourImpl>>();
+    factory.register_function<FunctionInsert<InsertImpl>>();
 
     /// @TEMPORARY: for be_exec_version=3
     factory.register_alternative_function<FunctionSubstringOld<Substr3ImplOld>>();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -197,6 +197,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Ignore;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Initcap;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.InnerProduct;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Insert;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Instr;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.InttoUuid;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Ipv4CIDRToRange;
@@ -626,6 +627,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(Ignore.class, "ignore"),
             scalar(Initcap.class, "initcap"),
             scalar(InnerProduct.class, "inner_product"),
+            scalar(Insert.class, "insert"),
             scalar(Instr.class, "instr"),
             scalar(InttoUuid.class, "int_to_uuid"),
             scalar(Ipv4NumToString.class, "ipv4_num_to_string", "inet_ntoa"),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Insert.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Insert.java
@@ -39,14 +39,10 @@ public class Insert extends ScalarFunction
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
-                .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE),
+                .args(VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE, IntegerType.INSTANCE,
+                    VarcharType.SYSTEM_DEFAULT),
             FunctionSignature.ret(StringType.INSTANCE)
-                .args(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE),
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
-                .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE,
-                    IntegerType.INSTANCE),
-            FunctionSignature.ret(StringType.INSTANCE)
-                .args(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE, IntegerType.INSTANCE)
+                .args(StringType.INSTANCE, IntegerType.INSTANCE, IntegerType.INSTANCE, StringType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Insert.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Insert.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.scalar;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
+import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.StringType;
+import org.apache.doris.nereids.types.VarcharType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * ScalarFunction 'insert'
+ */
+public class Insert extends ScalarFunction
+        implements ExplicitlyCastableSignature, AlwaysNullable {
+
+    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                .args(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE,
+                    IntegerType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                .args(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE, IntegerType.INSTANCE)
+    );
+
+    /**
+     * constructor with 4 arguments.
+     */
+    public Insert(Expression arg0, Expression arg1, Expression arg2, Expression arg3) {
+        super("insert", arg0, arg1, arg2, arg3);
+    }
+
+    /**
+     * withChildren.
+     */
+    @Override
+    public Insert withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.size() == 4);
+        return new Insert(children.get(0), children.get(1), children.get(2), children.get(3));
+    }
+
+    @Override
+    public List<FunctionSignature> getSignatures() {
+        return SIGNATURES;
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitInsert(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ScalarFunctionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ScalarFunctionVisitor.java
@@ -200,6 +200,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Ignore;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Initcap;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.InnerProduct;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Insert;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Instr;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.InttoUuid;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Ipv4CIDRToRange;
@@ -1189,6 +1190,10 @@ public interface ScalarFunctionVisitor<R, C> {
 
     default R visitInitcap(Initcap initcap, C context) {
         return visitScalarFunction(initcap, context);
+    }
+
+    default R visitInsert(Insert insert, C context) {
+        return visitScalarFunction(insert, context);
     }
 
     default R visitInnerProduct(InnerProduct innerProduct, C context) {

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1554,7 +1554,6 @@ visible_functions = {
     "String": [
         [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
-        [['insert'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['mask'], 'STRING', ['STRING', '...'], ''],
         [['mask_first_n'], 'STRING', ['STRING'], ''],
         [['mask_first_n'], 'STRING', ['STRING', 'INT'], ''],
@@ -1617,12 +1616,12 @@ visible_functions = {
 
         [['sub_replace'], 'VARCHAR', ['VARCHAR', 'VARCHAR', 'INT'], 'ALWAYS_NULLABLE'],
         [['sub_replace'], 'VARCHAR', ['VARCHAR', 'VARCHAR', 'INT', 'INT'], 'ALWAYS_NULLABLE'],
+        [['insert'], 'VARCHAR', ['VARCHAR', 'INT', 'INT', 'VARCHAR'], 'ALWAYS_NULLABLE'],
 
         [['char'], 'VARCHAR', ['VARCHAR', 'INT', '...'], 'ALWAYS_NULLABLE'],
 
         [['substr', 'substring'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['substr', 'substring'], 'STRING', ['STRING', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
-        [['insert'], 'STRING', ['STRING', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['strleft', 'left'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['strright', 'right'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['ends_with'], 'BOOLEAN', ['STRING', 'STRING'], ''],
@@ -2253,8 +2252,7 @@ null_result_with_one_null_param_functions = [
     'ST_LineFromText',
     'ST_Polygon',
     'ST_Contains',
-    'from_unixtime',
-    'insert'
+    'from_unixtime'
 ]
 
 invisible_functions = [

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1554,6 +1554,7 @@ visible_functions = {
     "String": [
         [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
+        [['insert'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['mask'], 'STRING', ['STRING', '...'], ''],
         [['mask_first_n'], 'STRING', ['STRING'], ''],
         [['mask_first_n'], 'STRING', ['STRING', 'INT'], ''],
@@ -1621,6 +1622,7 @@ visible_functions = {
 
         [['substr', 'substring'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['substr', 'substring'], 'STRING', ['STRING', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
+        [['insert'], 'STRING', ['STRING', 'INT', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['strleft', 'left'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['strright', 'right'], 'STRING', ['STRING', 'INT'], 'DEPEND_ON_ARGUMENT'],
         [['ends_with'], 'BOOLEAN', ['STRING', 'STRING'], ''],
@@ -2251,7 +2253,8 @@ null_result_with_one_null_param_functions = [
     'ST_LineFromText',
     'ST_Polygon',
     'ST_Contains',
-    'from_unixtime'
+    'from_unixtime',
+    'insert'
 ]
 
 invisible_functions = [

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -366,4 +366,21 @@ suite("test_string_function", "arrow_flight_sql") {
     qt_sql_func_char9 """ select char(0) = ' '; """
     qt_sql_func_char10 """ select char(0) = '\0'; """
 
+
+    qt_sql """SELECT `INSERT`('bbbbb', 1, 1, 'a');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 1, 1, 'xxxxx');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 7, 5, 'xxxxx');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 6, 5, 'xxxxx');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 5, 1, 'xxxxx');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 10, 1, 'xxxxx');"""
+
+    qt_sql """SELECT `INSERT`('abcdefghij', -2147483648, 1, 'a');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', -2147483647, 1, 'a');"""
+    qt_sql """SELECT `INSERT`('abcdefghij', 2147483647, 1, 'a');"""
+
+    qt_sql """SELECT `INSERT`(NULL, 1, 1, 'a');"""
+    qt_sql """SELECT `INSERT`('bbbbb', NULL, 1, 'a');"""
+    qt_sql """SELECT `INSERT`('bbbbb', 1, NULL, 'a');"""
+    qt_sql """SELECT `INSERT`('bbbbb', 1, 1, NULL);"""
+    qt_sql """SELECT `INSERT`(NULL, NULL, NULL, NULL);"""
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close [#33094](https://github.com/apache/doris/issues/33094)

Hi all,

I added the support for `INSERT` for string function. [MYSQL's manual](https://dev.mysql.com/doc/refman/8.3/en/string-functions.html#function_insert).

The regression tests are under construction.

In addition, I have a question. It seems that the usage of this function should like this:
```sql
SELECT `INSERT`('bbbbb', 1, 1, 'a');
```
instead of:
```sql
SELECT INSERT('bbbbb', 1, 1, 'a');
```

It this correct? Thanks ;)
