### PR TITLE
[fix](memory) Allocator address sanitizers enable print stack trace 

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1060,7 +1060,7 @@ DEFINE_mString(kerberos_krb5_conf_path, "/etc/krb5.conf");
 
 DEFINE_mString(get_stack_trace_tool, "libunwind");
 DEFINE_mString(dwarf_location_info_mode, "FAST");
-DEFINE_mBool(enable_address_sanitizers_with_stack_trace, "false");
+DEFINE_mBool(enable_address_sanitizers_with_stack_trace, "true");
 
 // the ratio of _prefetch_size/_batch_size in AutoIncIDBuffer
 DEFINE_mInt64(auto_inc_prefetch_size_ratio, "10");

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -152,13 +152,13 @@ void MemTrackerLimiter::add_address_sanitizers(void* buf, size_t size) {
                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
                       << ", size: " << size << ", old buf: " << it->first
                       << ", old size: " << it->second.size
-                      << ", new stack_trace: " << get_stack_trace()
+                      << ", new stack_trace: " << get_stack_trace(1, "DISABLED")
                       << ", old stack_trace: " << it->second.stack_trace;
         }
 
         // if alignment not equal to 0, maybe usable_size > size.
         AddressSanitizer as = {size, doris::config::enable_address_sanitizers_with_stack_trace
-                                             ? get_stack_trace()
+                                             ? get_stack_trace(1, "DISABLED")
                                              : ""};
         _address_sanitizers.emplace(buf, as);
     }
@@ -176,7 +176,7 @@ void MemTrackerLimiter::remove_address_sanitizers(void* buf, size_t size) {
                           << ", peak consumption: " << _consumption->peak_value()
                           << ", buf: " << buf << ", size: " << size << ", old buf: " << it->first
                           << ", old size: " << it->second.size
-                          << ", new stack_trace: " << get_stack_trace()
+                          << ", new stack_trace: " << get_stack_trace(1, "DISABLED")
                           << ", old stack_trace: " << it->second.stack_trace;
             }
             _address_sanitizers.erase(buf);
@@ -184,7 +184,7 @@ void MemTrackerLimiter::remove_address_sanitizers(void* buf, size_t size) {
             LOG(INFO) << "[Address Sanitizer] memory buf not exist, mem tracker label: " << _label
                       << ", consumption: " << _consumption->current_value()
                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
-                      << ", size: " << size << ", stack_trace: " << get_stack_trace();
+                      << ", size: " << size << ", stack_trace: " << get_stack_trace(1, "DISABLED");
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Allocator address sanitizers enable `dwarf_location_info_mode=DISABLED` stack trace, this will no stack line numbers, maybe cause performance reduce 1x

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

