### PR TITLE
[chore](third-party) Fix compatibility issues with GLIBC(>= 2.34) for prebuilt thirdparty packages

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -421,3 +421,14 @@ if [[ "${BASE64_SOURCE}" = "base64-0.5.2" ]]; then
     cd -
 fi
 echo "Finished patching ${BASE64_SOURCE}"
+
+# patch krb
+if [[ "${KRB5_SOURCE}" = "krb5-1.19" ]]; then
+    cd "${TP_SOURCE_DIR}/${KRB5_SOURCE}"
+    if [[ ! -f "${PATCHED_MARK}" ]]; then
+        patch -p1 <"${TP_PATCH_DIR}/krb5-1.19.patch"
+        touch "${PATCHED_MARK}"
+    fi
+    cd -
+fi
+echo "Finished patching ${KRB5_SOURCE}"

--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/krb5/os/dnsglue.c b/src/lib/krb5/os/dnsglue.c
+index 0cd213f..2514fcd 100644
+--- a/src/lib/krb5/os/dnsglue.c
++++ b/src/lib/krb5/os/dnsglue.c
+@@ -87,6 +87,8 @@ static int initparse(struct krb5int_dns_state *);
+ 
+ #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
+ 
++__asm__(".symver __res_nsearch,__res_nsearch@GLIBC_2.2.5");
++
+ /* Use res_ninit, res_nsearch, and res_ndestroy or res_nclose. */
+ #define DECLARE_HANDLE(h) struct __res_state h
+ #define INIT_HANDLE(h) (memset(&h, 0, sizeof(h)), res_ninit(&h) == 0)


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Some symbols changed after GLIBC 2.34 according to the [release notes](https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html).
> Various symbols previously defined in libresolv have been moved to libc
  in order to prepare for libresolv moving entirely into libc (see earlier
  entry for merging libraries into libc).  The symbols __dn_comp,
  __dn_expand, __dn_skipname, __res_dnok, __res_hnok, __res_mailok,
  __res_mkquery, __res_nmkquery, __res_nquery, __res_nquerydomain,
  __res_nsearch, __res_nsend, __res_ownok, __res_query, __res_querydomain,
  __res_search, __res_send formerly in libresolv have been renamed and no
  longer have a __ prefix.  They are now available in libc.

This may cause the following linkage errors if we use GLIBC(>= 2.34).
```shell
>>> referenced by dnsglue.c
>>>               dnsglue.o:(krb5int_dns_init) in archive /Programs/doris/thirdparty/installed/lib/libkrb5.a
>>> did you mean: __res_nsearch@GLIBC_2.2.5
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

