### PR TITLE
[runtime filter](fix) Fix wrong results caused by IN_OR_BLOOM filter

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -347,6 +347,9 @@ public:
             // BloomFilter may be not init
             RETURN_IF_ERROR(bf->init_with_fixed_length());
             insert_to_bloom_filter(bf);
+        } else {
+            DCHECK(_context->hybrid_set == nullptr || _context->hybrid_set->size() == 0)
+                    << "set size: " << (_context->hybrid_set ? _context->hybrid_set->size() : 0);
         }
         // release in filter
         _context->hybrid_set.reset();

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -522,7 +522,7 @@ public:
                 } else {
                     VLOG_DEBUG << " change runtime filter to bloom filter(id=" << _filter_id
                                << ") because: already exist a bloom filter";
-                    RETURN_IF_ERROR(change_to_bloom_filter(false));
+                    RETURN_IF_ERROR(change_to_bloom_filter(!_build_bf_exactly));
                     RETURN_IF_ERROR(_context->bloom_filter_func->merge(
                             wrapper->_context->bloom_filter_func.get()));
                 }
@@ -1318,8 +1318,9 @@ bool IRuntimeFilter::get_ignored() {
 std::string IRuntimeFilter::formatted_state() const {
     return fmt::format(
             "[IsPushDown = {}, RuntimeFilterState = {}, HasRemoteTarget = {}, "
-            "HasLocalTarget = {}]",
-            _is_push_down, _get_explain_state_string(), _has_remote_target, _has_local_target);
+            "HasLocalTarget = {}, Ignored = {}]",
+            _is_push_down, _get_explain_state_string(), _has_remote_target, _has_local_target,
+            _wrapper->_context->ignored);
 }
 
 BloomFilterFuncBase* IRuntimeFilter::get_bloomfilter() const {

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -74,17 +74,17 @@ public:
             if (filter->get_real_type() != RuntimeFilterType::IN_FILTER) {
                 continue;
             }
-            if (has_in_filter.contains(filter->filter_id())) {
+            if (has_in_filter.contains(filter->expr_order())) {
                 filter->set_ignored();
                 continue;
             }
-            has_in_filter.insert(filter->filter_id());
+            has_in_filter.insert(filter->expr_order());
         }
 
         // process ignore filter when it has IN_FILTER on same expr, and init bloom filter size
         for (auto* filter : _runtime_filters) {
             if (filter->get_real_type() == RuntimeFilterType::IN_FILTER ||
-                !has_in_filter.contains(filter->filter_id())) {
+                !has_in_filter.contains(filter->expr_order())) {
                 continue;
             }
             filter->set_ignored();

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -74,17 +74,17 @@ public:
             if (filter->get_real_type() != RuntimeFilterType::IN_FILTER) {
                 continue;
             }
-            if (has_in_filter.contains(filter->expr_order())) {
+            if (has_in_filter.contains(filter->filter_id())) {
                 filter->set_ignored();
                 continue;
             }
-            has_in_filter.insert(filter->expr_order());
+            has_in_filter.insert(filter->filter_id());
         }
 
         // process ignore filter when it has IN_FILTER on same expr, and init bloom filter size
         for (auto* filter : _runtime_filters) {
             if (filter->get_real_type() == RuntimeFilterType::IN_FILTER ||
-                !has_in_filter.contains(filter->expr_order())) {
+                !has_in_filter.contains(filter->filter_id())) {
                 continue;
             }
             filter->set_ignored();


### PR DESCRIPTION
## Proposed changes

Introduced by #32180.

1. When in filter needs to be transformed to bloom filter, we should initialize this bloom filter with the right size.
2. Use filter id as the unique label instead of `expr_order`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

