### PR TITLE
[fix](external catalog) Reset external table creation status on log replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -152,6 +152,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             // So we need add a validation here to avoid table(s) not found, this is just a temporary solution
             // because later we will remove all the logics about InitCatalogLog/InitDatabaseLog.
             if (table != null) {
+                table.unsetObjectCreated();
                 tmpTableNameToId.put(table.getName(), table.getId());
                 tmpIdToTbl.put(table.getId(), table);
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR addresses an issue where external table status was not being correctly updated on Follower nodes during the log replay process. Previously, certain operations forwarded to the Master would update the edit log, and while the Follower nodes would fetch and replay these logs to update their metadata, they wouldn't reset the creation status of the external tables involved. This could lead to inconsistencies in table state across different nodes.

Changes in this PR ensure that during the log replay on Follower nodes, the `objectCreated` status of external tables is appropriately reset. This is achieved by invoking the `unsetObjectCreated()` method on the table objects during the replay of initialization logs. This adjustment ensures that the state of external tables is consistent and up-to-date across all nodes, aligning with the latest metadata changes propagated from the Master.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

