### PR TITLE
[Fix](executor)Fix alter policy failed

### DIFF
--- a/be/src/exec/schema_scanner/schema_workload_sched_policy_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_workload_sched_policy_scanner.cpp
@@ -34,6 +34,7 @@ std::vector<SchemaScanner::ColumnDesc> SchemaWorkloadSchedulePolicyScanner::_s_t
         {"PRIORITY", TYPE_INT, sizeof(int32_t), true},
         {"ENABLED", TYPE_BOOLEAN, sizeof(bool), true},
         {"VERSION", TYPE_INT, sizeof(int32_t), true},
+        {"WORKLOAD_GROUP", TYPE_STRING, sizeof(StringRef), true},
 };
 
 SchemaWorkloadSchedulePolicyScanner::SchemaWorkloadSchedulePolicyScanner()

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -508,6 +508,7 @@ public class SchemaTable extends Table {
                                     .column("PRIORITY", ScalarType.createType(PrimitiveType.INT))
                                     .column("ENABLED", ScalarType.createType(PrimitiveType.BOOLEAN))
                                     .column("VERSION", ScalarType.createType(PrimitiveType.INT))
+                                    .column("WORKLOAD_GROUP", ScalarType.createStringType())
                                     .build()))
             .build();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicy.java
@@ -172,7 +172,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
         return retType;
     }
 
-    public void updateProperty(Map<String, String> property, List<Long> wgIdList) {
+    public void updatePropertyIfNotNull(Map<String, String> property, List<Long> wgIdList) {
         String enabledStr = property.get(ENABLED);
         if (enabledStr != null) {
             this.enabled = Boolean.parseBoolean(enabledStr);
@@ -183,7 +183,11 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
             this.priority = Integer.parseInt(priorityStr);
         }
 
-        if (wgIdList.size() > 0) {
+        String workloadGroupIdStr = property.get(WORKLOAD_GROUP);
+        // workloadGroupIdStr != null means user set workload group property,
+        // then we should overwrite policy's workloadGroupIdList
+        // if workloadGroupIdStr.length == 0, it means the policy should match all query.
+        if (workloadGroupIdStr != null) {
             this.workloadGroupIdList = wgIdList;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicyMgr.java
@@ -435,7 +435,7 @@ public class WorkloadSchedPolicyMgr implements Writable, GsonPostProcessable {
             Map<String, String> properties = alterStmt.getProperties();
             List<Long> wgIdList = new ArrayList<>();
             checkProperties(properties, wgIdList);
-            policy.updateProperty(properties, wgIdList);
+            policy.updatePropertyIfNotNull(properties, wgIdList);
             policy.incrementVersion();
             Env.getCurrentEnv().getEditLog().logAlterWorkloadSchedPolicy(policy);
         } finally {

--- a/regression-test/data/workload_manager_p0/test_workload_sched_policy.out
+++ b/regression-test/data/workload_manager_p0/test_workload_sched_policy.out
@@ -7,3 +7,18 @@ test_cancel_policy	query_time > 10	cancel_query	0	false	0
 
 -- !select_policy_tvf_after_drop --
 
+-- !select_alter_1 --
+test_alter_policy	username = test_alter_policy_user	set_session_variable "parallel_pipeline_task_num=0"	0	true	0	normal
+
+-- !select_alter_2 --
+test_alter_policy	username = test_alter_policy_user	set_session_variable "parallel_pipeline_task_num=0"	0	true	1	
+
+-- !select_alter_3 --
+test_alter_policy	username = test_alter_policy_user	set_session_variable "parallel_pipeline_task_num=0"	0	false	2	
+
+-- !select_alter_4 --
+test_alter_policy	username = test_alter_policy_user	set_session_variable "parallel_pipeline_task_num=0"	9	false	3	
+
+-- !select_alter_5 --
+test_alter_policy	username = test_alter_policy_user	set_session_variable "parallel_pipeline_task_num=0"	9	false	4	normal
+


### PR DESCRIPTION
## Proposed changes
Fix alter policy's workload group failed.

```
mysql [(none)]>create workload schedule policy test_cancel_3s_query conditions(query_time > 3000) actions(cancel_query) properties('workload_group'='policy_group');
Query OK, 0 rows affected (0.00 sec)

mysql [(none)]>alter workload schedule policy test_cancel_3s_query properties('workload_group'='');
Query OK, 0 rows affected (0.00 sec)

mysql [(none)]>show workload schedule policy;
+-------+----------------------+-------------------+--------------+----------+---------+---------+---------------+
| Id    | Name                 | Condition         | Action       | Priority | Enabled | Version | WorkloadGroup |
+-------+----------------------+-------------------+--------------+----------+---------+---------+---------------+
| 78073 | test_cancel_3s_query | query_time > 3000 | cancel_query | 0        | true    | 1       | policy_group  |
+-------+----------------------+-------------------+--------------+----------+---------+---------+---------------+
1 row in set (0.00 sec)
```