### PR TITLE
[fix](catalog) Remove unexpected cleanup when reading jdbc data

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/DefaultJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/DefaultJdbcExecutor.java
@@ -276,8 +276,6 @@ public class DefaultJdbcExecutor {
         } catch (Exception e) {
             LOG.warn("jdbc get block address exception: ", e);
             throw new UdfRuntimeException("jdbc get block address: ", e);
-        } finally {
-            block.clear();
         }
         return outputTable.getMetaAddress();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the old `DefaultJdbcExecutor`, since the logic of initializing `block` is different from the new `BaseJdbcExecutor`, we cannot clear block after `getBlockAddress`, which will affect reading data larger than 4064 rows.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

