### PR TITLE
[bug](mem_tracker) fix mem_tracker dcheck failed as not used correctly

### DIFF
--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -106,6 +106,7 @@ int64_t ChecksumAction::do_checksum(int64_t tablet_id, int64_t version, int32_t 
     Status res = Status::OK();
     uint32_t checksum;
     EngineChecksumTask engine_task(_engine, tablet_id, schema_hash, version, &checksum);
+    SCOPED_ATTACH_TASK(engine_task.mem_tracker());
     res = engine_task.execute();
     if (!res.ok()) {
         LOG(WARNING) << "checksum failed. status: " << res << ", signature: " << tablet_id;

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -56,7 +56,6 @@ EngineChecksumTask::EngineChecksumTask(StorageEngine& engine, TTabletId tablet_i
 EngineChecksumTask::~EngineChecksumTask() = default;
 
 Status EngineChecksumTask::execute() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     return _compute_checksum();
 } // execute
 

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -56,6 +56,7 @@ EngineChecksumTask::EngineChecksumTask(StorageEngine& engine, TTabletId tablet_i
 EngineChecksumTask::~EngineChecksumTask() = default;
 
 Status EngineChecksumTask::execute() {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     return _compute_checksum();
 } // execute
 


### PR DESCRIPTION
## Proposed changes
```
F20240408 11:37:36.291920 1780373 thread_context.h:203] Check failed: !doris::config::enable_memory_orphan_check || thread_mem_tracker()->label() != "Orphan" If you crash here, it means that SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the thread will crash. If you want to switch MemTrackerLimiter during thread execution, please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach. Of course, you can modify enable_memory_orphan_check=false in be.conf to avoid this crash.
*** Check failure stack trace: ***
    @     0x55fcd6b3b7a6  google::LogMessage::SendToLog()
    @     0x55fcd6b381f0  google::LogMessage::Flush()
    @     0x55fcd6b3bfe9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55fcc6f850d3  doris::ThreadContext::consume_memory()
    @     0x55fccd44b263  Allocator<>::consume_memory()
    @     0x55fccd44bb7d  Allocator<>::alloc_impl()
    @     0x55fccd44bb25  Allocator<>::alloc()
    @     0x55fcc5bb7308  doris::vectorized::Arena::Chunk::Chunk()
    @     0x55fcc5bb6d98  doris::vectorized::Arena::Arena()
    @     0x55fcc6778d37  doris::vectorized::BlockReader::BlockReader()
    @     0x55fcc6d729c6  doris::EngineChecksumTask::_compute_checksum()
    @     0x55fcc6d72720  doris::EngineChecksumTask::execute()
    @     0x55fcc7a800f0  doris::ChecksumAction::do_checksum()
    @     0x55fcc7a7fe3a  doris::ChecksumAction::handle()
```



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

