### PR TITLE
[Fix](executor)Fix stream load can only use default group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1917,8 +1917,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             // mysql load request not carry user info, need fix it later.
             boolean hasUserName = !StringUtils.isEmpty(request.getUser());
             if (Config.enable_workload_group && hasUserName) {
-                ConnectContext ctx = ConnectContext.get();
-                tWorkloadGroupList = Env.getCurrentEnv().getWorkloadGroupMgr().getWorkloadGroup(ctx);
+                UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(), "%");
+                tWorkloadGroupList = Env.getCurrentEnv().getWorkloadGroupMgr().getWorkloadGroupByUser(userIdentity);
             }
             if (!Strings.isNullOrEmpty(request.getLoadSql())) {
                 httpStreamPutImpl(request, result);


### PR DESCRIPTION
## Proposed changes
In stream load, when be request a plan from FE, it has no session variable which means its session variables has default value.
But stream load currently get workload group from session, this means its group is always default group.
The correct approach is to stream load should get workload group from http args or user's property.
Currently PR is to fix the problem which stream load not gets workload group from user's property correctly.
