### PR TITLE
[refine](node) Remove the cse  DCHECK from the constructor.

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -90,10 +90,7 @@ ExecNode::ExecNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
                 descs, std::vector {tnode.output_tuple_id}, std::vector {true});
     }
     if (!tnode.intermediate_output_tuple_id_list.empty()) {
-        DCHECK(tnode.__isset.output_tuple_id) << " no final output tuple id";
         // common subexpression elimination
-        DCHECK_EQ(tnode.intermediate_output_tuple_id_list.size(),
-                  tnode.intermediate_projections_list.size());
         _intermediate_output_row_descriptor.reserve(tnode.intermediate_output_tuple_id_list.size());
         for (auto output_tuple_id : tnode.intermediate_output_tuple_id_list) {
             _intermediate_output_row_descriptor.push_back(
@@ -108,6 +105,19 @@ ExecNode::~ExecNode() = default;
 
 Status ExecNode::init(const TPlanNode& tnode, RuntimeState* state) {
     init_runtime_profile(get_name());
+    if (!tnode.intermediate_output_tuple_id_list.empty()) {
+        if (!tnode.__isset.output_tuple_id) {
+            return Status::InternalError("no final output tuple id");
+        }
+        if (tnode.intermediate_output_tuple_id_list.size() !=
+            tnode.intermediate_projections_list.size()) {
+            return Status::InternalError(
+                    "intermediate_output_tuple_id_list size:{} not match "
+                    "intermediate_projections_list size:{}",
+                    tnode.intermediate_output_tuple_id_list.size(),
+                    tnode.intermediate_projections_list.size());
+        }
+    }
 
     if (tnode.__isset.vconjunct) {
         vectorized::VExprContextSPtr context;

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -109,6 +109,19 @@ std::string OperatorXBase::debug_string(RuntimeState* state, int indentation_lev
 
 Status OperatorXBase::init(const TPlanNode& tnode, RuntimeState* /*state*/) {
     std::string node_name = print_plan_node_type(tnode.node_type);
+    if (!tnode.intermediate_output_tuple_id_list.empty()) {
+        if (!tnode.__isset.output_tuple_id) {
+            return Status::InternalError("no final output tuple id");
+        }
+        if (tnode.intermediate_output_tuple_id_list.size() !=
+            tnode.intermediate_projections_list.size()) {
+            return Status::InternalError(
+                    "intermediate_output_tuple_id_list size:{} not match "
+                    "intermediate_projections_list size:{}",
+                    tnode.intermediate_output_tuple_id_list.size(),
+                    tnode.intermediate_projections_list.size());
+        }
+    }
     auto substr = node_name.substr(0, node_name.find("_NODE"));
     _op_name = substr + "_OPERATOR";
 

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -164,10 +164,7 @@ public:
                     descs, std::vector {tnode.output_tuple_id}, std::vector {true});
         }
         if (!tnode.intermediate_output_tuple_id_list.empty()) {
-            DCHECK(tnode.__isset.output_tuple_id) << " no final output tuple id";
             // common subexpression elimination
-            DCHECK_EQ(tnode.intermediate_output_tuple_id_list.size(),
-                      tnode.intermediate_projections_list.size());
             _intermediate_output_row_descriptor.reserve(
                     tnode.intermediate_output_tuple_id_list.size());
             for (auto output_tuple_id : tnode.intermediate_output_tuple_id_list) {


### PR DESCRIPTION
## Proposed changes


It's possible that a failure in the fe caused the check to fail, and at that moment, it may not be possible to retrieve the corresponding query ID from be.out.

like this 
```
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1713359077 (unix time) try "date -d @1713359077" if you are using GNU date ***
*** Current BE git commitID: ac1ac6cb3b ***
*** SIGABRT unknown detail explain (@0x283f) received by PID 10303 (TID 10826 OR 0x7f29fdab9700) from PID 10303; stack trace: ***
    @     0x55f7435c082f  std::_Function_handler<>::_M_invoke()
    @     0x55f73f1342a7  std::function<>::operator()()
    @     0x55f73f1342a7  std::function<>::operator()()
    @     0x55f743559f74  doris::Thread::supervise_thread()
    @     0x7f2cdbeb3609  start_thread
    @     0x7f2cdc160133  clone
    @              (nil)  (unknown)
    @     0x55f743559f74  doris::Thread::supervise_thread()
    @     0x7f2cdbeb3609  start_thread
    @     0x7f2cdc160133  clone
    @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F2CDC084090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x000055F773230EAD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 5# 0x000055F77322354A in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# doris::ExecNode::ExecNode(doris::ObjectPool*, doris::TPlanNode const&, doris::DescriptorTbl const&) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be

```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

