### PR TITLE
[enhancement](rpc) should print fe address in error msg during thrift rpc call

### DIFF
--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -94,7 +94,8 @@ Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
                 std::chrono::milliseconds(config::thrift_client_retry_interval_ms * 2));
         // just reopen to disable this connection
         static_cast<void>(client.reopen(timeout_ms));
-        return Status::RpcError("failed to call frontend service, reason: {}", e.what());
+        return Status::RpcError("failed to call frontend service, FE address={}:{}, reason: {}", ip,
+                                port, e.what());
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

We often meet this ERROR, but we do not know the FE address from the error, and has to go to BE and analysis log.

Need add the fe address to the error msg.

Exception:
java.sql.SQLException: errCode = 2, detailMessage = (172.30.0.24)[CANCELLED]failed to call frontend service, reason: Internal error processing fetchSchemaTableData
  at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
  at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
  at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
  at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:371)
  at org.apache.doris.regression.util.JdbcUtils$_executeToList_closure1.doCall(JdbcUtils.groovy:31)
  at sun.reflect.GeneratedMethodAccessor13.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
  at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
  at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaCla

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

