### PR TITLE
[chore](ci) adjust conf of external pipepline

### DIFF
--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -1,4 +1,3 @@
-package pipeline.external.conf
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -26,6 +25,11 @@ targetJdbcUrl = "jdbc:mysql://172.19.0.2:9131/?useLocalSessionState=true&allowLo
 jdbcUser = "root"
 jdbcPassword = ""
 
+ccrDownstreamUrl = "jdbc:mysql://172.19.0.2:9131/?useLocalSessionState=true&allowLoadLocalInfile=true"
+ccrDownstreamUser = "root"
+ccrDownstreamPassword = ""
+ccrDownstreamFeThriftAddress = "127.0.0.1:9020"
+
 feSourceThriftAddress = "127.0.0.1:9020"
 feTargetThriftAddress = "127.0.0.1:9020"
 feSyncerUser = "root"
@@ -42,7 +46,6 @@ dataPath = "${DORIS_HOME}/regression-test/data"
 pluginPath = "${DORIS_HOME}/regression-test/plugins"
 realDataPath = "${DORIS_HOME}/regression-test/realdata"
 trinoPluginsPath = "/tmp/trino_connector"
-
 // sf1DataPath can be url like "https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com" or local path like "/data"
 //sf1DataPath = "https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com"
 
@@ -57,13 +60,26 @@ testDirectories = ""
 // this groups will not be executed
 excludeGroups = ""
 // this suites will not be executed
+// load_stream_fault_injection may cause bad disk
+
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "test_analyze_stats_p1," +
-    "test_broker_load," +
-    "test_cast_string_to_array," +
+    "test_bitmap_filter," +
+    "test_dump_image," +
+    "test_index_failure_injection," +
+    "test_information_schema_external," +
+    "test_profile," +
     "test_refresh_mtmv," +
     "test_spark_load," +
     "test_broker_load_func," +
+    "test_stream_stub_fault_injection," +
+    "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
+
+// this directories will not be executed
+excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
+    "cloud," +
+    "cloud_p0," +
+    "nereids_rules_p0/subquery," +
+    "workload_manager_p1," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 customConf1 = "test_custom_conf_value"
@@ -83,21 +99,28 @@ enableBrokerLoad=true
 // See `docker/thirdparties/start-thirdparties-docker.sh`
 enableJdbcTest=true
 mysql_57_port=3316
-pg_14_port=7121
-oracle_11_port=1521
-sqlserver_2022_port=1433
-clickhouse_22_port=8123
-db2_11_port=50000
-
+pg_14_port=5442
+mariadb_10_port=3326
 // hive catalog test config
 // To enable jdbc test, you need first start hive container.
 // See `docker/thirdparties/start-thirdparties-docker.sh`
 enableHiveTest=true
-hms_port=7141
+hms_port=9083
+hiveServerPort=10000
 hive_pg_port=5432
 
+// kafka test config
+// to enable kafka test, you need firstly to start kafka container
+// See `docker/thirdparties/start-thirdparties-docker.sh`
+enableKafkaTest=true
+kafka_port=19193
+
+// iceberg test config
+iceberg_rest_uri_port=18181
+iceberg_minio_port=19001
+
 enableEsTest=true
-es_6_port="19200/"
+es_6_port=19200
 es_7_port=29200
 es_8_port=39200
 
@@ -111,3 +134,10 @@ max_failure_num=50
 
 externalEnvIp="127.0.0.1"
 
+enablePaimonTest=true
+
+hdfs_port=8020
+
+oracle_11_port=1521
+sqlserver_2022_port=1433
+clickhouse_22_port=8123


### PR DESCRIPTION
Right now, the external pipeline also uses conf in regression-test/pipeline/p0/conf/, it is better to use conf in regression-test/pipeline/external/conf/. this pr prepare the conf first, then I will adjust the pipeline script in TeamCity.