### PR TITLE
[profile](scanner) Fix wrong metrics

### DIFF
--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -186,10 +186,7 @@ Status VScanner::_filter_output_block(Block* block) {
 }
 
 Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Block* output_block) {
-    auto& projection_timer = _parent ? _parent->_projection_timer : _local_state->_projection_timer;
-    auto& exec_timer = _parent ? _parent->_exec_timer : _local_state->_exec_timer;
-    SCOPED_TIMER(exec_timer);
-    SCOPED_TIMER(projection_timer);
+    SCOPED_RAW_TIMER(&_per_scanner_timer);
 
     const size_t rows = origin_block->rows();
     if (rows == 0) {


### PR DESCRIPTION
## Proposed changes

Now projections are done in parallel scanners. Timer for projections are cumulated to scan operator's exec time which is not correct.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

