### PR TITLE
[fix](memory) temporarily close Allocator address sanitizers

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -123,7 +123,7 @@ MemTrackerLimiter::~MemTrackerLimiter() {
 #ifdef NDEBUG
             LOG(INFO) << err_msg;
 #else
-            LOG(FATAL) << err_msg << print_address_sanitizers();
+            LOG(INFO) << err_msg << print_address_sanitizers();
 #endif
         }
         if (ExecEnv::tracking_memory()) {
@@ -132,10 +132,10 @@ MemTrackerLimiter::~MemTrackerLimiter() {
         _consumption->set(0);
 #ifndef NDEBUG
     } else if (!_address_sanitizers.empty()) {
-        LOG(FATAL) << "[Address Sanitizer] consumption is 0, but address sanitizers not empty. "
-                   << ", mem tracker label: " << _label
-                   << ", peak consumption: " << _consumption->peak_value()
-                   << print_address_sanitizers();
+        LOG(INFO) << "[Address Sanitizer] consumption is 0, but address sanitizers not empty. "
+                  << ", mem tracker label: " << _label
+                  << ", peak consumption: " << _consumption->peak_value()
+                  << print_address_sanitizers();
 #endif
     }
     g_memtrackerlimiter_cnt << -1;
@@ -147,13 +147,13 @@ void MemTrackerLimiter::add_address_sanitizers(void* buf, size_t size) {
         std::lock_guard<std::mutex> l(_address_sanitizers_mtx);
         auto it = _address_sanitizers.find(buf);
         if (it != _address_sanitizers.end()) {
-            LOG(FATAL) << "[Address Sanitizer] memory buf repeat add, mem tracker label: " << _label
-                       << ", consumption: " << _consumption->current_value()
-                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
-                       << ", size: " << size << ", old buf: " << it->first
-                       << ", old size: " << it->second.size
-                       << ", new stack_trace: " << get_stack_trace()
-                       << ", old stack_trace: " << it->second.stack_trace;
+            LOG(INFO) << "[Address Sanitizer] memory buf repeat add, mem tracker label: " << _label
+                      << ", consumption: " << _consumption->current_value()
+                      << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
+                      << ", size: " << size << ", old buf: " << it->first
+                      << ", old size: " << it->second.size
+                      << ", new stack_trace: " << get_stack_trace()
+                      << ", old stack_trace: " << it->second.stack_trace;
         }
 
         // if alignment not equal to 0, maybe usable_size > size.
@@ -170,21 +170,21 @@ void MemTrackerLimiter::remove_address_sanitizers(void* buf, size_t size) {
         auto it = _address_sanitizers.find(buf);
         if (it != _address_sanitizers.end()) {
             if (it->second.size != size) {
-                LOG(FATAL) << "[Address Sanitizer] free memory buf size inaccurate, mem tracker "
-                              "label: "
-                           << _label << ", consumption: " << _consumption->current_value()
-                           << ", peak consumption: " << _consumption->peak_value()
-                           << ", buf: " << buf << ", size: " << size << ", old buf: " << it->first
-                           << ", old size: " << it->second.size
-                           << ", new stack_trace: " << get_stack_trace()
-                           << ", old stack_trace: " << it->second.stack_trace;
+                LOG(INFO) << "[Address Sanitizer] free memory buf size inaccurate, mem tracker "
+                             "label: "
+                          << _label << ", consumption: " << _consumption->current_value()
+                          << ", peak consumption: " << _consumption->peak_value()
+                          << ", buf: " << buf << ", size: " << size << ", old buf: " << it->first
+                          << ", old size: " << it->second.size
+                          << ", new stack_trace: " << get_stack_trace()
+                          << ", old stack_trace: " << it->second.stack_trace;
             }
             _address_sanitizers.erase(buf);
         } else {
-            LOG(FATAL) << "[Address Sanitizer] memory buf not exist, mem tracker label: " << _label
-                       << ", consumption: " << _consumption->current_value()
-                       << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
-                       << ", size: " << size << ", stack_trace: " << get_stack_trace();
+            LOG(INFO) << "[Address Sanitizer] memory buf not exist, mem tracker label: " << _label
+                      << ", consumption: " << _consumption->current_value()
+                      << ", peak consumption: " << _consumption->peak_value() << ", buf: " << buf
+                      << ", size: " << size << ", stack_trace: " << get_stack_trace();
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

temporarily close check query memory tracker equal to 0 , fix https://github.com/apache/doris/pull/33396, requires more testing.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

