### PR TITLE
[fix](nereids)move ReplaceVariableByLiteral rule to analyze phase

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
@@ -44,6 +44,7 @@ import org.apache.doris.nereids.rules.analysis.ProjectToGlobalAggregate;
 import org.apache.doris.nereids.rules.analysis.ProjectWithDistinctToAggregate;
 import org.apache.doris.nereids.rules.analysis.ReplaceExpressionByChildOutput;
 import org.apache.doris.nereids.rules.analysis.SubqueryToApply;
+import org.apache.doris.nereids.rules.analysis.VariableToLiteral;
 import org.apache.doris.nereids.rules.rewrite.MergeProjects;
 import org.apache.doris.nereids.rules.rewrite.SemiJoinCommute;
 import org.apache.doris.nereids.rules.rewrite.SimplifyAggGroupBy;
@@ -157,6 +158,7 @@ public class Analyzer extends AbstractBatchJobExecutor {
                 new NormalizeRepeat()
             ),
             bottomUp(new AdjustAggregateNullableForEmptySet()),
+            topDown(new VariableToLiteral()),
             // run CheckAnalysis before EliminateGroupByConstant in order to report error message correctly like bellow
             // select SUM(lo_tax) FROM lineorder group by 1;
             // errCode = 2, detailMessage = GROUP BY expression must not contain aggregate functions: sum(lo_tax)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
@@ -158,6 +158,16 @@ public class Analyzer extends AbstractBatchJobExecutor {
                 new NormalizeRepeat()
             ),
             bottomUp(new AdjustAggregateNullableForEmptySet()),
+            // consider sql with user defined var @t_zone
+            // set @t_zone='GMT';
+            // SELECT
+            //     DATE_FORMAT(convert_tz(dt, time_zone, @t_zone),'%Y-%m-%d') day
+            // FROM
+            //     t
+            // GROUP BY
+            //     1;
+            // @t_zone must be replaced as 'GMT' before EliminateGroupByConstant and NormalizeAggregate rule.
+            // So need run VariableToLiteral rule before the two rules.
             topDown(new VariableToLiteral()),
             // run CheckAnalysis before EliminateGroupByConstant in order to report error message correctly like bellow
             // select SUM(lo_tax) FROM lineorder group by 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/VariableToLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/VariableToLiteral.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.nereids.rules.expression.ExpressionRewrite;
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteRule;
+import org.apache.doris.nereids.rules.expression.ExpressionRuleExecutor;
+import org.apache.doris.nereids.rules.expression.rules.ReplaceVariableByLiteral;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * replace Variable To Literal
+ */
+public class VariableToLiteral extends ExpressionRewrite {
+    public static final List<ExpressionRewriteRule> NORMALIZE_REWRITE_RULES =
+            ImmutableList.of(bottomUp(ReplaceVariableByLiteral.INSTANCE));
+
+    public VariableToLiteral() {
+        super(new ExpressionRuleExecutor(NORMALIZE_REWRITE_RULES));
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.rules.expression.rules.FoldConstantRule;
 import org.apache.doris.nereids.rules.expression.rules.InPredicateDedup;
 import org.apache.doris.nereids.rules.expression.rules.InPredicateToEqualToRule;
 import org.apache.doris.nereids.rules.expression.rules.NormalizeBinaryPredicatesRule;
-import org.apache.doris.nereids.rules.expression.rules.ReplaceVariableByLiteral;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyArithmeticComparisonRule;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyArithmeticRule;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyCastRule;
@@ -43,7 +42,6 @@ public class ExpressionNormalization extends ExpressionRewrite {
     // from_unixtime(timestamp, 'yyyyMMdd') to 'yyyyMMdd'
     public static final List<ExpressionRewriteRule> NORMALIZE_REWRITE_RULES = ImmutableList.of(
             bottomUp(
-                ReplaceVariableByLiteral.INSTANCE,
                 SupportJavaDateFormatter.INSTANCE,
                 NormalizeBinaryPredicatesRule.INSTANCE,
                 InPredicateDedup.INSTANCE,

--- a/regression-test/suites/nereids_p0/test_user_var.groovy
+++ b/regression-test/suites/nereids_p0/test_user_var.groovy
@@ -31,4 +31,39 @@ suite("test_user_var") {
     qt_boolean 'select @d1, @d2;'
     qt_null_literal 'select @f1, @f2;'
     qt_function 'select @func_1'
+
+    multi_sql(
+        """
+            drop table if exists dwd_login_ttt;
+
+            CREATE TABLE `dwd_login_ttt` (
+            `game_code` varchar(100) NOT NULL DEFAULT "-" ,
+            `plat_code` varchar(100) NOT NULL DEFAULT "-" ,
+            `userid` varchar(255) NULL DEFAULT "-" ,
+            `dt` datetime NOT NULL,
+            `time_zone` varchar(100) NULL 
+            ) ENGINE=OLAP
+            UNIQUE KEY(`game_code`, `plat_code`)
+            DISTRIBUTED BY HASH(`game_code`) BUCKETS 16
+            PROPERTIES("replication_num" = "1");
+
+            drop view if exists dwd_login_ttt_view;
+
+            create view dwd_login_ttt_view as
+            SELECT  game_code,plat_code,time_zone,DATE_FORMAT(convert_tz(dt,time_zone,@t_zone),'%Y-%m-%d') day,count(distinct userid) 
+            from  dwd_login_ttt
+            where  dt>=convert_tz(@t_day,'Asia/Shanghai',@t_zone) 
+            and dt<convert_tz(date_add(@t_day,1),'Asia/Shanghai',@t_zone)
+            GROUP  by 1,2,3,4;
+
+            set @t_day='2024-02-01';
+            set @t_zone='GMT';
+        """
+    )
+
+    explain {
+        sql("shape plan select * from dwd_login_ttt_view where day='2024-04-01';")
+        contains "dt < '2024-02-01 16:00:00'"
+        contains "dt >= '2024-01-31 16:00:00'"
+    }
 }


### PR DESCRIPTION
consider sql with user defined var @t_zone
```
set @t_zone='GMT';
SELECT 
    DATE_FORMAT(convert_tz(dt, time_zone, @t_zone),'%Y-%m-%d') day
FROM 
    t
GROUP BY 
    1;
```
@t_zone must be replaced as 'GMT' before EliminateGroupByConstant and NormalizeAggregate rule. So this pr move ReplaceVariableByLiteral rule from rewrite phase to analyze phase and put it before the two rules to make it work.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

