### PR TITLE
[improve](load) lock free flush_async and wait_flush in LoadChannel

### DIFF
--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -100,19 +100,22 @@ public:
 
     bool is_high_priority() const { return _is_high_priority; }
 
-    void flush_memtable_async(int64_t index_id, int64_t tablet_id) {
+    std::shared_ptr<TabletsChannel> get_load_channel(int64_t index_id) {
         std::lock_guard<std::mutex> l(_lock);
-        auto it = _tablets_channels.find(index_id);
-        if (it != _tablets_channels.end()) {
-            it->second->flush_memtable_async(tablet_id);
+        return _tablets_channels[index_id];
+    }
+
+    void flush_memtable_async(int64_t index_id, int64_t tablet_id) {
+        auto channel = get_load_channel(index_id);
+        if (channel != nullptr) {
+            channel->flush_memtable_async(tablet_id);
         }
     }
 
     void wait_flush(int64_t index_id, int64_t tablet_id) {
-        std::lock_guard<std::mutex> l(_lock);
-        auto it = _tablets_channels.find(index_id);
-        if (it != _tablets_channels.end()) {
-            it->second->wait_flush(tablet_id);
+        auto channel = get_load_channel(index_id);
+        if (channel != nullptr) {
+            channel->wait_flush(tablet_id);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

`flush_async` may wait for the `_lock` acquired by `wait_flush`, causing active memtable flush to take too long.

Do not hold this lock when doing `flush_async` or `wait_flush`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

