### PR TITLE
[fix](fd) remove fd from cache when tablet is deleted

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -105,7 +105,8 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     bool eof = false;
     while (!eof && !StorageEngine::instance()->stopped()) {
         if (tablet->tabelt_state() == TABLET_SHUTDOWN) {
-            return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more", tablet->tablet_id());
+            return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more",
+                                                 tablet->tablet_id());
         }
 
         // Read one block from block reader

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -104,6 +104,10 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     size_t output_rows = 0;
     bool eof = false;
     while (!eof && !StorageEngine::instance()->stopped()) {
+        if (tablet->tabelt_state() == TABLET_SHUTDOWN) {
+            return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more", tablet->tablet_id());
+        }
+
         // Read one block from block reader
         RETURN_NOT_OK_STATUS_WITH_WARN(
                 reader.next_block_with_aggregation(&block, &eof),

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -104,7 +104,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     size_t output_rows = 0;
     bool eof = false;
     while (!eof && !StorageEngine::instance()->stopped()) {
-        if (tablet->tabelt_state() == TABLET_SHUTDOWN) {
+        if (tablet->tablet_state() == TABLET_SHUTDOWN) {
             return Status::Error<INTERNAL_ERROR>("tablet {} is not used any more",
                                                  tablet->tablet_id());
         }

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -125,7 +125,7 @@ void BetaRowset::clear_inverted_index_cache() {
         auto seg_path = segment_file_path(i);
         for (auto& column : tablet_schema()->columns()) {
             const TabletIndex* index_meta =
-                    tablet_schema()->get_inverted_index(column.column_unique_id());
+                    tablet_schema()->get_inverted_index(column.unique_id());
             if (index_meta) {
                 std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
                         seg_path, index_meta->index_id());

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -488,4 +488,17 @@ Status BetaRowset::add_to_binlog() {
     return Status::OK();
 }
 
+void Rowset::clear_cache() {
+    SegmentCache::CacheKey cache_key(rowset_id());
+    SegmentLoader::instance()->erase_segments(cache_key);
+    clear_inverted_index_cache();
+    for (int i = 0; i < num_segments(); ++i) {
+        auto seg_path = segment_file_path(i);
+        if (fs->type() != io::FileSystemType::LOCAL) {
+            auto cache_path = segment_cache_path(i);
+            FileCacheManager::instance()->remove_file_cache(cache_path);
+        }
+    }
+}
+
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -124,8 +124,8 @@ void BetaRowset::clear_inverted_index_cache() {
     for (int i = 0; i < num_segments(); ++i) {
         auto seg_path = segment_file_path(i);
         for (auto& column : tablet_schema()->columns()) {
-            const TabletIndex* index_meta = tablet_schema()->get_inverted_index(
-                    column.column_unique_id());
+            const TabletIndex* index_meta =
+                    tablet_schema()->get_inverted_index(column.column_unique_id());
             if (index_meta) {
                 std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
                         seg_path, index_meta->index_id());

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -127,7 +127,7 @@ void BetaRowset::clear_inverted_index_cache() {
             const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
             if (index_meta) {
                 std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
-                        seg_path, index_meta->index_id(), index_meta->get_index_suffix());
+                        seg_path, index_meta->index_id());
                 (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
                         inverted_index_file);
             }

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -488,10 +488,12 @@ Status BetaRowset::add_to_binlog() {
     return Status::OK();
 }
 
-void Rowset::clear_cache() {
+void BetaRowset::clear_cache() {
     SegmentCache::CacheKey cache_key(rowset_id());
     SegmentLoader::instance()->erase_segments(cache_key);
     clear_inverted_index_cache();
+
+    auto fs = _rowset_meta->fs();
     for (int i = 0; i < num_segments(); ++i) {
         auto seg_path = segment_file_path(i);
         if (fs->type() != io::FileSystemType::LOCAL) {

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -124,7 +124,8 @@ void BetaRowset::clear_inverted_index_cache() {
     for (int i = 0; i < num_segments(); ++i) {
         auto seg_path = segment_file_path(i);
         for (auto& column : tablet_schema()->columns()) {
-            const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
+            const TabletIndex* index_meta = tablet_schema()->get_inverted_index(
+                    column.column_unique_id());
             if (index_meta) {
                 std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
                         seg_path, index_meta->index_id());

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -126,12 +126,10 @@ void BetaRowset::clear_inverted_index_cache() {
         for (auto& column : tablet_schema()->columns()) {
             const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
             if (index_meta) {
-                std::string inverted_index_file =
-                        InvertedIndexDescriptor::get_index_file_name(
-                                seg_path, index_meta->index_id(),
-                                index_meta->get_index_suffix());
+                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
+                        seg_path, index_meta->index_id(), index_meta->get_index_suffix());
                 (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
-                                inverted_index_file);
+                        inverted_index_file);
             }
         }
     }

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -98,6 +98,8 @@ public:
 
     [[nodiscard]] virtual Status add_to_binlog() override;
 
+    void clear_cache() override;
+
 protected:
     BetaRowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,
                const RowsetMetaSharedPtr& rowset_meta);

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -94,6 +94,8 @@ public:
 
     Status get_segments_size(std::vector<size_t>* segments_size);
 
+    void clear_inverted_index_cache() override;
+
     [[nodiscard]] virtual Status add_to_binlog() override;
 
 protected:

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -95,17 +95,4 @@ void Rowset::merge_rowset_meta(const RowsetMetaSharedPtr& other) {
     }
 }
 
-void Rowset::clear_cache() {
-    SegmentCache::CacheKey cache_key(rowset_id());
-    SegmentLoader::instance()->erase_segments(cache_key);
-    clear_inverted_index_cache();
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_file_path(i);
-        if (fs->type() != io::FileSystemType::LOCAL) {
-            auto cache_path = segment_cache_path(i);
-            FileCacheManager::instance()->remove_file_cache(cache_path);
-        }
-    }
-}
-
 } // namespace doris

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -19,7 +19,9 @@
 
 #include <gen_cpp/olap_file.pb.h>
 
+#include "io/cache/file_cache_manager.h"
 #include "olap/olap_define.h"
+#include "olap/segment_loader.h"
 #include "olap/tablet_schema.h"
 #include "util/time.h"
 
@@ -96,6 +98,10 @@ void Rowset::merge_rowset_meta(const RowsetMetaSharedPtr& other) {
 void Rowset::clear_cache() {
     SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
     clear_inverted_index_cache();
+    if (fs->type() != io::FileSystemType::LOCAL) {
+        auto cache_path = segment_cache_path(i);
+        FileCacheManager::instance()->remove_file_cache(cache_path);
+    }
 }
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -96,11 +96,15 @@ void Rowset::merge_rowset_meta(const RowsetMetaSharedPtr& other) {
 }
 
 void Rowset::clear_cache() {
-    SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+    SegmentCache::CacheKey cache_key(rowset_id());
+    SegmentLoader::instance()->erase_segments(cache_key);
     clear_inverted_index_cache();
-    if (fs->type() != io::FileSystemType::LOCAL) {
-        auto cache_path = segment_cache_path(i);
-        FileCacheManager::instance()->remove_file_cache(cache_path);
+    for (int i = 0; i < num_segments(); ++i) {
+        auto seg_path = segment_file_path(i);
+        if (fs->type() != io::FileSystemType::LOCAL) {
+            auto cache_path = segment_cache_path(i);
+            FileCacheManager::instance()->remove_file_cache(cache_path);
+        }
     }
 }
 

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -93,4 +93,9 @@ void Rowset::merge_rowset_meta(const RowsetMetaSharedPtr& other) {
     }
 }
 
+void Rowset::clear_cache() {
+    SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+    clear_inverted_index_cache();
+}
+
 } // namespace doris

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -312,6 +312,9 @@ public:
     // set skip index compaction next time
     void set_skip_index_compaction(int32_t column_id) { skip_index_compaction.insert(column_id); }
 
+    virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
+    void clear_cache();
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -313,7 +313,7 @@ public:
     void set_skip_index_compaction(int32_t column_id) { skip_index_compaction.insert(column_id); }
 
     virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
-    void clear_cache();
+    virtual void clear_cache();
 
 protected:
     friend class RowsetFactory;

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -313,7 +313,7 @@ public:
     void set_skip_index_compaction(int32_t column_id) { skip_index_compaction.insert(column_id); }
 
     virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
-    virtual void clear_cache();
+    virtual void clear_cache() { LOG(INFO) << "should not reach here"; }
 
 protected:
     friend class RowsetFactory;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1074,6 +1074,7 @@ void StorageEngine::start_delete_unused_rowset() {
                 }
                 // remote rowset data will be reclaimed by `remove_unused_remote_files`
                 evict_querying_rowset(it->second->rowset_id());
+                it->second->clear_cache();
                 it = _unused_rowsets.erase(it);
             } else {
                 ++it;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -572,6 +572,8 @@ public:
     void set_alter_failed(bool alter_failed) { _alter_failed = alter_failed; }
     bool is_alter_failed() { return _alter_failed; }
 
+    void clear_cache();
+
 private:
     Status _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
@@ -619,6 +621,8 @@ private:
 
     void _remove_sentinel_mark_from_delete_bitmap(DeleteBitmapPtr delete_bitmap);
     std::string _get_rowset_info_str(RowsetSharedPtr rowset, bool delete_flag);
+
+    void _clear_cache_by_rowset(const BetaRowsetSharedPtr& rowset);
 
 public:
     static const int64_t K_INVALID_CUMULATIVE_POINT = -1;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -553,40 +553,8 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TReplicaId repl
     _remove_tablet_from_partition(to_drop_tablet);
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
     tablet_map.erase(tablet_id);
-    {
-        std::shared_lock rlock(to_drop_tablet->get_header_lock());
-        static auto recycle_segment_cache = [](const auto& rowset_map) {
-            for (auto& [_, rowset] : rowset_map) {
-                // If the tablet was deleted, it need to remove all rowsets fds directly
-                SegmentLoader::instance()->erase_segments(
-                        SegmentCache::CacheKey(rowset->rowset_id()));
-            }
-        };
-        recycle_segment_cache(to_drop_tablet->rowset_map());
-        recycle_segment_cache(to_drop_tablet->stale_rowset_map());
-        // recycle inverted index cache
-        static auto recycle_inverted_index_cache = [](const auto& rowset_map) {
-            for (auto& [_, rowset] : rowset_map) {
-                auto rs = std::static_pointer_cast<BetaRowset>(rowset);
-                for (int i = 0; i < rs->num_segments(); ++i) {
-                    auto seg_path = rs->segment_file_path(i);
-                    for (auto& column : rs->tablet_schema()->columns()) {
-                        const TabletIndex* index_meta =
-                                rs->tablet_schema()->get_inverted_index(column.unique_id());
-                        if (index_meta) {
-                            std::string inverted_index_file =
-                                    InvertedIndexDescriptor::get_index_file_name(
-                                            seg_path, index_meta->index_id());
-                            (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
-                                    inverted_index_file);
-                        }
-                    }
-                }
-            }
-        };
-        recycle_inverted_index_cache(to_drop_tablet->rowset_map());
-        recycle_inverted_index_cache(to_drop_tablet->stale_rowset_map());
-    }
+    to_drop_tablet->clear_cache();
+
     if (!keep_files) {
         // drop tablet will update tablet meta, should lock
         std::lock_guard<std::shared_mutex> wrlock(to_drop_tablet->get_header_lock());
@@ -1167,6 +1135,9 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                          << " cur tablet_uid=" << tablet_meta->tablet_uid();
             return true;
         }
+
+        tablet->clear_cache();
+
         // move data to trash
         const auto& tablet_path = tablet->tablet_path();
         bool exists = false;
@@ -1208,6 +1179,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                   << ", schema_hash=" << tablet->schema_hash() << ", tablet_path=" << tablet_path;
         return true;
     } else {
+        tablet->clear_cache();
         // if could not find tablet info in meta store, then check if dir existed
         const auto& tablet_path = tablet->tablet_path();
         bool exists = false;


### PR DESCRIPTION
When tablet is set shutdown, a compaction on it may be running. So we should remove fds from cache when tablet's dir is deleted.

#34003

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

