### PR TITLE
[fix](planner)cast expr should do nothing in compactForLiteral method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -592,4 +592,9 @@ public class CastExpr extends Expr {
     public boolean isNotFold() {
         return this.notFold;
     }
+
+    @Override
+    protected void compactForLiteral(Type type) {
+        // do nothing
+    }
 }

--- a/regression-test/suites/correctness_p0/test_cast_decimal.groovy
+++ b/regression-test/suites/correctness_p0/test_cast_decimal.groovy
@@ -34,4 +34,15 @@ suite("test_cast_decimal") {
         sql """select cast(32123.34212456734 as decimal(3,2));"""
         contains "CAST(32123.34212456734 AS DECIMALV3(3, 2))"
     }
+
+    sql """drop table if exists test_ttt"""
+    sql """create table test_ttt(big_key bigint)DISTRIBUTED BY HASH(big_key) BUCKETS 1 PROPERTIES ("replication_num" = "1");"""
+    sql """set enable_nereids_planner=false;"""
+    sql """set enable_fold_constant_by_be = false; """
+    sql """SELECT 1
+            FROM test_ttt e1
+            HAVING truncate(100, 2) < -2308.57
+            AND cast(round(round(465.56, min(-5.987)), 2) AS DECIMAL) in
+            (SELECT cast(truncate(round(8990.65 - 4556.2354, 2.4652), 2)AS DECIMAL)
+            FROM test_ttt r2);"""
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

