### PR TITLE
[chore](config) Add config to control BufferedReader and S3FileWriter's thread pool's min max nums

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1212,12 +1212,13 @@ DEFINE_mBool(enable_injection_point, "false");
 
 DEFINE_mBool(ignore_schema_change_check, "false");
 
+// The min thread num for BufferedReaderPrefetchThreadPool
 DEFINE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num, "16");
-
+// The max thread num for BufferedReaderPrefetchThreadPool
 DEFINE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num, "64");
-
+// The min thread num for S3FileUploadThreadPool
 DEFINE_Int64(s3_file_upload_thread_pool_min_thread_num, "16");
-
+// The max thread num for S3FileUploadThreadPool
 DEFINE_Int64(s3_file_upload_thread_pool_max_thread_num, "64");
 
 // clang-format off

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1026,7 +1026,7 @@ DEFINE_mInt64(row_column_page_size, "4096");
 // it must be larger than or equal to 5MB
 DEFINE_mInt64(s3_write_buffer_size, "5242880");
 // Log interval when doing s3 upload task
-DEFINE_mInt32(s3_file_writer_log_interval, "60");
+DEFINE_mInt32(s3_file_writer_log_interval_second, "60");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
 DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "4"); // 4MB
 
@@ -1212,13 +1212,13 @@ DEFINE_mBool(enable_injection_point, "false");
 DEFINE_mBool(ignore_schema_change_check, "false");
 
 // The min thread num for BufferedReaderPrefetchThreadPool
-DEFINE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num, "16");
+DEFINE_Int64(num_buffered_reader_prefetch_thread_pool_min_thread, "16");
 // The max thread num for BufferedReaderPrefetchThreadPool
-DEFINE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num, "64");
+DEFINE_Int64(num_buffered_reader_prefetch_thread_pool_max_thread, "64");
 // The min thread num for S3FileUploadThreadPool
-DEFINE_Int64(s3_file_upload_thread_pool_min_thread_num, "16");
+DEFINE_Int64(num_s3_file_upload_thread_pool_min_thread, "16");
 // The max thread num for S3FileUploadThreadPool
-DEFINE_Int64(s3_file_upload_thread_pool_max_thread_num, "64");
+DEFINE_Int64(num_s3_file_upload_thread_pool_max_thread, "64");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1025,9 +1025,8 @@ DEFINE_mInt32(tablet_path_check_batch_size, "1000");
 DEFINE_mInt64(row_column_page_size, "4096");
 // it must be larger than or equal to 5MB
 DEFINE_mInt64(s3_write_buffer_size, "5242880");
-DEFINE_mInt32(s3_task_check_interval, "60");
-// The timeout config for S3 buffer allocation
-DEFINE_mInt32(s3_file_writer_log_interval, "300");
+// Log interval when doing s3 upload task
+DEFINE_mInt32(s3_file_writer_log_interval, "60");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
 DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "4"); // 4MB
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1027,7 +1027,7 @@ DEFINE_mInt64(row_column_page_size, "4096");
 DEFINE_mInt64(s3_write_buffer_size, "5242880");
 DEFINE_mInt32(s3_task_check_interval, "60");
 // The timeout config for S3 buffer allocation
-DEFINE_mInt32(s3_writer_buffer_allocation_timeout, "300");
+DEFINE_mInt32(s3_file_writer_log_interval, "300");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
 DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "4"); // 4MB
 
@@ -1211,6 +1211,14 @@ DEFINE_Bool(enable_index_compaction, "false");
 DEFINE_mBool(enable_injection_point, "false");
 
 DEFINE_mBool(ignore_schema_change_check, "false");
+
+DEFINE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num, "16");
+
+DEFINE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num, "64");
+
+DEFINE_Int64(s3_file_upload_thread_pool_min_thread_num, "16");
+
+DEFINE_Int64(s3_file_upload_thread_pool_max_thread_num, "64");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1070,9 +1070,8 @@ DECLARE_mInt32(tablet_path_check_batch_size);
 DECLARE_mInt64(row_column_page_size);
 // it must be larger than or equal to 5MB
 DECLARE_mInt64(s3_write_buffer_size);
-DECLARE_mInt32(s3_task_check_interval);
-// The timeout config for S3 buffer allocation
-DECLARE_mInt32(s3_writer_buffer_allocation_timeout);
+// Log interval when doing s3 upload task
+DECLARE_mInt32(s3_file_writer_log_interval);
 // the max number of cached file handle for block segemnt
 DECLARE_mInt64(file_cache_max_file_reader_cache_size);
 DECLARE_mInt64(hdfs_write_batch_buffer_size_mb);
@@ -1297,6 +1296,14 @@ DECLARE_mInt32(thrift_client_open_num_tries);
 DECLARE_mBool(enable_injection_point);
 
 DECLARE_mBool(ignore_schema_change_check);
+
+DECLARE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num);
+
+DECLARE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num);
+
+DECLARE_Int64(s3_file_upload_thread_pool_min_thread_num);
+
+DECLARE_Int64(s3_file_upload_thread_pool_max_thread_num);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1071,7 +1071,7 @@ DECLARE_mInt64(row_column_page_size);
 // it must be larger than or equal to 5MB
 DECLARE_mInt64(s3_write_buffer_size);
 // Log interval when doing s3 upload task
-DECLARE_mInt32(s3_file_writer_log_interval);
+DECLARE_mInt32(s3_file_writer_log_interval_second);
 // the max number of cached file handle for block segemnt
 DECLARE_mInt64(file_cache_max_file_reader_cache_size);
 DECLARE_mInt64(hdfs_write_batch_buffer_size_mb);
@@ -1298,13 +1298,13 @@ DECLARE_mBool(enable_injection_point);
 DECLARE_mBool(ignore_schema_change_check);
 
 // The min thread num for BufferedReaderPrefetchThreadPool
-DECLARE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num);
+DECLARE_Int64(num_buffered_reader_prefetch_thread_pool_min_thread);
 // The max thread num for BufferedReaderPrefetchThreadPool
-DECLARE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num);
+DECLARE_Int64(num_buffered_reader_prefetch_thread_pool_max_thread);
 // The min thread num for S3FileUploadThreadPool
-DECLARE_Int64(s3_file_upload_thread_pool_min_thread_num);
+DECLARE_Int64(num_s3_file_upload_thread_pool_min_thread);
 // The max thread num for S3FileUploadThreadPool
-DECLARE_Int64(s3_file_upload_thread_pool_max_thread_num);
+DECLARE_Int64(num_s3_file_upload_thread_pool_max_thread);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1297,12 +1297,13 @@ DECLARE_mBool(enable_injection_point);
 
 DECLARE_mBool(ignore_schema_change_check);
 
+// The min thread num for BufferedReaderPrefetchThreadPool
 DECLARE_Int64(buffered_reader_prefetch_thread_pool_min_thread_num);
-
+// The max thread num for BufferedReaderPrefetchThreadPool
 DECLARE_Int64(buffered_reader_prefetch_thread_pool_max_thread_num);
-
+// The min thread num for S3FileUploadThreadPool
 DECLARE_Int64(s3_file_upload_thread_pool_min_thread_num);
-
+// The max thread num for S3FileUploadThreadPool
 DECLARE_Int64(s3_file_upload_thread_pool_max_thread_num);
 
 #ifdef BE_TEST

--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -184,7 +184,7 @@ struct DownloadTaskExecutor {
                 LOG_WARNING("").error(st);
             }
         }
-        auto timeout_duration = config::s3_file_writer_log_interval;
+        auto timeout_duration = config::s3_file_writer_log_interval_second;
         timespec current_time;
         // We don't need high accuracy here, so we use time(nullptr)
         // since it's the fastest way to get current time(second)

--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -184,7 +184,7 @@ struct DownloadTaskExecutor {
                 LOG_WARNING("").error(st);
             }
         }
-        auto timeout_duration = config::s3_task_check_interval;
+        auto timeout_duration = config::s3_file_writer_log_interval;
         timespec current_time;
         // We don't need high accuracy here, so we use time(nullptr)
         // since it's the fastest way to get current time(second)

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -135,7 +135,7 @@ Status S3FileWriter::_create_multi_upload_request() {
 }
 
 void S3FileWriter::_wait_until_finish(std::string_view task_name) {
-    auto timeout_duration = config::s3_file_writer_log_interval;
+    auto timeout_duration = config::s3_file_writer_log_interval_second;
     auto msg = fmt::format(
             "{} multipart upload already takes {} seconds, bucket={}, key={}, upload_id={}",
             task_name, timeout_duration, _bucket, _path.native(), _upload_id);

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -135,7 +135,7 @@ Status S3FileWriter::_create_multi_upload_request() {
 }
 
 void S3FileWriter::_wait_until_finish(std::string_view task_name) {
-    auto timeout_duration = config::s3_writer_buffer_allocation_timeout;
+    auto timeout_duration = config::s3_file_writer_log_interval;
     auto msg = fmt::format(
             "{} multipart upload already takes {} seconds, bucket={}, key={}, upload_id={}",
             task_name, timeout_duration, _bucket, _path.native(), _upload_id);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -185,8 +185,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .build(&_send_batch_thread_pool));
 
     static_cast<void>(ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
-                              .set_min_threads(16)
-                              .set_max_threads(64)
+                              .set_min_threads(config::buffered_reader_prefetch_thread_pool_min_thread_num)
+                              .set_max_threads(config::buffered_reader_prefetch_thread_pool_max_thread_num)
                               .build(&_buffered_reader_prefetch_thread_pool));
 
     static_cast<void>(ThreadPoolBuilder("SendTableStatsThreadPool")
@@ -200,8 +200,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .build(&_s3_downloader_download_poller_thread_pool));
 
     static_cast<void>(ThreadPoolBuilder("S3FileUploadThreadPool")
-                              .set_min_threads(16)
-                              .set_max_threads(64)
+                              .set_min_threads(config::s3_file_upload_thread_pool_min_thread_num)
+                              .set_max_threads(config::s3_file_upload_thread_pool_max_thread_num)
                               .build(&_s3_file_upload_thread_pool));
 
     // min num equal to fragment pool's min num

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -142,20 +142,9 @@ static void init_doris_metrics(const std::vector<StorePath>& store_paths) {
     DorisMetrics::instance()->initialize(init_system_metrics, disk_devices, network_interfaces);
 }
 
-static pair<int64_t, int64_t> get_buffered_reader_prefetch_threads_num() {
-    int64_t num_cores = doris::CpuInfo::num_cores();
-    auto min_num = config::num_buffered_reader_prefetch_thread_pool_min_thread;
-    auto max_num = config::num_buffered_reader_prefetch_thread_pool_max_thread;
-    auto factor = max_num / min_num;
-    min_num = std::min(num_cores * factor, min_num);
-    max_num = std::min(min_num * factor, max_num);
-    return {min_num, max_num};
-}
-
-static pair<int, int> get_s3_file_writer_upload_threads_num() {
-    int64_t num_cores = doris::CpuInfo::num_cores();
-    auto min_num = config::num_s3_file_upload_thread_pool_min_thread;
-    auto max_num = config::num_s3_file_upload_thread_pool_max_thread;
+// Used to calculate the num of min thread and max thread based on the passed config
+static pair<size_t, size_t> get_num_threads(size_t min_num, size_t max_num) {
+    auto num_cores = doris::CpuInfo::num_cores();
     auto factor = max_num / min_num;
     min_num = std::min(num_cores * factor, min_num);
     max_num = std::min(min_num * factor, max_num);
@@ -205,7 +194,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .build(&_send_batch_thread_pool));
 
     auto [buffered_reader_min_threads, buffered_reader_max_threads] =
-            get_buffered_reader_prefetch_threads_num();
+            get_num_threads(config::num_buffered_reader_prefetch_thread_pool_min_thread,
+                            config::num_buffered_reader_prefetch_thread_pool_max_thread);
     static_cast<void>(ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
                               .set_min_threads(buffered_reader_min_threads)
                               .set_max_threads(buffered_reader_max_threads)
@@ -222,7 +212,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .build(&_s3_downloader_download_poller_thread_pool));
 
     auto [s3_file_upload_min_threads, s3_file_upload_max_threads] =
-            get_s3_file_writer_upload_threads_num();
+            get_num_threads(config::num_s3_file_upload_thread_pool_min_thread,
+                            config::num_s3_file_upload_thread_pool_max_thread);
     static_cast<void>(ThreadPoolBuilder("S3FileUploadThreadPool")
                               .set_min_threads(s3_file_upload_min_threads)
                               .set_max_threads(s3_file_upload_max_threads)

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -144,8 +144,8 @@ static void init_doris_metrics(const std::vector<StorePath>& store_paths) {
 
 static pair<int64_t, int64_t> get_buffered_reader_prefetch_threads_num() {
     int64_t num_cores = doris::CpuInfo::num_cores();
-    auto min_num = config::buffered_reader_prefetch_thread_pool_min_thread_num;
-    auto max_num = config::buffered_reader_prefetch_thread_pool_max_thread_num;
+    auto min_num = config::num_buffered_reader_prefetch_thread_pool_min_thread;
+    auto max_num = config::num_buffered_reader_prefetch_thread_pool_max_thread;
     auto factor = max_num / min_num;
     min_num = std::min(num_cores * factor, min_num);
     max_num = std::min(min_num * factor, max_num);
@@ -154,8 +154,8 @@ static pair<int64_t, int64_t> get_buffered_reader_prefetch_threads_num() {
 
 static pair<int, int> get_s3_file_writer_upload_threads_num() {
     int64_t num_cores = doris::CpuInfo::num_cores();
-    auto min_num = config::s3_file_upload_thread_pool_min_thread_num;
-    auto max_num = config::s3_file_upload_thread_pool_max_thread_num;
+    auto min_num = config::num_s3_file_upload_thread_pool_min_thread;
+    auto max_num = config::num_s3_file_upload_thread_pool_max_thread;
     auto factor = max_num / min_num;
     min_num = std::min(num_cores * factor, min_num);
     max_num = std::min(min_num * factor, max_num);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -145,6 +145,8 @@ static void init_doris_metrics(const std::vector<StorePath>& store_paths) {
 // Used to calculate the num of min thread and max thread based on the passed config
 static pair<size_t, size_t> get_num_threads(size_t min_num, size_t max_num) {
     auto num_cores = doris::CpuInfo::num_cores();
+    min_num = (min_num == 0) ? num_cores : min_num;
+    max_num = (max_num == 0) ? num_cores : max_num;
     auto factor = max_num / min_num;
     min_num = std::min(num_cores * factor, min_num);
     max_num = std::min(min_num * factor, max_num);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -184,10 +184,11 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_max_queue_size(config::send_batch_thread_pool_queue_size)
                               .build(&_send_batch_thread_pool));
 
-    static_cast<void>(ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
-                              .set_min_threads(config::buffered_reader_prefetch_thread_pool_min_thread_num)
-                              .set_max_threads(config::buffered_reader_prefetch_thread_pool_max_thread_num)
-                              .build(&_buffered_reader_prefetch_thread_pool));
+    static_cast<void>(
+            ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
+                    .set_min_threads(config::buffered_reader_prefetch_thread_pool_min_thread_num)
+                    .set_max_threads(config::buffered_reader_prefetch_thread_pool_max_thread_num)
+                    .build(&_buffered_reader_prefetch_thread_pool));
 
     static_cast<void>(ThreadPoolBuilder("SendTableStatsThreadPool")
                               .set_min_threads(8)


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR is mainly to provide more granular control over the thread pool size for remote IO. When import prefetching finds that the prefetch speed is too fast or too slow, you can adjust buffered_reader_prefetch_thread_pool_{min,max}thread_num to control the corresponding number of prefetch threads. When the upload speed to S3 is too fast or too slow, you can adjust s3_file_upload_thread_pool{min,max}_thread_num.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

