### PR TITLE
[fix](schema change) fix schema change check does not calculate reader merged rows

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1206,6 +1206,8 @@ DEFINE_Bool(enable_index_compaction, "false");
 // enable injection point in regression-test
 DEFINE_mBool(enable_injection_point, "false");
 
+DEFINE_mBool(ignore_schema_change_check, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1293,6 +1293,8 @@ DECLARE_mInt32(thrift_client_open_num_tries);
 // enable injection point in regression-test
 DECLARE_mBool(enable_injection_point);
 
+DECLARE_mBool(ignore_schema_change_check);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -306,6 +306,9 @@ Status BetaRowsetReader::_init_iterator() {
     std::vector<RowwiseIteratorUPtr> iterators;
     RETURN_IF_ERROR(get_segment_iterators(_read_context, &iterators));
 
+    if (_read_context->merged_rows == nullptr) {
+        _read_context->merged_rows = &_merged_rows;
+    }
     // merge or union segment iterator
     if (_is_merge_iterator()) {
         auto sequence_loc = -1;
@@ -316,9 +319,6 @@ Status BetaRowsetReader::_init_iterator() {
                     break;
                 }
             }
-        }
-        if (_read_context->merged_rows == nullptr) {
-            _read_context->merged_rows = &_merged_rows;
         }
         _iterator = vectorized::new_merge_iterator(
                 std::move(iterators), sequence_loc, _read_context->is_unique,

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -317,6 +317,9 @@ Status BetaRowsetReader::_init_iterator() {
                 }
             }
         }
+        if (_read_context->merged_rows == nullptr) {
+            _read_context->merged_rows = &_merged_rows;
+        }
         _iterator = vectorized::new_merge_iterator(
                 std::move(iterators), sequence_loc, _read_context->is_unique,
                 _read_context->read_orderby_key_reverse, _read_context->merged_rows);

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -72,6 +72,10 @@ public:
                _stats->rows_vec_cond_filtered + _stats->rows_short_circuit_cond_filtered;
     }
 
+    uint64_t merged_rows() override {
+        return *(_read_context->merged_rows);
+    }
+
     RowsetTypePB type() const override { return RowsetTypePB::BETA_ROWSET; }
 
     Status current_block_row_locations(std::vector<RowLocation>* locations) override {
@@ -126,6 +130,7 @@ private:
 
     bool _empty = false;
     size_t _topn_limit = 0;
+    uint64_t _merged_rows = 0;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -72,9 +72,7 @@ public:
                _stats->rows_vec_cond_filtered + _stats->rows_short_circuit_cond_filtered;
     }
 
-    uint64_t merged_rows() override {
-        return *(_read_context->merged_rows);
-    }
+    uint64_t merged_rows() override { return *(_read_context->merged_rows); }
 
     RowsetTypePB type() const override { return RowsetTypePB::BETA_ROWSET; }
 

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -74,6 +74,8 @@ public:
 
     virtual int64_t filtered_rows() = 0;
 
+    virtual uint64_t merged_rows() = 0;
+
     virtual RowsetTypePB type() const = 0;
 
     virtual int64_t newest_write_timestamp() = 0;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -126,8 +126,11 @@ public:
         }
 
         LOG(INFO) << "all row nums. source_rows=" << rowset_reader->rowset()->num_rows()
+                  << ", source_filtered_rows=" << rowset_reader->filtered_rows()
+                  << ", source_merged_rows=" << rowset_reader->merged_rows()
                   << ", merged_rows=" << merged_rows() << ", filtered_rows=" << filtered_rows()
-                  << ", new_index_rows=" << rowset_writer->num_rows();
+                  << ", new_index_rows=" << rowset_writer->num_rows()
+                  << ", writer_filtered_rows=" << rowset_writer->num_rows_filtered();
         return Status::OK();
     }
 
@@ -147,16 +150,19 @@ protected:
     }
 
     virtual bool _check_row_nums(RowsetReaderSharedPtr reader, const RowsetWriter& writer) const {
-        if (reader->rowset()->num_rows() - reader->filtered_rows() !=
+        if (reader->rowset()->num_rows() - reader->filtered_rows() - reader->merged_rows() !=
             writer.num_rows() + writer.num_rows_filtered() + _merged_rows + _filtered_rows) {
             LOG(WARNING) << "fail to check row num! "
                          << "source_rows=" << reader->rowset()->num_rows()
                          << ", source_filtered_rows=" << reader->filtered_rows()
+                         << ", source_merged_rows=" << reader->merged_rows()
                          << ", written_rows=" << writer.num_rows()
                          << ", writer_filtered_rows=" << writer.num_rows_filtered()
                          << ", merged_rows=" << merged_rows()
                          << ", filtered_rows=" << filtered_rows();
-            return false;
+            if (!config::ignore_schema_change_check) {
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
### 1 bugfix
In the unique table, when there are multiple segments in a rowset and the same key exists in different segments, reading the rowset will merge these same keys. However, during schema change check, these merged keys are not calculated. May cause schema change check to fail
### 2 add config
Add configuration to ignore schema change verification results

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

