### PR TITLE
[fix](memory) Fix SnapshotManager MemTracker attach thread

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -55,6 +55,7 @@
 #include "olap/tablet_schema.h"
 #include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 #include "util/uid_util.h"
 
@@ -66,14 +67,16 @@ using std::vector;
 namespace doris {
 using namespace ErrorCode;
 
-SnapshotManager::SnapshotManager(StorageEngine& engine)
-        : _engine(engine), _mem_tracker(std::make_shared<MemTracker>("SnapshotManager")) {}
+SnapshotManager::SnapshotManager(StorageEngine& engine) : _engine(engine) {
+    _mem_tracker =
+            MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER, "SnapshotManager");
+}
 
 SnapshotManager::~SnapshotManager() = default;
 
 Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* snapshot_path,
                                       bool* allow_incremental_clone) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
+    SCOPED_ATTACH_TASK(_mem_tracker);
     Status res = Status::OK();
     if (snapshot_path == nullptr) {
         return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
@@ -98,7 +101,7 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
 Status SnapshotManager::release_snapshot(const string& snapshot_path) {
     // If the requested snapshot_path is located in the root/snapshot folder, it is considered legal and can be deleted.
     // Otherwise, it is considered an illegal request and returns an error result.
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
+    SCOPED_ATTACH_TASK(_mem_tracker);
     auto stores = _engine.get_stores();
     for (auto* store : stores) {
         std::string abs_path;
@@ -119,7 +122,7 @@ Status SnapshotManager::release_snapshot(const string& snapshot_path) {
 Result<std::vector<PendingRowsetGuard>> SnapshotManager::convert_rowset_ids(
         const std::string& clone_dir, int64_t tablet_id, int64_t replica_id, int64_t partition_id,
         int32_t schema_hash) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     std::vector<PendingRowsetGuard> guards;
     // check clone dir existed
     bool exists = true;

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -31,7 +31,7 @@ class RowsetMetaPB;
 class TSnapshotRequest;
 struct RowsetId;
 class StorageEngine;
-class MemTracker;
+class MemTrackerLimiter;
 
 class SnapshotManager {
 public:
@@ -84,7 +84,7 @@ private:
     StorageEngine& _engine;
     std::atomic<uint64_t> _snapshot_base_id {0};
 
-    std::shared_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 }; // SnapshotManager
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

fix
```
F20240410 19:52:38.560148 2996054 thread_context.h:293] __builtin_unreachable, If you crash here, it means that SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of each thread is expected to use SCOPED_ATTACH_TASK t
o bind a MemTrackerLimiter belonging to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the thread will crash. If you want to switch MemTrackerLimiter during thread execution, please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not r
epeat Attach. Of course, you can modify enable_memory_orphan_check=false in be.conf to avoid this crash.
*** Check failure stack trace: ***
    @     0x55ccbdee4346  google::LogMessage::SendToLog()
    @     0x55ccbdee0d90  google::LogMessage::Flush()
    @     0x55ccbdee4b89  google::LogMessageFatal::~LogMessageFatal()
    @     0x55cc8dbad2ee  doris::thread_context()
    @     0x55cc8dbac50e  doris::MemTracker::bind_parent()
    @     0x55cc8dbac1cb  doris::MemTracker::MemTracker()
    @     0x55cc8ce4acd5  _ZSt12construct_atIN5doris10MemTrackerEJRA16_KcEEDTgsnwcvPvLi0E_T_pispclsr3stdE7declvalIT0_EEEEPS6_DpOS7_
    @     0x55cc8ce4ab83  std::allocator_traits<>::construct<>()
    @     0x55cc8ce4aa87  std::_Sp_counted_ptr_inplace<>::_Sp_counted_ptr_inplace<>()
    @     0x55cc8ce4a75c  std::__shared_count<>::__shared_count<>()
    @     0x55cc8ce4a498  std::__shared_ptr<>::__shared_ptr<>()
    @     0x55cc8ce4a278  std::shared_ptr<>::shared_ptr<>()
    @     0x55cc8ce4a0a5  std::allocate_shared<>()
    @     0x55cc8ce49e7d  std::make_shared<>()
    @     0x55cc8ce4087b  doris::SnapshotManager::SnapshotManager()
    @     0x55cc8ce2020b  doris::SnapshotManager::instance()
    @     0x55cc8e117c32  doris::AgentServer::make_snapshot()
    @     0x55cc8e0f7963  doris::BackendService::make_snapshot()
    @     0x55cc8e927232  doris::BackendServiceProcessor::process_make_snapshot()
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

