### PR TITLE
[Feature](Cloud) Add show storage vault stmt

### DIFF
--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -980,7 +980,6 @@ void MetaServiceImpl::create_instance(google::protobuf::RpcController* controlle
     }
     if (request->has_hdfs_info()) {
         StorageVaultPB hdfs_param;
-        hdfs_param.set_name("Default");
         hdfs_param.mutable_hdfs_info()->MergeFrom(request->hdfs_info());
         if (0 != add_hdfs_storage_vault(instance, txn.get(), std::move(hdfs_param), code, msg)) {
             return;

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3976,6 +3976,10 @@ show_stmt ::=
     {:
         RESULT = new ShowPolicyStmt(PolicyTypeEnum.STORAGE, null, null);
     :}
+    | KW_SHOW KW_STORAGE KW_VAULT
+    {:
+        RESULT = new ShowStorageVaultStmt();
+    :}
     ;
 
 show_param ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowStorageVaultStmt.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.StorageVault;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ShowResultSetMetaData;
+
+/**
+ * Show storage vault statement
+ * syntax:
+ * SHOW STORAGE VAULT
+ **/
+public class ShowStorageVaultStmt extends ShowStmt {
+
+    private final String stmt = "SHOW STORAGE VAULT";
+
+    public ShowStorageVaultStmt() {
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        super.analyze(analyzer);
+        // check auth
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
+        }
+    }
+
+    @Override
+    public String toSql() {
+        return this.stmt;
+    }
+
+    @Override
+    public ShowResultSetMetaData getMetaData() {
+        return StorageVault.STORAGE_VAULT_META_DATA;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.analysis.CreateStorageVaultStmt;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
@@ -153,4 +154,11 @@ public abstract class StorageVault {
     }
 
     public abstract Map<String, String> getCopiedProperties();
+
+    public static final ShowResultSetMetaData STORAGE_VAULT_META_DATA =
+            ShowResultSetMetaData.builder()
+                .addColumn(new Column("StorageVaultName", ScalarType.createVarchar(100)))
+                .addColumn(new Column("StoragevaultId", ScalarType.createVarchar(20)))
+                .addColumn(new Column("Propeties", ScalarType.createVarchar(65535)))
+                .build();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -18,14 +18,18 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.CreateStorageVaultStmt;
+import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
+import com.google.protobuf.TextFormat;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -161,4 +165,29 @@ public abstract class StorageVault {
                 .addColumn(new Column("StoragevaultId", ScalarType.createVarchar(20)))
                 .addColumn(new Column("Propeties", ScalarType.createVarchar(65535)))
                 .build();
+
+    public static List<String> convertToShowStorageVaultProperties(Cloud.ObjectStoreInfoPB info) {
+        Cloud.ObjectStoreInfoPB.Builder builder = Cloud.ObjectStoreInfoPB.newBuilder();
+        builder.mergeFrom(info);
+        List<String> row = new ArrayList<>();
+        row.add(info.getVaultName());
+        row.add(info.getId());
+        TextFormat.Printer printer = TextFormat.printer();
+        builder.clearId();
+        builder.clearVaultName();
+        builder.setSk("xxxxxxx");
+        row.add(printer.shortDebugString(builder));
+        return row;
+    }
+
+    public static List<String> convertToShowStorageVaultProperties(Cloud.StorageVaultPB vault) {
+        List<String> row = new ArrayList<>();
+        row.add(vault.getName());
+        row.add(vault.getId());
+        Cloud.HdfsVaultInfo.Builder builder = Cloud.HdfsVaultInfo.newBuilder();
+        builder.mergeFrom(vault.getHdfsInfo());
+        TextFormat.Printer printer = TextFormat.printer();
+        row.add(printer.shortDebugString(builder));
+        return row;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
@@ -325,4 +325,15 @@ public class MetaServiceClient {
         }
         return blockingStub.getRlTaskCommitAttach(request);
     }
+
+    public Cloud.GetObjStoreInfoResponse
+            getObjStoreInfo(Cloud.GetObjStoreInfoRequest request) {
+        if (!request.hasCloudUniqueId()) {
+            Cloud.GetObjStoreInfoRequest.Builder builder =
+                    Cloud.GetObjStoreInfoRequest.newBuilder();
+            builder.mergeFrom(request);
+            return blockingStub.getObjStoreInfo(builder.setCloudUniqueId(Config.cloud_unique_id).build());
+        }
+        return blockingStub.getObjStoreInfo(request);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
@@ -453,4 +453,14 @@ public class MetaServiceProxy {
             throw new RpcException("", e.getMessage(), e);
         }
     }
+
+    public Cloud.GetObjStoreInfoResponse
+            getObjStoreInfo(Cloud.GetObjStoreInfoRequest request) throws RpcException {
+        try {
+            final MetaServiceClient client = getProxy();
+            return client.getObjStoreInfo(request);
+        } catch (Exception e) {
+            throw new RpcException("", e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

User can get all their storage vault's information use ShowStorageVaultStmt

``` sql
mysql> show storage vault;
+------------------------+----------------+------------------------------------------------------------+
| StorageVaultName       | StoragevaultId | Propeties                                                  |
+------------------------+----------------+------------------------------------------------------------+
| built_in_storage_vault | 1              | build_conf { fs_name: "hdfs://127.0.0.1:8020" } prefix: "" |
+------------------------+----------------+------------------------------------------------------------+
1 row in set (0.05 sec)
```

TODO: Add regression test after S3 Vault is supported

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

