### PR TITLE
[improve](load) limit flush thread num proportional to CPU count

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -662,6 +662,9 @@ DEFINE_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
 DEFINE_Int32(flush_thread_num_per_store, "6");
 // number of thread for flushing memtable per store, for high priority load task
 DEFINE_Int32(high_priority_flush_thread_num_per_store, "6");
+// number of threads = min(flush_thread_num_per_store * num_store,
+//                         max_flush_thread_num_per_cpu * num_cpu)
+DEFINE_Int32(max_flush_thread_num_per_cpu, "4");
 
 // config for tablet meta checkpoint
 DEFINE_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -715,6 +715,9 @@ DECLARE_mInt64(storage_flood_stage_left_capacity_bytes); // 1GB
 DECLARE_Int32(flush_thread_num_per_store);
 // number of thread for flushing memtable per store, for high priority load task
 DECLARE_Int32(high_priority_flush_thread_num_per_store);
+// number of threads = min(flush_thread_num_per_store * num_store,
+//                         max_flush_thread_num_per_cpu * num_cpu)
+DECLARE_Int32(max_flush_thread_num_per_cpu);
 
 // config for tablet meta checkpoint
 DECLARE_mInt32(tablet_meta_checkpoint_min_new_rowsets_num);

--- a/be/src/runtime/load_stream_mgr.cpp
+++ b/be/src/runtime/load_stream_mgr.cpp
@@ -37,9 +37,13 @@ LoadStreamMgr::LoadStreamMgr(uint32_t segment_file_writer_thread_num,
         : _num_threads(segment_file_writer_thread_num),
           _heavy_work_pool(heavy_work_pool),
           _light_work_pool(light_work_pool) {
+    uint32_t num_cpu = std::thread::hardware_concurrency();
+    uint32_t thread_num = num_cpu == 0 ? segment_file_writer_thread_num
+                                       : std::min(segment_file_writer_thread_num,
+                                                  num_cpu * config::max_flush_thread_num_per_cpu);
     static_cast<void>(ThreadPoolBuilder("SegmentFileWriterThreadPool")
-                              .set_min_threads(segment_file_writer_thread_num)
-                              .set_max_threads(segment_file_writer_thread_num)
+                              .set_min_threads(thread_num)
+                              .set_max_threads(thread_num)
                               .build(&_file_writer_thread_pool));
 }
 


### PR DESCRIPTION
## Proposed changes

Add BE config `max_flush_thread_num_per_cpu` and `max_high_priority_flush_thread_num_per_cpu `.
The default value is `8`.

The max threads for flush thread pool will be:

```
number of threads = min(flush_thread_num_per_store * num_store,
                        max_flush_thread_num_per_cpu * num_cpu)
number of threads = min(high_priority_flush_thread_num_per_store * num_store,
                        max_high_priority_flush_thread_num_per_cpu * num_cpu)
```

This is for preventing the flush thread pool to be too large when the machine has a lot of disks.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

