### PR TITLE
[branch-2.0](cherry-pick) compaction should not check correctness if tablet is not ready (#33435)

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -423,7 +423,8 @@ Status Compaction::do_compaction_impl(int64_t permits) {
         if (!allow_delete_in_cumu_compaction()) {
             missed_rows_size = missed_rows.size();
             if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION &&
-                stats.merged_rows != missed_rows_size) {
+                stats.merged_rows != missed_rows_size &&
+                _tablet->tablet_state() == TABLET_RUNNING) {
                 std::string err_msg = fmt::format(
                         "cumulative compaction: the merged rows({}) is not equal to missed "
                         "rows({}) in rowid conversion, tablet_id: {}, table_id:{}",
@@ -818,7 +819,8 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         if (!allow_delete_in_cumu_compaction()) {
             missed_rows_size = missed_rows.size();
             if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION && stats != nullptr &&
-                stats->merged_rows != missed_rows_size) {
+                stats->merged_rows != missed_rows_size &&
+                _tablet->tablet_state() == TABLET_RUNNING) {
                 std::string err_msg = fmt::format(
                         "cumulative compaction: the merged rows({}) is not equal to missed "
                         "rows({}) in rowid conversion, tablet_id: {}, table_id:{}",


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

cherry-pick #33435

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

