### PR TITLE
[fix](merge-on-write) schema change may cause mow duplicate key

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -961,7 +961,6 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
         sc_params.enable_unique_key_merge_on_write =
                 _new_tablet->enable_unique_key_merge_on_write();
         res = _convert_historical_rowsets(sc_params, &real_alter_version);
-        DCHECK_GE(real_alter_version, request.alter_version);
         {
             std::lock_guard<std::shared_mutex> wrlock(_mutex);
             _tablet_ids_in_converting.erase(_new_tablet->tablet_id());
@@ -969,6 +968,8 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
         if (!res) {
             break;
         }
+
+        DCHECK_GE(real_alter_version, request.alter_version);
 
         if (_new_tablet->keys_type() == UNIQUE_KEYS &&
             _new_tablet->enable_unique_key_merge_on_write()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

#29386 fixed an issue that may cause duplicate key, but it breaks some schema change cases.
Then #29733 reverted some change of #29386, which also brought back this issue.

issue description:
1. all rowsets written to the new tablet with TABLET_NOTREADY state, are skipped the step of delete bitmap calculation
2. after the new tablet created, double write start writing rowsets to new tablet
3. alter process will calculate a version on base tablet, for the rowsets that need to be converted to new schema, and clean all rowsets older than that version on the new tablet, before start converting the historical data
4. but the max_version of new tablet may lag behind base tablet, e.g. new tablet's max version is 6, and base tablet's max convert version is 10. So after the rowset clear operation of step3, double write may still write version 7,8,9,10 into new tablet
5. after the historical data conversion, alter process will add new converted rowsets into new tablet, but it will fail while adding rowsets between version 7 and 10, because these version already existed
6. the delete bitmap of rowsets between 7 and 10 is not calculated, so duplicate key happened.

solution:
1. #29386 return failure when such situation happened, but it will break some schema change cases
2. In this PR, I propose to update the variable `real_alter_version` to 6 (see previous case), recalculate delete bitmaps on all rowsets that older than `real_alter_version`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

