### PR TITLE
[Improvement](executor)cancel query when a query is queued

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -504,6 +504,9 @@ public class StmtExecutor {
                 if (!e.getMessage().contains(FeConstants.CLOUD_RETRY_E230) || i == retryTime) {
                     throw e;
                 }
+                if (this.coord.isQueryCancelled()) {
+                    throw e;
+                }
                 TUniqueId lastQueryId = queryId;
                 uuid = UUID.randomUUID();
                 queryId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
@@ -803,6 +806,9 @@ public class StmtExecutor {
                 break;
             } catch (RpcException | UserException e) {
                 if (Config.isCloudMode() && e.getMessage().contains(FeConstants.CLOUD_RETRY_E230)) {
+                    throw e;
+                }
+                if (this.coord.isQueryCancelled()) {
                     throw e;
                 }
                 // cloud mode retry

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -504,7 +504,7 @@ public class StmtExecutor {
                 if (!e.getMessage().contains(FeConstants.CLOUD_RETRY_E230) || i == retryTime) {
                     throw e;
                 }
-                if (this.coord.isQueryCancelled()) {
+                if (this.coord != null && this.coord.isQueryCancelled()) {
                     throw e;
                 }
                 TUniqueId lastQueryId = queryId;
@@ -808,7 +808,7 @@ public class StmtExecutor {
                 if (Config.isCloudMode() && e.getMessage().contains(FeConstants.CLOUD_RETRY_E230)) {
                     throw e;
                 }
-                if (this.coord.isQueryCancelled()) {
+                if (this.coord != null && this.coord.isQueryCancelled()) {
                     throw e;
                 }
                 // cloud mode retry


### PR DESCRIPTION
## Proposed changes
Support kill query when it is queued.
```
// case 1: use kill stmt;
kill query 0;

// case 2: use ctr + c
mysql [hits]>select count(1) from hits.hits;
^C^C -- query aborted
ERROR 1105 (HY000): errCode = 2, detailMessage = query is cancelled in queue

```
