### PR TITLE
[bugfix](hive)delete write path after hive insert

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertCommandContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertCommandContext.java
@@ -22,6 +22,8 @@ package org.apache.doris.nereids.trees.plans.commands.insert;
  */
 public class HiveInsertCommandContext extends InsertCommandContext {
     private boolean overwrite = false;
+    private String writePath;
+    private String queryId;
 
     public boolean isOverwrite() {
         return overwrite;
@@ -29,5 +31,21 @@ public class HiveInsertCommandContext extends InsertCommandContext {
 
     public void setOverwrite(boolean overwrite) {
         this.overwrite = overwrite;
+    }
+
+    public String getWritePath() {
+        return writePath;
+    }
+
+    public void setWritePath(String writePath) {
+        this.writePath = writePath;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertExecutor.java
@@ -35,10 +35,12 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionManager;
 import org.apache.doris.transaction.TransactionStatus;
 import org.apache.doris.transaction.TransactionType;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -97,6 +99,13 @@ public class HiveInsertExecutor extends AbstractInsertExecutor {
     @Override
     protected void beforeExec() {
         // check params
+        HMSTransaction transaction = (HMSTransaction) transactionManager.getTransaction(txnId);
+        Preconditions.checkArgument(insertCtx.isPresent(), "insert context must be present");
+        HiveInsertCommandContext ctx = (HiveInsertCommandContext) insertCtx.get();
+        TUniqueId tUniqueId = ConnectContext.get().queryId();
+        Preconditions.checkArgument(tUniqueId != null, "query id shouldn't be null");
+        ctx.setQueryId(DebugUtil.printId(tUniqueId));
+        transaction.beginInsertTable(ctx);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -173,7 +173,8 @@ public class InsertIntoTableCommand extends Command implements ForwardWithSync, 
                         .setEnableMemtableOnSinkNode(isEnableMemtableOnSinkNode);
             } else if (physicalSink instanceof PhysicalHiveTableSink) {
                 HMSExternalTable hiveExternalTable = (HMSExternalTable) targetTableIf;
-                insertExecutor = new HiveInsertExecutor(ctx, hiveExternalTable, label, planner, insertCtx);
+                insertExecutor = new HiveInsertExecutor(ctx, hiveExternalTable, label, planner,
+                        Optional.of(insertCtx.orElse((new HiveInsertCommandContext()))));
                 // set hive query options
             } else {
                 // TODO: support other table types

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
@@ -141,6 +141,7 @@ public class HiveTableSink extends DataSink {
         if (insertCtx.isPresent()) {
             HiveInsertCommandContext context = (HiveInsertCommandContext) insertCtx.get();
             tSink.setOverwrite(context.isOverwrite());
+            context.setWritePath(writeTempPath);
         }
         tDataSink = new TDataSink(getDataSinkType());
         tDataSink.setHiveTableSink(tSink);


### PR DESCRIPTION
## Proposed changes

Issue #31442

1. delete file according query id
2. delete write path after insert

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

