### PR TITLE
[Fix](thrift) circumvent Thrift catch stack false alarm by ASAN

### DIFF
--- a/be/src/gutil/asan_circumvention.h
+++ b/be/src/gutil/asan_circumvention.h
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#ifdef ADDRESS_SANITIZER
+#define ASAN_CIRCUMVENT(SENDER) std::cerr
+#else
+#define ASAN_CIRCUMVENT(SENDER) SENDER
+#endif


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before, in ASAN mode if thrift throw exception because transport reason, BE will directly crash in some environment. This is clearly known as a false alarm of ASAN. So in this situation, we just print log to `be.out` but not `be.INFO` or `be.WARNING`, and maybe with information simplification. Because of in test environment, that's acceptable.

test in: https://github.com/apache/doris/pull/33761

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

