### PR TITLE
[opt](profile) parallel serialize fragment and add detail schedule profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -63,14 +63,18 @@ public class SummaryProfile {
     public static final String INIT_SCAN_NODE_TIME = "Init Scan Node Time";
     public static final String FINALIZE_SCAN_NODE_TIME = "Finalize Scan Node Time";
     public static final String GET_SPLITS_TIME = "Get Splits Time";
-    public static final String GET_PARTITIONS_TIME = "Get PARTITIONS Time";
-    public static final String GET_PARTITION_FILES_TIME = "Get PARTITION FILES Time";
+    public static final String GET_PARTITIONS_TIME = "Get Partitions Time";
+    public static final String GET_PARTITION_FILES_TIME = "Get Partition Files Time";
     public static final String CREATE_SCAN_RANGE_TIME = "Create Scan Range Time";
     public static final String PLAN_TIME = "Plan Time";
     public static final String SCHEDULE_TIME = "Schedule Time";
+    public static final String ASSIGN_FRAGMENT_TIME = "Fragment Assign Time";
+    public static final String FRAGMENT_SERIALIZE_TIME = "Fragment Serialize Time";
+    public static final String SEND_FRAGMENT_PHASE1_TIME = "Fragment RPC Phase1 Time";
+    public static final String SEND_FRAGMENT_PHASE2_TIME = "Fragment RPC Phase2 Time";
+    public static final String WAIT_FETCH_RESULT_TIME = "Wait and Fetch Result Time";
     public static final String FETCH_RESULT_TIME = "Fetch Result Time";
     public static final String WRITE_RESULT_TIME = "Write Result Time";
-    public static final String WAIT_FETCH_RESULT_TIME = "Wait and Fetch Result Time";
     public static final String GET_PARTITION_VERSION_TIME = "Get Partition Version Time";
     public static final String GET_PARTITION_VERSION_COUNT = "Get Partition Version Count";
     public static final String GET_PARTITION_VERSION_BY_HAS_DATA_COUNT = "Get Partition Version Count (hasData)";
@@ -83,45 +87,82 @@ public class SummaryProfile {
     public static final String NEREIDS_OPTIMIZE_TIME = "Nereids Optimize Time";
     public static final String NEREIDS_TRANSLATE_TIME = "Nereids Translate Time";
 
+    public static final String FRAGMENT_COMPRESSED_SIZE = "Fragment Compressed Size";
+    public static final String FRAGMENT_RPC_COUNT = "Fragment RPC Count";
+
     // These info will display on FE's web ui table, every one will be displayed as
     // a column, so that should not
     // add many columns here. Add to ExcecutionSummary list.
     public static final ImmutableList<String> SUMMARY_KEYS = ImmutableList.of(PROFILE_ID, TASK_TYPE,
             START_TIME, END_TIME, TOTAL_TIME, TASK_STATE, USER, DEFAULT_DB, SQL_STATEMENT);
 
+    // The display order of execution summary items.
     public static final ImmutableList<String> EXECUTION_SUMMARY_KEYS = ImmutableList.of(
-            PARSE_SQL_TIME, NEREIDS_ANALYSIS_TIME, NEREIDS_REWRITE_TIME, NEREIDS_OPTIMIZE_TIME, NEREIDS_TRANSLATE_TIME,
-            WORKLOAD_GROUP, ANALYSIS_TIME,
-            PLAN_TIME, JOIN_REORDER_TIME, CREATE_SINGLE_NODE_TIME, QUERY_DISTRIBUTED_TIME,
-            INIT_SCAN_NODE_TIME, FINALIZE_SCAN_NODE_TIME, GET_SPLITS_TIME, GET_PARTITIONS_TIME,
-            GET_PARTITION_FILES_TIME, CREATE_SCAN_RANGE_TIME, GET_PARTITION_VERSION_TIME,
-            GET_PARTITION_VERSION_BY_HAS_DATA_COUNT, GET_PARTITION_VERSION_COUNT, GET_TABLE_VERSION_TIME,
-            GET_TABLE_VERSION_COUNT, SCHEDULE_TIME, FETCH_RESULT_TIME,
-            WRITE_RESULT_TIME, WAIT_FETCH_RESULT_TIME, DORIS_VERSION, IS_NEREIDS, IS_PIPELINE,
-            IS_CACHED, TOTAL_INSTANCES_NUM, INSTANCES_NUM_PER_BE, PARALLEL_FRAGMENT_EXEC_INSTANCE, TRACE_ID);
+            PARSE_SQL_TIME,
+            NEREIDS_ANALYSIS_TIME,
+            NEREIDS_REWRITE_TIME,
+            NEREIDS_OPTIMIZE_TIME,
+            NEREIDS_TRANSLATE_TIME,
+            WORKLOAD_GROUP,
+            ANALYSIS_TIME,
+            PLAN_TIME,
+            JOIN_REORDER_TIME,
+            CREATE_SINGLE_NODE_TIME,
+            QUERY_DISTRIBUTED_TIME,
+            INIT_SCAN_NODE_TIME,
+            FINALIZE_SCAN_NODE_TIME,
+            GET_SPLITS_TIME, GET_PARTITIONS_TIME,
+            GET_PARTITION_FILES_TIME,
+            CREATE_SCAN_RANGE_TIME,
+            GET_PARTITION_VERSION_TIME,
+            GET_PARTITION_VERSION_BY_HAS_DATA_COUNT,
+            GET_PARTITION_VERSION_COUNT,
+            GET_TABLE_VERSION_TIME,
+            GET_TABLE_VERSION_COUNT,
+            SCHEDULE_TIME,
+            ASSIGN_FRAGMENT_TIME,
+            FRAGMENT_SERIALIZE_TIME,
+            SEND_FRAGMENT_PHASE1_TIME,
+            SEND_FRAGMENT_PHASE2_TIME,
+            FRAGMENT_COMPRESSED_SIZE,
+            FRAGMENT_RPC_COUNT,
+            WAIT_FETCH_RESULT_TIME,
+            FETCH_RESULT_TIME,
+            WRITE_RESULT_TIME,
+            DORIS_VERSION,
+            IS_NEREIDS,
+            IS_PIPELINE,
+            IS_CACHED,
+            TOTAL_INSTANCES_NUM,
+            INSTANCES_NUM_PER_BE,
+            PARALLEL_FRAGMENT_EXEC_INSTANCE,
+            TRACE_ID);
 
     // Ident of each item. Default is 0, which doesn't need to present in this Map.
     // Please set this map for new profile items if they need ident.
-    public static ImmutableMap<String, Integer> EXECUTION_SUMMARY_KEYS_IDENTATION = ImmutableMap.of();
-
-    {
-        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder<>();
-        builder.put(JOIN_REORDER_TIME, 1);
-        builder.put(CREATE_SINGLE_NODE_TIME, 1);
-        builder.put(QUERY_DISTRIBUTED_TIME, 1);
-        builder.put(INIT_SCAN_NODE_TIME, 1);
-        builder.put(FINALIZE_SCAN_NODE_TIME, 1);
-        builder.put(GET_SPLITS_TIME, 2);
-        builder.put(GET_PARTITIONS_TIME, 3);
-        builder.put(GET_PARTITION_FILES_TIME, 3);
-        builder.put(CREATE_SCAN_RANGE_TIME, 2);
-        builder.put(GET_PARTITION_VERSION_TIME, 1);
-        builder.put(GET_PARTITION_VERSION_COUNT, 1);
-        builder.put(GET_PARTITION_VERSION_BY_HAS_DATA_COUNT, 1);
-        builder.put(GET_TABLE_VERSION_TIME, 1);
-        builder.put(GET_TABLE_VERSION_COUNT, 1);
-        EXECUTION_SUMMARY_KEYS_IDENTATION = builder.build();
-    }
+    public static ImmutableMap<String, Integer> EXECUTION_SUMMARY_KEYS_IDENTATION
+            = ImmutableMap.<String, Integer>builder()
+            .put(JOIN_REORDER_TIME, 1)
+            .put(CREATE_SINGLE_NODE_TIME, 1)
+            .put(QUERY_DISTRIBUTED_TIME, 1)
+            .put(INIT_SCAN_NODE_TIME, 1)
+            .put(FINALIZE_SCAN_NODE_TIME, 1)
+            .put(GET_SPLITS_TIME, 2)
+            .put(GET_PARTITIONS_TIME, 3)
+            .put(GET_PARTITION_FILES_TIME, 3)
+            .put(CREATE_SCAN_RANGE_TIME, 2)
+            .put(GET_PARTITION_VERSION_TIME, 1)
+            .put(GET_PARTITION_VERSION_COUNT, 1)
+            .put(GET_PARTITION_VERSION_BY_HAS_DATA_COUNT, 1)
+            .put(GET_TABLE_VERSION_TIME, 1)
+            .put(GET_TABLE_VERSION_COUNT, 1)
+            .put(ASSIGN_FRAGMENT_TIME, 1)
+            .put(FRAGMENT_SERIALIZE_TIME, 1)
+            .put(SEND_FRAGMENT_PHASE1_TIME, 1)
+            .put(SEND_FRAGMENT_PHASE2_TIME, 1)
+            .put(FRAGMENT_COMPRESSED_SIZE, 1)
+            .put(FRAGMENT_RPC_COUNT, 1)
+            .build();
 
     private RuntimeProfile summaryProfile;
     private RuntimeProfile executionSummaryProfile;
@@ -153,6 +194,12 @@ public class SummaryProfile {
     private long createScanRangeFinishTime = -1;
     // Plan end time
     private long queryPlanFinishTime = -1;
+    private long assignFragmentTime = -1;
+    private long fragmentSerializeTime = -1;
+    private long fragmentSendPhase1Time = -1;
+    private long fragmentSendPhase2Time = -1;
+    private long fragmentCompressedSize = 0;
+    private long fragmentRpcCount = 0;
     // Fragment schedule and send end time
     private long queryScheduleFinishTime = -1;
     // Query result fetch end time
@@ -229,23 +276,47 @@ public class SummaryProfile {
         executionSummaryProfile.addInfoString(NEREIDS_REWRITE_TIME, getPrettyNereidsRewriteTime());
         executionSummaryProfile.addInfoString(NEREIDS_OPTIMIZE_TIME, getPrettyNereidsOptimizeTime());
         executionSummaryProfile.addInfoString(NEREIDS_TRANSLATE_TIME, getPrettyNereidsTranslateTime());
-        executionSummaryProfile.addInfoString(ANALYSIS_TIME, getPrettyQueryAnalysisFinishTime());
-        executionSummaryProfile.addInfoString(PLAN_TIME, getPrettyQueryPlanFinishTime());
-        executionSummaryProfile.addInfoString(JOIN_REORDER_TIME, getPrettyQueryJoinReorderFinishTime());
-        executionSummaryProfile.addInfoString(CREATE_SINGLE_NODE_TIME, getPrettyCreateSingleNodeFinishTime());
-        executionSummaryProfile.addInfoString(QUERY_DISTRIBUTED_TIME, getPrettyQueryDistributedFinishTime());
-        executionSummaryProfile.addInfoString(INIT_SCAN_NODE_TIME, getPrettyInitScanNodeTime());
-        executionSummaryProfile.addInfoString(FINALIZE_SCAN_NODE_TIME, getPrettyFinalizeScanNodeTime());
-        executionSummaryProfile.addInfoString(GET_SPLITS_TIME, getPrettyGetSplitsTime());
-        executionSummaryProfile.addInfoString(GET_PARTITIONS_TIME, getPrettyGetPartitionsTime());
-        executionSummaryProfile.addInfoString(GET_PARTITION_FILES_TIME, getPrettyGetPartitionFilesTime());
-        executionSummaryProfile.addInfoString(CREATE_SCAN_RANGE_TIME, getPrettyCreateScanRangeTime());
-        executionSummaryProfile.addInfoString(SCHEDULE_TIME, getPrettyQueryScheduleFinishTime());
+        executionSummaryProfile.addInfoString(ANALYSIS_TIME,
+                getPrettyTime(queryAnalysisFinishTime, queryBeginTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(PLAN_TIME,
+                getPrettyTime(queryPlanFinishTime, queryAnalysisFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(JOIN_REORDER_TIME,
+                getPrettyTime(queryJoinReorderFinishTime, queryAnalysisFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(CREATE_SINGLE_NODE_TIME,
+                getPrettyTime(queryCreateSingleNodeFinishTime, queryJoinReorderFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(QUERY_DISTRIBUTED_TIME,
+                getPrettyTime(queryDistributedFinishTime, queryCreateSingleNodeFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(INIT_SCAN_NODE_TIME,
+                getPrettyTime(initScanNodeFinishTime, initScanNodeStartTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(FINALIZE_SCAN_NODE_TIME,
+                getPrettyTime(finalizeScanNodeFinishTime, finalizeScanNodeStartTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(GET_SPLITS_TIME,
+                getPrettyTime(getSplitsFinishTime, getSplitsStartTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(GET_PARTITIONS_TIME,
+                getPrettyTime(getPartitionsFinishTime, getSplitsStartTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(GET_PARTITION_FILES_TIME,
+                getPrettyTime(getPartitionFilesFinishTime, getPartitionsFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(CREATE_SCAN_RANGE_TIME,
+                getPrettyTime(createScanRangeFinishTime, getSplitsFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(SCHEDULE_TIME,
+                getPrettyTime(queryScheduleFinishTime, queryPlanFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(ASSIGN_FRAGMENT_TIME,
+                getPrettyTime(assignFragmentTime, queryPlanFinishTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(FRAGMENT_SERIALIZE_TIME,
+                getPrettyTime(fragmentSerializeTime, assignFragmentTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(SEND_FRAGMENT_PHASE1_TIME,
+                getPrettyTime(fragmentSendPhase1Time, fragmentSerializeTime, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(SEND_FRAGMENT_PHASE2_TIME,
+                getPrettyTime(fragmentSendPhase2Time, fragmentSendPhase1Time, TUnit.TIME_MS));
+        executionSummaryProfile.addInfoString(FRAGMENT_COMPRESSED_SIZE,
+                RuntimeProfile.printCounter(fragmentCompressedSize, TUnit.BYTES));
+        executionSummaryProfile.addInfoString(FRAGMENT_RPC_COUNT, "" + fragmentRpcCount);
+        executionSummaryProfile.addInfoString(WAIT_FETCH_RESULT_TIME,
+                getPrettyTime(queryFetchResultFinishTime, queryScheduleFinishTime, TUnit.TIME_MS));
         executionSummaryProfile.addInfoString(FETCH_RESULT_TIME,
                 RuntimeProfile.printCounter(queryFetchResultConsumeTime, TUnit.TIME_MS));
         executionSummaryProfile.addInfoString(WRITE_RESULT_TIME,
                 RuntimeProfile.printCounter(queryWriteResultConsumeTime, TUnit.TIME_MS));
-        executionSummaryProfile.addInfoString(WAIT_FETCH_RESULT_TIME, getPrettyQueryFetchResultFinishTime());
 
         if (Config.isCloudMode()) {
             executionSummaryProfile.addInfoString(GET_PARTITION_VERSION_TIME, getPrettyGetPartitionVersionTime());
@@ -359,6 +430,30 @@ public class SummaryProfile {
 
     public void freshWriteResultConsumeTime() {
         this.queryWriteResultConsumeTime += TimeUtils.getStartTimeMs() - tempStarTime;
+    }
+
+    public void setAssignFragmentTime() {
+        this.assignFragmentTime = TimeUtils.getStartTimeMs();
+    }
+
+    public void setFragmentSerializeTime() {
+        this.fragmentSerializeTime = TimeUtils.getStartTimeMs();
+    }
+
+    public void setFragmentSendPhase1Time() {
+        this.fragmentSendPhase1Time = TimeUtils.getStartTimeMs();
+    }
+
+    public void setFragmentSendPhase2Time() {
+        this.fragmentSendPhase2Time = TimeUtils.getStartTimeMs();
+    }
+
+    public void updateFragmentCompressedSize(long size) {
+        this.fragmentCompressedSize += size;
+    }
+
+    public void updateFragmentRpcCount(long count) {
+        this.fragmentRpcCount += count;
     }
 
     public void addGetPartitionVersionTime(long ns) {
@@ -478,129 +573,23 @@ public class SummaryProfile {
     }
 
     public String getPrettyParseSqlTime() {
-        if (parseSqlStartTime == -1 || parseSqlFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(parseSqlFinishTime - parseSqlStartTime, TUnit.TIME_MS);
+        return getPrettyTime(parseSqlStartTime, parseSqlFinishTime, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsAnalysisTime() {
-        if (nereidsAnalysisFinishTime == -1 || queryAnalysisFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(nereidsAnalysisFinishTime - queryBeginTime, TUnit.TIME_MS);
+        return getPrettyTime(nereidsAnalysisFinishTime, queryBeginTime, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsRewriteTime() {
-        if (nereidsRewriteFinishTime == -1 || nereidsAnalysisFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(nereidsRewriteFinishTime - nereidsAnalysisFinishTime, TUnit.TIME_MS);
+        return getPrettyTime(nereidsRewriteFinishTime, nereidsAnalysisFinishTime, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsOptimizeTime() {
-        if (nereidsOptimizeFinishTime == -1 || nereidsRewriteFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(nereidsOptimizeFinishTime - nereidsRewriteFinishTime, TUnit.TIME_MS);
+        return getPrettyTime(nereidsOptimizeFinishTime, nereidsRewriteFinishTime, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsTranslateTime() {
-        if (nereidsTranslateFinishTime == -1 || nereidsOptimizeFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(nereidsTranslateFinishTime - nereidsOptimizeFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryAnalysisFinishTime() {
-        if (queryBeginTime == -1 || queryAnalysisFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryAnalysisFinishTime - queryBeginTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryJoinReorderFinishTime() {
-        if (queryAnalysisFinishTime == -1 || queryJoinReorderFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryJoinReorderFinishTime - queryAnalysisFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyCreateSingleNodeFinishTime() {
-        if (queryJoinReorderFinishTime == -1 || queryCreateSingleNodeFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryCreateSingleNodeFinishTime - queryJoinReorderFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryDistributedFinishTime() {
-        if (queryCreateSingleNodeFinishTime == -1 || queryDistributedFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryDistributedFinishTime - queryCreateSingleNodeFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyInitScanNodeTime() {
-        if (initScanNodeStartTime == -1 || initScanNodeFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(initScanNodeFinishTime - initScanNodeStartTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyFinalizeScanNodeTime() {
-        if (finalizeScanNodeFinishTime == -1 || finalizeScanNodeStartTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(finalizeScanNodeFinishTime - finalizeScanNodeStartTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyGetSplitsTime() {
-        if (getSplitsFinishTime == -1 || getSplitsStartTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(getSplitsFinishTime - getSplitsStartTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyGetPartitionsTime() {
-        if (getSplitsStartTime == -1 || getPartitionsFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(getPartitionsFinishTime - getSplitsStartTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyGetPartitionFilesTime() {
-        if (getPartitionsFinishTime == -1 || getPartitionFilesFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(getPartitionFilesFinishTime - getPartitionsFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyCreateScanRangeTime() {
-        if (getSplitsFinishTime == -1 || createScanRangeFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(createScanRangeFinishTime - getSplitsFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryPlanFinishTime() {
-        if (queryAnalysisFinishTime == -1 || queryPlanFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryPlanFinishTime - queryAnalysisFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryScheduleFinishTime() {
-        if (queryPlanFinishTime == -1 || queryScheduleFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryScheduleFinishTime - queryPlanFinishTime, TUnit.TIME_MS);
-    }
-
-    private String getPrettyQueryFetchResultFinishTime() {
-        if (queryScheduleFinishTime == -1 || queryFetchResultFinishTime == -1) {
-            return "N/A";
-        }
-        return RuntimeProfile.printCounter(queryFetchResultFinishTime - queryScheduleFinishTime, TUnit.TIME_MS);
+        return getPrettyTime(nereidsTranslateFinishTime, nereidsOptimizeFinishTime, TUnit.TIME_MS);
     }
 
     private String getPrettyGetPartitionVersionTime() {
@@ -627,5 +616,12 @@ public class SummaryProfile {
 
     private String getPrettyGetTableVersionCount() {
         return RuntimeProfile.printCounter(getTableVersionCount, TUnit.UNIT);
+    }
+
+    private String getPrettyTime(long end, long start, TUnit unit) {
+        if (start == -1 || end == -1) {
+            return "N/A";
+        }
+        return RuntimeProfile.printCounter(end - start, unit);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -90,8 +90,7 @@ public class BrokerUtil {
                     brokerDesc.getName(), brokerDesc.getStorageType(), brokerDesc.getProperties());
             Status st = fileSystem.list(path, rfiles, false);
             if (!st.ok()) {
-                throw new UserException(brokerDesc.getName() + " list path failed. path=" + path
-                        + ",msg=" + st.getErrMsg());
+                throw new UserException(st.getErrMsg());
             }
         } catch (Exception e) {
             LOG.warn("{} list path exception, path={}", brokerDesc.getName(), path, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -718,7 +718,9 @@ public class Coordinator implements CoordInterface {
             LOG.info("dispatch load job: {} to {}", DebugUtil.printId(queryId), addressToBackendID.keySet());
         }
 
-        context.getExecutor().getSummaryProfile().setAssignFragmentTime();
+        if (context != null) {
+            context.getExecutor().getSummaryProfile().setAssignFragmentTime();
+        }
         if (enablePipelineEngine) {
             sendPipelineCtx();
         } else {
@@ -1008,8 +1010,11 @@ public class Coordinator implements CoordInterface {
                     throw new RuntimeException(e);
                 }
             });
-            context.getExecutor().getSummaryProfile().updateFragmentCompressedSize(compressedSize.get());
-            context.getExecutor().getSummaryProfile().setFragmentSerializeTime();
+
+            if (context != null) {
+                context.getExecutor().getSummaryProfile().updateFragmentCompressedSize(compressedSize.get());
+                context.getExecutor().getSummaryProfile().setFragmentSerializeTime();
+            }
 
             // 4.2 send fragments rpc
             List<Triple<PipelineExecContexts, BackendServiceProxy, Future<InternalService.PExecPlanFragmentResult>>>
@@ -1022,8 +1027,11 @@ public class Coordinator implements CoordInterface {
                 futures.add(ImmutableTriple.of(ctxs, proxy, ctxs.execRemoteFragmentsAsync(proxy)));
             }
             waitPipelineRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send fragments");
-            context.getExecutor().getSummaryProfile().updateFragmentRpcCount(futures.size());
-            context.getExecutor().getSummaryProfile().setFragmentSendPhase1Time();
+
+            if (context != null) {
+                context.getExecutor().getSummaryProfile().updateFragmentRpcCount(futures.size());
+                context.getExecutor().getSummaryProfile().setFragmentSendPhase1Time();
+            }
 
             if (twoPhaseExecution) {
                 // 5. send and wait execution start rpc
@@ -1032,8 +1040,10 @@ public class Coordinator implements CoordInterface {
                     futures.add(ImmutableTriple.of(ctxs, proxy, ctxs.execPlanFragmentStartAsync(proxy)));
                 }
                 waitPipelineRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send execution start");
-                context.getExecutor().getSummaryProfile().updateFragmentRpcCount(futures.size());
-                context.getExecutor().getSummaryProfile().setFragmentSendPhase2Time();
+                if (context != null) {
+                    context.getExecutor().getSummaryProfile().updateFragmentRpcCount(futures.size());
+                    context.getExecutor().getSummaryProfile().setFragmentSendPhase2Time();
+                }
             }
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -270,6 +270,7 @@ public class StmtExecutor {
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
         Preconditions.checkState(context.getConnectType().equals(ConnectType.MYSQL));
         this.context = context;
+        this.context.setExecutor(this);
         this.originStmt = originStmt;
         this.serializer = context.getMysqlChannel().getSerializer();
         this.isProxy = isProxy;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -270,7 +270,6 @@ public class StmtExecutor {
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
         Preconditions.checkState(context.getConnectType().equals(ConnectType.MYSQL));
         this.context = context;
-        this.context.setExecutor(this);
         this.originStmt = originStmt;
         this.serializer = context.getMysqlChannel().getSerializer();
         this.isProxy = isProxy;

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -199,7 +199,23 @@ public class BackendServiceProxy {
         // VERSION 3 means we send TPipelineFragmentParamsList
         builder.setVersion(InternalService.PFragmentRequestVersion.VERSION_3);
 
-        final InternalService.PExecPlanFragmentRequest pRequest = builder.build();
+        return execPlanFragmentsAsync(address, builder.build(), twoPhaseExecution);
+    }
+
+    public Future<InternalService.PExecPlanFragmentResult> execPlanFragmentsAsync(TNetworkAddress address,
+            ByteString serializedFragments, boolean twoPhaseExecution) throws RpcException {
+        InternalService.PExecPlanFragmentRequest.Builder builder =
+                InternalService.PExecPlanFragmentRequest.newBuilder();
+        builder.setRequest(serializedFragments);
+        builder.setCompact(true);
+        // VERSION 3 means we send TPipelineFragmentParamsList
+        builder.setVersion(InternalService.PFragmentRequestVersion.VERSION_3);
+        return execPlanFragmentsAsync(address, builder.build(), twoPhaseExecution);
+    }
+
+    public Future<InternalService.PExecPlanFragmentResult> execPlanFragmentsAsync(TNetworkAddress address,
+            InternalService.PExecPlanFragmentRequest pRequest, boolean twoPhaseExecution)
+            throws RpcException {
         MetricRepo.BE_COUNTER_QUERY_RPC_ALL.getOrAdd(address.hostname).increase(1L);
         MetricRepo.BE_COUNTER_QUERY_RPC_SIZE.getOrAdd(address.hostname).increase((long) pRequest.getSerializedSize());
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -168,7 +168,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         try {
             BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
         } catch (UserException e) {
-            throw new AnalysisException("parse file failed, path = " + path + ", reason: " + e);
+            throw new AnalysisException("parse file failed, err: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

1. Add detail schedule profile

	```
	-  Schedule  Time:  652ms
       -  Fragment  Assign  Time:  57ms
       -  Fragment  Serialize  Time:  70ms
       -  Fragment  RPC  Phase1  Time:  522ms
       -  Fragment  RPC  Phase2  Time:  3ms
       -  Fragment  Compressed  Size:  6.82  MB
       -  Fragment  RPC  Count:  2
   -  Wait  and  Fetch  Result  Time:  N/A
       -  Fetch  Result  Time:  0ms
       -  Write  Result  Time:  0ms
   ```
   
   - Fragment Serialize Time: Time to serialized the fragment thrift
   - Fragment RPC Phase1 Time: Time to send first fragment RPC
   - Fragment RPC Phase1 Time: Time to send second fragment RPC
   - Fragment Compressed Size: Total serialized size for fragment in bytes
   - Fragment RPC Count: Number of RPC

2. Separate the serialization of RPC send step

	In previous, Doris will serialize and send fragment to each BE
	one by one. If fragment is large, it is costy.
	In this PR, I separate these 2 steps by first serializing the
	fragment in parallel, and than send it one by one.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

