### PR TITLE
[enhancement](auditlog) ignore any errors in write audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -31,13 +31,29 @@ import org.apache.doris.plugin.audit.AuditEvent.AuditEventBuilder;
 import org.apache.doris.plugin.audit.AuditEvent.EventType;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.service.FrontendOptions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Strings;
 import org.apache.commons.codec.digest.DigestUtils;
 
 public class AuditLogHelper {
 
+    private static final Logger LOG = LogManager.getLogger(AuditLogHelper.class);
+
+    // Add a new method to wrap original logAuditLog to catch all exceptions. Because write audit
+    // log may write to a doris internal table, we may meet errors. We do not want this affect the
+    // query process. Ignore this error and just write warning log.
     public static void logAuditLog(ConnectContext ctx, String origStmt, StatementBase parsedStmt,
+            org.apache.doris.proto.Data.PQueryStatistics statistics, boolean printFuzzyVariables) {
+        try {
+            logAuditLogImpl(ctx, origStmt, parsedStmt, statistics, printFuzzyVariables);
+        } catch (Throwable t) {
+            LOG.warn("Failed to write audit log.", t);
+        }
+    }
+
+    private static void logAuditLogImpl(ConnectContext ctx, String origStmt, StatementBase parsedStmt,
             org.apache.doris.proto.Data.PQueryStatistics statistics, boolean printFuzzyVariables) {
         origStmt = origStmt.replace("\n", " ");
         // slow query

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -31,11 +31,11 @@ import org.apache.doris.plugin.audit.AuditEvent.AuditEventBuilder;
 import org.apache.doris.plugin.audit.AuditEvent.EventType;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.service.FrontendOptions;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Strings;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AuditLogHelper {
 


### PR DESCRIPTION
## Proposed changes

Add a new method to wrap original logAuditLog to catch all exceptions. Because write audit
 log may write to a doris internal table, we may meet errors. We do not want this affect the
query process. Ignore this error and just write warning log.

like this error. https://ask.selectdb.com/questions/D1at/yi-ji-lu-ying-yong-jdbc-lian-jie-doris-ou-fa-bao-cuo-ying-yong-ri-zhi-caused-by-java-sql-sqlexception-nullpointerexception-msg-null
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

