### PR TITLE
[improve](routine-load) timely pause job if Kafka cluster exception when consume

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -780,7 +780,13 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 cachedPartitionWithLatestOffsets.put(pair.first, pair.second);
             }
         } catch (Exception e) {
-            LOG.warn("failed to get latest partition offset. {}", e.getMessage(), e);
+            // It needs to pause job when can not get partition meta.
+            // To ensure the stability of the routine load,
+            // the scheduler will automatically pull up routine load job in this scenario,
+            // to avoid some network and Kafka exceptions causing the routine load job to stop
+            updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.PARTITIONS_ERR,
+                        "failed to get latest partition offset. {}" + e.getMessage()),
+                        false /* not replay */);
             return false;
         }
 


### PR DESCRIPTION
## Proposed changes

When Doris consumes data from Kafka, the Kafka cluster encounters problems that prevent communication. Doris continues to create tasks to consume, which in turn time out and result in the creation of a large amount of ineffective resources. 

**In actual production, this affects the inability to perform queries.**

It needs to pause job when can not get partition meta. To ensure the stability of the routine load,
the scheduler will automatically pull up routine load job in this scenario, to avoid some network and Kafka exceptions causing the routine load job to stop.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

