### PR TITLE
[bugfix](paimon) Create paimon catalog with hadoop user

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -120,13 +120,15 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     }
 
     protected Catalog createCatalog() {
-        Options options = new Options();
-        Map<String, String> paimonOptionsMap = getPaimonOptionsMap();
-        for (Map.Entry<String, String> kv : paimonOptionsMap.entrySet()) {
-            options.set(kv.getKey(), kv.getValue());
-        }
-        CatalogContext context = CatalogContext.create(options, getConfiguration());
-        return createCatalogImpl(context);
+        return HadoopUGI.ugiDoAs(authConf, () -> {
+            Options options = new Options();
+            Map<String, String> paimonOptionsMap = getPaimonOptionsMap();
+            for (Map.Entry<String, String> kv : paimonOptionsMap.entrySet()) {
+                options.set(kv.getKey(), kv.getValue());
+            }
+            CatalogContext context = CatalogContext.create(options, getConfiguration());
+            return createCatalogImpl(context);
+        });
     }
 
     protected Catalog createCatalogImpl(CatalogContext context) {


### PR DESCRIPTION
## Proposed changes

When creating a catalog, paimon will create a warehouse on HDFS, so we need to use the corresponding user with permissions to create it.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

