### PR TITLE
[Feature][Enhancement](hive-writer) Add hive-writer runtime profiles, change output file names and Use `table_sink_partition_write_max_partition_nums_per_writer`.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1275,7 +1275,7 @@ DECLARE_mInt64(table_sink_partition_write_skewed_data_processed_rebalance_thresh
 DECLARE_mInt32(table_sink_partition_write_max_partition_nums_per_writer);
 
 /** Hive sink configurations **/
-DECLARE_mInt64(hive_sink_max_file_size); // 1GB
+DECLARE_mInt64(hive_sink_max_file_size);
 
 // Number of open tries, default 1 means only try to open once.
 // Retry the Open num_retries time waiting 100 milliseconds between retries.

--- a/be/src/vec/sink/writer/vhive_partition_writer.h
+++ b/be/src/vec/sink/writer/vhive_partition_writer.h
@@ -52,7 +52,8 @@ public:
                          const VExprContextSPtrs& write_output_expr_ctxs,
                          const std::set<size_t>& non_write_columns_indices,
                          const std::vector<THiveColumn>& columns, WriteInfo write_info,
-                         std::string file_name, TFileFormatType::type file_format_type,
+                         std::string file_name, int file_name_index,
+                         TFileFormatType::type file_format_type,
                          TFileCompressType::type hive_compress_type,
                          const std::map<std::string, std::string>& hadoop_conf);
 
@@ -64,6 +65,10 @@ public:
 
     Status close(const Status& status);
 
+    inline const std::string& file_name() const { return _file_name; }
+
+    inline int file_name_index() const { return _file_name_index; }
+
     inline size_t written_len() { return _file_format_transformer->written_len(); }
 
 private:
@@ -72,6 +77,9 @@ private:
                                         doris::vectorized::Block* output_block);
 
     THivePartitionUpdate _build_partition_update();
+
+    std::string _get_file_extension(TFileFormatType::type file_format_type,
+                                    TFileCompressType::type write_compress_type);
 
     std::string _path;
 
@@ -89,6 +97,7 @@ private:
     const std::vector<THiveColumn>& _columns;
     WriteInfo _write_info;
     std::string _file_name;
+    int _file_name_index;
     TFileFormatType::type _file_format_type;
     TFileCompressType::type _hive_compress_type;
     const std::map<std::string, std::string>& _hadoop_conf;

--- a/be/src/vec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/vec/sink/writer/vhive_table_writer.cpp
@@ -42,6 +42,19 @@ Status VHiveTableWriter::open(RuntimeState* state, RuntimeProfile* profile) {
     _state = state;
     _profile = profile;
 
+    // add all counter
+    _written_rows_counter = ADD_COUNTER(_profile, "WrittenRows", TUnit::UNIT);
+    _send_data_timer = ADD_TIMER(_profile, "SendDataTime");
+    _partition_writers_dispatch_timer =
+            ADD_CHILD_TIMER(_profile, "PartitionsDispatchTime", "SendDataTime");
+    _partition_writers_write_timer =
+            ADD_CHILD_TIMER(_profile, "PartitionsWriteTime", "SendDataTime");
+    _partition_writers_count = ADD_COUNTER(_profile, "PartitionsWriteCount", TUnit::UNIT);
+    _open_timer = ADD_TIMER(_profile, "OpenTime");
+    _close_timer = ADD_TIMER(_profile, "CloseTime");
+    _write_file_counter = ADD_COUNTER(_profile, "WriteFileCount", TUnit::UNIT);
+
+    SCOPED_TIMER(_open_timer);
     for (int i = 0; i < _t_sink.hive_table_sink.columns.size(); ++i) {
         switch (_t_sink.hive_table_sink.columns[i].column_type) {
         case THiveColumnType::PARTITION_KEY: {
@@ -68,94 +81,120 @@ Status VHiveTableWriter::open(RuntimeState* state, RuntimeProfile* profile) {
 }
 
 Status VHiveTableWriter::write(vectorized::Block& block) {
+    SCOPED_RAW_TIMER(&_send_data_ns);
     std::unordered_map<std::shared_ptr<VHivePartitionWriter>, IColumn::Filter> writer_positions;
-
+    _row_count += block.rows();
     auto& hive_table_sink = _t_sink.hive_table_sink;
 
     if (_partition_columns_input_index.empty()) {
-        auto writer_iter = _partitions_to_writers.find("");
-        if (writer_iter == _partitions_to_writers.end()) {
-            try {
-                std::shared_ptr<VHivePartitionWriter> writer = _create_partition_writer(block, -1);
-                _partitions_to_writers.insert({"", writer});
-                RETURN_IF_ERROR(writer->open(_state, _profile));
-                RETURN_IF_ERROR(writer->write(block));
-            } catch (doris::Exception& e) {
-                return e.to_status();
-            }
-            return Status::OK();
-        } else {
-            std::shared_ptr<VHivePartitionWriter> writer;
-            if (writer_iter->second->written_len() > config::hive_sink_max_file_size) {
-                static_cast<void>(writer_iter->second->close(Status::OK()));
-                _partitions_to_writers.erase(writer_iter);
+        std::shared_ptr<VHivePartitionWriter> writer;
+        {
+            SCOPED_RAW_TIMER(&_partition_writers_dispatch_ns);
+            auto writer_iter = _partitions_to_writers.find("");
+            if (writer_iter == _partitions_to_writers.end()) {
                 try {
                     writer = _create_partition_writer(block, -1);
-                    _partitions_to_writers.insert({"", writer});
-                    RETURN_IF_ERROR(writer->open(_state, _profile));
                 } catch (doris::Exception& e) {
                     return e.to_status();
                 }
+                _partitions_to_writers.insert({"", writer});
+                RETURN_IF_ERROR(writer->open(_state, _profile));
             } else {
-                writer = writer_iter->second;
+                if (writer_iter->second->written_len() > config::hive_sink_max_file_size) {
+                    std::string file_name(writer_iter->second->file_name());
+                    int file_name_index = writer_iter->second->file_name_index();
+                    {
+                        SCOPED_RAW_TIMER(&_close_ns);
+                        static_cast<void>(writer_iter->second->close(Status::OK()));
+                    }
+                    _partitions_to_writers.erase(writer_iter);
+                    try {
+                        writer = _create_partition_writer(block, -1, &file_name,
+                                                          file_name_index + 1);
+                    } catch (doris::Exception& e) {
+                        return e.to_status();
+                    }
+                    _partitions_to_writers.insert({"", writer});
+                    RETURN_IF_ERROR(writer->open(_state, _profile));
+                } else {
+                    writer = writer_iter->second;
+                }
             }
-            RETURN_IF_ERROR(writer->write(block));
-            return Status::OK();
         }
+        SCOPED_RAW_TIMER(&_partition_writers_write_ns);
+        RETURN_IF_ERROR(writer->write(block));
+        return Status::OK();
     }
 
-    for (int i = 0; i < block.rows(); ++i) {
-        std::vector<std::string> partition_values;
-        try {
-            partition_values = _create_partition_values(block, i);
-        } catch (doris::Exception& e) {
-            return e.to_status();
-        }
-        std::string partition_name = VHiveUtils::make_partition_name(
-                hive_table_sink.columns, _partition_columns_input_index, partition_values);
-
-        auto create_and_open_writer =
-                [&](const std::string& partition_name, int position,
-                    std::shared_ptr<VHivePartitionWriter>& writer_ptr) -> Status {
+    {
+        SCOPED_RAW_TIMER(&_partition_writers_dispatch_ns);
+        for (int i = 0; i < block.rows(); ++i) {
+            std::vector<std::string> partition_values;
             try {
-                auto writer = _create_partition_writer(block, position);
-                RETURN_IF_ERROR(writer->open(_state, _profile));
-                IColumn::Filter filter(block.rows(), 0);
-                filter[position] = 1;
-                writer_positions.insert({writer, std::move(filter)});
-                _partitions_to_writers.insert({partition_name, writer});
-                writer_ptr = writer;
+                partition_values = _create_partition_values(block, i);
             } catch (doris::Exception& e) {
                 return e.to_status();
             }
-            return Status::OK();
-        };
+            std::string partition_name = VHiveUtils::make_partition_name(
+                    hive_table_sink.columns, _partition_columns_input_index, partition_values);
 
-        auto writer_iter = _partitions_to_writers.find(partition_name);
-        if (writer_iter == _partitions_to_writers.end()) {
-            std::shared_ptr<VHivePartitionWriter> writer;
-            RETURN_IF_ERROR(create_and_open_writer(partition_name, i, writer));
-        } else {
-            std::shared_ptr<VHivePartitionWriter> writer;
-            if (writer_iter->second->written_len() > config::hive_sink_max_file_size) {
-                static_cast<void>(writer_iter->second->close(Status::OK()));
-                writer_positions.erase(writer_iter->second);
-                _partitions_to_writers.erase(writer_iter);
-                RETURN_IF_ERROR(create_and_open_writer(partition_name, i, writer));
+            auto create_and_open_writer =
+                    [&](const std::string& partition_name, int position,
+                        const std::string* file_name, int file_name_index,
+                        std::shared_ptr<VHivePartitionWriter>& writer_ptr) -> Status {
+                try {
+                    auto writer =
+                            _create_partition_writer(block, position, file_name, file_name_index);
+                    RETURN_IF_ERROR(writer->open(_state, _profile));
+                    IColumn::Filter filter(block.rows(), 0);
+                    filter[position] = 1;
+                    writer_positions.insert({writer, std::move(filter)});
+                    _partitions_to_writers.insert({partition_name, writer});
+                    writer_ptr = writer;
+                } catch (doris::Exception& e) {
+                    return e.to_status();
+                }
+                return Status::OK();
+            };
+
+            auto writer_iter = _partitions_to_writers.find(partition_name);
+            if (writer_iter == _partitions_to_writers.end()) {
+                std::shared_ptr<VHivePartitionWriter> writer;
+                if (_partitions_to_writers.size() + 1 >
+                    config::table_sink_partition_write_max_partition_nums_per_writer) {
+                    return Status::InternalError(
+                            "Too many open partitions {}",
+                            config::table_sink_partition_write_max_partition_nums_per_writer);
+                }
+                RETURN_IF_ERROR(create_and_open_writer(partition_name, i, nullptr, 0, writer));
             } else {
-                writer = writer_iter->second;
-            }
-            auto writer_pos_iter = writer_positions.find(writer);
-            if (writer_pos_iter == writer_positions.end()) {
-                IColumn::Filter filter(block.rows(), 0);
-                filter[i] = 1;
-                writer_positions.insert({writer, std::move(filter)});
-            } else {
-                writer_pos_iter->second[i] = 1;
+                std::shared_ptr<VHivePartitionWriter> writer;
+                if (writer_iter->second->written_len() > config::hive_sink_max_file_size) {
+                    std::string file_name(writer_iter->second->file_name());
+                    int file_name_index = writer_iter->second->file_name_index();
+                    {
+                        SCOPED_RAW_TIMER(&_close_ns);
+                        static_cast<void>(writer_iter->second->close(Status::OK()));
+                    }
+                    writer_positions.erase(writer_iter->second);
+                    _partitions_to_writers.erase(writer_iter);
+                    RETURN_IF_ERROR(create_and_open_writer(partition_name, i, &file_name,
+                                                           file_name_index + 1, writer));
+                } else {
+                    writer = writer_iter->second;
+                }
+                auto writer_pos_iter = writer_positions.find(writer);
+                if (writer_pos_iter == writer_positions.end()) {
+                    IColumn::Filter filter(block.rows(), 0);
+                    filter[i] = 1;
+                    writer_positions.insert({writer, std::move(filter)});
+                } else {
+                    writer_pos_iter->second[i] = 1;
+                }
             }
         }
     }
-
+    SCOPED_RAW_TIMER(&_partition_writers_write_ns);
     for (auto it = writer_positions.begin(); it != writer_positions.end(); ++it) {
         RETURN_IF_ERROR(it->first->write(block, &it->second));
     }
@@ -163,19 +202,34 @@ Status VHiveTableWriter::write(vectorized::Block& block) {
 }
 
 Status VHiveTableWriter::close(Status status) {
-    for (const auto& pair : _partitions_to_writers) {
-        Status st = pair.second->close(status);
-        if (st != Status::OK()) {
-            LOG(WARNING) << fmt::format("Unsupported type for partition {}", st.to_string());
-            continue;
+    int64_t partitions_to_writers_size = _partitions_to_writers.size();
+    {
+        SCOPED_RAW_TIMER(&_close_ns);
+        for (const auto& pair : _partitions_to_writers) {
+            Status st = pair.second->close(status);
+            if (st != Status::OK()) {
+                LOG(WARNING) << fmt::format("Unsupported type for partition {}", st.to_string());
+                continue;
+            }
         }
+        _partitions_to_writers.clear();
     }
-    _partitions_to_writers.clear();
+    if (status.ok()) {
+        SCOPED_TIMER(_profile->total_time_counter());
+
+        COUNTER_SET(_written_rows_counter, static_cast<int64_t>(_row_count));
+        COUNTER_SET(_send_data_timer, _send_data_ns);
+        COUNTER_SET(_partition_writers_dispatch_timer, _partition_writers_dispatch_ns);
+        COUNTER_SET(_partition_writers_write_timer, _partition_writers_write_ns);
+        COUNTER_SET(_partition_writers_count, partitions_to_writers_size);
+        COUNTER_SET(_close_timer, _close_ns);
+        COUNTER_SET(_write_file_counter, _write_file_count);
+    }
     return Status::OK();
 }
 
 std::shared_ptr<VHivePartitionWriter> VHiveTableWriter::_create_partition_writer(
-        vectorized::Block& block, int position) {
+        vectorized::Block& block, int position, const std::string* file_name, int file_name_index) {
     auto& hive_table_sink = _t_sink.hive_table_sink;
     std::vector<std::string> partition_values;
     std::string partition_name;
@@ -247,13 +301,12 @@ std::shared_ptr<VHivePartitionWriter> VHiveTableWriter::_create_partition_writer
         }
     }
 
+    _write_file_count++;
     return std::make_shared<VHivePartitionWriter>(
             _t_sink, std::move(partition_name), update_mode, _vec_output_expr_ctxs,
             _write_output_vexpr_ctxs, _non_write_columns_indices, hive_table_sink.columns,
-            std::move(write_info),
-            fmt::format("{}{}", _compute_file_name(),
-                        _get_file_extension(file_format_type, write_compress_type)),
-            file_format_type, write_compress_type, hive_table_sink.hadoop_config);
+            std::move(write_info), (file_name == nullptr) ? _compute_file_name() : *file_name,
+            file_name_index, file_format_type, write_compress_type, hive_table_sink.hadoop_config);
 }
 
 std::vector<std::string> VHiveTableWriter::_create_partition_values(vectorized::Block& block,
@@ -395,46 +448,6 @@ std::string VHiveTableWriter::_to_partition_value(const TypeDescriptor& type_des
                                "Unsupported type for partition {}", type_desc.debug_string());
     }
     }
-}
-
-std::string VHiveTableWriter::_get_file_extension(TFileFormatType::type file_format_type,
-                                                  TFileCompressType::type write_compress_type) {
-    std::string compress_name;
-    switch (write_compress_type) {
-    case TFileCompressType::SNAPPYBLOCK: {
-        compress_name = ".snappy";
-        break;
-    }
-    case TFileCompressType::ZLIB: {
-        compress_name = ".zlib";
-        break;
-    }
-    case TFileCompressType::ZSTD: {
-        compress_name = ".zstd";
-        break;
-    }
-    default: {
-        compress_name = "";
-        break;
-    }
-    }
-
-    std::string file_format_name;
-    switch (file_format_type) {
-    case TFileFormatType::FORMAT_PARQUET: {
-        file_format_name = ".parquet";
-        break;
-    }
-    case TFileFormatType::FORMAT_ORC: {
-        file_format_name = ".orc";
-        break;
-    }
-    default: {
-        file_format_name = "";
-        break;
-    }
-    }
-    return fmt::format("{}{}", compress_name, file_format_name);
 }
 
 std::string VHiveTableWriter::_compute_file_name() {


### PR DESCRIPTION
## Proposed changes

Issue Number: #31442 

- Add hive-writer runtime profiles.
- Change output file names to `${query_id}${uuid}-${index}.${compression}.${format}`. e.g. `"d8735c6fa444a6d-acd392981e510c2b_34fbdcbb-b2e1-4f2c-b68c-a384238954a9-0.snappy.parquet"`. For the same partition writer, when the file size exceeds `hive_sink_max_file_size`, the currently written file will be closed and a new file will be generated, in which ${index} in the new file name will be incremented, while the rest will be the same .
- Use `table_sink_partition_write_max_partition_nums_per_writer` to control max open partitions in hive sink.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

