### PR TITLE
[fix](exception) Fix Block noexcept method not throw exception

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -142,8 +142,7 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     {
         SCOPED_CONSUME_MEM_TRACKER(memtable->flush_mem_tracker());
         std::unique_ptr<vectorized::Block> block = memtable->to_block();
-        SKIP_MEMORY_CHECK(RETURN_IF_ERROR(
-                _rowset_writer->flush_memtable(block.get(), segment_id, flush_size)));
+        RETURN_IF_ERROR(_rowset_writer->flush_memtable(block.get(), segment_id, flush_size));
     }
     _memtable_stat += memtable->stat();
     DorisMetrics::instance()->memtable_flush_total->increment(1);

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -594,6 +594,7 @@ Status BaseBetaRowsetWriter::flush() {
 
 Status BaseBetaRowsetWriter::flush_memtable(vectorized::Block* block, int32_t segment_id,
                                             int64_t* flush_size) {
+    SCOPED_SKIP_MEMORY_CHECK();
     if (block->rows() == 0) {
         return Status::OK();
     }

--- a/be/src/olap/rowset/beta_rowset_writer_v2.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.cpp
@@ -92,6 +92,7 @@ Status BetaRowsetWriterV2::add_segment(uint32_t segment_id, const SegmentStatist
 
 Status BetaRowsetWriterV2::flush_memtable(vectorized::Block* block, int32_t segment_id,
                                           int64_t* flush_size) {
+    SCOPED_SKIP_MEMORY_CHECK();
     if (block->rows() == 0) {
         return Status::OK();
     }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -85,7 +85,6 @@ class RoutineLoadTaskExecutor;
 class SmallFileMgr;
 class BlockSpillManager;
 class BackendServiceClient;
-class ThreadContext;
 class TPaloBrokerServiceClient;
 class PBackendService_Stub;
 class PFunctionService_Stub;
@@ -166,7 +165,6 @@ public:
         return nullptr;
     }
 
-    ThreadContext* env_thread_context() { return _env_thread_context; }
     // Save all MemTrackerLimiters in use.
     // Each group corresponds to several MemTrackerLimiters and has a lock.
     // Multiple groups are used to reduce the impact of locks.
@@ -357,7 +355,6 @@ private:
     ClientCache<FrontendServiceClient>* _frontend_client_cache = nullptr;
     ClientCache<TPaloBrokerServiceClient>* _broker_client_cache = nullptr;
 
-    ThreadContext* _env_thread_context = nullptr;
     // The default tracker consumed by mem hook. If the thread does not attach other trackers,
     // by default all consumption will be passed to the process tracker through the orphan tracker.
     // In real time, `consumption of all limiter trackers` + `orphan tracker consumption` = `process tracker consumption`.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -418,7 +418,6 @@ Status ExecEnv::_init_mem_env() {
     // 1. init mem tracker
     init_mem_tracker();
     thread_context()->thread_mem_tracker_mgr->init();
-    _env_thread_context = thread_context();
 #if defined(USE_MEM_TRACKER) && !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && \
         !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
     init_hook();

--- a/be/src/vec/columns/subcolumn_tree.h
+++ b/be/src/vec/columns/subcolumn_tree.h
@@ -278,6 +278,7 @@ public:
 
     SubcolumnsTree() {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->subcolumns_tree_tracker());
+        SCOPED_SKIP_MEMORY_CHECK();
         strings_pool = std::make_shared<Arena>();
     }
 

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -692,6 +692,7 @@ std::string Block::print_use_count() {
 }
 
 void Block::clear_column_data(int column_size) noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     // data.size() greater than column_size, means here have some
     // function exec result in block, need erase it here
     if (column_size != -1 and data.size() > column_size) {
@@ -707,12 +708,14 @@ void Block::clear_column_data(int column_size) noexcept {
 }
 
 void Block::swap(Block& other) noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     data.swap(other.data);
     index_by_name.swap(other.index_by_name);
     row_same_bit.swap(other.row_same_bit);
 }
 
 void Block::swap(Block&& other) noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     clear();
     data = std::move(other.data);
     index_by_name = std::move(other.index_by_name);
@@ -944,6 +947,7 @@ size_t MutableBlock::rows() const {
 }
 
 void MutableBlock::swap(MutableBlock& another) noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     _columns.swap(another._columns);
     _data_types.swap(another._data_types);
     _names.swap(another._names);
@@ -951,6 +955,7 @@ void MutableBlock::swap(MutableBlock& another) noexcept {
 }
 
 void MutableBlock::swap(MutableBlock&& another) noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     clear();
     _columns = std::move(another._columns);
     _data_types = std::move(another._data_types);
@@ -1134,6 +1139,7 @@ size_t MutableBlock::allocated_bytes() const {
 }
 
 void MutableBlock::clear_column_data() noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     for (auto& col : _columns) {
         if (col) {
             col->clear();
@@ -1142,6 +1148,7 @@ void MutableBlock::clear_column_data() noexcept {
 }
 
 void MutableBlock::reset_column_data() noexcept {
+    SCOPED_SKIP_MEMORY_CHECK();
     _columns.clear();
     for (int i = 0; i < _names.size(); i++) {
         _columns.emplace_back(_data_types[i]->create_column());


### PR DESCRIPTION
## Proposed changes

fix:
```
terminate called after throwing an instance of 'doris::Exception'
05:02:23     what():  [E11] Allocator sys memory check failed: Cannot alloc:4096, consuming tracker:<SubcolumnsTree>, peak used 52011008, current used 3768320, exec node:<>, process memory used 48.90 GB exceed limit 48.85 GB or sys available memory 7.47 GB less than low water mark 1.60 GB.
05:02:23   
05:02:23     0#  doris::Exception::Exception(int, std::basic_string_view<char, std::char_traits<char> > const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
05:02:23     1#  Allocator<false, false, false>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.cpp:121
05:02:23     2#  Allocator<false, false, false>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.cpp:167
05:02:23     3#  doris::vectorized::SubcolumnsTree<doris::vectorized::ColumnObject::Subcolumn>::SubcolumnsTree() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:0
05:02:23     4#  doris::vectorized::ColumnObject::clear() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_object.cpp:0
05:02:23     5#  doris::vectorized::ColumnNullable::clear() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/columns/column_nullable.h:317
05:02:23     6#  doris::vectorized::Block::clear_column_data(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/core/block.cpp:704
05:02:23     7#  doris::segment_v2::SegmentIterator::_init_current_block(doris::vectorized::Block*, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1291
05:02:23     8#  doris::segment_v2::SegmentIterator::_next_batch_internal(doris::vectorized::Block*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.h:449
05:02:23     9#  doris::segment_v2::SegmentIterator::next_batch(doris::vectorized::Block*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.h:449
05:02:23     10# doris::BetaRowsetReader::next_block(doris::vectorized::Block*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.h:449
05:02:23     11# doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.h:449
05:02:23     12# doris::vectorized::VCollectIterator::Level0Iterator::init(bool) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/olap/vcollect_iterator.cpp:473
05:02:23     13# doris::vectorized::VCollectIterator::build_heap(std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > >&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/status.h:449
05:02:23     14# doris::vectorized::BlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_branch-2.1/d
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

