### PR TITLE
[bugfix](deadlock) should not use query cancelled in fragment mgr

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1118,36 +1118,6 @@ void FragmentMgr::cancel_fragment(const TUniqueId& query_id, int32_t fragment_id
     }
 }
 
-bool FragmentMgr::query_is_canceled(const TUniqueId& query_id) {
-    std::lock_guard<std::mutex> lock(_lock);
-    auto ctx = _query_ctx_map.find(query_id);
-
-    if (ctx != _query_ctx_map.end()) {
-        const bool is_pipeline_version = ctx->second->enable_pipeline_exec();
-        const bool is_pipeline_x = ctx->second->enable_pipeline_x_exec();
-        if (is_pipeline_x) {
-            return ctx->second->is_cancelled();
-        } else {
-            for (auto itr : ctx->second->fragment_instance_ids) {
-                if (is_pipeline_version) {
-                    auto pipeline_ctx_iter = _pipeline_map.find(itr);
-                    if (pipeline_ctx_iter != _pipeline_map.end() && pipeline_ctx_iter->second) {
-                        return pipeline_ctx_iter->second->is_canceled();
-                    }
-                } else {
-                    auto fragment_instance_itr = _fragment_instance_map.find(itr);
-                    if (fragment_instance_itr != _fragment_instance_map.end() &&
-                        fragment_instance_itr->second) {
-                        return fragment_instance_itr->second->is_canceled();
-                    }
-                }
-            }
-        }
-    }
-
-    return true;
-}
-
 void FragmentMgr::cancel_worker() {
     LOG(INFO) << "FragmentMgr cancel worker start working.";
     do {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -110,8 +110,6 @@ public:
     void cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
                       const std::string& msg = "");
 
-    bool query_is_canceled(const TUniqueId& query_id);
-
     void cancel_worker();
 
     void debug(std::stringstream& ss) override;

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -88,6 +88,10 @@ public:
 
     bool is_attach_query() { return _query_id != TUniqueId(); }
 
+    bool is_query_cancelled() { return _is_query_cancelled; }
+
+    void reset_query_cancelled_flag(bool new_val) { _is_query_cancelled = new_val; }
+
     std::shared_ptr<MemTrackerLimiter> limiter_mem_tracker() {
         CHECK(init());
         return _limiter_tracker;

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -88,7 +88,7 @@ public:
 
     bool is_attach_query() { return _query_id != TUniqueId(); }
 
-    bool is_query_cancelled() { return _is_query_cancelled; }
+    bool is_query_cancelled() const { return _is_query_cancelled; }
 
     void reset_query_cancelled_flag(bool new_val) { _is_query_cancelled = new_val; }
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -168,6 +168,7 @@ public:
         thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
         thread_mem_tracker_mgr->set_query_id(_task_id);
         thread_mem_tracker_mgr->enable_wait_gc();
+        thread_mem_tracker_mgr->reset_query_cancelled_flag(false);
     }
 
     void detach_task() {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -66,8 +66,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::sys_memory_check(size_t 
         }
 
         // TODO, Save the query context in the thread context, instead of finding whether the query id is canceled in fragment_mgr.
-        if (doris::ExecEnv::GetInstance()->fragment_mgr()->query_is_canceled(
-                    doris::thread_context()->task_id())) {
+        if (doris::thread_context()->thread_mem_tracker_mgr->is_query_cancelled()) {
             if (doris::enable_thread_catch_bad_alloc) {
                 throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err_msg);
             }
@@ -88,8 +87,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap>::sys_memory_check(size_t 
                     doris::MemInfo::refresh_interval_memory_growth += size;
                     break;
                 }
-                if (doris::ExecEnv::GetInstance()->fragment_mgr()->query_is_canceled(
-                            doris::thread_context()->task_id())) {
+                if (doris::thread_context()->thread_mem_tracker_mgr->is_query_cancelled()) {
                     if (doris::enable_thread_catch_bad_alloc) {
                         throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err_msg);
                     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

