### PR TITLE
[fix](ms_bvars) fix the units of bvar in meta service

### DIFF
--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -155,7 +155,7 @@ inline MetaServiceCode cast_as(TxnErrorCode code) {
         finish_rpc(#func_name, ctrl, response);                                          \
         closure_guard.reset(nullptr);                                                    \
         if (config::use_detailed_metrics && !instance_id.empty() && !drop_request) {     \
-            g_bvar_ms_##func_name.put(instance_id, sw.elapsed_us());                     \
+            g_bvar_ms_##func_name.put(instance_id, sw.elapsed_us() / 1000);              \
         }                                                                                \
     });
 


### PR DESCRIPTION

## Proposed changes

fix the value unit of g_bvar_ms_##func_name from us to ms


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

