### PR TITLE
[bugfix](hive)Modify the method used to obtain the txnId

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -148,7 +148,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
         }
         HiveMetadataOps hiveOps = ExternalMetadataOperations.newHiveMetadataOps(hiveConf, jdbcClientConfig, this);
         transactionManager = TransactionManagerFactory.createHiveTransactionManager(hiveOps);
-        transactionManager.setEditLog(Env.getCurrentEnv().getEditLog());
         metadataOps = hiveOps;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/HiveTransactionManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/HiveTransactionManager.java
@@ -17,10 +17,10 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.hive.HMSTransaction;
 import org.apache.doris.datasource.hive.HiveMetadataOps;
-import org.apache.doris.persist.EditLog;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,25 +28,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class HiveTransactionManager implements TransactionManager {
 
     private final Map<Long, HMSTransaction> transactions = new ConcurrentHashMap<>();
-    private final TransactionIdGenerator idGenerator = new TransactionIdGenerator();
     private final HiveMetadataOps ops;
 
     public HiveTransactionManager(HiveMetadataOps ops) {
         this.ops = ops;
     }
 
-    public Long getNextTransactionId() {
-        return idGenerator.getNextTransactionId();
-    }
-
-    @Override
-    public void setEditLog(EditLog editLog) {
-        this.idGenerator.setEditLog(editLog);
-    }
-
     @Override
     public long begin() {
-        long id = idGenerator.getNextTransactionId();
+        long id = Env.getCurrentEnv().getNextId();
         HMSTransaction hiveTransaction = new HMSTransaction(ops);
         transactions.put(id, hiveTransaction);
         return id;

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionManager.java
@@ -18,11 +18,8 @@
 package org.apache.doris.transaction;
 
 import org.apache.doris.common.UserException;
-import org.apache.doris.persist.EditLog;
 
 public interface TransactionManager {
-
-    void setEditLog(EditLog editLog);
 
     long begin();
 


### PR DESCRIPTION
## Proposed changes

fix #32726
Issue #31442

Use `MetaIdGenerator` instead of the `TransactionIdGenerator`. Because the `TransactionIdGenerator` will record `OP_SAVE_TRANSACTION_ID` data in the editlog, when restoring the data, it will restore the data to `CloudGlobalTransactionMgr` in cloud mode, and `TransactionIdGenerator` is not supported `CloudGlobalTransactionMgr`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

