### PR TITLE
[enhancement](merge-iterator) catch exception to avoid coredump when copy_rows

### DIFF
--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -136,42 +136,48 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
 }
 
 // `advanced = false` when current block finished
-void VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
+Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
     Block& dst = *block;
     if (_cur_batch_num == 0) {
-        return;
+        return Status::OK();
     }
 
     // copy a row to dst block column by column
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
 
-    for (size_t i = 0; i < _num_columns; ++i) {
-        auto& s_col = src.get_by_position(i);
-        auto& d_col = dst.get_by_position(i);
+    RETURN_IF_CATCH_EXCEPTION({
+        for (size_t i = 0; i < _num_columns; ++i) {
+            auto& s_col = src.get_by_position(i);
+            auto& d_col = dst.get_by_position(i);
 
-        ColumnPtr& s_cp = s_col.column;
-        ColumnPtr& d_cp = d_col.column;
+            ColumnPtr& s_cp = s_col.column;
+            ColumnPtr& d_cp = d_col.column;
 
-        d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
-    }
+            d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
+        }
+    });
     const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
     dst.set_same_bit(tmp_pre_ctx_same_bit.begin(), tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
     _cur_batch_num = 0;
+    return Status::OK();
 }
 
-void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
+Status VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
     if (_cur_batch_num == 0) {
-        return;
+        return Status::OK();
     }
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
 
     const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
-    for (size_t i = 0; i < _cur_batch_num; ++i) {
-        view->push_back({_block, static_cast<int>(start + i), tmp_pre_ctx_same_bit[i]});
-    }
+    RETURN_IF_CATCH_EXCEPTION({
+        for (size_t i = 0; i < _cur_batch_num; ++i) {
+            view->push_back({_block, static_cast<int>(start + i), tmp_pre_ctx_same_bit[i]});
+        }
+    });
 
     _cur_batch_num = 0;
+    return Status::OK();
 }
 
 // This iterator will generate ordered data. For example for schema

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -108,9 +108,9 @@ public:
     bool compare(const VMergeIteratorContext& rhs) const;
 
     // `advanced = false` when current block finished
-    void copy_rows(Block* block, bool advanced = true);
+    Status copy_rows(Block* block, bool advanced = true);
 
-    void copy_rows(BlockView* view, bool advanced = true);
+    Status copy_rows(BlockView* view, bool advanced = true);
 
     RowLocation current_row_location() {
         DCHECK(_record_rowids);
@@ -245,7 +245,7 @@ private:
                 ctx->add_cur_batch();
                 if (pre_ctx != ctx) {
                     if (pre_ctx) {
-                        pre_ctx->copy_rows(block);
+                        RETURN_IF_ERROR(pre_ctx->copy_rows(block));
                     }
                     pre_ctx = ctx;
                 }
@@ -257,14 +257,14 @@ private:
                 if (ctx->is_cur_block_finished() || row_idx >= _block_row_max) {
                     // current block finished, ctx not advance
                     // so copy start_idx = (_index_in_block - _cur_batch_num + 1)
-                    ctx->copy_rows(block, false);
+                    RETURN_IF_ERROR(ctx->copy_rows(block, false));
                     pre_ctx = nullptr;
                 }
             } else if (_merged_rows != nullptr) {
                 (*_merged_rows)++;
                 // need skip cur row, so flush rows in pre_ctx
                 if (pre_ctx) {
-                    pre_ctx->copy_rows(block);
+                    RETURN_IF_ERROR(pre_ctx->copy_rows(block));
                     pre_ctx = nullptr;
                 }
             }


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
```
terminate called after throwing an instance of 'doris::Exception'
  what():  [E-3113] string column length is too large: total_length=4295271408, element_number=1311

	0#  doris::Exception::Exception(int, std::basic_string_view<char, std::char_traits<char> >) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
	1#  doris::Exception::Exception<unsigned long&, unsigned long&>(int, std::basic_string_view<char, std::char_traits<char> >, unsigned long&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
	2#  doris::vectorized::ColumnString::insert_range_from(doris::vectorized::IColumn const&, unsigned long, unsigned long) at /home/zcp/repo_center/doris_enterprise/doris/be/src/vec/columns/column_string.h:71
	3#  doris::vectorized::ColumnNullable::insert_range_from(doris::vectorized::IColumn const&, unsigned long, unsigned long) at /home/zcp/repo_center/doris_enterprise/doris/be/src/vec/common/cow.h:194
	4#  doris::vectorized::VMergeIteratorContext::copy_rows(doris::vectorized::Block*, bool) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:386
	5#  doris::Status doris::vectorized::VMergeIterator::_next_batch<doris::vectorized::Block>(doris::vectorized::Block*) at /home/zcp/repo_center/doris_enterprise/doris/be/src/vec/olap/vgeneric_iterators.h:251
	6#  doris::vectorized::VMergeIterator::next_batch(doris::vectorized::Block*) at /home/zcp/repo_center/doris_enterprise/doris/be/src/vec/olap/vgeneric_iterators.h:208
	7#  doris::BetaRowsetReader::next_block(doris::vectorized::Block*) at /home/zcp/repo_center/doris_enterprise/doris/be/src/common/status.h:446
	8#  doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row() at /home/zcp/repo_center/doris_enterprise/doris/be/src/common/status.h:446
	9#  doris::vectorized::VCollectIterator::Level0Iterator::init(bool) at /home/zcp/repo_center/doris_enterprise/doris/be/src/vec/olap/vcollect_iterator.cpp:472
	10# doris::vectorized::VCollectIterator::build_heap(std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > >&) at /home/zcp/repo_center/doris_enterprise/doris/be/src/common/status.h:446
	11# doris::vectorized::BlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_enterprise/doris/be/src/common/status.h:446
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

