### PR TITLE
[enhancement](Nereids) Enable parse sql from sql cache

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.common;
 
-import org.apache.doris.common.ConfigBase.ConfField;
-
 public class Config extends ConfigBase {
 
     @ConfField(description = {"用户自定义配置文件的路径，用于存放 fe_custom.conf。该文件中的配置会覆盖 fe.conf 中的配置",
@@ -2004,6 +2002,14 @@ public class Config extends ConfigBase {
                     + "the old load statement will be degraded."})
     public static boolean enable_nereids_load = false;
 
+    /**
+     * the plan cache num which can be reused for the next query
+     */
+    @ConfField(mutable = false, varType = VariableAnnotation.EXPERIMENTAL, description = {
+            "当前默认设置为 100，用来控制控制NereidsSqlCacheManager管理的sql cache数量。",
+            "Now default set to 100, this config is used to control the number of "
+                    + "sql cache managed by NereidsSqlCacheManager"})
+    public static int sql_cache_manage_num = 100;
 
     /**
      * Maximum number of events to poll in each RPC.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
@@ -43,6 +43,10 @@ public class Pair<F, S> {
         this.second = second;
     }
 
+    public static <P, K extends P> Pair<K, K> ofSame(K same) {
+        return new Pair<>(same, same);
+    }
+
     public static <F, S> Pair<F, S> of(F first, S second) {
         return new Pair<>(first, second);
     }

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -499,6 +499,11 @@ under the License.
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.17</version>
+        </dependency>
+        <dependency>
             <groupId>hu.webarticum</groupId>
             <artifactId>tree-printer</artifactId>
         </dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -499,11 +499,6 @@ under the License.
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-            <version>0.17</version>
-        </dependency>
-        <dependency>
             <groupId>hu.webarticum</groupId>
             <artifactId>tree-printer</artifactId>
         </dependency>

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -269,10 +269,10 @@ public class SqlBlockRuleMgr implements Writable {
             return;
         }
         // match global rule
-        List<SqlBlockRule> globalRules =
-                nameToSqlBlockRuleMap.values().stream().filter(SqlBlockRule::getGlobal).collect(Collectors.toList());
-        for (SqlBlockRule rule : globalRules) {
-            checkLimitations(rule, partitionNum, tabletNum, cardinality);
+        for (SqlBlockRule rule : nameToSqlBlockRuleMap.values()) {
+            if (rule.getGlobal()) {
+                checkLimitations(rule, partitionNum, tabletNum, cardinality);
+            }
         }
         // match user rule
         String[] bindSqlBlockRules = Env.getCurrentEnv().getAuth().getSqlBlockRules(user);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -105,6 +105,7 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.NereidsSqlCacheManager;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
@@ -530,6 +531,8 @@ public class Env {
 
     private DNSCache dnsCache;
 
+    private final NereidsSqlCacheManager sqlCacheManager;
+
     public List<TFrontendInfo> getFrontendInfos() {
         List<TFrontendInfo> res = new ArrayList<>();
 
@@ -766,6 +769,9 @@ public class Env {
         this.mtmvService = new MTMVService();
         this.insertOverwriteManager = new InsertOverwriteManager();
         this.dnsCache = new DNSCache();
+        this.sqlCacheManager = new NereidsSqlCacheManager(
+                Config.sql_cache_manage_num, Config.cache_last_version_interval_second
+        );
     }
 
     public static void destroyCheckpoint() {
@@ -6090,6 +6096,10 @@ public class Env {
 
     public MasterDaemon getTabletStatMgr() {
         return tabletStatMgr;
+    }
+
+    public NereidsSqlCacheManager getSqlCacheManager() {
+        return sqlCacheManager;
     }
 
     public void alterMTMVRefreshInfo(AlterMTMVRefreshInfo info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/NereidsSqlCacheManager.java
@@ -1,0 +1,360 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.View;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.mysql.privilege.DataMaskPolicy;
+import org.apache.doris.mysql.privilege.RowFilterPolicy;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
+import org.apache.doris.nereids.SqlCacheContext.FullColumnName;
+import org.apache.doris.nereids.SqlCacheContext.FullTableName;
+import org.apache.doris.nereids.SqlCacheContext.ScanTable;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.analyzer.UnboundVariable;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.rules.analysis.ExpressionAnalyzer;
+import org.apache.doris.nereids.rules.analysis.UserAuthentication;
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
+import org.apache.doris.nereids.rules.expression.rules.FoldConstantRuleOnFE;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Variable;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
+import org.apache.doris.proto.InternalService;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.cache.CacheAnalyzer;
+import org.apache.doris.qe.cache.SqlCache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/** NereidsSqlCacheManager */
+public class NereidsSqlCacheManager {
+    // key: <user>:<sql>
+    // value: CacheAnalyzer
+    private final Cache<String, SqlCacheContext> sqlCache;
+
+    public NereidsSqlCacheManager(int sqlCacheNum, long cacheIntervalSeconds) {
+        sqlCache = Caffeine.newBuilder()
+                .maximumSize(sqlCacheNum)
+                .expireAfterAccess(Duration.ofSeconds(cacheIntervalSeconds))
+                // auto evict cache when jvm memory too low
+                .softValues()
+                .build();
+    }
+
+    /** tryAddCache */
+    public void tryAddCache(
+            ConnectContext connectContext, String sql,
+            CacheAnalyzer analyzer, boolean currentMissParseSqlFromSqlCache) {
+        Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
+        if (!sqlCacheContextOpt.isPresent()) {
+            return;
+        }
+        if (!(analyzer.getCache() instanceof SqlCache)) {
+            return;
+        }
+        SqlCacheContext sqlCacheContext = sqlCacheContextOpt.get();
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        String key = currentUserIdentity.toString() + ":" + sql.trim();
+        if (analyzer.getCache() instanceof SqlCache
+                && (currentMissParseSqlFromSqlCache || sqlCache.getIfPresent(key) == null)) {
+            SqlCache cache = (SqlCache) analyzer.getCache();
+            sqlCacheContext.setCacheKeyMd5(cache.getOrComputeCacheMd5());
+            sqlCacheContext.setSumOfPartitionNum(cache.getSumOfPartitionNum());
+            sqlCacheContext.setLatestPartitionId(cache.getLatestId());
+            sqlCacheContext.setLatestPartitionVersion(cache.getLatestVersion());
+            sqlCacheContext.setLatestPartitionTime(cache.getLatestTime());
+            sqlCacheContext.setCacheProxy(cache.getProxy());
+
+            for (ScanTable scanTable : analyzer.getScanTables()) {
+                sqlCacheContext.addScanTable(scanTable);
+            }
+
+            sqlCache.put(key, sqlCacheContext);
+        }
+    }
+
+    /** invalidateCache */
+    public void invalidateCache(ConnectContext connectContext, String sql) {
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        String key = currentUserIdentity.toString() + ":" + sql.trim();
+        sqlCache.invalidate(key);
+    }
+
+    /** tryParseSql */
+    public Optional<LogicalSqlCache> tryParseSql(ConnectContext connectContext, String sql) {
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        Env env = connectContext.getEnv();
+        String key = currentUserIdentity.toString() + ":" + sql.trim();
+        SqlCacheContext sqlCacheContext = sqlCache.getIfPresent(key);
+        if (sqlCacheContext == null) {
+            return Optional.empty();
+        }
+
+        // LOG.info("Total size: " + GraphLayout.parseInstance(sqlCacheContext).totalSize());
+
+        // check table and view and their columns authority
+        if (privilegeChanged(connectContext, env, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+        if (tablesOrDataChanged(env, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+        if (viewsChanged(env, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+        if (usedVariablesChanged(sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+
+        LogicalEmptyRelation whateverPlan = new LogicalEmptyRelation(new RelationId(0), ImmutableList.of());
+        if (nondeterministicFunctionChanged(whateverPlan, connectContext, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+
+        // table structure and data not changed, now check policy
+        if (rowPoliciesChanged(currentUserIdentity, env, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+        if (dataMaskPoliciesChanged(currentUserIdentity, env, sqlCacheContext)) {
+            return invalidateCache(key);
+        }
+
+        try {
+            Status status = new Status();
+            InternalService.PFetchCacheResult cacheData =
+                    SqlCache.getCacheData(sqlCacheContext.getCacheProxy(),
+                            sqlCacheContext.getCacheKeyMd5(), sqlCacheContext.getLatestPartitionId(),
+                            sqlCacheContext.getLatestPartitionVersion(), sqlCacheContext.getLatestPartitionTime(),
+                            sqlCacheContext.getSumOfPartitionNum(), status);
+
+            if (status.ok() && cacheData != null && cacheData.getStatus() == InternalService.PCacheStatus.CACHE_OK) {
+                List<InternalService.PCacheValue> cacheValues = cacheData.getValuesList();
+                String cachedPlan = sqlCacheContext.getPhysicalPlan();
+                String backendAddress = SqlCache.findCacheBe(sqlCacheContext.getCacheKeyMd5()).getAddress();
+
+                MetricRepo.COUNTER_CACHE_HIT_SQL.increase(1L);
+
+                LogicalSqlCache logicalSqlCache = new LogicalSqlCache(
+                        sqlCacheContext.getQueryId(), sqlCacheContext.getColLabels(),
+                        sqlCacheContext.getResultExprs(), cacheValues, backendAddress, cachedPlan);
+                return Optional.of(logicalSqlCache);
+            }
+            return Optional.empty();
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    private boolean tablesOrDataChanged(Env env, SqlCacheContext sqlCacheContext) {
+        long latestPartitionTime = sqlCacheContext.getLatestPartitionTime();
+        long latestPartitionVersion = sqlCacheContext.getLatestPartitionVersion();
+
+        if (sqlCacheContext.hasUnsupportedTables()) {
+            return true;
+        }
+
+        for (ScanTable scanTable : sqlCacheContext.getScanTables()) {
+            FullTableName fullTableName = scanTable.fullTableName;
+            TableIf tableIf = findTableIf(env, fullTableName);
+            if (!(tableIf instanceof OlapTable)) {
+                return true;
+            }
+            OlapTable olapTable = (OlapTable) tableIf;
+            long currentTableTime = olapTable.getVisibleVersionTime();
+            long cacheTableTime = scanTable.latestTimestamp;
+            long currentTableVersion = olapTable.getVisibleVersion();
+            long cacheTableVersion = scanTable.latestVersion;
+            // some partitions have been dropped, or delete or update or insert rows into new partition?
+            if (currentTableTime > cacheTableTime
+                    || (currentTableTime == cacheTableTime && currentTableVersion > cacheTableVersion)) {
+                return true;
+            }
+
+            for (Long scanPartitionId : scanTable.getScanPartitions()) {
+                Partition partition = olapTable.getPartition(scanPartitionId);
+                // partition == null: is this partition truncated?
+                if (partition == null || partition.getVisibleVersionTime() > latestPartitionTime
+                        || (partition.getVisibleVersionTime() == latestPartitionTime
+                        && partition.getVisibleVersion() > latestPartitionVersion)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean viewsChanged(Env env, SqlCacheContext sqlCacheContext) {
+        for (Entry<FullTableName, String> cacheView : sqlCacheContext.getUsedViews().entrySet()) {
+            TableIf currentView = findTableIf(env, cacheView.getKey());
+            if (currentView == null) {
+                return true;
+            }
+
+            String cacheValueDdlSql = cacheView.getValue();
+            if (currentView instanceof View) {
+                if (!((View) currentView).getInlineViewDef().equals(cacheValueDdlSql)) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean rowPoliciesChanged(UserIdentity currentUserIdentity, Env env, SqlCacheContext sqlCacheContext) {
+        for (Entry<FullTableName, List<RowFilterPolicy>> kv : sqlCacheContext.getRowPolicies().entrySet()) {
+            FullTableName qualifiedTable = kv.getKey();
+            List<? extends RowFilterPolicy> cachedPolicies = kv.getValue();
+
+            List<? extends RowFilterPolicy> rowPolicies = env.getAccessManager().evalRowFilterPolicies(
+                    currentUserIdentity, qualifiedTable.catalog, qualifiedTable.db, qualifiedTable.table);
+            if (!CollectionUtils.isEqualCollection(cachedPolicies, rowPolicies)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean dataMaskPoliciesChanged(
+            UserIdentity currentUserIdentity, Env env, SqlCacheContext sqlCacheContext) {
+        for (Entry<FullColumnName, Optional<DataMaskPolicy>> kv : sqlCacheContext.getDataMaskPolicies().entrySet()) {
+            FullColumnName qualifiedColumn = kv.getKey();
+            Optional<DataMaskPolicy> cachedPolicy = kv.getValue();
+
+            Optional<DataMaskPolicy> dataMaskPolicy = env.getAccessManager()
+                    .evalDataMaskPolicy(currentUserIdentity, qualifiedColumn.catalog,
+                            qualifiedColumn.db, qualifiedColumn.table, qualifiedColumn.column);
+            if (!Objects.equals(cachedPolicy, dataMaskPolicy)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean privilegeChanged(ConnectContext connectContext, Env env, SqlCacheContext sqlCacheContext) {
+        StatementContext currentStatementContext = connectContext.getStatementContext();
+        for (Entry<FullTableName, Set<String>> kv : sqlCacheContext.getCheckPrivilegeTablesOrViews().entrySet()) {
+            Set<String> usedColumns = kv.getValue();
+            TableIf tableIf = findTableIf(env, kv.getKey());
+            if (tableIf == null) {
+                return true;
+            }
+            // release when close statementContext
+            currentStatementContext.addTableReadLock(tableIf);
+            try {
+                UserAuthentication.checkPermission(tableIf, connectContext, usedColumns);
+            } catch (Throwable t) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean usedVariablesChanged(SqlCacheContext sqlCacheContext) {
+        for (Variable variable : sqlCacheContext.getUsedVariables()) {
+            Variable currentVariable = ExpressionAnalyzer.resolveUnboundVariable(
+                    new UnboundVariable(variable.getName(), variable.getType()));
+            if (!Objects.equals(currentVariable, variable)
+                    || variable.getRealExpression().anyMatch(Nondeterministic.class::isInstance)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean nondeterministicFunctionChanged(
+            Plan plan, ConnectContext connectContext, SqlCacheContext sqlCacheContext) {
+        if (sqlCacheContext.containsCannotProcessExpression()) {
+            return true;
+        }
+
+        List<Pair<Expression, Expression>> nondeterministicFunctions = sqlCacheContext.getFoldNondeterministicPairs();
+        if (nondeterministicFunctions.isEmpty()) {
+            return false;
+        }
+
+        CascadesContext tempCascadeContext = CascadesContext.initContext(
+                connectContext.getStatementContext(), plan, PhysicalProperties.ANY);
+        ExpressionRewriteContext rewriteContext = new ExpressionRewriteContext(tempCascadeContext);
+        for (Pair<Expression, Expression> foldPair : nondeterministicFunctions) {
+            Expression nondeterministic = foldPair.first;
+            Expression deterministic = foldPair.second;
+            Expression fold = nondeterministic.accept(FoldConstantRuleOnFE.VISITOR_INSTANCE, rewriteContext);
+            if (!Objects.equals(deterministic, fold)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidDbAndTable(TableIf tableIf, Env env) {
+        return getTableFromEnv(tableIf, env) != null;
+    }
+
+    private TableIf getTableFromEnv(TableIf tableIf, Env env) {
+        Optional<Database> db = env.getInternalCatalog().getDb(tableIf.getDatabase().getId());
+        if (!db.isPresent()) {
+            return null;
+        }
+        Optional<Table> table = db.get().getTable(tableIf.getId());
+        return table.orElse(null);
+    }
+
+    private Optional<LogicalSqlCache> invalidateCache(String key) {
+        sqlCache.invalidate(key);
+        return Optional.empty();
+    }
+
+    private TableIf findTableIf(Env env, FullTableName fullTableName) {
+        CatalogIf<DatabaseIf<TableIf>> catalog = env.getCatalogMgr().getCatalog(fullTableName.catalog);
+        if (catalog == null) {
+            return null;
+        }
+        Optional<DatabaseIf<TableIf>> db = catalog.getDb(fullTableName.db);
+        if (!db.isPresent()) {
+            return null;
+        }
+        return db.get().getTable(fullTableName.table).orElse(null);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -631,7 +631,7 @@ public class SummaryProfile {
     }
 
     public String getPrettyParseSqlTime() {
-        return getPrettyTime(parseSqlStartTime, parseSqlFinishTime, TUnit.TIME_MS);
+        return getPrettyTime(parseSqlFinishTime, parseSqlStartTime, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsAnalysisTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -102,7 +102,7 @@ public class CascadesContext implements ScheduleContext {
     private Optional<RootRewriteJobContext> currentRootRewriteJobContext;
     // in optimize stage, the plan will storage in the memo
     private Memo memo;
-    private final StatementContext statementContext;
+    private StatementContext statementContext;
 
     private final CTEContext cteContext;
     private final RuleSet ruleSet;
@@ -265,6 +265,10 @@ public class CascadesContext implements ScheduleContext {
         return memo;
     }
 
+    public void releaseMemo() {
+        this.memo = null;
+    }
+
     public void setTables(List<TableIf> tables) {
         this.tables = tables.stream().collect(Collectors.toMap(TableIf::getId, t -> t, (t1, t2) -> t1));
     }
@@ -367,6 +371,10 @@ public class CascadesContext implements ScheduleContext {
 
     public void addMaterializationContext(MaterializationContext materializationContext) {
         this.materializationContexts.add(materializationContext);
+    }
+
+    public void release() {
+        statementContext = null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -373,10 +373,6 @@ public class CascadesContext implements ScheduleContext {
         this.materializationContexts.add(materializationContext);
     }
 
-    public void release() {
-        statementContext = null;
-    }
-
     /**
      * getAndCacheSessionVariable
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -52,10 +52,12 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.RuntimeFilter;
@@ -95,6 +97,7 @@ public class NereidsPlanner extends Planner {
     private PhysicalPlan physicalPlan;
     // The cost of optimized plan
     private double cost = 0;
+    private LogicalPlanAdapter logicalPlanAdapter;
     private List<PlannerHook> hooks = new ArrayList<>();
 
     public NereidsPlanner(StatementContext statementContext) {
@@ -112,7 +115,7 @@ public class NereidsPlanner extends Planner {
             throw new RuntimeException("Wrong type of queryStmt, expected: <? extends LogicalPlanAdapter>");
         }
 
-        LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) queryStmt;
+        logicalPlanAdapter = (LogicalPlanAdapter) queryStmt;
 
         ExplainLevel explainLevel = getExplainLevel(queryStmt.getExplainOptions());
 
@@ -129,35 +132,7 @@ public class NereidsPlanner extends Planner {
             return;
         }
         physicalPlan = (PhysicalPlan) resultPlan;
-        PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
-        PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator(planTranslatorContext,
-                statementContext.getConnectContext().getStatsErrorEstimator());
-        if (statementContext.getConnectContext().getExecutor() != null) {
-            statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsTranslateTime();
-        }
-        if (cascadesContext.getConnectContext().getSessionVariable().isEnableNereidsTrace()) {
-            CounterEvent.clearCounter();
-        }
-        if (cascadesContext.getConnectContext().getSessionVariable().isPlayNereidsDump()) {
-            return;
-        }
-        PlanFragment root = physicalPlanTranslator.translatePlan(physicalPlan);
-
-        scanNodeList.addAll(planTranslatorContext.getScanNodes());
-        descTable = planTranslatorContext.getDescTable();
-        fragments = new ArrayList<>(planTranslatorContext.getPlanFragments());
-        for (int seq = 0; seq < fragments.size(); seq++) {
-            fragments.get(seq).setFragmentSequenceNum(seq);
-        }
-        // set output exprs
-        logicalPlanAdapter.setResultExprs(root.getOutputExprs());
-        ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)
-                .collect(Collectors.toCollection(ArrayList::new));
-        logicalPlanAdapter.setColLabels(columnLabelList);
-        logicalPlanAdapter.setViewDdlSqls(statementContext.getViewDdlSqls());
-
-        // update scan nodes visible version at the end of plan phase.
-        ScanNode.setVisibleVersionForOlapScanNodes(getScanNodes());
+        translate(physicalPlan);
     }
 
     @VisibleForTesting
@@ -187,84 +162,98 @@ public class NereidsPlanner extends Planner {
      */
     public Plan plan(LogicalPlan plan, PhysicalProperties requireProperties,
                 ExplainLevel explainLevel, boolean showPlanProcess) {
-        if (explainLevel == ExplainLevel.PARSED_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
-            parsedPlan = plan;
-            if (explainLevel == ExplainLevel.PARSED_PLAN) {
-                return parsedPlan;
+        try {
+            if (plan instanceof LogicalSqlCache) {
+                rewrittenPlan = analyzedPlan = plan;
+                LogicalSqlCache logicalSqlCache = (LogicalSqlCache) plan;
+                physicalPlan = new PhysicalSqlCache(
+                        logicalSqlCache.getQueryId(), logicalSqlCache.getColumnLabels(),
+                        logicalSqlCache.getResultExprs(), logicalSqlCache.getCacheValues(),
+                        logicalSqlCache.getBackendAddress(), logicalSqlCache.getPlanBody()
+                );
+                return physicalPlan;
             }
-        }
-
-        // pre-process logical plan out of memo, e.g. process SET_VAR hint
-        plan = preprocess(plan);
-
-        initCascadesContext(plan, requireProperties);
-
-        try (Lock lock = new Lock(plan, cascadesContext)) {
-            // resolve column, table and function
-            // analyze this query
-            analyze(showAnalyzeProcess(explainLevel, showPlanProcess));
-            // minidump of input must be serialized first, this process ensure minidump string not null
-            try {
-                MinidumpUtils.serializeInputsToDumpFile(plan, cascadesContext.getTables());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-
-            if (statementContext.getConnectContext().getExecutor() != null) {
-                statementContext.getConnectContext().getExecutor().getSummaryProfile().setQueryAnalysisFinishTime();
-                statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsAnalysisTime();
-            }
-
-            if (explainLevel == ExplainLevel.ANALYZED_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
-                analyzedPlan = cascadesContext.getRewritePlan();
-                if (explainLevel == ExplainLevel.ANALYZED_PLAN) {
-                    return analyzedPlan;
+            if (explainLevel == ExplainLevel.PARSED_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
+                parsedPlan = plan;
+                if (explainLevel == ExplainLevel.PARSED_PLAN) {
+                    return parsedPlan;
                 }
             }
 
-            // rule-based optimize
-            rewrite(showRewriteProcess(explainLevel, showPlanProcess));
-            if (statementContext.getConnectContext().getExecutor() != null) {
-                statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsRewriteTime();
-            }
+            // pre-process logical plan out of memo, e.g. process SET_VAR hint
+            plan = preprocess(plan);
 
-            if (explainLevel == ExplainLevel.REWRITTEN_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
-                rewrittenPlan = cascadesContext.getRewritePlan();
-                if (explainLevel == ExplainLevel.REWRITTEN_PLAN) {
-                    return rewrittenPlan;
+            initCascadesContext(plan, requireProperties);
+
+            try (Lock lock = new Lock(plan, cascadesContext)) {
+                // resolve column, table and function
+                // analyze this query
+                analyze(showAnalyzeProcess(explainLevel, showPlanProcess));
+                // minidump of input must be serialized first, this process ensure minidump string not null
+                try {
+                    MinidumpUtils.serializeInputsToDumpFile(plan, cascadesContext.getTables());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
-            }
 
-            optimize();
-            if (statementContext.getConnectContext().getExecutor() != null) {
-                statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsOptimizeTime();
-            }
+                if (statementContext.getConnectContext().getExecutor() != null) {
+                    statementContext.getConnectContext().getExecutor().getSummaryProfile().setQueryAnalysisFinishTime();
+                    statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsAnalysisTime();
+                }
 
-            // print memo before choose plan.
-            // if chooseNthPlan failed, we could get memo to debug
-            if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
-                String memo = cascadesContext.getMemo().toString();
-                LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + memo);
-            }
+                if (explainLevel == ExplainLevel.ANALYZED_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
+                    analyzedPlan = cascadesContext.getRewritePlan();
+                    if (explainLevel == ExplainLevel.ANALYZED_PLAN) {
+                        return analyzedPlan;
+                    }
+                }
 
-            int nth = cascadesContext.getConnectContext().getSessionVariable().getNthOptimizedPlan();
-            PhysicalPlan physicalPlan = chooseNthPlan(getRoot(), requireProperties, nth);
+                // rule-based optimize
+                rewrite(showRewriteProcess(explainLevel, showPlanProcess));
+                if (statementContext.getConnectContext().getExecutor() != null) {
+                    statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsRewriteTime();
+                }
 
-            physicalPlan = postProcess(physicalPlan);
-            if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
-                String tree = physicalPlan.treeString();
-                LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + tree);
-            }
-            if (explainLevel == ExplainLevel.OPTIMIZED_PLAN
-                    || explainLevel == ExplainLevel.ALL_PLAN
-                    || explainLevel == ExplainLevel.SHAPE_PLAN) {
-                optimizedPlan = physicalPlan;
-            }
-            // serialize optimized plan to dumpfile, dumpfile do not have this part means optimize failed
-            MinidumpUtils.serializeOutputToDumpFile(physicalPlan);
-            NereidsTracer.output(statementContext.getConnectContext());
+                if (explainLevel == ExplainLevel.REWRITTEN_PLAN || explainLevel == ExplainLevel.ALL_PLAN) {
+                    rewrittenPlan = cascadesContext.getRewritePlan();
+                    if (explainLevel == ExplainLevel.REWRITTEN_PLAN) {
+                        return rewrittenPlan;
+                    }
+                }
 
-            return physicalPlan;
+                optimize();
+                if (statementContext.getConnectContext().getExecutor() != null) {
+                    statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsOptimizeTime();
+                }
+
+                // print memo before choose plan.
+                // if chooseNthPlan failed, we could get memo to debug
+                if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
+                    String memo = cascadesContext.getMemo().toString();
+                    LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + memo);
+                }
+
+                int nth = cascadesContext.getConnectContext().getSessionVariable().getNthOptimizedPlan();
+                PhysicalPlan physicalPlan = chooseNthPlan(getRoot(), requireProperties, nth);
+
+                physicalPlan = postProcess(physicalPlan);
+                if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
+                    String tree = physicalPlan.treeString();
+                    LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + tree);
+                }
+                if (explainLevel == ExplainLevel.OPTIMIZED_PLAN
+                        || explainLevel == ExplainLevel.ALL_PLAN
+                        || explainLevel == ExplainLevel.SHAPE_PLAN) {
+                    optimizedPlan = physicalPlan;
+                }
+                // serialize optimized plan to dumpfile, dumpfile do not have this part means optimize failed
+                MinidumpUtils.serializeOutputToDumpFile(physicalPlan);
+                NereidsTracer.output(statementContext.getConnectContext());
+
+                return physicalPlan;
+            }
+        } finally {
+            statementContext.releasePlannerResources();
         }
     }
 
@@ -315,6 +304,50 @@ public class NereidsPlanner extends Planner {
         if (LOG.isDebugEnabled()) {
             LOG.debug("End optimize plan");
         }
+    }
+
+    private void translate(PhysicalPlan resultPlan) throws UserException {
+        if (resultPlan instanceof PhysicalSqlCache) {
+            return;
+        }
+
+        PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
+        PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator(planTranslatorContext,
+                statementContext.getConnectContext().getStatsErrorEstimator());
+        if (statementContext.getConnectContext().getExecutor() != null) {
+            statementContext.getConnectContext().getExecutor().getSummaryProfile().setNereidsTranslateTime();
+        }
+        if (cascadesContext.getConnectContext().getSessionVariable().isEnableNereidsTrace()) {
+            CounterEvent.clearCounter();
+        }
+        if (cascadesContext.getConnectContext().getSessionVariable().isPlayNereidsDump()) {
+            return;
+        }
+        PlanFragment root = physicalPlanTranslator.translatePlan(physicalPlan);
+
+        scanNodeList.addAll(planTranslatorContext.getScanNodes());
+        descTable = planTranslatorContext.getDescTable();
+        fragments = new ArrayList<>(planTranslatorContext.getPlanFragments());
+        for (int seq = 0; seq < fragments.size(); seq++) {
+            fragments.get(seq).setFragmentSequenceNum(seq);
+        }
+        // set output exprs
+        logicalPlanAdapter.setResultExprs(root.getOutputExprs());
+        ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)
+                .collect(Collectors.toCollection(ArrayList::new));
+        logicalPlanAdapter.setColLabels(columnLabelList);
+        logicalPlanAdapter.setViewDdlSqls(statementContext.getViewDdlSqls());
+        if (statementContext.getSqlCacheContext().isPresent()) {
+            SqlCacheContext sqlCacheContext = statementContext.getSqlCacheContext().get();
+            sqlCacheContext.setColLabels(columnLabelList);
+            sqlCacheContext.setResultExprs(root.getOutputExprs());
+            sqlCacheContext.setPhysicalPlan(resultPlan.treeString());
+        }
+
+        cascadesContext.releaseMemo();
+
+        // update scan nodes visible version at the end of plan phase.
+        ScanNode.setVisibleVersionForOlapScanNodes(getScanNodes());
     }
 
     private PhysicalPlan postProcess(PhysicalPlan physicalPlan) {
@@ -571,6 +604,10 @@ public class NereidsPlanner extends Planner {
 
     public PhysicalPlan getPhysicalPlan() {
         return physicalPlan;
+    }
+
+    public LogicalPlanAdapter getLogicalPlanAdapter() {
+        return logicalPlanAdapter;
     }
 
     public List<PlannerHook> getHooks() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
@@ -1,0 +1,353 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Pair;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.mysql.privilege.DataMaskPolicy;
+import org.apache.doris.mysql.privilege.RowFilterPolicy;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Variable;
+import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.proto.Types.PUniqueId;
+import org.apache.doris.qe.cache.CacheProxy;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/** SqlCacheContext */
+public class SqlCacheContext {
+    private final UserIdentity userIdentity;
+    private final TUniqueId queryId;
+    // if contains udf/udaf/tableValuesFunction we can not process it and skip use sql cache
+    private volatile boolean cannotProcessExpression;
+    private volatile String physicalPlan;
+    private volatile long latestPartitionId = -1;
+    private volatile long latestPartitionTime = -1;
+    private volatile long latestPartitionVersion = -1;
+    private volatile long sumOfPartitionNum = -1;
+    private final Set<FullTableName> usedTables = Sets.newLinkedHashSet();
+    // value: ddl sql
+    private final Map<FullTableName, String> usedViews = Maps.newLinkedHashMap();
+    // value: usedColumns
+    private final Map<FullTableName, Set<String>> checkPrivilegeTablesOrViews = Maps.newLinkedHashMap();
+    private final Map<FullTableName, List<RowFilterPolicy>> rowPolicies = Maps.newLinkedHashMap();
+    private final Map<FullColumnName, Optional<DataMaskPolicy>> dataMaskPolicies = Maps.newLinkedHashMap();
+    private final Set<Variable> usedVariables = Sets.newLinkedHashSet();
+    // key: the expression which contains nondeterministic function, e.g. date(now())
+    // value: the expression which already try to fold nondeterministic function, e.g. '2024-01-01'
+    // note that value maybe contains nondeterministic function too, when fold failed
+    private final List<Pair<Expression, Expression>> foldNondeterministicPairs = Lists.newArrayList();
+    private volatile boolean hasUnsupportedTables;
+    private final List<ScanTable> scanTables = Lists.newArrayList();
+    private volatile CacheProxy cacheProxy;
+
+    private volatile List<Expr> resultExprs;
+    private volatile List<String> colLabels;
+
+    private volatile PUniqueId cacheKeyMd5;
+
+    public SqlCacheContext(UserIdentity userIdentity, TUniqueId queryId) {
+        this.userIdentity = Objects.requireNonNull(userIdentity, "userIdentity cannot be null");
+        this.queryId = Objects.requireNonNull(queryId, "queryId cannot be null");
+    }
+
+    public String getPhysicalPlan() {
+        return physicalPlan;
+    }
+
+    public void setPhysicalPlan(String physicalPlan) {
+        this.physicalPlan = physicalPlan;
+    }
+
+    public void setCannotProcessExpression(boolean cannotProcessExpression) {
+        this.cannotProcessExpression = cannotProcessExpression;
+    }
+
+    public boolean containsCannotProcessExpression() {
+        return cannotProcessExpression;
+    }
+
+    public boolean hasUnsupportedTables() {
+        return hasUnsupportedTables;
+    }
+
+    public void setHasUnsupportedTables(boolean hasUnsupportedTables) {
+        this.hasUnsupportedTables = hasUnsupportedTables;
+    }
+
+    /** addUsedTable */
+    public synchronized void addUsedTable(TableIf tableIf) {
+        if (tableIf == null) {
+            return;
+        }
+        DatabaseIf database = tableIf.getDatabase();
+        if (database == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+        CatalogIf catalog = database.getCatalog();
+        if (catalog == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+
+        usedTables.add(
+                new FullTableName(database.getCatalog().getName(), database.getFullName(), tableIf.getName())
+        );
+    }
+
+    /** addUsedView */
+    public synchronized void addUsedView(TableIf tableIf, String ddlSql) {
+        if (tableIf == null) {
+            return;
+        }
+        DatabaseIf database = tableIf.getDatabase();
+        if (database == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+        CatalogIf catalog = database.getCatalog();
+        if (catalog == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+
+        usedViews.put(
+                new FullTableName(database.getCatalog().getName(), database.getFullName(), tableIf.getName()),
+                ddlSql
+        );
+    }
+
+    /** addNeedCheckPrivilegeTablesOrViews */
+    public synchronized void addCheckPrivilegeTablesOrViews(TableIf tableIf, Set<String> usedColumns) {
+        if (tableIf == null) {
+            return;
+        }
+        DatabaseIf database = tableIf.getDatabase();
+        if (database == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+        CatalogIf catalog = database.getCatalog();
+        if (catalog == null) {
+            setCannotProcessExpression(true);
+            return;
+        }
+        FullTableName fullTableName = new FullTableName(catalog.getName(), database.getFullName(), tableIf.getName());
+        Set<String> existsColumns = checkPrivilegeTablesOrViews.get(fullTableName);
+        if (existsColumns == null) {
+            checkPrivilegeTablesOrViews.put(fullTableName, usedColumns);
+        } else {
+            ImmutableSet.Builder<String> allUsedColumns = ImmutableSet.builderWithExpectedSize(
+                    existsColumns.size() + usedColumns.size());
+            allUsedColumns.addAll(existsColumns);
+            allUsedColumns.addAll(usedColumns);
+            checkPrivilegeTablesOrViews.put(fullTableName, allUsedColumns.build());
+        }
+    }
+
+    public synchronized void setRowFilterPolicy(
+            String catalog, String db, String table, List<? extends RowFilterPolicy> rowFilterPolicy) {
+        rowPolicies.put(new FullTableName(catalog, db, table), Utils.fastToImmutableList(rowFilterPolicy));
+    }
+
+    public synchronized Map<FullTableName, List<RowFilterPolicy>> getRowFilterPolicies() {
+        return ImmutableMap.copyOf(rowPolicies);
+    }
+
+    public synchronized void addDataMaskPolicy(
+            String catalog, String db, String table, String columnName, Optional<DataMaskPolicy> dataMaskPolicy) {
+        dataMaskPolicies.put(
+                new FullColumnName(catalog, db, table, columnName.toLowerCase(Locale.ROOT)), dataMaskPolicy
+        );
+    }
+
+    public synchronized Map<FullColumnName, Optional<DataMaskPolicy>> getDataMaskPolicies() {
+        return ImmutableMap.copyOf(dataMaskPolicies);
+    }
+
+    public synchronized void addUsedVariable(Variable value) {
+        usedVariables.add(value);
+    }
+
+    public synchronized List<Variable> getUsedVariables() {
+        return ImmutableList.copyOf(usedVariables);
+    }
+
+    public synchronized void addFoldNondeterministicPair(Expression unfold, Expression fold) {
+        foldNondeterministicPairs.add(Pair.of(unfold, fold));
+    }
+
+    public synchronized List<Pair<Expression, Expression>> getFoldNondeterministicPairs() {
+        return ImmutableList.copyOf(foldNondeterministicPairs);
+    }
+
+    public boolean isCannotProcessExpression() {
+        return cannotProcessExpression;
+    }
+
+    public UserIdentity getUserIdentity() {
+        return userIdentity;
+    }
+
+    public long getLatestPartitionTime() {
+        return latestPartitionTime;
+    }
+
+    public void setLatestPartitionTime(long latestPartitionTime) {
+        this.latestPartitionTime = latestPartitionTime;
+    }
+
+    public long getLatestPartitionVersion() {
+        return latestPartitionVersion;
+    }
+
+    public void setLatestPartitionVersion(long latestPartitionVersion) {
+        this.latestPartitionVersion = latestPartitionVersion;
+    }
+
+    public long getLatestPartitionId() {
+        return latestPartitionId;
+    }
+
+    public void setLatestPartitionId(long latestPartitionId) {
+        this.latestPartitionId = latestPartitionId;
+    }
+
+    public long getSumOfPartitionNum() {
+        return sumOfPartitionNum;
+    }
+
+    public void setSumOfPartitionNum(long sumOfPartitionNum) {
+        this.sumOfPartitionNum = sumOfPartitionNum;
+    }
+
+    public CacheProxy getCacheProxy() {
+        return cacheProxy;
+    }
+
+    public void setCacheProxy(CacheProxy cacheProxy) {
+        this.cacheProxy = cacheProxy;
+    }
+
+    public Set<FullTableName> getUsedTables() {
+        return ImmutableSet.copyOf(usedTables);
+    }
+
+    public Map<FullTableName, String> getUsedViews() {
+        return ImmutableMap.copyOf(usedViews);
+    }
+
+    public synchronized Map<FullTableName, Set<String>> getCheckPrivilegeTablesOrViews() {
+        return ImmutableMap.copyOf(checkPrivilegeTablesOrViews);
+    }
+
+    public synchronized Map<FullTableName, List<RowFilterPolicy>> getRowPolicies() {
+        return ImmutableMap.copyOf(rowPolicies);
+    }
+
+    public boolean isHasUnsupportedTables() {
+        return hasUnsupportedTables;
+    }
+
+    public synchronized void addScanTable(ScanTable scanTable) {
+        this.scanTables.add(scanTable);
+    }
+
+    public synchronized List<ScanTable> getScanTables() {
+        return ImmutableList.copyOf(scanTables);
+    }
+
+    public List<Expr> getResultExprs() {
+        return resultExprs;
+    }
+
+    public void setResultExprs(List<Expr> resultExprs) {
+        this.resultExprs = ImmutableList.copyOf(resultExprs);
+    }
+
+    public List<String> getColLabels() {
+        return colLabels;
+    }
+
+    public void setColLabels(List<String> colLabels) {
+        this.colLabels = ImmutableList.copyOf(colLabels);
+    }
+
+    public TUniqueId getQueryId() {
+        return queryId;
+    }
+
+    public PUniqueId getCacheKeyMd5() {
+        return cacheKeyMd5;
+    }
+
+    public void setCacheKeyMd5(PUniqueId cacheKeyMd5) {
+        this.cacheKeyMd5 = cacheKeyMd5;
+    }
+
+    /** FullTableName */
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    public static class FullTableName {
+        public final String catalog;
+        public final String db;
+        public final String table;
+    }
+
+    /** FullColumnName */
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    public static class FullColumnName {
+        public final String catalog;
+        public final String db;
+        public final String table;
+        public final String column;
+    }
+
+    /** ScanTable */
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    public static class ScanTable {
+        public final FullTableName fullTableName;
+        public final long latestTimestamp;
+        public final long latestVersion;
+        public final List<Long> scanPartitions = Lists.newArrayList();
+
+        public void addScanPartition(Long partitionId) {
+            this.scanPartitions.add(partitionId);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.parser;
 
+import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
@@ -26,6 +27,7 @@ import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.parser.plsql.PLSqlLogicalPlanBuilder;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.plugin.DialectConverterPlugin;
@@ -37,14 +39,18 @@ import com.google.common.collect.Lists;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -55,6 +61,21 @@ public class NereidsParser {
     public static final Logger LOG = LogManager.getLogger(NereidsParser.class);
     private static final ParseErrorListener PARSE_ERROR_LISTENER = new ParseErrorListener();
     private static final PostProcessor POST_PROCESSOR = new PostProcessor();
+
+    private static final BitSet EXPLAIN_TOKENS = new BitSet();
+
+    static {
+        EXPLAIN_TOKENS.set(DorisLexer.EXPLAIN);
+        EXPLAIN_TOKENS.set(DorisLexer.PARSED);
+        EXPLAIN_TOKENS.set(DorisLexer.ANALYZED);
+        EXPLAIN_TOKENS.set(DorisLexer.LOGICAL);
+        EXPLAIN_TOKENS.set(DorisLexer.REWRITTEN);
+        EXPLAIN_TOKENS.set(DorisLexer.PHYSICAL);
+        EXPLAIN_TOKENS.set(DorisLexer.OPTIMIZED);
+        EXPLAIN_TOKENS.set(DorisLexer.PLAN);
+        EXPLAIN_TOKENS.set(DorisLexer.PROCESS);
+
+    }
 
     /**
      * In MySQL protocol, client could send multi-statement in a single packet.
@@ -81,6 +102,98 @@ public class NereidsParser {
             statementBases.add(new LogicalPlanAdapter(parsedPlanToContext.first, parsedPlanToContext.second));
         }
         return statementBases;
+    }
+
+    /**
+     * scan to token
+     * for example: select id from tbl return Tokens: ['select', 'id', 'from', 'tbl']
+     */
+    public static TokenSource scan(String sql) {
+        return new DorisLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
+    }
+
+    /**
+     * tryParseExplainPlan
+     * @param sql sql
+     * @return key: ExplainOptions, value: explain body
+     */
+    public static Optional<Pair<ExplainOptions, String>> tryParseExplainPlan(String sql) {
+        try {
+            TokenSource tokenSource = scan(sql);
+            if (expect(tokenSource, DorisLexer.EXPLAIN) == null) {
+                return Optional.empty();
+            }
+
+            Token token = readUntilNonComment(tokenSource);
+            if (token == null) {
+                return Optional.empty();
+            }
+
+            int tokenType = token.getType();
+            ExplainLevel explainLevel = ExplainLevel.ALL_PLAN;
+            if (tokenType == DorisLexer.PARSED) {
+                explainLevel = ExplainLevel.PARSED_PLAN;
+                token = readUntilNonComment(tokenSource);
+            } else if (tokenType == DorisLexer.ANALYZED) {
+                explainLevel = ExplainLevel.ANALYZED_PLAN;
+                token = readUntilNonComment(tokenSource);
+            } else if (tokenType == DorisLexer.LOGICAL || tokenType == DorisLexer.REWRITTEN) {
+                explainLevel = ExplainLevel.REWRITTEN_PLAN;
+                token = readUntilNonComment(tokenSource);
+            } else if (tokenType == DorisLexer.PHYSICAL || tokenType == DorisLexer.OPTIMIZED) {
+                explainLevel = ExplainLevel.OPTIMIZED_PLAN;
+                token = readUntilNonComment(tokenSource);
+            }
+
+            if (token == null) {
+                return Optional.empty();
+            }
+            tokenType = token.getType();
+            if (tokenType != DorisLexer.PLAN) {
+                return Optional.empty();
+            }
+
+            token = readUntilNonComment(tokenSource);
+            Token explainPlanBody;
+            boolean showPlanProcess = false;
+            if (token.getType() == DorisLexer.PROCESS) {
+                showPlanProcess = true;
+                explainPlanBody = readUntilNonComment(tokenSource);
+            } else {
+                explainPlanBody = token;
+            }
+
+            if (explainPlanBody == null) {
+                return Optional.empty();
+            }
+            ExplainOptions explainOptions = new ExplainOptions(explainLevel, showPlanProcess);
+            return Optional.of(Pair.of(explainOptions, sql.substring(explainPlanBody.getStartIndex())));
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    private static Token expect(TokenSource tokenSource, int tokenType) {
+        Token nextToken = readUntilNonComment(tokenSource);
+        if (nextToken == null) {
+            return null;
+        }
+        return nextToken.getType() == tokenType ? nextToken : null;
+    }
+
+    private static Token readUntilNonComment(TokenSource tokenSource) {
+        Token token = tokenSource.nextToken();
+        while (token != null) {
+            int tokenType = token.getType();
+            if (tokenType == DorisLexer.BRACKETED_COMMENT
+                    || tokenType == DorisLexer.SIMPLE_COMMENT
+                    || tokenType == DorisLexer.WS) {
+                token = tokenSource.nextToken();
+                continue;
+            }
+            break;
+        }
+        return token;
     }
 
     private List<StatementBase> parseSQLWithDialect(String sql,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -31,6 +31,7 @@ import org.apache.doris.datasource.es.EsExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.nereids.CTEContext;
 import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
@@ -249,69 +250,90 @@ public class BindRelation extends OneAnalysisRuleFactory {
         });
         List<String> qualifierWithoutTableName = Lists.newArrayList();
         qualifierWithoutTableName.addAll(tableQualifier.subList(0, tableQualifier.size() - 1));
-        switch (table.getType()) {
-            case OLAP:
-            case MATERIALIZED_VIEW:
-                return makeOlapScan(table, unboundRelation, qualifierWithoutTableName);
-            case VIEW:
-                View view = (View) table;
-                String inlineViewDef = view.getInlineViewDef();
-                Plan viewBody = parseAndAnalyzeView(inlineViewDef, cascadesContext);
-                LogicalView<Plan> logicalView = new LogicalView<>(view, viewBody);
-                return new LogicalSubQueryAlias<>(tableQualifier, logicalView);
-            case HMS_EXTERNAL_TABLE:
-                HMSExternalTable hmsTable = (HMSExternalTable) table;
-                if (Config.enable_query_hive_views && hmsTable.isView()) {
-                    String hiveCatalog = hmsTable.getCatalog().getName();
-                    String ddlSql = hmsTable.getViewText();
-                    Plan hiveViewPlan = parseAndAnalyzeHiveView(hiveCatalog, ddlSql, cascadesContext);
-                    return new LogicalSubQueryAlias<>(tableQualifier, hiveViewPlan);
+        boolean isView = false;
+        try {
+            switch (table.getType()) {
+                case OLAP:
+                case MATERIALIZED_VIEW:
+                    return makeOlapScan(table, unboundRelation, qualifierWithoutTableName);
+                case VIEW:
+                    View view = (View) table;
+                    isView = true;
+                    String inlineViewDef = view.getInlineViewDef();
+                    Plan viewBody = parseAndAnalyzeView(view, inlineViewDef, cascadesContext);
+                    LogicalView<Plan> logicalView = new LogicalView<>(view, viewBody);
+                    return new LogicalSubQueryAlias<>(tableQualifier, logicalView);
+                case HMS_EXTERNAL_TABLE:
+                    HMSExternalTable hmsTable = (HMSExternalTable) table;
+                    if (Config.enable_query_hive_views && hmsTable.isView()) {
+                        isView = true;
+                        String hiveCatalog = hmsTable.getCatalog().getName();
+                        String ddlSql = hmsTable.getViewText();
+                        Plan hiveViewPlan = parseAndAnalyzeHiveView(hmsTable, hiveCatalog, ddlSql, cascadesContext);
+                        return new LogicalSubQueryAlias<>(tableQualifier, hiveViewPlan);
+                    }
+                    hmsTable.setScanParams(unboundRelation.getScanParams());
+                    return new LogicalFileScan(unboundRelation.getRelationId(), (HMSExternalTable) table,
+                            qualifierWithoutTableName, unboundRelation.getTableSample());
+                case ICEBERG_EXTERNAL_TABLE:
+                case PAIMON_EXTERNAL_TABLE:
+                case MAX_COMPUTE_EXTERNAL_TABLE:
+                case TRINO_CONNECTOR_EXTERNAL_TABLE:
+                    return new LogicalFileScan(unboundRelation.getRelationId(), (ExternalTable) table,
+                            qualifierWithoutTableName, unboundRelation.getTableSample());
+                case SCHEMA:
+                    return new LogicalSchemaScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
+                case JDBC_EXTERNAL_TABLE:
+                case JDBC:
+                    return new LogicalJdbcScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
+                case ODBC:
+                    return new LogicalOdbcScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
+                case ES_EXTERNAL_TABLE:
+                    return new LogicalEsScan(unboundRelation.getRelationId(), (EsExternalTable) table,
+                            qualifierWithoutTableName);
+                case TEST_EXTERNAL_TABLE:
+                    return new LogicalTestScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
+                default:
+                    try {
+                        // TODO: support other type table, such as ELASTICSEARCH
+                        cascadesContext.getConnectContext().getSessionVariable().enableFallbackToOriginalPlannerOnce();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                    throw new AnalysisException("Unsupported tableType " + table.getType());
+            }
+        } finally {
+            if (!isView) {
+                Optional<SqlCacheContext> sqlCacheContext = cascadesContext.getStatementContext().getSqlCacheContext();
+                if (sqlCacheContext.isPresent()) {
+                    if (table instanceof OlapTable) {
+                        sqlCacheContext.get().addUsedTable(table);
+                    } else {
+                        sqlCacheContext.get().setHasUnsupportedTables(true);
+                    }
                 }
-                hmsTable.setScanParams(unboundRelation.getScanParams());
-                return new LogicalFileScan(unboundRelation.getRelationId(), (HMSExternalTable) table,
-                        qualifierWithoutTableName, unboundRelation.getTableSample());
-            case ICEBERG_EXTERNAL_TABLE:
-            case PAIMON_EXTERNAL_TABLE:
-            case MAX_COMPUTE_EXTERNAL_TABLE:
-            case TRINO_CONNECTOR_EXTERNAL_TABLE:
-                return new LogicalFileScan(unboundRelation.getRelationId(), (ExternalTable) table,
-                        qualifierWithoutTableName, unboundRelation.getTableSample());
-            case SCHEMA:
-                return new LogicalSchemaScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
-            case JDBC_EXTERNAL_TABLE:
-            case JDBC:
-                return new LogicalJdbcScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
-            case ODBC:
-                return new LogicalOdbcScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
-            case ES_EXTERNAL_TABLE:
-                return new LogicalEsScan(unboundRelation.getRelationId(), (EsExternalTable) table,
-                        qualifierWithoutTableName);
-            case TEST_EXTERNAL_TABLE:
-                return new LogicalTestScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
-            default:
-                try {
-                    // TODO: support other type table, such as ELASTICSEARCH
-                    cascadesContext.getConnectContext().getSessionVariable().enableFallbackToOriginalPlannerOnce();
-                } catch (Exception e) {
-                    // ignore
-                }
-                throw new AnalysisException("Unsupported tableType " + table.getType());
+            }
         }
     }
 
-    private Plan parseAndAnalyzeHiveView(String hiveCatalog, String ddlSql, CascadesContext cascadesContext) {
+    private Plan parseAndAnalyzeHiveView(
+            HMSExternalTable table, String hiveCatalog, String ddlSql, CascadesContext cascadesContext) {
         ConnectContext ctx = cascadesContext.getConnectContext();
         String previousCatalog = ctx.getCurrentCatalog().getName();
         String previousDb = ctx.getDatabase();
         ctx.changeDefaultCatalog(hiveCatalog);
-        Plan hiveViewPlan = parseAndAnalyzeView(ddlSql, cascadesContext);
+        Plan hiveViewPlan = parseAndAnalyzeView(table, ddlSql, cascadesContext);
         ctx.changeDefaultCatalog(previousCatalog);
         ctx.setDatabase(previousDb);
         return hiveViewPlan;
     }
 
-    private Plan parseAndAnalyzeView(String ddlSql, CascadesContext parentContext) {
+    private Plan parseAndAnalyzeView(TableIf view, String ddlSql, CascadesContext parentContext) {
         parentContext.getStatementContext().addViewDdlSql(ddlSql);
+        Optional<SqlCacheContext> sqlCacheContext = parentContext.getStatementContext().getSqlCacheContext();
+        if (sqlCacheContext.isPresent()) {
+            sqlCacheContext.get().addUsedView(view, ddlSql);
+        }
         LogicalPlan parsedViewPlan = new NereidsParser().parseSingle(ddlSql);
         // TODO: use a good to do this, such as eliminate UnboundResultSink
         if (parsedViewPlan instanceof UnboundResultSink) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -22,8 +22,10 @@ import org.apache.doris.analysis.SetType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionRegistry;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.Scope;
 import org.apache.doris.nereids.analyzer.UnboundAlias;
@@ -34,6 +36,7 @@ import org.apache.doris.nereids.analyzer.UnboundVariable;
 import org.apache.doris.nereids.analyzer.UnboundVariable.VariableType;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
+import org.apache.doris.nereids.rules.expression.rules.FoldConstantRuleOnFE;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
@@ -60,12 +63,15 @@ import org.apache.doris.nereids.trees.expressions.Variable;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ElementAt;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.PushDownToProjectionFunction;
 import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.udf.JavaUdaf;
+import org.apache.doris.nereids.trees.expressions.functions.udf.JavaUdf;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -83,6 +89,7 @@ import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.qe.VariableVarConverters;
+import org.apache.doris.qe.cache.CacheAnalyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -112,6 +119,7 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
      */
     private final boolean enableExactMatch;
     private final boolean bindSlotInOuterScope;
+    private final boolean wantToParseSqlFromSqlCache;
     private boolean currentInLambda;
 
     // Keep track of which element_at function's level
@@ -119,17 +127,43 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
     //      element_at(v, 'repo') level 2
     // Only works with function ElementAt which satisfy condition PushDownToProjectionFunction.validToPushDown
     private int currentElementAtLevel = 0;
+    private boolean hasNondeterministic;
 
+    /** ExpressionAnalyzer */
     public ExpressionAnalyzer(Plan currentPlan, Scope scope, CascadesContext cascadesContext,
             boolean enableExactMatch, boolean bindSlotInOuterScope) {
         super(scope, cascadesContext);
         this.currentPlan = currentPlan;
         this.enableExactMatch = enableExactMatch;
         this.bindSlotInOuterScope = bindSlotInOuterScope;
+        this.wantToParseSqlFromSqlCache = CacheAnalyzer.canUseSqlCache(
+                cascadesContext.getConnectContext().getSessionVariable());
     }
 
+    /** analyze */
     public Expression analyze(Expression expression, ExpressionRewriteContext context) {
-        return expression.accept(this, context);
+        hasNondeterministic = false;
+        Expression analyzeResult = expression.accept(this, context);
+        if (wantToParseSqlFromSqlCache && hasNondeterministic
+                && context.cascadesContext.getStatementContext().getSqlCacheContext().isPresent()) {
+            hasNondeterministic = false;
+            StatementContext statementContext = context.cascadesContext.getStatementContext();
+            SqlCacheContext sqlCacheContext = statementContext.getSqlCacheContext().get();
+            Expression foldNondeterministic = new FoldConstantRuleOnFE(true) {
+                @Override
+                public Expression visitBoundFunction(BoundFunction boundFunction, ExpressionRewriteContext context) {
+                    Expression fold = super.visitBoundFunction(boundFunction, context);
+                    if (fold instanceof Nondeterministic) {
+                        sqlCacheContext.setCannotProcessExpression(true);
+                    }
+                    return fold;
+                }
+            }.rewrite(analyzeResult, context);
+
+            sqlCacheContext.addFoldNondeterministicPair(analyzeResult, foldNondeterministic);
+            return foldNondeterministic;
+        }
+        return analyzeResult;
     }
 
     @Override
@@ -163,6 +197,11 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
      * ******************************************************************************************** */
     @Override
     public Expression visitUnboundVariable(UnboundVariable unboundVariable, ExpressionRewriteContext context) {
+        return resolveUnboundVariable(unboundVariable);
+    }
+
+    /** resolveUnboundVariable */
+    public static Variable resolveUnboundVariable(UnboundVariable unboundVariable) throws AnalysisException {
         String name = unboundVariable.getName();
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         Literal literal = null;
@@ -322,13 +361,27 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
         String functionName = unboundFunction.getName();
         FunctionBuilder builder = functionRegistry.findFunctionBuilder(
                 unboundFunction.getDbName(), functionName, arguments);
+        Pair<? extends Expression, ? extends BoundFunction> buildResult = builder.build(functionName, arguments);
+        StatementContext statementContext = context.cascadesContext.getStatementContext();
+        if (buildResult.second instanceof Nondeterministic) {
+            hasNondeterministic = true;
+        }
+        Optional<SqlCacheContext> sqlCacheContext = statementContext.getSqlCacheContext();
+        if (builder instanceof AliasUdfBuilder
+                || buildResult.second instanceof JavaUdf || buildResult.second instanceof JavaUdaf) {
+            if (sqlCacheContext.isPresent()) {
+                sqlCacheContext.get().setCannotProcessExpression(true);
+            }
+        }
         if (builder instanceof AliasUdfBuilder) {
+            if (sqlCacheContext.isPresent()) {
+                sqlCacheContext.get().setCannotProcessExpression(true);
+            }
             // we do type coercion in build function in alias function, so it's ok to return directly.
-            return builder.build(functionName, arguments);
+            return buildResult.first;
         } else {
-            Expression boundFunction = TypeCoercionUtils
-                    .processBoundFunction((BoundFunction) builder.build(functionName, arguments));
-            if (boundFunction instanceof Count
+            Expression castFunction = TypeCoercionUtils.processBoundFunction((BoundFunction) buildResult.first);
+            if (castFunction instanceof Count
                     && context.cascadesContext.getOuterScope().isPresent()
                     && !context.cascadesContext.getOuterScope().get().getCorrelatedSlots()
                     .isEmpty()) {
@@ -338,20 +391,20 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
                 // if there is no match, the row from right table is filled with nulls
                 // but COUNT function is always not nullable.
                 // so wrap COUNT with Nvl to ensure it's result is 0 instead of null to get the correct result
-                boundFunction = new Nvl(boundFunction, new BigIntLiteral(0));
+                castFunction = new Nvl(castFunction, new BigIntLiteral(0));
             }
 
             if (currentElementAtLevel == 1
-                    && PushDownToProjectionFunction.validToPushDown(boundFunction)) {
+                    && PushDownToProjectionFunction.validToPushDown(castFunction)) {
                 // Only rewrite the top level of PushDownToProjectionFunction, otherwise invalid slot will be generated
                 // currentElementAtLevel == 1 means at the top of element_at function, other levels will be ignored.
                 currentElementAtLevel = 0;
-                return visitElementAt((ElementAt) boundFunction, context);
+                return visitElementAt((ElementAt) castFunction, context);
             }
-            if (boundFunction instanceof ElementAt) {
+            if (castFunction instanceof ElementAt) {
                 --currentElementAtLevel;
             }
-            return boundFunction;
+            return castFunction;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -181,10 +181,10 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
                 unboundFunction.getDbName(), functionName, arguments);
         if (builder instanceof AliasUdfBuilder) {
             // we do type coercion in build function in alias function, so it's ok to return directly.
-            return builder.build(functionName, arguments);
+            return builder.build(functionName, arguments).first;
         } else {
             Expression boundFunction = TypeCoercionUtils
-                    .processBoundFunction((BoundFunction) builder.build(functionName, arguments));
+                    .processBoundFunction((BoundFunction) builder.build(functionName, arguments).first);
             if (boundFunction instanceof Count
                     && context.cascadesContext.getOuterScope().isPresent()
                     && !context.cascadesContext.getOuterScope().get().getCorrelatedSlots()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BuiltinFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BuiltinFunctionBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.ReflectionUtils;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
@@ -86,12 +87,12 @@ public class BuiltinFunctionBuilder extends FunctionBuilder {
     }
 
     @Override
-    public BoundFunction build(String name, List<? extends Object> arguments) {
+    public Pair<BoundFunction, BoundFunction> build(String name, List<? extends Object> arguments) {
         try {
             if (isVariableLength) {
-                return builderMethod.newInstance(toVariableLengthArguments(arguments));
+                return Pair.ofSame(builderMethod.newInstance(toVariableLengthArguments(arguments)));
             } else {
-                return builderMethod.newInstance(arguments.toArray());
+                return Pair.ofSame(builderMethod.newInstance(arguments.toArray()));
             }
         } catch (Throwable t) {
             String argString = arguments.stream()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,7 @@ public abstract class FunctionBuilder {
     /** check whether arguments can apply to the constructor */
     public abstract boolean canApply(List<? extends Object> arguments);
 
-    public final Expression build(String name, Object argument) {
+    public final Pair<? extends Expression, ? extends BoundFunction> build(String name, Object argument) {
         return build(name, ImmutableList.of(argument));
     }
 
@@ -40,7 +41,10 @@ public abstract class FunctionBuilder {
      * build a BoundFunction by function name and arguments.
      * @param name function name which in the sql expression
      * @param arguments the function's argument expressions
-     * @return the concrete bound function instance
+     * @return the concrete bound function instance,
+     *          key: the final result expression that should return, e.g. the function wrapped some cast function,
+     *          value: the real BoundFunction
      */
-    public abstract Expression build(String name, List<? extends Object> arguments);
+    public abstract Pair<? extends Expression, ? extends BoundFunction> build(
+            String name, List<? extends Object> arguments);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ConnectionId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ConnectionId.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'ConnectionId'.
  */
 public class ConnectionId extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.StringType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'CurrentUser'.
  */
 public class CurrentUser extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(StringType.INSTANCE).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Database.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.VarcharType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'database'.
  */
 public class Database extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/User.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/User.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.VarcharType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'User'.
  */
 public class User extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/TableValuedFunction.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.Properties;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
@@ -44,7 +45,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** TableValuedFunction */
-public abstract class TableValuedFunction extends BoundFunction implements UnaryExpression, CustomSignature {
+public abstract class TableValuedFunction extends BoundFunction
+        implements UnaryExpression, CustomSignature, Nondeterministic {
 
     protected final Supplier<TableValuedFunctionIf> catalogFunctionCache = Suppliers.memoize(this::toCatalogFunction);
     protected final Supplier<FunctionGenTable> tableCache = Suppliers.memoize(() -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdfBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.udf;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.ReflectionUtils;
 import org.apache.doris.nereids.rules.expression.rules.FunctionBinder;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -72,7 +73,7 @@ public class AliasUdfBuilder extends UdfBuilder {
     }
 
     @Override
-    public Expression build(String name, List<?> arguments) {
+    public Pair<Expression, BoundFunction> build(String name, List<?> arguments) {
         // use AliasFunction to process TypeCoercion
         BoundFunction boundAliasFunction = ((BoundFunction) aliasUdf.withChildren(arguments.stream()
                 .map(Expression.class::cast).collect(Collectors.toList())));
@@ -95,7 +96,7 @@ public class AliasUdfBuilder extends UdfBuilder {
             replaceMap.put(slots.get(parameter), inputs.get(i));
         }
 
-        return SlotReplacer.INSTANCE.replace(boundFunction, replaceMap);
+        return Pair.of(SlotReplacer.INSTANCE.replace(boundFunction, replaceMap), boundAliasFunction);
     }
 
     private static class SlotReplacer extends DefaultExpressionRewriter<Map<SlotReference, Expression>> {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.udf;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.ReflectionUtils;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
@@ -32,19 +33,19 @@ import java.util.stream.Collectors;
  * function builder for java udaf
  */
 public class JavaUdafBuilder extends UdfBuilder {
-    private final JavaUdaf udf;
+    private final JavaUdaf udaf;
     private final int arity;
     private final boolean isVarArgs;
 
-    public JavaUdafBuilder(JavaUdaf udf) {
-        this.udf = udf;
-        this.isVarArgs = udf.hasVarArguments();
-        this.arity = udf.arity();
+    public JavaUdafBuilder(JavaUdaf udaf) {
+        this.udaf = udaf;
+        this.isVarArgs = udaf.hasVarArguments();
+        this.arity = udaf.arity();
     }
 
     @Override
     public List<DataType> getArgTypes() {
-        return Suppliers.memoize(() -> udf.getSignatures().get(0).argumentsTypes.stream()
+        return Suppliers.memoize(() -> udaf.getSignatures().get(0).argumentsTypes.stream()
                 .map(DataType.class::cast)
                 .collect(Collectors.toList())).get();
     }
@@ -71,7 +72,11 @@ public class JavaUdafBuilder extends UdfBuilder {
     }
 
     @Override
-    public BoundFunction build(String name, List<?> arguments) {
-        return udf.withChildren(arguments.stream().map(Expression.class::cast).collect(Collectors.toList()));
+    public Pair<JavaUdaf, JavaUdaf> build(String name, List<?> arguments) {
+        return Pair.ofSame((JavaUdaf) udaf.withChildren(
+                arguments.stream()
+                        .map(Expression.class::cast)
+                        .collect(Collectors.toList()))
+        );
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.udf;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.ReflectionUtils;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
@@ -73,14 +74,14 @@ public class JavaUdfBuilder extends UdfBuilder {
     }
 
     @Override
-    public BoundFunction build(String name, List<?> arguments) {
+    public Pair<JavaUdf, JavaUdf> build(String name, List<?> arguments) {
         List<Expression> exprs = arguments.stream().map(Expression.class::cast).collect(Collectors.toList());
         List<DataType> argTypes = udf.getSignatures().get(0).argumentsTypes;
 
         List<Expression> processedExprs = Lists.newArrayList();
         for (int i = 0; i < exprs.size(); ++i) {
-            processedExprs.add(TypeCoercionUtils.castIfNotSameType(exprs.get(i), ((DataType) argTypes.get(i))));
+            processedExprs.add(TypeCoercionUtils.castIfNotSameType(exprs.get(i), argTypes.get(i)));
         }
-        return udf.withChildren(processedExprs);
+        return Pair.ofSame(udf.withChildren(processedExprs));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.coercion.DateLikeType;
 import org.apache.doris.nereids.util.DateTimeFormatterUtils;
 import org.apache.doris.nereids.util.DateUtils;
-import org.apache.doris.nereids.util.StandardDateFormat;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -365,12 +364,36 @@ public class DateLiteral extends Literal {
 
     @Override
     public String getStringValue() {
+        if (0 <= year && year <= 9999 && 0 <= month && month <= 99 && 0 <= day && day <= 99) {
+            char[] format = new char[] {'0', '0', '0', '0', '-', '0', '0', '-', '0', '0'};
+            int offset = 3;
+            long year = this.year;
+            while (year > 0) {
+                format[offset--] = (char) ('0' + (year % 10));
+                year /= 10;
+            }
+
+            offset = 6;
+            long month = this.month;
+            while (month > 0) {
+                format[offset--] = (char) ('0' + (month % 10));
+                month /= 10;
+            }
+
+            offset = 9;
+            long day = this.day;
+            while (day > 0) {
+                format[offset--] = (char) ('0' + (day % 10));
+                day /= 10;
+            }
+            return String.valueOf(format);
+        }
         return String.format("%04d-%02d-%02d", year, month, day);
     }
 
     @Override
     public String toSql() {
-        return String.format("'%s'", toString());
+        return "'" + getStringValue() + "'";
     }
 
     @Override
@@ -380,7 +403,7 @@ public class DateLiteral extends Literal {
 
     @Override
     public String toString() {
-        return String.format("%04d-%02d-%02d", year, month, day);
+        return getStringValue();
     }
 
     @Override
@@ -401,22 +424,19 @@ public class DateLiteral extends Literal {
     }
 
     public Expression plusDays(long days) {
-        return fromJavaDateType(DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusDays(days));
+        return fromJavaDateType(toJavaDateType().plusDays(days));
     }
 
     public Expression plusMonths(long months) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusMonths(months));
+        return fromJavaDateType(toJavaDateType().plusMonths(months));
     }
 
     public Expression plusWeeks(long weeks) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusWeeks(weeks));
+        return fromJavaDateType(toJavaDateType().plusWeeks(weeks));
     }
 
     public Expression plusYears(long years) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusYears(years));
+        return fromJavaDateType(toJavaDateType().plusYears(years));
     }
 
     public LocalDateTime toJavaDateType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
@@ -25,7 +25,6 @@ import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.coercion.DateLikeType;
 import org.apache.doris.nereids.util.DateUtils;
-import org.apache.doris.nereids.util.StandardDateFormat;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -195,16 +194,63 @@ public class DateTimeLiteral extends DateLiteral {
 
     @Override
     public String toSql() {
-        return String.format("'%s'", toString());
+        return "'" + getStringValue() + "'";
     }
 
     @Override
     public String toString() {
-        return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+        return getStringValue();
     }
 
     @Override
     public String getStringValue() {
+        if (0 <= year && year <= 9999 && 0 <= month && month <= 99 && 0 <= day && day <= 99
+                && 0 <= hour && hour <= 99 && 0 <= minute && minute <= 99 && 0 <= second && second <= 99) {
+            char[] format = new char[] {
+                    '0', '0', '0', '0', '-', '0', '0', '-', '0', '0', ' ', '0', '0', ':', '0', '0', ':', '0', '0'};
+            int offset = 3;
+            long year = this.year;
+            while (year > 0) {
+                format[offset--] = (char) ('0' + (year % 10));
+                year /= 10;
+            }
+
+            offset = 6;
+            long month = this.month;
+            while (month > 0) {
+                format[offset--] = (char) ('0' + (month % 10));
+                month /= 10;
+            }
+
+            offset = 9;
+            long day = this.day;
+            while (day > 0) {
+                format[offset--] = (char) ('0' + (day % 10));
+                day /= 10;
+            }
+
+            offset = 12;
+            long hour = this.hour;
+            while (hour > 0) {
+                format[offset--] = (char) ('0' + (hour % 10));
+                hour /= 10;
+            }
+
+            offset = 15;
+            long minute = this.minute;
+            while (minute > 0) {
+                format[offset--] = (char) ('0' + (minute % 10));
+                minute /= 10;
+            }
+
+            offset = 18;
+            long second = this.second;
+            while (second > 0) {
+                format[offset--] = (char) ('0' + (second % 10));
+                second /= 10;
+            }
+            return String.valueOf(format);
+        }
         return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
     }
 
@@ -213,39 +259,32 @@ public class DateTimeLiteral extends DateLiteral {
         return new org.apache.doris.analysis.DateLiteral(year, month, day, hour, minute, second, Type.DATETIME);
     }
 
-    public Expression plusYears(long years) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusYears(years));
+    public Expression plusDays(long days) {
+        return fromJavaDateType(toJavaDateType().plusDays(days));
     }
 
     public Expression plusMonths(long months) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusMonths(months));
+        return fromJavaDateType(toJavaDateType().plusMonths(months));
     }
 
     public Expression plusWeeks(long weeks) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusWeeks(weeks));
+        return fromJavaDateType(toJavaDateType().plusWeeks(weeks));
     }
 
-    public Expression plusDays(long days) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusDays(days));
+    public Expression plusYears(long years) {
+        return fromJavaDateType(toJavaDateType().plusYears(years));
     }
 
     public Expression plusHours(long hours) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusHours(hours));
+        return fromJavaDateType(toJavaDateType().plusHours(hours));
     }
 
     public Expression plusMinutes(long minutes) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusMinutes(minutes));
+        return fromJavaDateType(toJavaDateType().plusMinutes(minutes));
     }
 
     public Expression plusSeconds(long seconds) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER, getStringValue()).plusSeconds(seconds));
+        return fromJavaDateType(toJavaDateType().plusSeconds(seconds));
     }
 
     public long getHour() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -110,10 +110,72 @@ public class DateTimeV2Literal extends DateTimeLiteral {
 
     @Override
     public String getStringValue() {
+        int scale = getDataType().getScale();
+        if (scale <= 0) {
+            return super.getStringValue();
+        }
+
+        if (0 <= year && year <= 9999 && 0 <= month && month <= 99 && 0 <= day && day <= 99
+                && 0 <= hour && hour <= 99 && 0 <= minute && minute <= 99 && 0 <= second && second <= 99
+                && 0 <= microSecond && microSecond <= MAX_MICROSECOND) {
+            char[] format = new char[] {
+                    '0', '0', '0', '0', '-', '0', '0', '-', '0', '0', ' ', '0', '0', ':', '0', '0', ':', '0', '0',
+                    '.', '0', '0', '0', '0', '0', '0'};
+            int offset = 3;
+            long year = this.year;
+            while (year > 0) {
+                format[offset--] = (char) ('0' + (year % 10));
+                year /= 10;
+            }
+
+            offset = 6;
+            long month = this.month;
+            while (month > 0) {
+                format[offset--] = (char) ('0' + (month % 10));
+                month /= 10;
+            }
+
+            offset = 9;
+            long day = this.day;
+            while (day > 0) {
+                format[offset--] = (char) ('0' + (day % 10));
+                day /= 10;
+            }
+
+            offset = 12;
+            long hour = this.hour;
+            while (hour > 0) {
+                format[offset--] = (char) ('0' + (hour % 10));
+                hour /= 10;
+            }
+
+            offset = 15;
+            long minute = this.minute;
+            while (minute > 0) {
+                format[offset--] = (char) ('0' + (minute % 10));
+                minute /= 10;
+            }
+
+            offset = 18;
+            long second = this.second;
+            while (second > 0) {
+                format[offset--] = (char) ('0' + (second % 10));
+                second /= 10;
+            }
+
+            offset = 19 + scale;
+            long microSecond = (int) (this.microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - scale));
+            while (microSecond > 0) {
+                format[offset--] = (char) ('0' + (microSecond % 10));
+                microSecond /= 10;
+            }
+            return String.valueOf(format, 0, 20 + scale);
+        }
+
         return String.format("%04d-%02d-%02d %02d:%02d:%02d"
-                        + (getDataType().getScale() > 0 ? ".%0" + getDataType().getScale() + "d" : ""),
+                        + (scale > 0 ? ".%0" + scale + "d" : ""),
                 year, month, day, hour, minute, second,
-                (int) (microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - getDataType().getScale())));
+                (int) (microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - scale)));
     }
 
     public String getMicrosecondString() {
@@ -124,59 +186,36 @@ public class DateTimeV2Literal extends DateTimeLiteral {
                 (int) (microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - getDataType().getScale())));
     }
 
-    @Override
-    public Expression plusYears(long years) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusYears(years), getDataType().getScale());
-    }
-
-    @Override
-    public Expression plusMonths(long months) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusMonths(months), getDataType().getScale());
-    }
-
-    @Override
-    public Expression plusWeeks(long weeks) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusWeeks(weeks), getDataType().getScale());
-    }
-
-    @Override
     public Expression plusDays(long days) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusDays(days), getDataType().getScale());
+        return fromJavaDateType(toJavaDateType().plusDays(days), getDataType().getScale());
     }
 
-    @Override
+    public Expression plusMonths(long months) {
+        return fromJavaDateType(toJavaDateType().plusMonths(months), getDataType().getScale());
+    }
+
+    public Expression plusWeeks(long weeks) {
+        return fromJavaDateType(toJavaDateType().plusWeeks(weeks), getDataType().getScale());
+    }
+
+    public Expression plusYears(long years) {
+        return fromJavaDateType(toJavaDateType().plusYears(years), getDataType().getScale());
+    }
+
     public Expression plusHours(long hours) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusHours(hours), getDataType().getScale());
+        return fromJavaDateType(toJavaDateType().plusHours(hours), getDataType().getScale());
     }
 
-    @Override
     public Expression plusMinutes(long minutes) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusMinutes(minutes), getDataType().getScale());
+        return fromJavaDateType(toJavaDateType().plusMinutes(minutes), getDataType().getScale());
     }
 
-    @Override
     public Expression plusSeconds(long seconds) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getStringValue())
-                        .plusSeconds(seconds), getDataType().getScale());
+        return fromJavaDateType(toJavaDateType().plusSeconds(seconds), getDataType().getScale());
     }
 
     public Expression plusMicroSeconds(long microSeconds) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_TIME_FORMATTER_TO_MICRO_SECOND, getFullMicroSecondValue())
-                        .plusNanos(microSeconds * 1000L), getDataType().getScale());
+        return fromJavaDateType(toJavaDateType().plusNanos(microSeconds * 1000L), getDataType().getScale());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateV2Literal.java
@@ -24,8 +24,6 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DateV2Type;
-import org.apache.doris.nereids.util.DateUtils;
-import org.apache.doris.nereids.util.StandardDateFormat;
 
 import java.time.LocalDateTime;
 
@@ -53,22 +51,19 @@ public class DateV2Literal extends DateLiteral {
     }
 
     public Expression plusDays(long days) {
-        return fromJavaDateType(DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusDays(days));
+        return fromJavaDateType(toJavaDateType().plusDays(days));
     }
 
     public Expression plusMonths(long months) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusMonths(months));
+        return fromJavaDateType(toJavaDateType().plusMonths(months));
     }
 
     public Expression plusWeeks(long weeks) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusWeeks(weeks));
+        return fromJavaDateType(toJavaDateType().plusWeeks(weeks));
     }
 
     public Expression plusYears(long years) {
-        return fromJavaDateType(
-                DateUtils.getTime(StandardDateFormat.DATE_FORMATTER, getStringValue()).plusYears(years));
+        return fromJavaDateType(toJavaDateType().plusYears(years));
     }
 
     public static Expression fromJavaDateType(LocalDateTime dateTime) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PlanType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PlanType.java
@@ -27,6 +27,7 @@ public enum PlanType {
 
     // logical plans
     // logical relations
+    LOGICAL_SQL_CACHE,
     LOGICAL_BOUND_RELATION,
     LOGICAL_CTE_CONSUMER,
     LOGICAL_FILE_SCAN,
@@ -83,6 +84,7 @@ public enum PlanType {
 
     // physical plans
     // physical relations
+    PHYSICAL_SQL_CACHE,
     PHYSICAL_CTE_CONSUMER,
     PHYSICAL_EMPTY_RELATION,
     PHYSICAL_ES_SCAN,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/TreeStringPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/TreeStringPlan.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.LineIterator;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Optional;
+import java.util.Stack;
+
+/** TreeStringPlan */
+public interface TreeStringPlan {
+    String getChildrenTreeString();
+
+    /** parseTreeStringNode */
+    default Optional<TreeStringNode> parseTreeStringNode() {
+        String treeString = getChildrenTreeString();
+        LineIterator lineIt = new LineIterator(new StringReader(treeString));
+
+        if (!lineIt.hasNext()) {
+            return Optional.empty();
+        }
+
+        Stack<ParseTreeStringNodeContext> parseStack = new Stack<>();
+        parseStack.push(new ParseTreeStringNodeContext(lineIt.next()));
+
+        while (lineIt.hasNext()) {
+            String line = lineIt.next();
+            int level = getLevel(line);
+            while (parseStack.size() >= level) {
+                ParseTreeStringNodeContext child = parseStack.pop();
+                parseStack.peek().children.add(
+                        new TreeStringNode(child.currentString, ImmutableList.copyOf(child.children))
+                );
+            }
+            parseStack.push(new ParseTreeStringNodeContext(line.substring((level - 1) * 3)));
+        }
+
+        while (parseStack.size() > 1) {
+            ParseTreeStringNodeContext child = parseStack.pop();
+            parseStack.peek().children.add(
+                    new TreeStringNode(child.currentString, ImmutableList.copyOf(child.children))
+            );
+        }
+
+        ParseTreeStringNodeContext top = parseStack.pop();
+        return Optional.of(new TreeStringNode(top.currentString, ImmutableList.copyOf(top.children)));
+    }
+
+    /** TreeStringNode */
+    class TreeStringNode {
+        /** currentString */
+        public final String currentString;
+        /** children */
+        public final List<TreeStringNode> children;
+
+        public TreeStringNode(String currentString, List<TreeStringNode> children) {
+            this.currentString = currentString;
+            this.children = children;
+        }
+
+        @Override
+        public String toString() {
+            return currentString.trim();
+        }
+    }
+
+    /** ParseTreeStringNodeContext */
+    class ParseTreeStringNodeContext {
+        /** currentString */
+        public final String currentString;
+        /** children */
+        public final List<TreeStringNode> children;
+
+        public ParseTreeStringNodeContext(String currentString) {
+            this.currentString = currentString;
+            this.children = Lists.newArrayList();
+        }
+    }
+
+    /** getLevel */
+    static int getLevel(String currentString) {
+        int prefix = 0;
+        for (int i = 0; i < currentString.length(); i++) {
+            char c = currentString.charAt(i);
+            if (c == ' ' || c == '|' || c == '-' || c == '+') {
+                prefix++;
+            } else {
+                break;
+            }
+        }
+        return prefix / 3 + 1;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/SqlCache.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.algebra;
+
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
+import org.apache.doris.qe.cache.CacheAnalyzer;
+
+/** SqlCache */
+public interface SqlCache {
+    /** computeChild */
+    static <P extends PhysicalPlan> P computeChild(CacheAnalyzer cacheAnalyzer) {
+        NereidsPlanner nereidsPlanner = (NereidsPlanner) cacheAnalyzer.getPlanner();
+        PhysicalPlan physicalPlan = nereidsPlanner.getPhysicalPlan();
+        while (physicalPlan instanceof PhysicalSqlCache) {
+            physicalPlan = (PhysicalPlan) physicalPlan.child(0);
+        }
+        return (P) physicalPlan;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSqlCache.java
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.FdItem;
+import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.TreeStringPlan;
+import org.apache.doris.nereids.trees.plans.algebra.SqlCache;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.proto.InternalService;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** LogicalSqlCache */
+public class LogicalSqlCache extends LogicalLeaf implements SqlCache, TreeStringPlan {
+    private final TUniqueId queryId;
+    private final List<String> columnLabels;
+    private final List<Expr> resultExprs;
+    private final List<InternalService.PCacheValue> cacheValues;
+    private final String backendAddress;
+    private final String planBody;
+
+    /** LogicalSqlCache */
+    public LogicalSqlCache(TUniqueId queryId,
+            List<String> columnLabels, List<Expr> resultExprs,
+            List<InternalService.PCacheValue> cacheValues, String backendAddress, String planBody) {
+        super(PlanType.LOGICAL_SQL_CACHE, Optional.empty(), Optional.empty());
+        this.queryId = Objects.requireNonNull(queryId, "queryId can not be null");
+        this.columnLabels = Objects.requireNonNull(columnLabels, "columnLabels can not be null");
+        this.resultExprs = Objects.requireNonNull(resultExprs, "resultExprs can not be null");
+        this.cacheValues = Objects.requireNonNull(cacheValues, "cacheValues can not be null");
+        this.backendAddress = Objects.requireNonNull(backendAddress, "backendAddress can not be null");
+        this.planBody = Objects.requireNonNull(planBody, "planBody can not be null");
+    }
+
+    public TUniqueId getQueryId() {
+        return queryId;
+    }
+
+    public List<InternalService.PCacheValue> getCacheValues() {
+        return cacheValues;
+    }
+
+    public String getBackendAddress() {
+        return backendAddress;
+    }
+
+    public List<String> getColumnLabels() {
+        return columnLabels;
+    }
+
+    public List<Expr> getResultExprs() {
+        return resultExprs;
+    }
+
+    public String getPlanBody() {
+        return planBody;
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toSqlString("LogicalSqlCache[" + id.asInt() + "]",
+                "queryId", DebugUtil.printId(queryId)
+        );
+    }
+
+    @Override
+    public Plan withChildren(List<Plan> children) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalSqlCache(this, context);
+    }
+
+    @Override
+    public List<? extends Expression> getExpressions() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties, List<Plan> children) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Slot> computeOutput() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getChildrenTreeString() {
+        return planBody;
+    }
+
+    @Override
+    public ImmutableSet<FdItem> computeFdItems() {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public void computeUnique(Builder fdBuilder) {
+
+    }
+
+    @Override
+    public void computeUniform(Builder fdBuilder) {
+
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.physical;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.TreeStringPlan;
+import org.apache.doris.nereids.trees.plans.algebra.SqlCache;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.proto.InternalService;
+import org.apache.doris.statistics.Statistics;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** PhysicalSqlCache */
+public class PhysicalSqlCache extends PhysicalLeaf implements SqlCache, TreeStringPlan {
+    private final TUniqueId queryId;
+    private final List<String> columnLabels;
+    private final List<Expr> resultExprs;
+    private final List<InternalService.PCacheValue> cacheValues;
+    private final String backendAddress;
+    private final String planBody;
+
+    /** PhysicalSqlCache */
+    public PhysicalSqlCache(TUniqueId queryId,
+            List<String> columnLabels, List<Expr> resultExprs,
+            List<InternalService.PCacheValue> cacheValues, String backendAddress, String planBody) {
+        super(PlanType.PHYSICAL_SQL_CACHE, Optional.empty(),
+                new LogicalProperties(() -> ImmutableList.of(), () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+        this.queryId = Objects.requireNonNull(queryId, "queryId can not be null");
+        this.columnLabels = Objects.requireNonNull(columnLabels, "colNames can not be null");
+        this.resultExprs = Objects.requireNonNull(resultExprs, "resultExprs can not be null");
+        this.cacheValues = Objects.requireNonNull(cacheValues, "cacheValues can not be null");
+        this.backendAddress = Objects.requireNonNull(backendAddress, "backendAddress can not be null");
+        this.planBody = Objects.requireNonNull(planBody, "planBody can not be null");
+    }
+
+    public TUniqueId getQueryId() {
+        return queryId;
+    }
+
+    public List<InternalService.PCacheValue> getCacheValues() {
+        return cacheValues;
+    }
+
+    public String getBackendAddress() {
+        return backendAddress;
+    }
+
+    public List<String> getColumnLabels() {
+        return columnLabels;
+    }
+
+    public List<Expr> getResultExprs() {
+        return resultExprs;
+    }
+
+    public String getPlanBody() {
+        return planBody;
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toSqlString("PhysicalSqlCache[" + id.asInt() + "]",
+                "queryId", DebugUtil.printId(queryId),
+                "backend", backendAddress
+        );
+    }
+
+    @Override
+    public Plan withChildren(List<Plan> children) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitPhysicalSqlCache(this, context);
+    }
+
+    @Override
+    public List<? extends Expression> getExpressions() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties, List<Plan> children) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Slot> computeOutput() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getChildrenTreeString() {
+        return planBody;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
@@ -45,6 +45,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSelectHint;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSetOperation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
@@ -73,6 +74,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRepeat;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSink;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalUnion;
@@ -128,6 +130,9 @@ public abstract class PlanVisitor<R, C> implements CommandVisitor<R, C>, Relatio
     // *******************************
     // Logical plans
     // *******************************
+    public R visitLogicalSqlCache(LogicalSqlCache sqlCache, C context) {
+        return visit(sqlCache, context);
+    }
 
     public R visitLogicalAggregate(LogicalAggregate<? extends Plan> aggregate, C context) {
         return visit(aggregate, context);
@@ -248,6 +253,9 @@ public abstract class PlanVisitor<R, C> implements CommandVisitor<R, C>, Relatio
     // *******************************
     // Physical plans
     // *******************************
+    public R visitPhysicalSqlCache(PhysicalSqlCache sqlCache, C context) {
+        return visit(sqlCache, context);
+    }
 
     public R visitPhysicalHashAggregate(PhysicalHashAggregate<? extends Plan> agg, C context) {
         return visit(agg, context);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.InsertStmt;
 import org.apache.doris.analysis.KillStmt;
 import org.apache.doris.analysis.LiteralExpr;
@@ -37,6 +38,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.NotImplementedException;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.SqlParserUtils;
@@ -49,6 +51,7 @@ import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.MysqlPacket;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.MysqlServerStatusFlag;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.nereids.exceptions.ParseException;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -56,10 +59,14 @@ import org.apache.doris.nereids.minidump.MinidumpUtils;
 import org.apache.doris.nereids.parser.Dialect;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.stats.StatsErrorEstimator;
+import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.plugin.DialectConverterPlugin;
 import org.apache.doris.plugin.PluginMgr;
 import org.apache.doris.proto.Data;
 import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TMasterOpRequest;
 import org.apache.doris.thrift.TMasterOpResult;
@@ -67,6 +74,8 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -80,6 +89,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -231,33 +241,46 @@ public abstract class ConnectProcessor {
         String sqlHash = DigestUtils.md5Hex(convertedStmt);
         ctx.setSqlHash(sqlHash);
 
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        boolean wantToParseSqlFromSqlCache = sessionVariable.isEnableNereidsPlanner()
+                && CacheAnalyzer.canUseSqlCache(sessionVariable);
         List<StatementBase> stmts = null;
         Exception nereidsParseException = null;
         long parseSqlStartTime = System.currentTimeMillis();
+        List<StatementBase> cachedStmts = null;
         // Nereids do not support prepare and execute now, so forbid prepare command, only process query command
-        if (mysqlCommand == MysqlCommand.COM_QUERY && ctx.getSessionVariable().isEnableNereidsPlanner()) {
-            try {
-                stmts = new NereidsParser().parseSQL(convertedStmt, ctx.getSessionVariable());
-            } catch (NotSupportedException e) {
-                // Parse sql failed, audit it and return
-                handleQueryException(e, convertedStmt, null, null);
-                return;
-            } catch (ParseException e) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Nereids parse sql failed. Reason: {}. Statement: \"{}\".",
-                            e.getMessage(), convertedStmt);
+        if (mysqlCommand == MysqlCommand.COM_QUERY && sessionVariable.isEnableNereidsPlanner()) {
+            if (wantToParseSqlFromSqlCache) {
+                cachedStmts = parseFromSqlCache(originStmt);
+                if (cachedStmts != null) {
+                    stmts = cachedStmts;
                 }
-                // ATTN: Do not set nereidsParseException in this case.
-                // Because ParseException means the sql is not supported by Nereids.
-                // It should be parsed by old parser, so not setting nereidsParseException to avoid
-                // suppressing the exception thrown by old parser.
-            } catch (Exception e) {
-                // TODO: We should catch all exception here until we support all query syntax.
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Nereids parse sql failed with other exception. Reason: {}. Statement: \"{}\".",
-                            e.getMessage(), convertedStmt);
+            }
+
+            if (cachedStmts == null) {
+                try {
+                    stmts = new NereidsParser().parseSQL(convertedStmt, sessionVariable);
+                } catch (NotSupportedException e) {
+                    // Parse sql failed, audit it and return
+                    handleQueryException(e, convertedStmt, null, null);
+                    return;
+                } catch (ParseException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Nereids parse sql failed. Reason: {}. Statement: \"{}\".",
+                                e.getMessage(), convertedStmt);
+                    }
+                    // ATTN: Do not set nereidsParseException in this case.
+                    // Because ParseException means the sql is not supported by Nereids.
+                    // It should be parsed by old parser, so not setting nereidsParseException to avoid
+                    // suppressing the exception thrown by old parser.
+                } catch (Exception e) {
+                    // TODO: We should catch all exception here until we support all query syntax.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Nereids parse sql failed with other exception. Reason: {}. Statement: \"{}\".",
+                                e.getMessage(), convertedStmt);
+                    }
+                    nereidsParseException = e;
                 }
-                nereidsParseException = e;
             }
         }
 
@@ -292,56 +315,102 @@ public abstract class ConnectProcessor {
         boolean usingOrigSingleStmt = origSingleStmtList != null && origSingleStmtList.size() == stmts.size();
         for (int i = 0; i < stmts.size(); ++i) {
             String auditStmt = usingOrigSingleStmt ? origSingleStmtList.get(i) : convertedStmt;
-
-            ctx.getState().reset();
-            if (i > 0) {
-                ctx.resetReturnRows();
-            }
-
-            StatementBase parsedStmt = stmts.get(i);
-            parsedStmt.setOrigStmt(new OriginStatement(convertedStmt, i));
-            parsedStmt.setUserInfo(ctx.getCurrentUserIdentity());
-            executor = new StmtExecutor(ctx, parsedStmt);
-            executor.getProfile().getSummaryProfile().setParseSqlStartTime(parseSqlStartTime);
-            executor.getProfile().getSummaryProfile().setParseSqlFinishTime(parseSqlFinishTime);
-            ctx.setExecutor(executor);
-
             try {
-                executor.execute();
-                if (connectType.equals(ConnectType.MYSQL)) {
-                    if (i != stmts.size() - 1) {
-                        ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
-                        if (ctx.getState().getStateType() != MysqlStateType.ERR) {
-                            finalizeCommand();
+                ctx.getState().reset();
+                if (i > 0) {
+                    ctx.resetReturnRows();
+                }
+
+                StatementBase parsedStmt = stmts.get(i);
+                parsedStmt.setOrigStmt(new OriginStatement(convertedStmt, i));
+                parsedStmt.setUserInfo(ctx.getCurrentUserIdentity());
+                executor = new StmtExecutor(ctx, parsedStmt);
+                executor.getProfile().getSummaryProfile().setParseSqlStartTime(parseSqlStartTime);
+                executor.getProfile().getSummaryProfile().setParseSqlFinishTime(parseSqlFinishTime);
+                ctx.setExecutor(executor);
+
+                try {
+                    executor.execute();
+                    if (connectType.equals(ConnectType.MYSQL)) {
+                        if (i != stmts.size() - 1) {
+                            ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
+                            if (ctx.getState().getStateType() != MysqlStateType.ERR) {
+                                finalizeCommand();
+                            }
+                        }
+                    } else if (connectType.equals(ConnectType.ARROW_FLIGHT_SQL)) {
+                        if (!ctx.isReturnResultFromLocal()) {
+                            returnResultFromRemoteExecutor.add(executor);
+                        }
+                        Preconditions.checkState(ctx.getFlightSqlChannel().resultNum() <= 1);
+                        if (ctx.getFlightSqlChannel().resultNum() == 1 && i != stmts.size() - 1) {
+                            String errMsg = "Only be one stmt that returns the result and it is at the end. "
+                                    + "stmts.size(): " + stmts.size();
+                            LOG.warn(errMsg);
+                            ctx.getState().setError(ErrorCode.ERR_ARROW_FLIGHT_SQL_MUST_ONLY_RESULT_STMT, errMsg);
+                            ctx.getState().setErrType(QueryState.ErrType.OTHER_ERR);
+                            break;
                         }
                     }
-                } else if (connectType.equals(ConnectType.ARROW_FLIGHT_SQL)) {
-                    if (!ctx.isReturnResultFromLocal()) {
-                        returnResultFromRemoteExecutor.add(executor);
-                    }
-                    Preconditions.checkState(ctx.getFlightSqlChannel().resultNum() <= 1);
-                    if (ctx.getFlightSqlChannel().resultNum() == 1 && i != stmts.size() - 1) {
-                        String errMsg = "Only be one stmt that returns the result and it is at the end. stmts.size(): "
-                                + stmts.size();
-                        LOG.warn(errMsg);
-                        ctx.getState().setError(ErrorCode.ERR_ARROW_FLIGHT_SQL_MUST_ONLY_RESULT_STMT, errMsg);
-                        ctx.getState().setErrType(QueryState.ErrType.OTHER_ERR);
+                    auditAfterExec(auditStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(),
+                            true);
+                    // execute failed, skip remaining stmts
+                    if (ctx.getState().getStateType() == MysqlStateType.ERR) {
                         break;
                     }
+                } catch (Throwable throwable) {
+                    handleQueryException(throwable, auditStmt, executor.getParsedStmt(),
+                            executor.getQueryStatisticsForAuditLog());
+                    // execute failed, skip remaining stmts
+                    throw throwable;
                 }
-                auditAfterExec(auditStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(),
-                        true);
-                // execute failed, skip remaining stmts
-                if (ctx.getState().getStateType() == MysqlStateType.ERR) {
-                    break;
+            } finally {
+                StatementContext statementContext = ctx.getStatementContext();
+                if (statementContext != null) {
+                    statementContext.close();
                 }
-            } catch (Throwable throwable) {
-                handleQueryException(throwable, auditStmt, executor.getParsedStmt(),
-                        executor.getQueryStatisticsForAuditLog());
-                // execute failed, skip remaining stmts
-                throw throwable;
             }
         }
+    }
+
+    private List<StatementBase> parseFromSqlCache(String originStmt) {
+        StatementContext statementContext = new StatementContext(ctx, new OriginStatement(originStmt, 0));
+        ctx.setStatementContext(statementContext);
+        try {
+            Optional<Pair<ExplainOptions, String>> explainPlan = NereidsParser.tryParseExplainPlan(originStmt);
+            String cacheSqlKey = originStmt;
+            if (explainPlan.isPresent()) {
+                cacheSqlKey = explainPlan.get().second;
+            }
+            Env env = ctx.getEnv();
+            Optional<LogicalSqlCache> sqlCachePlanOpt = env.getSqlCacheManager().tryParseSql(ctx, cacheSqlKey);
+            if (sqlCachePlanOpt.isPresent()) {
+                LogicalSqlCache logicalSqlCache = sqlCachePlanOpt.get();
+                LogicalPlan parsedPlan = logicalSqlCache;
+                if (explainPlan.isPresent()) {
+                    ExplainOptions explainOptions = explainPlan.get().first;
+                    parsedPlan = new ExplainCommand(
+                            explainOptions.getExplainLevel(),
+                            parsedPlan,
+                            explainOptions.showPlanProcess()
+                    );
+                }
+
+                LogicalPlanAdapter logicalPlanAdapter = new LogicalPlanAdapter(parsedPlan, statementContext);
+                logicalPlanAdapter.setColLabels(
+                        Lists.newArrayList(logicalSqlCache.getColumnLabels())
+                );
+                logicalPlanAdapter.setResultExprs(logicalSqlCache.getResultExprs());
+                logicalPlanAdapter.setOrigStmt(statementContext.getOriginStatement());
+                logicalPlanAdapter.setUserInfo(ctx.getCurrentUserIdentity());
+                return ImmutableList.of(logicalPlanAdapter);
+            }
+        } catch (Throwable t) {
+            LOG.warn("Parse from sql cache failed: " + t.getMessage(), t);
+        } finally {
+            statementContext.releasePlannerResources();
+        }
+        return null;
     }
 
     private String convertOriginStmt(String originStmt) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -106,6 +106,7 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.NereidsException;
+import org.apache.doris.common.NereidsSqlCacheManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.profile.Profile;
@@ -152,6 +153,7 @@ import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableComma
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
 import org.apache.doris.planner.DataSink;
 import org.apache.doris.planner.GroupCommitPlanner;
 import org.apache.doris.planner.GroupCommitScanNode;
@@ -177,6 +179,7 @@ import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.cache.Cache;
 import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.qe.cache.CacheAnalyzer.CacheMode;
+import org.apache.doris.qe.cache.SqlCache;
 import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.rewrite.mvrewrite.MVSelectFailedException;
 import org.apache.doris.rpc.BackendServiceProxy;
@@ -1666,15 +1669,30 @@ public class StmtExecutor {
      */
     private void handleCacheStmt(CacheAnalyzer cacheAnalyzer, MysqlChannel channel)
             throws Exception {
-        InternalService.PFetchCacheResult cacheResult = cacheAnalyzer.getCacheData();
-        if (cacheResult == null) {
-            if (ConnectContext.get() != null
-                    && !ConnectContext.get().getSessionVariable().testQueryCacheHit.equals("none")) {
-                throw new UserException("The variable test_query_cache_hit is set to "
-                        + ConnectContext.get().getSessionVariable().testQueryCacheHit
-                        + ", but the query cache is not hit.");
+        InternalService.PFetchCacheResult cacheResult = null;
+        boolean wantToParseSqlForSqlCache = planner instanceof NereidsPlanner
+                && CacheAnalyzer.canUseSqlCache(context.getSessionVariable());
+        try {
+            cacheResult = cacheAnalyzer.getCacheData();
+            if (cacheResult == null) {
+                if (ConnectContext.get() != null
+                        && !ConnectContext.get().getSessionVariable().testQueryCacheHit.equals("none")) {
+                    throw new UserException("The variable test_query_cache_hit is set to "
+                            + ConnectContext.get().getSessionVariable().testQueryCacheHit
+                            + ", but the query cache is not hit.");
+                }
+            }
+        } finally {
+            if (wantToParseSqlForSqlCache) {
+                String originStmt = parsedStmt.getOrigStmt().originStmt;
+                NereidsSqlCacheManager sqlCacheManager = context.getEnv().getSqlCacheManager();
+                if (cacheResult != null) {
+                    sqlCacheManager.tryAddCache(context, originStmt, cacheAnalyzer, false);
+                }
             }
         }
+
+
         CacheMode mode = cacheAnalyzer.getCacheMode();
         Queriable queryStmt = (Queriable) parsedStmt;
         boolean isSendFields = false;
@@ -1743,13 +1761,23 @@ public class StmtExecutor {
             channel = context.getMysqlChannel();
         }
         boolean isOutfileQuery = queryStmt.hasOutFileClause();
+        if (parsedStmt instanceof LogicalPlanAdapter) {
+            LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) parsedStmt;
+            LogicalPlan logicalPlan = logicalPlanAdapter.getLogicalPlan();
+            if (logicalPlan instanceof org.apache.doris.nereids.trees.plans.algebra.SqlCache) {
+                NereidsPlanner nereidsPlanner = (NereidsPlanner) planner;
+                PhysicalSqlCache physicalSqlCache = (PhysicalSqlCache) nereidsPlanner.getPhysicalPlan();
+                sendCachedValues(channel, physicalSqlCache.getCacheValues(), logicalPlanAdapter, false, true);
+                return;
+            }
+        }
 
         // Sql and PartitionCache
         CacheAnalyzer cacheAnalyzer = new CacheAnalyzer(context, parsedStmt, planner);
         // TODO support arrow flight sql
-        if (channel != null && cacheAnalyzer.enableCache() && !isOutfileQuery
-                && context.getSessionVariable().getSqlSelectLimit() < 0
-                && context.getSessionVariable().getDefaultOrderByLimit() < 0) {
+        // NOTE: If you want to add another condition about SessionVariable, please consider whether
+        // add to CacheAnalyzer.commonCacheCondition
+        if (channel != null && !isOutfileQuery && CacheAnalyzer.canUseCache(context.getSessionVariable())) {
             if (queryStmt instanceof QueryStmt || queryStmt instanceof LogicalPlanAdapter) {
                 handleCacheStmt(cacheAnalyzer, channel);
                 LOG.info("Query {} finished", DebugUtil.printId(context.queryId));
@@ -1864,6 +1892,16 @@ public class StmtExecutor {
                 }
 
                 cacheAnalyzer.updateCache();
+
+                Cache cache = cacheAnalyzer.getCache();
+                if (cache instanceof SqlCache && !cache.isDisableCache() && planner instanceof NereidsPlanner) {
+                    String originStmt = parsedStmt.getOrigStmt().originStmt;
+                    LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) queryStmt;
+                    boolean currentMissParseSqlFromSqlCache = !(logicalPlanAdapter.getLogicalPlan()
+                            instanceof org.apache.doris.nereids.trees.plans.algebra.SqlCache);
+                    context.getEnv().getSqlCacheManager().tryAddCache(
+                            context, originStmt, cacheAnalyzer, currentMissParseSqlFromSqlCache);
+                }
             }
             if (!isSendFields) {
                 if (!isOutfileQuery) {
@@ -1887,7 +1925,7 @@ public class StmtExecutor {
             context.getState().setEof();
             profile.getSummaryProfile().setQueryFetchResultFinishTime();
         } catch (Exception e) {
-            // notify all be cancel runing fragment
+            // notify all be cancel running fragment
             // in some case may block all fragment handle threads
             // details see issue https://github.com/apache/doris/issues/16203
             LOG.warn("cancel fragment query_id:{} cause {}", DebugUtil.printId(context.queryId()), e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
@@ -39,7 +39,7 @@ public abstract class Cache {
     }
 
     protected TUniqueId queryId;
-    protected SelectStmt selectStmt;
+    protected final SelectStmt selectStmt;
     protected RowBatchBuilder rowBatchBuilder;
     protected boolean disableCache = false;
     protected CacheAnalyzer.CacheTable latestTable;
@@ -50,14 +50,15 @@ public abstract class Cache {
     protected Cache(TUniqueId queryId, SelectStmt selectStmt) {
         this.queryId = queryId;
         this.selectStmt = selectStmt;
-        proxy = CacheProxy.getCacheProxy(CacheProxy.CacheProxyType.BE);
-        hitRange = HitRange.None;
+        this.proxy = CacheProxy.getCacheProxy(CacheProxy.CacheProxyType.BE);
+        this.hitRange = HitRange.None;
     }
 
     protected Cache(TUniqueId queryId) {
         this.queryId = queryId;
-        proxy = CacheProxy.getCacheProxy(CacheProxy.CacheProxyType.BE);
-        hitRange = HitRange.None;
+        this.selectStmt = null;
+        this.proxy = CacheProxy.getCacheProxy(CacheProxy.CacheProxyType.BE);
+        this.hitRange = HitRange.None;
     }
 
     public abstract InternalService.PFetchCacheResult getCacheData(Status status);
@@ -80,6 +81,10 @@ public abstract class Cache {
      * Update rowset to cache of be
      */
     public abstract void updateCache();
+
+    public boolean isDisableCache() {
+        return disableCache;
+    }
 
     protected boolean checkRowLimit() {
         if (disableCache || rowBatchBuilder == null) {
@@ -104,5 +109,9 @@ public abstract class Cache {
         } else {
             return true;
         }
+    }
+
+    public CacheProxy getProxy() {
+        return proxy;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -30,6 +30,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.TableRef;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionType;
@@ -40,18 +41,25 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.hive.source.HiveScanNode;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.nereids.SqlCacheContext.FullTableName;
+import org.apache.doris.nereids.SqlCacheContext.ScanTable;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.proto.InternalService;
+import org.apache.doris.proto.Types.PUniqueId;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.RowBatch;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -96,7 +104,10 @@ public class CacheAnalyzer {
     private Column partColumn;
     private CompoundPredicate partitionPredicate;
     private Cache cache;
-    private Set<String> allViewStmtSet;
+    private final Set<String> allViewStmtSet;
+    private String allViewExpandStmtListStr;
+    private Planner planner;
+    private List<ScanTable> scanTables = Lists.newArrayList();
 
     public Cache getCache() {
         return cache;
@@ -106,9 +117,10 @@ public class CacheAnalyzer {
         this.context = context;
         this.queryId = context.queryId();
         this.parsedStmt = parsedStmt;
-        scanNodes = planner.getScanNodes();
-        latestTable = new CacheTable();
-        allViewStmtSet = new HashSet<>();
+        this.scanNodes = planner.getScanNodes();
+        this.latestTable = new CacheTable();
+        this.allViewStmtSet = new HashSet<>();
+        this.planner = planner;
         checkCacheConfig();
     }
 
@@ -117,7 +129,7 @@ public class CacheAnalyzer {
         this.context = context;
         this.parsedStmt = parsedStmt;
         this.scanNodes = scanNodes;
-        allViewStmtSet = new HashSet<>();
+        this.allViewStmtSet = new HashSet<>();
         checkCacheConfig();
     }
 
@@ -134,36 +146,46 @@ public class CacheAnalyzer {
         }
     }
 
+    public TUniqueId getQueryId() {
+        return queryId;
+    }
+
     public CacheMode getCacheMode() {
         return cacheMode;
+    }
+
+    public Planner getPlanner() {
+        return planner;
     }
 
     public class CacheTable implements Comparable<CacheTable> {
         public TableIf table;
         public long latestPartitionId;
-        public long latestVersion;
-        public long latestTime;
+        public long latestPartitionVersion;
+        public long latestPartitionTime;
         public long partitionNum;
         public long sumOfPartitionNum;
 
         public CacheTable() {
             table = null;
             latestPartitionId = 0;
-            latestVersion = 0;
-            latestTime = 0;
+            latestPartitionVersion = 0;
+            latestPartitionTime = 0;
             partitionNum = 0;
             sumOfPartitionNum = 0;
         }
 
         @Override
         public int compareTo(CacheTable table) {
-            return Long.compare(table.latestTime, this.latestTime);
+            return Long.compare(table.latestPartitionTime, this.latestPartitionTime);
         }
 
         public void debug() {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("table {}, partition id {}, ver {}, time {}, partition num {}, sumOfPartitionNum: {}",
-                        table.getName(), latestPartitionId, latestVersion, latestTime, partitionNum, sumOfPartitionNum);
+                LOG.debug("table {}, partition id {}, ver {}, time {},"
+                                + "partition num {}, sumOfPartitionNum: {}",
+                        table.getName(), latestPartitionId, latestPartitionVersion, latestPartitionTime,
+                        partitionNum, sumOfPartitionNum);
             }
         }
     }
@@ -178,6 +200,19 @@ public class CacheAnalyzer {
 
     public boolean enablePartitionCache() {
         return enablePartitionCache;
+    }
+
+    public static boolean canUseCache(SessionVariable sessionVariable) {
+        return (sessionVariable.isEnableSqlCache() || sessionVariable.isEnablePartitionCache())
+                && commonCacheCondition(sessionVariable);
+    }
+
+    public static boolean canUseSqlCache(SessionVariable sessionVariable) {
+        return sessionVariable.isEnableSqlCache() && commonCacheCondition(sessionVariable);
+    }
+
+    public static boolean commonCacheCondition(SessionVariable sessionVariable) {
+        return sessionVariable.getSqlSelectLimit() < 0 && sessionVariable.getDefaultOrderByLimit() < 0;
     }
 
     /**
@@ -226,15 +261,17 @@ public class CacheAnalyzer {
         latestTable.debug();
 
         addAllViewStmt(selectStmt);
-        String allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, "|");
+        if (allViewExpandStmtListStr == null) {
+            allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, "|");
+        }
 
         if (now == 0) {
             now = nowtime();
         }
         if (enableSqlCache()
-                && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
+                && (now - latestTable.latestPartitionTime) >= Config.cache_last_version_interval_second * 1000L) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestTime,
+                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestPartitionTime,
                         Config.cache_last_version_interval_second * 1000);
             }
             cache = new SqlCache(this.queryId, this.selectStmt);
@@ -260,7 +297,7 @@ public class CacheAnalyzer {
         //Check if selectStmt matches partition key
         //Only one table can be updated in Config.cache_last_version_interval_second range
         for (int i = 1; i < tblTimeList.size(); i++) {
-            if ((now - tblTimeList.get(i).latestTime) < Config.cache_last_version_interval_second * 1000L) {
+            if ((now - tblTimeList.get(i).latestPartitionTime) < Config.cache_last_version_interval_second * 1000L) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("the time of other tables is newer than {} s, queryid {}",
                             Config.cache_last_version_interval_second, DebugUtil.printId(queryId));
@@ -343,9 +380,9 @@ public class CacheAnalyzer {
             now = nowtime();
         }
         if (enableSqlCache()
-                && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
+                && (now - latestTable.latestPartitionTime) >= Config.cache_last_version_interval_second * 1000L) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestTime,
+                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestPartitionTime,
                         Config.cache_last_version_interval_second * 1000);
             }
             cache = new SqlCache(this.queryId, parsedStmt.toSql());
@@ -377,29 +414,43 @@ public class CacheAnalyzer {
             return CacheMode.None;
         }
         latestTable = tblTimeList.get(0);
-        latestTable.sumOfPartitionNum = tblTimeList.stream().mapToLong(item -> item.partitionNum).sum();
+        long sumOfPartitionNum = 0;
+        for (CacheTable cacheTable : tblTimeList) {
+            sumOfPartitionNum += cacheTable.partitionNum;
+        }
+        latestTable.sumOfPartitionNum = sumOfPartitionNum;
         latestTable.debug();
 
         if (((LogicalPlanAdapter) parsedStmt).getStatementContext().getParsedStatement().isExplain()) {
             return CacheMode.NoNeed;
         }
 
-        allViewStmtSet.addAll(((LogicalPlanAdapter) parsedStmt).getViewDdlSqls());
-        String allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, "|");
+        boolean isNewAllViewExpandStmtListStr = allViewExpandStmtListStr == null;
+        if (isNewAllViewExpandStmtListStr) {
+            allViewStmtSet.addAll(((LogicalPlanAdapter) parsedStmt).getViewDdlSqls());
+            allViewExpandStmtListStr = StringUtils.join(allViewStmtSet, "|");
+        }
 
         if (now == 0) {
             now = nowtime();
         }
 
         if (enableSqlCache()
-                && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
+                && (now - latestTable.latestPartitionTime) >= Config.cache_last_version_interval_second * 1000L) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Query cache time :{},{},{}", now, latestTable.latestTime,
+                LOG.debug("Query cache time :{},{},{}", now, latestTable.latestPartitionTime,
                         Config.cache_last_version_interval_second * 1000);
+            }
+
+            PUniqueId existsMd5 = null;
+            if (cache instanceof SqlCache) {
+                existsMd5 = ((SqlCache) cache).getOrComputeCacheMd5();
             }
             cache = new SqlCache(this.queryId, ((LogicalPlanAdapter) parsedStmt).getStatementContext()
                     .getOriginStatement().originStmt);
-            ((SqlCache) cache).setCacheInfo(this.latestTable, allViewExpandStmtListStr);
+            SqlCache sqlCache = (SqlCache) cache;
+            sqlCache.setCacheInfo(this.latestTable, allViewExpandStmtListStr);
+            sqlCache.setCacheMd5(existsMd5);
             MetricRepo.COUNTER_CACHE_ADDED_SQL.increase(1L);
             return CacheMode.Sql;
         }
@@ -409,8 +460,15 @@ public class CacheAnalyzer {
     private List<CacheTable> buildCacheTableList() {
         //Check the last version time of the table
         MetricRepo.COUNTER_QUERY_TABLE.increase(1L);
-        long olapScanNodeSize = scanNodes.stream().filter(node -> node instanceof OlapScanNode).count();
-        long hiveScanNodeSize = scanNodes.stream().filter(node -> node instanceof HiveScanNode).count();
+        long olapScanNodeSize = 0;
+        long hiveScanNodeSize = 0;
+        for (ScanNode scanNode : scanNodes) {
+            if (scanNode instanceof OlapScanNode) {
+                olapScanNodeSize++;
+            } else if (scanNode instanceof HiveScanNode) {
+                hiveScanNodeSize++;
+            }
+        }
         if (olapScanNodeSize > 0) {
             MetricRepo.COUNTER_QUERY_OLAP_TABLE.increase(1L);
         }
@@ -621,12 +679,20 @@ public class CacheAnalyzer {
         OlapTable olapTable = node.getOlapTable();
         cacheTable.partitionNum = node.getSelectedPartitionIds().size();
         cacheTable.table = olapTable;
+
+        DatabaseIf database = olapTable.getDatabase();
+        CatalogIf catalog = database.getCatalog();
+        ScanTable scanTable = new ScanTable(
+                new FullTableName(catalog.getName(), database.getFullName(), olapTable.getName()),
+                olapTable.getVisibleVersionTime(), olapTable.getVisibleVersion());
+        scanTables.add(scanTable);
         for (Long partitionId : node.getSelectedPartitionIds()) {
             Partition partition = olapTable.getPartition(partitionId);
-            if (partition.getVisibleVersionTime() >= cacheTable.latestTime) {
+            if (partition.getVisibleVersionTime() >= cacheTable.latestPartitionTime) {
                 cacheTable.latestPartitionId = partition.getId();
-                cacheTable.latestTime = partition.getVisibleVersionTime();
-                cacheTable.latestVersion = partition.getVisibleVersion();
+                cacheTable.latestPartitionTime = partition.getVisibleVersionTime();
+                cacheTable.latestPartitionVersion = partition.getVisibleVersion();
+                scanTable.addScanPartition(partitionId);
             }
         }
         return cacheTable;
@@ -636,7 +702,14 @@ public class CacheAnalyzer {
         CacheTable cacheTable = new CacheTable();
         cacheTable.table = node.getTargetTable();
         cacheTable.partitionNum = node.getReadPartitionNum();
-        cacheTable.latestTime = cacheTable.table.getUpdateTime();
+        cacheTable.latestPartitionTime = cacheTable.table.getUpdateTime();
+        TableIf tableIf = cacheTable.table;
+        DatabaseIf database = tableIf.getDatabase();
+        CatalogIf catalog = database.getCatalog();
+        ScanTable scanTable = new ScanTable(new FullTableName(
+                catalog.getName(), database.getFullName(), tableIf.getName()
+        ), cacheTable.latestPartitionTime, 0);
+        scanTables.add(scanTable);
         return cacheTable;
     }
 
@@ -694,5 +767,28 @@ public class CacheAnalyzer {
             return;
         }
         cache.updateCache();
+    }
+
+    public List<ScanTable> getScanTables() {
+        return scanTables;
+    }
+
+    public CacheTable getLatestTable() {
+        return latestTable;
+    }
+
+    public boolean isEqualViewString(List<TableIf> views) {
+        Set<String> viewSet = Sets.newHashSet();
+        for (TableIf view : views) {
+            if (view instanceof View) {
+                viewSet.add(((View) view).getInlineViewDef());
+            } else if (view instanceof HMSExternalTable) {
+                viewSet.add(((HMSExternalTable) view).getViewText());
+            } else {
+                return false;
+            }
+        }
+
+        return StringUtils.equals(allViewExpandStmtListStr, StringUtils.join(viewSet, "|"));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheCoordinator.java
@@ -146,12 +146,11 @@ public class CacheCoordinator {
     }
 
     public void addBackend(Backend backend) {
-        if (realNodes.contains(backend.getId())) {
+        if (realNodes.putIfAbsent(backend.getId(), backend) != null) {
             return;
         }
-        realNodes.put(backend.getId(), backend);
         for (int i = 0; i < VIRTUAL_NODES; i++) {
-            String nodeName = String.valueOf(backend.getId()) + "::" + String.valueOf(i);
+            String nodeName = backend.getId() + "::" + i;
             Types.PUniqueId nodeId = CacheBeProxy.getMd5(nodeName);
             virtualNodes.put(nodeId.getHi(), backend);
             if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -22,7 +22,9 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.proto.InternalService;
+import org.apache.doris.proto.Types.PUniqueId;
 import org.apache.doris.qe.RowBatch;
+import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TUniqueId;
 
 import org.apache.logging.log4j.LogManager;
@@ -32,6 +34,7 @@ public class SqlCache extends Cache {
     private static final Logger LOG = LogManager.getLogger(SqlCache.class);
 
     private String originSql;
+    private PUniqueId cacheMd5;
 
     public SqlCache(TUniqueId queryId, SelectStmt selectStmt) {
         super(queryId, selectStmt);
@@ -46,6 +49,18 @@ public class SqlCache extends Cache {
     public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, String allViewExpandStmtListStr) {
         this.latestTable = latestTable;
         this.allViewExpandStmtListStr = allViewExpandStmtListStr;
+        this.cacheMd5 = null;
+    }
+
+    public PUniqueId getOrComputeCacheMd5() {
+        if (cacheMd5 == null) {
+            cacheMd5 = CacheProxy.getMd5(getSqlWithViewStmt());
+        }
+        return cacheMd5;
+    }
+
+    public void setCacheMd5(PUniqueId cacheMd5) {
+        this.cacheMd5 = cacheMd5;
     }
 
     public String getSqlWithViewStmt() {
@@ -57,27 +72,50 @@ public class SqlCache extends Cache {
         return cacheKey;
     }
 
+    public long getLatestId() {
+        return latestTable.latestPartitionId;
+    }
+
     public long getLatestTime() {
-        return latestTable.latestTime;
+        return latestTable.latestPartitionTime;
+    }
+
+    public long getLatestVersion() {
+        return latestTable.latestPartitionVersion;
     }
 
     public long getSumOfPartitionNum() {
         return latestTable.sumOfPartitionNum;
     }
 
-    public InternalService.PFetchCacheResult getCacheData(Status status) {
+    public static Backend findCacheBe(PUniqueId cacheMd5) {
+        return CacheCoordinator.getInstance().findBackend(cacheMd5);
+    }
+
+    public static InternalService.PFetchCacheResult getCacheData(CacheProxy proxy,
+            PUniqueId cacheKeyMd5, long latestPartitionId, long latestPartitionVersion,
+            long latestPartitionTime, long sumOfPartitionNum, Status status) {
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
-                .setSqlKey(CacheProxy.getMd5(getSqlWithViewStmt()))
+                .setSqlKey(cacheKeyMd5)
                 .addParams(InternalService.PCacheParam.newBuilder()
-                        .setPartitionKey(latestTable.latestPartitionId)
-                        .setLastVersion(latestTable.latestVersion)
-                        .setLastVersionTime(latestTable.latestTime)
-                        .setPartitionNum(latestTable.sumOfPartitionNum))
+                        .setPartitionKey(latestPartitionId)
+                        .setLastVersion(latestPartitionVersion)
+                        .setLastVersionTime(latestPartitionTime)
+                        .setPartitionNum(sumOfPartitionNum))
                 .build();
 
         InternalService.PFetchCacheResult cacheResult = proxy.fetchCache(request, 10000, status);
         if (status.ok() && cacheResult != null && cacheResult.getStatus() == InternalService.PCacheStatus.CACHE_OK) {
             cacheResult = cacheResult.toBuilder().setAllCount(1).build();
+        }
+        return cacheResult;
+    }
+
+    public InternalService.PFetchCacheResult getCacheData(Status status) {
+        InternalService.PFetchCacheResult cacheResult = getCacheData(proxy, getOrComputeCacheMd5(),
+                latestTable.latestPartitionId, latestTable.latestPartitionVersion,
+                latestTable.latestPartitionTime, latestTable.sumOfPartitionNum, status);
+        if (status.ok() && cacheResult != null && cacheResult.getStatus() == InternalService.PCacheStatus.CACHE_OK) {
             MetricRepo.COUNTER_CACHE_HIT_SQL.increase(1L);
             hitRange = HitRange.Full;
         }
@@ -105,7 +143,9 @@ public class SqlCache extends Cache {
 
         InternalService.PUpdateCacheRequest updateRequest =
                 rowBatchBuilder.buildSqlUpdateRequest(getSqlWithViewStmt(), latestTable.latestPartitionId,
-                        latestTable.latestVersion, latestTable.latestTime, latestTable.sumOfPartitionNum);
+                        latestTable.latestPartitionVersion, latestTable.latestPartitionTime,
+                        latestTable.sumOfPartitionNum
+                );
         if (updateRequest.getValuesCount() > 0) {
             CacheBeProxy proxy = new CacheBeProxy();
             Status status = new Status();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
@@ -121,7 +121,7 @@ public class FunctionRegistryTest implements MemoPatternMatchSupported {
 
         ImmutableList<Expression> arguments = ImmutableList.of(Literal.of(1));
         FunctionBuilder functionBuilder = functionRegistry.findFunctionBuilder("foo", arguments);
-        Expression function = functionBuilder.build("foo", arguments);
+        Expression function = functionBuilder.build("foo", arguments).first;
         Assertions.assertEquals(function.getClass(), ExtendFunction.class);
         Assertions.assertEquals(arguments, function.getArguments());
     }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/ExplainAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/ExplainAction.groovy
@@ -102,7 +102,7 @@ class ExplainAction implements SuiteAction {
             for (String string : containsStrings) {
                 if (!explainString.contains(string)) {
                     String msg = ("Explain and check failed, expect contains '${string}',"
-                            + "but actual explain string is:\n${explainString}").toString()
+                            + " but actual explain string is:\n${explainString}").toString()
                     log.info(msg)
                     def t = new IllegalStateException(msg)
                     throw t
@@ -111,7 +111,7 @@ class ExplainAction implements SuiteAction {
             for (String string : notContainsStrings) {
                 if (explainString.contains(string)) {
                     String msg = ("Explain and check failed, expect not contains '${string}',"
-                            + "but actual explain string is:\n${explainString}").toString()
+                            + " but actual explain string is:\n${explainString}").toString()
                     log.info(msg)
                     def t = new IllegalStateException(msg)
                     throw t

--- a/regression-test/plugins/test_helper.groovy
+++ b/regression-test/plugins/test_helper.groovy
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.Suite
+
+Suite.metaClass.createTestTable = { String tableName, boolean uniqueTable = false ->
+    Suite suite = delegate as Suite
+    def sql = { String sqlStr ->
+        suite.sql sqlStr
+    }
+
+    sql "set enable_nereids_planner=true"
+    sql "set enable_fallback_to_original_planner=false"
+
+    sql "drop table if exists ${tableName}"
+
+    sql """
+        create table ${tableName}
+        (
+            id int,
+            value int
+        )
+        ${uniqueTable ? "unique key(id)" : ""}
+        partition by range(id)
+        (
+            partition p1 values[('1'), ('2')),
+            partition p2 values[('2'), ('3')),
+            partition p3 values[('3'), ('4')),
+            partition p4 values[('4'), ('5')),
+            partition p5 values[('5'), ('6'))
+        )
+        distributed by hash(id)
+        properties(
+            'replication_num'='1'
+        )
+        """
+
+    sql """
+        insert into ${tableName}
+        values (1, 1), (1, 2),
+               (2, 1), (2, 2), 
+               (3, 1), (3, 2),
+               (4, 1), (4, 2),
+               (5, 1), (5, 2)
+        """
+}
+
+
+logger.info("Added 'createTestTable' function to Suite")

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -1,0 +1,550 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("parse_sql_from_sql_cache") {
+    def assertHasCache = { String sqlStr ->
+        explain {
+            sql ("physical plan ${sqlStr}")
+            contains("PhysicalSqlCache")
+        }
+    }
+
+    def assertNoCache = { String sqlStr ->
+        explain {
+            sql ("physical plan ${sqlStr}")
+            notContains("PhysicalSqlCache")
+        }
+    }
+
+
+    sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
+
+    combineFutures(
+        extraThread("testUsePlanCache", {
+            createTestTable "test_use_plan_cache"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache"
+
+            // create sql cache
+            sql "select * from test_use_plan_cache"
+
+            // use sql cache
+            assertHasCache "select * from test_use_plan_cache"
+        }),
+        extraThread("testAddPartitionAndInsert", {
+            createTestTable "test_use_plan_cache2"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache2"
+            sql "select * from test_use_plan_cache2"
+            assertHasCache "select * from test_use_plan_cache2"
+
+            // add empty partition can use cache
+            sql "alter table test_use_plan_cache2 add partition p6 values[('6'),('7'))"
+            assertHasCache "select * from test_use_plan_cache2"
+
+            // insert data can not use cache
+            sql "insert into test_use_plan_cache2 values(6, 1)"
+            assertNoCache "select * from test_use_plan_cache2"
+        }),
+        extraThread("testDropPartition", {
+            createTestTable "test_use_plan_cache3"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache3"
+            sql "select * from test_use_plan_cache3"
+            assertHasCache "select * from test_use_plan_cache3"
+
+            // drop partition can not use cache
+            sql "alter table test_use_plan_cache3 drop partition p5"
+            assertNoCache "select * from test_use_plan_cache3"
+        }),
+        extraThread("testReplacePartition", {
+            createTestTable "test_use_plan_cache4"
+
+            sql "alter table test_use_plan_cache4 add temporary partition tp1 values [('1'), ('2'))"
+
+            streamLoad {
+                table "test_use_plan_cache4"
+                set "temporaryPartitions", "tp1"
+                inputIterator([[1, 3], [1, 4]].iterator())
+            }
+            sql "sync"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache4"
+            sql "select * from test_use_plan_cache4"
+            assertHasCache "select * from test_use_plan_cache4"
+
+            // replace partition can not use cache
+            sql "alter table test_use_plan_cache4 replace partition (p1) with temporary partition(tp1)"
+            assertNoCache "select * from test_use_plan_cache4"
+        }),
+        extraThread("testStreamLoad", {
+            createTestTable "test_use_plan_cache5"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache5"
+            sql "select * from test_use_plan_cache5"
+            assertHasCache "select * from test_use_plan_cache5"
+
+            streamLoad {
+                table "test_use_plan_cache5"
+                set "partitions", "p1"
+                inputIterator([[1, 3], [1, 4]].iterator())
+            }
+
+            // stream load can not use cache
+            sql "select * from test_use_plan_cache5"
+            assertNoCache "select * from test_use_plan_cache5"
+        }),
+        extraThread("testUpdate",{
+            createTestTable "test_use_plan_cache6", uniqueTable=true
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache6"
+            sql "select * from test_use_plan_cache6"
+            assertHasCache "select * from test_use_plan_cache6"
+
+            sql "update test_use_plan_cache6 set value=3 where id=1"
+
+            // update can not use cache
+            sql "select * from test_use_plan_cache6"
+            assertNoCache "select * from test_use_plan_cache6"
+        }),
+        extraThread("testDelete", {
+            createTestTable "test_use_plan_cache7"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache7"
+            sql "select * from test_use_plan_cache7"
+            assertHasCache "select * from test_use_plan_cache7"
+
+            sql "delete from test_use_plan_cache7 where id = 1"
+
+            // delete can not use cache
+            sql "select * from test_use_plan_cache7"
+            assertNoCache "select * from test_use_plan_cache7"
+        }),
+        extraThread("testDropTable", {
+            createTestTable "test_use_plan_cache8"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache8"
+            sql "select * from test_use_plan_cache8"
+            assertHasCache "select * from test_use_plan_cache8"
+
+            sql "drop table test_use_plan_cache8"
+
+            // should visible the table has bean deleted
+            test {
+                sql "select * from test_use_plan_cache8"
+                exception "does not exist in database"
+            }
+        }),
+        extraThread("testCreateAndAlterView", {
+            createTestTable "test_use_plan_cache9"
+
+            sql "drop view if exists test_use_plan_cache9_view"
+            sql "create view test_use_plan_cache9_view as select * from test_use_plan_cache9"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache9_view"
+            sql "select * from test_use_plan_cache9_view"
+            assertHasCache "select * from test_use_plan_cache9_view"
+
+            // alter view should not use cache
+            sql "alter view test_use_plan_cache9_view as select id from test_use_plan_cache9"
+            assertNoCache "select * from test_use_plan_cache9_view"
+        }),
+        extraThread( "testDropView", {
+            createTestTable "test_use_plan_cache10"
+
+            sql "drop view if exists test_use_plan_cache10_view"
+            sql "create view test_use_plan_cache10_view as select * from test_use_plan_cache10"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache10_view"
+            sql "select * from test_use_plan_cache10_view"
+            assertHasCache "select * from test_use_plan_cache10_view"
+
+            sql "drop view test_use_plan_cache10_view"
+            // should visible the view has bean deleted
+            test {
+                sql "select * from test_use_plan_cache10_view"
+                exception "does not exist in database"
+            }
+        }),
+        extraThread("testBaseTableChanged", {
+            createTestTable "test_use_plan_cache11"
+
+            sql "drop view if exists test_use_plan_cache11_view"
+            sql "create view test_use_plan_cache11_view as select * from test_use_plan_cache11"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache11_view"
+            sql "select * from test_use_plan_cache11_view"
+            assertHasCache "select * from test_use_plan_cache11_view"
+
+            sql "insert into test_use_plan_cache11 values(1, 3)"
+
+            // base table already changed, can not use cache
+            assertNoCache "select * from test_use_plan_cache11_view"
+        }),
+        extraThread("testNotShareCacheBetweenUsers", {
+            sql "drop user if exists test_cache_user1"
+            sql "create user test_cache_user1 identified by 'DORIS@2024'"
+            def dbName = context.config.getDbNameByFile(context.file)
+            sql """GRANT SELECT_PRIV ON *.* TO test_cache_user1"""
+
+            createTestTable "test_use_plan_cache12"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select * from test_use_plan_cache12"
+            sql "select * from test_use_plan_cache12"
+            assertHasCache "select * from test_use_plan_cache12"
+
+
+            extraThread("test_cache_user1_thread", {
+                connect(user = "test_cache_user1", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache12"
+                }
+            }).get()
+        }),
+        extraThread("testAddRowPolicy", {
+            def dbName = context.config.getDbNameByFile(context.file)
+            sql "set enable_nereids_planner=false"
+            try_sql """
+                DROP ROW POLICY if exists test_cache_row_policy_2
+                ON ${dbName}.test_use_plan_cache13
+                FOR test_cache_user2"""
+            sql "set enable_nereids_planner=true"
+
+            sql "drop user if exists test_cache_user2"
+            sql "create user test_cache_user2 identified by 'DORIS@2024'"
+            sql """GRANT SELECT_PRIV ON *.* TO test_cache_user2"""
+
+            createTestTable "test_use_plan_cache13"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            extraThread("test_cache_user2_thread", {
+                connect(user = "test_cache_user2", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache13"
+                    sql "select * from test_use_plan_cache13"
+                    assertHasCache "select * from test_use_plan_cache13"
+                }
+            }).get()
+
+            sql "set enable_nereids_planner=false"
+            sql """
+                CREATE ROW POLICY test_cache_row_policy_2
+                ON ${dbName}.test_use_plan_cache13
+                AS RESTRICTIVE TO test_cache_user2
+                USING (id = 'concat(id, "**")')"""
+            sql "set enable_nereids_planner=true"
+
+            // after row policy changed, the cache is invalidate
+            extraThread("test_cache_user2_thread2", {
+                connect(user = "test_cache_user2", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache13"
+                }
+            }).get()
+        }),
+        extraThread("testDropRowPolicy", {
+            def dbName = context.config.getDbNameByFile(context.file)
+            sql "set enable_nereids_planner=false"
+            try_sql """
+            DROP ROW POLICY if exists test_cache_row_policy_3
+            ON ${dbName}.test_use_plan_cache14
+            FOR test_cache_user3"""
+            sql "set enable_nereids_planner=true"
+
+            sql "drop user if exists test_cache_user3"
+            sql "create user test_cache_user3 identified by 'DORIS@2024'"
+            sql """GRANT SELECT_PRIV ON *.* TO test_cache_user3"""
+
+            createTestTable "test_use_plan_cache14"
+
+            sql "set enable_nereids_planner=false"
+            sql """
+            CREATE ROW POLICY test_cache_row_policy_3
+            ON ${dbName}.test_use_plan_cache14
+            AS RESTRICTIVE TO test_cache_user3
+            USING (id = 'concat(id, "**")')"""
+            sql "set enable_nereids_planner=true"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            extraThread("test_cache_user3_thread", {
+                connect(user = "test_cache_user3", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache14"
+                    sql "select * from test_use_plan_cache14"
+                    assertHasCache "select * from test_use_plan_cache14"
+                }
+            }).get()
+
+            sql "set enable_nereids_planner=false"
+            try_sql """
+            DROP ROW POLICY if exists test_cache_row_policy_3
+            ON ${dbName}.test_use_plan_cache14
+            FOR test_cache_user3"""
+            sql "set enable_nereids_planner=true"
+
+            // after row policy changed, the cache is invalidate
+            extraThread("test_cache_user3_thread2", {
+                connect(user = "test_cache_user3", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache14"
+                }
+            }).get()
+        }),
+        extraThread("testRemovePrivilege", {
+            def dbName = context.config.getDbNameByFile(context.file)
+
+            createTestTable "test_use_plan_cache15"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "drop user if exists test_cache_user4"
+            sql "create user test_cache_user4 identified by 'DORIS@2024'"
+            sql "GRANT SELECT_PRIV ON regression_test.* TO test_cache_user4"
+            sql "GRANT SELECT_PRIV ON ${dbName}.test_use_plan_cache15 TO test_cache_user4"
+
+            extraThread("test_cache_user4_thread", {
+                connect(user = "test_cache_user4", password="DORIS@2024") {
+                    sql "use ${dbName}"
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    assertNoCache "select * from test_use_plan_cache15"
+                    sql "select * from test_use_plan_cache15"
+                    assertHasCache "select * from test_use_plan_cache15"
+                }
+            }).get()
+
+            sql "REVOKE SELECT_PRIV ON ${dbName}.test_use_plan_cache15 FROM test_cache_user4"
+
+            // after privileges changed, the cache is invalidate
+            extraThread("test_cache_user4_thread2", {
+                connect(user = "test_cache_user4", password="DORIS@2024") {
+                    sql "set enable_nereids_planner=true"
+                    sql "set enable_fallback_to_original_planner=false"
+                    sql "set enable_sql_cache=true"
+
+                    test {
+                        sql ("select * from ${dbName}.test_use_plan_cache15")
+                        exception "Permission denied"
+                    }
+                }
+            }).get()
+        }),
+        extraThread("testNondeterministic", {
+            createTestTable "test_use_plan_cache16"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select random() from test_use_plan_cache16"
+            // create sql cache
+            sql "select random() from test_use_plan_cache16"
+            // can not use sql cache
+            assertNoCache "select random() from test_use_plan_cache16"
+
+
+            assertNoCache "select year(now()) from test_use_plan_cache16"
+            sql "select year(now()) from test_use_plan_cache16"
+            assertHasCache "select year(now()) from test_use_plan_cache16"
+
+
+            assertNoCache "select second(now()) from test_use_plan_cache16"
+            sql "select second(now()) from test_use_plan_cache16"
+            sleep(1000)
+            assertNoCache "select second(now()) from test_use_plan_cache16"
+        }),
+        extraThread("testUserVariable", {
+            // make sure if the table has been dropped, the cache should invalidate,
+            // so we should retry twice to check
+            for (i in 0..2) {
+                createTestTable "test_use_plan_cache17"
+
+                // after partition changed 10s, the sql cache can be used
+                sleep(10000)
+
+                sql "set enable_nereids_planner=true"
+                sql "set enable_fallback_to_original_planner=false"
+                sql "set enable_sql_cache=true"
+
+                sql "set @custom_variable=10"
+                assertNoCache "select @custom_variable from test_use_plan_cache17"
+                // create sql cache
+                sql "select @custom_variable from test_use_plan_cache17"
+                // can use sql cache
+                assertHasCache "select @custom_variable from test_use_plan_cache17"
+
+                sql "set @custom_variable=20"
+                assertNoCache "select @custom_variable from test_use_plan_cache17"
+            }
+        }),
+        extraThread("test_udf", {
+            def jarPath = """${context.config.suitePath}/javaudf_p0/jars/java-udf-case-jar-with-dependencies.jar"""
+            try_sql("DROP FUNCTION IF EXISTS java_udf_string_test(string, int, int);")
+            try_sql("DROP TABLE IF EXISTS test_javaudf_string")
+
+            sql """ DROP TABLE IF EXISTS test_javaudf_string """
+            sql """
+                    CREATE TABLE IF NOT EXISTS test_javaudf_string (
+                        `user_id`     INT         NOT NULL COMMENT "用户id",
+                        `char_col`    CHAR        NOT NULL COMMENT "",
+                        `varchar_col` VARCHAR(10) NOT NULL COMMENT "",
+                        `string_col`  STRING      NOT NULL COMMENT ""
+                        )
+                        DISTRIBUTED BY HASH(user_id) PROPERTIES("replication_num" = "1");
+                    """
+
+            StringBuilder values = new StringBuilder()
+            int i = 1
+            for (; i < 9; i ++) {
+                values.append(" (${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg'),\n")
+            }
+            values.append("(${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg')")
+
+            sql "INSERT INTO test_javaudf_string VALUES ${values}"
+            sql "sync"
+
+            File path = new File(jarPath)
+            if (!path.exists()) {
+                throw new IllegalStateException("""${jarPath} doesn't exist! """)
+            }
+
+            sql """ CREATE FUNCTION java_udf_string_test(string, int, int) RETURNS string PROPERTIES (
+                        "file"="file://${jarPath}",
+                        "symbol"="org.apache.doris.udf.StringTest",
+                        "type"="JAVA_UDF"
+                    ); """
+
+            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+            sql "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+        })
+    ).get()
+}

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -211,5 +211,5 @@ suite("sql_cache") {
                         k1;
                 """
 
-    sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '900')"
+    sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
 }

--- a/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
@@ -53,7 +53,6 @@ suite("test_schema_change_duplicate", "p0") {
             set 'column_separator', ','
 
             file 'all_types.csv'
-            time 10000 // limit inflight 10s
 
             check { result, exception, startTime, endTime ->
                 if (exception != null) {


### PR DESCRIPTION
## Proposed changes

Before this pr, the query must pass through parser, analyzer, rewriter, optimizer and translator, then we can check whether this query can use sql cache, if the query is too long, or the number of join tables too big, the plan time usually >= 500ms.

This pr reduce this time by skip the fashion plan path, because we can reuse the previous physical plan and query result if no any changed. In some cases we should not parse sql from sql cache, e.g. table structure changed, data changed, user policies changed, privileges changed, contains non-deterministic functions, and user variables changed.

In my test case: query a view which has lots of join and union, and the tables has empty partition, the query latency is about 3ms. if not parse sql from sql cache, the plan time is about 550ms

## Features
1. use Config.sql_cache_manage_num to control how many sql cache be reused in on fe
2. if explain plan appear some plans contains `LogicalSqlCache` or `PhysicalSqlCache`, it means the query can use sql cache, like this:
```sql
mysql> set enable_sql_cache=true;
Query OK, 0 rows affected (0.00 sec)

mysql> explain physical plan select * from test.t;
+----------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                  |
+----------------------------------------------------------------------------------+
| cost = 3.135                                                                     |
| PhysicalResultSink[53] ( outputExprs=[c1#0, c2#1] )                              |
| +--PhysicalDistribute[50]@0 ( stats=3, distributionSpec=DistributionSpecGather ) |
|    +--PhysicalOlapScan[t]@0 ( stats=3 )                                          |
+----------------------------------------------------------------------------------+
4 rows in set (0.02 sec)

mysql> select * from test.t;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    2 |
|   -2 |   -2 |
| NULL |   30 |
+------+------+
3 rows in set (0.05 sec)

mysql> explain physical plan select * from test.t;
+-------------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                           |
+-------------------------------------------------------------------------------------------+
| cost = 0.0                                                                                |
| PhysicalSqlCache[2] ( queryId=78511f515cda466b-95385d892d6c68d0, backend=127.0.0.1:9050 ) |
| +--PhysicalResultSink[52] ( outputExprs=[c1#0, c2#1] )                                    |
|    +--PhysicalDistribute[49]@0 ( stats=3, distributionSpec=DistributionSpecGather )       |
|       +--PhysicalOlapScan[t]@0 ( stats=3 )                                                |
+-------------------------------------------------------------------------------------------+
5 rows in set (0.01 sec)
```