### PR TITLE
[fix](cloud) Fix coredump during graceful shutdown

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -72,7 +72,9 @@ CloudStorageEngine::CloudStorageEngine(const UniqueId& backend_uid)
           _cumulative_compaction_policy(
                   std::make_shared<CloudSizeBasedCumulativeCompactionPolicy>()) {}
 
-CloudStorageEngine::~CloudStorageEngine() = default;
+CloudStorageEngine::~CloudStorageEngine() {
+    stop();
+}
 
 static Status vault_process_error(std::string_view id,
                                   std::variant<S3Conf, cloud::HdfsVaultInfo>& vault, Status err) {

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -295,14 +295,14 @@ void CloudStorageEngine::_refresh_storage_vault_info_thread_callback() {
 void CloudStorageEngine::_vacuum_stale_rowsets_thread_callback() {
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::seconds(config::vacuum_stale_rowsets_interval_s))) {
-        _tablet_mgr->vacuum_stale_rowsets();
+        _tablet_mgr->vacuum_stale_rowsets(_stop_background_threads_latch);
     }
 }
 
 void CloudStorageEngine::_sync_tablets_thread_callback() {
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::seconds(config::schedule_sync_tablets_interval_s))) {
-        _tablet_mgr->sync_tablets();
+        _tablet_mgr->sync_tablets(_stop_background_threads_latch);
     }
 }
 

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -208,7 +208,7 @@ void CloudTabletMgr::erase_tablet(int64_t tablet_id) {
     _cache->erase(key);
 }
 
-void CloudTabletMgr::vacuum_stale_rowsets() {
+void CloudTabletMgr::vacuum_stale_rowsets(const CountDownLatch& stop_latch) {
     LOG_INFO("begin to vacuum stale rowsets");
     std::vector<std::shared_ptr<CloudTablet>> tablets_to_vacuum;
     tablets_to_vacuum.reserve(_tablet_map->size());
@@ -219,6 +219,10 @@ void CloudTabletMgr::vacuum_stale_rowsets() {
     });
     int num_vacuumed = 0;
     for (auto& t : tablets_to_vacuum) {
+        if (stop_latch.count() <= 0) {
+            break;
+        }
+
         num_vacuumed += t->delete_expired_stale_rowsets();
     }
     LOG_INFO("finish vacuum stale rowsets").tag("num_vacuumed", num_vacuumed);
@@ -231,7 +235,7 @@ std::vector<std::weak_ptr<CloudTablet>> CloudTabletMgr::get_weak_tablets() {
     return weak_tablets;
 }
 
-void CloudTabletMgr::sync_tablets() {
+void CloudTabletMgr::sync_tablets(const CountDownLatch& stop_latch) {
     LOG_INFO("begin to sync tablets");
     int64_t last_sync_time_bound = ::time(nullptr) - config::tablet_sync_interval_s;
 
@@ -256,6 +260,10 @@ void CloudTabletMgr::sync_tablets() {
 
     int num_sync = 0;
     for (auto&& [_, weak_tablet] : sync_time_tablet_set) {
+        if (stop_latch.count() <= 0) {
+            break;
+        }
+
         if (auto tablet = weak_tablet.lock()) {
             if (tablet->last_sync_time_s > last_sync_time_bound) {
                 continue;

--- a/be/src/cloud/cloud_tablet_mgr.h
+++ b/be/src/cloud/cloud_tablet_mgr.h
@@ -29,6 +29,7 @@ namespace doris {
 class CloudTablet;
 class CloudStorageEngine;
 class LRUCachePolicy;
+class CountDownLatch;
 
 class CloudTabletMgr {
 public:
@@ -41,13 +42,13 @@ public:
 
     void erase_tablet(int64_t tablet_id);
 
-    void vacuum_stale_rowsets();
+    void vacuum_stale_rowsets(const CountDownLatch& stop_latch);
 
     // Return weak ptr of all cached tablets.
     // We return weak ptr to avoid extend lifetime of tablets that are no longer cached.
     std::vector<std::weak_ptr<CloudTablet>> get_weak_tablets();
 
-    void sync_tablets();
+    void sync_tablets(const CountDownLatch& stop_latch);
 
     /**
      * Gets top N tablets that are considered to be compacted first


### PR DESCRIPTION
## Proposed changes

- Fix coredump during graceful shutdown
- Avoid waiting for a long time during graceful shutdown

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

