### PR TITLE
Revert "[opt](scan) read scan ranges in the order of partitions"

### DIFF
--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -73,53 +73,20 @@ void FileScanLocalState::set_scan_ranges(RuntimeState* state,
         _scan_ranges = scan_ranges;
     } else {
         // There is no need for the number of scanners to exceed the number of threads in thread pool.
-        _scan_ranges.resize(max_scanners);
-        std::vector<TScanRangeParams>& scan_ranges_ =
-                const_cast<std::vector<TScanRangeParams>&>(scan_ranges);
-        auto& first_ranges = scan_ranges_[0].scan_range.ext_scan_range.file_scan_range.ranges;
-        if (first_ranges[0].__isset.columns_from_path_keys &&
-            !first_ranges[0].columns_from_path_keys.empty()) {
-            int num_keys = first_ranges[0].columns_from_path_keys.size();
-            // In the insert statement, reading data in partition order can reduce the memory usage of BE
-            // and prevent the generation of smaller tables.
-            std::sort(scan_ranges_.begin(), scan_ranges_.end(),
-                      [&num_keys](TScanRangeParams r1, TScanRangeParams r2) {
-                          auto& path1 = r1.scan_range.ext_scan_range.file_scan_range.ranges[0]
-                                                .columns_from_path;
-                          auto& path2 = r2.scan_range.ext_scan_range.file_scan_range.ranges[0]
-                                                .columns_from_path;
-                          for (int i = 0; i < num_keys; ++i) {
-                              if (path1[i] < path2[i]) {
-                                  return true;
-                              }
-                          }
-                          return false;
-                      });
+        _scan_ranges.clear();
+        auto range_iter = scan_ranges.begin();
+        for (int i = 0; i < max_scanners && range_iter != scan_ranges.end(); ++i, ++range_iter) {
+            _scan_ranges.push_back(*range_iter);
         }
-        int num_ranges = scan_ranges.size() / max_scanners;
-        int num_add_one = scan_ranges.size() - num_ranges * max_scanners;
-        int scan_index = 0;
-        int range_index = 0;
-        for (int i = 0; i < num_add_one; ++i) {
-            _scan_ranges[scan_index] = scan_ranges_[range_index++];
-            auto& ranges =
-                    _scan_ranges[scan_index++].scan_range.ext_scan_range.file_scan_range.ranges;
-            for (int j = 0; j < num_ranges; j++) {
-                auto& merged_ranges = scan_ranges_[range_index++]
-                                              .scan_range.ext_scan_range.file_scan_range.ranges;
-                ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
+        for (int i = 0; range_iter != scan_ranges.end(); ++i, ++range_iter) {
+            if (i == max_scanners) {
+                i = 0;
             }
+            auto& ranges = _scan_ranges[i].scan_range.ext_scan_range.file_scan_range.ranges;
+            auto& merged_ranges = range_iter->scan_range.ext_scan_range.file_scan_range.ranges;
+            ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
         }
-        for (int i = num_add_one; i < max_scanners; ++i) {
-            _scan_ranges[scan_index] = scan_ranges_[range_index++];
-            auto& ranges =
-                    _scan_ranges[scan_index++].scan_range.ext_scan_range.file_scan_range.ranges;
-            for (int j = 0; j < num_ranges - 1; j++) {
-                auto& merged_ranges = scan_ranges_[range_index++]
-                                              .scan_range.ext_scan_range.file_scan_range.ranges;
-                ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
-            }
-        }
+        _scan_ranges.shrink_to_fit();
         LOG(INFO) << "Merge " << scan_ranges.size() << " scan ranges to " << _scan_ranges.size();
     }
     if (scan_ranges.size() > 0 &&

--- a/be/src/vec/exec/scan/new_file_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_file_scan_node.cpp
@@ -71,53 +71,20 @@ void NewFileScanNode::set_scan_ranges(RuntimeState* state,
         _scan_ranges = scan_ranges;
     } else {
         // There is no need for the number of scanners to exceed the number of threads in thread pool.
-        _scan_ranges.resize(max_scanners);
-        std::vector<TScanRangeParams>& scan_ranges_ =
-                const_cast<std::vector<TScanRangeParams>&>(scan_ranges);
-        auto& first_ranges = scan_ranges_[0].scan_range.ext_scan_range.file_scan_range.ranges;
-        if (first_ranges[0].__isset.columns_from_path_keys &&
-            !first_ranges[0].columns_from_path_keys.empty()) {
-            int num_keys = first_ranges[0].columns_from_path_keys.size();
-            // In the insert statement, reading data in partition order can reduce the memory usage of BE
-            // and prevent the generation of smaller tables.
-            std::sort(scan_ranges_.begin(), scan_ranges_.end(),
-                      [&num_keys](TScanRangeParams r1, TScanRangeParams r2) {
-                          auto& path1 = r1.scan_range.ext_scan_range.file_scan_range.ranges[0]
-                                                .columns_from_path;
-                          auto& path2 = r2.scan_range.ext_scan_range.file_scan_range.ranges[0]
-                                                .columns_from_path;
-                          for (int i = 0; i < num_keys; ++i) {
-                              if (path1[i] < path2[i]) {
-                                  return true;
-                              }
-                          }
-                          return false;
-                      });
+        _scan_ranges.clear();
+        auto range_iter = scan_ranges.begin();
+        for (int i = 0; i < max_scanners && range_iter != scan_ranges.end(); ++i, ++range_iter) {
+            _scan_ranges.push_back(*range_iter);
         }
-        int num_ranges = scan_ranges.size() / max_scanners;
-        int num_add_one = scan_ranges.size() - num_ranges * max_scanners;
-        int scan_index = 0;
-        int range_index = 0;
-        for (int i = 0; i < num_add_one; ++i) {
-            _scan_ranges[scan_index] = scan_ranges_[range_index++];
-            auto& ranges =
-                    _scan_ranges[scan_index++].scan_range.ext_scan_range.file_scan_range.ranges;
-            for (int j = 0; j < num_ranges; j++) {
-                auto& merged_ranges = scan_ranges_[range_index++]
-                                              .scan_range.ext_scan_range.file_scan_range.ranges;
-                ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
+        for (int i = 0; range_iter != scan_ranges.end(); ++i, ++range_iter) {
+            if (i == max_scanners) {
+                i = 0;
             }
+            auto& ranges = _scan_ranges[i].scan_range.ext_scan_range.file_scan_range.ranges;
+            auto& merged_ranges = range_iter->scan_range.ext_scan_range.file_scan_range.ranges;
+            ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
         }
-        for (int i = num_add_one; i < max_scanners; ++i) {
-            _scan_ranges[scan_index] = scan_ranges_[range_index++];
-            auto& ranges =
-                    _scan_ranges[scan_index++].scan_range.ext_scan_range.file_scan_range.ranges;
-            for (int j = 0; j < num_ranges - 1; j++) {
-                auto& merged_ranges = scan_ranges_[range_index++]
-                                              .scan_range.ext_scan_range.file_scan_range.ranges;
-                ranges.insert(ranges.end(), merged_ranges.begin(), merged_ranges.end());
-            }
-        }
+        _scan_ranges.shrink_to_fit();
         LOG(INFO) << "Merge " << scan_ranges.size() << " scan ranges to " << _scan_ranges.size();
     }
     if (scan_ranges.size() > 0 &&


### PR DESCRIPTION
Reverts apache/doris#31630

Sorting a vector of thrift objects will bring about deep copy problems:
```
*** SIGSEGV address not mapped to object (@0x58) received by PID 13345 (TID 15059 OR 0x7f443b935700) from PID 88; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /usr/lib/jvm/java/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /usr/lib/jvm/java/jre/lib/amd64/server/libjvm.so
 4# 0x00007F479AA14D10 in /lib64/libc.so.6
 5# void std::__unguarded_linear_insert<__gnu_cxx::__normal_iterator<doris::TScanRangeParams*, std::vector<doris::TScanRangeParams, std::allocator<doris::TScanRangeParams> > >, __gnu_cxx::__ops::_Val_comp_iter<doris::pipeline::FileScanLocalState::set_scan_ranges(doris::RuntimeState*, std::vector<doris::TScanRangeParams, std::allocator<doris::TScanRangeParams> > const&)::$_0> >(__gnu_cxx::__normal_iterator<doris::TScanRangeParams*, std::vector<doris::TScanRangeParams, std::allocator<doris::TScanRangeParams> > >, __gnu_cxx::__ops::_Val_comp_iter<doris::pipeline::FileScanLocalState::set_scan_ranges(doris::RuntimeState*, std::vector<doris::TScanRangeParams, std::allocator<doris::TScanRangeParams> > const&)::$_0>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:1806
 6# doris::pipeline::FileScanLocalState::set_scan_ranges(doris::RuntimeState*, std::vector<doris::TScanRangeParams, std::allocator<doris::TScanRangeParams> > const&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/file_scan_operator.cpp:85
 7# doris::pipeline::ScanLocalState<doris::pipeline::FileScanLocalState>::init(doris::RuntimeState*, doris::pipeline::LocalStateInfo&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/scan_operator.cpp:146
 8# doris::pipeline::FileScanLocalState::init(doris::RuntimeState*, doris::pipeline::LocalStateInfo&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/exec/file_scan_operator.cpp:135
 9# doris::pipeline::OperatorX<doris::pipeline::FileScanLocalState>::setup_local_state(doris::RuntimeState*, doris::pipeline::LocalStateInfo&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/operator.cpp:293
10# doris::pipeline::PipelineXTask::prepare(doris::TPipelineInstanceParams const&, doris::TDataSink const&, doris::QueryContext*) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:102
11# doris::pipeline::PipelineXFragmentContext::_build_pipeline_tasks(doris::TPipelineFragmentParams const&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:628
12# doris::pipeline::PipelineXFragmentContext::prepare(doris::TPipelineFragmentParams const&) at /home/zcp/repo_center/doris_release/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:246
13# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /home/zcp/repo_center/doris_release/doris/be/src/runtime/fragment_mgr.cpp:799
14# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&) at /home/zcp/repo_center/doris_release/doris/be/src/runtime/fragment_mgr.cpp:540
15# doris::PInternalServiceImpl::_exec_plan_fragment_impl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool, std::function<void (doris::RuntimeState*, doris::Status*)> const&) in /root/apache-doris-2.1.0-bin-x64/be/lib/doris_be
16# doris::PInternalServiceImpl::_exec_plan_fragment_in_pthread(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*) at /home/zcp/repo_center/doris_release/doris/be/src/service/internal_service.cpp:319
17# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_release/doris/be/src/util/work_thread_pool.hpp:159
18# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
19# start_thread in /lib64/libpthread.so.0
20# clone in /lib64/libc.so.6
```