### PR TITLE
[fix](stream agg) fix coredump when close if open failed

### DIFF
--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
@@ -65,6 +65,7 @@ private:
         _cache_block = block->clone_empty();
     }
 
+    bool _opened = false;
     std::shared_ptr<char> dummy_mapped_data;
     vectorized::IColumn::Selector _distinct_row;
     vectorized::Arena _arena;

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -246,8 +246,8 @@ Status PartitionedHashJoinSinkLocalState::revoke_memory(RuntimeState* state) {
 
         DCHECK(spilling_stream != nullptr);
 
-        auto* spill_io_pool =
-                ExecEnv::GetInstance()->spill_stream_mgr()->get_async_task_thread_pool();
+        auto* spill_io_pool = ExecEnv::GetInstance()->spill_stream_mgr()->get_spill_io_thread_pool(
+                spilling_stream->get_spill_root_dir());
         DCHECK(spill_io_pool != nullptr);
         auto execution_context = state->get_task_execution_context();
         _shared_state_holder = _shared_state->shared_from_this();

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -184,7 +184,7 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
                                (!p._have_conjuncts) && // no having conjunct
                                p._needs_finalize;      // agg's finalize step
     }
-    _init = true;
+    _opened = true;
     return Status::OK();
 }
 
@@ -1252,7 +1252,7 @@ Status StreamingAggOperatorX::open(RuntimeState* state) {
 }
 
 Status StreamingAggLocalState::close(RuntimeState* state) {
-    if (_closed) {
+    if (!_opened || _closed) {
         return Status::OK();
     }
     SCOPED_TIMER(Base::exec_time_counter());

--- a/be/src/pipeline/exec/streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.h
@@ -183,7 +183,7 @@ private:
     bool _child_eos = false;
     std::unique_ptr<vectorized::Block> _pre_aggregated_block = nullptr;
     std::vector<vectorized::AggregateDataPtr> _values;
-    bool _init = false;
+    bool _opened = false;
 
     void _destroy_agg_status(vectorized::AggregateDataPtr data);
 


### PR DESCRIPTION
## Proposed changes

If open failed, `_agg_data->method_variant` is not initialized, and will coredump when doning std::visit in `close`:
```
terminate called recursively
terminate called after throwing an instance of 'std::bad_variant_access'
terminate called recursively
*** Query id: 50a7b8b3fef74820-96f12509508f5bbc ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1713771863 (unix time) try "date -d @1713771863" if you are using GNU date ***
*** Current BE git commitID: 1c074f3976 ***
*** SIGABRT unknown detail explain (@0x43c002d0f58) received by PID 2953048 (TID 2969660 OR 0x734b8ee3b700) from PID 2953048; stack trace: ***
  what():  std::visit: variant is valueless
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/tengjianping/doris-39/be/src/common/signal_handler.h:421
 1# 0x00007FD6AC083B50 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# 0x0000557537ECA3F2 in /mnt/disk2/tengjianping/doris-39/output/be/lib/doris_be
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x0000557537EC8C51 in /mnt/disk2/tengjianping/doris-39/output/be/lib/doris_be
 7# 0x0000557537EC8DA4 in /mnt/disk2/tengjianping/doris-39/output/be/lib/doris_be
 8# 0x000055750414D262 in /mnt/disk2/tengjianping/doris-39/output/be/lib/doris_be
 9# _ZSt5visitIZN5doris8pipeline22StreamingAggLocalState5closeEPNS0_12RuntimeStateEE3$_0JRSt7variantIJNS0_10vectorized16MethodSerializedI9PHHashMapINS0_9StringRefEPc11DefaultHashISA_vELb0EEEENS7_15MethodOneNumberIhS9_IhSB_SC_IhvELb0EEEENSG_ItS9_ItSB_SC_ItvELb0EEEENSG_IjS9_IjSB_9HashCRC32IjELb0EEEENSG_ImS9_ImSB_SN_ImELb0EEEENS7_19MethodStringNoCacheINS0_13StringHashMapISB_9AllocatorILb1ELb1ELb0EEEEEENSG_INS7_7UInt128ES9_IS10_SB_SN_IS10_ELb0EEEENSG_IjS9_IjSB_14HashMixWrapperIjSO_ELb0EEEENSG_ImS9_ImSB_S14_ImSR_ELb0EEEENSG_IS10_S9_IS10_SB_S14_IS10_S11_ELb0EEEENS7_26MethodSingleNullableColumnINSG_IhNS7_15DataWithNullKeyISI_EEEEEENS1E_INSG_ItNS1F_ISL_EEEEEENS1E_INSG_IjNS1F_ISP_EEEEEENS1E_INSG_ImNS1F_ISS_EEEEEENS1E_INSG_IjNS1F_IS16_EEEEEENS1E_INSG_ImNS1F_IS19_EEEEEENS1E_INSG_IS10_NS1F_IS12_EEEEEENS1E_INSG_IS10_NS1F_IS1C_EEEEEENS1E_INSU_INS1F_ISY_EEEEEENS7_15MethodKeysFixedISS_Lb0EEENS27_ISS_Lb1EEENS27_IS12_Lb0EEENS27_IS12_Lb1EEENS27_IS9_INS7_7UInt256ESB_SN_IS2C_ELb0EELb0EEENS27_IS2E_Lb1EEENS27_IS9_INS7_7UInt136ESB_SN_IS2H_ELb0EELb0EEENS27_IS2J_Lb1EEENS27_IS19_Lb0EEENS27_IS19_Lb1EEENS27_IS1C_Lb0EEENS27_IS1C_Lb1EEENS27_IS9_IS2C_SB_S14_IS2C_S2D_ELb0EELb0EEENS27_IS2R_Lb1EEENS27_IS9_IS2H_SB_S14_IS2H_S2I_ELb0EELb0EEENS27_IS2V_Lb1EEEEEEEDcOT_DpOT0_ at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1752
10# doris::pipeline::StreamingAggLocalState::close(doris::RuntimeState*) at /mnt/disk2/tengjianping/doris-39/be/src/pipeline/exec/streaming_aggregation_operator.cpp:1273
11# doris::pipeline::OperatorXBase::close(doris::RuntimeState*) at /mnt/disk2/tengjianping/doris-39/be/src/pipeline/pipeline_x/operator.cpp:203
12# doris::pipeline::PipelineXTask::close(doris::Status) at /mnt/disk2/tengjianping/doris-39/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:378
13# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /mnt/disk2/tengjianping/doris-39/be/src/pipeline/task_scheduler.cpp:242
14# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /mnt/disk2/tengjianping/doris-39/be/src/pipeline/task_scheduler.cpp:369
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

