### PR TITLE
[fix](memory) Fix PODArray allocated_bytes

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -225,7 +225,12 @@ public:
     size_t capacity() const { return (c_end_of_storage - c_start) / ELEMENT_SIZE; }
 
     /// This method is safe to use only for information about memory usage.
-    size_t allocated_bytes() const { return c_end_of_storage - c_start + pad_right + pad_left; }
+    size_t allocated_bytes() const {
+        if (c_end_of_storage == null) {
+            return 0;
+        }
+        return c_end_of_storage - c_start + pad_right + pad_left;
+    }
 
     void clear() { c_end = c_start; }
 
@@ -489,6 +494,9 @@ public:
     }
 
     void swap(PODArray& rhs) {
+        DCHECK(this->pad_left == rhs.pad_left && this->pad_right == rhs.pad_right)
+                << ", this.pad_left: " << this->pad_left << ", rhs.pad_left: " << rhs.pad_left
+                << ", this.pad_right: " << this->pad_right << ", rhs.pad_right: " << rhs.pad_right;
 #ifndef NDEBUG
         this->unprotect();
         rhs.unprotect();


### PR DESCRIPTION
## Proposed changes

if c_end_of_storage == null,  allocated_bytes return 0.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

