### PR TITLE
[fix](feservice) remove connect context for all requests

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FeServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FeServer.java
@@ -19,6 +19,7 @@ package org.apache.doris.service;
 
 import org.apache.doris.common.ThriftServer;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.FrontendService;
 
 import org.apache.logging.log4j.LogManager;
@@ -62,6 +63,7 @@ public class FeServer {
                         // If exception occurs, do not deal it, just keep as the previous
                         throw t;
                     } finally {
+                        ConnectContext.remove();
                         feServiceLogger.debug("finish process request for {}", name);
                         if (MetricRepo.isInit) {
                             long end = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1911,8 +1911,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         StreamLoadHandler streamLoadHandler = new StreamLoadHandler(request, null, result, clientAddr);
 
         try {
-            // Some requests forget to remove the ConnectContext, so remove it firstly
-            ConnectContext.remove();
             streamLoadHandler.setCloudCluster();
 
             List<TPipelineWorkloadGroup> tWorkloadGroupList = null;


### PR DESCRIPTION
## Proposed changes

In `FrontendServiceImpl`, we need to remove ConnectContext if set it in thread local.
But some requests forget to remove it, such as: https://github.com/apache/doris/pull/33375
So remove it for all requests.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

