### PR TITLE
[feature](Cloud) Enhance for compatibility of old cloud create table logic

### DIFF
--- a/cloud/src/common/string_util.h
+++ b/cloud/src/common/string_util.h
@@ -22,7 +22,7 @@
 namespace doris::cloud {
 
 static inline std::string trim(std::string& str) {
-    const std::string drop = "/ \t";
+    constexpr std::string_view drop = "/ \t";
     str.erase(str.find_last_not_of(drop) + 1);
     return str.erase(0, str.find_first_not_of(drop));
 }

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -589,7 +589,6 @@ void MetaServiceImpl::create_tablets(::google::protobuf::RpcController* controll
         // In legacy compatible cloud instances we use the latest obj info's id as default vault id
         if(size_t idx = instance.obj_info().size() - 1; idx > 0) {
             response->set_storage_vault_id(instance.obj_info().at(idx - 1).id());
-            response->set_storage_vault_name(BUILT_IN_STORAGE_VAULT_NAME);
             break;
         }
 

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -587,7 +587,7 @@ void MetaServiceImpl::create_tablets(::google::protobuf::RpcController* controll
         // The obj info stores the legacy obj info for Cloud and stage.
         // All the obj info stored in obj_info is sorted in descending order by id
         // In legacy compatible cloud instances we use the latest obj info's id as default vault id
-        if(size_t idx = instance.obj_info().size() - 1; idx > 0) {
+        if(int idx = instance.obj_info().size() - 1; idx > 0) {
             response->set_storage_vault_id(instance.obj_info().at(idx - 1).id());
             break;
         }

--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -41,6 +41,9 @@ namespace doris::cloud {
 
 class Transaction;
 
+constexpr char BUILT_IN_STORAGE_VAULT_NAME[] = "built_in_storage_vault";
+constexpr char BUILT_IN_STORAGE_VAULT_ID[] = "1";
+
 class MetaServiceImpl : public cloud::MetaService {
 public:
     MetaServiceImpl(std::shared_ptr<TxnKv> txn_kv, std::shared_ptr<ResourceManager> resource_mgr,

--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -41,8 +41,8 @@ namespace doris::cloud {
 
 class Transaction;
 
-constexpr char BUILT_IN_STORAGE_VAULT_NAME[] = "built_in_storage_vault";
-constexpr char BUILT_IN_STORAGE_VAULT_ID[] = "1";
+constexpr std::string_view BUILT_IN_STORAGE_VAULT_NAME = "built_in_storage_vault";
+constexpr std::string_view BUILT_IN_STORAGE_VAULT_ID = "1";
 
 class MetaServiceImpl : public cloud::MetaService {
 public:

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -397,7 +397,7 @@ static int add_hdfs_storage_vault(InstanceInfoPB& instance, Transaction* txn,
     storage_vault_key({instance.instance_id(), vault_id}, &key);
     hdfs_param.set_id(vault_id);
     if (vault_id == BUILT_IN_STORAGE_VAULT_ID) {
-        hdfs_param.set_name(BUILT_IN_STORAGE_VAULT_NAME);
+        hdfs_param.set_name(BUILT_IN_STORAGE_VAULT_NAME.data());
     }
     std::string val = hdfs_param.SerializeAsString();
     txn->put(key, val);
@@ -649,7 +649,7 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
         last_item.set_provider(request->obj().provider());
         last_item.set_sse_enabled(instance.sse_enabled());
         if (last_item.id() == BUILT_IN_STORAGE_VAULT_ID) {
-            last_item.set_name(BUILT_IN_STORAGE_VAULT_NAME);
+            last_item.set_name(BUILT_IN_STORAGE_VAULT_NAME.data());
         }
          // TODO(ByteYue): Add S3 vault
         instance.add_obj_info()->CopyFrom(last_item);
@@ -982,7 +982,7 @@ static int create_instance_with_object_info(InstanceInfoPB& instance, const Obje
     obj_info.set_sse_enabled(sse_enabled);
     // TODO(ByteYue): Add S3 vault
     if (obj_info.id() == BUILT_IN_STORAGE_VAULT_ID) {
-        obj_info.set_name(BUILT_IN_STORAGE_VAULT_NAME);
+        obj_info.set_name(BUILT_IN_STORAGE_VAULT_NAME.data());
     }
     instance.mutable_obj_info()->Add(std::move(obj_info));
     return 0;

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -40,9 +40,6 @@ using namespace std::chrono;
 
 namespace doris::cloud {
 
-const static char* BUILT_IN_STORAGE_VAULT_NAME = "built_in_storage_vault";
-const static char* BUILT_IN_STORAGE_VAULT_ID = "1";
-
 static void* run_bthread_work(void* arg) {
     auto f = reinterpret_cast<std::function<void()>*>(arg);
     (*f)();
@@ -401,8 +398,6 @@ static int add_hdfs_storage_vault(InstanceInfoPB& instance, Transaction* txn,
     hdfs_param.set_id(vault_id);
     if (vault_id == BUILT_IN_STORAGE_VAULT_ID) {
         hdfs_param.set_name(BUILT_IN_STORAGE_VAULT_NAME);
-        instance.set_default_storage_vault_name(BUILT_IN_STORAGE_VAULT_NAME);
-        instance.set_default_storage_vault_id(BUILT_IN_STORAGE_VAULT_ID);
     }
     std::string val = hdfs_param.SerializeAsString();
     txn->put(key, val);
@@ -655,9 +650,8 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
         last_item.set_sse_enabled(instance.sse_enabled());
         if (last_item.id() == BUILT_IN_STORAGE_VAULT_ID) {
             last_item.set_name(BUILT_IN_STORAGE_VAULT_NAME);
-            instance.set_default_storage_vault_name(BUILT_IN_STORAGE_VAULT_NAME);
-            instance.set_default_storage_vault_id(BUILT_IN_STORAGE_VAULT_ID);
         }
+         // TODO(ByteYue): Add S3 vault
         instance.add_obj_info()->CopyFrom(last_item);
     } break;
     case AlterObjStoreInfoRequest::ADD_HDFS_INFO: {
@@ -986,10 +980,9 @@ static int create_instance_with_object_info(InstanceInfoPB& instance, const Obje
     obj_info.set_ctime(time);
     obj_info.set_mtime(time);
     obj_info.set_sse_enabled(sse_enabled);
+    // TODO(ByteYue): Add S3 vault
     if (obj_info.id() == BUILT_IN_STORAGE_VAULT_ID) {
         obj_info.set_name(BUILT_IN_STORAGE_VAULT_NAME);
-        instance.set_default_storage_vault_name(BUILT_IN_STORAGE_VAULT_NAME);
-        instance.set_default_storage_vault_id(BUILT_IN_STORAGE_VAULT_ID);
     }
     instance.mutable_obj_info()->Add(std::move(obj_info));
     return 0;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
For existing Cloud clusters, when creating tables, FE passes an empty vault name. Subsequently, it will look for the object info with the largest ID in the S3 object info and use it as the vault.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

