### PR TITLE
[Improvement](runtime-filter) make sync rf size work when need_local_merge

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1306,9 +1306,10 @@ void IRuntimeFilter::set_dependency(pipeline::CountedFinishDependency* dependenc
 }
 
 void IRuntimeFilter::set_synced_size(uint64_t global_size) {
-    CHECK(_dependency);
     _synced_size = global_size;
-    _dependency->sub();
+    if (_dependency) {
+        _dependency->sub();
+    }
 }
 
 void IRuntimeFilter::set_ignored() {

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -41,9 +41,9 @@ public:
         }
     }
 
-    Status send_filter_size(RuntimeState* state, uint64_t hash_table_size, bool publish_local,
+    Status send_filter_size(RuntimeState* state, uint64_t hash_table_size,
                             pipeline::CountedFinishDependency* dependency) {
-        if (_runtime_filters.empty() || publish_local) {
+        if (_runtime_filters.empty()) {
             return Status::OK();
         }
         for (auto* runtime_filter : _runtime_filters) {

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -537,10 +537,8 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         local_state._shared_state->build_block = std::make_shared<vectorized::Block>(
                 local_state._build_side_mutable_block.to_block());
 
-        const bool need_local_merge =
-                local_state._parent->cast<HashJoinBuildSinkOperatorX>()._need_local_merge;
         RETURN_IF_ERROR(local_state._runtime_filter_slots->send_filter_size(
-                state, local_state._shared_state->build_block->rows(), need_local_merge,
+                state, local_state._shared_state->build_block->rows(),
                 (CountedFinishDependency*)(local_state._finish_dependency.get())));
         RETURN_IF_ERROR(
                 local_state.process_build_block(state, (*local_state._shared_state->build_block)));

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -536,10 +536,10 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
     // So if `need_local_merge` is true, we will disable `build_bf_exactly`.
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_local_merge_producer_filter(
-                desc, query_options(), producer_filter, build_bf_exactly && !need_local_merge);
+                desc, query_options(), producer_filter, build_bf_exactly);
     } else {
         return local_runtime_filter_mgr()->register_producer_filter(
-                desc, query_options(), producer_filter, build_bf_exactly && !need_local_merge);
+                desc, query_options(), producer_filter, build_bf_exactly);
     }
 }
 


### PR DESCRIPTION
## Proposed changes
make sync rf size work when need_local_merge

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

