### PR TITLE
[Bug](runtime-filter) make need_local_merge unrelated with broadcast and support merge on bitmap_filter

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -537,6 +537,10 @@ public:
             }
             break;
         }
+        case RuntimeFilterType::BITMAP_FILTER: {
+            // do nothing because we assume bitmap filter join always have full data
+            break;
+        }
         default:
             return Status::InternalError("unknown runtime filter");
         }
@@ -1332,7 +1336,6 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     DCHECK(node_id >= 0 || (node_id == -1 && !is_consumer()));
 
     _is_broadcast_join = desc->is_broadcast_join;
-    _need_local_merge &= !_is_broadcast_join;
     _has_local_target = desc->has_local_targets;
     _has_remote_target = desc->has_remote_targets;
     _expr_order = desc->expr_order;

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
@@ -43,12 +43,8 @@ Status NestedLoopJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkSta
     _runtime_filters.resize(p._runtime_filter_descs.size());
     for (size_t i = 0; i < p._runtime_filter_descs.size(); i++) {
         RETURN_IF_ERROR(state->register_producer_runtime_filter(
-                p._runtime_filter_descs[i], p._need_local_merge, &_runtime_filters[i], false));
-        if (!_runtime_filters[i]->is_broadcast_join()) {
-            return Status::InternalError(
-                    "runtime filter({}) on NestedLoopJoin should be set to is_broadcast_join",
-                    _runtime_filters[i]->get_name());
-        }
+                p._runtime_filter_descs[i], p._need_local_merge, &_runtime_filters[i],
+                p._need_local_merge));
     }
     return Status::OK();
 }

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
@@ -43,8 +43,7 @@ Status NestedLoopJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkSta
     _runtime_filters.resize(p._runtime_filter_descs.size());
     for (size_t i = 0; i < p._runtime_filter_descs.size(); i++) {
         RETURN_IF_ERROR(state->register_producer_runtime_filter(
-                p._runtime_filter_descs[i], p._need_local_merge, &_runtime_filters[i],
-                p._need_local_merge));
+                p._runtime_filter_descs[i], p._need_local_merge, &_runtime_filters[i], false));
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -534,7 +534,6 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
     // If runtime filter need to be local merged, `build_bf_exactly` will lead to bloom filters with
     // different size need to be merged which is not allowed.
     // So if `need_local_merge` is true, we will disable `build_bf_exactly`.
-    need_local_merge &= !desc.is_broadcast_join;
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_local_merge_producer_filter(
                 desc, query_options(), producer_filter, build_bf_exactly && !need_local_merge);
@@ -547,7 +546,6 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
 Status RuntimeState::register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                                       bool need_local_merge, int node_id,
                                                       doris::IRuntimeFilter** consumer_filter) {
-    need_local_merge &= !desc.is_broadcast_join;
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_consumer_filter(desc, query_options(), node_id,
                                                                      consumer_filter, false, true);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -534,6 +534,7 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
     // If runtime filter need to be local merged, `build_bf_exactly` will lead to bloom filters with
     // different size need to be merged which is not allowed.
     // So if `need_local_merge` is true, we will disable `build_bf_exactly`.
+    need_local_merge &= !desc.is_broadcast_join;
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_local_merge_producer_filter(
                 desc, query_options(), producer_filter, build_bf_exactly && !need_local_merge);
@@ -546,7 +547,8 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
 Status RuntimeState::register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                                       bool need_local_merge, int node_id,
                                                       doris::IRuntimeFilter** consumer_filter) {
-    if (desc.has_remote_targets || (need_local_merge && !desc.is_broadcast_join)) {
+    need_local_merge &= !desc.is_broadcast_join;
+    if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_consumer_filter(desc, query_options(), node_id,
                                                                      consumer_filter, false, true);
     } else {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -546,7 +546,7 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
 Status RuntimeState::register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                                       bool need_local_merge, int node_id,
                                                       doris::IRuntimeFilter** consumer_filter) {
-    if (desc.has_remote_targets || need_local_merge) {
+    if (desc.has_remote_targets || (need_local_merge && !desc.is_broadcast_join)) {
         return global_runtime_filter_mgr()->register_consumer_filter(desc, query_options(), node_id,
                                                                      consumer_filter, false, true);
     } else {


### PR DESCRIPTION
## Proposed changes

registe consumer rf in local when rf is broadcast

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

