### PR TITLE
[fix](nereids)ExtractAndNormalizeWindowExpression should only normalize alias in output

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -123,9 +123,7 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
                 .collect(Collectors.toMap(expr -> ((Alias) expr).child(), expr -> ((Alias) expr).toSlot(),
                         (oldExpr, newExpr) -> oldExpr));
 
-        // customNormalizeMap is only for alias, so we just normalize alias in outputs too
-        List<NamedExpression> normalizedOutputs = context.normalizeToUseSlotRef(outputs,
-                (ctx, expr) -> expr instanceof Alias ? customNormalizeMap.getOrDefault(expr, null) : null);
+        List<NamedExpression> normalizedOutputs = ExpressionUtils.replaceNamedExpressions(outputs, customNormalizeMap);
         Set<WindowExpression> normalizedWindows =
                 ExpressionUtils.collect(normalizedOutputs, WindowExpression.class::isInstance);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -123,8 +123,9 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
                 .collect(Collectors.toMap(expr -> ((Alias) expr).child(), expr -> ((Alias) expr).toSlot(),
                         (oldExpr, newExpr) -> oldExpr));
 
+        // customNormalizeMap is only for alias, so we just normalize alias in outputs too
         List<NamedExpression> normalizedOutputs = context.normalizeToUseSlotRef(outputs,
-                (ctx, expr) -> customNormalizeMap.getOrDefault(expr, null));
+                (ctx, expr) -> expr instanceof Alias ? customNormalizeMap.getOrDefault(expr, null) : null);
         Set<WindowExpression> normalizedWindows =
                 ExpressionUtils.collect(normalizedOutputs, WindowExpression.class::isInstance);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -123,7 +123,11 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
                 .collect(Collectors.toMap(expr -> ((Alias) expr).child(), expr -> ((Alias) expr).toSlot(),
                         (oldExpr, newExpr) -> oldExpr));
 
-        List<NamedExpression> normalizedOutputs = ExpressionUtils.replaceNamedExpressions(outputs, customNormalizeMap);
+        // customNormalizeMap is only for alias, so we just normalize alias in outputs too
+        List<NamedExpression> normalizedOutputs = context.normalizeToUseSlotRef(outputs,
+                (ctx, expr) -> expr instanceof Alias ? customNormalizeMap.getOrDefault(expr, null) : null);
+        // replace child exprs in normalizedOutputs by customNormalizeMap
+        normalizedOutputs = ExpressionUtils.replaceNamedExpressions(normalizedOutputs, customNormalizeMap);
         Set<WindowExpression> normalizedWindows =
                 ExpressionUtils.collect(normalizedOutputs, WindowExpression.class::isInstance);
 

--- a/regression-test/suites/nereids_p0/aggregate/agg_window_project.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/agg_window_project.groovy
@@ -103,5 +103,7 @@ suite("agg_window_project") {
         contains "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
     }
 
+    sql """select a, a aa, row_number() over (partition by b) from test_window_table2;"""
+
     sql "DROP TABLE IF EXISTS test_window_table2;"
 }


### PR DESCRIPTION
…

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

