### PR TITLE
[fix](spill) fix hash join error 'invalid slot id'

### DIFF
--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
@@ -517,16 +517,6 @@ Status PartitionedHashJoinProbeOperatorX::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status PartitionedHashJoinProbeOperatorX::close(RuntimeState* state) {
-    // to avoid close _child_x twice
-    auto child_x = std::move(_child_x);
-    RETURN_IF_ERROR(JoinProbeOperatorX::close(state));
-    RETURN_IF_ERROR(_probe_operator->close(state));
-    RETURN_IF_ERROR(_sink_operator->close(state));
-    _child_x = std::move(child_x);
-    return Status::OK();
-}
-
 Status PartitionedHashJoinProbeOperatorX::push(RuntimeState* state, vectorized::Block* input_block,
                                                bool eos) const {
     auto& local_state = get_local_state(state);

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
@@ -153,6 +153,7 @@ public:
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     [[nodiscard]] Status get_block(RuntimeState* state, vectorized::Block* block,
                                    bool* eos) override;

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
@@ -153,7 +153,6 @@ public:
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
 
     [[nodiscard]] Status get_block(RuntimeState* state, vectorized::Block* block,
                                    bool* eos) override;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Fix error when join spill is enabled:
```
meet error status: [INTERNAL_ERROR]VSlotRef ss_customer_sk have invalid slot id: 435

        0#  doris::vectorized::VSlotRef::prepare(doris::RuntimeState*, doris::RowDescriptor const&, doris::vectorized::VExprContext*) at /mnt/datadisk0/yy/git/doris/be/src/vec/exprs/vslot_ref.cpp:72
        1#  doris::vectorized::VExprContext::prepare(doris::RuntimeState*, doris::RowDescriptor const&) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:348
        2#  doris::vectorized::VExpr::prepare(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, doris::RuntimeState*, doris::RowDescriptor const&) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:452
        3#  doris::pipeline::PartitionedHashJoinProbeOperatorX::prepare(doris::RuntimeState*) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:452
        4#  doris::pipeline::Pipeline::prepare(doris::RuntimeState*) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:452
        5#  doris::pipeline::PipelineXFragmentContext::prepare(doris::TPipelineFragmentParams const&) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:452
        6#  doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /mnt/datadisk0/yy/git/doris/be/src/common/status.h:452
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

