### PR TITLE
[fix](fs) Close local file writer when downloading finished

### DIFF
--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -320,8 +320,7 @@ Status HdfsFileSystem::download_impl(const Path& remote_file, const Path& local_
 
         RETURN_IF_ERROR(local_writer->append({read_buf.get(), read_len}));
     }
-
-    return Status::OK();
+    return local_writer->close();
 }
 
 } // namespace doris::io


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The `LocalFileWriter` will remove the file if it was not closed during destruction, so the `HdfsFileSystem::download_impl` downloads the target file and removes it later.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

