### PR TITLE
[fix](debug point) fix gcc compile

### DIFF
--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -159,7 +159,9 @@ public:
     void add(const std::string& name) { add(name, std::make_shared<DebugPoint>()); }
     void add_with_params(const std::string& name,
                          const std::map<std::string, std::string>& params) {
-        add(name, std::shared_ptr<DebugPoint>(new DebugPoint {.params = params}));
+        auto debug_point = std::make_shared<DebugPoint>();
+        debug_point->params = params;
+        add(debug_point);
     }
     template <typename T>
     void add_with_value(const std::string& name, const T& value) {
@@ -168,7 +170,9 @@ public:
 
     template <typename... ARGS>
     void add_with_callback(const std::string& name, std::function<void(ARGS...)> callback) {
-        add(name, std::shared_ptr<DebugPoint>(new DebugPoint {.callback = callback}));
+        auto debug_point = std::make_shared<DebugPoint>();
+        debug_point->callback = callback;
+        add(debug_point);
     }
 
     static DebugPoints* instance();

--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -161,7 +161,7 @@ public:
                          const std::map<std::string, std::string>& params) {
         auto debug_point = std::make_shared<DebugPoint>();
         debug_point->params = params;
-        add(debug_point);
+        add(name, debug_point);
     }
     template <typename T>
     void add_with_value(const std::string& name, const T& value) {
@@ -172,7 +172,7 @@ public:
     void add_with_callback(const std::string& name, std::function<void(ARGS...)> callback) {
         auto debug_point = std::make_shared<DebugPoint>();
         debug_point->callback = callback;
-        add(debug_point);
+        add(name, debug_point);
     }
 
     static DebugPoints* instance();

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -603,8 +603,8 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
     if (request->has_db_id()) {
         bool need_update_table_version = false;
         for (auto part_id : request->partition_ids()) {
-            std::string partition_ver_key = partition_version_key({
-                instance_id, request->db_id(), request->table_id(), part_id});
+            std::string partition_ver_key = partition_version_key(
+                    {instance_id, request->db_id(), request->table_id(), part_id});
             std::string ver_val_str;
             err = txn->get(partition_ver_key, &ver_val_str);
             if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {


### PR DESCRIPTION
performance pipeline enable missing-field-initializers warning,  it cause compile fail:

```
13:27:42   /root/doris/be/src/util/debug_points.h: In member function 'void doris::DebugPoints::add_with_params(const std::string&, const std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&)':
13:27:42   /root/doris/be/src/util/debug_points.h:159:79: error: missing initializer for member 'doris::DebugPoint::handler' [-Werror=missing-field-initializers]
13:27:42     159 |         add(name, std::shared_ptr<DebugPoint>(new DebugPoint {.params = params}));
13:27:42         |                                                                               ^
13:27:42   /root/doris/be/src/util/debug_points.h: In member function 'void doris::DebugPoints::add_with_handler(const std::string&, std::any)':
13:27:42   /root/doris/be/src/util/debug_points.h:167:81: error: missing initializer for member 'doris::DebugPoint::params' [-Werror=missing-field-initializers]
13:27:42     167 |         add(name, std::shared_ptr<DebugPoint>(new DebugPoint {.handler = handler}));
13:27:42         |                                                                                 ^
13:27:42   cc1plus: all warnings being treated as errors
13:27:43   [572/1346] Building CXX object src/http/CMakeFiles/Webserver.dir/action/stream_load.cpp.o
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

