### PR TITLE
[Improvement](executor)Refactor Workload group memory GC

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1121,6 +1121,8 @@ DEFINE_Bool(enable_flush_file_cache_async, "true");
 DEFINE_mString(doris_cgroup_cpu_path, "");
 DEFINE_mBool(enable_cgroup_cpu_soft_limit, "true");
 
+DEFINE_mBool(enable_workload_group_memory_gc, "true");
+
 DEFINE_Bool(ignore_always_true_predicate_for_segment, "true");
 
 // Dir of default timezone files

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1200,6 +1200,8 @@ DECLARE_mBool(exit_on_exception);
 DECLARE_mString(doris_cgroup_cpu_path);
 DECLARE_mBool(enable_cgroup_cpu_soft_limit);
 
+DECLARE_mBool(enable_workload_group_memory_gc);
+
 // This config controls whether the s3 file writer would flush cache asynchronously
 DECLARE_Bool(enable_flush_file_cache_async);
 

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -142,18 +142,42 @@ void WorkloadGroup::remove_mem_tracker_limiter(std::shared_ptr<MemTrackerLimiter
     }
 }
 
-int64_t WorkloadGroup::gc_memory(int64_t need_free_mem, RuntimeProfile* profile) {
+int64_t WorkloadGroup::gc_memory(int64_t need_free_mem, RuntimeProfile* profile, bool is_minor_gc) {
     if (need_free_mem <= 0) {
         return 0;
     }
     int64_t used_memory = memory_used();
     int64_t freed_mem = 0;
 
-    std::string cancel_str = fmt::format(
-            "work load group memory exceeded limit, group id:{}, name:{}, used:{}, limit:{}, "
-            "backend:{}.",
-            _id, _name, MemTracker::print_bytes(used_memory),
-            MemTracker::print_bytes(_memory_limit), BackendOptions::get_localhost());
+    std::string cancel_str = "";
+    if (is_minor_gc) {
+        cancel_str = fmt::format(
+                "try cancel memory overcommit query in workload group when MinorGC happens, group "
+                "id:{}, "
+                "name:{}, used:{}, limit:{}, "
+                "backend:{}.",
+                _id, _name, MemTracker::print_bytes(used_memory),
+                MemTracker::print_bytes(_memory_limit), BackendOptions::get_localhost());
+    } else {
+        if (_enable_memory_overcommit) {
+            cancel_str = fmt::format(
+                    "workload group release overcommit memory when FullGC happens which means sys "
+                    "memory is not enough, group id:{}, "
+                    "name:{}, used:{}, "
+                    "limit:{}, "
+                    "backend:{}.",
+                    _id, _name, MemTracker::print_bytes(used_memory),
+                    MemTracker::print_bytes(_memory_limit), BackendOptions::get_localhost());
+        } else {
+            cancel_str = fmt::format(
+                    "memory hard limit workload group release overcommit memory, group id:{}, "
+                    "name:{}, used:{}, "
+                    "limit:{}, "
+                    "backend:{}.",
+                    _id, _name, MemTracker::print_bytes(used_memory),
+                    MemTracker::print_bytes(_memory_limit), BackendOptions::get_localhost());
+        }
+    }
     auto cancel_top_overcommit_str = [cancel_str](int64_t mem_consumption,
                                                   const std::string& label) {
         return fmt::format(
@@ -188,7 +212,8 @@ int64_t WorkloadGroup::gc_memory(int64_t need_free_mem, RuntimeProfile* profile)
                 _mem_tracker_limiter_pool, cancel_top_overcommit_str, tmq_profile,
                 MemTrackerLimiter::GCType::WORK_LOAD_GROUP);
     }
-    if (freed_mem >= need_free_mem) {
+    // To be compatible with the non-group's gc logic, minorGC just gc overcommit query
+    if (is_minor_gc || freed_mem >= need_free_mem) {
         return freed_mem;
     }
 

--- a/be/src/runtime/workload_group/workload_group.h
+++ b/be/src/runtime/workload_group/workload_group.h
@@ -141,7 +141,7 @@ public:
         return _query_ctxs.size();
     }
 
-    int64_t gc_memory(int64_t need_free_mem, RuntimeProfile* profile);
+    int64_t gc_memory(int64_t need_free_mem, RuntimeProfile* profile, bool is_minor_gc);
 
     void upsert_task_scheduler(WorkloadGroupInfo* tg_info, ExecEnv* exec_env);
 

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -195,7 +195,7 @@ public:
 
     static int64_t tg_not_enable_overcommit_group_gc();
     static int64_t tg_enable_overcommit_group_gc(int64_t request_free_memory,
-                                                 RuntimeProfile* profile);
+                                                 RuntimeProfile* profile, bool is_minor_gc);
 
     // It is only used after the memory limit is exceeded. When multiple threads are waiting for the available memory of the process,
     // avoid multiple threads starting at the same time and causing OOM.


### PR DESCRIPTION
## Proposed changes
Currently when ```Minor GC``` happens, workload group must kill some query to release memory, when Doris upgrade from 2.0 to 2.1 or enable_workload_group, this may cause some query failed which they should success before.
```Minor GC``` is used to reduce the risk of OOM, if origin ```Minor GC``` runs stably, add a workload group gc here is meaningless.

On the contrary, when ```Full GC``` happens, workload group gc first is necessary, because if GC group's overcommit memory can release enough memory, then we can avoid undifferentiated kill query,  this is the purpose of the workload group.
That means if a workload group's query not exceeds group's memory, it can avoid cancel query even ```Full GC``` happens.

## LOG change
### hard limit
```
mysql [hits]>SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(length(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CANCELLED]memory hard limit workload group release overcommit memory, group id:70066, name:test_group, used:699.57 MB, limit:692.70 MB, backend:127.0.0.1. cancel top memory used tracker <Query#Id=736497b7383040d4-bd8ac8c5a1973b34> consumption 699.57 MB. execute again after enough memory, details see be.INFO.

```


### minor GC
```
mysql [hits]>SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(length(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CANCELLED]try cancel memory overcommit query in workload group when MinorGC happens, group id:70066, name:test_group, used:1.10 GB, limit:34.63 MB, backend:127.0.0.1. cancel top memory overcommit tracker <Query#Id=a7abb4ba380c4ea3-b68d3d49bff282ab> consumption 527.02 MB. execute again after enough memory, details see be.INFO.
```