### PR TITLE
[Improvement](executor)add backgroud workload group used for doris background workload

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -68,6 +68,9 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
 
     public static final Long DEFAULT_GROUP_ID = 1L;
 
+    public static final String DEFAULT_BG_WG_NAME = "bg_wg";
+    public static final Long DEFAULT_BG_WG_ID = 2L;
+
     public static final ImmutableList<String> WORKLOAD_GROUP_PROC_NODE_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Id").add("Name").add(WorkloadGroup.CPU_SHARE).add(WorkloadGroup.MEMORY_LIMIT)
             .add(WorkloadGroup.ENABLE_MEMORY_OVERCOMMIT)
@@ -152,14 +155,28 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
     }
 
     public void appendInternalWorkloadGroup() {
-        Map<String, String> properties = Maps.newHashMap();
-        properties.put(WorkloadGroup.CPU_SHARE, "1024");
-        properties.put(WorkloadGroup.MEMORY_LIMIT, "30%");
-        properties.put(WorkloadGroup.ENABLE_MEMORY_OVERCOMMIT, "true");
-        WorkloadGroup defaultWorkloadGroup = new WorkloadGroup(DEFAULT_GROUP_ID.longValue(), DEFAULT_GROUP_NAME,
-                properties);
-        nameToWorkloadGroup.put(DEFAULT_GROUP_NAME, defaultWorkloadGroup);
-        idToWorkloadGroup.put(defaultWorkloadGroup.getId(), defaultWorkloadGroup);
+            {
+                Map<String, String> properties = Maps.newHashMap();
+                properties.put(WorkloadGroup.CPU_SHARE, "1024");
+                properties.put(WorkloadGroup.MEMORY_LIMIT, "30%");
+                properties.put(WorkloadGroup.ENABLE_MEMORY_OVERCOMMIT, "true");
+                WorkloadGroup defaultWorkloadGroup = new WorkloadGroup(DEFAULT_GROUP_ID.longValue(), DEFAULT_GROUP_NAME,
+                        properties);
+                nameToWorkloadGroup.put(defaultWorkloadGroup.getName(), defaultWorkloadGroup);
+                idToWorkloadGroup.put(defaultWorkloadGroup.getId(), defaultWorkloadGroup);
+            }
+
+            {
+                Map<String, String> properties = Maps.newHashMap();
+                properties.put(WorkloadGroup.CPU_SHARE, "1024");
+                properties.put(WorkloadGroup.MEMORY_LIMIT, "1%");
+                properties.put(WorkloadGroup.ENABLE_MEMORY_OVERCOMMIT, "true");
+                properties.put(WorkloadGroup.SCAN_THREAD_NUM, "16"); // set 16 here because it can pass pr pipeline
+                WorkloadGroup defaultBgWg = new WorkloadGroup(DEFAULT_BG_WG_ID.longValue(), DEFAULT_BG_WG_NAME,
+                        properties);
+                nameToWorkloadGroup.put(defaultBgWg.getName(), defaultBgWg);
+                idToWorkloadGroup.put(defaultBgWg.getId(), defaultBgWg);
+            }
     }
 
     private void readLock() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -192,7 +192,7 @@ public class StatisticsUtil {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         sessionVariable.internalSession = true;
         sessionVariable.setMaxExecMemByte(Config.statistics_sql_mem_limit_in_bytes);
-        sessionVariable.workloadGroup = WorkloadGroupMgr.DEFAULT_GROUP_NAME;
+        sessionVariable.workloadGroup = WorkloadGroupMgr.DEFAULT_BG_WG_NAME;
         sessionVariable.setEnableInsertStrict(true);
         sessionVariable.enablePageCache = false;
         sessionVariable.enableProfile = Config.enable_profile_when_analyze;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -69,6 +69,7 @@ import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.statistics.AnalysisInfo;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
@@ -191,7 +192,7 @@ public class StatisticsUtil {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         sessionVariable.internalSession = true;
         sessionVariable.setMaxExecMemByte(Config.statistics_sql_mem_limit_in_bytes);
-        sessionVariable.cpuResourceLimit = Config.cpu_resource_limit_per_analyze_task;
+        sessionVariable.workloadGroup = WorkloadGroupMgr.DEFAULT_GROUP_NAME;
         sessionVariable.setEnableInsertStrict(true);
         sessionVariable.enablePageCache = false;
         sessionVariable.enableProfile = Config.enable_profile_when_analyze;

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -249,9 +249,9 @@ public class WorkloadGroupMgrTest {
 
         context.getSessionVariable().setWorkloadGroup(name);
         List<TopicInfo> tWorkloadGroups = workloadGroupMgr.getPublishTopicInfo();
-        Assert.assertEquals(2, tWorkloadGroups.size());
+        Assert.assertEquals(3, tWorkloadGroups.size());
         TopicInfo tWorkloadGroup1 = null;
-        for (int i = 0; i < 2; ++i) {
+        for (int i = 0; i < 3; ++i) {
             if (tWorkloadGroups.get(i).getWorkloadGroupInfo().getName().equals(name)) {
                 tWorkloadGroup1 = tWorkloadGroups.get(i);
                 break;

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -120,13 +120,13 @@ public class WorkloadGroupMgrTest {
         workloadGroupMgr.createWorkloadGroup(stmt1);
 
         Map<String, WorkloadGroup> nameToRG = workloadGroupMgr.getNameToWorkloadGroup();
-        Assert.assertEquals(2, nameToRG.size());
+        Assert.assertEquals(3, nameToRG.size());
         Assert.assertTrue(nameToRG.containsKey(name1));
         WorkloadGroup group1 = nameToRG.get(name1);
         Assert.assertEquals(name1, group1.getName());
 
         Map<Long, WorkloadGroup> idToRG = workloadGroupMgr.getIdToWorkloadGroup();
-        Assert.assertEquals(2, idToRG.size());
+        Assert.assertEquals(3, idToRG.size());
         Assert.assertTrue(idToRG.containsKey(group1.getId()));
 
         Map<String, String> properties2 = Maps.newHashMap();
@@ -137,11 +137,11 @@ public class WorkloadGroupMgrTest {
         workloadGroupMgr.createWorkloadGroup(stmt2);
 
         nameToRG = workloadGroupMgr.getNameToWorkloadGroup();
-        Assert.assertEquals(3, nameToRG.size());
+        Assert.assertEquals(4, nameToRG.size());
         Assert.assertTrue(nameToRG.containsKey(name2));
         WorkloadGroup group2 = nameToRG.get(name2);
         idToRG = workloadGroupMgr.getIdToWorkloadGroup();
-        Assert.assertEquals(3, idToRG.size());
+        Assert.assertEquals(4, idToRG.size());
         Assert.assertTrue(idToRG.containsKey(group2.getId()));
 
         try {
@@ -153,8 +153,8 @@ public class WorkloadGroupMgrTest {
 
         CreateWorkloadGroupStmt stmt3 = new CreateWorkloadGroupStmt(true, name2, properties2);
         workloadGroupMgr.createWorkloadGroup(stmt3);
-        Assert.assertEquals(3, workloadGroupMgr.getIdToWorkloadGroup().size());
-        Assert.assertEquals(3, workloadGroupMgr.getNameToWorkloadGroup().size());
+        Assert.assertEquals(4, workloadGroupMgr.getIdToWorkloadGroup().size());
+        Assert.assertEquals(4, workloadGroupMgr.getNameToWorkloadGroup().size());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
I add a Doris's internal Workload group named ```bg_wg``` to instead of ```cpu_resource_limit```, currently it's used for limit doris's analysis task.
