### PR TITLE
[Fix](compile) Fix gcc compile on master

### DIFF
--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -22,12 +22,11 @@
 #include <gen_cpp/internal_service.pb.h>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "common/status.h"
 #include "exec/tablet_info.h" // DorisNodesInfo
-#include "olap/storage_engine.h"
-#include "vec/columns/column_string.h"
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 
@@ -38,6 +37,9 @@ class RuntimeState;
 class TupleDescriptor;
 
 namespace vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 class MutableBlock;
 } // namespace vectorized
 
@@ -52,7 +54,7 @@ struct FetchOption {
 
 class RowIDFetcher {
 public:
-    RowIDFetcher(const FetchOption& fetch_opt) : _fetch_option(fetch_opt) {}
+    RowIDFetcher(FetchOption fetch_opt) : _fetch_option(std::move(fetch_opt)) {}
     Status init();
     Status fetch(const vectorized::ColumnPtr& row_ids, vectorized::Block* block);
 

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -203,23 +203,27 @@ public:
     virtual void find_batch(const doris::vectorized::IColumn& column, size_t rows,
                             doris::vectorized::ColumnUInt8::Container& results) {
         LOG(FATAL) << "HybridSetBase not support find_batch";
+        __builtin_unreachable();
     }
 
     virtual void find_batch_negative(const doris::vectorized::IColumn& column, size_t rows,
                                      doris::vectorized::ColumnUInt8::Container& results) {
         LOG(FATAL) << "HybridSetBase not support find_batch_negative";
+        __builtin_unreachable();
     }
 
     virtual void find_batch_nullable(const doris::vectorized::IColumn& column, size_t rows,
                                      const doris::vectorized::NullMap& null_map,
                                      doris::vectorized::ColumnUInt8::Container& results) {
         LOG(FATAL) << "HybridSetBase not support find_batch_nullable";
+        __builtin_unreachable();
     }
 
     virtual void find_batch_nullable_negative(const doris::vectorized::IColumn& column, size_t rows,
                                               const doris::vectorized::NullMap& null_map,
                                               doris::vectorized::ColumnUInt8::Container& results) {
         LOG(FATAL) << "HybridSetBase not support find_batch_nullable_negative";
+        __builtin_unreachable();
     }
 
     class IteratorBase {

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -283,6 +283,7 @@ public:
                     } while (false);
                 } else {
                     LOG(FATAL) << "column_dictionary must use StringRef predicate.";
+                    __builtin_unreachable();
                 }
             } else {
                 auto* data_array =
@@ -313,6 +314,7 @@ public:
                     } while (false);
                 } else {
                     LOG(FATAL) << "column_dictionary must use StringRef predicate.";
+                    __builtin_unreachable();
                 }
             } else {
                 auto* data_array =
@@ -518,6 +520,7 @@ private:
                                                     dict_code);
             } else {
                 LOG(FATAL) << "column_dictionary must use StringRef predicate.";
+                __builtin_unreachable();
             }
         } else {
             auto* data_array =

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -427,6 +427,7 @@ private:
                 }
             } else {
                 LOG(FATAL) << "column_dictionary must use StringRef predicate.";
+                __builtin_unreachable();
             }
         } else {
             auto& pred_col =
@@ -490,6 +491,7 @@ private:
                 }
             } else {
                 LOG(FATAL) << "column_dictionary must use StringRef predicate.";
+                __builtin_unreachable();
             }
         } else {
             auto* nested_col_ptr = vectorized::check_and_get_column<

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -129,6 +129,7 @@ private:
                 }
             } else {
                 LOG(FATAL) << "vectorized (not) like predicates should be dict column";
+                __builtin_unreachable();
             }
         } else {
             if (column.is_column_dictionary()) {
@@ -153,6 +154,7 @@ private:
                 }
             } else {
                 LOG(FATAL) << "vectorized (not) like predicates should be dict column";
+                __builtin_unreachable();
             }
         }
     }

--- a/be/src/olap/match_predicate.h
+++ b/be/src/olap/match_predicate.h
@@ -56,6 +56,7 @@ public:
     Status evaluate(BitmapIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* roaring) const override {
         LOG(FATAL) << "Not Implemented MatchPredicate::evaluate";
+        __builtin_unreachable();
     }
 
     //evaluate predicate on inverted

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -196,6 +196,7 @@ private:
         }
         default:
             LOG(FATAL) << "get error type page cache";
+            __builtin_unreachable();
         }
         LOG(FATAL) << "__builtin_unreachable";
         __builtin_unreachable();

--- a/be/src/olap/rowset/segment_v2/hierarchical_data_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/hierarchical_data_reader.cpp
@@ -76,6 +76,7 @@ Status HierarchicalDataReader::init(const ColumnIteratorOptions& opts) {
 
 Status HierarchicalDataReader::seek_to_first() {
     LOG(FATAL) << "Not implemented";
+    __builtin_unreachable();
 }
 
 Status HierarchicalDataReader::seek_to_ordinal(ordinal_t ord) {
@@ -154,6 +155,7 @@ Status ExtractReader::init(const ColumnIteratorOptions& opts) {
 
 Status ExtractReader::seek_to_first() {
     LOG(FATAL) << "Not implemented";
+    __builtin_unreachable();
 }
 
 Status ExtractReader::seek_to_ordinal(ordinal_t ord) {

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -440,6 +440,7 @@ void ExchangeSinkBuffer<Parent>::_ended(InstanceLoId id) {
         LOG(INFO) << ss.str();
 
         LOG(FATAL) << "not find the instance id";
+        __builtin_unreachable();
     } else {
         std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
         if (!_rpc_channel_is_idle[id]) {

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -177,6 +177,7 @@ public:
             LOG(FATAL) << "brpc callback error: " << exp.what();
         } catch (...) {
             LOG(FATAL) << "brpc callback error.";
+            __builtin_unreachable();
         }
     }
     int64_t start_rpc_time;

--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -124,6 +124,7 @@ Status SetProbeSinkOperatorX<is_intersect>::sink(RuntimeState* state, vectorized
                         return process_hashtable_ctx.mark_data_in_hashtable(arg);
                     } else {
                         LOG(FATAL) << "FATAL: uninited hash table";
+                        __builtin_unreachable();
                     }
                 },
                 *local_state._shared_state->hash_table_variants));
@@ -283,6 +284,7 @@ void SetProbeSinkOperatorX<is_intersect>::_refresh_hash_table(
                     }
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *hash_table_variants);

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -122,6 +122,7 @@ Status SetSinkOperatorX<is_intersect>::_process_build_block(
                     static_cast<void>(hash_table_build_process(arg, local_state._arena));
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *local_state._shared_state->hash_table_variants);

--- a/be/src/pipeline/exec/set_source_operator.cpp
+++ b/be/src/pipeline/exec/set_source_operator.cpp
@@ -102,6 +102,7 @@ Status SetSourceOperatorX<is_intersect>::get_block(RuntimeState* state, vectoriz
                                                                     state->batch_size(), eos);
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *local_state._shared_state->hash_table_variants);

--- a/be/src/runtime/jsonb_value.h
+++ b/be/src/runtime/jsonb_value.h
@@ -62,46 +62,57 @@ struct JsonBinaryValue {
 
     bool operator==(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
     // !=
     bool ne(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
     // <=
     bool le(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
     // >=
     bool ge(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
     // <
     bool lt(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
     // >
     bool gt(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     bool operator!=(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     bool operator<=(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     bool operator>=(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     bool operator<(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     bool operator>(const JsonBinaryValue& other) const {
         LOG(FATAL) << "comparing between JsonBinaryValue is not supported";
+        __builtin_unreachable();
     }
 
     Status from_json_string(const char* s, int len);

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -20,15 +20,13 @@
 #include <gen_cpp/Opcodes_types.h>
 #include <gen_cpp/Types_types.h>
 #include <glog/logging.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <string>
-#include <type_traits>
 
 #include "olap/decimal12.h"
 #include "runtime/define_primitive_type.h"
 #include "vec/columns/column_decimal.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/core/types.h"
@@ -36,6 +34,12 @@
 #include "vec/utils/template_helpers.hpp"
 
 namespace doris {
+
+namespace vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
+} // namespace vectorized
 
 class DecimalV2Value;
 struct StringRef;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -771,6 +771,7 @@ Status SnapshotLoader::move(const std::string& snapshot_path, TabletSharedPtr ta
 
     } else {
         LOG(FATAL) << "only support overwrite now";
+        __builtin_unreachable();
     }
 
     // snapshot loader not need to change tablet uid

--- a/be/src/util/easy_json.cc
+++ b/be/src/util/easy_json.cc
@@ -201,6 +201,7 @@ EasyJson EasyJson::PushBack(EasyJson::ComplexTypeInitializer val) {
         push_val.SetArray();
     } else {
         LOG(FATAL) << "Unknown initializer type";
+        __builtin_unreachable();
     }
     value_->PushBack(push_val, alloc_->allocator());
     return EasyJson(&(*value_)[value_->Size() - 1], alloc_);

--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -120,6 +120,7 @@ T next_from_charstream(int8_t*& src) {
         return value;
     } else {
         LOG(FATAL) << "Unknown endianess";
+        __builtin_unreachable();
     }
     LOG(FATAL) << "__builtin_unreachable";
     __builtin_unreachable();

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -18,11 +18,10 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <stddef.h>
-#include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -33,23 +32,20 @@
 #include "util/bitmap_value.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column_complex.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/io/io_helper.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
 class Arena;
 class BufferReadable;
 class BufferWritable;
 class IColumn;
-} // namespace vectorized
-} // namespace doris
-
-namespace doris::vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 template <typename T>
 struct AggOrthBitmapBaseData {

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -203,6 +203,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         LOG(FATAL) << "AggregateFunctionPercentileApproxMerge do not support add()";
+        __builtin_unreachable();
     }
 };
 

--- a/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
@@ -226,15 +226,19 @@ public:
                                 int64_t frame_end, AggregateDataPtr place, const IColumn** columns,
                                 Arena* arena) const override {
         LOG(FATAL) << "ReaderFunctionData do not support add_range_single_place";
+        __builtin_unreachable();
     }
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {
         LOG(FATAL) << "ReaderFunctionData do not support merge";
+        __builtin_unreachable();
     }
     void serialize(ConstAggregateDataPtr place, BufferWritable& buf) const override {
         LOG(FATAL) << "ReaderFunctionData do not support serialize";
+        __builtin_unreachable();
     }
     void deserialize(AggregateDataPtr place, BufferReadable& buf, Arena*) const override {
         LOG(FATAL) << "ReaderFunctionData do not support deserialize";
+        __builtin_unreachable();
     }
 
 private:

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -559,15 +559,19 @@ public:
     void add(AggregateDataPtr place, const IColumn** columns, ssize_t row_num,
              Arena* arena) const override {
         LOG(FATAL) << "WindowFunctionLeadLagData do not support add";
+        __builtin_unreachable();
     }
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {
         LOG(FATAL) << "WindowFunctionLeadLagData do not support merge";
+        __builtin_unreachable();
     }
     void serialize(ConstAggregateDataPtr place, BufferWritable& buf) const override {
         LOG(FATAL) << "WindowFunctionLeadLagData do not support serialize";
+        __builtin_unreachable();
     }
     void deserialize(AggregateDataPtr place, BufferReadable& buf, Arena*) const override {
         LOG(FATAL) << "WindowFunctionLeadLagData do not support deserialize";
+        __builtin_unreachable();
     }
 
 private:

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -339,22 +339,26 @@ public:
     virtual void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
                                size_t max_row_byte_size) const {
         LOG(FATAL) << "serialize_vec not supported";
+        __builtin_unreachable();
     }
 
     virtual void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
                                              const uint8_t* null_map) const {
         LOG(FATAL) << "serialize_vec_with_null_map not supported";
+        __builtin_unreachable();
     }
 
     // This function deserializes group-by keys into column in the vectorized way.
     virtual void deserialize_vec(std::vector<StringRef>& keys, const size_t num_rows) {
         LOG(FATAL) << "deserialize_vec not supported";
+        __builtin_unreachable();
     }
 
     // Used in ColumnNullable::deserialize_vec
     virtual void deserialize_vec_with_null_map(std::vector<StringRef>& keys, const size_t num_rows,
                                                const uint8_t* null_map) {
         LOG(FATAL) << "deserialize_vec_with_null_map not supported";
+        __builtin_unreachable();
     }
 
     /// TODO: SipHash is slower than city or xx hash, rethink we should have a new interface

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -93,6 +93,7 @@ ColumnArray::ColumnArray(MutableColumnPtr&& nested_column, MutableColumnPtr&& of
 
     if (!offsets_concrete) {
         LOG(FATAL) << "offsets_column must be a ColumnUInt64";
+        __builtin_unreachable();
     }
 
     if (!offsets_concrete->empty() && data) {
@@ -114,6 +115,7 @@ ColumnArray::ColumnArray(MutableColumnPtr&& nested_column, MutableColumnPtr&& of
 ColumnArray::ColumnArray(MutableColumnPtr&& nested_column) : data(std::move(nested_column)) {
     if (!data->empty()) {
         LOG(FATAL) << "Not empty data passed to ColumnArray, but no offsets passed";
+        __builtin_unreachable();
     }
 
     offsets = ColumnOffsets::create();
@@ -239,6 +241,7 @@ void ColumnArray::insert_data(const char* pos, size_t length) {
 
         if (pos != end)
             LOG(FATAL) << "Incorrect length argument for method ColumnArray::insert_data";
+        __builtin_unreachable();
     }
 
     get_offsets().push_back(get_offsets().back() + elems);
@@ -1101,6 +1104,7 @@ ColumnPtr ColumnArray::permute(const Permutation& perm, size_t limit) const {
     }
     if (perm.size() < limit) {
         LOG(FATAL) << "Size of permutation is less than required.";
+        __builtin_unreachable();
     }
     if (limit == 0) {
         return ColumnArray::create(data);

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -82,6 +82,7 @@ public:
             pvalue->deserialize(Slice(pos, length));
         } else {
             LOG(FATAL) << "Unexpected type in column complex";
+            __builtin_unreachable();
         }
     }
 
@@ -129,6 +130,7 @@ public:
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
         LOG(FATAL) << "get_indices_of_non_default_rows not implemented";
+        __builtin_unreachable();
     }
     [[noreturn]] ColumnPtr index(const IColumn& indexes, size_t limit) const override {
         LOG(FATAL) << "index not implemented";
@@ -358,6 +360,7 @@ ColumnPtr ColumnComplexType<T>::permute(const IColumn::Permutation& perm, size_t
 
     if (perm.size() < limit) {
         LOG(FATAL) << "Size of permutation is less than required.";
+        __builtin_unreachable();
     }
 
     auto res = this->create(limit);

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -296,6 +296,7 @@ public:
     void replace_column_data_default(size_t self_row = 0) override {
         DCHECK(size() > self_row);
         LOG(FATAL) << "should not call the method in column const";
+        __builtin_unreachable();
     }
 };
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -236,6 +236,7 @@ ColumnPtr ColumnDecimal<T>::permute(const IColumn::Permutation& perm, size_t lim
     size_t size = limit ? std::min(data.size(), limit) : data.size();
     if (perm.size() < size) {
         LOG(FATAL) << "Size of permutation is less than required.";
+        __builtin_unreachable();
     }
 
     auto res = this->create(size, scale);

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -72,25 +72,30 @@ public:
 
     void insert_from(const IColumn& src, size_t n) override {
         LOG(FATAL) << "insert_from not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override {
         LOG(FATAL) << "insert_range_from not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override {
         LOG(FATAL) << "insert_indices_from not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void pop_back(size_t n) override { LOG(FATAL) << "pop_back not supported in ColumnDictionary"; }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
         LOG(FATAL) << "update_hash_with_value not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
         LOG(FATAL) << "insert_data not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void insert_default() override { _codes.push_back(_dict.get_null_code()); }
@@ -109,6 +114,7 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          IColumn::Permutation& res) const override {
         LOG(FATAL) << "get_permutation not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void reserve(size_t n) override { _codes.reserve(n); }
@@ -122,6 +128,7 @@ public:
 
     void insert(const Field& x) override {
         LOG(FATAL) << "insert not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     Field operator[](size_t n) const override { return _codes[n]; }
@@ -155,6 +162,7 @@ public:
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
         LOG(FATAL) << "get_indices_of_non_default_rows not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     size_t size_of_value_if_fixed() const override { return sizeof(T); }
@@ -193,11 +201,13 @@ public:
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
         LOG(FATAL) << "append_data_by_selector is not supported in ColumnDictionary!";
+        __builtin_unreachable();
     }
 
     void append_data_by_selector(MutableColumnPtr& res, const IColumn::Selector& selector,
                                  size_t begin, size_t end) const override {
         LOG(FATAL) << "append_data_by_selector is not supported in ColumnDictionary!";
+        __builtin_unreachable();
     }
 
     [[noreturn]] ColumnPtr index(const IColumn& indexes, size_t limit) const override {
@@ -223,10 +233,12 @@ public:
 
     void replace_column_data(const IColumn&, size_t row, size_t self_row = 0) override {
         LOG(FATAL) << "should not call replace_column_data in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "should not call replace_column_data_default in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     /**

--- a/be/src/vec/columns/column_dummy.h
+++ b/be/src/vec/columns/column_dummy.h
@@ -99,6 +99,7 @@ public:
     ColumnPtr permute(const Permutation& perm, size_t limit) const override {
         if (s != perm.size()) {
             LOG(FATAL) << "Size of permutation doesn't match size of column.";
+            __builtin_unreachable();
         }
 
         return clone_dummy(limit ? std::min(s, limit) : s);
@@ -148,19 +149,23 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         LOG(FATAL) << "should not call the method in column dummy";
+        __builtin_unreachable();
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "should not call the method in column dummy";
+        __builtin_unreachable();
     }
 
     void get_indices_of_non_default_rows(Offsets64&, size_t, size_t) const override {
         LOG(FATAL) << "should not call the method in column dummy";
+        __builtin_unreachable();
     }
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override {
         if (indexes.size() < limit) {
             LOG(FATAL) << "Size of indexes is less than required.";
+            __builtin_unreachable();
         }
         return clone_dummy(limit ? limit : s);
     }

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -164,10 +164,12 @@ public:
     StringRef serialize_value_into_arena(size_t n, Arena& arena,
                                          char const*& begin) const override {
         LOG(FATAL) << "serialize_value_into_arena not supported";
+        __builtin_unreachable();
     }
 
     const char* deserialize_and_insert_from_arena(const char* pos) override {
         LOG(FATAL) << "deserialize_and_insert_from_arena not supported";
+        __builtin_unreachable();
     }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
@@ -199,15 +201,18 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          IColumn::Permutation& res) const override {
         LOG(FATAL) << "get_permutation not supported";
+        __builtin_unreachable();
     }
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override {
         LOG(FATAL) << "index not supported";
+        __builtin_unreachable();
     }
 
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
         LOG(FATAL) << "get_indices_of_non_default_rows not supported in ColumnDictionary";
+        __builtin_unreachable();
     }
 
     ColumnPtr replicate(const IColumn::Offsets& offsets) const override {
@@ -267,6 +272,7 @@ public:
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "replace_column_data_default not supported";
+        __builtin_unreachable();
     }
 
     void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets,

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -51,6 +51,7 @@ ColumnMap::ColumnMap(MutableColumnPtr&& keys, MutableColumnPtr&& values, Mutable
 
     if (!offsets_concrete) {
         LOG(FATAL) << "offsets_column must be a ColumnUInt64";
+        __builtin_unreachable();
     }
 
     if (!offsets_concrete->empty() && keys_column && values_column) {

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -126,6 +126,7 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          Permutation& res) const override {
         LOG(FATAL) << "get_permutation not implemented";
+        __builtin_unreachable();
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -44,6 +44,7 @@ ColumnNullable::ColumnNullable(MutableColumnPtr&& nested_column_, MutableColumnP
 
     if (is_column_const(*null_map)) {
         LOG(FATAL) << "ColumnNullable cannot have constant null map";
+        __builtin_unreachable();
     }
     _need_update_has_null = true;
 }
@@ -524,6 +525,7 @@ void ColumnNullable::apply_null_map_impl(const ColumnUInt8& map) {
 
     if (arr1.size() != arr2.size()) {
         LOG(FATAL) << "Inconsistent sizes of ColumnNullable objects";
+        __builtin_unreachable();
     }
 
     for (size_t i = 0, size = arr1.size(); i < size; ++i) {

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -356,6 +356,7 @@ public:
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "should not call the method in column nullable";
+        __builtin_unreachable();
     }
 
     MutableColumnPtr convert_to_predicate_column_if_dictionary() override {

--- a/be/src/vec/columns/column_object.h
+++ b/be/src/vec/columns/column_object.h
@@ -443,6 +443,7 @@ public:
 
     void insert_data(const char* pos, size_t length) override {
         LOG(FATAL) << "should not call the method in column object";
+        __builtin_unreachable();
     }
 
     ColumnPtr filter(const Filter&, ssize_t) const override;
@@ -461,6 +462,7 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          Permutation& res) const override {
         LOG(FATAL) << "should not call the method in column object";
+        __builtin_unreachable();
     }
 
     bool is_variable_length() const override { return true; }
@@ -471,6 +473,7 @@ public:
 
     void get_indices_of_non_default_rows(Offsets64&, size_t, size_t) const override {
         LOG(FATAL) << "should not call the method in column object";
+        __builtin_unreachable();
     }
 
     template <typename Func>

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -296,6 +296,7 @@ ColumnPtr ColumnStr<T>::permute(const IColumn::Permutation& perm, size_t limit) 
 
     if (perm.size() < limit) {
         LOG(FATAL) << "Size of permutation is less than required.";
+        __builtin_unreachable();
     }
 
     if (limit == 0) {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -21,10 +21,10 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <stdint.h>
 #include <sys/types.h>
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <typeinfo>
 #include <vector>
@@ -36,7 +36,6 @@
 #include "runtime/define_primitive_type.h"
 #include "util/hash_util.hpp"
 #include "vec/columns/column.h"
-#include "vec/columns/column_impl.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/cow.h"
 #include "vec/common/memcmp_small.h"
@@ -47,14 +46,9 @@
 #include "vec/core/field.h"
 #include "vec/core/types.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
 class Arena;
 class ColumnSorter;
-} // namespace vectorized
-} // namespace doris
-
-namespace doris::vectorized {
 
 /** Column for String values.
   */
@@ -99,9 +93,9 @@ private:
     template <bool positive>
     struct lessWithCollation;
 
-    ColumnStr<T>() = default;
+    ColumnStr() = default;
 
-    ColumnStr<T>(const ColumnStr<T>& src)
+    ColumnStr(const ColumnStr<T>& src)
             : offsets(src.offsets.begin(), src.offsets.end()),
               chars(src.chars.begin(), src.chars.end()) {}
 
@@ -554,11 +548,13 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         LOG(FATAL) << "Method replace_column_data is not supported for ColumnString";
+        __builtin_unreachable();
     }
 
     // should replace according to 0,1,2... ,size,0,1,2...
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "Method replace_column_data_default is not supported for ColumnString";
+        __builtin_unreachable();
     }
 
     void compare_internal(size_t rhs_row_id, const IColumn& rhs, int nan_direction_hint,

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -54,6 +54,7 @@ ColumnStruct::ColumnStruct(MutableColumns&& mutable_columns) {
     for (auto& column : mutable_columns) {
         if (is_column_const(*column)) {
             LOG(FATAL) << "ColumnStruct cannot have ColumnConst as its element";
+            __builtin_unreachable();
         }
         columns.push_back(std::move(column));
     }
@@ -63,6 +64,7 @@ ColumnStruct::Ptr ColumnStruct::create(const Columns& columns) {
     for (const auto& column : columns) {
         if (is_column_const(*column)) {
             LOG(FATAL) << "ColumnStruct cannot have ColumnConst as its element";
+            __builtin_unreachable();
         }
     }
     auto column_struct = ColumnStruct::create(MutableColumns());
@@ -74,6 +76,7 @@ ColumnStruct::Ptr ColumnStruct::create(const TupleColumns& tuple_columns) {
     for (const auto& column : tuple_columns) {
         if (is_column_const(*column)) {
             LOG(FATAL) << "ColumnStruct cannot have ColumnConst as its element";
+            __builtin_unreachable();
         }
     }
     auto column_struct = ColumnStruct::create(MutableColumns());
@@ -146,6 +149,7 @@ void ColumnStruct::insert_from(const IColumn& src_, size_t n) {
     const size_t tuple_size = columns.size();
     if (src.columns.size() != tuple_size) {
         LOG(FATAL) << "Cannot insert value of different size into tuple.";
+        __builtin_unreachable();
     }
 
     for (size_t i = 0; i < tuple_size; ++i) {

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -128,6 +128,7 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          Permutation& res) const override {
         LOG(FATAL) << "get_permutation not implemented";
+        __builtin_unreachable();
     }
     void append_data_by_selector(MutableColumnPtr& res, const Selector& selector) const override {
         return append_data_by_selector_impl<ColumnStruct>(res, selector);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -495,6 +495,7 @@ ColumnPtr ColumnVector<T>::permute(const IColumn::Permutation& perm, size_t limi
 
     if (perm.size() < limit) {
         LOG(FATAL) << "Size of permutation is less than required.";
+        __builtin_unreachable();
     }
 
     auto res = this->create(limit);

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -199,6 +199,7 @@ public:
             }
         } else {
             LOG(FATAL) << "double column not support insert_range_of_integer";
+            __builtin_unreachable();
         }
     }
 

--- a/be/src/vec/columns/columns_common.h
+++ b/be/src/vec/columns/columns_common.h
@@ -104,6 +104,7 @@ ColumnPtr select_index_impl(const Column& column, const IColumn& indexes, size_t
 
     if (indexes.size() < limit) {
         LOG(FATAL) << "Size of indexes is less than required.";
+        __builtin_unreachable();
     }
 
     if (auto* data_uint8 = detail::get_indexes_data<UInt8>(indexes)) {

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -115,33 +115,40 @@ public:
             return res;
         } else {
             LOG(FATAL) << "should not call get_data_at in predicate column except for string type";
+            __builtin_unreachable();
         }
     }
 
     void insert_from(const IColumn& src, size_t n) override {
         LOG(FATAL) << "insert_from not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override {
         LOG(FATAL) << "insert_range_from not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override {
         LOG(FATAL) << "insert_indices_from not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void pop_back(size_t n) override {
         LOG(FATAL) << "pop_back not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
         LOG(FATAL) << "update_hash_with_value not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
         LOG(FATAL) << "get_indices_of_non_default_rows not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     [[noreturn]] ColumnPtr index(const IColumn& indexes, size_t limit) const override {
@@ -305,6 +312,7 @@ public:
                     << "Copied size not equal to expected size";
         } else {
             LOG(FATAL) << "Method insert_many_binary_data is not supported";
+            __builtin_unreachable();
         }
     }
 
@@ -324,6 +332,7 @@ public:
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          IColumn::Permutation& res) const override {
         LOG(FATAL) << "get_permutation not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     void reserve(size_t n) override { data.reserve(n); }
@@ -337,6 +346,7 @@ public:
 
     void insert(const Field& x) override {
         LOG(FATAL) << "insert not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     [[noreturn]] Field operator[](size_t n) const override {
@@ -346,6 +356,7 @@ public:
 
     void get(size_t n, Field& res) const override {
         LOG(FATAL) << "get field not supported in PredicateColumnType";
+        __builtin_unreachable();
     }
 
     [[noreturn]] UInt64 get64(size_t n) const override {
@@ -432,10 +443,12 @@ public:
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
         LOG(FATAL) << "append_data_by_selector is not supported in PredicateColumnType!";
+        __builtin_unreachable();
     }
     void append_data_by_selector(MutableColumnPtr& res, const IColumn::Selector& selector,
                                  size_t begin, size_t end) const override {
         LOG(FATAL) << "append_data_by_selector is not supported in PredicateColumnType!";
+        __builtin_unreachable();
     }
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
@@ -452,10 +465,12 @@ public:
 
     void replace_column_data(const IColumn&, size_t row, size_t self_row = 0) override {
         LOG(FATAL) << "should not call replace_column_data in predicate column";
+        __builtin_unreachable();
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "should not call replace_column_data_default in predicate column";
+        __builtin_unreachable();
     }
 
 private:

--- a/be/src/vec/common/field_visitors.h
+++ b/be/src/vec/common/field_visitors.h
@@ -69,6 +69,7 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
         return visitor(field.template get<JsonbField>());
     default:
         LOG(FATAL) << "Bad type of Field";
+        __builtin_unreachable();
         return {};
     }
 }

--- a/be/src/vec/core/decimal_comparison.h
+++ b/be/src/vec/core/decimal_comparison.h
@@ -107,6 +107,7 @@ public:
         static const UInt32 max_scale = max_decimal_precision<Decimal256>();
         if (scale_a > max_scale || scale_b > max_scale) {
             LOG(FATAL) << "Bad scale of decimal field";
+            __builtin_unreachable();
         }
 
         Shift shift;
@@ -213,6 +214,7 @@ private:
                     constant_vector<scale_left, scale_right>(a, c1_vec->get_data(), vec_res, scale);
                 else {
                     LOG(FATAL) << "Wrong column in Decimal comparison";
+                    __builtin_unreachable();
                 }
             } else if (c1_is_const) {
                 const ColumnConst* c1_const = check_and_get_column_const<ColVecB>(c1.get());
@@ -221,6 +223,7 @@ private:
                     vector_constant<scale_left, scale_right>(c0_vec->get_data(), b, vec_res, scale);
                 else {
                     LOG(FATAL) << "Wrong column in Decimal comparison";
+                    __builtin_unreachable();
                 }
             } else {
                 if (const ColVecA* c0_vec = check_and_get_column<ColVecA>(c0.get())) {
@@ -229,9 +232,11 @@ private:
                                                                c1_vec->get_data(), vec_res, scale);
                     else {
                         LOG(FATAL) << "Wrong column in Decimal comparison";
+                        __builtin_unreachable();
                     }
                 } else {
                     LOG(FATAL) << "Wrong column in Decimal comparison";
+                    __builtin_unreachable();
                 }
             }
             return c_res;
@@ -258,6 +263,7 @@ private:
 
             if (overflow) {
                 LOG(FATAL) << "Can't compare";
+                __builtin_unreachable();
             }
         } else {
             if constexpr (scale_left) x *= scale;

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -217,29 +217,37 @@ public:
 
     bool operator<(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
     bool operator<=(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
     bool operator==(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
     bool operator>(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
     bool operator>=(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
     bool operator!=(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
+        __builtin_unreachable();
     }
 
     const JsonbField& operator+=(const JsonbField& r) {
         LOG(FATAL) << "Not support plus opration on JsonbField";
+        __builtin_unreachable();
     }
 
     const JsonbField& operator-=(const JsonbField& r) {
         LOG(FATAL) << "Not support minus opration on JsonbField";
+        __builtin_unreachable();
     }
 
 private:
@@ -298,6 +306,7 @@ public:
     const DecimalField<T>& operator+=(const DecimalField<T>& r) {
         if (scale != r.get_scale()) {
             LOG(FATAL) << "Add different decimal fields";
+            __builtin_unreachable();
         }
         dec += r.get_value();
         return *this;
@@ -306,6 +315,7 @@ public:
     const DecimalField<T>& operator-=(const DecimalField<T>& r) {
         if (scale != r.get_scale()) {
             LOG(FATAL) << "Sub different decimal fields";
+            __builtin_unreachable();
         }
         dec -= r.get_value();
         return *this;
@@ -415,6 +425,7 @@ public:
                 LOG(FATAL) << "type not supported, type=" << Types::to_string(which);
                 break;
             }
+            __builtin_unreachable();
         }
     };
 

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -282,6 +282,7 @@ public:
     T scale_factor_for(const DataTypeDecimal<U>& x, bool) const {
         if (get_scale() < x.get_scale()) {
             LOG(FATAL) << "Decimal result's scale is less then argiment's one";
+            __builtin_unreachable();
         }
 
         UInt32 scale_delta = get_scale() - x.get_scale(); /// scale_delta >= 0

--- a/be/src/vec/data_types/data_type_nothing.cpp
+++ b/be/src/vec/data_types/data_type_nothing.cpp
@@ -32,11 +32,13 @@ MutableColumnPtr DataTypeNothing::create_column() const {
 
 char* DataTypeNothing::serialize(const IColumn& column, char* buf, int be_exec_version) const {
     LOG(FATAL) << "not support";
+    __builtin_unreachable();
 }
 
 const char* DataTypeNothing::deserialize(const char* buf, IColumn* column,
                                          int be_exec_version) const {
     LOG(FATAL) << "not support";
+    __builtin_unreachable();
 }
 
 bool DataTypeNothing::equals(const IDataType& rhs) const {

--- a/be/src/vec/data_types/data_type_struct.cpp
+++ b/be/src/vec/data_types/data_type_struct.cpp
@@ -75,6 +75,7 @@ DataTypeStruct::DataTypeStruct(const DataTypes& elems_, const Strings& names_)
     size_t size = elems.size();
     if (names.size() != size) {
         LOG(FATAL) << "Wrong number of names passed to constructor of DataTypeStruct";
+        __builtin_unreachable();
     }
 
     Status st = check_tuple_names(names);
@@ -272,6 +273,7 @@ void add_element_safe(const DataTypes& elems, IColumn& column, F&& impl) {
                 // This is not a logical error because it may work with
                 // user-supplied data.
                 LOG(FATAL) << "Cannot read a tuple because not all elements are present";
+                __builtin_unreachable();
             }
         }
     } catch (...) {
@@ -342,6 +344,7 @@ size_t DataTypeStruct::get_position_by_name(const String& name) const {
         }
     }
     LOG(FATAL) << "Struct doesn't have element with name '" + name + "'";
+    __builtin_unreachable();
 }
 
 std::optional<size_t> DataTypeStruct::try_get_position_by_name(const String& name) const {

--- a/be/src/vec/data_types/data_type_struct.h
+++ b/be/src/vec/data_types/data_type_struct.h
@@ -97,6 +97,7 @@ public:
 
     Field get_field(const TExprNode& node) const override {
         LOG(FATAL) << "Unimplemented get_field for struct";
+        __builtin_unreachable();
     }
 
     void insert_default_into(IColumn& column) const override;

--- a/be/src/vec/data_types/serde/data_type_number_serde.h
+++ b/be/src/vec/data_types/serde/data_type_number_serde.h
@@ -312,6 +312,7 @@ Status DataTypeNumberSerDe<T>::write_one_cell_to_json(const IColumn& column,
         result.SetDouble(data[row_num]);
     } else {
         LOG(FATAL) << "unknown column type " << column.get_name() << " for writing to jsonb";
+        __builtin_unreachable();
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/parquet/byte_array_dict_decoder.h
+++ b/be/src/vec/exec/format/parquet/byte_array_dict_decoder.h
@@ -17,32 +17,26 @@
 
 #pragma once
 
-#include <string.h>
-
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
 #include "common/status.h"
-#include "util/bit_util.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/exec/format/format_common.h"
 #include "vec/exec/format/parquet/decoder.h"
 #include "vec/exec/format/parquet/parquet_common.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
 template <typename T>
 class ColumnDecimal;
-} // namespace vectorized
-} // namespace doris
-
-namespace doris::vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 class ByteArrayDictDecoder final : public BaseDictDecoder {
 public:

--- a/be/src/vec/exec/format/parquet/decoder.h
+++ b/be/src/vec/exec/format/parquet/decoder.h
@@ -19,20 +19,18 @@
 
 #include <gen_cpp/parquet_types.h>
 #include <glog/logging.h>
-#include <stddef.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ostream>
 #include <vector>
 
 #include "common/status.h"
-#include "schema_desc.h"
 #include "util/rle_encoding.h"
 #include "util/slice.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_dictionary.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
@@ -41,10 +39,13 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_decimal.h" // IWYU pragma: keep
 #include "vec/data_types/data_type_nullable.h"
-#include "vec/exec/format/format_common.h"
 #include "vec/exec/format/parquet/parquet_common.h"
 
 namespace doris::vectorized {
+
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 class Decoder {
 public:
@@ -84,6 +85,7 @@ public:
 
     virtual MutableColumnPtr convert_dict_column_to_string_column(const ColumnInt32* dict_column) {
         LOG(FATAL) << "Method convert_dict_column_to_string_column is not supported";
+        __builtin_unreachable();
     }
 
 protected:
@@ -95,16 +97,16 @@ protected:
 class BaseDictDecoder : public Decoder {
 public:
     BaseDictDecoder() = default;
-    virtual ~BaseDictDecoder() override = default;
+    ~BaseDictDecoder() override = default;
 
     // Set the data to be decoded
-    virtual void set_data(Slice* data) override {
+    void set_data(Slice* data) override {
         _data = data;
         _offset = 0;
         uint8_t bit_width = *data->data;
-        _index_batch_decoder.reset(
-                new RleBatchDecoder<uint32_t>(reinterpret_cast<uint8_t*>(data->data) + 1,
-                                              static_cast<int>(data->size) - 1, bit_width));
+        _index_batch_decoder = std::make_unique<RleBatchDecoder<uint32_t>>(
+                reinterpret_cast<uint8_t*>(data->data) + 1, static_cast<int>(data->size) - 1,
+                bit_width);
     }
 
 protected:
@@ -125,7 +127,7 @@ protected:
         while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
-                uint32_t* start_index = &_indexes[0];
+                uint32_t* start_index = _indexes.data();
                 column_data.insert(start_index + dict_index, start_index + dict_index + run_length);
                 dict_index += run_length;
                 break;
@@ -148,7 +150,7 @@ protected:
 
     Status skip_values(size_t num_values) override {
         _indexes.resize(num_values);
-        _index_batch_decoder->GetBatch(&_indexes[0], num_values);
+        _index_batch_decoder->GetBatch(_indexes.data(), num_values);
         return Status::OK();
     }
 

--- a/be/src/vec/exec/format/parquet/parquet_column_convert.h
+++ b/be/src/vec/exec/format/parquet/parquet_column_convert.h
@@ -19,13 +19,13 @@
 
 #include <gen_cpp/parquet_types.h>
 
-#include "gutil/endian.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/exec/format/column_type_convert.h"
 #include "vec/exec/format/format_common.h"
 #include "vec/exec/format/parquet/decoder.h"
 #include "vec/exec/format/parquet/parquet_common.h"
+#include "vec/exec/format/parquet/schema_desc.h"
 
 namespace doris::vectorized::parquet {
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <gen_cpp/parquet_types.h>
-#include <stddef.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -45,12 +45,15 @@ namespace io {
 class BufferedStreamReader;
 struct IOContext;
 } // namespace io
-namespace vectorized {
-struct FieldSchema;
-} // namespace vectorized
+
 } // namespace doris
 
 namespace doris::vectorized {
+
+struct FieldSchema;
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 /**
  * Read and decode parquet column data into doris block column.
@@ -91,7 +94,7 @@ public:
     Status init();
 
     // Whether the chunk reader has a more page to read.
-    bool has_next_page() { return _chunk_parsed_values < _metadata.num_values; }
+    bool has_next_page() const { return _chunk_parsed_values < _metadata.num_values; }
 
     // Deprecated
     // Seek to the specific page, page_header_offset must be the start offset of the page header.

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -40,15 +40,6 @@
 #include "vec/exec/format/parquet/level_decoder.h"
 #include "vparquet_column_chunk_reader.h"
 
-namespace cctz {
-class time_zone;
-} // namespace cctz
-namespace doris {
-namespace io {
-struct IOContext;
-} // namespace io
-} // namespace doris
-
 namespace doris::vectorized {
 
 static void fill_struct_null_map(FieldSchema* field, NullMap& null_map,

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -31,7 +31,6 @@
 #include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "parquet_column_convert.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/columns_number.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exec/format/parquet/parquet_common.h"
@@ -40,16 +39,17 @@
 namespace cctz {
 class time_zone;
 } // namespace cctz
-namespace doris {
-namespace io {
+
+namespace doris::io {
 struct IOContext;
-} // namespace io
-namespace vectorized {
-struct FieldSchema;
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::io
 
 namespace doris::vectorized {
+
+struct FieldSchema;
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 class ParquetColumnReader {
 public:
@@ -127,6 +127,7 @@ public:
 
     virtual MutableColumnPtr convert_dict_column_to_string_column(const ColumnInt32* dict_column) {
         LOG(FATAL) << "Method convert_dict_column_to_string_column is not supported";
+        __builtin_unreachable();
     }
 
     static Status create(io::FileReaderSPtr file, FieldSchema* field,

--- a/be/src/vec/exec/format/table/iceberg_reader.h
+++ b/be/src/vec/exec/format/table/iceberg_reader.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -32,7 +31,6 @@
 #include "table_format_reader.h"
 #include "util/runtime_profile.h"
 #include "vec/columns/column_dictionary.h"
-#include "vec/columns/column_string.h"
 
 namespace tparquet {
 class KeyValue;
@@ -53,6 +51,9 @@ struct IOContext;
 struct TypeDescriptor;
 
 namespace vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 class Block;
 class GenericReader;
 class ShardedKVCache;
@@ -125,7 +126,7 @@ private:
     Status _gen_col_name_maps(std::vector<tparquet::KeyValue> parquet_meta_kv);
     void _gen_file_col_names();
     void _gen_new_colname_to_value_range();
-    std::string _delet_file_cache_key(const std::string& path) { return "delete_" + path; }
+    static std::string _delet_file_cache_key(const std::string& path) { return "delete_" + path; }
 
     RuntimeProfile* _profile;
     RuntimeState* _state;

--- a/be/src/vec/exec/vdata_gen_scan_node.cpp
+++ b/be/src/vec/exec/vdata_gen_scan_node.cpp
@@ -55,6 +55,7 @@ VDataGenFunctionScanNode::VDataGenFunctionScanNode(ObjectPool* pool, const TPlan
         break;
     default:
         LOG(FATAL) << "Unsupported function type";
+        __builtin_unreachable();
     }
 }
 

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -268,6 +268,7 @@ Status VSetOperationNode<is_intersect>::pull(RuntimeState* state, Block* output_
                                                                    state->batch_size(), eos);
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *_hash_table_variants);
@@ -322,6 +323,7 @@ Status VSetOperationNode<is_intersect>::process_build_block(Block& block, Runtim
                     st = hash_table_build_process(arg, _arena);
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *_hash_table_variants);
@@ -372,6 +374,7 @@ Status VSetOperationNode<is_intersect>::sink_probe(RuntimeState* state, int chil
                         return process_hashtable_ctx.mark_data_in_hashtable(arg);
                     } else {
                         LOG(FATAL) << "FATAL: uninited hash table";
+                        __builtin_unreachable();
                     }
                 },
                 *_hash_table_variants));
@@ -558,6 +561,7 @@ void VSetOperationNode<is_intersect>::refresh_hash_table() {
                     }
                 } else {
                     LOG(FATAL) << "FATAL: uninited hash table";
+                    __builtin_unreachable();
                 }
             },
             *_hash_table_variants);

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -17,25 +17,22 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
 #include "common/status.h"
-#include "vec/columns/column_string.h"
 #include "vec/common/string_ref.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/table_function/table_function.h"
 
-namespace doris {
-namespace vectorized {
-class Block;
-} // namespace vectorized
-} // namespace doris
-
 namespace doris::vectorized {
+
+class Block;
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 class VExplodeSplitTableFunction final : public TableFunction {
     ENABLE_FACTORY_CREATOR(VExplodeSplitTableFunction);

--- a/be/src/vec/functions/array/function_array_enumerate_uniq.cpp
+++ b/be/src/vec/functions/array/function_array_enumerate_uniq.cpp
@@ -81,6 +81,7 @@ public:
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
         if (arguments.empty()) {
             LOG(FATAL) << "Incorrect number of arguments for array_enumerate_uniq function";
+            __builtin_unreachable();
         }
         bool is_nested_nullable = false;
         for (size_t i = 0; i < arguments.size(); ++i) {

--- a/be/src/vec/functions/array/function_arrays_overlap.h
+++ b/be/src/vec/functions/array/function_arrays_overlap.h
@@ -20,18 +20,14 @@
 #include <glog/logging.h>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
-#include <new>
 #include <ostream>
-#include <string>
 #include <utility>
 
 #include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
-#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
@@ -56,6 +52,10 @@ template <typename, typename>
 struct DefaultHash;
 
 namespace doris::vectorized {
+
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 
 template <typename T>
 struct OverlapSetImpl {
@@ -237,7 +237,7 @@ public:
     }
 
 private:
-    Status _execute_nullable(const ColumnArrayExecutionData& data, UInt8* dst_nullmap_data) const {
+    static Status _execute_nullable(const ColumnArrayExecutionData& data, UInt8* dst_nullmap_data) {
         for (ssize_t row = 0; row < data.offsets_ptr->size(); ++row) {
             if (dst_nullmap_data[row]) {
                 continue;

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -409,6 +409,7 @@ protected:
     FunctionBasePtr build_impl(const ColumnsWithTypeAndName& /*arguments*/,
                                const DataTypePtr& /*return_type*/) const final {
         LOG(FATAL) << "build_impl is not implemented for IFunction";
+        __builtin_unreachable();
         return {};
     }
 };

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -646,6 +646,7 @@ struct ConvertImplNumberToJsonb {
                 writer.writeDouble(data[i]);
             } else {
                 LOG(FATAL) << "unsupported type ";
+                __builtin_unreachable();
             }
             column_string->insert_data(writer.getOutput()->getBuffer(),
                                        writer.getOutput()->getSize());
@@ -893,6 +894,7 @@ struct ConvertImplFromJsonb {
                     }
                 } else {
                     LOG(FATAL) << "unsupported type ";
+                    __builtin_unreachable();
                 }
             }
 

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -790,6 +790,7 @@ private:
             }
         } else {
             LOG(FATAL) << "unexpected type ";
+            __builtin_unreachable();
         }
     }
 

--- a/be/src/vec/functions/function_variadic_arguments.h
+++ b/be/src/vec/functions/function_variadic_arguments.h
@@ -43,6 +43,7 @@ public:
             res = create_decimal(27, 9, true);
             if (!res) {
                 LOG(FATAL) << "Someting wrong with toDecimalNNOrZero() or toDecimalNNOrNull()";
+                __builtin_unreachable();
             }
         } else
             res = std::make_shared<ToDataType>();

--- a/be/src/vec/json/parse2column.h
+++ b/be/src/vec/json/parse2column.h
@@ -21,20 +21,19 @@
 #include <vector>
 
 #include "vec/columns/column.h"
-#include "vec/columns/column_string.h"
 #include "vec/common/string_ref.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
+
 class SimdJSONParser;
 enum class ExtractType;
 template <typename ParserImpl, bool>
 class JSONDataParser;
-} // namespace vectorized
-} // namespace doris
-
-namespace doris::vectorized {
+template <typename T>
+class ColumnStr;
+using ColumnString = ColumnStr<UInt32>;
 using JsonParser = JSONDataParser<SimdJSONParser, false>;
+
 // parse a batch of json strings into column object, throws doris::Execption when failed
 void parse_json_to_variant(IColumn& column, const ColumnString& raw_json_column);
 

--- a/be/src/vec/jsonb/serialize.h
+++ b/be/src/vec/jsonb/serialize.h
@@ -16,8 +16,8 @@
 // under the License.
 
 #pragma once
-#include <stddef.h>
 
+#include <cstddef>
 #include <unordered_map>
 
 #include "olap/tablet_schema.h"

--- a/be/src/vec/olap/olap_data_convertor.h
+++ b/be/src/vec/olap/olap_data_convertor.h
@@ -443,6 +443,7 @@ private:
         const void* get_data() const override { return _results.data(); };
         const void* get_data_at(size_t offset) const override {
             LOG(FATAL) << "now not support get_data_at for OlapColumnDataConvertorArray";
+            __builtin_unreachable();
         };
         Status convert_to_olap() override;
 
@@ -472,6 +473,7 @@ private:
         const void* get_data() const override { return _results.data(); };
         const void* get_data_at(size_t offset) const override {
             LOG(FATAL) << "now not support get_data_at for OlapColumnDataConvertorMap";
+            __builtin_unreachable();
         };
 
     private:

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -3407,6 +3407,7 @@ void DateV2Value<T>::set_time(uint8_t hour, uint8_t minute, uint8_t second, uint
         date_v2_value_.microsecond_ = microsecond;
     } else {
         LOG(FATAL) << "Invalid operation 'set_time' for date!";
+        __builtin_unreachable();
     }
 }
 
@@ -3416,6 +3417,7 @@ void DateV2Value<T>::set_microsecond(uint32_t microsecond) {
         date_v2_value_.microsecond_ = microsecond;
     } else {
         LOG(FATAL) << "Invalid operation 'set_microsecond' for date!";
+        __builtin_unreachable();
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This is imported by https://github.com/apache/doris/pull/33511. wrongly used
```c++
ColumnStr<T> ();
```
which violate C++20 standard(see https://wg21.cmeerw.net/cwg/issue2237) but still supported by clang up until now(see https://github.com/llvm/llvm-project/issues/58112)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

