### PR TITLE
[Exec](join) Support column string64 to avoid join failed in string size overflow the uint32

### DIFF
--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "exec/tablet_info.h" // DorisNodesInfo
 #include "olap/storage_engine.h"
+#include "vec/columns/column_string.h"
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 
@@ -37,7 +38,6 @@ class RuntimeState;
 class TupleDescriptor;
 
 namespace vectorized {
-class ColumnString;
 class MutableBlock;
 } // namespace vectorized
 

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -418,26 +418,39 @@ public:
         }
     }
 
+    void _insert_fixed_len_string(const auto& col, const uint8_t* __restrict nullmap, size_t start,
+                                  size_t end) {
+        for (size_t i = start; i < end; i++) {
+            if (nullmap != nullptr || !nullmap[i]) {
+                _set.insert(col.get_data_at(i).to_string());
+            } else {
+                _contains_null = true;
+            }
+        }
+    }
+
     void insert_fixed_len(const vectorized::ColumnPtr& column, size_t start) override {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const vectorized::ColumnNullable*>(column.get());
-            const auto& col =
-                    assert_cast<const vectorized::ColumnString&>(nullable->get_nested_column());
             const auto& nullmap =
                     assert_cast<const vectorized::ColumnUInt8&>(nullable->get_null_map_column())
                             .get_data();
-
-            for (size_t i = start; i < nullable->size(); i++) {
-                if (!nullmap[i]) {
-                    _set.insert(col.get_data_at(i).to_string());
-                } else {
-                    _contains_null = true;
-                }
+            if (nullable->get_nested_column().is_column_string64()) {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString64&>(
+                                                 nullable->get_nested_column()),
+                                         nullmap.data(), start, nullmap.size());
+            } else {
+                _insert_fixed_len_string(
+                        assert_cast<const vectorized::ColumnString&>(nullable->get_nested_column()),
+                        nullmap.data(), start, nullmap.size());
             }
         } else {
-            const auto& col = assert_cast<const vectorized::ColumnString*>(column.get());
-            for (size_t i = start; i < col->size(); i++) {
-                _set.insert(col->get_data_at(i).to_string());
+            if (column->is_column_string64()) {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString64&>(*column),
+                                         nullptr, start, column->size());
+            } else {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString&>(*column),
+                                         nullptr, start, column->size());
             }
         }
     }
@@ -567,26 +580,39 @@ public:
         }
     }
 
+    void _insert_fixed_len_string(const auto& col, const uint8_t* __restrict nullmap, size_t start,
+                                  size_t end) {
+        for (size_t i = start; i < end; i++) {
+            if (nullmap != nullptr || !nullmap[i]) {
+                _set.insert(col.get_data_at(i));
+            } else {
+                _contains_null = true;
+            }
+        }
+    }
+
     void insert_fixed_len(const vectorized::ColumnPtr& column, size_t start) override {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const vectorized::ColumnNullable*>(column.get());
-            const auto& col =
-                    assert_cast<const vectorized::ColumnString&>(nullable->get_nested_column());
             const auto& nullmap =
                     assert_cast<const vectorized::ColumnUInt8&>(nullable->get_null_map_column())
                             .get_data();
-
-            for (size_t i = start; i < nullable->size(); i++) {
-                if (!nullmap[i]) {
-                    _set.insert(col.get_data_at(i));
-                } else {
-                    _contains_null = true;
-                }
+            if (nullable->get_nested_column().is_column_string64()) {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString64&>(
+                                                 nullable->get_nested_column()),
+                                         nullmap.data(), start, nullmap.size());
+            } else {
+                _insert_fixed_len_string(
+                        assert_cast<const vectorized::ColumnString&>(nullable->get_nested_column()),
+                        nullmap.data(), start, nullmap.size());
             }
         } else {
-            const auto& col = assert_cast<const vectorized::ColumnString*>(column.get());
-            for (size_t i = start; i < col->size(); i++) {
-                _set.insert(col->get_data_at(i));
+            if (column->is_column_string64()) {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString64&>(*column),
+                                         nullptr, start, column->size());
+            } else {
+                _insert_fixed_len_string(assert_cast<const vectorized::ColumnString&>(*column),
+                                         nullptr, start, column->size());
             }
         }
     }

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -253,6 +253,7 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state,
         return Status::OK();
     }
     COUNTER_UPDATE(_build_rows_counter, rows);
+    block.replace_if_overflow();
 
     vectorized::ColumnRawPtrs raw_ptrs(_build_expr_ctxs.size());
 
@@ -519,7 +520,7 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                                                      res_col_ids));
 
             SCOPED_TIMER(local_state._build_side_merge_block_timer);
-            RETURN_IF_ERROR(local_state._build_side_mutable_block.merge(*in_block));
+            RETURN_IF_ERROR(local_state._build_side_mutable_block.merge_ignore_overflow(*in_block));
             COUNTER_UPDATE(local_state._build_blocks_memory_usage, in_block->bytes());
             local_state._mem_tracker->consume(in_block->bytes());
             if (local_state._build_side_mutable_block.rows() >

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -28,6 +28,7 @@
 #include "olap/decimal12.h"
 #include "runtime/define_primitive_type.h"
 #include "vec/columns/column_decimal.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/core/types.h"
@@ -35,10 +36,6 @@
 #include "vec/utils/template_helpers.hpp"
 
 namespace doris {
-
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
 
 class DecimalV2Value;
 struct StringRef;

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -33,6 +33,7 @@
 #include "util/bitmap_value.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column_complex.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_bitmap.h"
@@ -44,7 +45,6 @@ namespace vectorized {
 class Arena;
 class BufferReadable;
 class BufferWritable;
-class ColumnString;
 class IColumn;
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -77,14 +77,13 @@ private:
     /// If you want to copy column for modification, look at 'mutate' method.
     virtual MutablePtr clone() const = 0;
 
-protected:
+public:
     // 64bit offsets now only Array type used, so we make it protected
     // to avoid use IColumn::Offset64 directly.
     // please use ColumnArray::Offset64 instead if we need.
     using Offset64 = UInt64;
     using Offsets64 = PaddedPODArray<Offset64>;
 
-public:
     // 32bit offsets for string
     using Offset = UInt32;
     using Offsets = PaddedPODArray<Offset>;
@@ -99,6 +98,11 @@ public:
       * If column is constant, transforms constant to full column (if column type allows such transform) and return it.
       */
     virtual Ptr convert_to_full_column_if_const() const { return get_ptr(); }
+
+    /** If column isn't constant, returns nullptr (or itself).
+    * If column is constant, transforms constant to full column (if column type allows such transform) and return it.
+    */
+    virtual Ptr convert_to_full_column_if_overflow() { return get_ptr(); }
 
     /// If column isn't ColumnLowCardinality, return itself.
     /// If column is ColumnLowCardinality, transforms is to full column.

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -652,6 +652,8 @@ public:
 
     virtual bool is_column_string() const { return false; }
 
+    virtual bool is_column_string64() const { return false; }
+
     virtual bool is_column_decimal() const { return false; }
 
     virtual bool is_column_dictionary() const { return false; }
@@ -664,8 +666,6 @@ public:
 
     /// If the only value column can contain is NULL.
     virtual bool only_null() const { return false; }
-
-    virtual bool low_cardinality() const { return false; }
 
     virtual void sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                              IColumn::Permutation& perms, EqualRange& range,

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -99,10 +99,10 @@ public:
       */
     virtual Ptr convert_to_full_column_if_const() const { return get_ptr(); }
 
-    /** If column isn't constant, returns nullptr (or itself).
-    * If column is constant, transforms constant to full column (if column type allows such transform) and return it.
-    */
-    virtual Ptr convert_to_full_column_if_overflow() { return get_ptr(); }
+    /** If in join. the StringColumn size may overflow uint32_t, we need convert to uint64_t to ColumnLargeStringForJoin
+  * The Column: ColumnString, ColumnNullable, ColumnArray, ColumnStruct need impl the code
+  */
+    virtual Ptr convert_column_if_overflow() { return get_ptr(); }
 
     /// If column isn't ColumnLowCardinality, return itself.
     /// If column is ColumnLowCardinality, transforms is to full column.
@@ -225,6 +225,14 @@ public:
     /// Could be used to concatenate columns.
     /// TODO: we need `insert_range_from_const` for every column type.
     virtual void insert_range_from(const IColumn& src, size_t start, size_t length) = 0;
+
+    /// Appends range of elements from other column with the same type.
+    /// Do not need throw execption in ColumnString overflow uint32, only
+    /// use in join
+    virtual void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                                   size_t length) {
+        insert_range_from(src, start, length);
+    }
 
     /// Appends one element from other column with the same type multiple times.
     virtual void insert_many_from(const IColumn& src, size_t position, size_t length) {

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -99,7 +99,7 @@ public:
       */
     virtual Ptr convert_to_full_column_if_const() const { return get_ptr(); }
 
-    /** If in join. the StringColumn size may overflow uint32_t, we need convert to uint64_t to ColumnLargeStringForJoin
+    /** If in join. the StringColumn size may overflow uint32_t, we need convert to uint64_t to ColumnString64
   * The Column: ColumnString, ColumnNullable, ColumnArray, ColumnStruct need impl the code
   */
     virtual Ptr convert_column_if_overflow() { return get_ptr(); }

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -514,6 +514,40 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
     }
 }
 
+void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                                    size_t length) {
+    const ColumnArray& src_concrete = assert_cast<const ColumnArray&>(src);
+
+    if (start + length > src_concrete.get_offsets().size()) {
+        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+                               "Parameter out of bound in ColumnArray::insert_range_from method. "
+                               "[start({}) + length({}) > offsets.size({})]",
+                               std::to_string(start), std::to_string(length),
+                               std::to_string(src_concrete.get_offsets().size()));
+    }
+
+    size_t nested_offset = src_concrete.offset_at(start);
+    size_t nested_length = src_concrete.get_offsets()[start + length - 1] - nested_offset;
+
+    get_data().insert_range_from_ignore_overflow(src_concrete.get_data(), nested_offset,
+                                                 nested_length);
+
+    auto& cur_offsets = get_offsets();
+    const auto& src_offsets = src_concrete.get_offsets();
+
+    if (start == 0 && cur_offsets.empty()) {
+        cur_offsets.assign(src_offsets.begin(), src_offsets.begin() + length);
+    } else {
+        size_t old_size = cur_offsets.size();
+        // -1 is ok, because PaddedPODArray pads zeros on the left.
+        size_t prev_max_offset = cur_offsets.back();
+        cur_offsets.resize(old_size + length);
+
+        for (size_t i = 0; i < length; ++i)
+            cur_offsets[old_size + i] = src_offsets[start + i] - nested_offset + prev_max_offset;
+    }
+}
+
 double ColumnArray::get_ratio_of_default_rows(double sample_ratio) const {
     return get_ratio_of_default_rows_impl<ColumnArray>(sample_ratio);
 }

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -85,6 +85,8 @@ private:
 
     ColumnArray(const ColumnArray&) = default;
 
+    ColumnArray() = default;
+
 public:
     // offsets of array is 64bit wise
     using Offset64 = IColumn::Offset64;
@@ -152,6 +154,8 @@ public:
                                 const uint8_t* __restrict null_data = nullptr) const override;
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
+    void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                           size_t length) override;
     void insert(const Field& x) override;
     void insert_from(const IColumn& src_, size_t n) override;
     void insert_default() override;
@@ -215,6 +219,11 @@ public:
     void for_each_subcolumn(ColumnCallback callback) override {
         callback(offsets);
         callback(data);
+    }
+
+    ColumnPtr convert_column_if_overflow() override {
+        data = data->convert_column_if_overflow();
+        return IColumn::convert_column_if_overflow();
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -102,6 +102,8 @@ public:
 
     void insert_data(const char* pos, size_t length) override;
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
+    void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                           size_t length) override;
     void insert_from(const IColumn& src_, size_t n) override;
     void insert(const Field& x) override;
     void insert_default() override;
@@ -203,6 +205,12 @@ public:
 
     size_t ALWAYS_INLINE size_at(ssize_t i) const {
         return get_offsets()[i] - get_offsets()[i - 1];
+    }
+
+    ColumnPtr convert_column_if_overflow() override {
+        keys_column = keys_column->convert_column_if_overflow();
+        values_column = values_column->convert_column_if_overflow();
+        return IColumn::convert_column_if_overflow();
     }
 
 private:

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -283,6 +283,17 @@ void ColumnNullable::deserialize_vec(std::vector<StringRef>& keys, const size_t 
     }
 }
 
+void ColumnNullable::insert_range_from_ignore_overflow(const doris::vectorized::IColumn& src,
+                                                       size_t start, size_t length) {
+    const auto& nullable_col = assert_cast<const ColumnNullable&>(src);
+    _get_null_map_column().insert_range_from(*nullable_col.null_map, start, length);
+    get_nested_column().insert_range_from_ignore_overflow(*nullable_col.nested_column, start,
+                                                          length);
+    const auto& src_null_map_data = nullable_col.get_null_map_data();
+    _has_null = has_null();
+    _has_null |= simd::contain_byte(src_null_map_data.data() + start, length, 1);
+}
+
 void ColumnNullable::insert_range_from(const IColumn& src, size_t start, size_t length) {
     const auto& nullable_col = assert_cast<const ColumnNullable&>(src);
     _get_null_map_column().insert_range_from(*nullable_col.null_map, start, length);

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -121,6 +121,10 @@ public:
     void deserialize_vec(std::vector<StringRef>& keys, size_t num_rows) override;
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
+
+    void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                           size_t length) override;
+
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
     void insert_indices_from_not_has_null(const IColumn& src, const uint32_t* indices_begin,
@@ -237,7 +241,10 @@ public:
         append_data_by_selector_impl<ColumnNullable>(res, selector, begin, end);
     }
 
-    //    void gather(ColumnGathererStream & gatherer_stream) override;
+    ColumnPtr convert_column_if_overflow() override {
+        nested_column = nested_column->convert_column_if_overflow();
+        return get_ptr();
+    }
 
     void for_each_subcolumn(ColumnCallback callback) override {
         callback(nested_column);

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 // This file is copied from
-// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnString.cpp
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnStr<T>.cpp
 // and modified by Doris
 
 #include "vec/columns/column_string.h"
@@ -31,11 +31,11 @@
 #include "vec/common/memcmp_small.h"
 #include "vec/common/unaligned.h"
 #include "vec/core/sort_block.h"
-#include "vec/data_types/data_type.h"
 
 namespace doris::vectorized {
 
-void ColumnString::sanity_check() const {
+template <typename T>
+void ColumnStr<T>::sanity_check() const {
     auto count = offsets.size();
     if (chars.size() != offsets[count - 1]) {
         LOG(FATAL) << "row count: " << count << ", chars.size(): " << chars.size() << ", offset["
@@ -52,8 +52,9 @@ void ColumnString::sanity_check() const {
     }
 }
 
-MutableColumnPtr ColumnString::clone_resized(size_t to_size) const {
-    auto res = ColumnString::create();
+template <typename T>
+MutableColumnPtr ColumnStr<T>::clone_resized(size_t to_size) const {
+    auto res = ColumnStr<T>::create();
     if (to_size == 0) {
         return res;
     }
@@ -79,29 +80,31 @@ MutableColumnPtr ColumnString::clone_resized(size_t to_size) const {
     return res;
 }
 
-MutableColumnPtr ColumnString::get_shrinked_column() {
-    auto shrinked_column = ColumnString::create();
+template <typename T>
+MutableColumnPtr ColumnStr<T>::get_shrinked_column() {
+    auto shrinked_column = ColumnStr<T>::create();
     shrinked_column->get_offsets().reserve(offsets.size());
     shrinked_column->get_chars().reserve(chars.size());
     for (int i = 0; i < size(); i++) {
         StringRef str = get_data_at(i);
-        reinterpret_cast<ColumnString*>(shrinked_column.get())
+        reinterpret_cast<ColumnStr<T>*>(shrinked_column.get())
                 ->insert_data(str.data, strnlen(str.data, str.size));
     }
     return shrinked_column;
 }
 
-void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t length) {
+template <typename T>
+void ColumnStr<T>::insert_range_from(const IColumn& src, size_t start, size_t length) {
     if (length == 0) {
         return;
     }
 
-    const ColumnString& src_concrete = assert_cast<const ColumnString&>(src);
+    const ColumnStr<T>& src_concrete = assert_cast<const ColumnStr<T>&>(src);
 
     if (start + length > src_concrete.offsets.size()) {
         throw doris::Exception(
                 doris::ErrorCode::INTERNAL_ERROR,
-                "Parameter out of bound in IColumnString::insert_range_from method.");
+                "Parameter out of bound in IColumnStr<T>::insert_range_from method.");
     }
 
     size_t nested_offset = src_concrete.offset_at(start);
@@ -126,9 +129,10 @@ void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t le
     }
 }
 
-void ColumnString::insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
+template <typename T>
+void ColumnStr<T>::insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                                        const uint32_t* indices_end) {
-    const auto& src_str = assert_cast<const ColumnString&>(src);
+    const auto& src_str = assert_cast<const ColumnStr<T>&>(src);
     const auto* src_offset_data = src_str.offsets.data();
 
     auto old_char_size = chars.size();
@@ -159,7 +163,8 @@ void ColumnString::insert_indices_from(const IColumn& src, const uint32_t* indic
     }
 }
 
-void ColumnString::update_crcs_with_value(uint32_t* __restrict hashes, doris::PrimitiveType type,
+template <typename T>
+void ColumnStr<T>::update_crcs_with_value(uint32_t* __restrict hashes, doris::PrimitiveType type,
                                           uint32_t rows, uint32_t offset,
                                           const uint8_t* __restrict null_data) const {
     auto s = rows;
@@ -180,45 +185,50 @@ void ColumnString::update_crcs_with_value(uint32_t* __restrict hashes, doris::Pr
     }
 }
 
-ColumnPtr ColumnString::filter(const Filter& filt, ssize_t result_size_hint) const {
+template <typename T>
+ColumnPtr ColumnStr<T>::filter(const IColumn::Filter& filt, ssize_t result_size_hint) const {
     if (offsets.size() == 0) {
-        return ColumnString::create();
+        return ColumnStr<T>::create();
     }
 
-    auto res = ColumnString::create();
+    auto res = ColumnStr<T>::create();
 
     Chars& res_chars = res->chars;
-    Offsets& res_offsets = res->offsets;
+    IColumn::Offsets& res_offsets = res->offsets;
 
-    filter_arrays_impl<UInt8, Offset>(chars, offsets, res_chars, res_offsets, filt,
-                                      result_size_hint);
+    filter_arrays_impl<UInt8, IColumn::Offset>(chars, offsets, res_chars, res_offsets, filt,
+                                               result_size_hint);
     return res;
 }
 
-size_t ColumnString::filter(const Filter& filter) {
+template <typename T>
+size_t ColumnStr<T>::filter(const IColumn::Filter& filter) {
     CHECK_EQ(filter.size(), offsets.size());
     if (offsets.size() == 0) {
         resize(0);
         return 0;
     }
 
-    return filter_arrays_impl<UInt8, Offset>(chars, offsets, filter);
+    return filter_arrays_impl<UInt8, IColumn::Offset>(chars, offsets, filter);
 }
 
-Status ColumnString::filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) {
-    auto* col = static_cast<ColumnString*>(col_ptr);
+template <typename T>
+Status ColumnStr<T>::filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) {
+    auto* col = static_cast<ColumnStr<T>*>(col_ptr);
     Chars& res_chars = col->chars;
-    Offsets& res_offsets = col->offsets;
-    Filter filter;
+    IColumn::Offsets& res_offsets = col->offsets;
+    IColumn::Filter filter;
     filter.resize_fill(offsets.size(), 0);
     for (size_t i = 0; i < sel_size; i++) {
         filter[sel[i]] = 1;
     }
-    filter_arrays_impl<UInt8, Offset>(chars, offsets, res_chars, res_offsets, filter, sel_size);
+    filter_arrays_impl<UInt8, IColumn::Offset>(chars, offsets, res_chars, res_offsets, filter,
+                                               sel_size);
     return Status::OK();
 }
 
-ColumnPtr ColumnString::permute(const Permutation& perm, size_t limit) const {
+template <typename T>
+ColumnPtr ColumnStr<T>::permute(const IColumn::Permutation& perm, size_t limit) const {
     size_t size = offsets.size();
 
     if (limit == 0) {
@@ -232,13 +242,13 @@ ColumnPtr ColumnString::permute(const Permutation& perm, size_t limit) const {
     }
 
     if (limit == 0) {
-        return ColumnString::create();
+        return ColumnStr<T>::create();
     }
 
-    auto res = ColumnString::create();
+    auto res = ColumnStr<T>::create();
 
     Chars& res_chars = res->chars;
-    Offsets& res_offsets = res->offsets;
+    IColumn::Offsets& res_offsets = res->offsets;
 
     if (limit == size) {
         res_chars.resize(chars.size());
@@ -252,7 +262,7 @@ ColumnPtr ColumnString::permute(const Permutation& perm, size_t limit) const {
 
     res_offsets.resize(limit);
 
-    Offset current_new_offset = 0;
+    IColumn::Offset current_new_offset = 0;
 
     for (size_t i = 0; i < limit; ++i) {
         size_t j = perm[i];
@@ -269,7 +279,8 @@ ColumnPtr ColumnString::permute(const Permutation& perm, size_t limit) const {
     return res;
 }
 
-StringRef ColumnString::serialize_value_into_arena(size_t n, Arena& arena,
+template <typename T>
+StringRef ColumnStr<T>::serialize_value_into_arena(size_t n, Arena& arena,
                                                    char const*& begin) const {
     uint32_t string_size(size_at(n));
     uint32_t offset(offset_at(n));
@@ -284,7 +295,8 @@ StringRef ColumnString::serialize_value_into_arena(size_t n, Arena& arena,
     return res;
 }
 
-const char* ColumnString::deserialize_and_insert_from_arena(const char* pos) {
+template <typename T>
+const char* ColumnStr<T>::deserialize_and_insert_from_arena(const char* pos) {
     const uint32_t string_size = unaligned_load<uint32_t>(pos);
     pos += sizeof(string_size);
 
@@ -298,7 +310,8 @@ const char* ColumnString::deserialize_and_insert_from_arena(const char* pos) {
     return pos + string_size;
 }
 
-size_t ColumnString::get_max_row_byte_size() const {
+template <typename T>
+size_t ColumnStr<T>::get_max_row_byte_size() const {
     size_t max_size = 0;
     size_t num_rows = offsets.size();
     for (size_t i = 0; i < num_rows; ++i) {
@@ -308,7 +321,8 @@ size_t ColumnString::get_max_row_byte_size() const {
     return max_size + sizeof(uint32_t);
 }
 
-void ColumnString::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
+template <typename T>
+void ColumnStr<T>::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
                                  size_t max_row_byte_size) const {
     for (size_t i = 0; i < num_rows; ++i) {
         uint32_t offset(offset_at(i));
@@ -321,7 +335,8 @@ void ColumnString::serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
     }
 }
 
-void ColumnString::serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
+template <typename T>
+void ColumnStr<T>::serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
                                                const uint8_t* null_map) const {
     for (size_t i = 0; i < num_rows; ++i) {
         if (null_map[i] == 0) {
@@ -336,7 +351,8 @@ void ColumnString::serialize_vec_with_null_map(std::vector<StringRef>& keys, siz
     }
 }
 
-void ColumnString::deserialize_vec(std::vector<StringRef>& keys, const size_t num_rows) {
+template <typename T>
+void ColumnStr<T>::deserialize_vec(std::vector<StringRef>& keys, const size_t num_rows) {
     for (size_t i = 0; i != num_rows; ++i) {
         auto original_ptr = keys[i].data;
         keys[i].data = deserialize_and_insert_from_arena(original_ptr);
@@ -344,7 +360,8 @@ void ColumnString::deserialize_vec(std::vector<StringRef>& keys, const size_t nu
     }
 }
 
-void ColumnString::deserialize_vec_with_null_map(std::vector<StringRef>& keys,
+template <typename T>
+void ColumnStr<T>::deserialize_vec_with_null_map(std::vector<StringRef>& keys,
                                                  const size_t num_rows, const uint8_t* null_map) {
     for (size_t i = 0; i != num_rows; ++i) {
         if (null_map[i] == 0) {
@@ -357,16 +374,17 @@ void ColumnString::deserialize_vec_with_null_map(std::vector<StringRef>& keys,
     }
 }
 
+template <typename T>
 template <typename Type>
-ColumnPtr ColumnString::index_impl(const PaddedPODArray<Type>& indexes, size_t limit) const {
+ColumnPtr ColumnStr<T>::index_impl(const PaddedPODArray<Type>& indexes, size_t limit) const {
     if (limit == 0) {
-        return ColumnString::create();
+        return ColumnStr<T>::create();
     }
 
-    auto res = ColumnString::create();
+    auto res = ColumnStr<T>::create();
 
     Chars& res_chars = res->chars;
-    Offsets& res_offsets = res->offsets;
+    IColumn::Offsets& res_offsets = res->offsets;
 
     size_t new_chars_size = 0;
     for (size_t i = 0; i < limit; ++i) {
@@ -377,7 +395,7 @@ ColumnPtr ColumnString::index_impl(const PaddedPODArray<Type>& indexes, size_t l
 
     res_offsets.resize(limit);
 
-    Offset current_new_offset = 0;
+    IColumn::Offset current_new_offset = 0;
 
     for (size_t i = 0; i < limit; ++i) {
         size_t j = indexes[i];
@@ -394,10 +412,11 @@ ColumnPtr ColumnString::index_impl(const PaddedPODArray<Type>& indexes, size_t l
     return res;
 }
 
+template <typename T>
 template <bool positive>
-struct ColumnString::less {
-    const ColumnString& parent;
-    explicit less(const ColumnString& parent_) : parent(parent_) {}
+struct ColumnStr<T>::less {
+    const ColumnStr<T>& parent;
+    explicit less(const ColumnStr<T>& parent_) : parent(parent_) {}
     bool operator()(size_t lhs, size_t rhs) const {
         int res = memcmp_small_allow_overflow15(
                 parent.chars.data() + parent.offset_at(lhs), parent.size_at(lhs),
@@ -407,8 +426,9 @@ struct ColumnString::less {
     }
 };
 
-void ColumnString::get_permutation(bool reverse, size_t limit, int /*nan_direction_hint*/,
-                                   Permutation& res) const {
+template <typename T>
+void ColumnStr<T>::get_permutation(bool reverse, size_t limit, int /*nan_direction_hint*/,
+                                   IColumn::Permutation& res) const {
     size_t s = offsets.size();
     res.resize(s);
     for (size_t i = 0; i < s; ++i) {
@@ -434,24 +454,25 @@ void ColumnString::get_permutation(bool reverse, size_t limit, int /*nan_directi
     }
 }
 
-ColumnPtr ColumnString::replicate(const Offsets& replicate_offsets) const {
+template <typename T>
+ColumnPtr ColumnStr<T>::replicate(const IColumn::Offsets& replicate_offsets) const {
     size_t col_size = size();
     column_match_offsets_size(col_size, replicate_offsets.size());
 
-    auto res = ColumnString::create();
+    auto res = ColumnStr<T>::create();
 
     if (0 == col_size) {
         return res;
     }
 
     Chars& res_chars = res->chars;
-    Offsets& res_offsets = res->offsets;
+    IColumn::Offsets& res_offsets = res->offsets;
     res_chars.reserve(chars.size() / col_size * replicate_offsets.back());
     res_offsets.reserve(replicate_offsets.back());
 
-    Offset prev_replicate_offset = 0;
-    Offset prev_string_offset = 0;
-    Offset current_new_offset = 0;
+    IColumn::Offset prev_replicate_offset = 0;
+    IColumn::Offset prev_string_offset = 0;
+    IColumn::Offset current_new_offset = 0;
 
     for (size_t i = 0; i < col_size; ++i) {
         size_t size_to_replicate = replicate_offsets[i] - prev_replicate_offset;
@@ -474,12 +495,14 @@ ColumnPtr ColumnString::replicate(const Offsets& replicate_offsets) const {
     return res;
 }
 
-void ColumnString::reserve(size_t n) {
+template <typename T>
+void ColumnStr<T>::reserve(size_t n) {
     offsets.reserve(n);
     chars.reserve(n);
 }
 
-void ColumnString::resize(size_t n) {
+template <typename T>
+void ColumnStr<T>::resize(size_t n) {
     auto origin_size = size();
     if (origin_size > n) {
         offsets.resize(n);
@@ -488,18 +511,20 @@ void ColumnString::resize(size_t n) {
     }
 }
 
-void ColumnString::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
+template <typename T>
+void ColumnStr<T>::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                                IColumn::Permutation& perms, EqualRange& range,
                                bool last_column) const {
-    sorter->sort_column(static_cast<const ColumnString&>(*this), flags, perms, range, last_column);
+    sorter->sort_column(static_cast<const ColumnStr<T>&>(*this), flags, perms, range, last_column);
 }
 
-void ColumnString::compare_internal(size_t rhs_row_id, const IColumn& rhs, int nan_direction_hint,
+template <typename T>
+void ColumnStr<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs, int nan_direction_hint,
                                     int direction, std::vector<uint8>& cmp_res,
                                     uint8* __restrict filter) const {
     auto sz = this->size();
     DCHECK(cmp_res.size() == sz);
-    const auto& cmp_base = assert_cast<const ColumnString&>(rhs).get_data_at(rhs_row_id);
+    const auto& cmp_base = assert_cast<const ColumnStr<T>&>(rhs).get_data_at(rhs_row_id);
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);
@@ -518,8 +543,39 @@ void ColumnString::compare_internal(size_t rhs_row_id, const IColumn& rhs, int n
     }
 }
 
-ColumnPtr ColumnString::index(const IColumn& indexes, size_t limit) const {
+template <typename T>
+ColumnPtr ColumnStr<T>::index(const IColumn& indexes, size_t limit) const {
     return select_index_impl(*this, indexes, limit);
 }
 
+template <typename T>
+ColumnPtr ColumnStr<T>::convert_to_full_column_if_overflow() {
+    if (std::is_same_v<T, UInt32> && chars.size() > std::numeric_limits<UInt32>::max()) {
+        auto new_col = ColumnStr<uint64_t>::create();
+
+        const auto length = offsets.size();
+        std::swap(new_col->get_chars(), chars);
+        new_col->get_offsets().resize(length);
+
+        size_t base = 0;
+        size_t start = 0;
+        size_t end = length;
+
+        while (start < end) {
+            size_t mid = find_first_overflow_point(_offsets, start, end);
+            for (size_t i = start; i < mid; i++) {
+                new_column->get_offset()[i] = static_cast<uint64_t>(_offsets[i]) + base;
+            }
+            base += Column::MAX_CAPACITY_LIMIT;
+            start = mid;
+        }
+
+        offsets.clear();
+        return new_col;
+    }
+    return this->get_ptr();
+}
+
+template class ColumnStr<uint32_t>;
+template class ColumnStr<uint64_t>;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -572,7 +572,8 @@ ColumnPtr ColumnStr<T>::index(const IColumn& indexes, size_t limit) const {
 
 template <typename T>
 ColumnPtr ColumnStr<T>::convert_column_if_overflow() {
-    if (std::is_same_v<T, UInt32> && chars.size() > 10) {
+    // TODO: Try to fuzzy the overflow size to test more case in CI
+    if (std::is_same_v<T, UInt32> && chars.size() > std::numeric_limits<UInt32>::max()) {
         auto new_col = ColumnStr<uint64_t>::create();
 
         const auto length = offsets.size();

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -193,14 +193,15 @@ ColumnPtr ColumnStr<T>::filter(const IColumn::Filter& filt, ssize_t result_size_
 
     if constexpr (std::is_same_v<UInt32, T>) {
         auto res = ColumnStr<T>::create();
-        Chars &res_chars = res->chars;
-        IColumn::Offsets &res_offsets = res->offsets;
+        Chars& res_chars = res->chars;
+        IColumn::Offsets& res_offsets = res->offsets;
 
         filter_arrays_impl<UInt8, IColumn::Offset>(chars, offsets, res_chars, res_offsets, filt,
                                                    result_size_hint);
         return res;
     } else {
-        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR, "should not call filter in ColumnStr<UInt64>");
+        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+                               "should not call filter in ColumnStr<UInt64>");
     }
 }
 
@@ -215,16 +216,17 @@ size_t ColumnStr<T>::filter(const IColumn::Filter& filter) {
     if constexpr (std::is_same_v<UInt32, T>) {
         return filter_arrays_impl<UInt8, IColumn::Offset>(chars, offsets, filter);
     } else {
-        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR, "should not call filter in ColumnStr<UInt64>");
+        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+                               "should not call filter in ColumnStr<UInt64>");
     }
 }
 
 template <typename T>
 Status ColumnStr<T>::filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) {
     if constexpr (std::is_same_v<UInt32, T>) {
-        auto *col = static_cast<ColumnStr<T> *>(col_ptr);
-        Chars &res_chars = col->chars;
-        IColumn::Offsets &res_offsets = col->offsets;
+        auto* col = static_cast<ColumnStr<T>*>(col_ptr);
+        Chars& res_chars = col->chars;
+        IColumn::Offsets& res_offsets = col->offsets;
         IColumn::Filter filter;
         filter.resize_fill(offsets.size(), 0);
         for (size_t i = 0; i < sel_size; i++) {
@@ -560,8 +562,8 @@ ColumnPtr ColumnStr<T>::index(const IColumn& indexes, size_t limit) const {
 }
 
 template <typename T>
-ColumnPtr ColumnStr<T>::convert_to_full_column_if_overflow() {
-    if (std::is_same_v<T, UInt32> && chars.size() > std::numeric_limits<UInt32>::max()) {
+ColumnPtr ColumnStr<T>::convert_column_if_overflow() {
+    if (std::is_same_v<T, UInt32> && chars.size() > 10) {
         auto new_col = ColumnStr<uint64_t>::create();
 
         const auto length = offsets.size();

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -586,4 +586,5 @@ public:
 };
 
 using ColumnString = ColumnStr<UInt32>;
+using ColumnString64 = ColumnStr<UInt64>;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -523,9 +523,8 @@ public:
 
     void append_data_by_selector(MutableColumnPtr& res, const IColumn::Selector& selector,
                                  size_t begin, size_t end) const override {
-        append_data_by_selector_impl<ColumnString>(res, selector, begin, end);
+        this->template append_data_by_selector_impl<ColumnStr<T>>(res, selector, begin, end);
     }
-    //    void gather(ColumnGathererStream & gatherer_stream) override;
 
     void reserve(size_t n) override;
 
@@ -549,12 +548,12 @@ public:
     }
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
-        LOG(FATAL) << "Method replace_column_data is not supported for " << get_name();
+        LOG(FATAL) << "Method replace_column_data is not supported for ColumnString";
     }
 
     // should replace according to 0,1,2... ,size,0,1,2...
     void replace_column_data_default(size_t self_row = 0) override {
-        LOG(FATAL) << "Method replace_column_data_default is not supported for " << get_name();
+        LOG(FATAL) << "Method replace_column_data_default is not supported for ColumnString";
     }
 
     void compare_internal(size_t rhs_row_id, const IColumn& rhs, int nan_direction_hint,
@@ -582,7 +581,7 @@ public:
         return this->template get_ratio_of_default_rows_impl<ColumnStr<T>>(sample_ratio);
     }
 
-    ColumnPtr convert_to_full_column_if_overflow() override;
+    ColumnPtr convert_column_if_overflow() override;
 };
 
 using ColumnString = ColumnStr<UInt32>;

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 // This file is copied from
-// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnStr<T>.h
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnString.h
 // and modified by Doris
 
 #pragma once

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -482,6 +482,9 @@ public:
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
 
+    void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                           size_t length) override;
+
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
 

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 // This file is copied from
-// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnString.h
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnStr<T>.h
 // and modified by Doris
 
 #pragma once
@@ -58,7 +58,8 @@ namespace doris::vectorized {
 
 /** Column for String values.
   */
-class ColumnString final : public COWHelper<IColumn, ColumnString> {
+template <typename T>
+class ColumnStr final : public COWHelper<IColumn, ColumnStr<T>> {
 public:
     using Char = UInt8;
     using Chars = PaddedPODArray<UInt8>;
@@ -75,14 +76,14 @@ public:
 
 private:
     // currently Offsets is uint32, if chars.size() exceeds 4G, offset will overflow.
-    // limit chars.size() and check the size when inserting data into ColumnString.
+    // limit chars.size() and check the size when inserting data into ColumnStr<T>.
     static constexpr size_t MAX_STRING_SIZE = 0xffffffff;
 
-    friend class COWHelper<IColumn, ColumnString>;
+    friend class COWHelper<IColumn, ColumnStr<T>>;
     friend class OlapBlockDataConvertor;
 
     /// Maps i'th position to offset to i+1'th element. Last offset maps to the end of all chars (is the size of all chars).
-    Offsets offsets;
+    PaddedPODArray<T> offsets;
 
     /// Bytes of strings, placed contiguously.
     /// For convenience, every string ends with terminating zero byte. Note that strings could contain zero bytes in the middle.
@@ -98,9 +99,9 @@ private:
     template <bool positive>
     struct lessWithCollation;
 
-    ColumnString() = default;
+    ColumnStr<T>() = default;
 
-    ColumnString(const ColumnString& src)
+    ColumnStr<T>(const ColumnStr<T>& src)
             : offsets(src.offsets.begin(), src.offsets.end()),
               chars(src.chars.begin(), src.chars.end()) {}
 
@@ -164,7 +165,7 @@ public:
     }
 
     void insert_from(const IColumn& src_, size_t n) override {
-        const ColumnString& src = assert_cast<const ColumnString&>(src_);
+        const ColumnStr<T>& src = assert_cast<const ColumnStr<T>&>(src_);
         const size_t size_to_append =
                 src.offsets[n] - src.offsets[n - 1]; /// -1th index is Ok, see PaddedPODArray.
 
@@ -244,7 +245,6 @@ public:
 
     void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets_,
                                             const size_t num) override {
-        static_assert(sizeof(offsets_[0]) == sizeof(*offsets.data()));
         if (UNLIKELY(num == 0)) {
             return;
         }
@@ -313,9 +313,9 @@ public:
         }
     }
 
-    template <typename T, size_t copy_length>
-    void insert_many_strings_fixed_length(const StringRef* strings, size_t num)
-            __attribute__((noinline));
+    //    template <typename T, size_t copy_length>
+    //    void insert_many_strings_fixed_length(const StringRef* strings, size_t num)
+    //            __attribute__((noinline));
 
     template <size_t copy_length>
     void insert_many_strings_fixed_length(const StringRef* strings, size_t num) {
@@ -483,12 +483,12 @@ public:
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
 
-    ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
-    size_t filter(const Filter& filter) override;
+    ColumnPtr filter(const IColumn::Filter& filt, ssize_t result_size_hint) const override;
+    size_t filter(const IColumn::Filter& filter) override;
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override;
 
-    ColumnPtr permute(const Permutation& perm, size_t limit) const override;
+    ColumnPtr permute(const IColumn::Permutation& perm, size_t limit) const override;
 
     void sort_column(const ColumnSorter* sorter, EqualFlags& flags, IColumn::Permutation& perms,
                      EqualRange& range, bool last_column) const override;
@@ -506,19 +506,19 @@ public:
 
     int compare_at(size_t n, size_t m, const IColumn& rhs_,
                    int /*nan_direction_hint*/) const override {
-        const ColumnString& rhs = assert_cast<const ColumnString&>(rhs_);
+        const ColumnStr<T>& rhs = assert_cast<const ColumnStr<T>&>(rhs_);
         return memcmp_small_allow_overflow15(chars.data() + offset_at(n), size_at(n),
                                              rhs.chars.data() + rhs.offset_at(m), rhs.size_at(m));
     }
 
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
-                         Permutation& res) const override;
+                         IColumn::Permutation& res) const override;
 
-    ColumnPtr replicate(const Offsets& replicate_offsets) const override;
+    ColumnPtr replicate(const IColumn::Offsets& replicate_offsets) const override;
 
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
-        append_data_by_selector_impl<ColumnString>(res, selector);
+        this->template append_data_by_selector_impl<ColumnStr<T>>(res, selector);
     }
 
     void append_data_by_selector(MutableColumnPtr& res, const IColumn::Selector& selector,
@@ -534,14 +534,14 @@ public:
     bool is_column_string() const override { return true; }
 
     bool structure_equals(const IColumn& rhs) const override {
-        return typeid(rhs) == typeid(ColumnString);
+        return typeid(rhs) == typeid(ColumnStr<T>);
     }
 
     Chars& get_chars() { return chars; }
     const Chars& get_chars() const { return chars; }
 
-    Offsets& get_offsets() { return offsets; }
-    const Offsets& get_offsets() const { return offsets; }
+    auto& get_offsets() { return offsets; }
+    const auto& get_offsets() const { return offsets; }
 
     void clear() override {
         chars.clear();
@@ -561,25 +561,29 @@ public:
                           int direction, std::vector<uint8>& cmp_res,
                           uint8* __restrict filter) const override;
     MutableColumnPtr get_shinked_column() const {
-        auto shrinked_column = ColumnString::create();
+        auto shrinked_column = ColumnStr<T>::create();
         for (int i = 0; i < size(); i++) {
             StringRef str = get_data_at(i);
-            reinterpret_cast<ColumnString*>(shrinked_column.get())
+            reinterpret_cast<ColumnStr<T>*>(shrinked_column.get())
                     ->insert_data(str.data, strnlen(str.data, str.size));
         }
         return shrinked_column;
     }
 
-    void get_indices_of_non_default_rows(Offsets64& indices, size_t from,
+    void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
-        return get_indices_of_non_default_rows_impl<ColumnString>(indices, from, limit);
+        return this->template get_indices_of_non_default_rows_impl<ColumnStr<T>>(indices, from,
+                                                                                 limit);
     }
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override;
 
     double get_ratio_of_default_rows(double sample_ratio) const override {
-        return get_ratio_of_default_rows_impl<ColumnString>(sample_ratio);
+        return this->template get_ratio_of_default_rows_impl<ColumnStr<T>>(sample_ratio);
     }
+
+    ColumnPtr convert_to_full_column_if_overflow() override;
 };
 
+using ColumnString = ColumnStr<UInt32>;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -164,6 +164,8 @@ public:
         offsets.push_back(new_size);
     }
 
+    bool is_column_string64() const override { return sizeof(T) == sizeof(uint64_t); }
+
     void insert_from(const IColumn& src_, size_t n) override {
         const ColumnStr<T>& src = assert_cast<const ColumnStr<T>&>(src_);
         const size_t size_to_append =

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -251,6 +251,15 @@ void ColumnStruct::insert_range_from(const IColumn& src, size_t start, size_t le
     }
 }
 
+void ColumnStruct::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                                     size_t length) {
+    const size_t tuple_size = columns.size();
+    for (size_t i = 0; i < tuple_size; ++i) {
+        columns[i]->insert_range_from_ignore_overflow(
+                *assert_cast<const ColumnStruct&>(src).columns[i], start, length);
+    }
+}
+
 ColumnPtr ColumnStruct::filter(const Filter& filt, ssize_t result_size_hint) const {
     const size_t tuple_size = columns.size();
     Columns new_columns(tuple_size);

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -145,6 +145,8 @@ public:
     }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
+    void insert_range_from_ignore_overflow(const IColumn& src, size_t start,
+                                           size_t length) override;
     ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
     size_t filter(const Filter& filter) override;
     ColumnPtr permute(const Permutation& perm, size_t limit) const override;
@@ -175,9 +177,16 @@ public:
     ColumnPtr& get_column_ptr(size_t idx) { return columns[idx]; }
 
     void clear() override {
-        for (auto col : columns) {
+        for (auto& col : columns) {
             col->clear();
         }
+    }
+
+    ColumnPtr convert_column_if_overflow() override {
+        for (auto& col : columns) {
+            col = col->convert_column_if_overflow();
+        }
+        return IColumn::convert_column_if_overflow();
     }
 };
 

--- a/be/src/vec/core/sort_block.h
+++ b/be/src/vec/core/sort_block.h
@@ -333,7 +333,8 @@ private:
             if constexpr (std::is_same_v<ColumnType, ColumnVector<T>> ||
                           std::is_same_v<ColumnType, ColumnDecimal<T>>) {
                 permutation_for_column[i].inline_value = column.get_data()[row_id];
-            } else if constexpr (std::is_same_v<ColumnType, ColumnString> || std::is_same_v<ColumnType, ColumnString64>) {
+            } else if constexpr (std::is_same_v<ColumnType, ColumnString> ||
+                                 std::is_same_v<ColumnType, ColumnString64>) {
                 permutation_for_column[i].inline_value = column.get_data_at(row_id);
             } else {
                 static_assert(always_false_v<ColumnType>);

--- a/be/src/vec/core/sort_block.h
+++ b/be/src/vec/core/sort_block.h
@@ -223,6 +223,15 @@ public:
         }
     }
 
+    void sort_column(const ColumnString64& column, EqualFlags& flags, IColumn::Permutation& perms,
+                     EqualRange& range, bool last_column) const {
+        if (!_should_inline_value(perms)) {
+            _sort_by_default(column, flags, perms, range, last_column);
+        } else {
+            _sort_by_inlined_permutation<StringRef>(column, flags, perms, range, last_column);
+        }
+    }
+
     void sort_column(const ColumnNullable& column, EqualFlags& flags, IColumn::Permutation& perms,
                      EqualRange& range, bool last_column) const {
         if (!column.has_null()) {
@@ -324,7 +333,7 @@ private:
             if constexpr (std::is_same_v<ColumnType, ColumnVector<T>> ||
                           std::is_same_v<ColumnType, ColumnDecimal<T>>) {
                 permutation_for_column[i].inline_value = column.get_data()[row_id];
-            } else if constexpr (std::is_same_v<ColumnType, ColumnString>) {
+            } else if constexpr (std::is_same_v<ColumnType, ColumnString> || std::is_same_v<ColumnType, ColumnString64>) {
                 permutation_for_column[i].inline_value = column.get_data_at(row_id);
             } else {
                 static_assert(always_false_v<ColumnType>);
@@ -338,7 +347,8 @@ private:
                           EqualRange& range, bool last_column) const {
         int new_limit = _limit;
         auto comparator = [&](const size_t a, const size_t b) {
-            if constexpr (!std::is_same_v<ColumnType, ColumnString>) {
+            if constexpr (!std::is_same_v<ColumnType, ColumnString> &&
+                          !std::is_same_v<ColumnType, ColumnString64>) {
                 auto value_a = column.get_data()[a];
                 auto value_b = column.get_data()[b];
                 return value_a > value_b ? 1 : (value_a < value_b ? -1 : 0);

--- a/be/src/vec/exec/format/parquet/byte_array_dict_decoder.h
+++ b/be/src/vec/exec/format/parquet/byte_array_dict_decoder.h
@@ -26,6 +26,7 @@
 
 #include "common/status.h"
 #include "util/bit_util.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
@@ -36,7 +37,6 @@
 
 namespace doris {
 namespace vectorized {
-class ColumnString;
 template <typename T>
 class ColumnDecimal;
 } // namespace vectorized

--- a/be/src/vec/exec/format/parquet/decoder.h
+++ b/be/src/vec/exec/format/parquet/decoder.h
@@ -32,6 +32,7 @@
 #include "util/slice.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_dictionary.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
@@ -42,15 +43,6 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/exec/format/format_common.h"
 #include "vec/exec/format/parquet/parquet_common.h"
-
-namespace cctz {
-class time_zone;
-} // namespace cctz
-namespace doris {
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
-} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -29,6 +29,7 @@
 #include "decoder.h"
 #include "level_decoder.h"
 #include "util/slice.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/columns_number.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exec/format/parquet/parquet_common.h"
@@ -45,7 +46,6 @@ class BufferedStreamReader;
 struct IOContext;
 } // namespace io
 namespace vectorized {
-class ColumnString;
 struct FieldSchema;
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -47,9 +47,6 @@ namespace doris {
 namespace io {
 struct IOContext;
 } // namespace io
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
 } // namespace doris
 
 namespace doris::vectorized {

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -31,6 +31,7 @@
 #include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "parquet_column_convert.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/columns_number.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exec/format/parquet/parquet_common.h"
@@ -44,7 +45,6 @@ namespace io {
 struct IOContext;
 } // namespace io
 namespace vectorized {
-class ColumnString;
 struct FieldSchema;
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/format/table/iceberg_reader.h
+++ b/be/src/vec/exec/format/table/iceberg_reader.h
@@ -32,6 +32,7 @@
 #include "table_format_reader.h"
 #include "util/runtime_profile.h"
 #include "vec/columns/column_dictionary.h"
+#include "vec/columns/column_string.h"
 
 namespace tparquet {
 class KeyValue;
@@ -53,7 +54,6 @@ struct TypeDescriptor;
 
 namespace vectorized {
 class Block;
-class ColumnString;
 class GenericReader;
 class ShardedKVCache;
 class VExprContext;

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -744,7 +744,7 @@ Status HashJoinNode::sink(doris::RuntimeState* state, vectorized::Block* in_bloc
                                          res_col_ids));
 
             SCOPED_TIMER(_build_side_merge_block_timer);
-            RETURN_IF_ERROR(_build_side_mutable_block.merge(*in_block));
+            RETURN_IF_ERROR(_build_side_mutable_block.merge_ignore_overflow(*in_block));
             if (_build_side_mutable_block.rows() > JOIN_BUILD_SIZE_LIMIT) {
                 return Status::NotSupported(
                         "Hash join do not support build table rows"
@@ -942,6 +942,7 @@ Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block) {
     SCOPED_TIMER(_build_table_timer);
     size_t rows = block.rows();
     COUNTER_UPDATE(_build_rows_counter, rows);
+    block.replace_if_overflow();
 
     ColumnRawPtrs raw_ptrs(_build_expr_ctxs.size());
 

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "vec/columns/column_string.h"
 #include "vec/common/string_ref.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/table_function/table_function.h"
@@ -31,7 +32,6 @@
 namespace doris {
 namespace vectorized {
 class Block;
-class ColumnString;
 } // namespace vectorized
 } // namespace doris
 

--- a/be/src/vec/functions/array/function_arrays_overlap.h
+++ b/be/src/vec/functions/array/function_arrays_overlap.h
@@ -31,6 +31,7 @@
 #include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
@@ -50,10 +51,6 @@
 
 namespace doris {
 class FunctionContext;
-
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
 } // namespace doris
 template <typename, typename>
 struct DefaultHash;

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -50,8 +50,6 @@
 #include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
 
-namespace doris {} // namespace doris
-
 namespace doris::vectorized {
 
 struct InState {

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -37,6 +37,7 @@
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
 #include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/string_ref.h"
@@ -49,11 +50,7 @@
 #include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
 
-namespace doris {
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
-} // namespace doris
+namespace doris {} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/src/vec/json/parse2column.h
+++ b/be/src/vec/json/parse2column.h
@@ -21,11 +21,11 @@
 #include <vector>
 
 #include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
 namespace vectorized {
-class ColumnString;
 class SimdJSONParser;
 enum class ExtractType;
 template <typename ParserImpl, bool>

--- a/be/src/vec/jsonb/serialize.h
+++ b/be/src/vec/jsonb/serialize.h
@@ -28,10 +28,6 @@
 namespace doris {
 class TabletSchema;
 class TupleDescriptor;
-
-namespace vectorized {
-class ColumnString;
-} // namespace vectorized
 } // namespace doris
 
 namespace doris::vectorized {


### PR DESCRIPTION
## Proposed changes

Before:
join right table column string over uint32
`string column Length is too Large`

After:
get the right result, but may exec slowly

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

