### PR TITLE
[fix](mow) cloud full compaction should check unique key when trying to calculate delete bitmap

### DIFF
--- a/be/src/cloud/cloud_full_compaction.cpp
+++ b/be/src/cloud/cloud_full_compaction.cpp
@@ -202,7 +202,7 @@ Status CloudFullCompaction::modify_rowsets() {
     DeleteBitmapPtr output_rowset_delete_bitmap = nullptr;
     int64_t initiator =
             boost::hash_range(_uuid.begin(), _uuid.end()) & std::numeric_limits<int64_t>::max();
-    RETURN_IF_ERROR(_cloud_full_compaction_update_delete_bitmap(initiator));
+    RETURN_IF_ERROR(_cloud_full_compaction_update_delete_bitmap_if_necessary(initiator));
     compaction_job->set_delete_bitmap_lock_initiator(initiator);
 
     cloud::FinishTabletJobResponse resp;
@@ -295,8 +295,12 @@ void CloudFullCompaction::do_lease() {
     }
 }
 
-Status CloudFullCompaction::_cloud_full_compaction_update_delete_bitmap(int64_t initiator) {
+Status CloudFullCompaction::_cloud_full_compaction_update_delete_bitmap_if_necessary(
+        int64_t initiator) {
     if (_tablet->keys_type() != KeysType::UNIQUE_KEYS) {
+        return Status::OK();
+    }
+    if (!_tablet->enable_unique_key_merge_on_write()) {
         return Status::OK();
     }
     std::vector<RowsetSharedPtr> tmp_rowsets {};

--- a/be/src/cloud/cloud_full_compaction.cpp
+++ b/be/src/cloud/cloud_full_compaction.cpp
@@ -200,10 +200,13 @@ Status CloudFullCompaction::modify_rowsets() {
     compaction_job->add_output_rowset_ids(_output_rowset->rowset_id().to_string());
 
     DeleteBitmapPtr output_rowset_delete_bitmap = nullptr;
-    int64_t initiator =
-            boost::hash_range(_uuid.begin(), _uuid.end()) & std::numeric_limits<int64_t>::max();
-    RETURN_IF_ERROR(_cloud_full_compaction_update_delete_bitmap_if_necessary(initiator));
-    compaction_job->set_delete_bitmap_lock_initiator(initiator);
+    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+        _tablet->enable_unique_key_merge_on_write()) {
+        int64_t initiator =
+                boost::hash_range(_uuid.begin(), _uuid.end()) & std::numeric_limits<int64_t>::max();
+        RETURN_IF_ERROR(_cloud_full_compaction_update_delete_bitmap(initiator));
+        compaction_job->set_delete_bitmap_lock_initiator(initiator);
+    }
 
     cloud::FinishTabletJobResponse resp;
     auto st = _engine.meta_mgr().commit_tablet_job(job, &resp);
@@ -295,14 +298,7 @@ void CloudFullCompaction::do_lease() {
     }
 }
 
-Status CloudFullCompaction::_cloud_full_compaction_update_delete_bitmap_if_necessary(
-        int64_t initiator) {
-    if (_tablet->keys_type() != KeysType::UNIQUE_KEYS) {
-        return Status::OK();
-    }
-    if (!_tablet->enable_unique_key_merge_on_write()) {
-        return Status::OK();
-    }
+Status CloudFullCompaction::_cloud_full_compaction_update_delete_bitmap(int64_t initiator) {
     std::vector<RowsetSharedPtr> tmp_rowsets {};
     DeleteBitmapPtr delete_bitmap =
             std::make_shared<DeleteBitmap>(_tablet->tablet_meta()->tablet_id());

--- a/be/src/cloud/cloud_full_compaction.cpp
+++ b/be/src/cloud/cloud_full_compaction.cpp
@@ -296,6 +296,9 @@ void CloudFullCompaction::do_lease() {
 }
 
 Status CloudFullCompaction::_cloud_full_compaction_update_delete_bitmap(int64_t initiator) {
+    if (_tablet->keys_type() != KeysType::UNIQUE_KEYS) {
+        return Status::OK();
+    }
     std::vector<RowsetSharedPtr> tmp_rowsets {};
     DeleteBitmapPtr delete_bitmap =
             std::make_shared<DeleteBitmap>(_tablet->tablet_meta()->tablet_id());

--- a/be/src/cloud/cloud_full_compaction.h
+++ b/be/src/cloud/cloud_full_compaction.h
@@ -45,7 +45,7 @@ protected:
     void garbage_collection() override;
 
 private:
-    Status _cloud_full_compaction_update_delete_bitmap(int64_t initiator);
+    Status _cloud_full_compaction_update_delete_bitmap_if_necessary(int64_t initiator);
     Status _cloud_full_compaction_calc_delete_bitmap(const RowsetSharedPtr& rowset,
                                                      const int64_t& cur_version,
                                                      const DeleteBitmapPtr& delete_bitmap);

--- a/be/src/cloud/cloud_full_compaction.h
+++ b/be/src/cloud/cloud_full_compaction.h
@@ -45,7 +45,7 @@ protected:
     void garbage_collection() override;
 
 private:
-    Status _cloud_full_compaction_update_delete_bitmap_if_necessary(int64_t initiator);
+    Status _cloud_full_compaction_update_delete_bitmap(int64_t initiator);
     Status _cloud_full_compaction_calc_delete_bitmap(const RowsetSharedPtr& rowset,
                                                      const int64_t& cur_version,
                                                      const DeleteBitmapPtr& delete_bitmap);


### PR DESCRIPTION
## Proposed changes
now cloud full compaction on duplicate key will make be core, because it try to calculate delete bitmap which only exists in mow table.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

