### PR TITLE
[feature](windows function)Improve error handling for window functions.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.ExpressionTrait;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
+import org.apache.doris.nereids.trees.expressions.functions.window.WindowFunction;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Generate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
@@ -85,7 +86,7 @@ public class CheckAfterRewrite extends OneAnalysisRuleFactory {
                     throw new AnalysisException("aggregate function is not allowed in " + plan.getType());
                 } else if (!isAgg && expr instanceof GroupingScalarFunction) {
                     throw new AnalysisException("grouping scalar function is not allowed in " + plan.getType());
-                } else if (!isWindow && expr instanceof WindowExpression) {
+                } else if (!isWindow && (expr instanceof WindowExpression || expr instanceof WindowFunction)) {
                     throw new AnalysisException("analytic function is not allowed in " + plan.getType());
                 }
             });

--- a/regression-test/suites/correctness_p0/test_window_function_error.groovy
+++ b/regression-test/suites/correctness_p0/test_window_function_error.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_window_function_error") {
+    sql """ set enable_nereids_planner = true; """
+    sql """ set enable_fallback_to_original_planner = false; """
+  
+
+    sql """ DROP TABLE IF EXISTS win_func_error_db """
+    sql """
+         CREATE TABLE IF NOT EXISTS win_func_error_db (
+              `k1` INT(11) NOT NULL  COMMENT "",
+              `k2` INT(11) NOT NULL   COMMENT ""
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`k1`)
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "storage_format" = "V2"
+        );
+    """
+
+    sql """
+        insert into win_func_error_db values(1,0);
+    """
+
+    test {
+        sql """
+            select lag(k1,1,0) from win_func_error_db;
+        """
+        exception("analytic function is not allowed in LOGICAL_PROJECT")
+    }
+}


### PR DESCRIPTION
## Proposed changes

before
```
mysql [test]>select lag(k1,1,0) from db;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]Unknown expr node type: 0
```

now

```
mysql [test]>select lag(k1,1,0) from db;
ERROR 1105 (HY000): errCode = 2, detailMessage = lag only used in analytic function
```
The current error originates from the old planer. 
After removing the old planer code in the future, this case will need to be modified.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

