### PR TITLE
[fix](HDFS) Correctly set hdfs cache allocator's offset

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -223,6 +223,7 @@ Status HdfsFileWriter::_append(std::string_view content) {
         }
         size_t append_size = _batch_buffer.append(content);
         content.remove_prefix(append_size);
+        _bytes_appended += append_size;
         if (_batch_buffer.full()) {
             RETURN_IF_ERROR(_flush_buffer());
         }
@@ -237,7 +238,6 @@ Status HdfsFileWriter::appendv(const Slice* data, size_t data_cnt) {
 
     for (size_t i = 0; i < data_cnt; i++) {
         RETURN_IF_ERROR(_append({data[i].get_data(), data[i].get_size()}));
-        _bytes_appended += data[i].get_size();
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

We should refresh the `bytes_appended` field to correctly calculate the cache's offset.

```
F20240421 22:51:00.731791 2191196 block_file_cache.cpp:600] Check failed: !file_blocks.empty() 
*** Check failure stack trace: ***
    @     0x55f954283bc6  google::LogMessage::SendToLog()
    @     0x55f954280610  google::LogMessage::Flush()
    @     0x55f954284409  google::LogMessageFatal::~LogMessageFatal()
    @     0x55f9204cc65d  doris::io::BlockFileCache::get_or_set()
    @     0x55f92054afd8  doris::io::FileCacheAllocatorBuilder::allocate_cache_holder()
    @     0x55f920599fc0  doris::io::HdfsFileWriter::_write_into_local_file_cache()
    @     0x55f9205999ae  doris::io::HdfsFileWriter::_flush_buffer()
    @     0x55f92059be82  doris::io::HdfsFileWriter::_append()
    @     0x55f92059c3d3  doris::io::HdfsFileWriter::appendv()
    @     0x55f9229259f5  doris::segment_v2::PageIO::write_page()
    @     0x55f922a86be0  doris::segment_v2::PageIO::compress_and_write_page()
    @     0x55f922c06541  doris::segment_v2::ScalarColumnWriter::write_data()
    @     0x55f922d3c2c2  doris::segment_v2::VerticalSegmentWriter::write_batch()
    @     0x55f92254e2cf  doris::SegmentFlusher::_add_rows()
    @     0x55f92254992a  doris::SegmentFlusher::flush_single_block()
    @     0x55f922554348  doris::SegmentCreator::flush_single_block()
    @     0x55f922491396  doris::BaseBetaRowsetWriter::flush_memtable()
    @     0x55f92215d768  doris::FlushToken::_do_flush_memtable()
    @     0x55f92215f183  doris::FlushToken::_flush_memtable()
    @     0x55f92216e752  doris::MemtableFlushTask::run()
    @     0x55f9246b4a5f  doris::ThreadPool::dispatch_thread()
    @     0x55f9246e03d6  std::__invoke_impl<>()
    @     0x55f9246e027f  std::__invoke<>()
    @     0x55f9246e01f7  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x55f9246e0090  std::_Bind<>::operator()<>()
    @     0x55f9246dff97  std::__invoke_impl<>()
    @     0x55f9246dff09  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x55f9246dfacf  std::_Function_handler<>::_M_invoke()
    @     0x55f920250d77  std::function<>::operator()()
    @     0x55f924679214  doris::Thread::supervise_thread()
    @     0x7f18418d8609  start_thread
    @     0x7f1841b85133  clone
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

