### PR TITLE
[feature](cloud) Support hdfs accessor in Checker

### DIFF
--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -222,11 +222,12 @@ Status HdfsFileSystem::list_impl(const Path& path, bool only_file, std::vector<F
         if (only_file && file.mKind == kObjectKindDirectory) {
             continue;
         }
-        FileInfo file_info;
-        file_info.file_name = file.mName;
+        auto& file_info = files->emplace_back();
+        std::string_view fname(file.mName);
+        fname.remove_prefix(fname.rfind('/') + 1);
+        file_info.file_name = fname;
         file_info.file_size = file.mSize;
         file_info.is_file = (file.mKind != kObjectKindDirectory);
-        files->emplace_back(std::move(file_info));
     }
     hdfsFreeFileInfo(hdfs_file_info, numEntries);
     return Status::OK();

--- a/cloud/src/recycler/checker.cpp
+++ b/cloud/src/recycler/checker.cpp
@@ -43,6 +43,8 @@
 #include "meta-service/keys.h"
 #include "meta-service/txn_kv.h"
 #include "meta-service/txn_kv_error.h"
+#include "recycler/hdfs_accessor.h"
+#include "recycler/obj_store_accessor.h"
 #include "recycler/s3_accessor.h"
 #ifdef UNIT_TEST
 #include "../test/mock_accessor.h"
@@ -253,8 +255,6 @@ void Checker::do_inspect(const InstanceInfoPB& instance) {
         return;
     }
 
-    // TODO(plat1ko): No bucket lifecycle for hdfs vaults, should skip them or find similar
-    // semantics for them.
     int64_t bucket_lifecycle_days = 0;
     if (checker.get_bucket_lifecycle(&bucket_lifecycle_days) != 0) {
         LOG_CHECK_INTERVAL_ALARM << "failed to get bucket lifecycle, instance_id="
@@ -262,6 +262,12 @@ void Checker::do_inspect(const InstanceInfoPB& instance) {
         return;
     }
     DCHECK(bucket_lifecycle_days > 0);
+
+    if (bucket_lifecycle_days == INT64_MAX) {
+        // No s3 bucket (may all accessors are HdfsAccessor), skip inspect
+        return;
+    }
+
     int64_t last_ctime_ms = -1;
     auto job_status = JobRecyclePB::IDLE;
     auto has_last_ctime = [&]() {
@@ -342,6 +348,15 @@ InstanceChecker::InstanceChecker(std::shared_ptr<TxnKv> txn_kv, const std::strin
         : txn_kv_(std::move(txn_kv)), instance_id_(instance_id) {}
 
 int InstanceChecker::init(const InstanceInfoPB& instance) {
+    int ret = init_obj_store_accessors(instance);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return init_storage_vault_accessors(instance);
+}
+
+int InstanceChecker::init_obj_store_accessors(const InstanceInfoPB& instance) {
     for (const auto& obj_info : instance.obj_info()) {
         S3Conf s3_conf;
         s3_conf.ak = obj_info.ak();
@@ -373,6 +388,60 @@ int InstanceChecker::init(const InstanceInfoPB& instance) {
         }
         accessor_map_.emplace(obj_info.id(), std::move(accessor));
     }
+    return 0;
+}
+
+int InstanceChecker::init_storage_vault_accessors(const InstanceInfoPB& instance) {
+    if (instance.resource_ids().empty()) {
+        return 0;
+    }
+
+    std::string storage_vault_start = storage_vault_key({instance_id_, ""});
+    std::string storage_vault_end = storage_vault_key({instance_id_, "\xff"});
+    std::unique_ptr<RangeGetIterator> it;
+
+    do {
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv_->create_txn(&txn);
+        if (err != TxnErrorCode::TXN_OK) {
+            LOG(WARNING) << "failed to create txn. instance_id=" << instance.instance_id();
+            return -1;
+        }
+        err = txn->get(storage_vault_start, storage_vault_end, &it, true);
+        if (err != TxnErrorCode::TXN_OK) {
+            LOG(WARNING) << "failed to get storage vault, instance_id=" << instance_id_;
+            return -1;
+        }
+
+        while (it->has_next()) {
+            auto [k, v] = it->next();
+            StorageVaultPB vault;
+            if (!vault.ParseFromArray(v.data(), v.size())) {
+                LOG(WARNING) << "malformed storage vault, unable to deserialize key=" << hex(k);
+                return -1;
+            }
+
+            if (vault.has_hdfs_info()) {
+                auto accessor = std::make_shared<HdfsAccessor>(vault.hdfs_info());
+                int ret = accessor->init();
+                if (ret != 0) {
+                    LOG(WARNING) << "failed to init hdfs accessor. instance_id=" << instance_id_
+                                 << " resource_id=" << vault.id() << " name=" << vault.name();
+                    return ret;
+                }
+
+                accessor_map_.emplace(vault.id(), std::move(accessor));
+            }
+            // TODO: more vault type
+
+            if (!it->has_next()) {
+                storage_vault_start = k;
+            }
+        }
+        storage_vault_start.push_back('\x00'); // Update to next smallest key for iteration
+
+    } while (it->more());
+
     return 0;
 }
 
@@ -484,11 +553,16 @@ int InstanceChecker::do_check() {
 
 int InstanceChecker::get_bucket_lifecycle(int64_t* lifecycle_days) {
     // If there are multiple buckets, return the minimum lifecycle.
-    int64_t min_lifecycle_days = std::numeric_limits<int64_t>::max();
+    int64_t min_lifecycle_days = INT64_MAX;
     int64_t tmp_liefcycle_days = 0;
     for (const auto& [obj_info, accessor] : accessor_map_) {
-        if (accessor->check_bucket_versioning() != 0) return -1;
-        if (accessor->get_bucket_lifecycle(&tmp_liefcycle_days) != 0) return -1;
+        if (accessor->type() != AccessorType::S3) {
+            continue;
+        }
+
+        auto* s3_accessor = static_cast<S3Accessor*>(accessor.get());
+        if (s3_accessor->check_bucket_versioning() != 0) return -1;
+        if (s3_accessor->get_bucket_lifecycle(&tmp_liefcycle_days) != 0) return -1;
         if (tmp_liefcycle_days < min_lifecycle_days) min_lifecycle_days = tmp_liefcycle_days;
     }
     *lifecycle_days = min_lifecycle_days;
@@ -496,6 +570,12 @@ int InstanceChecker::get_bucket_lifecycle(int64_t* lifecycle_days) {
 }
 
 int InstanceChecker::do_inverted_check() {
+    if (accessor_map_.size() > 1) {
+        LOG(INFO) << "currently not support inverted check for multi accessor. instance_id="
+                  << instance_id_;
+        return 0;
+    }
+
     LOG(INFO) << "begin to inverted check objects instance_id=" << instance_id_;
     long num_scanned = 0;
     long num_check_failed = 0;
@@ -594,6 +674,13 @@ int InstanceChecker::do_inverted_check() {
         TEST_SYNC_POINT_RETURN_WITH_VALUE("InstanceChecker::do_inverted_check", &tmp_ret);
     }
     for (auto& [_, accessor] : accessor_map_) {
+        if (accessor->type() != AccessorType::S3) {
+            // FIXME(plat1ko): List hdfs accessor in current path style (i.e.
+            // data/{tablet_id}/{rowset_id}_{seg_num}.dat ) will consume too much memory if there
+            // are huge number of tablets.
+            continue;
+        }
+
         auto* s3_accessor = static_cast<S3Accessor*>(accessor.get());
         auto client = s3_accessor->s3_client();
         const auto& conf = s3_accessor->conf();

--- a/cloud/src/recycler/checker.h
+++ b/cloud/src/recycler/checker.h
@@ -52,7 +52,7 @@ private:
     friend class RecyclerServiceImpl;
 
     std::shared_ptr<TxnKv> txn_kv_;
-    std::atomic_bool stopped_{false};
+    std::atomic_bool stopped_ {false};
     std::string ip_port_;
     std::vector<std::thread> workers_;
 
@@ -67,7 +67,6 @@ private:
     std::condition_variable notifier_;
 
     WhiteBlackList instance_filter_;
-
 };
 
 class InstanceChecker {
@@ -83,17 +82,25 @@ public:
     // Return -1 if encountering the situation that need to abort checker.
     // Return -2 if having S3 access errors or data loss
     int do_check();
+    // If there are multiple buckets, return the minimum lifecycle; if there are no buckets (i.e.
+    // all accessors are HdfsAccessor), return INT64_MAX.
     // Return 0 if success, otherwise error
-    int get_bucket_lifecycle(int64_t* lifecycle);
+    int get_bucket_lifecycle(int64_t* lifecycle_days);
     void stop() { stopped_.store(true, std::memory_order_release); }
     bool stopped() const { return stopped_.load(std::memory_order_acquire); }
 
 private:
+    // returns 0 for success otherwise error
+    int init_obj_store_accessors(const InstanceInfoPB& instance);
+
+    // returns 0 for success otherwise error
+    int init_storage_vault_accessors(const InstanceInfoPB& instance);
+
     std::atomic_bool stopped_ {false};
     std::shared_ptr<TxnKv> txn_kv_;
     std::string instance_id_;
-    // TODO(plat1ko): Support hdfs vaults
-    std::unordered_map<std::string, std::shared_ptr<S3Accessor>> accessor_map_;
+    // id -> accessor
+    std::unordered_map<std::string, std::shared_ptr<ObjStoreAccessor>> accessor_map_;
 };
 
 } // namespace doris::cloud

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -23,6 +23,7 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "recycler/obj_store_accessor.h"
 
 namespace doris::cloud {
 namespace {
@@ -157,7 +158,8 @@ private:
     hdfsBuilder* hdfs_builder_ = nullptr;
 };
 
-HdfsAccessor::HdfsAccessor(const HdfsVaultInfo& info) : info_(info), prefix_(info.prefix()) {
+HdfsAccessor::HdfsAccessor(const HdfsVaultInfo& info)
+        : ObjStoreAccessor(AccessorType::HDFS), info_(info), prefix_(info.prefix()) {
     if (!prefix_.empty() && prefix_[0] != '/') {
         prefix_.insert(prefix_.begin(), '/');
     }
@@ -302,7 +304,7 @@ int HdfsAccessor::list(const std::string& relative_path, std::vector<ObjectMeta>
     for (int idx = 0; idx < num_entries; ++idx) {
         auto& file = hdfs_file_info[idx];
         std::string_view fname(file.mName);
-        fname = fname.substr(fname.rfind('/') + 1);
+        fname.remove_prefix(uri_.size() + 1);
         files->push_back({.path = std::string(fname), .size = file.mSize});
     }
 

--- a/cloud/src/recycler/hdfs_accessor.h
+++ b/cloud/src/recycler/hdfs_accessor.h
@@ -54,6 +54,7 @@ public:
     int put_object(const std::string& relative_path, const std::string& content) override;
 
     // returns 0 for success otherwise error
+    // Notice: list directory in hdfs has no recursive semantics
     int list(const std::string& relative_path, std::vector<ObjectMeta>* ObjectMeta) override;
 
     // return 0 if object exists, 1 if object is not found, negative for error
@@ -68,7 +69,7 @@ private:
 
     hdfsFS fs_ = nullptr;
 
-    std::string prefix_; // Start with '/'
+    std::string prefix_; // Either be empty or start with '/' if length > 1
     std::string uri_;
 };
 

--- a/cloud/src/recycler/obj_store_accessor.h
+++ b/cloud/src/recycler/obj_store_accessor.h
@@ -23,15 +23,22 @@
 namespace doris::cloud {
 
 struct ObjectMeta {
-    std::string path; // Relative path to parent directory
+    std::string path; // Relative path to accessor prefix
     int64_t size {0};
+};
+
+enum class AccessorType {
+    S3,
+    HDFS,
 };
 
 // TODO(plat1ko): Redesign `Accessor` interface to adapt to storage vaults other than S3 style
 class ObjStoreAccessor {
 public:
-    ObjStoreAccessor() = default;
+    explicit ObjStoreAccessor(AccessorType type) : type_(type) {}
     virtual ~ObjStoreAccessor() = default;
+
+    AccessorType type() const { return type_; }
 
     // root path
     virtual const std::string& path() const = 0;
@@ -57,6 +64,9 @@ public:
 
     // return 0 if object exists, 1 if object is not found, negative for error
     virtual int exist(const std::string& relative_path) = 0;
+
+private:
+    const AccessorType type_;
 };
 
 } // namespace doris::cloud

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -34,6 +34,7 @@
 
 #include "common/logging.h"
 #include "common/sync_point.h"
+#include "recycler/obj_store_accessor.h"
 
 namespace doris::cloud {
 #ifndef UNIT_TEST
@@ -66,7 +67,7 @@ private:
     Aws::SDKOptions aws_options_;
 };
 
-S3Accessor::S3Accessor(S3Conf conf) : conf_(std::move(conf)) {
+S3Accessor::S3Accessor(S3Conf conf) : ObjStoreAccessor(AccessorType::S3), conf_(std::move(conf)) {
     path_ = conf_.endpoint + '/' + conf_.bucket + '/' + conf_.prefix;
 }
 

--- a/cloud/test/hdfs_accessor_test.cpp
+++ b/cloud/test/hdfs_accessor_test.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    if (!cloud::init_glog("s3_accessor_test")) {
+    if (!cloud::init_glog("hdfs_accessor_test")) {
         std::cerr << "failed to init glog" << std::endl;
         return -1;
     }
@@ -101,7 +101,7 @@ TEST(HdfsAccessorTest, normal) {
     ret = accessor.list("dir_1", &files);
     ASSERT_EQ(ret, 0);
     ASSERT_EQ(files.size(), 1);
-    EXPECT_EQ(files[0].path, "file_4");
+    EXPECT_EQ(files[0].path, "dir_1/file_4");
 
     ret = accessor.delete_object("file_2");
     ASSERT_EQ(ret, 0);


### PR DESCRIPTION
## Proposed changes

- Support hdfs accessor in Checker.
- Fixed the returned path in `HdfsAccessor::list` to return the path excluding the accessor prefix rather than only file name (e.g. for path "/test_prefix/data/10001/abc_0.dat" and prefix "/test_prefix", original returned path is "abc_0.dat", now returned path is "data/10001/abc_0.dat"), in order to maintain consistency with `S3Accessor`.
- Fix the returned file_name in `HdfsFileSystem::list` to only return the file name portion. The original code returned the complete URI, which caused the wrong parsed rowset id when attempting to delete cooldowned data, leading to unexpected deletions.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

