### PR TITLE
[Fix](hdfs-writer) Fix hdfs file writer core with `check failed: _ref_cnt == 0` in dtor of `HdfsFileWriter`.

### DIFF
--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -123,14 +123,10 @@ Result<io::FileWriterPtr> FileFactory::create_file_writer(
     }
     case TFileType::FILE_HDFS: {
         THdfsParams hdfs_params = parse_properties(properties);
-        io::HdfsHandler* handler;
+        std::shared_ptr<io::HdfsHandler> handler;
         RETURN_IF_ERROR_RESULT(io::HdfsHandlerCache::instance()->get_connection(
                 hdfs_params, hdfs_params.fs_name, &handler));
-        auto res = io::HdfsFileWriter::create(path, handler, hdfs_params.fs_name, &options);
-        if (!res.has_value()) {
-            handler->dec_ref();
-        }
-        return res;
+        return io::HdfsFileWriter::create(path, handler, hdfs_params.fs_name, &options);
     }
     default:
         return ResultError(
@@ -165,7 +161,7 @@ Result<io::FileReaderSPtr> FileFactory::create_file_reader(
                 });
     }
     case TFileType::FILE_HDFS: {
-        io::HdfsHandler* handler;
+        std::shared_ptr<io::HdfsHandler> handler;
         // FIXME(plat1ko): Explain the difference between `system_properties.hdfs_params.fs_name`
         // and `file_description.fs_name`, it's so confused.
         const auto* fs_name = &file_description.fs_name;

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -86,13 +86,7 @@ HdfsFileSystem::HdfsFileSystem(const THdfsParams& hdfs_params, std::string fs_na
     }
 }
 
-HdfsFileSystem::~HdfsFileSystem() {
-    if (_fs_handle != nullptr) {
-        if (_fs_handle->from_cache) {
-            _fs_handle->dec_ref();
-        }
-    }
-}
+HdfsFileSystem::~HdfsFileSystem() = default;
 
 Status HdfsFileSystem::init() {
     RETURN_IF_ERROR(

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -90,8 +90,6 @@ HdfsFileSystem::~HdfsFileSystem() {
     if (_fs_handle != nullptr) {
         if (_fs_handle->from_cache) {
             _fs_handle->dec_ref();
-        } else {
-            delete _fs_handle;
         }
     }
 }
@@ -107,13 +105,11 @@ Status HdfsFileSystem::init() {
 
 Status HdfsFileSystem::create_file_impl(const Path& file, FileWriterPtr* writer,
                                         const FileWriterOptions* opts) {
-    _fs_handle->inc_ref();
     auto res = io::HdfsFileWriter::create(file, _fs_handle, _fs_name, opts);
     if (res.has_value()) {
         *writer = std::move(res).value();
         return Status::OK();
     } else {
-        _fs_handle->dec_ref();
         return std::move(res).error();
     }
 }

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -88,9 +88,7 @@ private:
                    RuntimeProfile* profile, std::string root_path);
     const THdfsParams& _hdfs_params; // Only used in init, so we can use reference here
     std::string _fs_name;
-    // do not use std::shared_ptr or std::unique_ptr
-    // _fs_handle is managed by HdfsFileSystemCache
-    HdfsHandler* _fs_handle = nullptr;
+    std::shared_ptr<HdfsHandler> _fs_handle = nullptr;
     RuntimeProfile* _profile = nullptr;
 };
 } // namespace io

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -48,7 +48,7 @@ static constexpr size_t MB = 1024 * 1024;
 HdfsFileWriter::HdfsFileWriter(Path path, std::shared_ptr<HdfsHandler> handler, hdfsFile hdfs_file,
                                std::string fs_name, const FileWriterOptions* opts)
         : _path(std::move(path)),
-          _hdfs_handler(handler),
+          _hdfs_handler(std::move(handler)),
           _hdfs_file(hdfs_file),
           _fs_name(std::move(fs_name)),
           _sync_file_data(opts ? opts->sync_file_data : true),
@@ -70,9 +70,6 @@ HdfsFileWriter::~HdfsFileWriter() {
         hdfsCloseFile(_hdfs_handler->hdfs_fs, _hdfs_file);
     }
 
-    if (_hdfs_handler->from_cache) {
-        _hdfs_handler->dec_ref();
-    }
     hdfs_file_being_written << -1;
 }
 

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -45,7 +45,7 @@ bvar::Adder<uint64_t> hdfs_file_being_written("hdfs_file_writer_file_being_writt
 
 static constexpr size_t MB = 1024 * 1024;
 
-HdfsFileWriter::HdfsFileWriter(Path path, HdfsHandler* handler, hdfsFile hdfs_file,
+HdfsFileWriter::HdfsFileWriter(Path path, std::shared_ptr<HdfsHandler> handler, hdfsFile hdfs_file,
                                std::string fs_name, const FileWriterOptions* opts)
         : _path(std::move(path)),
           _hdfs_handler(handler),
@@ -72,8 +72,6 @@ HdfsFileWriter::~HdfsFileWriter() {
 
     if (_hdfs_handler->from_cache) {
         _hdfs_handler->dec_ref();
-    } else {
-        delete _hdfs_handler;
     }
     hdfs_file_being_written << -1;
 }
@@ -266,7 +264,7 @@ Status HdfsFileWriter::finalize() {
     return Status::OK();
 }
 
-Result<FileWriterPtr> HdfsFileWriter::create(Path full_path, HdfsHandler* handler,
+Result<FileWriterPtr> HdfsFileWriter::create(Path full_path, std::shared_ptr<HdfsHandler> handler,
                                              const std::string& fs_name,
                                              const FileWriterOptions* opts) {
     auto path = convert_path(full_path, fs_name);

--- a/be/src/io/fs/hdfs_file_writer.h
+++ b/be/src/io/fs/hdfs_file_writer.h
@@ -36,11 +36,12 @@ public:
     // - fs_name/path_to_file
     // - /path_to_file
     // TODO(plat1ko): Support related path for cloud mode
-    static Result<FileWriterPtr> create(Path path, HdfsHandler* handler, const std::string& fs_name,
+    static Result<FileWriterPtr> create(Path path, std::shared_ptr<HdfsHandler> handler,
+                                        const std::string& fs_name,
                                         const FileWriterOptions* opts = nullptr);
 
-    HdfsFileWriter(Path path, HdfsHandler* handler, hdfsFile hdfs_file, std::string fs_name,
-                   const FileWriterOptions* opts = nullptr);
+    HdfsFileWriter(Path path, std::shared_ptr<HdfsHandler> handler, hdfsFile hdfs_file,
+                   std::string fs_name, const FileWriterOptions* opts = nullptr);
     ~HdfsFileWriter() override;
 
     Status close() override;
@@ -59,7 +60,7 @@ private:
     Status _append(std::string_view content);
 
     Path _path;
-    HdfsHandler* _hdfs_handler = nullptr;
+    std::shared_ptr<HdfsHandler> _hdfs_handler = nullptr;
     hdfsFile _hdfs_file = nullptr;
     std::string _fs_name;
     size_t _bytes_appended = 0;

--- a/be/src/io/hdfs_util.h
+++ b/be/src/io/hdfs_util.h
@@ -54,7 +54,6 @@ public:
     HdfsHandler(hdfsFS fs, bool cached)
             : hdfs_fs(fs),
               from_cache(cached),
-              _ref_cnt(0),
               _create_time(std::chrono::duration_cast<std::chrono::milliseconds>(
                                    std::chrono::system_clock::now().time_since_epoch())
                                    .count()),
@@ -62,7 +61,6 @@ public:
               _invalid(false) {}
 
     ~HdfsHandler() {
-        DCHECK(_ref_cnt == 0);
         if (hdfs_fs != nullptr) {
             // DO NOT call hdfsDisconnect(), or we will meet "Filesystem closed"
             // even if we create a new one
@@ -73,16 +71,13 @@ public:
 
     int64_t last_access_time() { return _last_access_time; }
 
-    void inc_ref() {
-        _ref_cnt++;
-        _last_access_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::system_clock::now().time_since_epoch())
-                                    .count();
+    void update_last_access_time() {
+        if (from_cache) {
+            _last_access_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                        std::chrono::system_clock::now().time_since_epoch())
+                                        .count();
+        }
     }
-
-    void dec_ref() { _ref_cnt--; }
-
-    int ref_cnt() { return _ref_cnt; }
 
     bool invalid() { return _invalid; }
 
@@ -94,8 +89,6 @@ public:
     const bool from_cache;
 
 private:
-    // the number of referenced client
-    std::atomic<int> _ref_cnt;
     // For kerberos authentication, we need to save create time so that
     // we can know if the kerberos ticket is expired.
     std::atomic<uint64_t> _create_time;

--- a/be/src/io/hdfs_util.h
+++ b/be/src/io/hdfs_util.h
@@ -118,13 +118,13 @@ public:
 
     // This function is thread-safe
     Status get_connection(const THdfsParams& hdfs_params, const std::string& fs_name,
-                          HdfsHandler** fs_handle);
+                          std::shared_ptr<HdfsHandler>* fs_handle);
 
 private:
     static constexpr int MAX_CACHE_HANDLE = 64;
 
     std::mutex _lock;
-    std::unordered_map<uint64_t, std::unique_ptr<HdfsHandler>> _cache;
+    std::unordered_map<uint64_t, std::shared_ptr<HdfsHandler>> _cache;
 
     HdfsHandlerCache() = default;
 


### PR DESCRIPTION
## Proposed changes

## Issue:
```
F20240421 17:14:37.494115 184986 hdfs_util.h:65] Check failed: _ref_cnt == 0 
*** Check failure stack trace: ***
F20240421 17:14:37.505879 185108 hdfs_util.h:65] Check failed: _ref_cnt == 0 
*** Check failure stack trace: ***
    @     0x556f5236d316  google::LogMessageFatal::~LogMessageFatal()
    @     0x556f5236d316  google::LogMessageFatal::~LogMessageFatal()
    @     0x556f2830e200  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f2830e200  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f2830e21e  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f2830e21e  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f507893b0  doris::vectorized::VHivePartitionWriter::~VHivePartitionWriter()
    @     0x556f507893b0  doris::vectorized::VHivePartitionWriter::~VHivePartitionWriter()
    @     0x556f506c005e  std::_Hashtable<>::clear()
    @     0x556f506c005e  std::_Hashtable<>::clear()
    @     0x556f50780f4f  doris::vectorized::VHiveTableWriter::close()
    @     0x556f50780f4f  doris::vectorized::VHiveTableWriter::close()
    @     0x556f5072bc4f  doris::vectorized::AsyncResultWriter::process_block()
    @     0x556f5072bc4f  doris::vectorized::AsyncResultWriter::process_block()
    @     0x556f5072cd01  std::_Function_handler<>::_M_invoke()
    @     0x556f5072cd01  std::_Function_handler<>::_M_invoke()
    @     0x556f2b02b73d  doris::ThreadPool::dispatch_thread()
    @     0x556f2b02b73d  doris::ThreadPool::dispatch_thread()
    @     0x556f2b008d59  doris::Thread::supervise_thread()
    @     0x556f2b008d59  doris::Thread::supervise_thread()
    @     0x7f2c2bfb4609  start_thread
    @     0x7f2c2bfb4609  start_thread
    @     0x7f2c2c261133  clone
    @     0x7f2c2c261133  clone
    @              (nil)  (unknown)
*** Query id: ac4f457c003d4489-b04ac56ef05b12f0 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1713690877 (unix time) try "date -d @1713690877" if you are using GNU date ***
*** Current BE git commitID: e6f4a2f ***
*** SIGABRT unknown detail explain (@0x38a6) received by PID 14502 (TID 184986 OR 0x7f21d0614700) from PID 14502; stack trace: ***
    @              (nil)  (unknown)
F20240421 17:14:37.505879 185108 hdfs_util.h:65] Check failed: _ref_cnt == 0 F20240421 17:14:37.887202 185110 hdfs_util.h:65] Check failed: _ref_cnt == 0 
*** Check failure stack trace: ***
    @     0x556f5236d316  google::LogMessageFatal::~LogMessageFatal()
    @     0x556f2830e200  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f2830e21e  doris::io::HdfsFileWriter::~HdfsFileWriter()
    @     0x556f507893b0  doris::vectorized::VHivePartitionWriter::~VHivePartitionWriter()
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
```
The root cause is
When it cannot be processed in the cache (such as when the cache is full), we will create a `fs_handler`, and the life cycle of `fs_handler` is managed by caller. We have separated the hdfs writer and can create `fs_handler` separately, so `HdfsFileSystem` and `HdfsFileWriter` may be callers. In `HdfsFileSystem`, the `fs_handler` of `HdfsFileWriter` is shared, so it needs to be changed to `shared_ptr`.

### Solution
Fix hdfs file writer core with `check failed: _ref_cnt == 0` in dtor of `HdfsFileWriter`.
Change `fs_handler` ptr to `shared_ptr` and remove ref count operations.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

