### PR TITLE
[enhancement](memory) Allocator support address sanitizers

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1059,6 +1059,7 @@ DEFINE_mString(kerberos_krb5_conf_path, "/etc/krb5.conf");
 
 DEFINE_mString(get_stack_trace_tool, "libunwind");
 DEFINE_mString(dwarf_location_info_mode, "FAST");
+DEFINE_mBool(enable_address_sanitizers_with_stack_trace, "false");
 
 // the ratio of _prefetch_size/_batch_size in AutoIncIDBuffer
 DEFINE_mInt64(auto_inc_prefetch_size_ratio, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1110,6 +1110,7 @@ DECLARE_mString(kerberos_krb5_conf_path);
 
 // Values include `none`, `glog`, `boost`, `glibc`, `libunwind`
 DECLARE_mString(get_stack_trace_tool);
+DECLARE_mBool(enable_address_sanitizers_with_stack_trace);
 
 // DISABLED: Don't resolve location info.
 // FAST: Perform CU lookup using .debug_aranges (might be incomplete).

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -178,6 +178,9 @@ public:
     std::shared_ptr<MemTrackerLimiter> segcompaction_mem_tracker() {
         return _segcompaction_mem_tracker;
     }
+    std::shared_ptr<MemTrackerLimiter> point_query_executor_mem_tracker() {
+        return _point_query_executor_mem_tracker;
+    }
     std::shared_ptr<MemTrackerLimiter> rowid_storage_reader_tracker() {
         return _rowid_storage_reader_tracker;
     }
@@ -348,6 +351,7 @@ private:
     std::shared_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
     // Count the memory consumption of segment compaction tasks.
     std::shared_ptr<MemTrackerLimiter> _segcompaction_mem_tracker;
+    std::shared_ptr<MemTrackerLimiter> _point_query_executor_mem_tracker;
 
     // TODO, looking forward to more accurate tracking.
     std::shared_ptr<MemTrackerLimiter> _rowid_storage_reader_tracker;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -538,6 +538,8 @@ void ExecEnv::init_mem_tracker() {
             std::make_shared<MemTracker>("IOBufBlockMemory", _details_mem_tracker_set.get());
     _segcompaction_mem_tracker =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "SegCompaction");
+    _point_query_executor_mem_tracker =
+            MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "PointQueryExecutor");
     _rowid_storage_reader_tracker =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "RowIdStorageReader");
     _subcolumns_tree_tracker =

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -152,7 +152,7 @@ static size_t allocator_malloc_usable_size(void* ptr) {
         !defined(THREAD_SANITIZER) && defined(USE_JEMALLOC)
     return jemalloc_usable_size(ptr);
 #else
-    return malloc_usable_size(ptr);
+    return 0; // TODO, ASAN malloc_usable_size(ptr) exist bug, may return 0.
 #endif
 }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -151,7 +151,7 @@ static size_t allocator_malloc_usable_size(void* ptr) {
 #ifdef USE_JEMALLOC
     return jemalloc_usable_size(ptr);
 #else
-    return 0; // malloc_usable_size(ptr);
+    return 0; // TODO, malloc_usable_size(ptr);
 #endif
 }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -38,6 +38,12 @@
 #include "util/perf_counters.h"
 #include "util/pretty_printer.h"
 #include "util/runtime_profile.h"
+#ifdef USE_JEMALLOC
+#include "jemalloc/jemalloc.h"
+#else
+#include <malloc.h>
+#endif
+#include "util/stack_util.h"
 
 namespace doris {
 
@@ -99,7 +105,7 @@ std::shared_ptr<MemTrackerLimiter> MemTrackerLimiter::create_shared(MemTrackerLi
 MemTrackerLimiter::~MemTrackerLimiter() {
     consume(_untracked_mem);
     static std::string mem_tracker_inaccurate_msg =
-            ", mem tracker not equal to 0 when mem tracker destruct, this usually means that "
+            "mem tracker not equal to 0 when mem tracker destruct, this usually means that "
             "memory tracking is inaccurate and SCOPED_ATTACH_TASK and "
             "SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. "
             "1. For query and load, memory leaks may have occurred, it is expected that the query "
@@ -115,18 +121,100 @@ MemTrackerLimiter::~MemTrackerLimiter() {
     if (_consumption->current_value() != 0) {
         // TODO, expect mem tracker equal to 0 at the task end.
         if (doris::config::enable_memory_orphan_check && _type == Type::QUERY) {
-            LOG(INFO) << "mem tracker label: " << _label
-                      << ", consumption: " << _consumption->current_value()
-                      << ", peak consumption: " << _consumption->peak_value()
-                      << mem_tracker_inaccurate_msg;
+            std::string err_msg =
+                    fmt::format("mem tracker label: {}, consumption: {}, peak consumption: {}, {}.",
+                                label(), _consumption->current_value(), _consumption->peak_value(),
+                                mem_tracker_inaccurate_msg);
+#ifdef NDEBUG
+            LOG(INFO) << err_msg;
+#else
+            LOG(FATAL) << err_msg << print_address_sanitizers();
+#endif
         }
         if (ExecEnv::tracking_memory()) {
             ExecEnv::GetInstance()->orphan_mem_tracker()->consume(_consumption->current_value());
         }
         _consumption->set(0);
+#ifdef DEBUG
+    } else if (!_address_sanitizers.empty()) {
+        LOG(FATAL) << "[Address Sanitizer] consumption is 0, but address sanitizers not empty. "
+                   << ", mem tracker label: " << _label
+                   << ", peak consumption: " << _consumption->peak_value()
+                   << print_address_sanitizers();
+#endif
     }
     g_memtrackerlimiter_cnt << -1;
 }
+
+#ifdef DEBUG
+static size_t allocator_malloc_usable_size(void* ptr) {
+#ifdef USE_JEMALLOC
+    return jemalloc_usable_size(ptr);
+#else
+    return 0 // malloc_usable_size(ptr);
+#endif
+}
+
+void MemTrackerLimiter::add_address_sanitizers(void* buf, size_t size) {
+    if (_type == Type::QUERY) {
+        std::lock_guard<std::mutex> l(_address_sanitizers_mtx);
+        auto it = _address_sanitizers.find(buf);
+        if (it != _address_sanitizers.end()) {
+            LOG(FATAL) << "[Address Sanitizer] memory buf repeat add, mem tracker label: " << _label
+                       << ", consumption: " << _consumption->current_value()
+                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
+                       << ", size: " << size << ", usable_size "
+                       << ", old buf: " << it->first << ", old size: " << it->second.size
+                       << ", new stack_trace: " << get_stack_trace()
+                       << ", old stack_trace: " << it->second.stack_trace;
+        }
+
+        // if alignment not equal to 0, maybe usable_size > size.
+        AddressSanitizer as = {
+                size, allocator_malloc_usable_size(buf),
+                doris::config::enable_address_sanitizers_with_stack_trace ? get_stack_trace() : ""};
+        _address_sanitizers.emplace(buf, as);
+    }
+}
+
+void MemTrackerLimiter::remove_address_sanitizers(void* buf, size_t size) {
+    if (_type == Type::QUERY) {
+        std::lock_guard<std::mutex> l(_address_sanitizers_mtx);
+        auto it = _address_sanitizers.find(buf);
+        if (it != _address_sanitizers.end()) {
+            if (it->second.size != size ||
+                it->second.usable_size != allocator_malloc_usable_size(buf)) {
+                LOG(FATAL) << "[Address Sanitizer] free memory buf size inaccurate, mem tracker "
+                              "label: "
+                           << _label << ", consumption: " << _consumption->current_value()
+                           << ", peak consumption: " << _consumption->peak_value()
+                           << ", buf: " << buf << ", size: " << size << ", usable_size "
+                           << allocator_malloc_usable_size(buf) << ", old buf: " << it->first
+                           << ", old size: " << it->second.size
+                           << ", old usable_size: " << it->second.usable_size
+                           << ", new stack_trace: " << get_stack_trace()
+                           << ", old stack_trace: " << it->second.stack_trace;
+            }
+            _address_sanitizers.erase(buf);
+        } else {
+            LOG(FATAL) << "[Address Sanitizer] memory buf not exist, mem tracker label: " << _label
+                       << ", consumption: " << _consumption->current_value()
+                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
+                       << ", size: " << size << ", stack_trace: " << get_stack_trace();
+        }
+    }
+}
+
+std::string MemTrackerLimiter::print_address_sanitizers() {
+    std::lock_guard<std::mutex> l(_address_sanitizers_mtx);
+    std::string detail = "[Address Sanitizer]:";
+    for (const auto& it : _address_sanitizers) {
+        detail += fmt::format("\n    {}, size {}, strack trace: {}", it.first, it.second.size,
+                              it.second.stack_trace);
+    }
+    return detail;
+}
+#endif
 
 MemTracker::Snapshot MemTrackerLimiter::make_snapshot() const {
     Snapshot snapshot;

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -151,7 +151,7 @@ static size_t allocator_malloc_usable_size(void* ptr) {
 #ifdef USE_JEMALLOC
     return jemalloc_usable_size(ptr);
 #else
-    return 0; // TODO, malloc_usable_size(ptr);
+    return malloc_usable_size(ptr);
 #endif
 }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -148,7 +148,8 @@ MemTrackerLimiter::~MemTrackerLimiter() {
 
 #ifndef NDEBUG
 static size_t allocator_malloc_usable_size(void* ptr) {
-#ifdef USE_JEMALLOC
+#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
+        !defined(THREAD_SANITIZER) && defined(USE_JEMALLOC)
     return jemalloc_usable_size(ptr);
 #else
     return malloc_usable_size(ptr);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -125,17 +125,17 @@ MemTrackerLimiter::~MemTrackerLimiter() {
                     fmt::format("mem tracker label: {}, consumption: {}, peak consumption: {}, {}.",
                                 label(), _consumption->current_value(), _consumption->peak_value(),
                                 mem_tracker_inaccurate_msg);
-#ifdef DEBUG
-            LOG(FATAL) << err_msg << print_address_sanitizers();
-#else
+#ifdef NDEBUG
             LOG(INFO) << err_msg;
+#else
+            LOG(FATAL) << err_msg << print_address_sanitizers();
 #endif
         }
         if (ExecEnv::tracking_memory()) {
             ExecEnv::GetInstance()->orphan_mem_tracker()->consume(_consumption->current_value());
         }
         _consumption->set(0);
-#ifdef DEBUG
+#ifndef NDEBUG
     } else if (!_address_sanitizers.empty()) {
         LOG(FATAL) << "[Address Sanitizer] consumption is 0, but address sanitizers not empty. "
                    << ", mem tracker label: " << _label
@@ -146,12 +146,12 @@ MemTrackerLimiter::~MemTrackerLimiter() {
     g_memtrackerlimiter_cnt << -1;
 }
 
-#ifdef DEBUG
+#ifndef NDEBUG
 static size_t allocator_malloc_usable_size(void* ptr) {
 #ifdef USE_JEMALLOC
     return jemalloc_usable_size(ptr);
 #else
-    return 0 // malloc_usable_size(ptr);
+    return 0; // malloc_usable_size(ptr);
 #endif
 }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -125,10 +125,10 @@ MemTrackerLimiter::~MemTrackerLimiter() {
                     fmt::format("mem tracker label: {}, consumption: {}, peak consumption: {}, {}.",
                                 label(), _consumption->current_value(), _consumption->peak_value(),
                                 mem_tracker_inaccurate_msg);
-#ifdef NDEBUG
-            LOG(INFO) << err_msg;
-#else
+#ifdef DEBUG
             LOG(FATAL) << err_msg << print_address_sanitizers();
+#else
+            LOG(INFO) << err_msg;
 #endif
         }
         if (ExecEnv::tracking_memory()) {

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -284,7 +284,6 @@ private:
 #ifndef NDEBUG
     struct AddressSanitizer {
         size_t size;
-        size_t usable_size;
         std::string stack_trace;
     };
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -232,6 +232,12 @@ public:
     // Log the memory usage when memory limit is exceeded.
     std::string tracker_limit_exceeded_str();
 
+#ifdef DEBUG
+    void add_address_sanitizers(void* buf, size_t size);
+    void remove_address_sanitizers(void* buf, size_t size);
+    std::string print_address_sanitizers();
+#endif
+
     std::string debug_string() override {
         std::stringstream msg;
         msg << "limit: " << _limit << "; "
@@ -274,6 +280,17 @@ private:
     // Avoid frequent printing.
     bool _enable_print_log_usage = false;
     static std::atomic<bool> _enable_print_log_process_usage;
+
+#ifdef DEBUG
+    struct AddressSanitizer {
+        size_t size;
+        size_t usable_size;
+        std::string stack_trace;
+    };
+
+    std::mutex _address_sanitizers_mtx;
+    std::unordered_map<void*, AddressSanitizer> _address_sanitizers;
+#endif
 };
 
 inline int64_t MemTrackerLimiter::add_untracked_mem(int64_t bytes) {

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -232,7 +232,7 @@ public:
     // Log the memory usage when memory limit is exceeded.
     std::string tracker_limit_exceeded_str();
 
-#ifdef DEBUG
+#ifndef NDEBUG
     void add_address_sanitizers(void* buf, size_t size);
     void remove_address_sanitizers(void* buf, size_t size);
     std::string print_address_sanitizers();
@@ -281,7 +281,7 @@ private:
     bool _enable_print_log_usage = false;
     static std::atomic<bool> _enable_print_log_process_usage;
 
-#ifdef DEBUG
+#ifndef NDEBUG
     struct AddressSanitizer {
         size_t size;
         size_t usable_size;

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -447,7 +447,7 @@ private:
 // must call create_thread_local_if_not_exits() before use thread_context().
 #define CONSUME_THREAD_MEM_TRACKER(size)                                                           \
     do {                                                                                           \
-        if (doris::use_mem_hook || size == 0) {                                                    \
+        if (size == 0 || doris::use_mem_hook) {                                                    \
             break;                                                                                 \
         }                                                                                          \
         if (doris::pthread_context_ptr_init) {                                                     \

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -40,6 +40,7 @@
 #include "olap/tablet_schema.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "runtime/thread_context.h"
 #include "util/key_util.h"
 #include "util/runtime_profile.h"
 #include "util/thrift_util.h"
@@ -165,7 +166,8 @@ void RowCache::erase(const RowCacheKey& key) {
 }
 
 PointQueryExecutor::~PointQueryExecutor() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
+            ExecEnv::GetInstance()->point_query_executor_mem_tracker());
     _tablet.reset();
     _reusable.reset();
     _result_block.reset();
@@ -179,10 +181,7 @@ Status PointQueryExecutor::init(const PTabletKeyLookupRequest* request,
     // using cache
     __int128_t uuid =
             static_cast<__int128_t>(request->uuid().uuid_high()) << 64 | request->uuid().uuid_low();
-    _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::QUERY,
-            fmt::format("PointQueryExecutor:{}#{}", uuid, request->tablet_id()));
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
+    SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->point_query_executor_mem_tracker());
     auto cache_handle = LookupConnectionCache::instance()->get(uuid);
     _binary_row_format = request->is_binary_row();
     if (cache_handle != nullptr) {
@@ -230,7 +229,7 @@ Status PointQueryExecutor::init(const PTabletKeyLookupRequest* request,
 }
 
 Status PointQueryExecutor::lookup_up() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
+    SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->point_query_executor_mem_tracker());
     RETURN_IF_ERROR(_lookup_row_key());
     RETURN_IF_ERROR(_lookup_row_data());
     RETURN_IF_ERROR(_output_data());

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -316,7 +316,6 @@ private:
     std::vector<RowReadContext> _row_read_ctxs;
     std::shared_ptr<Reusable> _reusable;
     std::unique_ptr<vectorized::Block> _result_block;
-    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
     Metrics _profile_metrics;
     bool _binary_row_format = false;
     // snapshot read version

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -192,6 +192,20 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::throw_bad_alloc(
     throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err);
 }
 
+#ifdef DEBUG
+template <bool clear_memory_, bool mmap_populate, bool use_mmap>
+void Allocator<clear_memory_, mmap_populate, use_mmap>::add_address_sanitizers(void* buf,
+                                                                               size_t size) const {
+    doris::thread_context()->thread_mem_tracker()->add_address_sanitizers(buf, size);
+}
+
+template <bool clear_memory_, bool mmap_populate, bool use_mmap>
+void Allocator<clear_memory_, mmap_populate, use_mmap>::remove_address_sanitizers(
+        void* buf, size_t size) const {
+    doris::thread_context()->thread_mem_tracker()->remove_address_sanitizers(buf, size);
+}
+#endif
+
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void* Allocator<clear_memory_, mmap_populate, use_mmap>::alloc(size_t size, size_t alignment) {
     return alloc_impl(size, alignment);

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -192,7 +192,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::throw_bad_alloc(
     throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err);
 }
 
-#ifdef DEBUG
+#ifndef NDEBUG
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void Allocator<clear_memory_, mmap_populate, use_mmap>::add_address_sanitizers(void* buf,
                                                                                size_t size) const {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -196,12 +196,22 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::throw_bad_alloc(
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void Allocator<clear_memory_, mmap_populate, use_mmap>::add_address_sanitizers(void* buf,
                                                                                size_t size) const {
+#ifdef BE_TEST
+    if (!doris::ExecEnv::ready()) {
+        return;
+    }
+#endif
     doris::thread_context()->thread_mem_tracker()->add_address_sanitizers(buf, size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 void Allocator<clear_memory_, mmap_populate, use_mmap>::remove_address_sanitizers(
         void* buf, size_t size) const {
+#ifdef BE_TEST
+    if (!doris::ExecEnv::ready()) {
+        return;
+    }
+#endif
     doris::thread_context()->thread_mem_tracker()->remove_address_sanitizers(buf, size);
 }
 #endif

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -90,7 +90,7 @@ public:
     void consume_memory(size_t size) const;
     void release_memory(size_t size) const;
     void throw_bad_alloc(const std::string& err) const;
-#ifdef DEBUG
+#ifndef NDEBUG
     void add_address_sanitizers(void* buf, size_t size) const;
     void remove_address_sanitizers(void* buf, size_t size) const;
 #endif
@@ -130,7 +130,7 @@ public:
                     release_memory(size);
                     throw_bad_alloc(fmt::format("Allocator: Cannot malloc {}.", size));
                 }
-#ifdef DEBUG
+#ifndef NDEBUG
                 add_address_sanitizers(buf, size);
 #endif
             } else {
@@ -142,7 +142,7 @@ public:
                     throw_bad_alloc(
                             fmt::format("Cannot allocate memory (posix_memalign) {}.", size));
                 }
-#ifdef DEBUG
+#ifndef NDEBUG
                 add_address_sanitizers(buf, size);
 #endif
 
@@ -159,7 +159,7 @@ public:
                 throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
             }
         } else {
-#ifdef DEBUG
+#ifndef NDEBUG
             remove_address_sanitizers(buf, size);
 #endif
             ::free(buf);
@@ -190,7 +190,7 @@ public:
                 throw_bad_alloc(fmt::format("Allocator: Cannot realloc from {} to {}.", old_size,
                                             new_size));
             }
-#ifdef DEBUG
+#ifndef NDEBUG
             remove_address_sanitizers(buf, old_size); // buf addr = new_buf addr
             add_address_sanitizers(new_buf, new_size);
 #endif
@@ -223,7 +223,7 @@ public:
             // Big allocs that requires a copy.
             void* new_buf = alloc(new_size, alignment);
             memcpy(new_buf, buf, std::min(old_size, new_size));
-#ifdef DEBUG
+#ifndef NDEBUG
             add_address_sanitizers(new_buf, new_size);
             remove_address_sanitizers(buf, old_size);
 #endif

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -90,6 +90,10 @@ public:
     void consume_memory(size_t size) const;
     void release_memory(size_t size) const;
     void throw_bad_alloc(const std::string& err) const;
+#ifdef DEBUG
+    void add_address_sanitizers(void* buf, size_t size) const;
+    void remove_address_sanitizers(void* buf, size_t size) const;
+#endif
 
     void* alloc(size_t size, size_t alignment = 0);
     void* realloc(void* buf, size_t old_size, size_t new_size, size_t alignment = 0);
@@ -97,6 +101,7 @@ public:
     /// Allocate memory range.
     void* alloc_impl(size_t size, size_t alignment = 0) {
         memory_check(size);
+        // consume memory in tracker before alloc, similar to early declaration.
         consume_memory(size);
         void* buf;
 
@@ -125,6 +130,9 @@ public:
                     release_memory(size);
                     throw_bad_alloc(fmt::format("Allocator: Cannot malloc {}.", size));
                 }
+#ifdef DEBUG
+                add_address_sanitizers(buf, size);
+#endif
             } else {
                 buf = nullptr;
                 int res = posix_memalign(&buf, alignment, size);
@@ -134,6 +142,9 @@ public:
                     throw_bad_alloc(
                             fmt::format("Cannot allocate memory (posix_memalign) {}.", size));
                 }
+#ifdef DEBUG
+                add_address_sanitizers(buf, size);
+#endif
 
                 if constexpr (clear_memory) memset(buf, 0, size);
             }
@@ -148,6 +159,9 @@ public:
                 throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
             }
         } else {
+#ifdef DEBUG
+            remove_address_sanitizers(buf, size);
+#endif
             ::free(buf);
         }
         release_memory(size);
@@ -176,6 +190,10 @@ public:
                 throw_bad_alloc(fmt::format("Allocator: Cannot realloc from {} to {}.", old_size,
                                             new_size));
             }
+#ifdef DEBUG
+            remove_address_sanitizers(buf, old_size); // buf addr = new_buf addr
+            add_address_sanitizers(new_buf, new_size);
+#endif
 
             buf = new_buf;
             if constexpr (clear_memory)
@@ -205,6 +223,10 @@ public:
             // Big allocs that requires a copy.
             void* new_buf = alloc(new_size, alignment);
             memcpy(new_buf, buf, std::min(old_size, new_size));
+#ifdef DEBUG
+            add_address_sanitizers(new_buf, new_size);
+            remove_address_sanitizers(buf, old_size);
+#endif
             free(buf, old_size);
             buf = new_buf;
         }

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -183,6 +183,9 @@ public:
         if (!use_mmap ||
             (old_size < doris::config::mmap_threshold && new_size < doris::config::mmap_threshold &&
              alignment <= MALLOC_MIN_ALIGNMENT)) {
+#ifndef NDEBUG
+            remove_address_sanitizers(buf, old_size);
+#endif
             /// Resize malloc'd memory region with no special alignment requirement.
             void* new_buf = ::realloc(buf, new_size);
             if (nullptr == new_buf) {
@@ -191,8 +194,8 @@ public:
                                             new_size));
             }
 #ifndef NDEBUG
-            remove_address_sanitizers(buf, old_size); // buf addr = new_buf addr
-            add_address_sanitizers(new_buf, new_size);
+            add_address_sanitizers(
+                    new_buf, new_size); // usually, buf addr = new_buf addr, asan maybe not equal.
 #endif
 
             buf = new_buf;

--- a/be/src/vec/common/pod_array_fwd.h
+++ b/be/src/vec/common/pod_array_fwd.h
@@ -36,9 +36,12 @@ template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocat
           size_t pad_right_ = 0, size_t pad_left_ = 0>
 class PODArray;
 
-/** For columns. Padding is enough to read and write xmm-register at the address of the last element. */
+/** For columns. Padding is enough to read and write xmm-register at the address of the last element. 
+  * TODO, pad_right is temporarily changed from 15 to 16, will waste 1 bytes,
+  * can rollback after fix wrong reinterpret_cast column and PODArray swap.
+  */
 template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
-using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 15, 16>;
+using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 16, 16>;
 
 /** A helper for declaring PODArray that uses inline memory.
   * The initial size is set to use all the inline bytes, since using less would

--- a/bin/run-fs-benchmark.sh
+++ b/bin/run-fs-benchmark.sh
@@ -189,7 +189,7 @@ else
 fi
 
 ## set asan and ubsan env to generate core file
-export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0
+export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
 export UBSAN_OPTIONS=print_stacktrace=1
 
 ## set TCMALLOC_HEAP_LIMIT_MB to limit memory used by tcmalloc

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -252,7 +252,8 @@ fi
 export AWS_MAX_ATTEMPTS=2
 
 ## set asan and ubsan env to generate core file
-export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0
+## detect_container_overflow=0, https://github.com/google/sanitizers/issues/193
+export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
 export UBSAN_OPTIONS=print_stacktrace=1
 
 ## set TCMALLOC_HEAP_LIMIT_MB to limit memory used by tcmalloc

--- a/regression-test/pipeline/common/doris-utils.sh
+++ b/regression-test/pipeline/common/doris-utils.sh
@@ -136,7 +136,7 @@ function start_doris_be() {
     ASAN_SYMBOLIZER_PATH="$(command -v llvm-symbolizer)"
     if [[ -z "${ASAN_SYMBOLIZER_PATH}" ]]; then ASAN_SYMBOLIZER_PATH='/var/local/ldb-toolchain/bin/llvm-symbolizer'; fi
     export ASAN_SYMBOLIZER_PATH
-    export ASAN_OPTIONS="symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:use_sigaltstack=0:detect_leaks=0:fast_unwind_on_malloc=0"
+    export ASAN_OPTIONS="symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:use_sigaltstack=0:detect_leaks=0:fast_unwind_on_malloc=0:check_malloc_usable_size=0"
     export TCMALLOC_SAMPLE_PARAMETER=524288
     sysctl -w vm.max_map_count=2000000 &&
         ulimit -n 200000 &&

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -405,7 +405,8 @@ export ORC_EXAMPLE_DIR="${DORIS_HOME}/be/src/apache-orc/examples"
 
 # set asan and ubsan env to generate core file
 export DORIS_HOME="${DORIS_TEST_BINARY_DIR}/"
-export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0
+## detect_container_overflow=0, https://github.com/google/sanitizers/issues/193
+export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
 export UBSAN_OPTIONS=print_stacktrace=1
 export JAVA_OPTS="-Xmx1024m -DlogPath=${DORIS_HOME}/log/jni.log -Xloggc:${DORIS_HOME}/log/be.gc.log.${CUR_DATE} -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDLE_TIME=300000"
 


### PR DESCRIPTION
## Proposed changes

1. If DEBUG build type, record size of each memory alloc and free, print no free size or no alloc size when query MemTracker is destructed, if necessary, record stack trace.

2. add global PointQueryExecutor memory tracker in ExecEnv, because memory may be shared between PointQueryExecutors of different pointer queries, but memory will not be shared between PointQueryExecutor and Fragment of the same pointer query.

3. If DEBUG build type, if query memory tracker not equal to 0 when query ends, BE will crash.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

