### PR TITLE
[Fix](fs-benchmark-tool) Fix open_read operation not work in hdfs benchmark tool.

### DIFF
--- a/be/src/io/fs/benchmark/hdfs_benchmark.hpp
+++ b/be/src/io/fs/benchmark/hdfs_benchmark.hpp
@@ -48,6 +48,7 @@ public:
         auto start = std::chrono::high_resolution_clock::now();
         io::FileReaderOptions reader_opts;
         FileSystemProperties params {
+                .system_type = TFileType::FILE_HDFS,
                 .hdfs_params = parse_properties(_conf_map),
         };
         FileDescription fd {.path = file_path};


### PR DESCRIPTION
## Proposed changes

[Fix] (fs-benchmark-tool) Fix open_read operation not work in hdfs benchmark tool.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

