### PR TITLE
[branch-2.0][fix](catalog) fix resource is not reopen when rename catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -119,6 +119,10 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     private void addCatalog(CatalogIf catalog) {
         nameToCatalog.put(catalog.getName(), catalog);
         idToCatalog.put(catalog.getId(), catalog);
+        String catalogName = catalog.getName();
+        if (!catalogName.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
+            ((ExternalCatalog) catalog).onRefresh(false);
+        }
         if (!Strings.isNullOrEmpty(catalog.getResource())) {
             Resource resource = Env.getCurrentEnv().getResourceMgr().getResource(catalog.getResource());
             if (resource != null) {

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
@@ -441,3 +441,8 @@ year	SMALLINT	Yes	false	\N	NONE
 -- !date_sub_sec --
 2	2022-01-01
 
+-- !sql --
+1
+
+-- !sql --
+1

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -525,7 +525,25 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
             "metadata_refresh_interval_sec" = "5"
         );"""
 
-        sql """drop catalog if exists mysql_refresh_property;"""
+        sql """drop catalog if exists mysql_rename1;"""
+
+        sql """create catalog if not exists mysql_rename1 properties(
+            "type"="jdbc",
+            "user"="root",
+            "password"="123456",
+            "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}/doris_test?useSSL=false&zeroDateTimeBehavior=convertToNull",
+            "driver_url" = "${driver_url}",
+            "driver_class" = "com.mysql.cj.jdbc.Driver"
+        );"""
+
+        qt_sql """select count(*) from mysql_rename1.doris_test.ex_tb1;"""
+
+        sql """alter catalog mysql_rename1 rename mysql_rename2"""
+
+        qt_sql """select count(*) from mysql_rename2.doris_test.ex_tb1;"""
+
+        sql """drop catalog if exists mysql_rename2;"""
+
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

pick  (#33432)
During the renaming of `JdbcCatalog`, I noticed that the `jdbcClient` was being closed, resulting in exceptions during subsequent queries. This happens because the `removeCatalog` method is invoked when changing the name, which in turn calls the `onClose` method of the catalog. Ideally, the client should not be closed when renaming the catalog. However, to avoid extra checks in the `removeCatalog` method, we can simply execute `onRefresh` in the `addCatalog` method to address this issue.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

