### PR TITLE
[feature](profile) sort pipelineX task by total time

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -572,7 +572,18 @@ public:
 
     void resize_op_id_to_local_state(int operator_size);
 
-    auto& pipeline_id_to_profile() { return _pipeline_id_to_profile; }
+    auto& pipeline_id_to_profile() {
+        for (auto& pipeline_profile : _pipeline_id_to_profile) {
+            // pipeline 0
+            //  pipeline task 0
+            //  pipeline task 1
+            //  pipleine task 2
+            //  .......
+            // sort by pipeline task total time
+            pipeline_profile->sort_children_by_total_time();
+        }
+        return _pipeline_id_to_profile;
+    }
 
     void set_task_execution_context(std::shared_ptr<TaskExecutionContext> context) {
         _task_execution_context_inited = true;

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -25,6 +25,7 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
 
@@ -714,6 +715,17 @@ void RuntimeProfile::print_child_counters(const std::string& prefix,
                                                  child_counter_map, s);
         }
     }
+}
+
+void RuntimeProfile::sort_children_by_total_time() {
+    std::lock_guard<std::mutex> l(_children_lock);
+    auto cmp = [](const std::pair<RuntimeProfile*, bool>& L,
+                  const std::pair<RuntimeProfile*, bool>& R) {
+        const RuntimeProfile* L_profile = L.first;
+        const RuntimeProfile* R_profile = R.first;
+        return L_profile->_counter_total_time.value() > R_profile->_counter_total_time.value();
+    };
+    std::sort(_children.begin(), _children.end(), cmp);
 }
 
 } // namespace doris

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -301,6 +301,8 @@ public:
         std::sort(_children.begin(), _children.end(), cmp);
     }
 
+    void sort_children_by_total_time();
+
     // Merges the src profile into this one, combining counters that have an identical
     // path. Info strings from profiles are not merged. 'src' would be a const if it
     // weren't for locking.


### PR DESCRIPTION
## Proposed changes

like this

```
Pipeline  :0    (host=TNetworkAddress(hostname:127.0.0.1,  port:9229)):
	PipelineXTask  (index=2):(Active:  183.123ms,  %  non-child:  0.00%)
	PipelineXTask  (index=1):(Active:  169.938ms,  %  non-child:  0.00%)
	PipelineXTask  (index=0):(Active:  134.697ms,  %  non-child:  0.00%)
	PipelineXTask  (index=3):(Active:  128.26ms,  %  non-child:  0.00%)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

