### PR TITLE
[fix](fe) Fix SHOW CREATE TABLE with AUTO PARTITION

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -23,7 +23,6 @@ import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.PartitionKeyDesc;
 import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SinglePartitionDesc;
-import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.RangeUtils;
@@ -266,14 +265,9 @@ public class RangePartitionInfo extends PartitionInfo {
         if (enableAutomaticPartition()) {
             sb.append("AUTO PARTITION BY RANGE ");
             for (Expr e : partitionExprs) {
-                boolean isSlotRef = (e instanceof SlotRef);
-                if (isSlotRef) {
-                    sb.append("(");
-                }
+                sb.append("(");
                 sb.append(e.toSql());
-                if (isSlotRef) {
-                    sb.append(")");
-                }
+                sb.append(")");
             }
             sb.append("\n(");
         } else {

--- a/regression-test/suites/ddl_p0/test_create_table_auto_partition.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_auto_partition.groovy
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// this suite is for creating table with timestamp datatype in defferent 
+// case. For example: 'year' and 'Year' datatype should also be valid in definition
+
+
+suite("test_create_table_auto_partition") {
+    def testTable = "test_create_table_auto_partition_table"
+
+    sql "DROP TABLE IF EXISTS ${testTable}"
+    sql """
+    CREATE TABLE `${testTable}` (
+        `TIME_STAMP` datev2 NOT NULL COMMENT 'Date of collection'
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`TIME_STAMP`)
+    AUTO PARTITION BY RANGE (date_trunc(`TIME_STAMP`, 'month'))
+    (
+    )
+    DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
+    PROPERTIES (
+    "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    // The AUTO PARTITION func call must wrapped with ().
+    def text = sql_return_maparray "show create table ${testTable}"
+    def createTable = text[0]['Create Table']
+    assertTrue(createTable.contains("AUTO PARTITION BY RANGE (date_trunc(`TIME_STAMP`, 'month')"))
+}
+


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

AUTO PARTITION grammar has changed since #31585, but the output of SHOW CREATE TABLE was left out to change, so the result is not able to be recognized by the FE parser.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

