### PR TITLE
[fix](http stream) Fix http stream no alive backends error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1905,6 +1905,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         StreamLoadHandler streamLoadHandler = new StreamLoadHandler(request, null, result, clientAddr);
 
         try {
+            // Some requests forget to remove the ConnectContext, so remove it firstly
+            ConnectContext.remove();
             streamLoadHandler.setCloudCluster();
 
             List<TPipelineWorkloadGroup> tWorkloadGroupList = null;
@@ -1998,6 +2000,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             status.setStatusCode(TStatusCode.INTERNAL_ERROR);
             status.addToErrorMsgs(e.getClass().getSimpleName() + ": " + Strings.nullToEmpty(e.getMessage()));
             return result;
+        } finally {
+            ConnectContext.remove();
         }
         if (Config.enable_pipeline_load) {
             result.setPipelineParams(planFragmentParamsList);

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -379,12 +379,14 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
     }
 
     protected Backend getBackend() {
-        ConnectContext ctx = ConnectContext.get();
         // For the http stream task, we should obtain the be for processing the task
-        long backendId = ctx.getBackendId();
         if (getTFileType() == TFileType.FILE_STREAM) {
+            long backendId = ConnectContext.get().getBackendId();
             Backend be = Env.getCurrentSystemInfo().getIdToBackend().get(backendId);
-            if (be == null || be.isAlive()) {
+            if (be == null || !be.isAlive()) {
+                LOG.warn("Backend {} is not alive", backendId);
+                return null;
+            } else {
                 return be;
             }
         }


### PR DESCRIPTION
## Proposed changes

`test_group_commit_http_stream` is flaky because:
```
024-04-08 16:29:30,404 WARN (thrift-server-pool-3|194) [FrontendServiceImpl.initHttpStreamPlan():2035] exec sql error
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = No Alive backends
        at org.apache.doris.tablefunction.ExternalFileTableValuedFunction.getTableColumns(ExternalFileTableValuedFunct
ion.java:328) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.tablefunction.TableValuedFunctionIf.getTable(TableValuedFunctionIf.java:38) ~[doris-fe.jar
:1.2-SNAPSHOT]
        at org.apache.doris.analysis.TableValuedFunctionRef.<init>(TableValuedFunctionRef.java:48) ~[doris-fe.jar:1.2-
SNAPSHOT]
        at org.apache.doris.analysis.CUP$SqlParser$actions.case972(SqlParser.java:34160) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.CUP$SqlParser$actions.CUP$SqlParser$do_action(SqlParser.java:10578) ~[doris-fe.ja
r:1.2-SNAPSHOT]
        at org.apache.doris.analysis.SqlParser.do_action(SqlParser.java:2906) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java_cup.runtime.lr_parser.parse(lr_parser.java:584) ~[jflex-1.4.3.jar:?]
        at org.apache.doris.common.util.SqlParserUtils.getFirstStmt(SqlParserUtils.java:46) ~[doris-fe.jar:1.2-SNAPSHO
T]
        at org.apache.doris.qe.StmtExecutor.generateHttpStreamLegacyPlan(StmtExecutor.java:3201) ~[doris-fe.jar:1.2-SN
APSHOT]
        at org.apache.doris.qe.StmtExecutor.generateHttpStreamPlan(StmtExecutor.java:3255) ~[doris-fe.jar:1.2-SNAPSHOT
]
        at org.apache.doris.service.FrontendServiceImpl.initHttpStreamPlan(FrontendServiceImpl.java:2020) ~[doris-fe.j
ar:1.2-SNAPSHOT]
        at org.apache.doris.service.FrontendServiceImpl.httpStreamPutImpl(FrontendServiceImpl.java:2066) ~[doris-fe.ja
r:1.2-SNAPSHOT]
        at org.apache.doris.service.FrontendServiceImpl.streamLoadPut(FrontendServiceImpl.java:1918) ~[doris-fe.jar:1.
2-SNAPSHOT]
```

the problem is that the backend_id is not set because the ConnectContext is not null, maybe some requests forget to remove it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

