### PR TITLE
[queryretry](errormsg) should not send retry request to BE again if the query is timeout

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2753,6 +2753,11 @@ public class Coordinator implements CoordInterface {
         }
     }
 
+
+    public boolean isTimeout() {
+        return System.currentTimeMillis() > this.timeoutDeadline;
+    }
+
     public void setMemTableOnSinkNode(boolean enableMemTableOnSinkNode) {
         this.queryOptions.setEnableMemtableOnSinkNode(enableMemTableOnSinkNode);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
@@ -109,7 +109,7 @@ public class ResultReceiver {
                         }
                     } catch (TimeoutException e) {
                         LOG.warn("Query {} get result timeout, get result duration {} ms",
-                                DebugUtil.printId(this.queryId), (timeoutTs - currentTs) / 1000);
+                                DebugUtil.printId(this.queryId), timeoutTs - currentTs);
                         setRunStatus(Status.TIMEOUT);
                         status.setStatus(Status.TIMEOUT);
                         updateCancelReason("fetch data timeout");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -828,7 +828,8 @@ public class StmtExecutor {
                 if (Config.isCloudMode() && e.getMessage().contains(FeConstants.CLOUD_RETRY_E230)) {
                     throw e;
                 }
-                if (this.coord != null && this.coord.isQueryCancelled()) {
+                // If the previous try is timeout or cancelled, then do not need try again.
+                if (this.coord != null && (this.coord.isQueryCancelled() || this.coord.isTimeout())) {
                     throw e;
                 }
                 // cloud mode retry
@@ -865,10 +866,6 @@ public class StmtExecutor {
                             }
                         }
                     }
-                }
-                // If the previous try is timeout, then do not need try again.
-                if (this.coord.isTimeout()) {
-                    isNeedRetry = false;
                 }
                 if (i != retryTime - 1 && isNeedRetry
                         && context.getConnectType().equals(ConnectType.MYSQL) && !context.getMysqlChannel().isSend()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -790,7 +790,6 @@ public class StmtExecutor {
     private void handleQueryWithRetry(TUniqueId queryId) throws Exception {
         // queue query here
         syncJournalIfNeeded();
-
         int retryTime = Config.max_query_retry_time;
         for (int i = 0; i < retryTime; i++) {
             try {
@@ -866,6 +865,10 @@ public class StmtExecutor {
                             }
                         }
                     }
+                }
+                // If the previous try is timeout, then do not need try again.
+                if (this.coord.isTimeout()) {
+                    isNeedRetry = false;
                 }
                 if (i != retryTime - 1 && isNeedRetry
                         && context.getConnectType().equals(ConnectType.MYSQL) && !context.getMysqlChannel().isSend()) {


### PR DESCRIPTION
## Proposed changes

If retry, then FE will send fragments to BE, but there is a timeout checker and will cancel the timeout query. But BE will run the fragment, it is useless and will cost CPU.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

