### PR TITLE
[improvement](merge-cloud) Add a delay for relocating replica‘s backend when backend is dead.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2714,6 +2714,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static boolean cloud_preheating_enabled = true;
 
+    @ConfField(mutable = true, masterOnly = true)
+    public static long cloud_tablet_relocate_delay_second = 0;
+
     @ConfField(mutable = true, masterOnly = false)
     public static String security_checker_class_name = "";
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -409,6 +409,10 @@ public class Backend implements Writable {
         return isAlive() && !isQueryDisabled() && !isShutDown.get();
     }
 
+    public boolean isShutDown() {
+        return isShutDown.get();
+    }
+
     public boolean isScheduleAvailable() {
         return isAlive() && !isDecommissioned();
     }


### PR DESCRIPTION
When a be shutdown,  its tablets will migrate to other backends quickly.  Make a little delay to avoid too many migration.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

