### PR TITLE
[fix](compress) data decompress failed while max_len equals 8M

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -133,7 +133,7 @@ public:
             compressed_buf.data = reinterpret_cast<char*>(output->data());
             compressed_buf.size = max_len;
         } else {
-            // reuse context buffer if max_len < MAX_COMPRESSION_BUFFER_FOR_REUSE
+            // reuse context buffer if max_len <= MAX_COMPRESSION_BUFFER_FOR_REUSE
             context->buffer.resize(max_len);
             compressed_buf.data = reinterpret_cast<char*>(context->buffer.data());
             compressed_buf.size = max_len;
@@ -148,7 +148,7 @@ public:
                                            compressed_buf.size);
         }
         output->resize(compressed_len);
-        if (max_len < MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
+        if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
             output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), compressed_len);
         }
         return Status::OK();
@@ -297,7 +297,7 @@ private:
             compressed_buf.data = reinterpret_cast<char*>(output->data());
             compressed_buf.size = max_len;
         } else {
-            // reuse context buffer if max_len < MAX_COMPRESSION_BUFFER_FOR_REUSE
+            // reuse context buffer if max_len <= MAX_COMPRESSION_BUFFER_FOR_REUSE
             context->buffer.resize(max_len);
             compressed_buf.data = reinterpret_cast<char*>(context->buffer.data());
             compressed_buf.size = max_len;
@@ -331,7 +331,7 @@ private:
         }
         offset += wbytes;
         output->resize(offset);
-        if (max_len < MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
+        if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
             output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), offset);
         }
 
@@ -492,7 +492,7 @@ public:
             compressed_buf.data = reinterpret_cast<char*>(output->data());
             compressed_buf.size = max_len;
         } else {
-            // reuse context buffer if max_len < MAX_COMPRESSION_BUFFER_FOR_REUSE
+            // reuse context buffer if max_len <= MAX_COMPRESSION_BUFFER_FOR_REUSE
             context->buffer.resize(max_len);
             compressed_buf.data = reinterpret_cast<char*>(context->buffer.data());
             compressed_buf.size = max_len;
@@ -506,7 +506,7 @@ public:
                                            compressed_buf.size);
         }
         output->resize(compressed_len);
-        if (max_len < MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
+        if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
             output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), compressed_len);
         }
         return Status::OK();
@@ -805,7 +805,7 @@ public:
             compressed_buf.data = reinterpret_cast<char*>(output->data());
             compressed_buf.size = max_len;
         } else {
-            // reuse context buffer if max_len < MAX_COMPRESSION_BUFFER_FOR_REUSE
+            // reuse context buffer if max_len <= MAX_COMPRESSION_BUFFER_FOR_REUSE
             context->buffer.resize(max_len);
             compressed_buf.data = reinterpret_cast<char*>(context->buffer.data());
             compressed_buf.size = max_len;
@@ -856,7 +856,7 @@ public:
 
         // set compressed size for caller
         output->resize(out_buf.pos);
-        if (max_len < MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
+        if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
             output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), out_buf.pos);
         }
 

--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -603,8 +603,8 @@ void MetaServiceImpl::drop_partition(::google::protobuf::RpcController* controll
     if (request->has_db_id()) {
         bool need_update_table_version = false;
         for (auto part_id : request->partition_ids()) {
-            std::string partition_ver_key = partition_version_key({
-                instance_id, request->db_id(), request->table_id(), part_id});
+            std::string partition_ver_key = partition_version_key(
+                    {instance_id, request->db_id(), request->table_id(), part_id});
             std::string ver_val_str;
             err = txn->get(partition_ver_key, &ver_val_str);
             if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {


### PR DESCRIPTION
## Proposed changes

issue: https://github.com/apache/doris/issues/33455

come from pr: https://github.com/apache/doris/pull/12573

<!--Describe your changes.-->

While `max_len == MAX_COMPRESSION_BUFFER_FOR_REUSE`, we reuse context buffer, but do not copy them to the final output buf, make the data corrupted.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

