### PR TITLE
[chore](log) Avoid too many 'token parser result is empty'

### DIFF
--- a/be/src/vec/functions/match.cpp
+++ b/be/src/vec/functions/match.cpp
@@ -279,7 +279,7 @@ Status FunctionMatchPhrase::execute_match(const std::string& column_name,
             query_tokens, reader.get(), inverted_index_ctx->analyzer, column_name,
             doris::segment_v2::InvertedIndexQueryType::MATCH_PHRASE_QUERY);
     if (query_tokens.empty()) {
-        LOG(WARNING) << fmt::format(
+        VLOG_DEBUG << fmt::format(
                 "token parser result is empty for query, "
                 "please check your query: '{}' and index parser: '{}'",
                 match_query_str, inverted_index_parser_type_to_string(parser_type));


### PR DESCRIPTION
there may be too many logs
![image](https://github.com/apache/doris/assets/6919662/e152a50a-1f9e-47f3-8d99-c099915e415a)
