### PR TITLE
[enhancement](cloud) Obtain meta object lock to table before doing partition op

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -212,7 +212,11 @@ public class Alter {
         } else if (currentAlterOps.hasPartitionOp()) {
             Preconditions.checkState(!alterClauses.isEmpty());
             for (AlterClause alterClause : alterClauses) {
-                olapTable.writeLockOrDdlException();
+                if (Config.isCloudMode()) {
+                    olapTable.commitLock();
+                } else {
+                    olapTable.writeLockOrDdlException();
+                }
                 try {
                     if (alterClause instanceof DropPartitionClause) {
                         if (!((DropPartitionClause) alterClause).isTempPartition()) {
@@ -257,7 +261,11 @@ public class Alter {
                         throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                     }
                 } finally {
-                    olapTable.writeUnlock();
+                    if (Config.isCloudMode()) {
+                        olapTable.commitUnlock();
+                    } else {
+                        olapTable.writeUnlock();
+                    }
                 }
             }
         } else if (currentAlterOps.hasRenameOp()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

During the Drop/Replace [temp] partition, some meta objects belonging to the table will be modified (such as version of tbl), and these meta objects will also be modified when committing transactions. 

Therefore, when performing these operations, it is necessary to first obtain the meta object lock of the table to avoid fdb-txn conflicts.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

