### PR TITLE
[bugfix](core) close method should check if the pointer is nullptr

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -685,7 +685,8 @@ Status ExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
     if (_closed) {
         return Status::OK();
     }
-    if (_part_type == TPartitionType::TABLET_SINK_SHUFFLE_PARTITIONED) {
+    if (_part_type == TPartitionType::TABLET_SINK_SHUFFLE_PARTITIONED &&
+        _block_convertor != nullptr && _tablet_finder != nullptr) {
         _state->update_num_rows_load_filtered(_block_convertor->num_filtered_rows() +
                                               _tablet_finder->num_filtered_rows());
         _state->update_num_rows_load_unselected(


### PR DESCRIPTION
## Proposed changes

The ptr is inited at open method, but
1. the open method maybe not called.
2. the open method is called, but it return error before init the pointer.

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007FC5DCDDC090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::pipeline::ExchangeSinkLocalState::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/exchange_sink_operator.cpp:690
 6# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/operator.h:657
 7# doris::pipeline::PipelineXTask::close(doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:373
 8# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:242
 9# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:300
10# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/branch21-deploy/be/lib/doris_be
11# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
12# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
13# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

