### PR TITLE
[pipelineX](fix) Fix coredump by incorrect cancel order

### DIFF
--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -171,13 +171,13 @@ void QueryContext::set_execution_dependency_ready() {
 }
 
 void QueryContext::cancel(std::string msg, Status new_status, int fragment_id) {
+    set_exec_status(new_status);
     // Just for CAS need a left value
     bool false_cancel = false;
     if (!_is_cancelled.compare_exchange_strong(false_cancel, true)) {
         return;
     }
     DCHECK(!false_cancel && _is_cancelled);
-    set_exec_status(new_status);
 
     set_ready_to_execute(true);
     std::vector<std::weak_ptr<pipeline::PipelineFragmentContext>> ctx_to_cancel;
@@ -197,7 +197,6 @@ void QueryContext::cancel(std::string msg, Status new_status, int fragment_id) {
             pipeline_ctx->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, msg);
         }
     }
-    return;
 }
 
 void QueryContext::cancel_all_pipeline_context(const PPlanFragmentCancelReason& reason,

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -171,6 +171,7 @@ void QueryContext::set_execution_dependency_ready() {
 }
 
 void QueryContext::cancel(std::string msg, Status new_status, int fragment_id) {
+    // we must get this wrong status once query ctx's `_is_cancelled` = true.
     set_exec_status(new_status);
     // Just for CAS need a left value
     bool false_cancel = false;


### PR DESCRIPTION
## Proposed changes

*** Query id: 8c6c8b72147840e0-bc9376ccdbda18a0 ***
17:58:59   *** is nereids: 1 ***
17:58:59   *** tablet id: 0 ***
17:58:59   *** Aborted at 1712397259 (unix time) try "date -d @1712397259" if you are using GNU date ***
17:58:59   *** Current BE git commitID: c5fff3b ***
17:58:59   *** SIGABRT unknown detail explain (@0x3408) received by PID 13320 (TID 15501 OR 0x7f2c3bae5700) from PID 13320; stack trace: ***
17:58:59    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
17:58:59    1# 0x00007F2CF9872090 in /lib/x86_64-linux-gnu/libc.so.6
17:58:59    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
17:58:59    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
17:58:59    4# 0x0000565277D9DF9D in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
17:58:59    5# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
17:58:59    6# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
17:58:59    7# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
17:58:59    8# 0x0000565277832C5F at /root/doris/be/src/pipeline/pipeline_x/local_exchange/local_exchange_sink_operator.cpp:49
17:58:59    9# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/pipeline/pipeline_x/operator.h:655
17:58:59   10# doris::pipeline::PipelineXTask::close(doris::Status) at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:380
17:58:59   11# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /root/doris/be/src/pipeline/task_scheduler.cpp:242
17:58:59   12# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:300
17:58:59   13# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:551
17:58:59   14# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
17:58:59   15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
17:58:59   16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

