### PR TITLE
[Fix](nereids) fix rule merge_aggregate when has project

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -300,6 +300,7 @@ public class Rewriter extends AbstractBatchJobExecutor {
             topic("Eliminate GroupBy",
                     topDown(new EliminateGroupBy(),
                             new MergeAggregate(),
+                            // need to adjust min/max/sum nullable attribute after merge aggregate
                             new AdjustAggregateNullableForEmptySet())
             ),
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -299,7 +299,8 @@ public class Rewriter extends AbstractBatchJobExecutor {
 
             topic("Eliminate GroupBy",
                     topDown(new EliminateGroupBy(),
-                            new MergeAggregate())
+                            new MergeAggregate(),
+                            new AdjustAggregateNullableForEmptySet())
             ),
 
             topic("Eager aggregation",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeAggregate.java
@@ -34,10 +34,12 @@ import org.apache.doris.nereids.util.PlanUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -138,13 +140,17 @@ public class MergeAggregate implements RewriteRuleFactory {
     }
 
     boolean commonCheck(LogicalAggregate<? extends Plan> outerAgg, LogicalAggregate<Plan> innerAgg,
-            boolean sameGroupBy) {
+            boolean sameGroupBy, Optional<LogicalProject> projectOptional) {
         innerAggExprIdToAggFunc = innerAgg.getOutputExpressions().stream()
                 .filter(expr -> (expr instanceof Alias) && (expr.child(0) instanceof AggregateFunction))
                 .collect(Collectors.toMap(NamedExpression::getExprId, value -> (AggregateFunction) value.child(0),
                         (existValue, newValue) -> existValue));
         Set<AggregateFunction> aggregateFunctions = outerAgg.getAggregateFunctions();
-        for (AggregateFunction outerFunc : aggregateFunctions) {
+        List<AggregateFunction> replacedAggFunctions = projectOptional.map(project ->
+                (List<AggregateFunction>) PlanUtils.replaceExpressionByProjections(
+                projectOptional.get().getProjects(), new ArrayList<>(aggregateFunctions)))
+                .orElse(new ArrayList<>(aggregateFunctions));
+        for (AggregateFunction outerFunc : replacedAggFunctions) {
             if (!(ALLOW_MERGE_AGGREGATE_FUNCTIONS.contains(outerFunc.getName()))) {
                 return false;
             }
@@ -188,7 +194,7 @@ public class MergeAggregate implements RewriteRuleFactory {
         }
         boolean sameGroupBy = (innerAgg.getGroupByExpressions().size() == outerAgg.getGroupByExpressions().size());
 
-        return commonCheck(outerAgg, innerAgg, sameGroupBy);
+        return commonCheck(outerAgg, innerAgg, sameGroupBy, Optional.empty());
     }
 
     private boolean canMergeAggregateWithProject(LogicalAggregate<LogicalProject<LogicalAggregate<Plan>>> outerAgg) {
@@ -206,6 +212,6 @@ public class MergeAggregate implements RewriteRuleFactory {
             return false;
         }
         boolean sameGroupBy = (innerAgg.getGroupByExpressions().size() == outerAgg.getGroupByExpressions().size());
-        return commonCheck(outerAgg, innerAgg, sameGroupBy);
+        return commonCheck(outerAgg, innerAgg, sameGroupBy, Optional.of(project));
     }
 }

--- a/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
+++ b/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
@@ -246,3 +246,29 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[mal_test1]
 
+-- !test_has_project_distinct_cant_transform --
+1
+
+-- !test_has_project_distinct_cant_transform_shape --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------hashAgg[GLOBAL]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------hashAgg[LOCAL]
+----------------PhysicalProject
+------------------PhysicalOlapScan[mal_test_merge_agg]
+
+-- !test_has_project_distinct_expr_transform --
+-1
+
+-- !test_has_project_distinct_expr_transform_shape --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------PhysicalOlapScan[mal_test_merge_agg]
+

--- a/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
+++ b/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
@@ -287,3 +287,13 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------PhysicalOlapScan[mal_test_merge_agg]
 
+-- !test_sum_empty_table --
+\N	\N	\N
+
+-- !test_sum_empty_table_shape --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------hashAgg[LOCAL]
+--------PhysicalOlapScan[mal_test2]
+

--- a/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
+++ b/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
@@ -261,14 +261,29 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[mal_test_merge_agg]
 
--- !test_has_project_distinct_expr_transform --
+-- !test_distinct_expr_transform --
 -1
 
--- !test_has_project_distinct_expr_transform_shape --
+-- !test_distinct_expr_transform_shape --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
 --------PhysicalProject
 ----------PhysicalOlapScan[mal_test_merge_agg]
+
+-- !test_has_project_distinct_expr_transform --
+1
+1
+1
+
+-- !test_has_project_distinct_expr_transform --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----PhysicalProject
+------hashAgg[GLOBAL]
+--------PhysicalDistribute[DistributionSpecHash]
+----------hashAgg[LOCAL]
+------------PhysicalProject
+--------------PhysicalOlapScan[mal_test_merge_agg]
 

--- a/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
@@ -209,7 +209,7 @@ suite("merge_aggregate") {
         ) t ;
     """
 
-    qt_test_has_project_distinct_expr_transform """
+    qt_test_distinct_expr_transform """
         select max(count_col)
         from (
             select k4,
@@ -217,7 +217,7 @@ suite("merge_aggregate") {
             from mal_test_merge_agg group by k4
         ) t ;
     """
-    qt_test_has_project_distinct_expr_transform_shape """
+    qt_test_distinct_expr_transform_shape """
         explain shape plan
         select max(count_col)
         from (
@@ -225,5 +225,24 @@ suite("merge_aggregate") {
             max(-abs(k1)) as count_col
             from mal_test_merge_agg group by k4
         ) t ;
+    """
+
+    qt_test_has_project_distinct_expr_transform """
+        select sum(count_col)
+        from (
+            select k4,
+            count(distinct case when k3 is null then 1 else 0 end) as count_col
+            from mal_test_merge_agg group by k4
+        ) t  group by k4;
+    """
+
+    qt_test_has_project_distinct_expr_transform """
+        explain shape plan
+        select sum(count_col)
+        from (
+            select k4,
+            count(distinct case when k3 is null then 1 else 0 end) as count_col
+            from mal_test_merge_agg group by k4
+        ) t  group by k4;
     """
 }

--- a/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
@@ -245,4 +245,13 @@ suite("merge_aggregate") {
             from mal_test_merge_agg group by k4
         ) t  group by k4;
     """
+
+    qt_test_sum_empty_table """
+        select sum(col1),min(col2),max(col3) from (select sum(a) col1, min(b) col2, max(pk) col3 from mal_test2 group by a) t;
+    """
+
+    qt_test_sum_empty_table_shape """
+        explain shape plan
+        select sum(col1),min(col2),max(col3) from (select sum(a) col1, min(b) col2, max(pk) col3 from mal_test2 group by a) t;
+    """
 }


### PR DESCRIPTION
This pr fix 2 problem of merge_aggregate:
1.The map innerAggExprIdToAggFunc key is the inner agg output agg func exprid, value is the Agg func. When a LogicalProject is between 2 agg,  the outeragg func child refer to the project output, I forget to do the rewrite to make the outeragg func child refer to the inneragg output. This can lead to an incorrect judgment when determining whether the outer agg func child exists in the inner agg func outputs. This pr fix this bug.
2.When merging 2 sum/min/max, the outer agg group by key is empty, and the inner agg group by key is not empty, the nullable attribute need to be adjusted. Because the sum without group by key is always nullable, the sum with group by key nullable attribute determined by the sum child nullable attribute. This pr fix this bug.