### PR TITLE
[Fix](Jdbc-Hive) fix the order of partition keys

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PostgreSQLJdbcHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PostgreSQLJdbcHMSCachedClient.java
@@ -229,7 +229,7 @@ public class PostgreSQLJdbcHMSCachedClient extends JdbcHMSCachedClient {
 
     private List<String> getPartitionValues(int partitionId) {
         String sql = String.format("SELECT \"PART_KEY_VAL\" FROM \"PARTITION_KEY_VALS\""
-                + " WHERE \"PART_ID\" = " + partitionId);
+                + " WHERE \"PART_ID\" = " + partitionId + " ORDER BY \"INTEGER_IDX\"");
         if (LOG.isDebugEnabled()) {
             LOG.debug("getPartitionValues exec sql: {}", sql);
         }
@@ -366,7 +366,7 @@ public class PostgreSQLJdbcHMSCachedClient extends JdbcHMSCachedClient {
 
     private List<FieldSchema> getTablePartitionKeys(int tableId) {
         String sql = "SELECT \"PKEY_NAME\", \"PKEY_TYPE\", \"PKEY_COMMENT\" from \"PARTITION_KEYS\""
-                + " WHERE \"TBL_ID\"= " + tableId;
+                + " WHERE \"TBL_ID\"= " + tableId + " ORDER BY \"INTEGER_IDX\"";
         if (LOG.isDebugEnabled()) {
             LOG.debug("getTablePartitionKeys exec sql: {}", sql);
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The partition key information recorded in `PARTITION_KEYS` table is sorted according to the `INTEGER_IDX` field, so we need to add an 'order by' clause to ensure that the obtained partition names are ordered.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

