### PR TITLE
[feature](backend) Add cpu core count and memory usage to "show backends" command.

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -34,6 +34,7 @@
 #include "runtime/heartbeat_flags.h"
 #include "service/backend_options.h"
 #include "util/debug_util.h"
+#include "util/mem_info.h"
 #include "util/network_util.h"
 #include "util/thrift_server.h"
 #include "util/time.h"
@@ -88,6 +89,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
                 get_fragment_executing_count());
         heartbeat_result.backend_info.__set_fragment_last_active_time(
                 get_fragment_last_active_time());
+        heartbeat_result.backend_info.__set_be_mem(MemInfo::physical_mem());
     }
     watch.stop();
     if (watch.elapsed_time() > 1000L * 1000L * 1000L) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -22,9 +22,11 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ListComparator;
+import org.apache.doris.common.util.RuntimeProfile;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TUnit;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -48,7 +50,7 @@ public class BackendsProcDir implements ProcDirInterface {
             .add("LastStartTime").add("LastHeartbeat").add("Alive").add("SystemDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("TrashUsedCapcacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
             .add("MaxDiskUsedPct").add("RemoteUsedCapacity").add("Tag").add("ErrMsg").add("Version").add("Status")
-            .add("HeartbeatFailureCounter").add("NodeRole")
+            .add("HeartbeatFailureCounter").add("NodeRole").add("CpuCores").add("Memory")
             .build();
 
     public static final ImmutableList<String> DISK_TITLE_NAMES = new ImmutableList.Builder<String>()
@@ -166,6 +168,11 @@ public class BackendsProcDir implements ProcDirInterface {
             // node role, show the value only when backend is alive.
             backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
 
+            // cpu cores
+            backendInfo.add(String.valueOf(backend.getCputCores()));
+
+            // memory
+            backendInfo.add(RuntimeProfile.printCounter(backend.getBeMemory(), TUnit.BYTES));
             comparableBackendInfos.add(backendInfo);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -126,7 +126,9 @@ public class Backend implements Writable {
     // cpu cores
     @SerializedName("cpuCores")
     private int cpuCores = 1;
-
+    // The physical memory available for use by BE.
+    @SerializedName("beMemory")
+    private long beMemory = 0;
     // from config::pipeline_executor_size , default equal cpuCores
     @SerializedName("pipelineExecutorSize")
     private int pipelineExecutorSize = 1;
@@ -377,6 +379,10 @@ public class Backend implements Writable {
 
     public int getCputCores() {
         return cpuCores;
+    }
+
+    public long getBeMemory() {
+        return beMemory;
     }
 
     public int getPipelineExecutorSize() {
@@ -769,6 +775,10 @@ public class Backend implements Writable {
                     hbResponse.getNodeRole())) {
                 isChanged = true;
                 this.nodeRoleTag = Tag.createNotCheck(Tag.TYPE_ROLE, hbResponse.getNodeRole());
+            }
+            if (this.beMemory != hbResponse.getBeMemory()) {
+                isChanged = true;
+                this.beMemory = hbResponse.getBeMemory();
             }
 
             this.lastUpdateMs = hbResponse.getHbTime();

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -52,6 +52,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private long lastFragmentUpdateTime;
     @SerializedName(value = "isShutDown")
     private boolean isShutDown = false;
+    // The physical memory available for use by BE.
+    private long beMemory = 0;
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -74,6 +76,26 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.lastFragmentUpdateTime = lastFragmentUpdateTime;
         this.isShutDown = isShutDown;
         this.arrowFlightSqlPort = arrowFlightSqlPort;
+    }
+
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort, long hbTime, long beStartTime,
+            String version, String nodeRole, long fragmentNum, long lastFragmentUpdateTime,
+            boolean isShutDown, int arrowFlightSqlPort, long beMemory) {
+        super(HeartbeatResponse.Type.BACKEND);
+        this.beId = beId;
+        this.status = HbStatus.OK;
+        this.bePort = bePort;
+        this.httpPort = httpPort;
+        this.brpcPort = brpcPort;
+        this.hbTime = hbTime;
+        this.beStartTime = beStartTime;
+        this.version = version;
+        this.nodeRole = nodeRole;
+        this.fragmentNum = fragmentNum;
+        this.lastFragmentUpdateTime = lastFragmentUpdateTime;
+        this.isShutDown = isShutDown;
+        this.arrowFlightSqlPort = arrowFlightSqlPort;
+        this.beMemory = beMemory;
     }
 
     public BackendHbResponse(long beId, String errMsg) {
@@ -133,6 +155,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public boolean isShutDown() {
         return isShutDown;
+    }
+
+    public long getBeMemory() {
+        return beMemory;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -276,9 +276,10 @@ public class HeartbeatMgr extends MasterDaemon {
                     if (tBackendInfo.isSetIsShutdown()) {
                         isShutDown = tBackendInfo.isIsShutdown();
                     }
+                    long beMemory = tBackendInfo.isSetBeMem() ? tBackendInfo.getBeMem() : 0;
                     return new BackendHbResponse(backendId, bePort, httpPort, brpcPort,
                             System.currentTimeMillis(), beStartTime, version, nodeRole,
-                            fragmentNum, lastFragmentUpdateTime, isShutDown, arrowFlightSqlPort);
+                            fragmentNum, lastFragmentUpdateTime, isShutDown, arrowFlightSqlPort, beMemory);
                 } else {
                     return new BackendHbResponse(backendId, backend.getHost(),
                             result.getStatus().getErrorMsgs().isEmpty()

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowBackendsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowBackendsStmtTest.java
@@ -71,7 +71,7 @@ public class ShowBackendsStmtTest {
     public void getMetaData() {
         ShowBackendsStmt stmt = new ShowBackendsStmt();
         ShowResultSetMetaData result = stmt.getMetaData();
-        Assertions.assertEquals(result.getColumnCount(), 25);
+        Assertions.assertEquals(result.getColumnCount(), 27);
         result.getColumns().forEach(col -> Assertions.assertEquals(col.getType(), ScalarType.createVarchar(30)));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -199,13 +199,13 @@ public class DemoMultiBackendsTest {
         ProcResult result = dir.fetchResult();
         Assert.assertEquals(BackendsProcDir.TITLE_NAMES.size(), result.getColumnNames().size());
         Assert.assertEquals("{\"location\" : \"default\"}",
-                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 6));
+                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 8));
         Assert.assertEquals(
                 "{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,"
                         + "\"isLoadDisabled\":false,\"isActive\":true,\"currentFragmentNum\":0,\"lastFragmentUpdateTime\":0}",
-                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 3));
-        Assert.assertEquals("0", result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 2));
-        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 1));
+                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 5));
+        Assert.assertEquals("0", result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 4));
+        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 3));
     }
 
     private static void updateReplicaPathHash() {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -51,7 +51,7 @@ struct TBackendInfo {
     7: optional string be_node_role
     8: optional bool is_shutdown
     9: optional Types.TPort arrow_flight_sql_port
-
+    10: optional i64 be_mem // The physical memory available for use by BE.
     // For cloud
     1000: optional i64 fragment_executing_count
     1001: optional i64 fragment_last_active_time


### PR DESCRIPTION
## Proposed changes

```
mysql [(none)]>show backends\G;
*************************** 1. row ***************************
              BackendId: 10016
                   Host: 127.0.0.1
          HeartbeatPort: 9229
                 BePort: 9239
               HttpPort: 8219
               BrpcPort: 8239
     ArrowFlightSqlPort: -1
          LastStartTime: 2024-04-19 15:50:26
          LastHeartbeat: 2024-04-19 15:50:30
                  Alive: true
   SystemDecommissioned: false
              TabletNum: 17247
       DataUsedCapacity: 31.558 GB
     TrashUsedCapcacity: 0.000 
          AvailCapacity: 387.957 GB
          TotalCapacity: 3.437 TB
                UsedPct: 88.98 %
         MaxDiskUsedPct: 88.98 %
     RemoteUsedCapacity: 0.000 
                    Tag: {"location" : "default"}
                 ErrMsg: 
                Version: doris-0.0.0-trunk-049729a361
                 Status: {"lastSuccessReportTabletsTime":"2024-04-19 15:50:31","lastStreamLoadTime":-1,"isQueryDisabled":false,"isLoadDisabled":false,"isActive":true,"currentFragmentNum":0,"lastFragmentUpdateTime":1713513015892}
HeartbeatFailureCounter: 0
               NodeRole: mix
               CpuCores: 96
                 Memory: 375.81 GB
1 row in set (0.04 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

