### PR TITLE
[fix](fd) release fd for shutdown tablets

### DIFF
--- a/be/src/cloud/cloud_base_compaction.cpp
+++ b/be/src/cloud/cloud_base_compaction.cpp
@@ -96,7 +96,7 @@ Status CloudBaseCompaction::prepare_compact() {
             cloud_tablet()->last_sync_time_s = 0;
         } else if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
             // tablet not found
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         return st;
     }
@@ -293,7 +293,7 @@ Status CloudBaseCompaction::modify_rowsets() {
     auto st = _engine.meta_mgr().commit_tablet_job(job, &resp);
     if (!st.ok()) {
         if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         return st;
     }

--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -123,7 +123,7 @@ PREPARE_TRY_AGAIN:
             cloud_tablet()->last_sync_time_s = 0;
         } else if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
             // tablet not found
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         } else if (resp.status().code() == cloud::JOB_TABLET_BUSY) {
             if (config::enable_parallel_cumu_compaction && resp.version_in_compaction_size() > 0 &&
                 ++tried <= 2) {

--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -414,7 +414,7 @@ void CloudCumulativeCompaction::update_cumulative_point() {
     st = _engine.meta_mgr().commit_tablet_job(job, &finish_resp);
     if (!st.ok()) {
         if (finish_resp.status().code() == cloud::TABLET_NOT_FOUND) {
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         LOG_WARNING("failed to update cumulative point to meta srv")
                 .tag("job_id", _uuid)

--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -248,7 +248,7 @@ Status CloudCumulativeCompaction::modify_rowsets() {
     auto st = _engine.meta_mgr().commit_tablet_job(job, &resp);
     if (!st.ok()) {
         if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         return st;
     }
@@ -398,7 +398,7 @@ void CloudCumulativeCompaction::update_cumulative_point() {
             cloud_tablet()->last_sync_time_s = 0;
         } else if (start_resp.status().code() == cloud::TABLET_NOT_FOUND) {
             // tablet not found
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         LOG_WARNING("failed to update cumulative point to meta srv")
                 .tag("job_id", _uuid)

--- a/be/src/cloud/cloud_full_compaction.cpp
+++ b/be/src/cloud/cloud_full_compaction.cpp
@@ -90,7 +90,7 @@ Status CloudFullCompaction::prepare_compact() {
             cloud_tablet()->last_sync_time_s = 0;
         } else if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
             // tablet not found
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         return st;
     }
@@ -212,7 +212,7 @@ Status CloudFullCompaction::modify_rowsets() {
     auto st = _engine.meta_mgr().commit_tablet_job(job, &resp);
     if (!st.ok()) {
         if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
-            cloud_tablet()->recycle_cached_data();
+            cloud_tablet()->clear_cache();
         }
         return st;
     }

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -319,13 +319,17 @@ void CloudTablet::update_base_size(const Rowset& rs) {
     }
 }
 
-void CloudTablet::recycle_cached_data() {
+void CloudTablet::clear_cache() {
     CloudTablet::recycle_cached_data(get_snapshot_rowset(true));
     _engine.tablet_mgr().erase_tablet(tablet_id());
 }
 
 void CloudTablet::recycle_cached_data(const std::vector<RowsetSharedPtr>& rowsets) {
-    std::unordered_map<int, int> map;
+    for (auto& rs : rowsets) {
+        // Clear cached opened segments and inverted index cache in memory
+        rs->clear_cache();
+    }
+
     if (config::enable_file_cache) {
         for (const auto& rs : rowsets) {
             for (int seg_id = 0; seg_id < rs->num_segments(); ++seg_id) {

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -126,7 +126,7 @@ Status CloudTablet::sync_rowsets(int64_t query_version, bool warmup_delta_data) 
 
     auto st = _engine.meta_mgr().sync_tablet_rowsets(this, warmup_delta_data);
     if (st.is<ErrorCode::NOT_FOUND>()) {
-        recycle_cached_data();
+        clear_cache();
     }
     return st;
 }
@@ -153,7 +153,7 @@ Status CloudTablet::sync_if_not_running() {
     auto st = _engine.meta_mgr().get_tablet_meta(tablet_id(), &tablet_meta);
     if (!st.ok()) {
         if (st.is<ErrorCode::NOT_FOUND>()) {
-            recycle_cached_data();
+            clear_cache();
         }
         return st;
     }
@@ -178,7 +178,7 @@ Status CloudTablet::sync_if_not_running() {
 
     st = _engine.meta_mgr().sync_tablet_rowsets(this);
     if (st.is<ErrorCode::NOT_FOUND>()) {
-        recycle_cached_data();
+        clear_cache();
     }
     return st;
 }

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -89,7 +89,7 @@ public:
     // When the tablet is dropped, we need to recycle cached data:
     // 1. The data in file cache
     // 2. The memory in tablet cache
-    void recycle_cached_data();
+    void clear_cache() override;
 
     static void recycle_cached_data(const std::vector<RowsetSharedPtr>& rowsets);
 

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -91,8 +91,6 @@ public:
     // 2. The memory in tablet cache
     void clear_cache() override;
 
-    static void recycle_cached_data(const std::vector<RowsetSharedPtr>& rowsets);
-
     // Return number of deleted stale rowsets
     int delete_expired_stale_rowsets();
 
@@ -205,6 +203,8 @@ public:
 private:
     // FIXME(plat1ko): No need to record base size if rowsets are ordered by version
     void update_base_size(const Rowset& rs);
+
+    static void recycle_cached_data(const std::vector<RowsetSharedPtr>& rowsets);
 
     Status sync_if_not_running();
 

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -241,7 +241,7 @@ public:
 
     std::vector<RowsetSharedPtr> get_snapshot_rowset(bool include_stale_rowset = false) const;
 
-    virtual void clear_cache() { LOG(INFO) << "should not reach here"; }
+    virtual void clear_cache() = 0;
 
 protected:
     // Find the missed versions until the spec_version.

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -241,6 +241,8 @@ public:
 
     std::vector<RowsetSharedPtr> get_snapshot_rowset(bool include_stale_rowset = false) const;
 
+    virtual void clear_cache() { LOG(INFO) << "should not reach here"; }
+
 protected:
     // Find the missed versions until the spec_version.
     //

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -133,6 +133,7 @@ Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
     bool eof = false;
     while (!eof && !ExecEnv::GetInstance()->storage_engine().stopped()) {
         if (tablet->tablet_state() == TABLET_SHUTDOWN) {
+            tablet->clear_cache();
             return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more",
                                                  tablet->tablet_id());
         }

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -132,6 +132,11 @@ Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
     size_t output_rows = 0;
     bool eof = false;
     while (!eof && !ExecEnv::GetInstance()->storage_engine().stopped()) {
+        if (tablet->tablet_state() == TABLET_SHUTDOWN) {
+            return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more",
+                                                 tablet->tablet_id());
+        }
+
         // Read one block from block reader
         RETURN_NOT_OK_STATUS_WITH_WARN(reader.next_block_with_aggregation(&block, &eof),
                                        "failed to read next block when merging rowsets of tablet " +

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -204,8 +204,8 @@ Status BetaRowset::remove() {
                 << ", version:" << start_version() << "-" << end_version()
                 << ", tabletid:" << _rowset_meta->tablet_id();
     // If the rowset was removed, it need to remove the fds in segment cache directly
-    SegmentLoader::instance()->erase_segments(_rowset_meta->rowset_id(),
-                                              _rowset_meta->num_segments());
+    clear_cache();
+
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");
@@ -242,10 +242,6 @@ Status BetaRowset::remove() {
                         LOG(WARNING) << st.to_string();
                         success = false;
                     }
-                }
-                if (success) {
-                    RETURN_IF_ERROR(segment_v2::InvertedIndexSearcherCache::instance()->erase(
-                            inverted_index_file));
                 }
             }
         }

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -131,12 +131,10 @@ void BetaRowset::clear_inverted_index_cache() {
         for (auto& column : tablet_schema()->columns()) {
             const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
             if (index_meta) {
-                std::string inverted_index_file =
-                        InvertedIndexDescriptor::get_index_file_name(
-                                seg_path, index_meta->index_id(),
-                                index_meta->get_index_suffix());
+                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
+                        seg_path, index_meta->index_id(), index_meta->get_index_suffix());
                 (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
-                                inverted_index_file);
+                        inverted_index_file);
             }
         }
     }
@@ -634,6 +632,5 @@ Status BetaRowset::add_to_binlog() {
 
     return Status::OK();
 }
-
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <utility>
 
+#include "beta_rowset.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -122,6 +123,23 @@ Status BetaRowset::get_inverted_index_size(size_t* index_size) {
         }
     }
     return Status::OK();
+}
+
+void BetaRowset::clear_inverted_index_cache() {
+    for (int i = 0; i < num_segments(); ++i) {
+        auto seg_path = segment_file_path(i);
+        for (auto& column : tablet_schema()->columns()) {
+            const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
+            if (index_meta) {
+                std::string inverted_index_file =
+                        InvertedIndexDescriptor::get_index_file_name(
+                                seg_path, index_meta->index_id(),
+                                index_meta->get_index_suffix());
+                (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
+                                inverted_index_file);
+            }
+        }
+    }
 }
 
 Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
@@ -616,5 +634,6 @@ Status BetaRowset::add_to_binlog() {
 
     return Status::OK();
 }
+
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -94,7 +94,9 @@ public:
     Status load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment);
 
     Status get_segments_size(std::vector<size_t>* segments_size);
+
     Status get_inverted_index_size(size_t* index_size);
+    void clear_inverted_index_cache() override;
 
     [[nodiscard]] virtual Status add_to_binlog() override;
 

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -115,7 +115,6 @@ protected:
     void clear_inverted_index_cache() override;
 
 private:
-
     friend class RowsetFactory;
     friend class BetaRowsetReader;
 

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -96,7 +96,6 @@ public:
     Status get_segments_size(std::vector<size_t>* segments_size);
 
     Status get_inverted_index_size(size_t* index_size);
-    void clear_inverted_index_cache() override;
 
     [[nodiscard]] virtual Status add_to_binlog() override;
 
@@ -113,7 +112,10 @@ protected:
 
     bool check_current_rowset_segment() override;
 
+    void clear_inverted_index_cache() override;
+
 private:
+
     friend class RowsetFactory;
     friend class BetaRowsetReader;
 

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -20,6 +20,7 @@
 #include <gen_cpp/olap_file.pb.h>
 
 #include "olap/olap_define.h"
+#include "olap/segment_loader.h"
 #include "olap/tablet_schema.h"
 #include "util/time.h"
 
@@ -91,6 +92,11 @@ std::string Rowset::get_rowset_info_str() {
                        _rowset_meta->has_delete_predicate() ? "DELETE" : "DATA",
                        SegmentsOverlapPB_Name(_rowset_meta->segments_overlap()),
                        rowset_id().to_string(), disk_size);
+}
+
+void Rowset::clear_cache() {
+    SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+    clear_inverted_index_cache();
 }
 
 Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -303,6 +303,9 @@ public:
 
     std::string get_rowset_info_str();
 
+    virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
+    void clear_cache();
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -303,7 +303,6 @@ public:
 
     std::string get_rowset_info_str();
 
-    virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
     void clear_cache();
 
 protected:
@@ -323,6 +322,8 @@ protected:
     virtual void do_close() = 0;
 
     virtual bool check_current_rowset_segment() = 0;
+
+    virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
 
     TabletSchemaSPtr _schema;
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1087,6 +1087,7 @@ void StorageEngine::start_delete_unused_rowset() {
                 if (rs->is_local()) {
                     unused_rowsets_copy.push_back(std::move(rs));
                 }
+                it->second->clear_cache();
                 it = _unused_rowsets.erase(it);
             } else {
                 if (rs.use_count() != 1) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1084,10 +1084,10 @@ void StorageEngine::start_delete_unused_rowset() {
             auto&& rs = it->second;
             if (rs.use_count() == 1 && rs->need_delete_file()) {
                 // remote rowset data will be reclaimed by `remove_unused_remote_files`
+                it->second->clear_cache();
                 if (rs->is_local()) {
                     unused_rowsets_copy.push_back(std::move(rs));
                 }
-                it->second->clear_cache();
                 it = _unused_rowsets.erase(it);
             } else {
                 if (rs.use_count() != 1) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1084,7 +1084,6 @@ void StorageEngine::start_delete_unused_rowset() {
             auto&& rs = it->second;
             if (rs.use_count() == 1 && rs->need_delete_file()) {
                 // remote rowset data will be reclaimed by `remove_unused_remote_files`
-                it->second->clear_cache();
                 if (rs->is_local()) {
                     unused_rowsets_copy.push_back(std::move(rs));
                 }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -728,7 +728,6 @@ void Tablet::delete_expired_stale_rowset() {
                     if (it->second->is_local()) {
                         _engine.add_unused_rowset(it->second);
                     }
-                    it->second->clear_cache();
                     _stale_rs_version_map.erase(it);
                     VLOG_NOTICE << "delete stale rowset tablet=" << tablet_id() << " version["
                                 << timestampedVersion->version().first << ","

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -724,6 +724,7 @@ void Tablet::delete_expired_stale_rowset() {
             for (auto& timestampedVersion : to_delete_version) {
                 auto it = _stale_rs_version_map.find(timestampedVersion->version());
                 if (it != _stale_rs_version_map.end()) {
+                    it->second->clear_cache();
                     // delete rowset
                     if (it->second->is_local()) {
                         _engine.add_unused_rowset(it->second);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -107,6 +107,7 @@
 #include "olap/utils.h"
 #include "segment_loader.h"
 #include "service/point_query_executor.h"
+#include "tablet.h"
 #include "util/bvar_helper.h"
 #include "util/debug_points.h"
 #include "util/defer_op.h"
@@ -727,6 +728,7 @@ void Tablet::delete_expired_stale_rowset() {
                     if (it->second->is_local()) {
                         _engine.add_unused_rowset(it->second);
                     }
+                    it->second->clear_cache();
                     _stale_rs_version_map.erase(it);
                     VLOG_NOTICE << "delete stale rowset tablet=" << tablet_id() << " version["
                                 << timestampedVersion->version().first << ","
@@ -2524,5 +2526,17 @@ void Tablet::gc_binlogs(int64_t version) {
 Status Tablet::ingest_binlog_metas(RowsetBinlogMetasPB* metas_pb) {
     return RowsetMetaManager::ingest_binlog_metas(_data_dir->get_meta(), tablet_uid(), metas_pb);
 }
+
+void Tablet::clear_cache() {
+    std::shared_lock rlock(get_header_lock());
+    static auto recycle_segment_cache = [](const auto& rowset_map) {
+        for (auto& [_, rowset] : rowset_map) {
+            rowset->clear_cache();
+        }
+    };
+    recycle_segment_cache(rowset_map());
+    recycle_segment_cache(stale_rowset_map());
+}
+
 
 } // namespace doris

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2538,5 +2538,4 @@ void Tablet::clear_cache() {
     recycle_segment_cache(stale_rowset_map());
 }
 
-
 } // namespace doris

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -459,6 +459,8 @@ public:
     void set_alter_failed(bool alter_failed) { _alter_failed = alter_failed; }
     bool is_alter_failed() { return _alter_failed; }
 
+    void clear_cache();
+
 private:
     Status _init_once_action();
     bool _contains_rowset(const RowsetId rowset_id);
@@ -492,6 +494,8 @@ private:
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
+
+    void _clear_cache_by_rowset(const BetaRowsetSharedPtr& rowset);
 
 public:
     static const int64_t K_INVALID_CUMULATIVE_POINT = -1;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -459,7 +459,7 @@ public:
     void set_alter_failed(bool alter_failed) { _alter_failed = alter_failed; }
     bool is_alter_failed() { return _alter_failed; }
 
-    void clear_cache();
+    void clear_cache() override;
 
 private:
     Status _init_once_action();

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -551,41 +551,9 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TReplicaId repl
     _remove_tablet_from_partition(to_drop_tablet);
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
     tablet_map.erase(tablet_id);
-    {
-        std::shared_lock rlock(to_drop_tablet->get_header_lock());
-        static auto recycle_segment_cache = [](const auto& rowset_map) {
-            for (auto& [_, rowset] : rowset_map) {
-                // If the tablet was deleted, it need to remove all rowsets fds directly
-                SegmentLoader::instance()->erase_segments(rowset->rowset_id(),
-                                                          rowset->num_segments());
-            }
-        };
-        recycle_segment_cache(to_drop_tablet->rowset_map());
-        recycle_segment_cache(to_drop_tablet->stale_rowset_map());
-        // recycle inverted index cache
-        static auto recycle_inverted_index_cache = [](const auto& rowset_map) {
-            for (auto& [_, rowset] : rowset_map) {
-                auto rs = std::static_pointer_cast<BetaRowset>(rowset);
-                for (int i = 0; i < rs->num_segments(); ++i) {
-                    auto seg_path = rs->segment_file_path(i);
-                    for (auto& column : rs->tablet_schema()->columns()) {
-                        const TabletIndex* index_meta =
-                                rs->tablet_schema()->get_inverted_index(*column);
-                        if (index_meta) {
-                            std::string inverted_index_file =
-                                    InvertedIndexDescriptor::get_index_file_name(
-                                            seg_path, index_meta->index_id(),
-                                            index_meta->get_index_suffix());
-                            (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
-                                    inverted_index_file);
-                        }
-                    }
-                }
-            }
-        };
-        recycle_inverted_index_cache(to_drop_tablet->rowset_map());
-        recycle_inverted_index_cache(to_drop_tablet->stale_rowset_map());
-    }
+
+    to_drop_tablet->clear_cache();
+
     if (!keep_files) {
         // drop tablet will update tablet meta, should lock
         std::lock_guard<std::shared_mutex> wrlock(to_drop_tablet->get_header_lock());
@@ -1154,6 +1122,9 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                          << " cur tablet_uid=" << tablet_meta->tablet_uid();
             return true;
         }
+
+        tablet->clear_cache();
+
         // move data to trash
         const auto& tablet_path = tablet->tablet_path();
         bool exists = false;
@@ -1195,6 +1166,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                   << ", schema_hash=" << tablet->schema_hash() << ", tablet_path=" << tablet_path;
         return true;
     } else {
+        tablet->clear_cache();
         // if could not find tablet info in meta store, then check if dir existed
         const auto& tablet_path = tablet->tablet_path();
         bool exists = false;

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -28,10 +28,10 @@
 set -eo pipefail
 
 build_version_prefix="doris"
-build_version_major=0
+build_version_major=4
 build_version_minor=0
 build_version_patch=0
-build_version_rc_version="trunk"
+build_version_rc_version="preview"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}-${build_version_rc_version}"
 


### PR DESCRIPTION
When a tablet is shutdown, maybe there is a running compaction on it, the compaction would put fd in cache, so we should clear them when move the directory to the trash and fail the compaction due to shutdown state.

e.g.
t0: a compaction is running on tablet t;
t1: tablet t is set shutdown, files of tablet are removed from segment cache.
t2: the compaction stops and files of tablet are added to the segment cache again.
t3: tablet t is moved to trash due to it is not used any more.
t4: the files are deleted from trash.
t5: the tablet's cache in segment cache remains and the capacity consumed by the files is not freed.

When a stale rowset is expired, it is removed when it is not used any more, and remove() function deletes files and removes the cache. However, there is no harm in clearing cache when a rowset is expired.

We reconstruct code related to clearing cache in object oriented way.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

