### PR TITLE
[fix](memory) Fix pipelinex submit task attach memory tracker

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -180,7 +180,7 @@ void alter_tablet(StorageEngine& engine, const TAgentTaskRequest& agent_task_req
         new_tablet_id = agent_task_req.alter_tablet_req_v2.new_tablet_id;
         new_schema_hash = agent_task_req.alter_tablet_req_v2.new_schema_hash;
         auto mem_tracker = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::SCHEMA_CHANGE,
+                MemTrackerLimiter::Type::OTHER,
                 fmt::format("EngineAlterTabletTask#baseTabletId={}:newTabletId={}",
                             std::to_string(agent_task_req.alter_tablet_req_v2.base_tablet_id),
                             std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id),
@@ -249,7 +249,7 @@ void alter_cloud_tablet(CloudStorageEngine& engine, const TAgentTaskRequest& age
     if (status.ok()) {
         new_tablet_id = agent_task_req.alter_tablet_req_v2.new_tablet_id;
         auto mem_tracker = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::SCHEMA_CHANGE,
+                MemTrackerLimiter::Type::OTHER,
                 fmt::format("EngineAlterTabletTask#baseTabletId={}:newTabletId={}",
                             std::to_string(agent_task_req.alter_tablet_req_v2.base_tablet_id),
                             std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id),

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -42,7 +42,7 @@ CloudEngineCalcDeleteBitmapTask::CloudEngineCalcDeleteBitmapTask(
           _cal_delete_bitmap_req(cal_delete_bitmap_req),
           _error_tablet_ids(error_tablet_ids),
           _succ_tablet_ids(succ_tablet_ids) {
-    _mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::SCHEMA_CHANGE,
+    _mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
                                                     "CloudEngineCalcDeleteBitmapTask");
 }
 
@@ -134,7 +134,7 @@ CloudTabletCalcDeleteBitmapTask::CloudTabletCalcDeleteBitmapTask(
           _transaction_id(transaction_id),
           _version(version) {
     _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            MemTrackerLimiter::Type::OTHER,
             fmt::format("CloudTabletCalcDeleteBitmapTask#_transaction_id={}", _transaction_id));
 }
 

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -82,7 +82,7 @@ EnginePublishVersionTask::EnginePublishVersionTask(
           _succ_tablets(succ_tablets),
           _discontinuous_version_tablets(discontinuous_version_tablets),
           _table_id_to_num_delta_rows(table_id_to_num_delta_rows) {
-    _mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::SCHEMA_CHANGE,
+    _mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
                                                     "TabletPublishTxnTask");
 }
 
@@ -357,7 +357,7 @@ TabletPublishTxnTask::TabletPublishTxnTask(StorageEngine& engine,
           _transaction_id(transaction_id),
           _version(version),
           _tablet_info(tablet_info),
-          _mem_tracker(MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::SCHEMA_CHANGE,
+          _mem_tracker(MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
                                                         "TabletPublishTxnTask")) {
     _stats.submit_time_us = MonotonicMicros();
 }

--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -121,7 +121,7 @@ public:
               _partition_id(partition_id),
               _transaction_id(transaction_id),
               _version(version),
-              _mem_tracker(MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::SCHEMA_CHANGE,
+              _mem_tracker(MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
                                                             "AsyncTabletPublishTask")) {
         _stats.submit_time_us = MonotonicMicros();
     }

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -160,7 +160,7 @@ Status FoldConstantExecutor::_init(const TQueryGlobals& query_globals,
     fragment_params.params = params;
     fragment_params.protocol_version = PaloInternalServiceVersion::V1;
     _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            MemTrackerLimiter::Type::OTHER,
             fmt::format("FoldConstant:query_id={}", print_id(_query_id)));
     _runtime_state =
             RuntimeState::create_unique(fragment_params.params, query_options, query_globals,

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -195,6 +195,7 @@ std::string FragmentMgr::to_http_path(const std::string& file_name) {
 Status FragmentMgr::trigger_pipeline_context_report(
         const ReportStatusRequest req, std::shared_ptr<pipeline::PipelineFragmentContext>&& ctx) {
     return _async_report_thread_pool->submit_func([this, req, ctx]() {
+        SCOPED_ATTACH_TASK(ctx->get_query_ctx()->query_mem_tracker);
         coordinator_callback(req);
         if (!req.done) {
             ctx->refresh_next_report_time();
@@ -900,6 +901,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
         return Status::OK();
     } else {
         auto pre_and_submit = [&](int i) {
+            SCOPED_ATTACH_TASK_WITH_ID(query_ctx->query_mem_tracker, params.query_id);
             const auto& local_params = params.local_params[i];
 
             const TUniqueId& fragment_instance_id = local_params.fragment_instance_id;

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -104,7 +104,7 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     const auto& local_tablet_uid = local_tablet->tablet_uid();
 
     std::shared_ptr<MemTrackerLimiter> mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE, fmt::format("IngestBinlog#TxnId={}", txn_id));
+            MemTrackerLimiter::Type::OTHER, fmt::format("IngestBinlog#TxnId={}", txn_id));
     SCOPED_ATTACH_TASK(mem_tracker);
 
     auto& request = arg->request;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -728,7 +728,7 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
         const TFileScanRangeParams& params = file_scan_range.params;
 
         std::shared_ptr<MemTrackerLimiter> mem_tracker = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::SCHEMA_CHANGE,
+                MemTrackerLimiter::Type::OTHER,
                 fmt::format("{}#{}", params.format_type, params.file_type));
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(mem_tracker);
 


### PR DESCRIPTION
## Proposed changes

fix
```
F20240415 23:42:47.509416  9710 thread_context.h:204] Check failed: !doris::config::enable_memory_orphan_check || thread_mem_tracker()->label() != "Orphan" If you crash here, it means that SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the thread will crash. If you want to switch MemTrackerLimiter during thread execution, please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach. Of course, you can modify enable_memory_orphan_check=false in be.conf to avoid this crash.F20240415 23:42:47.509719  9730 thread_context.h:204] Check failed: !doris::config::enable_memory_orphan_check || thread_mem_tracker()->label() != "Orphan" If you crash here, it means that SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the thread will crash. If you want to switch MemTrackerLimiter during thread execution, please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach. Of course, you can modify enable_memory_orphan_check=false in be.conf to avoid this crash.
23:54:03   *** Check failure stack trace: ***
23:54:03    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
23:54:03    1# 0x00007F4CB957A090 in /lib/x86_64-linux-gnu/libc.so.6
23:54:03    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
23:54:03    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
23:54:03    4# 0x000055D07A68DBDD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03    5# 0x000055D07A68027A in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03    6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03    7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03    8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03    9# doris::ThreadContext::consume_memory(long) const in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03   10# Allocator<false, false, false>::release_memory(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:177
23:54:03   11# Allocator<false, false, false>::free(void*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:154
23:54:03   12# doris::vectorized::Arena::Chunk::~Chunk() at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/arena.h:77
23:54:03   13# doris::vectorized::Arena::~Arena() at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/arena.h:142
23:54:03   14# void std::destroy_at<doris::vectorized::Arena>(doris::vectorized::Arena*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:89
23:54:03   15# void std::allocator_traits<std::allocator<doris::vectorized::Arena> >::destroy<doris::vectorized::Arena>(std::allocator<doris::vectorized::Arena>&, doris::vectorized::Arena*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533
23:54:03   16# std::_Sp_counted_ptr_inplace<doris::vectorized::Arena, std::allocator<doris::vectorized::Arena>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:529
23:54:03   17# std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
23:54:03   18# std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:703
23:54:03   19# std::__shared_ptr<doris::vectorized::Arena, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
23:54:03   20# std::__shared_ptr<doris::vectorized::Arena, (__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_ptr<doris::vectorized::Arena, (__gnu_cxx::_Lock_policy)2>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1245
23:54:03   21# std::shared_ptr<doris::vectorized::Arena>::operator=(std::shared_ptr<doris::vectorized::Arena>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:385
23:54:03   22# doris::vectorized::HashJoinNode::_release_mem() at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/join/vhash_join_node.cpp:1111
23:54:03   23# doris::vectorized::HashJoinNode::release_resource(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/join/vhash_join_node.cpp:685
23:54:03   24# doris::ExecNode::close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/exec/exec_node.cpp:236
23:54:03   25# doris::vectorized::VJoinNodeBase::close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/join/vjoin_node_base.cpp:153
23:54:03   26# doris::vectorized::HashJoinNode::close(doris::RuntimeState*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23:54:03   27# doris::pipeline::PipelineFragmentContext::close_if_prepare_failed(doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_fragment_context.cpp:796
23:54:03   28# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_1::operator()(int) const at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:934
23:54:03   29# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::operator()() const at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:984
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

