### PR TITLE
[opt](fe-ui) support read hardware info from aarch64 MacOS (#23708)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -453,12 +453,12 @@ under the License.
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.5.0</version>
+            <version>5.13.0</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>5.5.0</version>
+            <version>5.13.0</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -285,7 +285,7 @@ under the License.
         <validation-api.version>1.1.0.Final</validation-api.version>
         <zjsonpatch.version>0.2.3</zjsonpatch.version>
         <kafka-clients.version>3.4.0</kafka-clients.version>
-        <oshi-core.version>4.0.0</oshi-core.version>
+        <oshi-core.version>6.4.5</oshi-core.version>
         <xnio-nio.version>3.8.9.Final</xnio-nio.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
update the version of oshi and jna to support read hardware info from aarch64 MacOS

(cherry picked from #23708)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

