### PR TITLE
[enhancement](testutil) add new function for function test in be-ut

### DIFF
--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <stdint.h>
-
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -43,7 +42,7 @@ TEST(function_string_test, function_string_substr_test) {
     std::string func_name = "substr";
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::Int32};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("asd你好"), 4, 10}, std::string("\xE4\xBD\xA0\xE5\xA5\xBD")}, //你好
@@ -56,13 +55,30 @@ TEST(function_string_test, function_string_substr_test) {
                 {{std::string(""), 0, 4}, std::string("")},
                 {{std::string("123"), 0, 4}, std::string("")},
                 {{std::string("123"), 1, 0}, std::string("")},
-                {{Null(), 5, 4}, Null()}};
+                {{Null(), 5, 4}, Null()},
+                {{std::string("abbcc"), 1, -1}, std::string("")},
+                {{std::string("abc"), -10, 3}, std::string("")},
+                {{Null(), Null(), Null()}, Null()},
+                {{std::string(1e6, 'a'), Null(), Null()}, Null {}},
+                {{std::string(1e6, 'a'), std::numeric_limits<int>::max(), Null()}, Null()},
+                {{std::string("test——test"), Null(), 1}, Null()},
+                {{std::string("test——test"), 1, Null()}, Null()},
+                {{Null(), Null(), 1}, Null()},
+                {{std::string("test——test"), -10, 1}, std::string("t")},
+                {{std::string("test——test"), -20, 1}, std::string("")},
+                {{std::string("test——test"), -10, 10}, std::string("test——test")},
+                //{{std::string("abcdef"), 3, 2}, std::string("cd")},
+                {{Null(), 1, 1}, Null()},
+                {{std::string("test——test"), Null(), 1}, Null()},
+                {{std::string("test——test"), 1, Null()}, Null()},
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        };
+
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("asd你好"), 4}, std::string("\xE4\xBD\xA0\xE5\xA5\xBD")}, //你好
@@ -74,116 +90,228 @@ TEST(function_string_test, function_string_substr_test) {
                 {{std::string("12"), 3}, std::string("")},
                 {{std::string(""), 0}, std::string("")},
                 {{std::string("123"), 0}, std::string("")},
-                {{Null(), 5, 4}, Null()}};
+                {{Null(), 5}, Null()},
+                {{std::string("abc"), Null()}, Null()},
+                {{std::string("12345"), 10}, std::string("")},
+                {{std::string("12345"), -10}, std::string("")},
+                {{std::string(""), Null()}, Null()},
+                {{Null(), -100}, Null()},
+                {{std::string("12345"), 12345}, std::string("")},
+        };
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_string_strright_test) {
     std::string func_name = "strright";
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
-    DataSet data_set = {{{std::string("asd"), 1}, std::string("d")},
-                        {{std::string("hello word"), -2}, std::string("ello word")},
-                        {{std::string("hello word"), 20}, std::string("hello word")},
-                        {{std::string("HELLO,!^%"), 2}, std::string("^%")},
-                        {{std::string(""), 3}, std::string("")},
-                        {{Null(), 3}, Null()}};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        DataSet data_set = {{{std::string("asd"), 1}, std::string("d")},
+                            {{std::string("hello word"), -2}, std::string("ello word")},
+                            {{std::string("hello word"), 20}, std::string("hello word")},
+                            {{std::string("HELLO,!^%"), 2}, std::string("^%")},
+                            {{std::string(""), 3}, std::string("")},
+                            {{Null(), 3}, Null()},
+                            {{std::string("12345"), 10}, std::string("12345")},
+                            {{std::string("12345"), -10}, std::string("")},
+                            {{std::string(""), Null()}, Null()},
+                            {{Null(), -100}, Null()},
+                            {{std::string("12345"), 12345}, std::string("12345")},
+                            {{std::string(""), 1}, std::string()},
+                            {{std::string("a b c d _ %"), -3}, std::string("b c d _ %")},
+                            {{std::string(""), Null()}, Null()},
+                            {{std::string("hah hah"), -1}, std::string("hah hah")},
+                            {{std::string("🤣"), -1}, std::string("🤣")},
+                            {{std::string("🤣😃😄"), -2}, std::string("😃😄")},
+                            {{std::string("12345"), 6}, std::string("12345")},
+                            {{std::string("12345"), 12345}, std::string("12345")},
+                            {{std::string("-12345"), -1}, std::string("-12345")},
+                            {{std::string("-12345"), -12345}, std::string()},
+                            {{Null(), -12345}, Null()},
+                            {{std::string("😡"), Null()}, Null()},
+                            {{std::string("🤣"), 0}, std::string()}
+
+        };
+
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+    }
 }
 
 TEST(function_string_test, function_string_strleft_test) {
     std::string func_name = "strleft";
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
-    DataSet data_set = {{{std::string("asd"), 1}, std::string("a")},
-                        {{std::string("hel  lo  "), 5}, std::string("hel  ")},
-                        {{std::string("hello word"), 20}, std::string("hello word")},
-                        {{std::string("HELLO,!^%"), 7}, std::string("HELLO,!")},
-                        {{std::string(""), 2}, std::string("")},
-                        {{std::string(""), -2}, std::string("")},
-                        {{std::string(""), 0}, std::string("")},
-                        {{std::string("123"), 0}, std::string("")},
-                        {{Null(), 3}, Null()}};
+        DataSet data_set = {
+                {{std::string("asd"), 1}, std::string("a")},
+                {{std::string("hel  lo  "), 5}, std::string("hel  ")},
+                {{std::string("hello word"), 20}, std::string("hello word")},
+                {{std::string("HELLO,!^%"), 7}, std::string("HELLO,!")},
+                {{std::string(""), 2}, std::string("")},
+                {{std::string(""), -2}, std::string("")},
+                {{std::string(""), 0}, std::string("")},
+                {{std::string("123"), 0}, std::string("")},
+                {{Null(), 3}, Null()},
+                {{std::string("12321"), 3}, std::string("123")},
+                {{std::string("123"), 0}, std::string()},
+                {{std::string("123"), -1}, std::string()},
+                {{std::string("123"), Null()}, Null()},
+                {{Null(), 0}, Null()},
+                {{std::string("🫢"), 0}, std::string()},
+                {{std::string("123"), 4}, std::string("123")},
+                {{std::string("哈哈hh🤣"), 1}, std::string("哈")},
+                {{std::string("哈哈hh🤣"), 100}, std::string("哈哈hh🤣")},
+                {{std::string("mnzxv"), -1}, std::string()},
+                {{std::string("123"), Null()}, Null()},
+                {{std::string(1e6, 'a'), Null()}, Null()},
+                {{std::string(""), -100}, std::string()},
+                {{std::string("abcdef"), 4}, std::string("abcd")},
+                {{std::string("NULL"), 3}, std::string("NUL")},
+                {{std::string("NuLl"), 4}, std::string("NuLl")},
+                {{Null(), 123}, Null()},
+        };
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+    }
 }
 
 TEST(function_string_test, function_string_lower_test) {
     std::string func_name = "lower";
-    InputTypeSet input_types = {TypeIndex::String};
-    DataSet data_set = {{{std::string("ASD")}, std::string("asd")},
-                        {{std::string("HELLO123")}, std::string("hello123")},
-                        {{std::string("MYtestSTR")}, std::string("myteststr")},
-                        {{std::string("HELLO,!^%")}, std::string("hello,!^%")},
-                        {{std::string("")}, std::string("")}};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String};
+        DataSet data_set = {
+                {{std::string("ASD")}, std::string("asd")},
+                {{std::string("HELLO123")}, std::string("hello123")},
+                {{std::string("MYtestSTR")}, std::string("myteststr")},
+                {{std::string("HELLO,!^%")}, std::string("hello,!^%")},
+                {{std::string("")}, std::string("")},
+                {{Null()}, Null()},
+                {{std::string("🤣a aB B11   3_ _!&")}, std::string("🤣a ab b11   3_ _!&")},
+                {{std::string("")}, std::string("")},
+                {{std::string("你好HELLO!")}, std::string("你好hello!")},
+                {{std::string("")}, std::string("")},
+                {{std::string("123ABC_")}, std::string("123abc_")},
+        };
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+        check_function_all_arg_comb<DataTypeString, true>(std::string("lcase"), input_types,
+                                                          data_set);
+    }
 }
 
 TEST(function_string_test, function_string_upper_test) {
     std::string func_name = "upper";
-    InputTypeSet input_types = {TypeIndex::String};
-    DataSet data_set = {{{std::string("asd")}, std::string("ASD")},
-                        {{std::string("hello123")}, std::string("HELLO123")},
-                        {{std::string("HELLO,!^%")}, std::string("HELLO,!^%")},
-                        {{std::string("MYtestStr")}, std::string("MYTESTSTR")},
-                        {{std::string("")}, std::string("")}};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String};
+        DataSet data_set = {{{std::string("asd")}, std::string("ASD")},
+                            {{std::string("hello123")}, std::string("HELLO123")},
+                            {{std::string("HELLO,!^%")}, std::string("HELLO,!^%")},
+                            {{std::string("MYtestStr")}, std::string("MYTESTSTR")},
+                            {{std::string("")}, std::string("")},
+                            {{Null {}}, Null {}},
+                            {{std::string("123123")}, std::string("123123")},
+                            {{std::string("AaBbCcDd")}, std::string("AABBCCDD")},
+                            {{std::string("你好hello")}, std::string("你好HELLO")}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+        check_function_all_arg_comb<DataTypeString, true>(std::string("ucase"), input_types,
+                                                          data_set);
+    }
 }
 
 TEST(function_string_test, function_string_trim_test) {
     std::string func_name = "trim";
-    InputTypeSet input_types = {TypeIndex::String};
-    DataSet data_set = {{{std::string("a sd")}, std::string("a sd")},
-                        {{std::string("  hello 123  ")}, std::string("hello 123")},
-                        {{std::string("  HELLO,!^%")}, std::string("HELLO,!^%")},
-                        {{std::string("MY test Str你好  ")}, std::string("MY test Str你好")},
-                        {{Null()}, Null()},
-                        {{std::string("")}, std::string("")}};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String};
+        DataSet data_set = {{{std::string("a sd")}, std::string("a sd")},
+                            {{std::string("  hello 123  ")}, std::string("hello 123")},
+                            {{std::string("  HELLO,!^%")}, std::string("HELLO,!^%")},
+                            {{std::string("MY test Str你好  ")}, std::string("MY test Str你好")},
+                            {{Null()}, Null()},
+                            {{std::string("")}, std::string("")},
+                            {{std::string("a sd")}, std::string("a sd")},
+                            {{std::string("  hello 123  ")}, std::string("hello 123")},
+                            {{std::string("  HELLO,!^%")}, std::string("HELLO,!^%")},
+                            {{std::string("MY test Str你好  ")}, std::string("MY test Str你好")},
+                            {{Null()}, Null()},
+                            {{std::string("")}, std::string("")}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+    }
+
+    // todo
+    //  Argument at index 1 for function trim must be constant
+    // {
+    //     BaseInputTypeSet input_types = {TypeIndex::String, Consted {TypeIndex::String}};
+    //     DataSet data_set = {
+    //             {{std::string("ABCABCABCABCABC"), std::string("ABC")}, std::string("")},
+    //             {{std::string("ABCCCABC"), std::string("ABC")}, std::string("CC")},
+    //             {{std::string("NULL"), std::string("L")}, std::string("NU")},
+    //             {{std::string(""), Null()}, Null()},
+    //             {{Null(), std::string("ABC")}, Null()},
+    //             {{std::string("ABCABC"), std::string("")}, std::string("ABCABC")},
+    //             {{std::string(""), std::string("")}, std::string("")},
+    //             {{std::string("- - -AA__BBc"), std::string("- -")}, std::string(" -AA__BBc")},
+    //             {{std::string("--- -++- ---"), std::string("-")}, std::string(" -++-")}};
+
+    //     for (const auto& line : data_set) {
+    //         DataSet tmp_set {line};
+    //         static_cast<void>(
+    //                 check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, tmp_set));
+    //     }
+    // }
 }
 
 TEST(function_string_test, function_string_ltrim_test) {
     std::string func_name = "ltrim";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("a sd")}, std::string("a sd")},
             {{std::string("  hello 123  ")}, std::string("hello 123  ")},
             {{std::string("  HELLO,!^%")}, std::string("HELLO,!^%")},
             {{std::string("  你好MY test Str你好  ")}, std::string("你好MY test Str你好  ")},
             {{std::string("")}, std::string("")}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_string_rtrim_test) {
     std::string func_name = "rtrim";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{std::string("a sd ")}, std::string("a sd")},
                         {{std::string("hello 123  ")}, std::string("hello 123")},
                         {{std::string("  HELLO,!^%")}, std::string("  HELLO,!^%")},
                         {{std::string("  MY test Str你好  ")}, std::string("  MY test Str你好")},
                         {{std::string("")}, std::string("")}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
+
 TEST(function_string_test, function_string_repeat_test) {
     std::string func_name = "repeat";
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
-    DataSet data_set = {{{std::string("a"), 3}, std::string("aaa")},
-                        {{std::string("hel lo"), 2}, std::string("hel lohel lo")},
-                        {{std::string("hello word"), -1}, std::string("")},
-                        {{std::string(""), 1}, std::string("")},
-                        {{std::string("HELLO,!^%"), 2}, std::string("HELLO,!^%HELLO,!^%")},
-                        {{std::string("你"), 2}, std::string("你你")}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        DataSet data_set = {{{std::string("a"), 3}, std::string("aaa")},
+                            {{std::string("hel lo"), 2}, std::string("hel lohel lo")},
+                            {{std::string("hello word"), -1}, std::string("")},
+                            {{std::string(""), 1}, std::string("")},
+                            {{std::string("HELLO,!^%"), 2}, std::string("HELLO,!^%HELLO,!^%")},
+                            {{std::string("你"), 2}, std::string("你你")},
+                            {{Null(), 4}, Null()},
+                            {{std::string(""), Null()}, Null()},
+                            {{Null(), Null()}, Null()},
+                            {{Null(), 0}, Null()},
+                            {{Null(), -1}, Null()},
+                            {{std::string("HELLO"), -100}, std::string("")}};
+
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+    }
 
     {
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
         DataSet data_set = {{{std::string("a"), 1073741825},
                              std::string("aaaaaaaaaa")}}; // ut repeat max num 10
         Status st = check_function<DataTypeString, true>(func_name, input_types, data_set, true);
@@ -193,57 +321,69 @@ TEST(function_string_test, function_string_repeat_test) {
 
 TEST(function_string_test, function_string_reverse_test) {
     std::string func_name = "reverse";
-    InputTypeSet input_types = {TypeIndex::String};
-    DataSet data_set = {{{std::string("asd ")}, std::string(" dsa")},
-                        {{std::string("  hello 123  ")}, std::string("  321 olleh  ")},
-                        {{std::string("  HELLO,!^%")}, std::string("%^!,OLLEH  ")},
-                        {{std::string("你好啊")}, std::string("啊好你")},
-                        {{std::string("")}, std::string("")}};
-
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    {
+        BaseInputTypeSet input_types = {TypeIndex::String};
+        DataSet data_set = {{{std::string("asd ")}, std::string(" dsa")},
+                            {{std::string("  hello 123  ")}, std::string("  321 olleh  ")},
+                            {{std::string("  HELLO,!^%")}, std::string("%^!,OLLEH  ")},
+                            {{std::string("你好啊")}, std::string("啊好你")},
+                            {{std::string("")}, std::string("")},
+                            {{std::string("你好你好你")}, std::string("你好你好你")},
+                            {{std::string("kjaj _aksjdb !@!$$** ajs _")},
+                             std::string("_ sja **$$!@! bdjska_ jajk")},
+                            {{Null()}, Null()}};
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
+    }
 }
 
 TEST(function_string_test, function_string_length_test) {
     std::string func_name = "length";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{std::string("asd ")}, int32_t(4)},
                         {{std::string("  hello 123  ")}, int32_t(13)},
                         {{std::string("  HELLO,!^%")}, int32_t(11)},
                         {{std::string("你好啊")}, int32_t(9)},
-                        {{std::string("")}, int32_t(0)}};
+                        {{std::string("")}, int32_t(0)},
+                        {{Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_string_quote_test) {
     std::string func_name = "quote";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{std::string("hello")}, std::string(R"('hello')")},
                         {{std::string("hello\t\n\nworld")}, std::string("'hello\t\n\nworld'")},
                         {{std::string("HELLO,!^%")}, std::string("'HELLO,!^%'")},
                         {{std::string("MYtestStr\\t\\n")}, std::string("'MYtestStr\\t\\n'")},
                         {{std::string("")}, std::string("''")},
                         {{Null()}, Null()}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_append_trailing_char_if_absent_test) {
     std::string func_name = "append_trailing_char_if_absent";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("ASD"), std::string("D")}, std::string("ASD")},
                         {{std::string("AS"), std::string("D")}, std::string("ASD")},
                         {{std::string(""), std::string("")}, Null()},
-                        {{std::string(""), std::string("A")}, std::string("A")}};
+                        {{std::string(""), std::string("A")}, std::string("A")},
+                        {{std::string("AC"), std::string("BACBAC")}, Null()},
+                        {{Null(), Null()}, Null()},
+                        {{std::string("ABC"), Null()}, Null()},
+                        {{Null(), std::string("ABC")}, Null()},
+                        {{std::string(""), Null()}, Null()},
+                        {{Null(), std::string("")}, Null()}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_starts_with_test) {
     std::string func_name = "starts_with";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hello world"), std::string("hello")}, uint8_t(1)},
                         {{std::string("hello world"), std::string("world")}, uint8_t(0)},
@@ -252,28 +392,29 @@ TEST(function_string_test, function_starts_with_test) {
                         {{std::string("你好"), Null()}, Null()},
                         {{Null(), std::string("")}, Null()}};
 
-    static_cast<void>(check_function<DataTypeUInt8, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeUInt8, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_ends_with_test) {
     std::string func_name = "ends_with";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hello world"), std::string("hello")}, uint8_t(0)},
                         {{std::string("hello world"), std::string("world")}, uint8_t(1)},
                         {{std::string("你好"), std::string("好")}, uint8_t(1)},
                         {{std::string(""), std::string("")}, uint8_t(1)},
                         {{std::string("你好"), Null()}, Null()},
-                        {{Null(), std::string("")}, Null()}};
+                        {{Null(), std::string("")}, Null()},
+                        {{Null(), Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeUInt8, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeUInt8, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_lpad_test) {
     std::string func_name = "lpad";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hi"), 5, std::string("?")}, std::string("???hi")},
                         {{std::string("g8%7IgY%AHx7luNtf8Kh"), 20, std::string("")},
@@ -286,15 +427,18 @@ TEST(function_string_test, function_lpad_test) {
                         {{std::string("hi"), 5, std::string("")}, Null()},
                         {{std::string("hi"), 5, std::string("ab")}, std::string("abahi")},
                         {{std::string("hi"), 5, std::string("呵呵")}, std::string("呵呵呵hi")},
-                        {{std::string("呵呵"), 5, std::string("hi")}, std::string("hih呵呵")}};
+                        {{std::string("呵呵"), 5, std::string("hi")}, std::string("hih呵呵")},
+                        {{std::string(""), 5, std::string("")}, Null()},
+                        {{std::string("AA"), Null(), std::string("BB")}, Null()},
+                        {{Null(), 100, Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_rpad_test) {
     std::string func_name = "rpad";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hi"), 5, std::string("?")}, std::string("hi???")},
                         {{std::string("g8%7IgY%AHx7luNtf8Kh"), 20, std::string("")},
@@ -307,61 +451,65 @@ TEST(function_string_test, function_rpad_test) {
                         {{std::string("hi"), 5, std::string("")}, Null()},
                         {{std::string("hi"), 5, std::string("ab")}, std::string("hiaba")},
                         {{std::string("hi"), 5, std::string("呵呵")}, std::string("hi呵呵呵")},
-                        {{std::string("呵呵"), 5, std::string("hi")}, std::string("呵呵hih")}};
+                        {{std::string("呵呵"), 5, std::string("hi")}, std::string("呵呵hih")},
+                        {{std::string("1"), 5, std::string("")}, Null()},
+                        {{Null(), 1, Null()}, Null()},
+                        {{Null(), -1, Null()}, Null()},
+                        {{std::string(""), 0, Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_ascii_test) {
     std::string func_name = "ascii";
 
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("")}, 0},
                         {{std::string("aa")}, 97},
                         {{std::string("我")}, 230},
                         {{Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_char_length_test) {
     std::string func_name = "char_length";
 
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("")}, 0},    {{std::string("aa")}, 2},
                         {{std::string("我")}, 1},  {{std::string("我a")}, 2},
                         {{std::string("a我")}, 2}, {{std::string("123")}, 3},
-                        {{Null()}, Null()}};
+                        {{Null()}, Null()},        {{std::string("哈哈你好!")}, 5}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_concat_test) {
     std::string func_name = "concat";
     {
-        InputTypeSet input_types = {TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String};
 
         DataSet data_set = {{{std::string("")}, std::string("")},
                             {{std::string("123")}, std::string("123")},
                             {{Null()}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {{{std::string(""), std::string("")}, std::string("")},
                             {{std::string("123"), std::string("45")}, std::string("12345")},
                             {{std::string("123"), Null()}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string(""), std::string("1"), std::string("")}, std::string("1")},
@@ -369,7 +517,7 @@ TEST(function_string_test, function_concat_test) {
                  std::string("123456789")},
                 {{std::string("123"), Null(), std::string("789")}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 }
 
@@ -377,50 +525,29 @@ TEST(function_string_test, function_elt_test) {
     std::string func_name = "elt";
 
     {
-        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::Int32, TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {{{1, std::string("hello"), std::string("world")}, std::string("hello")},
                             {{1, std::string("你好"), std::string("百度")}, std::string("你好")},
-                            {{1, std::string("hello"), std::string("")}, std::string("hello")}};
-
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
-    };
-
-    {
-        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::String, TypeIndex::String};
-
-        DataSet data_set = {{{2, std::string("hello"), std::string("world")}, std::string("world")},
+                            {{1, std::string("hello"), std::string("")}, std::string("hello")},
+                            {{2, std::string("hello"), std::string("world")}, std::string("world")},
                             {{2, std::string("你好"), std::string("百度")}, std::string("百度")},
-                            {{2, std::string("hello"), std::string("")}, std::string("")}};
-
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
-    };
-
-    {
-        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::String, TypeIndex::String};
-
-        DataSet data_set = {{{0, std::string("hello"), std::string("world")}, Null()},
+                            {{2, std::string("hello"), std::string("")}, std::string("")},
+                            {{0, std::string("hello"), std::string("world")}, Null()},
                             {{0, std::string("你好"), std::string("百度")}, Null()},
-                            {{0, std::string("hello"), std::string("")}, Null()}};
-
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
-    };
-
-    {
-        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::String, TypeIndex::String};
-
-        DataSet data_set = {{{3, std::string("hello"), std::string("world")}, Null()},
+                            {{0, std::string("hello"), std::string("")}, Null()},
+                            {{3, std::string("hello"), std::string("world")}, Null()},
                             {{3, std::string("你好"), std::string("百度")}, Null()},
                             {{3, std::string("hello"), std::string("")}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 }
 
 TEST(function_string_test, function_concat_ws_test) {
     std::string func_name = "concat_ws";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {{{std::string("-"), std::string("")}, std::string("")},
                             {{std::string(""), std::string("123")}, std::string("123")},
@@ -428,11 +555,11 @@ TEST(function_string_test, function_concat_ws_test) {
                             {{Null(), std::string("")}, Null()},
                             {{Null(), Null()}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("-"), std::string(""), std::string("")}, std::string("-")},
@@ -441,12 +568,12 @@ TEST(function_string_test, function_concat_ws_test) {
                 {{Null(), std::string(""), std::string("")}, Null()},
                 {{Null(), std::string(""), Null()}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("-"), std::string(""), std::string(""), std::string("")},
@@ -459,11 +586,11 @@ TEST(function_string_test, function_concat_ws_test) {
                 {{std::string("-"), std::string("123"), Null(), std::string("456")},
                  std::string("123-456")}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
 
         Array vec1 = {Field("", 0), Field("", 0), Field("", 0)};
         Array vec2 = {Field("123", 3), Field("456", 3), Field("789", 3)};
@@ -476,40 +603,43 @@ TEST(function_string_test, function_concat_ws_test) {
                             {{Null(), vec4}, Null()},
                             {{std::string("-"), vec5}, std::string("abc-def-ghi")}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     };
 }
 
 TEST(function_string_test, function_null_or_empty_test) {
     std::string func_name = "null_or_empty";
 
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("")}, uint8(true)},
                         {{std::string("aa")}, uint8(false)},
                         {{std::string("我")}, uint8(false)},
                         {{Null()}, uint8(true)}};
 
-    static_cast<void>(check_function<DataTypeUInt8, false>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeUInt8, false>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_to_base64_test) {
     std::string func_name = "to_base64";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("asd你好")}, {std::string("YXNk5L2g5aW9")}},
                         {{std::string("hello world")}, {std::string("aGVsbG8gd29ybGQ=")}},
                         {{std::string("HELLO,!^%")}, {std::string("SEVMTE8sIV4l")}},
                         {{std::string("")}, {std::string("")}},
                         {{std::string("MYtestSTR")}, {std::string("TVl0ZXN0U1RS")}},
-                        {{std::string("ò&ø")}, {std::string("w7Imw7g=")}}};
+                        {{std::string("ò&ø")}, {std::string("w7Imw7g=")}},
+                        {{std::string("啊哈哈哈😄 。——!")},
+                         std::string("5ZWK5ZOI5ZOI5ZOI8J+YhCDjgILigJTigJQh")},
+                        {{Null()}, Null()}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_from_base64_test) {
     std::string func_name = "from_base64";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("YXNk5L2g5aW9")}, {std::string("asd你好")}},
                         {{std::string("aGVsbG8gd29ybGQ=")}, {std::string("hello world")}},
@@ -518,14 +648,18 @@ TEST(function_string_test, function_from_base64_test) {
                         {{std::string("TVl0ZXN0U1RS")}, {std::string("MYtestSTR")}},
                         {{std::string("w7Imw7g=")}, {std::string("ò&ø")}},
                         {{std::string("ò&ø")}, {Null()}},
-                        {{std::string("你好哈喽")}, {Null()}}};
+                        {{std::string("你好哈喽")}, {Null()}},
+                        {{Null()}, Null()},
+                        {{std::string("😡")}, Null()},
+                        {{std::string("5ZWK5ZOI5ZOI5ZOI8J+YhCDjgILigJTigJQh")},
+                         std::string("啊哈哈哈😄 。——!")}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_reverse_test) {
     std::string func_name = "reverse";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("")}, {std::string("")}},
             {{std::string("a")}, {std::string("a")}},
@@ -535,13 +669,13 @@ TEST(function_string_test, function_reverse_test) {
             {{std::string("A攀c")}, {std::string("c攀A")}},
             {{std::string("NULL")}, {std::string("LLUN")}}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_instr_test) {
     std::string func_name = "instr";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {
             {{STRING("abcdefg"), STRING("efg")}, INT(5)}, {{STRING("aa"), STRING("a")}, INT(1)},
@@ -549,14 +683,14 @@ TEST(function_string_test, function_instr_test) {
             {{STRING("abcdef"), STRING("")}, INT(1)},     {{STRING(""), STRING("")}, INT(1)},
             {{STRING("aaaab"), STRING("bb")}, INT(0)}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_locate_test) {
     std::string func_name = "locate";
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {{{STRING("efg"), STRING("abcdefg")}, INT(5)},
                             {{STRING("a"), STRING("aa")}, INT(1)},
@@ -566,11 +700,11 @@ TEST(function_string_test, function_locate_test) {
                             {{STRING(""), STRING("")}, INT(1)},
                             {{STRING("bb"), STRING("aaaab")}, INT(0)}};
 
-        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {{{STRING("bar"), STRING("foobarbar"), INT(5)}, INT(7)},
                             {{STRING("xbar"), STRING("foobar"), INT(1)}, INT(0)},
@@ -580,14 +714,15 @@ TEST(function_string_test, function_locate_test) {
                             {{STRING("A"), STRING("大A写的A"), INT(2)}, INT(2)},
                             {{STRING("A"), STRING("大A写的A"), INT(3)}, INT(5)}};
 
-        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+        static_cast<void>(
+                check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set));
     }
 }
 
 TEST(function_string_test, function_find_in_set_test) {
     std::string func_name = "find_in_set";
 
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("abcdefg"), std::string("a,b,c")}, 0},
                         {{std::string("aa"), std::string("a,aa,aaa")}, 2},
@@ -597,14 +732,15 @@ TEST(function_string_test, function_find_in_set_test) {
                         {{std::string("a"), std::string("")}, 0},
                         {{std::string(""), std::string(",,")}, 1}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    static_cast<void>(
+            check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set));
 }
 
 TEST(function_string_test, function_md5sum_test) {
     std::string func_name = "md5sum";
 
     {
-        InputTypeSet input_types = {TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd你好")}, {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                 {{std::string("hello world")}, {std::string("5eb63bbbe01eeed093cb22bb8f5acdc3")}},
@@ -615,11 +751,11 @@ TEST(function_string_test, function_md5sum_test) {
                 {{std::string("MYtestSTR")}, {std::string("cd24c90b3fc1192eb1879093029e87d4")}},
                 {{std::string("ò&ø")}, {std::string("fd157b4cb921fa91acc667380184d59c")}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {{{std::string("asd"), std::string("你好")},
                              {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                             {{std::string("hello "), std::string("world")},
@@ -628,11 +764,11 @@ TEST(function_string_test, function_md5sum_test) {
                              {std::string("b8e6e34d1cc3dc76b784ddfdfb7df800")}},
                             {{Null(), std::string("HELLO")}, {Null()}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {{{std::string("a"), std::string("sd"), std::string("你好")},
                              {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                             {{std::string(""), std::string(""), std::string("")},
@@ -641,7 +777,7 @@ TEST(function_string_test, function_md5sum_test) {
                              {std::string("b8e6e34d1cc3dc76b784ddfdfb7df800")}},
                             {{Null(), std::string("HELLO"), Null()}, {Null()}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
@@ -649,7 +785,7 @@ TEST(function_string_test, function_sm3sum_test) {
     std::string func_name = "sm3sum";
 
     {
-        InputTypeSet input_types = {TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -668,11 +804,11 @@ TEST(function_string_test, function_sm3sum_test) {
                  {std::string(
                          "aa47ac31c85aa819d4cc80c932e7900fa26a3073a67aa7eb011bc2ba4924a066")}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd"), std::string("你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -682,11 +818,11 @@ TEST(function_string_test, function_sm3sum_test) {
                  {std::string("1f5866e786ebac9ffed0dbd8f2586e3e99d1d05f7efe7c5915478b57b7423570")}},
                 {{Null(), std::string("HELLO")}, {Null()}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("a"), std::string("sd"), std::string("你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -696,14 +832,14 @@ TEST(function_string_test, function_sm3sum_test) {
                  {std::string("5fc6e38f40b31a659a59e1daba9b68263615f20c02037b419d9deb3509e6b5c6")}},
                 {{Null(), std::string("HELLO"), Null()}, {Null()}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_aes_encrypt_test) {
     std::string func_name = "aes_encrypt";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         const char* mode = "AES_128_ECB";
         const char* key = "doris";
@@ -728,11 +864,11 @@ TEST(function_string_test, function_aes_encrypt_test) {
                             {{std::string(src[5]), std::string(key), std::string(mode)}, Null()},
                             {{Null(), std::string(key), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
         const char* iv = "0123456789abcdef";
         const char* mode = "AES_256_ECB";
         const char* key = "vectorized";
@@ -764,14 +900,14 @@ TEST(function_string_test, function_aes_encrypt_test) {
                  Null()},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_aes_decrypt_test) {
     std::string func_name = "aes_decrypt";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         const char* mode = "AES_128_ECB";
         const char* key = "doris";
@@ -795,11 +931,11 @@ TEST(function_string_test, function_aes_decrypt_test) {
                             {{r[4], std::string(key), std::string(mode)}, std::string(src[4])},
                             {{Null(), std::string(key), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
         const char* mode = "AES_128_OFB";
@@ -828,15 +964,15 @@ TEST(function_string_test, function_aes_decrypt_test) {
                 {{r[4], std::string(key), std::string(iv), std::string(mode)}, std::string(src[4])},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_sm4_encrypt_test) {
     std::string func_name = "sm4_encrypt";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
 
         const char* key = "doris";
         const char* iv = "0123456789abcdef";
@@ -869,12 +1005,12 @@ TEST(function_string_test, function_sm4_encrypt_test) {
                  Null()},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
 
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
@@ -907,15 +1043,15 @@ TEST(function_string_test, function_sm4_encrypt_test) {
                  Null()},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_sm4_decrypt_test) {
     std::string func_name = "sm4_decrypt";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
 
         const char* key = "doris";
         const char* iv = "0123456789abcdef";
@@ -946,12 +1082,12 @@ TEST(function_string_test, function_sm4_decrypt_test) {
                 {{r[4], std::string(key), std::string(iv), std::string(mode)}, std::string(src[4])},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                    TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+                                        TypeIndex::String};
 
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
@@ -982,13 +1118,13 @@ TEST(function_string_test, function_sm4_decrypt_test) {
                 {{r[4], std::string(key), std::string(iv), std::string(mode)}, std::string(src[4])},
                 {{Null(), Null(), std::string(iv), std::string(mode)}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_extract_url_parameter_test) {
     std::string func_name = "extract_url_parameter";
-    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
     DataSet data_set = {
             {{VARCHAR(""), VARCHAR("k1")}, {VARCHAR("")}},
             {{VARCHAR("http://doris.apache.org?k1=aa"), VARCHAR("")}, {VARCHAR("")}},
@@ -1008,14 +1144,14 @@ TEST(function_string_test, function_extract_url_parameter_test) {
             {{VARCHAR("http://doris.apache.org?k1=aa&k2=bb&test=dd#999/"), VARCHAR("test")},
              {VARCHAR("dd")}}};
 
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_parse_url_test) {
     std::string func_name = "parse_url";
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("zhangsan"), std::string("HOST")}, {Null()}},
                 {{std::string("facebook.com/path/p1"), std::string("HOST")}, {Null()}},
@@ -1051,13 +1187,17 @@ TEST(function_string_test, function_parse_url_test) {
                  {std::string("9090")}},
                 {{std::string("http://www.baidu.com/a/b/c?a=b"), std::string("PORT")}, {Null()}},
                 {{std::string("http://fb.com/path/p1.p?q=1#f"), std::string("QUERY")},
-                 {std::string("q=1")}}};
+                 {std::string("q=1")}},
+                {{std::string(
+                          "https://www.facebook.com/aa/bb?returnpage=https://www.facebook.com/"),
+                  std::string("HosT")},
+                 std::string("www.facebook.com")}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("http://fb.com/path/p1.p?q=1#f"), std::string("QUERY"),
                   std::string("q")},
@@ -1071,13 +1211,13 @@ TEST(function_string_test, function_parse_url_test) {
                   std::string("q")},
                  {Null()}}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_hex_test) {
     std::string func_name = "hex";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{Null()}, Null()},
                         {{std::string("0")}, std::string("30")},
                         {{std::string("1")}, std::string("31")},
@@ -1088,12 +1228,12 @@ TEST(function_string_test, function_hex_test) {
                         {{std::string("我")}, std::string("E68891")},
                         {{std::string("?")}, std::string("3F")},
                         {{std::string("？")}, std::string("EFBC9F")}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_unhex_test) {
     std::string func_name = "unhex";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{Null()}, {Null()}},
                         {{std::string("@!#")}, std::string("")},
                         {{std::string("")}, std::string("")},
@@ -1103,45 +1243,46 @@ TEST(function_string_test, function_unhex_test) {
                         {{std::string("41")}, std::string("A")},
                         {{std::string("313233")}, std::string("123")},
                         {{std::string("EFBC9F")}, std::string("？")}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_coalesce_test) {
     std::string func_name = "coalesce";
     {
-        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::Int32, TypeIndex::Int32};
+        BaseInputTypeSet input_types = {TypeIndex::Int32, TypeIndex::Int32, TypeIndex::Int32};
         DataSet data_set = {{{Null(), Null(), (int32_t)1}, {(int32_t)1}},
                             {{Null(), Null(), (int32_t)2}, {(int32_t)2}},
                             {{Null(), Null(), (int32_t)3}, {(int32_t)3}},
                             {{Null(), Null(), (int32_t)4}, {(int32_t)4}}};
-        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+        static_cast<void>(
+                check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set));
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
         DataSet data_set = {
                 {{std::string("qwer"), Null(), (int32_t)1}, {std::string("qwer")}},
                 {{std::string("asdf"), Null(), (int32_t)2}, {std::string("asdf")}},
                 {{std::string("zxcv"), Null(), (int32_t)3}, {std::string("zxcv")}},
                 {{std::string("vbnm"), Null(), (int32_t)4}, {std::string("vbnm")}},
         };
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{Null(), std::string("abc"), std::string("hij")}, {std::string("abc")}},
                 {{Null(), std::string("def"), std::string("klm")}, {std::string("def")}},
                 {{Null(), std::string(""), std::string("xyz")}, {std::string("")}},
                 {{Null(), Null(), std::string("uvw")}, {std::string("uvw")}}};
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_replace) {
     std::string func_name = "replace";
-    InputTypeSet input_types = {
+    BaseInputTypeSet input_types = {
             TypeIndex::String,
             TypeIndex::String,
             TypeIndex::String,
@@ -1152,12 +1293,12 @@ TEST(function_string_test, function_replace) {
                         {{VARCHAR("aaaaa"), VARCHAR("a"), VARCHAR("")}, {VARCHAR("")}},
                         {{VARCHAR("aaaaa"), VARCHAR("aa"), VARCHAR("")}, {VARCHAR("a")}},
                         {{VARCHAR("aaaaa"), VARCHAR("aa"), VARCHAR("a")}, {VARCHAR("aaa")}}};
-    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 TEST(function_string_test, function_bit_length_test) {
     std::string func_name = "bit_length";
-    InputTypeSet input_types = {TypeIndex::String};
+    BaseInputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{{Null()}, {Null()}},
                         {{std::string("@!#")}, 24},
                         {{std::string("")}, 0},
@@ -1167,13 +1308,14 @@ TEST(function_string_test, function_bit_length_test) {
                         {{std::string("hello你好")}, 88},
                         {{std::string("313233")}, 48},
                         {{std::string("EFBC9F")}, 48}};
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    static_cast<void>(
+            check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set));
 }
 
 TEST(function_string_test, function_uuid_test) {
     {
         std::string func_name = "uuid_to_int";
-        InputTypeSet input_types = {TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String};
         uint64_t high = 9572195551486940809ULL;
         uint64_t low = 1759290071393952876ULL;
         __int128 result = (__int128)high * (__int128)10000000000000000000ULL + (__int128)low;
@@ -1183,11 +1325,12 @@ TEST(function_string_test, function_uuid_test) {
                             {{std::string("ffffffff-ffff-ffff-ffff-ffffffffffff")}, (__int128)-1},
                             {{std::string("00000000-0000-0000-0000-000000000000")}, (__int128)0},
                             {{std::string("123")}, Null()}};
-        static_cast<void>(check_function<DataTypeInt128, true>(func_name, input_types, data_set));
+        static_cast<void>(check_function_all_arg_comb<DataTypeInt128, true>(func_name, input_types,
+                                                                            data_set));
     }
     {
         std::string func_name = "int_to_uuid";
-        InputTypeSet input_types = {TypeIndex::Int128};
+        BaseInputTypeSet input_types = {TypeIndex::Int128};
         uint64_t high = 9572195551486940809ULL;
         uint64_t low = 1759290071393952876ULL;
         __int128 value = (__int128)high * (__int128)10000000000000000000ULL + (__int128)low;
@@ -1195,14 +1338,14 @@ TEST(function_string_test, function_uuid_test) {
                             {{value}, std::string("6ce4766f-6783-4b30-b357-bba1c7600348")},
                             {{(__int128)-1}, std::string("ffffffff-ffff-ffff-ffff-ffffffffffff")},
                             {{(__int128)0}, std::string("00000000-0000-0000-0000-000000000000")}};
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 
 TEST(function_string_test, function_strcmp_test) {
     std::string func_name = "strcmp";
     {
-        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {{{Null(), Null()}, Null()},
                             {{std::string(""), std::string("")}, (int8_t)0},
@@ -1217,52 +1360,25 @@ TEST(function_string_test, function_strcmp_test) {
                             {{VARCHAR("test"), VARCHAR("test1")}, (int8_t)-1},
                             {{Null(), VARCHAR("test")}, Null()},
                             {{VARCHAR("test"), Null()}, Null()}};
-        static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
+        static_cast<void>(
+                check_function_all_arg_comb<DataTypeInt8, true>(func_name, input_types, data_set));
     }
-    {
-        InputTypeSet input_types = {Consted {TypeIndex::String}, TypeIndex::String};
-        DataSet data_set = {{{Null(), Null()}, Null()},
-                            {{std::string(""), std::string("")}, (int8_t)0},
-                            {{std::string("test"), std::string("test")}, (int8_t)0},
-                            {{std::string("test1"), std::string("test")}, (int8_t)1},
-                            {{std::string("test"), std::string("test1")}, (int8_t)-1},
-                            {{Null(), std::string("test")}, Null()},
-                            {{std::string("test"), Null()}, Null()},
-                            {{VARCHAR(""), VARCHAR("")}, (int8_t)0},
-                            {{VARCHAR("test"), VARCHAR("test")}, (int8_t)0},
-                            {{VARCHAR("test1"), VARCHAR("test")}, (int8_t)1},
-                            {{VARCHAR("test"), VARCHAR("test1")}, (int8_t)-1},
-                            {{Null(), VARCHAR("test")}, Null()},
-                            {{VARCHAR("test"), Null()}, Null()}};
+}
 
-        for (const auto& line : data_set) {
-            DataSet const_dataset = {line};
-            static_cast<void>(
-                    check_function<DataTypeInt8, true>(func_name, input_types, const_dataset));
-        }
-    }
-    {
-        InputTypeSet input_types = {TypeIndex::String, Consted {TypeIndex::String}};
-        DataSet data_set = {{{Null(), Null()}, Null()},
-                            {{std::string(""), std::string("")}, (int8_t)0},
-                            {{std::string("test"), std::string("test")}, (int8_t)0},
-                            {{std::string("test1"), std::string("test")}, (int8_t)1},
-                            {{std::string("test"), std::string("test1")}, (int8_t)-1},
-                            {{Null(), std::string("test")}, Null()},
-                            {{std::string("test"), Null()}, Null()},
-                            {{VARCHAR(""), VARCHAR("")}, (int8_t)0},
-                            {{VARCHAR("test"), VARCHAR("test")}, (int8_t)0},
-                            {{VARCHAR("test1"), VARCHAR("test")}, (int8_t)1},
-                            {{VARCHAR("test"), VARCHAR("test1")}, (int8_t)-1},
-                            {{Null(), VARCHAR("test")}, Null()},
-                            {{VARCHAR("test"), Null()}, Null()}};
+TEST(function_string_test, function_initcap) {
+    std::string func_name {"initcap"};
 
-        for (const auto& line : data_set) {
-            DataSet const_dataset = {line};
-            static_cast<void>(
-                    check_function<DataTypeInt8, true>(func_name, input_types, const_dataset));
-        }
-    }
+    BaseInputTypeSet input_types = {TypeIndex::String};
+
+    DataSet data_set = {{{std::string("SKJ_ASD_SAD _1A")}, std::string("Skj_Asd_Sad _1a")},
+                        {{std::string("BC'S aaaaA'' 'S")}, std::string("Bc'S Aaaaa'' 'S")},
+                        {{std::string("NULL")}, std::string("Null")},
+                        {{Null()}, Null()},
+                        {{std::string("HELLO, WORLD!")}, std::string("Hello, World!")},
+                        {{std::string("HHHH+-1; asAAss__!")}, std::string("Hhhh+-1; Asaass__!")},
+                        {{std::string("a,B,C,D")}, std::string("A,B,C,D")}};
+
+    check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
 }
 
 } // namespace doris::vectorized

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -38,7 +38,6 @@
 #include "runtime/types.h"
 #include "testutil/any_type.h"
 #include "testutil/function_utils.h"
-#include "testutil/test_util.h"
 #include "udf/udf.h"
 #include "util/bitmap_value.h"
 #include "util/jsonb_utils.h"
@@ -298,10 +297,6 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
     EXPECT_TRUE(column != nullptr);
 
     for (int i = 0; i < row_size; ++i) {
-        // update current line
-        if (row_size > 1) {
-            TestCaseInfo::cur_cast_line = i;
-        }
         auto check_column_data = [&]() {
             if constexpr (std::is_same_v<ReturnType, DataTypeJsonb>) {
                 const auto& expect_data = any_cast<String>(data_set[i].second);
@@ -371,10 +366,8 @@ template <typename ReturnType, bool nullable = false>
 void check_function_all_arg_comb(const std::string& func_name, const BaseInputTypeSet& base_set,
                                  const DataSet& data_set) {
     int arg_cnt = base_set.size();
-    TestCaseInfo::arg_size = arg_cnt;
     // Consider each parameter as a bit, if the j-th bit is 1, the j-th parameter is const; otherwise, it is not.
     for (int i = 0; i < (1 << arg_cnt); i++) {
-        TestCaseInfo::arg_const_info = i, TestCaseInfo::cur_cast_line = -1;
         InputTypeSet input_types {};
         for (int j = 0; j < arg_cnt; j++) {
             if ((1 << j) & i) {
@@ -384,12 +377,9 @@ void check_function_all_arg_comb(const std::string& func_name, const BaseInputTy
             }
         }
 
-        TestCaseInfo::arg_const_info = i, TestCaseInfo::cur_cast_line = -1;
         // exists parameter are const
         if (i != 0) {
-            int cur_case = 0;
             for (const auto& line : data_set) {
-                TestCaseInfo::cur_cast_line = cur_case++;
                 DataSet tmp_set {line};
                 static_cast<void>(check_function<ReturnType, nullable>(func_name, input_types,
                                                                        tmp_set, false));

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -17,11 +17,17 @@
 
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
-#include <stdint.h>
-#include <time.h>
+#include <mysql/mysql.h>
+#include <cstdint>
+#include <ctime>
 
+#include <algorithm>
+#include <concepts>
+#include <format>
 #include <memory>
+#include <span>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -50,6 +56,7 @@
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 #include "vec/functions/simple_function_factory.h"
 
 namespace doris::vectorized {
@@ -354,6 +361,9 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
 
 using BaseInputTypeSet = std::vector<TypeIndex>;
 
+// Each parameter may be decorated with 'const', but each invocation of 'check_function' can only handle one state of the parameters.
+// If there are 'n' parameters, it would require manually calling 'check_function' 2^n times, whereas through this function, only one
+// invocation is needed.
 template <typename ReturnType, bool nullable = false>
 void check_function_all_arg_comb(const std::string& func_name, const BaseInputTypeSet& base_set,
                                  const DataSet& data_set) {
@@ -383,5 +393,4 @@ void check_function_all_arg_comb(const std::string& func_name, const BaseInputTy
         }
     }
 }
-
 } // namespace doris::vectorized

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -18,11 +18,11 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 #include <mysql/mysql.h>
-#include <cstdint>
-#include <ctime>
 
 #include <algorithm>
 #include <concepts>
+#include <cstdint>
+#include <ctime>
 #include <format>
 #include <memory>
 #include <span>

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -23,7 +23,6 @@
 #include <concepts>
 #include <cstdint>
 #include <ctime>
-#include <format>
 #include <memory>
 #include <span>
 #include <string>
@@ -39,6 +38,7 @@
 #include "runtime/types.h"
 #include "testutil/any_type.h"
 #include "testutil/function_utils.h"
+#include "testutil/test_util.h"
 #include "udf/udf.h"
 #include "util/bitmap_value.h"
 #include "util/jsonb_utils.h"
@@ -58,7 +58,6 @@
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/simple_function_factory.h"
-
 namespace doris::vectorized {
 
 class DataTypeJsonb;
@@ -299,6 +298,10 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
     EXPECT_TRUE(column != nullptr);
 
     for (int i = 0; i < row_size; ++i) {
+        // update current line
+        if (row_size > 1) {
+            TestCaseInfo::cur_cast_line = i;
+        }
         auto check_column_data = [&]() {
             if constexpr (std::is_same_v<ReturnType, DataTypeJsonb>) {
                 const auto& expect_data = any_cast<String>(data_set[i].second);
@@ -368,9 +371,10 @@ template <typename ReturnType, bool nullable = false>
 void check_function_all_arg_comb(const std::string& func_name, const BaseInputTypeSet& base_set,
                                  const DataSet& data_set) {
     int arg_cnt = base_set.size();
-
+    TestCaseInfo::arg_size = arg_cnt;
     // Consider each parameter as a bit, if the j-th bit is 1, the j-th parameter is const; otherwise, it is not.
     for (int i = 0; i < (1 << arg_cnt); i++) {
+        TestCaseInfo::arg_const_info = i, TestCaseInfo::cur_cast_line = -1;
         InputTypeSet input_types {};
         for (int j = 0; j < arg_cnt; j++) {
             if ((1 << j) & i) {
@@ -380,12 +384,15 @@ void check_function_all_arg_comb(const std::string& func_name, const BaseInputTy
             }
         }
 
+        TestCaseInfo::arg_const_info = i, TestCaseInfo::cur_cast_line = -1;
         // exists parameter are const
         if (i != 0) {
+            int cur_case = 0;
             for (const auto& line : data_set) {
+                TestCaseInfo::cur_cast_line = cur_case++;
                 DataSet tmp_set {line};
-                static_cast<void>(
-                        check_function<ReturnType, nullable>(func_name, input_types, tmp_set));
+                static_cast<void>(check_function<ReturnType, nullable>(func_name, input_types,
+                                                                       tmp_set, false));
             }
         } else {
             static_cast<void>(


### PR DESCRIPTION
## Proposed changes

"When conducting unit testing, when function parameters require arg1, arg2, we may need to consider all scenarios such as (const arg1, arg2) or (arg1, const arg2), etc., to sequentially execute check_function(func_name, input_type, data_set). Now, with the new function, passing an input_type without any parameters marked as const suffices to automatically execute all scenarios."

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

