### PR TITLE
[fix](memory) Fix memory tracker destructor deadlock

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -207,11 +207,11 @@ void Daemon::memory_maintenance_thread() {
         doris::PerfCounters::refresh_proc_status();
         doris::MemInfo::refresh_proc_meminfo();
         doris::MemInfo::refresh_proc_mem_no_allocator_cache();
-        doris::MemTrackerLimiter::clean_tracker_limiter_group();
 
         // Update and print memory stat when the memory changes by 256M.
         if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
             last_print_proc_mem = PerfCounters::get_vm_rss();
+            doris::MemTrackerLimiter::clean_tracker_limiter_group();
             doris::MemTrackerLimiter::enable_print_log_process_usage();
 
             // Refresh mem tracker each type counter.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -207,6 +207,7 @@ void Daemon::memory_maintenance_thread() {
         doris::PerfCounters::refresh_proc_status();
         doris::MemInfo::refresh_proc_meminfo();
         doris::MemInfo::refresh_proc_mem_no_allocator_cache();
+        doris::MemTrackerLimiter::clean_tracker_limiter_group();
 
         // Update and print memory stat when the memory changes by 256M.
         if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -160,6 +160,7 @@ public:
     }
 
     static void refresh_global_counter();
+    static void clean_tracker_limiter_group();
 
     Snapshot make_snapshot() const override;
     // Returns a list of all the valid tracker snapshots.
@@ -241,7 +242,6 @@ public:
     }
 
     // Iterator into mem_tracker_limiter_pool for this object. Stored to have O(1) remove.
-    std::list<std::weak_ptr<MemTrackerLimiter>>::iterator tracker_limiter_group_it;
     std::list<std::weak_ptr<MemTrackerLimiter>>::iterator tg_tracker_limiter_group_it;
 
 private:


### PR DESCRIPTION
## Proposed changes

fix deadlock:
```
Thread 1644 (Thread 0x7f91d2d59700 (LWP 2982688) "memory_gc_threa"):
#0  __lll_lock_wait (futex=futex@entry=0x7f95305e75d8, private=0) at lowlevellock.c:52
#1  0x00007f9557ec40a3 in __GI___pthread_mutex_lock (mutex=0x7f95305e75d8) at ../nptl/pthread_mutex_lock.c:80
#2  0x0000565210c87cc7 in __gthread_mutex_lock (__mutex=0x7f95305e75d8) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749
#3  std::mutex::lock (this=0x7f95305e75d8) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:100
#4  std::lock_guard<std::mutex>::lock_guard (__m=..., this=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:229
#5  doris::MemTrackerLimiter::~MemTrackerLimiter (this=0x7f8a19813510) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:133
#6  0x0000565210c89ebb in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
#7  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702
#8  std::__shared_ptr<doris::MemTrackerLimiter, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
#9  doris::MemTrackerLimiter::make_top_consumption_snapshots (snapshots=snapshots@entry=0x7f91d2d528a0, top_num=top_num@entry=15) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:264
#10 0x0000565210c8c4f0 in doris::MemTrackerLimiter::log_process_usage_str[abi:cxx11]() () at /home/zcp/repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:329
#11 0x0000565210c8ce83 in doris::MemTrackerLimiter::print_log_process_usage () at /home/zcp/repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:352
#12 0x0000565210019c16 in doris::Daemon::memory_gc_thread (this=0x7ffd179e65d0) at /home/zcp/repo_center/doris_master/doris/be/src/common/daemon.cpp:273
#13 0x0000565210eae841 in std::function<void ()>::operator()() const (this=0x7f95305e75d8) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#14 doris::Thread::supervise_thread (arg=0x7f952af79ae0) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:498
#15 0x00007f9557ec1609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#16 0x00007f955816e133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

