### PR TITLE
[fix](nereids)EliminateGroupBy should keep the output's datatype same as old ones

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.PlanUtils;
+import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -79,7 +80,8 @@ public class EliminateGroupBy extends OneRewriteRuleFactory {
                         if (ne instanceof Alias && ne.child(0) instanceof AggregateFunction) {
                             AggregateFunction f = (AggregateFunction) ne.child(0);
                             if (f instanceof Sum || f instanceof Min || f instanceof Max) {
-                                newOutput.add(new Alias(ne.getExprId(), f.child(0), ne.getName()));
+                                newOutput.add(new Alias(ne.getExprId(), TypeCoercionUtils
+                                        .castIfNotSameType(f.child(0), f.getDataType()), ne.getName()));
                             } else if (f instanceof Count) {
                                 newOutput.add((NamedExpression) ne.withChildren(
                                         new If(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
@@ -65,7 +65,7 @@ class EliminateGroupByTest extends TestWithFeService implements MemoPatternMatch
                 .rewrite()
                 .matches(
                         logicalProject().when(p -> p.getProjects().get(0).toSql().equals("id")
-                                && p.getProjects().get(1).toSql().equals("age AS `min(age)`"))
+                                && p.getProjects().get(1).toSql().equals("cast(age as BIGINT) AS `sum(age)`"))
                 );
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
@@ -65,7 +65,7 @@ class EliminateGroupByTest extends TestWithFeService implements MemoPatternMatch
                 .rewrite()
                 .matches(
                         logicalProject().when(p -> p.getProjects().get(0).toSql().equals("id")
-                                && p.getProjects().get(1).toSql().equals("cast(age as BIGINT) AS `sum(age)`"))
+                                && p.getProjects().get(1).toSql().equals("age AS `min(age)`"))
                 );
     }
 
@@ -79,7 +79,7 @@ class EliminateGroupByTest extends TestWithFeService implements MemoPatternMatch
                 .rewrite()
                 .matches(
                         logicalProject().when(p -> p.getProjects().get(0).toSql().equals("id")
-                                && p.getProjects().get(1).toSql().equals("age AS `sum(age)`"))
+                                && p.getProjects().get(1).toSql().equals("cast(age as BIGINT) AS `sum(age)`"))
                 );
     }
 


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

