### PR TITLE
[enhance](Cloud) Add case to test if vault is forbid for cloud mode without vault

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowStorageVaultStmt.java
@@ -19,9 +19,12 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.StorageVault;
+import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
@@ -41,6 +44,15 @@ public class ShowStorageVaultStmt extends ShowStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+        if (Config.isNotCloudMode()) {
+            throw new AnalysisException("Storage Vault is only supported for cloud mode");
+        }
+        if (!FeConstants.runningUnitTest) {
+            // In legacy cloud mode, some s3 back-ended storage does need to use storage vault.
+            if (!((CloudEnv) Env.getCurrentEnv()).getEnableStorageVault()) {
+                throw new AnalysisException("Your cloud instance doesn't support storage vault");
+            }
+        }
         super.analyze(analyzer);
         // check auth
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {

--- a/regression-test/suites/vaults/forbid/forbid.groovy
+++ b/regression-test/suites/vaults/forbid/forbid.groovy
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("forbid_vault") {
+    if (enableStoragevault()) {
+        logger.info("skip forbid storgage vault case")
+        return
+    }
+
+    expectExceptionLike({
+        sql """
+            set not_exist as default storage vault
+        """
+    }, "Your cloud instance doesn't support storage vault")
+
+    expectExceptionLike({
+        sql """
+            CREATE STORAGE VAULT IF NOT EXISTS hdfs_vault
+            PROPERTIES (
+            "type"="hdfs",
+            "fs.defaultFS"="hdfs://127.0.0.1:8020"
+            );
+        """
+    }, "Your cloud instance doesn't support storage vault")
+
+    expectExceptionLike({
+        sql """
+            show storage vault
+        """
+    }, "Your cloud instance doesn't support storage vault")
+}

--- a/regression-test/suites/vaults/forbid/forbid.groovy
+++ b/regression-test/suites/vaults/forbid/forbid.groovy
@@ -17,7 +17,12 @@
 
 suite("forbid_vault") {
     if (enableStoragevault()) {
-        logger.info("skip forbid storgage vault case")
+        logger.info("skip forbid storage vault case because storage vault enabled")
+        return
+    }
+
+    if (!isCloudMode()) {
+        logger.info("skip forbid storage vault case because not cloud mode")
         return
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Ideally we want vault only works for cloud mode with vault, this pr mainly adds case to test if the vault stmt if forbidden for cloud mode without vault

4.0-preview needs

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

