### PR TITLE
[feature](Nereids): date literal support Zone

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -247,19 +247,6 @@ public class DateLiteral extends Literal {
 
         sb.append(s.substring(i));
 
-        // Zone Part
-        // while(i < s.length()) {
-        //
-        // }
-
-        // add missing :00 in Zone part
-        // int len = sb.length();
-        // int signIdx = sb.indexOf("+", 10); // from index:10, skip date part (it contains '-')
-        // signIdx = signIdx == -1 ? sb.indexOf("-", 10) : signIdx;
-        // if (signIdx != -1 && len - signIdx == 3) {
-        //     sb.append(":00");
-        // }
-
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
@@ -41,7 +41,6 @@ import java.time.temporal.ChronoField;
 public class DateTimeFormatterUtils {
     public static final DateTimeFormatter ZONE_FORMATTER = new DateTimeFormatterBuilder()
             .optionalStart()
-            // .appendZoneText(TextStyle.FULL)
             .appendZoneOrOffsetId()
             .optionalEnd()
             .toFormatter()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -428,32 +428,6 @@ public class ExpressionUtils {
         }
     }
 
-    private static class ExpressionReplacerContext {
-        private final Map<? extends Expression, ? extends Expression> replaceMap;
-        // if the key of replaceMap is named expr and withAlias is true, we should
-        // add alias after replaced
-        private final boolean withAliasIfKeyNamed;
-
-        private ExpressionReplacerContext(Map<? extends Expression, ? extends Expression> replaceMap,
-                boolean withAliasIfKeyNamed) {
-            this.replaceMap = replaceMap;
-            this.withAliasIfKeyNamed = withAliasIfKeyNamed;
-        }
-
-        public static ExpressionReplacerContext of(Map<? extends Expression, ? extends Expression> replaceMap,
-                boolean withAliasIfKeyNamed) {
-            return new ExpressionReplacerContext(replaceMap, withAliasIfKeyNamed);
-        }
-
-        public Map<? extends Expression, ? extends Expression> getReplaceMap() {
-            return replaceMap;
-        }
-
-        public boolean isWithAliasIfKeyNamed() {
-            return withAliasIfKeyNamed;
-        }
-    }
-
     /**
      * merge arguments into an expression array
      *
@@ -831,13 +805,6 @@ public class ExpressionUtils {
             set.addAll(expr.getInputSlots());
         }
         return set;
-    }
-
-    public static boolean checkTypeSkipCast(Expression expression, Class<? extends Expression> cls) {
-        while (expression instanceof Cast) {
-            expression = ((Cast) expression).child();
-        }
-        return cls.isInstance(expression);
     }
 
     public static Expression getExpressionCoveredByCast(Expression expression) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -137,25 +137,7 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2022-08-01 01:01:01Z");
         new DateTimeV2Literal("2022-08-01 01:01:01Europe/Berlin");
         new DateTimeV2Literal("2022-08-01 01:01:01Europe/London");
-    }
-
-    @Test
-    @Disabled("Test results can change over time")
-    void testZoneOrOffsetRight() {
-        java.util.function.BiConsumer<DateTimeV2Literal, Long> assertHour = (dateTimeV2Literal, expectHour) -> {
-            Assertions.assertEquals(dateTimeV2Literal.hour, expectHour);
-        };
-        DateTimeV2Literal dateTimeV2Literal;
-        dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00Europe/London"); // +01:00
-        assertHour.accept(dateTimeV2Literal, 7L);
-        dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00America/New_York"); // -04:00
-        assertHour.accept(dateTimeV2Literal, 12L);
-        dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00Asia/Shanghai");
-        assertHour.accept(dateTimeV2Literal, 0L);
-        dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00+01:00");
-        assertHour.accept(dateTimeV2Literal, 7L);
-        dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00-01:00");
-        assertHour.accept(dateTimeV2Literal, 9L);
+        new DateTimeV2Literal("2022-08-01 00:00:00Asia/Shanghai");
     }
 
     @Test
@@ -236,6 +218,27 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2022-04-01T01:02:55UTC-6");
 
         new DateTimeV2Literal("0001-01-01");
+    }
+
+    @Test
+    void testDateTimeZone1() {
+        Consumer<DateTimeV2Literal> assertFunc = (datetime) -> {
+            Assertions.assertEquals(2022, datetime.year);
+            Assertions.assertEquals(1, datetime.month);
+            Assertions.assertEquals(2, datetime.day);
+            Assertions.assertEquals(12, datetime.hour);
+            Assertions.assertEquals(0, datetime.minute);
+            Assertions.assertEquals(0, datetime.second);
+        };
+        DateTimeV2Literal literal;
+        literal = new DateTimeV2Literal("2022-01-02 12:00:00UTC+08:00");
+        assertFunc.accept(literal);
+        literal = new DateTimeV2Literal("2022-01-02 04:00:00UTC");
+        assertFunc.accept(literal);
+        literal = new DateTimeV2Literal("2022-01-01 20:00:00UTC-08:00");
+        assertFunc.accept(literal);
+        literal = new DateTimeV2Literal("2022-01-02 04:00:00Z");
+        assertFunc.accept(literal);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

support
```
'2022-05-01 01:02:55 +02:30
'2022-05-01 01:02:55 Asia/Shanghai
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

