### PR TITLE
[improve](table function) opt explode/explode_map/explode_json table function

### DIFF
--- a/be/src/vec/exprs/table_function/table_function.h
+++ b/be/src/vec/exprs/table_function/table_function.h
@@ -54,17 +54,7 @@ public:
     }
 
     virtual void get_value(MutableColumnPtr& column) = 0;
-
-    virtual int get_value(MutableColumnPtr& column, int max_step) {
-        max_step = std::max(1, std::min(max_step, (int)(_cur_size - _cur_offset)));
-        int i = 0;
-        // TODO: this for loop maybe could refactor, and call once get_value function, it's could insert into max_step value once
-        for (; i < max_step && !eos(); i++) {
-            get_value(column);
-            forward();
-        }
-        return i;
-    }
+    virtual int get_value(MutableColumnPtr& column, int max_step) = 0;
 
     virtual Status close() { return Status::OK(); }
 

--- a/be/src/vec/exprs/table_function/table_function_factory.cpp
+++ b/be/src/vec/exprs/table_function/table_function_factory.cpp
@@ -19,6 +19,7 @@
 
 #include <gen_cpp/Types_types.h>
 
+#include <memory>
 #include <string_view>
 #include <utility>
 
@@ -40,31 +41,21 @@ struct TableFunctionCreator {
     std::unique_ptr<TableFunction> operator()() { return TableFunctionType::create_unique(); }
 };
 
-template <>
-struct TableFunctionCreator<VExplodeJsonArrayTableFunction> {
-    ExplodeJsonArrayType type;
-    std::unique_ptr<TableFunction> operator()() const {
-        return VExplodeJsonArrayTableFunction::create_unique(type);
+template <typename DataImpl>
+struct VExplodeJsonArrayCreator {
+    std::unique_ptr<TableFunction> operator()() {
+        return VExplodeJsonArrayTableFunction<DataImpl>::create_unique();
     }
 };
-
-inline auto VExplodeJsonArrayIntCreator =
-        TableFunctionCreator<VExplodeJsonArrayTableFunction> {ExplodeJsonArrayType::INT};
-inline auto VExplodeJsonArrayDoubleCreator =
-        TableFunctionCreator<VExplodeJsonArrayTableFunction> {ExplodeJsonArrayType::DOUBLE};
-inline auto VExplodeJsonArrayStringCreator =
-        TableFunctionCreator<VExplodeJsonArrayTableFunction> {ExplodeJsonArrayType::STRING};
-inline auto VExplodeJsonArrayJsonCreator =
-        TableFunctionCreator<VExplodeJsonArrayTableFunction> {ExplodeJsonArrayType::JSON};
 
 const std::unordered_map<std::string, std::function<std::unique_ptr<TableFunction>()>>
         TableFunctionFactory::_function_map {
                 {"explode_split", TableFunctionCreator<VExplodeSplitTableFunction>()},
                 {"explode_numbers", TableFunctionCreator<VExplodeNumbersTableFunction>()},
-                {"explode_json_array_int", VExplodeJsonArrayIntCreator},
-                {"explode_json_array_double", VExplodeJsonArrayDoubleCreator},
-                {"explode_json_array_string", VExplodeJsonArrayStringCreator},
-                {"explode_json_array_json", VExplodeJsonArrayJsonCreator},
+                {"explode_json_array_int", VExplodeJsonArrayCreator<ParsedDataInt>()},
+                {"explode_json_array_double", VExplodeJsonArrayCreator<ParsedDataDouble>()},
+                {"explode_json_array_string", VExplodeJsonArrayCreator<ParsedDataString>()},
+                {"explode_json_array_json", VExplodeJsonArrayCreator<ParsedDataJSON>()},
                 {"explode_bitmap", TableFunctionCreator<VExplodeBitmapTableFunction>()},
                 {"explode_map", TableFunctionCreator<VExplodeMapTableFunction> {}},
                 {"explode", TableFunctionCreator<VExplodeTableFunction> {}}};

--- a/be/src/vec/exprs/table_function/vexplode.cpp
+++ b/be/src/vec/exprs/table_function/vexplode.cpp
@@ -47,7 +47,8 @@ Status VExplodeTableFunction::process_init(Block* block, RuntimeState* state) {
 
     _array_column =
             block->get_by_position(value_column_idx).column->convert_to_full_column_if_const();
-
+    LOG(INFO) << "block dump:" << block->dump_structure();
+    LOG(INFO) << block->dump_data();
     if (!extract_column_array_info(*_array_column, _detail)) {
         return Status::NotSupported("column type {} not supported now",
                                     block->get_by_position(value_column_idx).column->get_name());
@@ -90,4 +91,28 @@ void VExplodeTableFunction::get_value(MutableColumnPtr& column) {
     }
 }
 
+int VExplodeTableFunction::get_value(MutableColumnPtr& column, int max_step) {
+    max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
+    size_t pos = _array_offset + _cur_offset;
+    if (current_empty()) {
+        column->insert_default();
+        max_step = 1;
+    } else {
+        if (_is_nullable) {
+            auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
+            auto nested_column = nullable_column->get_nested_column_ptr();
+            auto* nullmap_column =
+                    assert_cast<ColumnUInt8*>(nullable_column->get_null_map_column_ptr().get());
+            nested_column->insert_range_from(*_detail.nested_col, pos, max_step);
+            size_t old_size = nullmap_column->size();
+            nullmap_column->resize(old_size + max_step);
+            memcpy(nullmap_column->get_data().data() + old_size,
+                   _detail.nested_nullmap_data + pos * sizeof(UInt8), max_step * sizeof(UInt8));
+        } else {
+            column->insert_range_from(*_detail.nested_col, pos, max_step);
+        }
+    }
+    forward(max_step);
+    return max_step;
+}
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode.cpp
+++ b/be/src/vec/exprs/table_function/vexplode.cpp
@@ -47,8 +47,6 @@ Status VExplodeTableFunction::process_init(Block* block, RuntimeState* state) {
 
     _array_column =
             block->get_by_position(value_column_idx).column->convert_to_full_column_if_const();
-    LOG(INFO) << "block dump:" << block->dump_structure();
-    LOG(INFO) << block->dump_data();
     if (!extract_column_array_info(*_array_column, _detail)) {
         return Status::NotSupported("column type {} not supported now",
                                     block->get_by_position(value_column_idx).column->get_name());

--- a/be/src/vec/exprs/table_function/vexplode.h
+++ b/be/src/vec/exprs/table_function/vexplode.h
@@ -44,6 +44,7 @@ public:
     void process_row(size_t row_idx) override;
     void process_close() override;
     void get_value(MutableColumnPtr& column) override;
+    int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:
     ColumnPtr _array_column;

--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -93,10 +93,10 @@ int ParsedData::set_output(rapidjson::Document& document) {
         break;
     }
     case ExplodeJsonArrayType::STRING: {
-        int32_t wbytes = 0;
         _data_string_ref.clear();
         _backup_string.clear();
         _values_null_flag.clear();
+        int32_t wbytes = 0;
         for (auto& v : document.GetArray()) {
             switch (v.GetType()) {
             case rapidjson::Type::kStringType: {
@@ -107,7 +107,7 @@ int ParsedData::set_output(rapidjson::Document& document) {
                 // Because the address of the string stored in `_backup_string` may
                 // change each time `emplace_back()` is called.
             }
-            case rapidjson::Type::kNumberType:
+            case rapidjson::Type::kNumberType: {
                 if (v.IsUint()) {
                     wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%u", v.GetUint());
                 } else if (v.IsInt()) {
@@ -125,6 +125,7 @@ int ParsedData::set_output(rapidjson::Document& document) {
                 // Because the address of the string stored in `_backup_string` may
                 // change each time `emplace_back()` is called.
                 break;
+            }
             case rapidjson::Type::kFalseType:
                 _backup_string.emplace_back(true_value);
                 _values_null_flag.emplace_back(false);
@@ -134,11 +135,11 @@ int ParsedData::set_output(rapidjson::Document& document) {
                 _values_null_flag.emplace_back(false);
                 break;
             case rapidjson::Type::kNullType:
-                _backup_string.emplace_back("", 0);
+                _backup_string.emplace_back();
                 _values_null_flag.emplace_back(true);
                 break;
             default:
-                _backup_string.emplace_back("", 0);
+                _backup_string.emplace_back();
                 _values_null_flag.emplace_back(true);
                 break;
             }
@@ -162,7 +163,7 @@ int ParsedData::set_output(rapidjson::Document& document) {
                 _backup_string.emplace_back(buffer.GetString(), buffer.GetSize());
                 _values_null_flag.emplace_back(false);
             } else {
-                _backup_string.emplace_back("", 0);
+                _backup_string.emplace_back();
                 _values_null_flag.emplace_back(true);
             }
         }

--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -17,6 +17,7 @@
 
 #include "vec/exprs/table_function/vexplode_json_array.h"
 
+#include <glog/logging.h>
 #include <inttypes.h>
 #include <rapidjson/rapidjson.h>
 #include <stdio.h>
@@ -28,8 +29,10 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "vec/columns/column.h"
+#include "vec/columns/columns_number.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
+#include "vec/core/types.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 
@@ -40,17 +43,16 @@ std::string ParsedData::false_value = "false";
 auto max_value = std::numeric_limits<int64_t>::max(); //9223372036854775807
 auto min_value = std::numeric_limits<int64_t>::min(); //-9223372036854775808
 
-int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& document) {
+int ParsedData::set_output(rapidjson::Document& document) {
     int size = document.GetArray().Size();
-    switch (type) {
+    _values_null_flag.resize(size, 0);
+    switch (_data_type) {
     case ExplodeJsonArrayType::INT: {
-        _data.resize(size);
         _backup_int.resize(size);
         int i = 0;
         for (auto& v : document.GetArray()) {
             if (v.IsInt64()) {
                 _backup_int[i] = v.GetInt64();
-                _data[i] = &_backup_int[i];
             } else if (v.IsUint64()) {
                 auto value = v.GetUint64();
                 if (value > max_value) {
@@ -58,7 +60,6 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
                 } else {
                     _backup_int[i] = value;
                 }
-                _data[i] = &_backup_int[i];
             } else if (v.IsDouble()) {
                 auto value = v.GetDouble();
                 if (value > max_value) {
@@ -68,42 +69,35 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
                 } else {
                     _backup_int[i] = long(value);
                 }
-                _data[i] = &_backup_int[i];
             } else {
-                _data[i] = nullptr;
+                _values_null_flag[i] = 1;
+                _backup_int[i] = 0;
             }
             ++i;
         }
         break;
     }
     case ExplodeJsonArrayType::DOUBLE: {
-        _data.resize(size);
         _backup_double.resize(size);
         int i = 0;
         for (auto& v : document.GetArray()) {
             if (v.IsDouble()) {
                 _backup_double[i] = v.GetDouble();
-                _data[i] = &_backup_double[i];
             } else {
-                _data[i] = nullptr;
+                _backup_double[i] = 0;
+                _values_null_flag[i] = 1;
             }
             ++i;
         }
         break;
     }
     case ExplodeJsonArrayType::STRING: {
-        _data_string.clear();
-        _backup_string.clear();
-        _string_nulls.clear();
         int32_t wbytes = 0;
+        int i = 0;
         for (auto& v : document.GetArray()) {
             switch (v.GetType()) {
             case rapidjson::Type::kStringType:
                 _backup_string.emplace_back(v.GetString(), v.GetStringLength());
-                _string_nulls.push_back(false);
-                // do not set _data_string here.
-                // Because the address of the string stored in `_backup_string` may
-                // change each time `emplace_back()` is called.
                 break;
             case rapidjson::Type::kNumberType:
                 if (v.IsUint()) {
@@ -118,64 +112,91 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
                     wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%f", v.GetDouble());
                 }
                 _backup_string.emplace_back(tmp_buf, wbytes);
-                _string_nulls.push_back(false);
-                // do not set _data_string here.
-                // Because the address of the string stored in `_backup_string` may
-                // change each time `emplace_back()` is called.
                 break;
             case rapidjson::Type::kFalseType:
                 _backup_string.emplace_back(true_value);
-                _string_nulls.push_back(false);
                 break;
             case rapidjson::Type::kTrueType:
                 _backup_string.emplace_back(false_value);
-                _string_nulls.push_back(false);
                 break;
             case rapidjson::Type::kNullType:
-                _backup_string.emplace_back();
-                _string_nulls.push_back(true);
+                _backup_string.emplace_back("", 0);
+                _values_null_flag[i] = 1;
                 break;
             default:
-                _backup_string.emplace_back();
-                _string_nulls.push_back(true);
+                _backup_string.emplace_back("", 0);
+                _values_null_flag[i] = 1;
                 break;
             }
-        }
-        // Must set _data_string at the end, so that we can
-        // save the real addr of string in `_backup_string` to `_data_string`.
-        for (auto& str : _backup_string) {
-            _data_string.emplace_back(str);
+            ++i;
         }
         break;
     }
     case ExplodeJsonArrayType::JSON: {
-        _data_string.clear();
-        _backup_string.clear();
-        _string_nulls.clear();
+        int i = 0;
         for (auto& v : document.GetArray()) {
             if (v.IsObject()) {
                 rapidjson::StringBuffer buffer;
                 rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
                 v.Accept(writer);
                 _backup_string.emplace_back(buffer.GetString(), buffer.GetSize());
-                _string_nulls.push_back(false);
             } else {
-                _data_string.push_back({});
-                _string_nulls.push_back(true);
+                _backup_string.emplace_back("", 0);
+                _values_null_flag[i] = 1;
             }
-        }
-        // Must set _data_string at the end, so that we can
-        // save the real addr of string in `_backup_string` to `_data_string`.
-        for (auto& str : _backup_string) {
-            _data_string.emplace_back(str);
+            ++i;
         }
         break;
     }
     default:
-        CHECK(false) << type;
+        CHECK(false) << _data_type;
         break;
     }
     return size;
+}
+
+Status ParsedData::insert_result_from_parsed_data(MutableColumnPtr& column, int max_step,
+                                                  int64_t cur_offset) {
+    switch (_data_type) {
+    case ExplodeJsonArrayType::INT: {
+        assert_cast<ColumnInt32*>(column.get())
+                ->insert_many_raw_data(
+                        reinterpret_cast<const char*>(_backup_int.data() + cur_offset), max_step);
+    }
+    case ExplodeJsonArrayType::DOUBLE: {
+        assert_cast<ColumnFloat64*>(column.get())
+                ->insert_many_raw_data(
+                        reinterpret_cast<const char*>(_backup_double.data() + cur_offset),
+                        max_step);
+    }
+    case ExplodeJsonArrayType::JSON:
+    case ExplodeJsonArrayType::STRING: {
+        assert_cast<ColumnString*>(column.get())
+                ->insert_many_strings(_backup_string.data() + cur_offset, max_step);
+    }
+    default:
+        auto error_msg = fmt::format(
+                "Type not implemented:{} need check it in function explode array insert into "
+                "result",
+                _data_type);
+        return Status::InternalError(error_msg);
+    }
+    return Status::OK();
+}
+
+Status ParsedData::set_type(ExplodeJsonArrayType type) {
+    switch (type) {
+    case ExplodeJsonArrayType::INT:
+    case ExplodeJsonArrayType::DOUBLE:
+    case ExplodeJsonArrayType::JSON:
+    case ExplodeJsonArrayType::STRING:
+        _data_type = type;
+    default:
+        auto error_msg = fmt::format(
+                "Type not implemented:{} need check it in function explode array", type);
+        return Status::InternalError(error_msg);
+    }
+    return Status::OK();
 }
 
 VExplodeJsonArrayTableFunction::VExplodeJsonArrayTableFunction(ExplodeJsonArrayType type)
@@ -191,7 +212,7 @@ Status VExplodeJsonArrayTableFunction::process_init(Block* block, RuntimeState* 
     RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute(_expr_context.get(), block,
                                                                   &text_column_idx));
     _text_column = block->get_by_position(text_column_idx).column;
-
+    RETURN_IF_ERROR(_parsed_data.set_type(_type));
     return Status::OK();
 }
 
@@ -203,22 +224,45 @@ void VExplodeJsonArrayTableFunction::process_row(size_t row_idx) {
         rapidjson::Document document;
         document.Parse(text.data, text.size);
         if (!document.HasParseError() && document.IsArray() && document.GetArray().Size()) {
-            _cur_size = _parsed_data.set_output(_type, document);
+            _cur_size = _parsed_data.set_output(document);
         }
     }
 }
 
 void VExplodeJsonArrayTableFunction::process_close() {
     _text_column = nullptr;
+    _parsed_data.reset();
 }
 
 void VExplodeJsonArrayTableFunction::get_value(MutableColumnPtr& column) {
-    if (current_empty() || _parsed_data.get_value(_type, _cur_offset, true) == nullptr) {
+    DCHECK(false) << " should not run into VExplodeJsonArrayTableFunction::get_value";
+}
+
+int VExplodeJsonArrayTableFunction::get_value(MutableColumnPtr& column, int max_step) {
+    max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
+    if (current_empty()) {
         column->insert_default();
+        max_step = 1;
     } else {
-        column->insert_data((char*)_parsed_data.get_value(_type, _cur_offset, true),
-                            _parsed_data.get_value_length(_type, _cur_offset));
+        if (_is_nullable) {
+            auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
+            auto nested_column = nullable_column->get_nested_column_ptr();
+            RETURN_IF_ERROR(
+                    _parsed_data.insert_result_from_parsed_data(column, max_step, _cur_offset));
+
+            auto* nullmap_column =
+                    assert_cast<ColumnUInt8*>(nullable_column->get_null_map_column_ptr().get());
+            size_t old_size = nullmap_column->size();
+            nullmap_column->resize(old_size + max_step);
+            memcpy(nullmap_column->get_data().data() + old_size,
+                   _parsed_data.get_null_flag_address(_cur_offset), max_step * sizeof(UInt8));
+        } else {
+            RETURN_IF_ERROR(
+                    _parsed_data.insert_result_from_parsed_data(column, max_step, _cur_offset));
+        }
     }
+    forward(max_step);
+    return max_step;
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -29,6 +29,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/columns/columns_number.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
@@ -268,7 +269,7 @@ void VExplodeJsonArrayTableFunction::get_value(MutableColumnPtr& column) {
     if (current_empty()) {
         column->insert_default();
     } else {
-        static_cast<void>(_parsed_data.insert_result_from_parsed_data(column, 1, _cur_offset));
+        static_cast<void>(get_value(column, 1));
     }
 }
 
@@ -282,7 +283,7 @@ int VExplodeJsonArrayTableFunction::get_value(MutableColumnPtr& column, int max_
             auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
             auto nested_column = nullable_column->get_nested_column_ptr();
             RETURN_IF_ERROR(
-                    _parsed_data.insert_result_from_parsed_data(column, max_step, _cur_offset));
+                    _parsed_data.insert_result_from_parsed_data(nested_column, max_step, _cur_offset));
 
             auto* nullmap_column =
                     assert_cast<ColumnUInt8*>(nullable_column->get_null_map_column_ptr().get());

--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -36,10 +36,6 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
-
-std::string ParsedDataStringBase::true_value = "true";
-std::string ParsedDataStringBase::false_value = "false";
-
 template <typename DataImpl>
 VExplodeJsonArrayTableFunction<DataImpl>::VExplodeJsonArrayTableFunction() : TableFunction() {
     _fn_name = "vexplode_json_array";

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -49,7 +49,8 @@ struct ParsedData {
 
     std::vector<int64_t> _backup_int;
     std::vector<double> _backup_double;
-    std::vector<StringRef> _backup_string;
+    std::vector<StringRef> _data_string_ref;
+    std::vector<std::string> _backup_string;
     std::vector<UInt8> _values_null_flag;
     ExplodeJsonArrayType _data_type;
     char tmp_buf[128] = {0};
@@ -66,6 +67,7 @@ struct ParsedData {
         _backup_double.clear();
         _backup_string.clear();
         _values_null_flag.clear();
+        _data_string_ref.clear();
     }
 };
 

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -132,7 +132,7 @@ struct ParsedDataStringBase : public ParsedData<std::string> {
     }
 
     static constexpr const char* TRUE_VALUE = "true";
-    static constexpr const char* FALSE_VALUE = "true";
+    static constexpr const char* FALSE_VALUE = "false";
     std::vector<StringRef> _data_string_ref;
     char tmp_buf[128] = {0};
 };

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -47,9 +47,9 @@ struct ParsedData {
     static std::string true_value;
     static std::string false_value;
 
+    std::vector<StringRef> _data_string_ref;
     std::vector<int64_t> _backup_int;
     std::vector<double> _backup_double;
-    std::vector<StringRef> _data_string_ref;
     std::vector<std::string> _backup_string;
     std::vector<UInt8> _values_null_flag;
     ExplodeJsonArrayType _data_type;

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -83,6 +83,7 @@ public:
     void process_close() override;
     void get_value(MutableColumnPtr& column) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
+    Status insert_values_into_column(MutableColumnPtr& column, int max_step);
 
 private:
     ParsedData _parsed_data;

--- a/be/src/vec/exprs/table_function/vexplode_map.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_map.cpp
@@ -122,4 +122,30 @@ void VExplodeMapTableFunction::get_value(MutableColumnPtr& column) {
     ret->get_column(1).insert_from(_map_detail.map_col->get_values(), pos);
 }
 
+int VExplodeMapTableFunction::get_value(MutableColumnPtr& column, int max_step) {
+    max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
+    size_t pos = _collection_offset + _cur_offset;
+    if (current_empty()) {
+        column->insert_default();
+        max_step = 1;
+    } else {
+        if (_is_nullable) {
+            auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
+            auto* nested_column =
+                    assert_cast<ColumnStruct*>(nullable_column->get_nested_column_ptr().get());
+            auto* nullmap_column =
+                    assert_cast<ColumnUInt8*>(nullable_column->get_null_map_column_ptr().get());
+
+            nested_column->insert_range_from(*_map_detail.map_col, pos, max_step);
+            size_t old_size = nullmap_column->size();
+            nullmap_column->resize(old_size + max_step);
+            memcpy(nullmap_column->get_data().data() + old_size,
+                   _map_detail.map_nullmap_data + pos * sizeof(UInt8), max_step * sizeof(UInt8));
+        } else {
+            column->insert_range_from(*_map_detail.map_col, pos, max_step);
+        }
+    }
+    forward(max_step);
+    return max_step;
+}
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_map.h
+++ b/be/src/vec/exprs/table_function/vexplode_map.h
@@ -58,6 +58,7 @@ public:
     void process_row(size_t row_idx) override;
     void process_close() override;
     void get_value(MutableColumnPtr& column) override;
+    int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:
     ColumnPtr _collection_column;


### PR DESCRIPTION
before get_value, it's will insert one row into column once, 
now could insert many result into column once, could reduce some virtual function call

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

