### PR TITLE
[fix](compile) fix two compile errors on MacOS

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -60,7 +60,11 @@ Status HdfsFileWriter::close() {
     _closed = true;
 
     if (_sync_file_data) {
+#ifdef USE_LIBHDFS3
+        int ret = hdfsSync(_hdfs_handler->hdfs_fs, _hdfs_file);
+#else
         int ret = hdfsHSync(_hdfs_handler->hdfs_fs, _hdfs_file);
+#endif
         if (ret != 0) {
             return Status::InternalError("failed to sync hdfs file. fs_name={} path={} : {}",
                                          _fs_name, _path.native(), hdfs_error());

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -256,11 +256,11 @@ public:
         read_pod_binary(is_set_contains_null, buf);
         data.value->change_contains_null_value(is_set_contains_null);
         read_pod_binary(data.init, buf);
-        size_t size;
+        UInt64 size;
         read_var_uint(size, buf);
 
         T element;
-        for (size_t i = 0; i < size; ++i) {
+        for (UInt64 i = 0; i < size; ++i) {
             read_int_binary(element, buf);
             data.value->insert(static_cast<void*>(&element));
         }
@@ -484,11 +484,11 @@ public:
         read_pod_binary(is_set_contains_null, buf);
         data.value->change_contains_null_value(is_set_contains_null);
         read_pod_binary(data.init, buf);
-        size_t size;
+        UInt64 size;
         read_var_uint(size, buf);
 
         StringRef element;
-        for (size_t i = 0; i < size; ++i) {
+        for (UInt64 i = 0; i < size; ++i) {
             element = read_string_binary_into(*arena, buf);
             data.value->insert((void*)element.data, element.size);
         }


### PR DESCRIPTION
1. MacOS use libhdfs3, so we need call different function. 
    this compile error intro by PR #33680

2. size_t is not UInt64 on MacOS.
    this compile error intro by PR #33265



