### PR TITLE
[chore](errmsg) Fix confusing error message and clang tidy hints

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,8 @@ Checks: |
   -readability-inconsistent-declaration-parameter-name,
   -readability-isolate-declaration,
   -readability-named-parameter,
+  -readability-avoid-const-params-in-decls,
+  -readability-convert-member-functions-to-static,
   portability-simd-intrinsics,
   performance-type-promotion-in-math-fn,
   performance-faster-string-find,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
@@ -186,9 +186,13 @@ public class PartitionDesc {
             boolean found = false;
             for (ColumnDef columnDef : columnDefs) {
                 if (columnDef.getName().equals(partitionCol)) {
-                    if (!columnDef.isKey() && (columnDef.getAggregateType() != AggregateType.NONE
-                            || enableUniqueKeyMergeOnWrite)) {
-                        throw new AnalysisException("The partition column could not be aggregated column");
+                    if (!columnDef.isKey()) {
+                        if (columnDef.getAggregateType() != AggregateType.NONE) {
+                            throw new AnalysisException("The partition column could not be aggregated column");
+                        }
+                        if (enableUniqueKeyMergeOnWrite) {
+                            throw new AnalysisException("Merge-on-Write table's partition column must be KEY column");
+                        }
                     }
                     if (columnDef.getType().isFloatingPointType()) {
                         throw new AnalysisException("Floating point type column can not be partition column");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
@@ -121,9 +121,13 @@ public class PartitionTableInfo {
 
     private void validatePartitionColumn(ColumnDefinition column, ConnectContext ctx,
                                          boolean isEnableMergeOnWrite, boolean isExternal) {
-        if (!column.isKey()
-                && (!column.getAggType().equals(AggregateType.NONE) || isEnableMergeOnWrite)) {
-            throw new AnalysisException("The partition column could not be aggregated column");
+        if (!column.isKey()) { // value column
+            if (!column.getAggType().equals(AggregateType.NONE)) { // agg column
+                throw new AnalysisException("The partition column could not be aggregated column");
+            }
+            if (isEnableMergeOnWrite) { // MoW table
+                throw new AnalysisException("Merge-on-Write table's partition column must be KEY column");
+            }
         }
         if (column.getType().isFloatLikeType()) {
             throw new AnalysisException("Floating point type column can not be partition column");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. removed clang-tidy options which nonsense or always false alarm: `readability-avoid-const-params-in-decls` and `readability-convert-member-functions-to-static`
2. for MoW table try use VALUE column as PARTITION column, 
before got:
```
The partition column could not be aggregated column
```
now:
```
Merge-on-Write table's partition column must be KEY column
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

