### PR TITLE
[fix](fs) Fix BE UT(macOS) compile error to use hdfsSync instead of h…

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -60,7 +60,7 @@ Status HdfsFileWriter::close() {
     _closed = true;
 
     if (_sync_file_data) {
-        int ret = hdfsHSync(_hdfs_handler->hdfs_fs, _hdfs_file);
+        int ret = hdfsSync(_hdfs_handler->hdfs_fs, _hdfs_file);
         if (ret != 0) {
             return Status::InternalError("failed to sync hdfs file. fs_name={} path={} : {}",
                                          _fs_name, _path.native(), hdfs_error());


### PR DESCRIPTION
…dfsHSync

## Proposed changes
change from hdfsHSync to hdfsSync

PR #33680 makes BE UT(macOS) fails here：
[BE UT (macOS)](https://github.com/apache/doris/actions/runs/8720549173/job/23926149116?pr=33792#logs)
/Users/runner/work/doris/doris/be/src/io/fs/hdfs_file_writer.cpp:63:19: error: use of undeclared identifier 'hdfsHSync'; did you mean 'hdfsSync'?
        int ret = hdfsHSync(_hdfs_handler->hdfs_fs, _hdfs_file);
                  ^~~~~~~~~
                  hdfsSync
/Users/runner/work/doris/doris/thirdparty/installed/include/hdfs/hdfs.h:404:5: note: 'hdfsSync' declared here

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

