### PR TITLE
[exec](table_fun) opt bitmap/split vexplode table func performance

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -43,6 +43,8 @@ public:
 
     void reset() override;
     void get_value(MutableColumnPtr& column) override;
+    int get_value(MutableColumnPtr& column, int max_step) override;
+
     void forward(int step = 1) override;
 
     Status process_init(Block* block, RuntimeState* state) override;

--- a/be/src/vec/exprs/table_function/vexplode_split.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_split.cpp
@@ -89,7 +89,7 @@ void VExplodeSplitTableFunction::process_row(size_t row_idx) {
     if (!(_test_null_map && _test_null_map[row_idx]) && _delimiter.data != nullptr) {
         // TODO: use the function to be better string_view/StringRef split
         auto split = [](std::string_view strv, std::string_view delims = " ") {
-            std::vector<std::string_view> output;
+            std::vector<StringRef> output;
             const auto* first = strv.begin();
             const auto* last = strv.end();
 
@@ -97,8 +97,9 @@ void VExplodeSplitTableFunction::process_row(size_t row_idx) {
                 const auto* second =
                         std::search(first, last, std::cbegin(delims), std::cend(delims));
                 if (first != second) {
-                    output.emplace_back(strv.substr(std::distance(strv.begin(), first),
-                                                    std::distance(first, second)));
+                    auto view = strv.substr(std::distance(strv.begin(), first),
+                                            std::distance(first, second));
+                    output.emplace_back(view.data(), view.length());
                 } else {
                     output.emplace_back("", 0);
                 }
@@ -128,9 +129,31 @@ void VExplodeSplitTableFunction::get_value(MutableColumnPtr& column) {
     if (current_empty()) {
         column->insert_default();
     } else {
-        column->insert_data(const_cast<char*>(_backup[_cur_offset].data()),
-                            _backup[_cur_offset].length());
+        column->insert_data(_backup[_cur_offset].data, _backup[_cur_offset].size);
     }
 }
 
+int VExplodeSplitTableFunction::get_value(doris::vectorized::MutableColumnPtr& column,
+                                          int max_step) {
+    max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
+    // should dispose the empty status, forward one step
+    if (current_empty()) {
+        column->insert_default();
+        max_step = 1;
+    } else {
+        ColumnString* target = nullptr;
+        if (_is_nullable) {
+            target = assert_cast<ColumnString*>(
+                    assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get());
+            assert_cast<ColumnUInt8*>(
+                    assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
+                    ->insert_many_defaults(max_step);
+        } else {
+            target = assert_cast<ColumnString*>(column.get());
+        }
+        target->insert_many_strings(_backup.data() + _cur_offset, max_step);
+    }
+    TableFunction::forward(max_step);
+    return max_step;
+}
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -49,9 +49,10 @@ public:
     void process_row(size_t row_idx) override;
     void process_close() override;
     void get_value(MutableColumnPtr& column) override;
+    int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:
-    std::vector<std::string_view> _backup;
+    std::vector<StringRef> _backup;
 
     ColumnPtr _text_column;
     const uint8_t* _test_null_map = nullptr;


### PR DESCRIPTION
## Proposed changes

Before
```
[tpch]>select count(e1) from (select k1 from bit) as t lateral view explode_btimap(k1) tmp1 as e1;
+------------+
| count(e1)  |
+------------+
| 1000000000 |
+------------+
1 row in set (6.60 sec)
```

After
```
[tpch]>select count(e1) from (select k1 from bit) as t lateral view explode_btimap(k1) tmp1 as e1;
+------------+
| count(e1)  |
+------------+
| 1000000000 |
+------------+
1 row in set (5.80 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

