### PR TITLE
[test](cloud) Reduce testing duration when there is no fdb available

### DIFF
--- a/cloud/test/fdb_injection_test.cpp
+++ b/cloud/test/fdb_injection_test.cpp
@@ -70,6 +70,8 @@ int main(int argc, char** argv) {
     cloud::config::txn_store_retry_base_intervals_ms = 1;
     cloud::config::fdb_cluster_file_path = "fdb.cluster";
     cloud::config::write_schema_kv = true;
+    // UT may be run without fdb, it will take unnecessary time with the default value
+    cloud::config::fdb_txn_timeout_ms = 500;
 
     auto sp = cloud::SyncPoint::get_instance();
     sp->enable_processing();

--- a/cloud/test/mem_txn_kv_test.cpp
+++ b/cloud/test/mem_txn_kv_test.cpp
@@ -35,6 +35,8 @@ std::shared_ptr<cloud::TxnKv> fdb_txn_kv;
 int main(int argc, char** argv) {
     cloud::config::init(nullptr, true);
     cloud::config::fdb_cluster_file_path = "fdb.cluster";
+    // UT may be run without fdb, it will take unnecessary time with the default value
+    cloud::config::fdb_txn_timeout_ms = 500;
     fdb_txn_kv = std::dynamic_pointer_cast<cloud::TxnKv>(std::make_shared<cloud::FdbTxnKv>());
     if (!fdb_txn_kv.get()) {
         std::cout << "exit get FdbTxnKv error" << std::endl;

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -42,6 +42,8 @@ std::shared_ptr<TxnKv> txn_kv;
 
 void init_txn_kv() {
     config::fdb_cluster_file_path = "fdb.cluster";
+    // UT may be run without fdb, it will take unnecessary time with the default value
+    config::fdb_txn_timeout_ms = 500;
     txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<FdbTxnKv>());
     ASSERT_NE(txn_kv.get(), nullptr);
     int ret = txn_kv->init();


### PR DESCRIPTION
This commit changes the config, fdb_txn_timeout_ms reduced to 500ms, in fdb-related UTs which may be run without fdb support, it will take unnecessary time with the default value before this PR.

Make it fail quickly to save time.