### PR TITLE
[fix][mow] free _memtable_flush_executor and _calc_delete_bitmap_executor resource before stop CloudStorageEngine

### DIFF
--- a/be/src/cloud/cloud_full_compaction.cpp
+++ b/be/src/cloud/cloud_full_compaction.cpp
@@ -340,7 +340,9 @@ Status CloudFullCompaction::_cloud_full_compaction_calc_delete_bitmap(
     std::vector<RowsetSharedPtr> specified_rowsets(1, _output_rowset);
 
     OlapStopWatch watch;
-    auto token = _engine.calc_delete_bitmap_executor()->create_token();
+    CalcDeleteBitmapExecutor* executor = nullptr;
+    RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(executor));
+    auto token = executor->create_token();
     RETURN_IF_ERROR(BaseTablet::calc_delete_bitmap(_tablet, published_rowset, segments,
                                                    specified_rowsets, delete_bitmap, cur_version,
                                                    token.get(), _output_rs_writer.get()));

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -78,7 +78,9 @@ Status CloudRowsetBuilder::init() {
     context.rowset_dir = _tablet->tablet_path();
     _rowset_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
 
-    _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();
+    CalcDeleteBitmapExecutor* executor= nullptr;
+    RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(executor));
+    _calc_delete_bitmap_token = executor->create_token();
 
     RETURN_IF_ERROR(_engine.meta_mgr().prepare_rowset(*_rowset_writer->rowset_meta()));
 

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -78,7 +78,7 @@ Status CloudRowsetBuilder::init() {
     context.rowset_dir = _tablet->tablet_path();
     _rowset_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
 
-    CalcDeleteBitmapExecutor* executor= nullptr;
+    CalcDeleteBitmapExecutor* executor = nullptr;
     RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(executor));
     _calc_delete_bitmap_token = executor->create_token();
 

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -211,6 +211,9 @@ void CloudStorageEngine::stop() {
             t->join();
         }
     }
+    _memtable_flush_executor.reset(nullptr);
+    _calc_delete_bitmap_executor.reset(nullptr);
+    LOG(INFO) << "Storage engine is stopped.";
 }
 
 bool CloudStorageEngine::stopped() {

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -130,6 +130,16 @@ public:
         return *_sync_load_for_tablets_thread_pool;
     }
 
+    Status calc_delete_bitmap_executor(CalcDeleteBitmapExecutor*& executor) override {
+        if (stopped()) {
+            LOG(WARNING) << "fail to get _calc_delete_bitmap_executor, engine is stopped";
+            return Status::InternalError(
+                    "fail to get _calc_delete_bitmap_executor, engine is stopped");
+        }
+        executor = _calc_delete_bitmap_executor.get();
+        return Status::OK();
+    }
+
 private:
     void _refresh_storage_vault_info_thread_callback();
     void _vacuum_stale_rowsets_thread_callback();

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -591,7 +591,6 @@ std::vector<RowsetSharedPtr> CloudTablet::pick_candidate_rowsets_to_full_compact
     return candidate_rowsets;
 }
 
-
 Status CloudTablet::calc_delete_bitmap_executor(
         CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) {
     RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(calc_delete_bitmap_executor));

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -591,8 +591,11 @@ std::vector<RowsetSharedPtr> CloudTablet::pick_candidate_rowsets_to_full_compact
     return candidate_rowsets;
 }
 
-CalcDeleteBitmapExecutor* CloudTablet::calc_delete_bitmap_executor() {
-    return _engine.calc_delete_bitmap_executor();
+
+Status CloudTablet::calc_delete_bitmap_executor(
+        CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) {
+    RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(calc_delete_bitmap_executor));
+    return Status::OK();
 }
 
 Status CloudTablet::save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t txn_id,

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -175,7 +175,8 @@ public:
             const Rowset& rowset, std::shared_ptr<PartialUpdateInfo> partial_update_info,
             int64_t txn_expiration = 0) override;
 
-    CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() override;
+    Status calc_delete_bitmap_executor(
+            CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) override;
 
     Status save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t txn_id,
                               DeleteBitmapPtr delete_bitmap, RowsetWriter* rowset_writer,

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -1203,7 +1203,9 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, const Tablet
                                            cur_version - 1, nullptr, transient_rs_writer.get()));
 
     } else {
-        auto token = self->calc_delete_bitmap_executor()->create_token();
+        CalcDeleteBitmapExecutor* executor = nullptr;
+        RETURN_IF_ERROR(self->calc_delete_bitmap_executor(executor));
+        auto token = executor->create_token();
         RETURN_IF_ERROR(calc_delete_bitmap(self, rowset, segments, specified_rowsets, delete_bitmap,
                                            cur_version - 1, token.get(),
                                            transient_rs_writer.get()));
@@ -1409,7 +1411,9 @@ Status BaseTablet::update_delete_bitmap_without_lock(
     }
 
     OlapStopWatch watch;
-    auto token = self->calc_delete_bitmap_executor()->create_token();
+    CalcDeleteBitmapExecutor* executor = nullptr;
+    RETURN_IF_ERROR(self->calc_delete_bitmap_executor(executor));
+    auto token = executor->create_token();
     RETURN_IF_ERROR(calc_delete_bitmap(self, rowset, segments, specified_rowsets, delete_bitmap,
                                        cur_version - 1, token.get()));
     RETURN_IF_ERROR(token->wait());

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -216,7 +216,8 @@ public:
     virtual Status save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t txn_id,
                                       DeleteBitmapPtr delete_bitmap, RowsetWriter* rowset_writer,
                                       const RowsetIdUnorderedSet& cur_rowset_ids) = 0;
-    virtual CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() = 0;
+    virtual Status calc_delete_bitmap_executor(
+            CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) = 0;
 
     void calc_compaction_output_rowset_delete_bitmap(
             const std::vector<RowsetSharedPtr>& input_rowsets,

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -217,7 +217,9 @@ Status RowsetBuilder::init() {
     _rowset_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
     _pending_rs_guard = _engine.pending_local_rowsets().add(context.rowset_id);
 
-    _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();
+    CalcDeleteBitmapExecutor* executor = nullptr;
+    RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(executor));
+    _calc_delete_bitmap_token = executor->create_token();
 
     _is_init = true;
     return Status::OK();

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -121,9 +121,7 @@ public:
     RowsetId next_rowset_id();
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
-    CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() {
-        return _calc_delete_bitmap_executor.get();
-    }
+    virtual Status calc_delete_bitmap_executor(CalcDeleteBitmapExecutor*& executor) = 0;
 
     void add_quering_rowset(RowsetSharedPtr rs);
 
@@ -272,6 +270,14 @@ public:
     bool remove_broken_path(std::string path);
 
     std::set<string> get_broken_paths() { return _broken_paths; }
+
+    Status calc_delete_bitmap_executor(CalcDeleteBitmapExecutor*& executor) override {
+        if (stopped()) {
+            return Status::InternalError("engine is stopped");
+        }
+        executor = _calc_delete_bitmap_executor.get();
+        return Status::OK();
+    }
 
 private:
     // Instance should be inited from `static open()`

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2383,8 +2383,9 @@ void Tablet::update_max_version_schema(const TabletSchemaSPtr& tablet_schema) {
     }
 }
 
-CalcDeleteBitmapExecutor* Tablet::calc_delete_bitmap_executor() {
-    return _engine.calc_delete_bitmap_executor();
+Status Tablet::calc_delete_bitmap_executor(CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) {
+    RETURN_IF_ERROR(_engine.calc_delete_bitmap_executor(calc_delete_bitmap_executor));
+    return Status::OK();
 }
 
 Status Tablet::save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t txn_id,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -399,7 +399,8 @@ public:
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
 
-    CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() override;
+    Status calc_delete_bitmap_executor(
+            CalcDeleteBitmapExecutor* calc_delete_bitmap_executor) override;
     Status save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t txn_id,
                               DeleteBitmapPtr delete_bitmap, RowsetWriter* rowset_writer,
                               const RowsetIdUnorderedSet& cur_rowset_ids) override;

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -468,7 +468,13 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     }
 
     // Step 7.2 calculate delete bitmap before commit
-    auto calc_delete_bitmap_token = engine.calc_delete_bitmap_executor()->create_token();
+    CalcDeleteBitmapExecutor* executor = nullptr;
+    auto st = engine.calc_delete_bitmap_executor(executor);
+    if (!st.ok()) {
+        LOG(WARNING) << "failed to get calc_delete_bitmap_executor, status=" << st.to_string();
+        return;
+    }
+    auto calc_delete_bitmap_token = executor->create_token();
     DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(local_tablet_id);
     RowsetIdUnorderedSet pre_rowset_ids;
     if (local_tablet->enable_unique_key_merge_on_write()) {


### PR DESCRIPTION
## Proposed changes
_memtable_flush_executor and _calc_delete_bitmap_executor should free before stop CloudStorageEngine,like StorageEngine does, otherwise be may core when it's going to exit.

F20240415 20:51:24.190708 2398227 threadpool.cpp:253] Check failed: 1 == _tokens.size() (1 vs. 4) Threadpool TabletCalcDeleteBitmapThreadPool destroyed with 4 allocated tokens

Check failure stack trace: ***
@ 0x555c7f8c2246 google::LogMessage::SendToLog()
@ 0x555c7f8bec90 google::LogMessage::Flush()
@ 0x555c7f8c2a89 google::LogMessageFatal::~LogMessageFatal()
@ 0x555c4fe3cf2f doris::ThreadPool::~ThreadPool()
@ 0x555c4b9df87d std::default_delete<>::operator()()
@ 0x555c4b99238c std::unique_ptr<>::~unique_ptr()
@ 0x555c4e7abc40 doris::CalcDeleteBitmapExecutor::~CalcDeleteBitmapExecutor()
@ 0x555c4e7abb3d std::default_delete<>::operator()()
@ 0x555c4e7938b0 std::unique_ptr<>::~unique_ptr()
@ 0x555c4e75ac28 doris::BaseStorageEngine::~BaseStorageEngine()
@ 0x555c7f72f748 doris::CloudStorageEngine::~CloudStorageEngine()
@ 0x555c7f72fa39 doris::CloudStorageEngine::~CloudStorageEngine()
@ 0x555c4ef57c65 std::default_delete<>::operator()()
@ 0x555c4efb8a84 std::__uniq_ptr_impl<>::reset()
@ 0x555c4ef87d2f std::unique_ptr<>::reset()
@ 0x555c4ef71d3f doris::ExecEnv::destroy()
@ 0x555c4b84b8ba main
@ 0x7f461097a083 __libc_start_main
@ 0x555c4b76d02a _start
@ (nil) (unknown)

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

