### PR TITLE
[fix](statistics)Improve analyze timeout logic.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -867,7 +867,7 @@ public class AnalysisManager implements Writable {
                 executor.submit(() -> {
                     try {
                         if (cancelled) {
-                            errorMessages.add("Query timeout or user cancelled."
+                            errorMessages.add("Query Timeout or user Cancelled."
                                     + "Could set analyze_timeout to a bigger value.");
                             return;
                         }
@@ -890,7 +890,7 @@ public class AnalysisManager implements Writable {
             }
             if (!colNames.isEmpty()) {
                 if (cancelled) {
-                    throw new RuntimeException("Cancelled");
+                    throw new RuntimeException("User Cancelled or Timeout.");
                 }
                 throw new RuntimeException("Failed to analyze following columns:[" + String.join(",", colNames)
                         + "] Reasons: " + String.join(",", errorMessages));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
@@ -56,6 +56,9 @@ public class ExternalAnalysisTask extends BaseAnalysisTask {
     }
 
     public void doExecute() throws Exception {
+        if (killed) {
+            return;
+        }
         if (isTableLevelTask) {
             getTableStats();
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/JdbcAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/JdbcAnalysisTask.java
@@ -60,6 +60,9 @@ public class JdbcAnalysisTask extends BaseAnalysisTask {
     }
 
     public void doExecute() throws Exception {
+        if (killed) {
+            return;
+        }
         if (isTableLevelTask) {
             getTableStats();
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -64,6 +64,9 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     }
 
     public void doExecute() throws Exception {
+        if (killed) {
+            return;
+        }
         // For empty table, write empty result directly, no need to run SQL to collect stats.
         if (info.rowCount == 0 && tableSample != null) {
             StatsId statsId = new StatsId(concatColumnStatsId(), info.catalogId, info.dbId,

--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic_timeout.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic_timeout.groovy
@@ -34,9 +34,10 @@ suite("test_hive_statistic_timeout", "p2,external,hive,external_remote,external_
         sql """use ${catalog_name}.tpch_1000_parquet"""
         sql """set global analyze_timeout=1"""
         try {
-            sql """analyze table part (p_partkey, p_container, p_type, p_retailprice) with sync with full;"""
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains("Cancelled"));
+            test {
+                sql """analyze table part (p_partkey, p_container, p_type, p_retailprice) with sync with full;"""
+                exception "Timeout"
+            }
         } finally {
             sql """set global analyze_timeout=43200"""
         }


### PR DESCRIPTION
Before, analyze_timeout will also affect analyze stmt, which may cause failed to cancel analyze task. This PR change analyze_timeout to only affect timeout value for executing analyze sql.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

