### PR TITLE
[fix](row-count-cache) use cached row count for show

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -662,4 +662,9 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
     public List<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
         return Lists.newArrayList();
     }
+
+    @Override
+    public long getCachedRowCount() {
+        return getRowCount();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -160,6 +160,11 @@ public interface TableIf {
 
     long getRowCount();
 
+    // Get the row count from cache,
+    // If miss, just return 0
+    // This is used for external table, because for external table, the fetching row count may be expensive
+    long getCachedRowCount();
+
     long fetchRowCount();
 
     long getDataLength();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -89,7 +89,7 @@ public class ExternalMetaCacheMgr {
     public ExternalMetaCacheMgr() {
         rowCountRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
                 Config.max_external_cache_loader_thread_pool_size,
-                Config.max_external_cache_loader_thread_pool_size,
+                Config.max_external_cache_loader_thread_pool_size * 1000,
                 "RowCountRefreshExecutor", 0, true);
 
         commonRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -114,4 +114,28 @@ public class ExternalRowCountCache {
         return 0;
     }
 
+    /**
+     * Get cached row count for the given table if present. Return 0 if cached not loaded.
+     * This method will not trigger async loading if cache is missing.
+     *
+     * @param catalogId
+     * @param dbId
+     * @param tableId
+     * @return
+     */
+    public long getCachedRowCountIfPresent(long catalogId, long dbId, long tableId) {
+        RowCountKey key = new RowCountKey(catalogId, dbId, tableId);
+        try {
+            CompletableFuture<Optional<Long>> f = rowCountCache.getIfPresent(key);
+            if (f == null) {
+                return 0;
+            } else if (f.isDone()) {
+                return f.get().orElse(0L);
+            }
+        } catch (Exception e) {
+            LOG.warn("Unexpected exception while returning row count if present", e);
+        }
+        return 0;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -207,6 +207,19 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     }
 
     @Override
+    public long getCachedRowCount() {
+        // Return 0 if makeSureInitialized throw exception.
+        // For example, init hive table may throw NotSupportedException.
+        try {
+            makeSureInitialized();
+        } catch (Exception e) {
+            LOG.warn("Failed to initialize table {}.{}.{}", catalog.getName(), dbName, name, e);
+            return 0;
+        }
+        return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache().getCachedRowCount(catalog.getId(), dbId, id);
+    }
+
+    @Override
     /**
      * Default return 0. Subclass need to implement this interface.
      * This is called by ExternalRowCountCache to load row count cache.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -989,7 +989,7 @@ public class ShowExecutor {
                 // Row_format
                 row.add(null);
                 // Rows
-                row.add(String.valueOf(table.getRowCount()));
+                row.add(String.valueOf(table.getCachedRowCount()));
                 // Avg_row_length
                 row.add(String.valueOf(table.getAvgRowLength()));
                 // Data_length
@@ -2545,7 +2545,7 @@ public class ShowExecutor {
            tableStats == null means it's not analyzed, in this case show the estimated row count.
          */
         if (tableStats == null) {
-            resultSet = showTableStatsStmt.constructResultSet(tableIf.getRowCount());
+            resultSet = showTableStatsStmt.constructResultSet(tableIf.getCachedRowCount());
         } else {
             resultSet = showTableStatsStmt.constructResultSet(tableStats);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -624,7 +624,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                             status.setUpdateTime(table.getUpdateTime() / 1000);
                             status.setCheckTime(lastCheckTime / 1000);
                             status.setCollation("utf-8");
-                            status.setRows(table.getRowCount());
+                            status.setRows(table.getCachedRowCount());
                             status.setDataLength(table.getDataLength());
                             status.setAvgRowLength(table.getAvgRowLength());
                             tablesResult.add(status);


### PR DESCRIPTION
## Proposed changes

Followup #33449

Some operation, like `show tables status` may traverse all tables and call table's getRowCount() method.
This method may trigger the row count cache refresh async, and may take all executor thread and block other
query requests.

This PR change the logic, for some `show` request like `show table status`, use a new method `getCachedRowCount()`.
This method will get row count from cache if present, and will not trigger cache refresh if cache miss.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

