### PR TITLE
[exec](table_fun) opt numbers table func performance

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_numbers.h
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.h
@@ -28,11 +28,9 @@
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/table_function/table_function.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
 class Block;
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized
 
 namespace doris::vectorized {
 
@@ -48,8 +46,8 @@ public:
     void process_close() override;
     void get_value(MutableColumnPtr& column) override;
     int get_value(MutableColumnPtr& column, int max_step) override {
+        max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
         if (_is_const) {
-            max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
             if (_is_nullable) {
                 static_cast<ColumnInt32*>(
                         static_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
@@ -61,12 +59,24 @@ public:
                 static_cast<ColumnInt32*>(column.get())
                         ->insert_range_from(*_elements_column, _cur_offset, max_step);
             }
-
-            forward(max_step);
-            return max_step;
+        } else {
+            ColumnInt32* target = nullptr;
+            if (_is_nullable) {
+                target = assert_cast<ColumnInt32*>(
+                        assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get());
+                assert_cast<ColumnUInt8*>(
+                        assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
+                        ->insert_many_defaults(max_step);
+            } else {
+                target = assert_cast<ColumnInt32*>(column.get());
+            }
+            auto origin_size = target->size();
+            target->resize(origin_size + max_step);
+            std::iota(target->get_data().data() + origin_size,
+                      target->get_data().data() + origin_size + max_step, _cur_offset);
         }
-
-        return TableFunction::get_value(column, max_step);
+        forward(max_step);
+        return max_step;
     }
 
 private:


### PR DESCRIPTION
## Proposed changes

before：
```
[tpch]>select count(e1) from (select 1 as k1) as t lateral view explode_numbers(1000000000) tmp1 as e1;
+------------+
| count(e1)  |
+------------+
| 1000000000 |
+------------+
1 row in set (5.60 sec)
```

after：
```
[tpch]>select count(e1) from (select 1 as k1) as t lateral view explode_numbers(1000000000) tmp1 as e1;
+------------+
| count(e1)  |
+------------+
| 1000000000 |
+------------+
1 row in set (0.60 sec)
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

