### PR TITLE
[fix](resource)fix check available fail when s3 aws_token  is set and reset as, sk faild on be.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1365,6 +1365,7 @@ void update_s3_resource(const TStorageResource& param, io::RemoteFileSystemSPtr 
                         .region = param.s3_storage_param.region,
                         .ak = param.s3_storage_param.ak,
                         .sk = param.s3_storage_param.sk,
+                        .token = param.s3_storage_param.token,
                         .max_connections = param.s3_storage_param.max_conn,
                         .request_timeout_ms = param.s3_storage_param.request_timeout_ms,
                         .connect_timeout_ms = param.s3_storage_param.conn_timeout_ms,
@@ -1384,6 +1385,7 @@ void update_s3_resource(const TStorageResource& param, io::RemoteFileSystemSPtr 
         S3ClientConf conf {
                 .ak = param.s3_storage_param.ak,
                 .sk = param.s3_storage_param.sk,
+                .token = param.s3_storage_param.token,
         };
         st = client->reset(conf);
         fs = std::move(existed_fs);

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -115,13 +115,14 @@ Status S3ClientHolder::init() {
 }
 
 Status S3ClientHolder::reset(const S3ClientConf& conf) {
-    S3ClientConf reset_conf = _conf;
+    S3ClientConf reset_conf;
     {
         std::shared_lock lock(_mtx);
         if (conf.ak == _conf.ak && conf.sk == _conf.sk && conf.token == _conf.token) {
             return Status::OK(); // Same conf
         }
 
+        reset_conf = _conf;
         reset_conf.ak = conf.ak;
         reset_conf.sk = conf.sk;
         reset_conf.token = conf.token;

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -115,16 +115,20 @@ Status S3ClientHolder::init() {
 }
 
 Status S3ClientHolder::reset(const S3ClientConf& conf) {
+    S3ClientConf reset_conf = _conf;
     {
         std::shared_lock lock(_mtx);
-        if (conf.ak == _conf.ak && conf.sk == _conf.sk) {
+        if (conf.ak == _conf.ak && conf.sk == _conf.sk && conf.token == _conf.token) {
             return Status::OK(); // Same conf
         }
 
+        reset_conf.ak = conf.ak;
+        reset_conf.sk = conf.sk;
+        reset_conf.token = conf.token;
         // Should check endpoint here?
     }
 
-    auto client = S3ClientFactory::instance().create(conf);
+    auto client = S3ClientFactory::instance().create(reset_conf);
     if (!client) {
         return Status::InternalError("failed to init s3 client with conf {}", conf.to_string());
     }
@@ -134,8 +138,7 @@ Status S3ClientHolder::reset(const S3ClientConf& conf) {
     {
         std::lock_guard lock(_mtx);
         _client = std::move(client);
-        _conf.ak = conf.ak;
-        _conf.sk = conf.sk;
+        _conf = std::move(reset_conf);
     }
 
     return Status::OK();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
@@ -265,6 +265,7 @@ public class S3Properties extends BaseProperties {
         s3Info.setRegion(properties.get(S3Properties.REGION));
         s3Info.setAk(properties.get(S3Properties.ACCESS_KEY));
         s3Info.setSk(properties.get(S3Properties.SECRET_KEY));
+        s3Info.setToken(properties.get(S3Properties.SESSION_TOKEN));
 
         s3Info.setRootPath(properties.get(S3Properties.ROOT_PATH));
         s3Info.setBucket(properties.get(S3Properties.BUCKET));

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -73,6 +73,7 @@ struct TS3StorageParam {
     8: optional string root_path
     9: optional string bucket
     10: optional bool use_path_style = false
+    11: optional string token
 }
 
 struct TStoragePolicy {

--- a/regression-test/suites/cold_heat_separation/policy/alter.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/alter.groovy
@@ -39,6 +39,7 @@ suite("alter_policy") {
             "AWS_ROOT_PATH" = "path/to/rootaaaa",
             "AWS_ACCESS_KEY" = "bbba",
             "AWS_SECRET_KEY" = "aaaa",
+            "AWS_TOKEN" = "session_token",
             "AWS_MAX_CONNECTIONS" = "50",
             "AWS_REQUEST_TIMEOUT_MS" = "3000",
             "AWS_CONNECTION_TIMEOUT_MS" = "1000",
@@ -68,6 +69,10 @@ suite("alter_policy") {
 
         def alter_result_succ_7 = try_sql """
             ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_REQUEST_TIMEOUT_MS" = "7777");
+        """
+
+        def alter_result_succ_8 = try_sql """
+            ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_TOKEN" = "new_session_token");
         """
 
         // errCode = 2, detailMessage = current not support modify property : AWS_REGION
@@ -112,6 +117,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -133,6 +139,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "10101010")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_SECRET_KEY
+        assertEquals(show_alter_result[10][3], "******")
     }
 
     def check_alter_resource_result_with_policy = { resource_name ->
@@ -151,6 +159,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -172,6 +181,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "path/to/rootaaaa")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_SECRET_KEY
+        assertEquals(show_alter_result[10][3], "******")
     }
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. fe return 'S3 can't use, please check your properties' when AWS_TOKEN is set
`
CREATE RESOURCE "test_resources"
PROPERTIES
(
    "type" = "s3",
    "AWS_ENDPOINT" = "http://cos.ap-guangzhou.myqcloud.com",
    "AWS_ACCESS_KEY"="ak",
    "AWS_SECRET_KEY"="sk",
    "AWS_TOKEN"="token",
    "AWS_REGION" = "ap-guangzhou",
    "AWS_BUCKET" = "bucket",
    "AWS_ROOT_PATH" = "path/to/dir",    
    "AWS_MAX_CONNECTIONS" = "50",
    "AWS_REQUEST_TIMEOUT_MS" = "3000",
    "AWS_CONNECTION_TIMEOUT_MS" = "1000"
);

ERROR 1105 (HY000): errCode = 2, detailMessage = S3 can't use, please check your properties
`

2. When altering the AK/SK resource, only the AK and SK are set in the S3ClientHolder::reset method. Therefore, creating a new S3 client without other parameters is not possible.
