### PR TITLE
[fix](cloud) Fix alter table colocate in cloud (#3168)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4527,9 +4527,11 @@ public class Env {
                 colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
             }
 
-            // set this group as unstable
-            colocateTableIndex.markGroupUnstable(groupId, "Colocation group modified by user",
-                    false /* edit log is along with modify table log */);
+            if (Config.isNotCloudMode()) {
+                // set this group as unstable
+                colocateTableIndex.markGroupUnstable(groupId, "Colocation group modified by user",
+                        false /* edit log is along with modify table log */);
+            }
             table.setColocateGroup(assignedGroup);
         } else {
             // unset colocation group

--- a/regression-test/suites/cloud/alter_clause_p0/alter_table_colocate/test_alter_table_colocate.groovy
+++ b/regression-test/suites/cloud/alter_clause_p0/alter_table_colocate/test_alter_table_colocate.groovy
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_alter_table_colocate") {
+    sql """
+        CREATE TABLE IF NOT EXISTS `t_event`
+        (
+            `@event_name` varchar(255) NOT NULL COMMENT '事件名称',
+            `@event_time` datetime NOT NULL COMMENT '事件时间',
+            `@dt` datetime NOT NULL COMMENT '分区时间',
+            `@user_id` bigint NULL COMMENT '用户id',
+            `@guid` varchar(255) NULL COMMENT '设备id',
+            `@platform` varchar(100) NULL COMMENT '平台',
+            `@ip` varchar(255) NULL COMMENT 'ip',
+            `@country` varchar(255) NULL COMMENT '国家',
+            `@province` varchar(255) NULL COMMENT '省份',
+            `@city` varchar(255) NULL COMMENT '城市',
+            `@isp` varchar(255) NULL COMMENT '运营商',
+            `@country_code` varchar(255) NULL COMMENT '国家代码'
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`@event_name`, `@event_time`)
+        COMMENT '事件表'
+        PARTITION BY RANGE(`@dt`)()
+        DISTRIBUTED BY HASH(`@user_id`) BUCKETS 10
+        PROPERTIES (
+            "replication_num" = "1",
+            "dynamic_partition.enable" = "true",
+            "dynamic_partition.time_unit" = "HOUR",
+            "dynamic_partition.end" = "5",
+            "dynamic_partition.prefix" = "p",
+            "dynamic_partition.buckets" = "10"
+        );
+    """
+    sql """
+    CREATE TABLE `t_user`
+    (
+        `@user_id`bigint(20) NOT NULL COMMENT '用户id',
+        `@account`bigint(20) REPLACE_IF_NOT_NULL NULL COMMENT '数字账号',
+        `@register_date`datetime REPLACE_IF_NOT_NULL NULL COMMENT '注册时间',
+        `@gender`int(11) REPLACE_IF_NOT_NULL NULL COMMENT '性别'
+    ) ENGINE=OLAP
+    AGGREGATE KEY(`@user_id`)
+    COMMENT 'OLAP'
+    DISTRIBUTED BY HASH(`@user_id`) BUCKETS 10
+    PROPERTIES (
+        "colocate_with" = "group_xa_test_alter_table_colocate"
+    );
+    """
+
+    sql """ALTER TABLE t_event SET ("colocate_with" = "group_xa_test_alter_table_colocate");"""
+    def result = sql_return_maparray """SHOW PROC '/colocation_group'"""
+    result.each {
+        if(result.GroupName.contains("group_xa_test_alter_table_colocate")){
+            assertEquals(result.IsStable, "true")
+        }
+    }
+    sql "DROP TABLE IF EXISTS t_event FORCE"
+    sql "DROP TABLE IF EXISTS t_user FORCE"
+}


### PR DESCRIPTION



## Proposed changes

Issue Number: close #xxx

修复 cloud 上 alter table的colocate属性不生效
原因：
1. 非 cloud 的alter table 修改表的colocate属性，可以生效是因为colocate alter后会先balance tablet，之后会把isStable改为true。
2. 而 cloud的balance 并没有这个逻辑，所以cloud上的table alter colocate后isStable状态一直没有变化。导致cloud上的alter colocate 不生效


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

