### PR TITLE
[Improve](config)The stream_load label length is changed to a configurable

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2724,6 +2724,11 @@ public class Config extends ConfigBase {
             + "for example: jdbc_driver_url_white_list=a,b,c"
     })
     public static String[] jdbc_driver_url_white_list = {};
+
+    @ConfField(description = {"Stream_Load 导入时，label 被限制的最大长度",
+            "Stream_Load When importing, the maximum length of label is limited"})
+    public static int label_regex_length = 128;
+
     //==========================================================================
     //                      end of cloud config
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -29,7 +29,7 @@ import org.apache.doris.qe.VariableMgr;
 import com.google.common.base.Strings;
 
 public class FeNameFormat {
-    private static final String LABEL_REGEX = "^[-_A-Za-z0-9:]{1,128}$";
+    private static final String LABEL_REGEX = "^[-_A-Za-z0-9:]{1," + Config.label_regex_length + "}$";
     private static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]{0,63}$";
     private static final String UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z][a-zA-Z0-9-_]{0,63}$";
     private static final String TABLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]*$";


### PR DESCRIPTION
## Proposed changes
When importing using stream load, the length of the label may exceed the default 128 character limit.
You can change the label length by configuring `label_regex_length`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

