### PR TITLE
[Config](thrift) set default timeout for thrift rpc in FE

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -332,13 +332,10 @@ fi
 if [[ -z "${WITH_MYSQL}" ]]; then
     WITH_MYSQL='OFF'
 fi
-if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
-    if [[ "$(uname -s)" != 'Darwin' ]]; then
-        GLIBC_COMPATIBILITY='ON'
-    else
-        GLIBC_COMPATIBILITY='OFF'
-    fi
-fi
+
+# test
+GLIBC_COMPATIBILITY='OFF'
+
 if [[ -z "${USE_AVX2}" ]]; then
     USE_AVX2='ON'
 fi

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -392,7 +392,7 @@ public class Config extends ConfigBase {
 
     @ConfField(description = {"thrift client 的连接超时时间，单位是毫秒。0 表示不设置超时时间。",
             "The connection timeout of thrift client, in milliseconds. 0 means no timeout."})
-    public static int thrift_client_timeout_ms = 0;
+    public static int thrift_client_timeout_ms = 10000;
 
     @ConfField(description = {"thrift server 的 backlog 数量。"
             + "如果调大这个值，则需同时调整 /proc/sys/net/core/somaxconn 的值",


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

otherwise if something's wrong with the other end or thrift itself, FE will hang.

docs pr: https://github.com/apache/doris-website/pull/528

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

