### PR TITLE
[fix](jdbc catalog) fix db2 test connection sql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcDB2Client.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcDB2Client.java
@@ -34,6 +34,10 @@ public class JdbcDB2Client extends JdbcClient {
         super(jdbcClientConfig);
     }
 
+    public String getTestQuery() {
+        return "select 1 from sysibm.sysdummy1";
+    }
+
     @Override
     public List<String> getDatabaseNameList() {
         Connection conn = getConnection();

--- a/regression-test/suites/external_table_p0/jdbc/test_db2_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_db2_jdbc_catalog.groovy
@@ -261,7 +261,7 @@ suite("test_db2_jdbc_catalog", "p0,external,db2,external_docker,external_docker_
 
             order_qt_desc_db "show databases from ${catalog_name};"
 
-            order_qt_select_xml "select * from db2.TEST.BOOKS;"
+            order_qt_select_xml "select * from TEST.BOOKS;"
 
             sql """ drop catalog if exists ${catalog_name} """
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When creating the db2 catalog, you need to provide a special select 1 statement to test the connection

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

