### PR TITLE
[Fix](executor)Fix routine load failed when can not find group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -149,9 +149,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         }
         if (tWgList.size() == 0) {
             tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getTWorkloadGroupByUserIdentity(routineLoadJob.getUserIdentity());
+                    .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
         }
-        tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        if (tWgList.size() != 0) {
+            tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        }
 
         return tExecPlanFragmentParams;
     }
@@ -176,9 +178,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         }
         if (tWgList.size() == 0) {
             tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getTWorkloadGroupByUserIdentity(routineLoadJob.getUserIdentity());
+                    .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
         }
-        tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        if (tWgList.size() != 0) {
+            tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        }
 
         return tExecPlanFragmentParams;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -147,10 +147,12 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
             if (wgId > 0) {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
                         .getTWorkloadGroupById(wgId);
-            }
-            if (tWgList.size() == 0) {
+                if (tWgList.size() == 0) {
+                    throw new UserException("can not find workload group, id=" + wgId);
+                }
+            } else {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                        .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
+                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity());
             }
             if (tWgList.size() != 0) {
                 tExecPlanFragmentParams.setWorkloadGroups(tWgList);
@@ -178,10 +180,12 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
             if (wgId > 0) {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
                         .getTWorkloadGroupById(wgId);
-            }
-            if (tWgList.size() == 0) {
+                if (tWgList.size() == 0) {
+                    throw new UserException("can not find workload group, id=" + wgId);
+                }
+            } else {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                        .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
+                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity());
             }
             if (tWgList.size() != 0) {
                 tExecPlanFragmentParams.setWorkloadGroups(tWgList);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -141,18 +141,20 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tExecPlanFragmentParams.getQueryOptions().setQueryTimeout((int) timeoutS);
         tExecPlanFragmentParams.getQueryOptions().setExecutionTimeout((int) timeoutS);
 
-        long wgId = routineLoadJob.getWorkloadId();
-        List<TPipelineWorkloadGroup> tWgList = new ArrayList<>();
-        if (wgId > 0) {
-            tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getTWorkloadGroupById(wgId);
-        }
-        if (tWgList.size() == 0) {
-            tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
-        }
-        if (tWgList.size() != 0) {
-            tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        if (Config.enable_workload_group) {
+            long wgId = routineLoadJob.getWorkloadId();
+            List<TPipelineWorkloadGroup> tWgList = new ArrayList<>();
+            if (wgId > 0) {
+                tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
+                        .getTWorkloadGroupById(wgId);
+            }
+            if (tWgList.size() == 0) {
+                tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
+                        .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
+            }
+            if (tWgList.size() != 0) {
+                tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+            }
         }
 
         return tExecPlanFragmentParams;
@@ -170,18 +172,20 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tExecPlanFragmentParams.getQueryOptions().setQueryTimeout((int) timeoutS);
         tExecPlanFragmentParams.getQueryOptions().setExecutionTimeout((int) timeoutS);
 
-        long wgId = routineLoadJob.getWorkloadId();
-        List<TPipelineWorkloadGroup> tWgList = new ArrayList<>();
-        if (wgId > 0) {
-            tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getTWorkloadGroupById(wgId);
-        }
-        if (tWgList.size() == 0) {
-            tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                    .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
-        }
-        if (tWgList.size() != 0) {
-            tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+        if (Config.enable_workload_group) {
+            long wgId = routineLoadJob.getWorkloadId();
+            List<TPipelineWorkloadGroup> tWgList = new ArrayList<>();
+            if (wgId > 0) {
+                tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
+                        .getTWorkloadGroupById(wgId);
+            }
+            if (tWgList.size() == 0) {
+                tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
+                        .getWorkloadGroupForRoutineLoad(routineLoadJob.getUserIdentity());
+            }
+            if (tWgList.size() != 0) {
+                tExecPlanFragmentParams.setWorkloadGroups(tWgList);
+            }
         }
 
         return tExecPlanFragmentParams;

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -223,7 +223,7 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
         return tWorkloadGroups;
     }
 
-    public List<TPipelineWorkloadGroup> getWorkloadGroupForRoutineLoad(UserIdentity user) throws UserException {
+    public List<TPipelineWorkloadGroup> getWorkloadGroupByUser(UserIdentity user) throws UserException {
         String groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(user.getQualifiedUser());
         List<TPipelineWorkloadGroup> ret = new ArrayList<>();
         WorkloadGroup wg = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -223,14 +223,23 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
         return tWorkloadGroups;
     }
 
-    public List<TPipelineWorkloadGroup> getTWorkloadGroupByUserIdentity(UserIdentity user) throws UserException {
+    public List<TPipelineWorkloadGroup> getWorkloadGroupForRoutineLoad(UserIdentity user) throws UserException {
         String groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(user.getQualifiedUser());
         List<TPipelineWorkloadGroup> ret = new ArrayList<>();
+        WorkloadGroup wg = null;
         readLock();
         try {
-            WorkloadGroup wg = nameToWorkloadGroup.get(groupName);
-            if (wg == null) {
-                throw new UserException("can not find workload group " + groupName);
+            if (groupName == null || groupName.isEmpty()) {
+                wg = nameToWorkloadGroup.get(DEFAULT_GROUP_NAME);
+                if (wg == null) {
+                    throw new RuntimeException("can not find normal workload group for routineload");
+                }
+            } else {
+                wg = nameToWorkloadGroup.get(groupName);
+                if (wg == null) {
+                    throw new UserException(
+                            "can not find workload group " + groupName + " for user " + user.getQualifiedUser());
+                }
             }
             ret.add(wg.toThrift());
         } finally {


### PR DESCRIPTION
## Proposed changes
```
ErrorReason{code=errCode = 2, msg='failed to create task: errCode = 2, detailMessage = can not find workload group null'}
```

Fix routineload may failed because of can not find workload group.
