### PR TITLE
[feature](pipelineX)  Add type check between upstream and downstream operators.

### DIFF
--- a/be/src/pipeline/exec/assert_num_rows_operator.h
+++ b/be/src/pipeline/exec/assert_num_rows_operator.h
@@ -43,6 +43,10 @@ public:
         return {ExchangeType::PASSTHROUGH};
     }
 
+    [[nodiscard]] const RowDescriptor& input_row_desc() const override {
+        return OperatorX<AssertNumRowsLocalState>::_child_x->output_row_desc();
+    }
+
 private:
     friend class AssertNumRowsLocalState;
 

--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -76,7 +76,7 @@ public:
     Status close(RuntimeState* state) override;
     [[nodiscard]] bool is_source() const override { return true; }
 
-    [[nodiscard]] RowDescriptor input_row_desc() const { return _input_row_desc; }
+    [[nodiscard]] const RowDescriptor& input_row_desc() const override { return _input_row_desc; }
 
     [[nodiscard]] int num_senders() const { return _num_senders; }
     [[nodiscard]] bool is_merging() const { return _is_merging; }

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -451,7 +451,6 @@ public:
 
     [[nodiscard]] virtual Status setup_local_state(RuntimeState* state,
                                                    LocalSinkStateInfo& info) = 0;
-
     template <class TARGET>
     TARGET& cast() {
         DCHECK(dynamic_cast<TARGET*>(this))
@@ -706,6 +705,7 @@ public:
 
     [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
     [[nodiscard]] virtual RowDescriptor& row_descriptor() { return _row_descriptor; }
+    [[nodiscard]] virtual const RowDescriptor& row_descriptor() const { return _row_descriptor; }
 
     [[nodiscard]] int id() const override { return node_id(); }
     [[nodiscard]] int operator_id() const { return _operator_id; }
@@ -720,6 +720,12 @@ public:
     [[nodiscard]] const RowDescriptor* output_row_descriptor() {
         return _output_row_descriptor.get();
     }
+
+    [[nodiscard]] virtual const RowDescriptor& input_row_desc() const { return row_descriptor(); }
+
+    [[nodiscard]] const RowDescriptor& output_row_desc() const { return row_desc(); }
+
+    Status check_upstream_row_desc_match();
 
     bool has_output_row_desc() const { return _output_row_descriptor != nullptr; }
 
@@ -829,6 +835,9 @@ public:
     [[nodiscard]] virtual Status push(RuntimeState* state, vectorized::Block* input_block,
                                       bool eos) const = 0;
     bool need_more_input_data(RuntimeState* state) const override { return true; }
+    [[nodiscard]] const RowDescriptor& input_row_desc() const override {
+        return OperatorX<LocalStateType>::_child_x->output_row_desc();
+    }
 };
 
 template <typename Writer, typename Parent>

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.h
@@ -67,7 +67,7 @@ public:
     const RowDescriptor& intermediate_row_desc() const override {
         return _child_x->intermediate_row_desc();
     }
-    RowDescriptor& row_descriptor() override { return _child_x->row_descriptor(); }
+    const RowDescriptor& row_descriptor() const override { return _child_x->row_descriptor(); }
     const RowDescriptor& row_desc() const override { return _child_x->row_desc(); }
 
     Status get_block(RuntimeState* state, vectorized::Block* block, bool* eos) override;

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -88,7 +88,7 @@ Status VScanner::prepare(RuntimeState* state, const VExprContextSPtrs& conjuncts
 
 Status VScanner::get_block_after_projects(RuntimeState* state, vectorized::Block* block,
                                           bool* eos) {
-    auto& row_descriptor =
+    const auto& row_descriptor =
             _parent ? _parent->_row_descriptor : _local_state->_parent->row_descriptor();
     if (_output_row_descriptor) {
         _origin_block.clear_column_data(row_descriptor.num_materialized_slots());


### PR DESCRIPTION
## Proposed changes
Perform the check during prepare rather than during execution.
```
java.sql.SQLException: errCode = 2, detailMessage = (172.16.0.236)[INTERNAL_ERROR]upstream operator output type [Int64,name:number] not match current operator input type [Nullable(Int64),name:number].
upstream operator : EXCHANGE_OPERATOR: id=1, parallel_tasks=1, Info: (_num_senders = 1, _is_merging = false),
current operator : ASSERT_NUM_ROWS_OPERATOR: id=2, parallel_tasks=1
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

