### PR TITLE
[feature](spark-load) add Hive HLL UDFs

### DIFF
--- a/fe/hive-udf/src/main/java/org/apache/doris/common/HllUtil.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/common/HllUtil.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.common.io.Hll;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class HllUtil {
+    public static byte[] serializeToBytes(Hll hll) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        hll.serialize(dos);
+        dos.close();
+        return bos.toByteArray();
+    }
+
+    public static Hll deserializeToHll(byte[] bytes) throws IOException {
+        Hll hll = new Hll();
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+        hll.deserialize(in);
+        in.close();
+        return hll;
+    }
+}

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/HllCardinalityUDF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/HllCardinalityUDF.java
@@ -30,8 +30,12 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 
 import java.io.IOException;
 
-@Description(name = "hll_cardinality", value = "a _FUNC_ b - Returns the number of distinct integers"
-        + " added to the hll (e.g., number of bits set)")
+/**
+ * HllCardinality.
+ *
+ */
+@Description(name = "hll_cardinality", value = "a _FUNC_ b - Returns the number of distinct elements"
+        + " added to the hll")
 public class HllCardinalityUDF extends GenericUDF {
     private transient BinaryObjectInspector inputOI;
 

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/HllCardinalityUDF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/HllCardinalityUDF.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.udf;
+
+import org.apache.doris.common.HllUtil;
+import org.apache.doris.common.io.Hll;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.io.IOException;
+
+@Description(name = "hll_cardinality", value = "a _FUNC_ b - Returns the number of distinct integers"
+        + " added to the hll (e.g., number of bits set)")
+public class HllCardinalityUDF extends GenericUDF {
+    private transient BinaryObjectInspector inputOI;
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+
+        ObjectInspector input = arguments[0];
+        if (!(input instanceof BinaryObjectInspector)) {
+            throw new UDFArgumentException("first argument must be a binary");
+        }
+
+        this.inputOI = (BinaryObjectInspector) input;
+
+        return PrimitiveObjectInspectorFactory.javaLongObjectInspector;
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[]  args) throws HiveException {
+        if (args[0] == null) {
+            return 0;
+        }
+        byte[] inputBytes = this.inputOI.getPrimitiveJavaObject(args[0].get());
+
+        try {
+            Hll hll = HllUtil.deserializeToHll(inputBytes);
+            return hll.estimateCardinality();
+        } catch (IOException ioException) {
+            throw new HiveException(ioException);
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return "Usage: hll_cardinality(hll)";
+    }
+}

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.udf;
+
+import org.apache.doris.common.HllUtil;
+import org.apache.doris.common.io.Hll;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.io.IOException;
+
+/**
+ * hll_union.
+ *
+ */
+@SuppressWarnings("deprecation")
+@Description(name = "hll_union", value = "_FUNC_(expr) - Calculate the grouped hll"
+        + " union , Returns an doris hll representation of a column.")
+public class HllUnionUDAF extends AbstractGenericUDAFResolver {
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(TypeInfo[] parameters)
+            throws SemanticException {
+        if (parameters.length != 1) {
+            throw new UDFArgumentTypeException(parameters.length - 1,
+                    "Exactly one argument is expected.");
+        }
+        return new GenericEvaluate();
+    }
+
+    //The UDAF evaluator assumes that all rows it's evaluating have
+    //the same (desired) value.
+    public static class GenericEvaluate extends GenericUDAFEvaluator {
+
+        private transient BinaryObjectInspector inputOI;
+        private transient BinaryObjectInspector internalMergeOI;
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters)
+                throws HiveException {
+            super.init(m, parameters);
+            // init output object inspectors
+            // The output of a partial aggregation is a binary
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+                this.inputOI = (BinaryObjectInspector) parameters[0];
+            } else {
+                this.internalMergeOI = (BinaryObjectInspector) parameters[0];
+            }
+            return PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+        }
+
+        /** class for storing the current partial result aggregation */
+        @AggregationType(estimable = true)
+        static class HllAgg extends AbstractAggregationBuffer {
+            Hll hll;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            ((HllAgg) agg).hll = new Hll();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            HllAgg result = new HllAgg();
+            reset(result);
+            return result;
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            assert (parameters.length == 1);
+            Object p = parameters[0];
+            if (p != null) {
+                HllAgg myagg = (HllAgg) agg;
+                byte[] partialResult = this.inputOI.getPrimitiveJavaObject(parameters[0]);
+                try {
+                    myagg.hll.merge(HllUtil.deserializeToHll(partialResult));
+                } catch (IOException ioException) {
+                    throw new HiveException(ioException);
+                }
+            }
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer agg) {
+            HllAgg myagg = (HllAgg) agg;
+            try {
+                return HllUtil.serializeToBytes(myagg.hll);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) {
+            HllAgg myagg = (HllAgg) agg;
+            byte[] partialResult = this.internalMergeOI.getPrimitiveJavaObject(partial);
+            try {
+                myagg.hll.merge(HllUtil.deserializeToHll(partialResult));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) {
+            return terminate(agg);
+        }
+    }
+}

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
@@ -37,7 +37,6 @@ import java.io.IOException;
  * hll_union.
  *
  */
-@SuppressWarnings("deprecation")
 @Description(name = "hll_union", value = "_FUNC_(expr) - Calculate the grouped hll"
         + " union , Returns an doris hll representation of a column.")
 public class HllUnionUDAF extends AbstractGenericUDAFResolver {

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/HllUnionUDAF.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import java.io.IOException;
 
 /**
- * hll_union.
+ * HllUnion.
  *
  */
 @Description(name = "hll_union", value = "_FUNC_(expr) - Calculate the grouped hll"

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/ToHllUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/ToHllUDAF.java
@@ -39,7 +39,6 @@ import java.io.IOException;
  * ToHll.
  *
  */
-@SuppressWarnings("deprecation")
 @Description(name = "to_hll", value = "_FUNC_(expr) - Returns an doris hll representation of a column.")
 public class ToHllUDAF extends AbstractGenericUDAFResolver {
 

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/ToHllUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/ToHllUDAF.java
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.udf;
+
+import org.apache.doris.common.HllUtil;
+import org.apache.doris.common.io.Hll;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.io.IOException;
+
+/**
+ * ToHll.
+ *
+ */
+@SuppressWarnings("deprecation")
+@Description(name = "to_hll", value = "_FUNC_(expr) - Returns an doris hll representation of a column.")
+public class ToHllUDAF extends AbstractGenericUDAFResolver {
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(TypeInfo[] parameters)
+            throws SemanticException {
+        if (parameters.length != 1) {
+            throw new UDFArgumentTypeException(parameters.length - 1,
+                    "Exactly one argument is expected.");
+        }
+        return new GenericEvaluate();
+    }
+
+    //The UDAF evaluator assumes that all rows it's evaluating have
+    //the same (desired) value.
+    public static class GenericEvaluate extends GenericUDAFEvaluator {
+
+        // For PARTIAL1 and COMPLETE: ObjectInspectors for original data
+        private PrimitiveObjectInspector inputOI;
+
+        // For PARTIAL2 and FINAL: ObjectInspectors for partial aggregations
+        // (doris hlls)
+
+        private transient BinaryObjectInspector internalMergeOI;
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters)
+                throws HiveException {
+            super.init(m, parameters);
+            // init output object inspectors
+            // The output of a partial aggregation is a binary
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+                inputOI = (PrimitiveObjectInspector) parameters[0];
+            } else {
+                this.internalMergeOI = (BinaryObjectInspector) parameters[0];
+            }
+            return PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+        }
+
+        /** class for storing the current partial result aggregation */
+        @AggregationType(estimable = true)
+        static class HllAgg extends AbstractAggregationBuffer {
+            Hll hll;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            ((HllAgg) agg).hll = new Hll();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            HllAgg result = new HllAgg();
+            reset(result);
+            return result;
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            assert (parameters.length == 1);
+            Object p = parameters[0];
+            if (p != null) {
+                HllAgg myagg = (HllAgg) agg;
+                try {
+                    long row = PrimitiveObjectInspectorUtils.getLong(p, inputOI);
+                    addHll(row, myagg);
+                } catch (NumberFormatException e) {
+                    throw new HiveException(e);
+                }
+            }
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer agg) {
+            HllAgg myagg = (HllAgg) agg;
+            try {
+                return HllUtil.serializeToBytes(myagg.hll);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) {
+            HllAgg myagg = (HllAgg) agg;
+            byte[] partialResult = this.internalMergeOI.getPrimitiveJavaObject(partial);
+            try {
+                myagg.hll.merge(HllUtil.deserializeToHll(partialResult));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) {
+            return terminate(agg);
+        }
+
+        private void addHll(long newRow, HllAgg myagg) {
+            myagg.hll.updateWithHash(newRow);
+        }
+    }
+}

--- a/fe/hive-udf/src/test/java/org/apache/doris/HllUDFTest.java
+++ b/fe/hive-udf/src/test/java/org/apache/doris/HllUDFTest.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris;
+
+import org.apache.doris.common.HllUtil;
+import org.apache.doris.common.io.Hll;
+import org.apache.doris.udf.HllCardinalityUDF;
+import org.apache.doris.udf.HllUnionUDAF;
+import org.apache.doris.udf.ToHllUDAF;
+
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaConstantBinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+// hive hll udf test
+public class HllUDFTest {
+
+    private byte[] hll0Bytes;
+    private byte[] hll1Bytes;
+
+    private BinaryObjectInspector inputOI0 = new JavaConstantBinaryObjectInspector(new byte[0]);
+    private BinaryObjectInspector inputOI1 = new JavaConstantBinaryObjectInspector(new byte[0]);
+
+    @Before
+    public void initData() throws IOException {
+        Hll hll0 = new Hll();
+        Hll hll1 = new Hll();
+
+        hll0.updateWithHash(1);
+        hll0.updateWithHash(2);
+
+        hll1.updateWithHash(2);
+        hll1.updateWithHash(3);
+        hll1.updateWithHash(4);
+
+        hll0Bytes = HllUtil.serializeToBytes(hll0);
+        hll1Bytes = HllUtil.serializeToBytes(hll1);
+    }
+
+    @Test
+    public void hllCardinalityTest() throws Exception {
+        // Small cardinality test. It is expected that in this scenario, the relative error is 0.
+        HllCardinalityUDF hllCardinalityUDF = new HllCardinalityUDF();
+        hllCardinalityUDF.initialize(new ObjectInspector[] { inputOI0 });
+        Object evaluate = hllCardinalityUDF
+                .evaluate(new GenericUDF.DeferredObject[] { new GenericUDF.DeferredJavaObject(hll0Bytes) });
+        Assert.assertEquals(2L, evaluate);
+
+        hllCardinalityUDF.initialize(new ObjectInspector[] { inputOI1 });
+        Object evaluate1 = hllCardinalityUDF
+                .evaluate(new GenericUDF.DeferredObject[] { new GenericUDF.DeferredJavaObject(hll1Bytes) });
+        Assert.assertEquals(3L, evaluate1);
+
+        // Large cardinality test. Testing with one billion has been passed(cost about 5 minutes), in order to
+        // shorten the test time, we chose one million for testing. What's more, we expect the relative error
+        // should be less than 2% in this scenario.
+        Hll hllLarge = new Hll();
+        long largeInputSize = 1000000L;
+        for (long i = 1; i <= largeInputSize; i++) {
+            hllLarge.updateWithHash(i);
+        }
+        byte[] hllLargeBytes = HllUtil.serializeToBytes(hllLarge);
+        hllCardinalityUDF.initialize(new ObjectInspector[] { inputOI0 });
+        Object evaluateLarge = hllCardinalityUDF
+                .evaluate(new GenericUDF.DeferredObject[] { new GenericUDF.DeferredJavaObject(hllLargeBytes) });
+        long actualCardinality = (long) evaluateLarge;
+
+        double relativeError = Math.abs(actualCardinality - largeInputSize) / (double) largeInputSize;
+        Assert.assertTrue("Relative error should be less than 2%", relativeError <= 0.02);
+    }
+
+    @Test
+    public void hllUnionUDAFTest() throws Exception {
+        HllUnionUDAF hllUnionUDAF = new HllUnionUDAF();
+        HllUnionUDAF.GenericEvaluate evaluator = (HllUnionUDAF.GenericEvaluate) hllUnionUDAF
+                .getEvaluator(new TypeInfo[] { TypeInfoFactory.binaryTypeInfo });
+
+        GenericUDAFEvaluator.AggregationBuffer aggBuffer = evaluator.getNewAggregationBuffer();
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, new ObjectInspector[] { inputOI0 });
+        evaluator.iterate(aggBuffer, new Object[] { hll0Bytes });
+        evaluator.iterate(aggBuffer, new Object[] { hll1Bytes });
+        byte[] mergedHllBytes = (byte[]) evaluator.terminate(aggBuffer);
+
+        Hll mergedHll = HllUtil.deserializeToHll(mergedHllBytes);
+        Assert.assertEquals(4L, mergedHll.estimateCardinality());
+    }
+
+    @Test
+    public void toHllUDAFTest() throws Exception {
+        ToHllUDAF toHllUDAF = new ToHllUDAF();
+        ToHllUDAF.GenericEvaluate evaluator = (ToHllUDAF.GenericEvaluate) toHllUDAF
+                .getEvaluator(new TypeInfo[] { TypeInfoFactory.longTypeInfo });
+
+        GenericUDAFEvaluator.AggregationBuffer aggBuffer = evaluator.getNewAggregationBuffer();
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1,
+                new ObjectInspector[] { PrimitiveObjectInspectorFactory.javaLongObjectInspector });
+        evaluator.iterate(aggBuffer, new Object[] { 1L });
+        evaluator.iterate(aggBuffer, new Object[] { 2L });
+        byte[] hllBytes = (byte[]) evaluator.terminate(aggBuffer);
+
+        Hll hll = HllUtil.deserializeToHll(hllBytes);
+        Assert.assertEquals(2L, hll.estimateCardinality());
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Currently, we already have some Bitmap UDFs in hive and spark load can use them. However, Hll UDF is also needed by users in some cases, so in this PR we support three UDFs:

- UDAF

1. **to_hll**: aggregation function, returns a Doris Hll column, similar to to_bitmap function
2. **hll_union**: aggregation function, the function is the same as the BE function of Doris with the same name. It calculates the union of groups and returns a Doris Hll column, similar to the bitmap_union function

- UDF 

1. **hll_cardinality**: r eturns the number of distinct elements added to Hll, similar to the bitmap_count function

For more detail, you can see the doc [hive hll udf](https://github.com/apache/doris-website/blob/master/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/hive-hll-udf.md).

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

