### PR TITLE
[Bug](json) fix heap use after free when json parse failed

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -1070,7 +1070,7 @@ Status NewJsonReader::_simdjson_handle_simple_json(RuntimeState* /*state*/, Bloc
             return Status::OK();
         }
         RETURN_IF_ERROR(st);
-        if (*is_empty_row) {
+        if (*is_empty_row || *eof) {
             return Status::OK();
         }
 

--- a/regression-test/data/load_p0/stream_load/load_json_parse_failed/test
+++ b/regression-test/data/load_p0/stream_load/load_json_parse_failed/test
@@ -1,0 +1,4 @@
+{
+    "event_id":"a",
+    "time_stamp":"aa"
+}

--- a/regression-test/suites/load_p0/stream_load/load_json_parse_failed/load_json_parse_failed.groovy
+++ b/regression-test/suites/load_p0/stream_load/load_json_parse_failed/load_json_parse_failed.groovy
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.codehaus.groovy.runtime.IOGroovyMethods
+
+suite ("load_json_parse_failed") {
+
+    sql """ DROP TABLE IF EXISTS test; """
+
+    sql """
+        CREATE TABLE `test` (
+            `event_id` varchar(50) NULL,
+            `time_stamp` varchar(50) NULL,
+            ) ENGINE=OLAP
+            DISTRIBUTED BY HASH(`event_id`) BUCKETS AUTO
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        ); 
+        """
+    streamLoad {
+        table "test"
+        set 'format', 'json'
+        set 'read_json_by_line', 'true'
+        file './test'
+
+        check { result, exception, startTime, endTime ->
+            if (exception != null) {
+                throw exception
+            }
+            log.info("Stream load result: ${result}".toString())
+            def json = parseJson(result)
+            assertEquals("fail", json.Status.toLowerCase())
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes
fix heap use after free when json parse failed

```cpp

=================================================================
==1481748==ERROR: AddressSanitizer: heap-use-after-free on address 0x51200c06e740 at pc 0x55819b51261a bp 0x7f16d45595a0 sp 0x7f16d4559598
READ of size 4 at 0x51200c06e740 thread T4425 (RScan_normal [w)
    #0 0x55819b512619 in simdjson::fallback::ondemand::token_iterator::peek(unsigned int const*) const /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/token_iterator-inl.h:22:15
    #1 0x55819b51254c in simdjson::fallback::ondemand::json_iterator::peek(unsigned int const*) const /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/json_iterator-inl.h:266:16
    #2 0x55819b5124c9 in simdjson::fallback::ondemand::value_iterator::peek_start() const /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:784:22
    #3 0x55819b511f45 in simdjson::fallback::ondemand::value_iterator::type() const /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:955:12
    #4 0x55819b512a6b in simdjson::fallback::ondemand::value::type() /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/value-inl.h:151:15
    #5 0x55819bde248e in doris::vectorized::NewJsonReader::_simdjson_handle_simple_json_write_columns(doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, bool*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/format/json/new_json_reader.cpp:1100:25
    #6 0x55819bddb2f4 in doris::vectorized::NewJsonReader::_simdjson_handle_simple_json(doris::RuntimeState*, doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, bool*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/format/json/new_json_reader.cpp:1078:9
    #7 0x55819bdcee99 in doris::vectorized::NewJsonReader::_read_json_column(doris::RuntimeState*, doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, bool*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/format/json/new_json_reader.cpp:461:12
    #8 0x55819bdceabe in doris::vectorized::NewJsonReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/format/json/new_json_reader.cpp:227:9
    #9 0x55819ff8fcb1 in doris::vectorized::VFileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/vfile_scanner.cpp:333:13
    #10 0x5581a02cde3b in doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/vscanner.cpp:132:17
    #11 0x5581a02cd09c in doris::vectorized::VScanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/vscanner.cpp:99:12
    #12 0x55819ff2d0cf in doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:267:27
    #13 0x55819ff31704 in doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:177:21
    #14 0x55819ff315d4 in void std::__invoke_impl<void, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #15 0x55819ff31574 in std::enable_if<is_invocable_r_v<void, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3&>, void>::type std::__invoke_r<void, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #16 0x55819ff3133c in std::_Function_handler<void (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_3>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #17 0x55818643f2c2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #18 0x55819ff3c204 in doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/scanner_scheduler.h:133:65
    #19 0x55819ff3c1e4 in void std::__invoke_impl<void, doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()&>(std::__invoke_other, doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #20 0x55819ff3c184 in std::enable_if<is_invocable_r_v<void, doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()&>, void>::type std::__invoke_r<void, doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()&>(doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #21 0x55819ff3be8c in std::_Function_handler<void (), doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::'lambda'()>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #22 0x55818643f2c2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #23 0x558189f0e6e8 in doris::FunctionRunnable::run() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:48:27
    #24 0x558189efd86d in doris::ThreadPool::dispatch_thread() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:543:24
    #25 0x558189f23923 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74:14
    #26 0x558189f237fc in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14
    #27 0x558189f23784 in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:506:11
    #28 0x558189f2362d in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::operator()<void>() /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:591:17
    #29 0x558189f23544 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #30 0x558189f234e4 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #31 0x558189f2324c in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #32 0x55818643f2c2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #33 0x558189ecf7db in doris::Thread::supervise_thread(void*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:498:5
    #34 0x558186288e0a in asan_thread_start(void*) crtstuff.c
    #35 0x7f2c2b6ec1c9 in start_thread (/lib64/libpthread.so.0+0x81c9) (BuildId: 823fccea3475e5870a4167dfe47df20e53222db0)
    #36 0x7f2c2c0dbe72 in clone (/lib64/libc.so.6+0x39e72) (BuildId: ec3d7025354f1f1985831ff08ef0eb3b50aefbce)

0x51200c06e740 is located 0 bytes inside of 292-byte region [0x51200c06e740,0x51200c06e864)
freed by thread T4425 (RScan_normal [w) here:
    #0 0x5581862c853d in operator delete[](void*) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x222e753d) (BuildId: 7a5bef97464127fb)
    #1 0x5581b8adafa9 in simdjson::haswell::dom_parser_implementation::set_capacity(unsigned long) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x54af9fa9) (BuildId: 7a5bef97464127fb)

previously allocated by thread T4425 (RScan_normal [w) here:
    #0 0x5581862c7efd in operator new[](unsigned long, std::nothrow_t const&) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x222e6efd) (BuildId: 7a5bef97464127fb)
    #1 0x5581b8adaf97 in simdjson::haswell::dom_parser_implementation::set_capacity(unsigned long) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x54af9f97) (BuildId: 7a5bef97464127fb)

Thread T4425 (RScan_normal [w) created by T3209 here:
    #0 0x558186270cad in pthread_create (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x2228fcad) (BuildId: 7a5bef97464127fb)
    #1 0x558189ece71f in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:449:15
    #2 0x558189f06cc1 in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.h:56:16
    #3 0x558189efadb8 in doris::ThreadPool::create_thread() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:611:12
    #4 0x558189efa88b in doris::ThreadPool::init() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:265:25
    #5 0x5581863e4026 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.h:121:13
    #6 0x5581899a89f8 in doris::vectorized::SimplifiedScanScheduler::start(int, int, int) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/scanner_scheduler.h:122:9
    #7 0x5581899a0dbd in doris::WorkloadGroup::upsert_task_scheduler(doris::WorkloadGroupInfo*, doris::ExecEnv*) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/workload_group/workload_group.cpp:402:40
    #8 0x558186481d42 in doris::WorkloadGroupListener::handle_topic_info(std::vector<doris::TopicInfo, std::allocator<doris::TopicInfo>> const&) /mnt/disk1/xiaolei/incubator-doris/be/src/agent/workload_group_listener.cpp:54:13
    #9 0x5581864533fa in doris::TopicSubscriber::handle_topic_info(doris::TPublishTopicRequest const&) /mnt/disk1/xiaolei/incubator-doris/be/src/agent/topic_subscriber.cpp:46:35
    #10 0x558189a4ffa4 in doris::BaseBackendService::publish_topic_info(doris::TPublishTopicResult&, doris::TPublishTopicRequest const&) /mnt/disk1/xiaolei/incubator-doris/be/src/service/backend_service.h:84:48
    #11 0x55818a1258a2 in doris::BackendServiceProcessor::process_publish_topic_info(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /mnt/disk1/xiaolei/incubator-doris/gensrc/build/gen_cpp/BackendService.cpp:8317:13
    #12 0x55818a103c24 in doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int, void*) /mnt/disk1/xiaolei/incubator-doris/gensrc/build/gen_cpp/BackendService.cpp:6886:3
    #13 0x5581863919ad in apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/thrift/TDispatchProcessor.h:121:12
    #14 0x5581b6e821df in apache::thrift::server::TConnectedClient::run() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea11df) (BuildId: 7a5bef97464127fb)
    #15 0x5581b6e8346a in apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea246a) (BuildId: 7a5bef97464127fb)
    #16 0x5581b6e8833b in apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea733b) (BuildId: 7a5bef97464127fb)
    #17 0x5581b6e881e1 in void std::__invoke_impl<void, void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(std::__invoke_other, void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea71e1) (BuildId: 7a5bef97464127fb)
    #18 0x5581b6e88134 in std::__invoke_result<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>::type std::__invoke<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea7134) (BuildId: 7a5bef97464127fb)
    #19 0x5581b6e880a4 in void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea70a4) (BuildId: 7a5bef97464127fb)
    #20 0x5581b6e88029 in std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::operator()() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea7029) (BuildId: 7a5bef97464127fb)
    #21 0x5581b6e87fcd in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>>::_M_run() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea6fcd) (BuildId: 7a5bef97464127fb)
    #22 0x5581b96d483e in execute_native_thread_routine pthread_atfork.c

Thread T3209 created by T2054 here:
    #0 0x558186270cad in pthread_create (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x2228fcad) (BuildId: 7a5bef97464127fb)
    #1 0x5581b96d4967 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x556f3967) (BuildId: 7a5bef97464127fb)
    #2 0x5581b6e869da in apache::thrift::concurrency::Thread::start() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea59da) (BuildId: 7a5bef97464127fb)
    #3 0x5581b6e8319a in apache::thrift::server::TThreadedServer::onClientConnected(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea219a) (BuildId: 7a5bef97464127fb)
    #4 0x5581b6e7f5f0 in apache::thrift::server::TServerFramework::newlyConnectedClient(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52e9e5f0) (BuildId: 7a5bef97464127fb)
    #5 0x5581b6e7ec8b in apache::thrift::server::TServerFramework::serve() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52e9dc8b) (BuildId: 7a5bef97464127fb)
    #6 0x5581b6e82f05 in apache::thrift::server::TThreadedServer::serve() (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x52ea1f05) (BuildId: 7a5bef97464127fb)
    #7 0x558189f2e716 in doris::ThriftServer::ThriftServerEventProcessor::supervise() /mnt/disk1/xiaolei/incubator-doris/be/src/util/thrift_server.cpp:163:34
    #8 0x558189f3d723 in void std::__invoke_impl<void, void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>(std::__invoke_memfun_deref, void (doris::ThriftServer::ThriftServerEventProcessor::*&&)(), doris::ThriftServer::ThriftServerEventProcessor*&&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74:14
    #9 0x558189f3d5fc in std::__invoke_result<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>::type std::__invoke<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>(void (doris::ThriftServer::ThriftServerEventProcessor::*&&)(), doris::ThriftServer::ThriftServerEventProcessor*&&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14
    #10 0x558189f3d5d1 in void std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:292:13
    #11 0x558189f3d594 in std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>::operator()() /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:11
    #12 0x558189f3d3a8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>>>::_M_run() /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:244:13
    #13 0x5581b96d483e in execute_native_thread_routine pthread_atfork.c

Thread T2054 created by T0 here:
    #0 0x558186270cad in pthread_create (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x2228fcad) (BuildId: 7a5bef97464127fb)
    #1 0x5581b96d4967 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x556f3967) (BuildId: 7a5bef97464127fb)
    #2 0x558189f2d3e4 in doris::ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() /mnt/disk1/xiaolei/incubator-doris/be/src/util/thrift_server.cpp:129:17
    #3 0x558189f32dcc in doris::ThriftServer::start() /mnt/disk1/xiaolei/incubator-doris/be/src/util/thrift_server.cpp:378:5
    #4 0x5581862d1303 in main /mnt/disk1/xiaolei/incubator-doris/be/src/service/doris_main.cpp:558:25
    #5 0x7f2c2c0dcd84 in __libc_start_main (/lib64/libc.so.6+0x3ad84) (BuildId: ec3d7025354f1f1985831ff08ef0eb3b50aefbce)

SUMMARY: AddressSanitizer: heap-use-after-free /mnt/disk1/xiaolei/incubator-doris/thirdparty/installed/include/simdjson/generic/ondemand/token_iterator-inl.h:22:15 in simdjson::fallback::ondemand::token_iterator::peek(unsigned int const*) const
Shadow bytes around the buggy address:
  0x51200c06e480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200c06e500: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x51200c06e580: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x51200c06e600: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200c06e680: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
=>0x51200c06e700: fa fa fa fa fa fa fa fa[fd]fd fd fd fd fd fd fd
  0x51200c06e780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200c06e800: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x51200c06e880: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x51200c06e900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200c06e980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1481748==ABORTING
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

