### PR TITLE
[bugfix](deadlock) avoid deadlock in memtracker cancel query

### DIFF
--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -35,8 +35,10 @@ public:
         ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
                 _query_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, _exceed_msg);
     }
+
+private:
     TUniqueId _query_id;
-    std::string _exceed_msg
+    std::string _exceed_msg;
 };
 
 void ThreadMemTrackerMgr::attach_limiter_tracker(

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -28,7 +28,7 @@ class AsyncCancelQueryTask : public Runnable {
     ENABLE_FACTORY_CREATOR(AsyncCancelQueryTask);
 
 public:
-    AsyncCancelQueryTask(TUniqueId query_id, std::string& exceed_msg)
+    AsyncCancelQueryTask(TUniqueId query_id, const std::string& exceed_msg)
             : _query_id(query_id), _exceed_msg(exceed_msg) {}
     ~AsyncCancelQueryTask() override = default;
     void run() override {
@@ -38,7 +38,7 @@ public:
 
 private:
     TUniqueId _query_id;
-    std::string _exceed_msg;
+    const std::string _exceed_msg;
 };
 
 void ThreadMemTrackerMgr::attach_limiter_tracker(

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -61,7 +61,7 @@ void ThreadMemTrackerMgr::detach_limiter_tracker(
 void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {
     if (is_attach_query() && !_is_query_cancelled) {
         Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
-                std::make_shared<AsyncCancelQueryTask>(_query_id, exceed_msg));
+                AsyncCancelQueryTask::create_shared(_query_id, exceed_msg));
         if (submit_st.ok()) {
             // Use this flag to avoid the cancel request submit to pool many times, because even we cancel the query
             // successfully, but the application may not use if (state.iscancelled) to exist quickly. And it may try to

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -24,6 +24,21 @@
 
 namespace doris {
 
+class AsyncCancelQueryTask : public Runnable {
+    ENABLE_FACTORY_CREATOR(AsyncCancelQueryTask);
+
+public:
+    AsyncCancelQueryTask(TUniqueId query_id, std::string& exceed_msg)
+            : _query_id(query_id), _exceed_msg(exceed_msg) {}
+    ~AsyncCancelQueryTask() override = default;
+    void run() override {
+        ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
+                _query_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, _exceed_msg);
+    }
+    TUniqueId _query_id;
+    std::string _exceed_msg
+};
+
 void ThreadMemTrackerMgr::attach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
     DCHECK(mem_tracker);
@@ -42,9 +57,18 @@ void ThreadMemTrackerMgr::detach_limiter_tracker(
 }
 
 void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {
-    if (is_attach_query()) {
-        ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-                _query_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, exceed_msg);
+    if (is_attach_query() && !_is_query_cancelled) {
+        Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
+                std::make_shared<AsyncCancelQueryTask>(_query_id, exceed_msg));
+        if (submit_st.ok()) {
+            // Use this flag to avoid the cancel request submit to pool many times, because even we cancel the query
+            // successfully, but the application may not use if (state.iscancelled) to exist quickly. And it may try to
+            // allocate memory and may failed again and the pool will be full.
+            _is_query_cancelled = true;
+        } else {
+            LOG(WARNING) << "Failed to submit cancel query task to pool, query_id "
+                         << print_id(_query_id) << ", error st " << submit_st;
+        }
     }
 }
 

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -136,6 +136,7 @@ private:
     // If there is a memory new/delete operation in the consume method, it may enter infinite recursion.
     bool _stop_consume = false;
     TUniqueId _query_id = TUniqueId();
+    bool _is_query_cancelled = false;
 };
 
 inline bool ThreadMemTrackerMgr::init() {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -125,7 +125,7 @@ QueryContext::~QueryContext() {
     if (_thread_token) {
         Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
                 std::make_shared<DelayReleaseToken>(std::move(_thread_token)));
-        if (!st.ok()) {
+        if (!submit_st.ok()) {
             LOG(WARNING) << "Failed to release query context thread token, query_id "
                          << print_id(_query_id) << ", error status " << submit_st;
         }

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -124,7 +124,7 @@ QueryContext::~QueryContext() {
     // release the token hang, the thread maybe a pipeline task scheduler thread.
     if (_thread_token) {
         Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
-                std::make_shared<DelayReleaseToken>(std::move(_thread_token)));
+                DelayReleaseToken::create_shared(std::move(_thread_token)));
         if (!submit_st.ok()) {
             LOG(WARNING) << "Failed to release query context thread token, query_id "
                          << print_id(_query_id) << ", error status " << submit_st;

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -30,6 +30,8 @@
 namespace doris {
 
 class DelayReleaseToken : public Runnable {
+    ENABLE_FACTORY_CREATOR(DelayReleaseToken);
+
 public:
     DelayReleaseToken(std::unique_ptr<ThreadPoolToken>&& token) { token_ = std::move(token); }
     ~DelayReleaseToken() override = default;
@@ -121,8 +123,12 @@ QueryContext::~QueryContext() {
     // And also thread token need shutdown, it may take some time, may cause the thread that
     // release the token hang, the thread maybe a pipeline task scheduler thread.
     if (_thread_token) {
-        static_cast<void>(ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
-                std::make_shared<DelayReleaseToken>(std::move(_thread_token))));
+        Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
+                std::make_shared<DelayReleaseToken>(std::move(_thread_token)));
+        if (!st.ok()) {
+            LOG(WARNING) << "Failed to release query context thread token, query_id "
+                         << print_id(_query_id) << ", error status " << submit_st;
+        }
     }
 
     //TODO: check if pipeline and tracing both enabled


### PR DESCRIPTION
## Proposed changes

get_query_ctx(hold query ctx map lock) ---> QueryCtx ---> runtime statistics mgr --->

runtime statistics mgr ---> allocate block memory ---> cancel query

1. memtracker will try to cancel query when memory is not available during allocator.
2. BUT the allocator is a foundermental API, if it call the upper API it may deadlock.

Should not call any API during allocator.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

