### PR TITLE
[fix](merge-cloud) Add retry when delete bitmap lock expired on insert into select

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2685,6 +2685,9 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, masterOnly = false)
     public static String security_checker_class_name = "";
+
+    @ConfField(mutable = true)
+    public static int mow_insert_into_commit_retry_times = 10;
     //==========================================================================
     //                      end of cloud config
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -185,15 +185,15 @@ public abstract class AbstractInsertExecutor {
             if (!checkStrictMode()) {
                 return;
             }
-            int retry_times = 0;
-            while (retry_times < Config.mow_insert_into_commit_retry_times) {
+            int retryTimes = 0;
+            while (retryTimes < Config.mow_insert_into_commit_retry_times) {
                 try {
                     onComplete();
                     break;
                 } catch (UserException e) {
                     LOG.warn("failed to commit txn", e);
                     if (e.getErrorCode() == InternalErrorCode.DELETE_BITMAP_LOCK_ERR) {
-                        retry_times++;
+                        retryTimes++;
                     } else {
                         throw e;
                     }


### PR DESCRIPTION
## Proposed changes
this pr do the same things with https://github.com/apache/doris/pull/32829
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

