### PR TITLE
[test](p0 case) Increase the batch size in  test leading cases

### DIFF
--- a/regression-test/suites/nereids_p0/hint/test_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_leading.groovy
@@ -75,6 +75,8 @@ suite("test_leading") {
         time 10000
     }
 
+    sql""" set BATCH_SIZE = 4064;"""
+
 //// check table count
     qt_select1_1 """select count(*) from t1;"""
     qt_select1_2 """select count(*) from t2;"""


### PR DESCRIPTION
## Proposed changes

Due to the presence of fuzziness, the batch size may be set to 50, and this case runs very slowly locally, making it prone to timeouts.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

