### PR TITLE
[fix](tablet invert index) fix tablet invert index leaky caused by auto partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1451,7 +1451,9 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (olapTable.checkPartitionNameExist(partitionName)) {
                 if (singlePartitionDesc.isSetIfNotExists()) {
                     LOG.info("add partition[{}] which already exists", partitionName);
-                    return;
+                    if (!DebugPointUtil.isEnable("InternalCatalog.addPartition.noCheckExists")) {
+                        return;
+                    }
                 } else {
                     ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
                 }
@@ -1608,6 +1610,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         if (!Strings.isNullOrEmpty(dataProperty.getStoragePolicy())) {
             storagePolicy = dataProperty.getStoragePolicy();
         }
+        boolean ignoreException = false;
         try {
             long partitionId = idGeneratorBuffer.getNextId();
             List<Long> partitionIds = Lists.newArrayList(partitionId);
@@ -1631,11 +1634,10 @@ public class InternalCatalog implements CatalogIf<Database> {
                 // check partition name
                 if (olapTable.checkPartitionNameExist(partitionName)) {
                     if (singlePartitionDesc.isSetIfNotExists()) {
-                        LOG.info("add partition[{}] which already exists", partitionName);
-                        return;
-                    } else {
-                        ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
+                        ignoreException = true;
                     }
+                    LOG.info("add partition[{}] which already exists", partitionName);
+                    ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
                 }
 
                 // check if meta changed
@@ -1679,8 +1681,6 @@ public class InternalCatalog implements CatalogIf<Database> {
                         }
                     }
                 }
-
-
 
                 if (metaChanged) {
                     throw new DdlException("Table[" + tableName + "]'s meta has been changed. try again.");
@@ -1728,7 +1728,9 @@ public class InternalCatalog implements CatalogIf<Database> {
             for (Long tabletId : tabletIdSet) {
                 Env.getCurrentInvertedIndex().deleteTablet(tabletId);
             }
-            throw e;
+            if (!ignoreException) {
+                throw e;
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class AddExistsPartitionTest extends TestWithFeService {
+
+    @Override
+    protected void beforeCreatingConnectContext() throws Exception {
+        Config.enable_debug_points = true;
+    }
+
+    @Test
+    public void testAddExistsPartition() throws Exception {
+        DebugPointUtil.addDebugPoint("InternalCatalog.addPartition.noCheckExists", new DebugPoint());
+        createDatabase("test");
+        createTable("CREATE TABLE test.tbl (k INT) DISTRIBUTED BY HASH(k) "
+                + " BUCKETS 5 PROPERTIES ( \"replication_num\" = \"" + backendNum() + "\" )");
+        List<Long> backendIds = Env.getCurrentSystemInfo().getAllBackendIds();
+        for (long backendId : backendIds) {
+            Assertions.assertEquals(5, Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId).size());
+        }
+
+        String addPartitionSql = "ALTER TABLE test.tbl  ADD PARTITION  IF NOT EXISTS tbl"
+            + " DISTRIBUTED BY HASH(k) BUCKETS 5";
+        Assertions.assertNotNull(getSqlStmtExecutor(addPartitionSql));
+        for (long backendId : backendIds) {
+            Assertions.assertEquals(5, Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId).size());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
@@ -47,7 +47,7 @@ public class AddExistsPartitionTest extends TestWithFeService {
         }
 
         String addPartitionSql = "ALTER TABLE test.tbl  ADD PARTITION  IF NOT EXISTS tbl"
-            + " DISTRIBUTED BY HASH(k) BUCKETS 5";
+                + " DISTRIBUTED BY HASH(k) BUCKETS 5";
         Assertions.assertNotNull(getSqlStmtExecutor(addPartitionSql));
         for (long backendId : backendIds) {
             Assertions.assertEquals(5, Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId).size());


### PR DESCRIPTION
BUG:

When creating a partition,   it will call InternalCatalog.createPartitionWithIndices  and the partition's tablet will add to tablet invert index.  And drop or discard a partition, need to clean its tablet in tablet invert index.

We found a issue oneline: user create a table with auto partition, they concurrent insert data, and then  concurrent create partitions with the same partition name.  Then the later created partition will raise exists partition eror.  But it forget to clear the related tablets in tablet invert index.  

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

