### PR TITLE
[feature](proc)Add table's indexes info in show proc interface (#33438)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowIndexStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowIndexStmt.java
@@ -47,7 +47,6 @@ public class ShowIndexStmt extends ShowStmt {
                     .addColumn(new Column("Index_type", ScalarType.createVarchar(80)))
                     .addColumn(new Column("Comment", ScalarType.createVarchar(80)))
                     .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("Index_id", ScalarType.createVarchar(30)))
                     .build();
     private String dbName;
     private TableName tableName;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexesProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexesProcNode.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.catalog.Index;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Arrays;
+import java.util.List;
+
+/*
+ * SHOW PROC /dbs/dbId/tableId/indexes
+ * show indexes' detail info within a table
+ */
+public class IndexesProcNode implements ProcNodeInterface {
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("Table").add("IndexId")
+            .add("NonUnique").add("KeyName")
+            .add("SeqInIndex").add("ColumnName").add("Collation").add("Cardinality")
+            .add("SubPart").add("Packed").add("Null").add("IndexType").add("Comment")
+            .add("Properties").build();
+
+    private TableIf table;
+
+    public IndexesProcNode(TableIf table) {
+        this.table = table;
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        Preconditions.checkNotNull(table);
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+
+        if (table instanceof OlapTable) {
+            table.readLock();
+            try {
+                List<Index> indexes = ((OlapTable) table).getIndexes();
+                for (Index index : indexes) {
+                    List<String> rowList = Arrays.asList(table.getName(),
+                            String.valueOf(index.getIndexId()),
+                            "",
+                            index.getIndexName(),
+                            "",
+                            String.join(",", index.getColumns()),
+                            "", "", "", "", "",
+                            index.getIndexType().name(),
+                            index.getComment(),
+                            index.getPropertiesString());
+                    result.addRow(rowList);
+                }
+            } finally {
+                table.readUnlock();
+            }
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TableProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TableProcDir.java
@@ -40,9 +40,11 @@ public class TableProcDir implements ProcDirInterface {
     public static final String INDEX_SCHEMA = "index_schema";
     private static final String PARTITIONS = "partitions";
     private static final String TEMP_PARTITIONS = "temp_partitions";
+    private static final String INDEXES = "indexes";
 
     private static final ImmutableList<String> CHILDREN_NODES =
-            new ImmutableList.Builder<String>().add(PARTITIONS).add(TEMP_PARTITIONS).add(INDEX_SCHEMA).build();
+            new ImmutableList.Builder<String>().add(PARTITIONS).add(TEMP_PARTITIONS).add(INDEX_SCHEMA)
+                    .add(INDEXES).build();
 
     private DatabaseIf db;
     private TableIf table;
@@ -93,6 +95,8 @@ public class TableProcDir implements ProcDirInterface {
             }
         } else if (entryName.equals(INDEX_SCHEMA)) {
             return new IndexInfoProcDir(db, table);
+        } else if (entryName.equals(INDEXES)) {
+            return new IndexesProcNode(table);
         } else {
             throw new AnalysisException("Not implemented yet: " + entryName);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1113,8 +1113,7 @@ public class ShowExecutor {
             for (Index index : indexes) {
                 rows.add(Lists.newArrayList(showStmt.getTableName().toString(), "", index.getIndexName(),
                         "", String.join(",", index.getColumns()), "", "", "", "",
-                        "", index.getIndexType().name(), index.getComment(), index.getPropertiesString(),
-                        String.valueOf(index.getIndexId())));
+                        "", index.getIndexType().name(), index.getComment(), index.getPropertiesString()));
             }
         } finally {
             table.readUnlock();

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.analysis.IndexDef.IndexType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.HashDistributionInfo;
+import org.apache.doris.catalog.Index;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.TableIndexes;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IndexesProcNodeTest {
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        List<Index> indexes = new ArrayList<>();
+        Index indexBitmap = new Index(1, "bitmap_index", Lists.newArrayList("col_1"),
+                IndexType.BITMAP, null, "bitmap index on col_1");
+        Map<String, String> invertedProperties = new HashMap<>();
+        invertedProperties.put("parser", "unicode");
+        Index indexInverted = new Index(2, "inverted_index", Lists.newArrayList("col_2"),
+                        IndexType.INVERTED, invertedProperties, "inverted index on col_2");
+        Index indexBf = new Index(3, "bloomfilter_index", Lists.newArrayList("col_3"),
+                IndexType.BLOOMFILTER, null, "bloomfilter index on col_3");
+        Map<String, String> ngramProperties = new HashMap<>();
+        ngramProperties.put("gram_size", "3");
+        ngramProperties.put("bf_size", "256");
+        Index indexNgramBf = new Index(4, "ngram_bf_index", Lists.newArrayList("col_4"),
+                        IndexType.NGRAM_BF, ngramProperties, "ngram_bf index on col_4");
+        indexes.add(indexBitmap);
+        indexes.add(indexInverted);
+        indexes.add(indexBf);
+        indexes.add(indexNgramBf);
+
+        OlapTable table = new OlapTable(1, "tbl_test_indexes_proc", Lists.newArrayList(new Column()), KeysType.DUP_KEYS, new PartitionInfo(),
+                new HashDistributionInfo(), new TableIndexes(indexes));
+
+        IndexesProcNode indexesProcNode = new IndexesProcNode(table);
+        ProcResult procResult = indexesProcNode.fetchResult();
+
+        Assert.assertEquals(4, procResult.getRows().size());
+        Assert.assertEquals(procResult.getRows().get(0).get(0), "tbl_test_indexes_proc");
+        Assert.assertEquals(procResult.getRows().get(0).get(1), "1");
+        Assert.assertEquals(procResult.getRows().get(0).get(3), "bitmap_index");
+        Assert.assertEquals(procResult.getRows().get(0).get(5), "col_1");
+        Assert.assertEquals(procResult.getRows().get(0).get(11), "BITMAP");
+        Assert.assertEquals(procResult.getRows().get(0).get(12), "bitmap index on col_1");
+        Assert.assertEquals(procResult.getRows().get(0).get(13), "");
+
+        Assert.assertEquals(procResult.getRows().get(1).get(0), "tbl_test_indexes_proc");
+        Assert.assertEquals(procResult.getRows().get(1).get(1), "2");
+        Assert.assertEquals(procResult.getRows().get(1).get(3), "inverted_index");
+        Assert.assertEquals(procResult.getRows().get(1).get(5), "col_2");
+        Assert.assertEquals(procResult.getRows().get(1).get(11), "INVERTED");
+        Assert.assertEquals(procResult.getRows().get(1).get(12), "inverted index on col_2");
+        Assert.assertEquals(procResult.getRows().get(1).get(13), "(\"parser\" = \"unicode\")");
+
+        Assert.assertEquals(procResult.getRows().get(2).get(0), "tbl_test_indexes_proc");
+        Assert.assertEquals(procResult.getRows().get(2).get(1), "3");
+        Assert.assertEquals(procResult.getRows().get(2).get(3), "bloomfilter_index");
+        Assert.assertEquals(procResult.getRows().get(2).get(5), "col_3");
+        Assert.assertEquals(procResult.getRows().get(2).get(11), "BLOOMFILTER");
+        Assert.assertEquals(procResult.getRows().get(2).get(12), "bloomfilter index on col_3");
+        Assert.assertEquals(procResult.getRows().get(2).get(13), "");
+
+        Assert.assertEquals(procResult.getRows().get(3).get(0), "tbl_test_indexes_proc");
+        Assert.assertEquals(procResult.getRows().get(3).get(1), "4");
+        Assert.assertEquals(procResult.getRows().get(3).get(3), "ngram_bf_index");
+        Assert.assertEquals(procResult.getRows().get(3).get(5), "col_4");
+        Assert.assertEquals(procResult.getRows().get(3).get(11), "NGRAM_BF");
+        Assert.assertEquals(procResult.getRows().get(3).get(12), "ngram_bf index on col_4");
+        Assert.assertEquals(procResult.getRows().get(3).get(13), "(\"gram_size\" = \"3\", \"bf_size\" = \"256\")");
+
+    }
+}


### PR DESCRIPTION
1. Add show proc `/dbs/db_id/table_id/indexes` impl
2. Remove index_id in `show index from table`
3. Add test cases

---------

pick #33438 

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

