### PR TITLE
[fix](regression test) fix test_decommission_with_replica_num_fail due to set force_olap_table_replication_num

### DIFF
--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -22,7 +22,7 @@ suite('test_decommission_with_replica_num_fail') {
 
     def tbl = 'test_decommission_with_replica_num_fail'
     def backends = sql_return_maparray('show backends')
-    def replicaNum = 0
+    int replicaNum = 0
     def targetBackend = null
     for (def be : backends) {
         def alive = be.Alive.toBoolean()
@@ -33,6 +33,11 @@ suite('test_decommission_with_replica_num_fail') {
         }
     }
     assertTrue(replicaNum > 0)
+
+    def forceReplicaNum = getFeConfig('force_olap_table_replication_num') as int
+    if (forceReplicaNum > 0 && forceReplicaNum != replicaNum) {
+        return
+    }
 
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
     sql """


### PR DESCRIPTION
BUG: The test pipeline set force_olap_table_replication_num  = 3,  but has 4 backends. Then decommission will not throw exception.  So we need to modify partition's replication num to 4.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

