### PR TITLE
[Improvement](pipeline) Use hash shuffle for 1-phase Agg/Analytic operator

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -616,7 +616,8 @@ void AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& p
 }
 
 AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                                   const DescriptorTbl& descs)
+                                   const DescriptorTbl& descs,
+                                   const bool follow_by_bucket_shuffle_join)
         : DataSinkOperatorX<AggSinkLocalState>(operator_id, tnode.node_id),
           _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
           _intermediate_tuple_desc(nullptr),
@@ -629,9 +630,13 @@ AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, const TPla
           _limit(tnode.limit),
           _have_conjuncts((tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()) ||
                           (tnode.__isset.conjuncts && !tnode.conjuncts.empty())),
-          _partition_exprs(tnode.__isset.distribute_expr_lists ? tnode.distribute_expr_lists[0]
-                                                               : std::vector<TExpr> {}),
-          _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate),
+          _partition_exprs(
+                  tnode.__isset.distribute_expr_lists && tnode.agg_node.__isset.is_colocate &&
+                                  tnode.agg_node.is_colocate && follow_by_bucket_shuffle_join
+                          ? tnode.distribute_expr_lists[0]
+                          : tnode.agg_node.grouping_exprs),
+          _bucket_shuffled(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate &&
+                           follow_by_bucket_shuffle_join),
           _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples) {}
 
 Status AggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {

--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -634,7 +634,7 @@ AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, const TPla
                                    : tnode.agg_node.grouping_exprs),
           _bucket_shuffled(should_be_bucket_shuffled),
           _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
-          _is_colocate(tnode.agg_node.__isset.is_colocate),
+          _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate),
           _num_group_keys(tnode.agg_node.grouping_exprs.size()) {}
 
 Status AggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {

--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -143,7 +143,7 @@ protected:
 class AggSinkOperatorX final : public DataSinkOperatorX<AggSinkLocalState> {
 public:
     AggSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                     const DescriptorTbl& descs);
+                     const DescriptorTbl& descs, const bool follow_by_bucket_shuffle_join);
     ~AggSinkOperatorX() override = default;
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TPlanNode",
@@ -164,8 +164,9 @@ public:
                            ? DataDistribution(ExchangeType::PASSTHROUGH)
                            : DataSinkOperatorX<AggSinkLocalState>::required_data_distribution();
         }
-        return _is_colocate ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
-                            : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
+        return _bucket_shuffled
+                       ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
+                       : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
     }
     size_t get_revocable_mem_size(RuntimeState* state) const;
 
@@ -212,7 +213,7 @@ protected:
     bool _have_conjuncts;
 
     const std::vector<TExpr> _partition_exprs;
-    const bool _is_colocate;
+    const bool _bucket_shuffled;
 
     RowDescriptor _agg_fn_output_row_descriptor;
 };

--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -152,6 +152,10 @@ public:
 
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
 
+    int get_num_bucket_shuffled_keys() const override {
+        return _is_colocate ? _num_group_keys : -1;
+    }
+
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
 
@@ -216,6 +220,9 @@ protected:
     const bool _bucket_shuffled;
 
     RowDescriptor _agg_fn_output_row_descriptor;
+
+    const bool _is_colocate;
+    const int _num_group_keys;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -193,14 +193,19 @@ vectorized::BlockRowPos AnalyticSinkLocalState::_get_partition_by_end() {
 }
 
 AnalyticSinkOperatorX::AnalyticSinkOperatorX(ObjectPool* pool, int operator_id,
-                                             const TPlanNode& tnode, const DescriptorTbl& descs)
+                                             const TPlanNode& tnode, const DescriptorTbl& descs,
+                                             const bool follow_by_bucket_shuffle_join)
         : DataSinkOperatorX(operator_id, tnode.node_id),
           _buffered_tuple_id(tnode.analytic_node.__isset.buffered_tuple_id
                                      ? tnode.analytic_node.buffered_tuple_id
                                      : 0),
-          _is_colocate(tnode.analytic_node.__isset.is_colocate && tnode.analytic_node.is_colocate),
-          _partition_exprs(tnode.__isset.distribute_expr_lists ? tnode.distribute_expr_lists[0]
-                                                               : std::vector<TExpr> {}) {}
+          _bucket_shuffled(tnode.analytic_node.__isset.is_colocate &&
+                           tnode.analytic_node.is_colocate && follow_by_bucket_shuffle_join),
+          _partition_exprs(
+                  tnode.__isset.distribute_expr_lists && tnode.analytic_node.__isset.is_colocate &&
+                                  tnode.analytic_node.is_colocate && follow_by_bucket_shuffle_join
+                          ? tnode.distribute_expr_lists[0]
+                          : tnode.analytic_node.partition_exprs) {}
 
 Status AnalyticSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(DataSinkOperatorX::init(tnode, state));

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -203,7 +203,7 @@ AnalyticSinkOperatorX::AnalyticSinkOperatorX(ObjectPool* pool, int operator_id,
           _partition_exprs(tnode.__isset.distribute_expr_lists && should_be_bucket_shuffled
                                    ? tnode.distribute_expr_lists[0]
                                    : tnode.analytic_node.partition_exprs),
-          _is_colocate(tnode.analytic_node.__isset.is_colocate),
+          _is_colocate(tnode.analytic_node.__isset.is_colocate && tnode.analytic_node.is_colocate),
           _num_group_keys(tnode.analytic_node.partition_exprs.size()) {}
 
 Status AnalyticSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -203,7 +203,6 @@ AnalyticSinkOperatorX::AnalyticSinkOperatorX(ObjectPool* pool, int operator_id,
           _partition_exprs(tnode.__isset.distribute_expr_lists && should_be_bucket_shuffled
                                    ? tnode.distribute_expr_lists[0]
                                    : tnode.analytic_node.partition_exprs),
-          _is_colocate(tnode.analytic_node.__isset.is_colocate && tnode.analytic_node.is_colocate),
           _num_group_keys(tnode.analytic_node.partition_exprs.size()) {}
 
 Status AnalyticSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -86,13 +86,17 @@ private:
 class AnalyticSinkOperatorX final : public DataSinkOperatorX<AnalyticSinkLocalState> {
 public:
     AnalyticSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                          const DescriptorTbl& descs, const bool follow_by_bucket_shuffle_join);
+                          const DescriptorTbl& descs, const bool should_be_bucket_shuffled);
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TPlanNode",
                                      DataSinkOperatorX<AnalyticSinkLocalState>::_name);
     }
 
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
+
+    int get_num_bucket_shuffled_keys() const override {
+        return _is_colocate ? _num_group_keys : -1;
+    }
 
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
@@ -126,6 +130,9 @@ private:
     std::vector<size_t> _num_agg_input;
     const bool _bucket_shuffled;
     const std::vector<TExpr> _partition_exprs;
+
+    const bool _is_colocate;
+    const int _num_group_keys;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -86,7 +86,7 @@ private:
 class AnalyticSinkOperatorX final : public DataSinkOperatorX<AnalyticSinkLocalState> {
 public:
     AnalyticSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                          const DescriptorTbl& descs);
+                          const DescriptorTbl& descs, const bool follow_by_bucket_shuffle_join);
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TPlanNode",
                                      DataSinkOperatorX<AnalyticSinkLocalState>::_name);
@@ -102,7 +102,7 @@ public:
         if (_partition_by_eq_expr_ctxs.empty()) {
             return {ExchangeType::PASSTHROUGH};
         } else if (_order_by_eq_expr_ctxs.empty()) {
-            return _is_colocate
+            return _bucket_shuffled
                            ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
                            : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
         }
@@ -124,7 +124,7 @@ private:
     const TTupleId _buffered_tuple_id;
 
     std::vector<size_t> _num_agg_input;
-    const bool _is_colocate;
+    const bool _bucket_shuffled;
     const std::vector<TExpr> _partition_exprs;
 };
 

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -94,9 +94,7 @@ public:
 
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
 
-    int get_num_bucket_shuffled_keys() const override {
-        return _is_colocate ? _num_group_keys : -1;
-    }
+    bool force_to_bucket_shuffled() const override { return true; }
 
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
@@ -131,7 +129,6 @@ private:
     const bool _bucket_shuffled;
     const std::vector<TExpr> _partition_exprs;
 
-    const bool _is_colocate;
     const int _num_group_keys;
 };
 

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -387,7 +387,7 @@ DistinctStreamingAggOperatorX::DistinctStreamingAggOperatorX(ObjectPool* pool, i
                                    ? tnode.distribute_expr_lists[0]
                                    : tnode.agg_node.grouping_exprs),
           _bucket_shuffled(should_be_bucket_shuffled),
-          _is_colocate(tnode.agg_node.__isset.is_colocate),
+          _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate),
           _num_group_keys(tnode.agg_node.grouping_exprs.size()) {
     if (tnode.agg_node.__isset.use_streaming_preaggregation) {
         _is_streaming_preagg = tnode.agg_node.use_streaming_preaggregation;

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -372,9 +372,9 @@ void DistinctStreamingAggLocalState::_emplace_into_hash_table_to_distinct(
             _agg_data->method_variant);
 }
 
-DistinctStreamingAggOperatorX::DistinctStreamingAggOperatorX(ObjectPool* pool, int operator_id,
-                                                             const TPlanNode& tnode,
-                                                             const DescriptorTbl& descs)
+DistinctStreamingAggOperatorX::DistinctStreamingAggOperatorX(
+        ObjectPool* pool, int operator_id, const TPlanNode& tnode, const DescriptorTbl& descs,
+        const bool follow_by_bucket_shuffle_join)
         : StatefulOperatorX<DistinctStreamingAggLocalState>(pool, tnode, operator_id, descs),
           _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
           _intermediate_tuple_desc(nullptr),
@@ -382,9 +382,13 @@ DistinctStreamingAggOperatorX::DistinctStreamingAggOperatorX(ObjectPool* pool, i
           _output_tuple_desc(nullptr),
           _needs_finalize(tnode.agg_node.need_finalize),
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
-          _partition_exprs(tnode.__isset.distribute_expr_lists ? tnode.distribute_expr_lists[0]
-                                                               : std::vector<TExpr> {}),
-          _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate) {
+          _partition_exprs(
+                  tnode.__isset.distribute_expr_lists && tnode.agg_node.__isset.is_colocate &&
+                                  tnode.agg_node.is_colocate && follow_by_bucket_shuffle_join
+                          ? tnode.distribute_expr_lists[0]
+                          : tnode.agg_node.grouping_exprs),
+          _bucket_shuffled(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate &&
+                           follow_by_bucket_shuffle_join) {
     if (tnode.agg_node.__isset.use_streaming_preaggregation) {
         _is_streaming_preagg = tnode.agg_node.use_streaming_preaggregation;
         if (_is_streaming_preagg) {

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -178,6 +178,11 @@ public:
         return _join_distribution == TJoinDistributionType::PARTITIONED;
     }
 
+    bool is_bucket_shuffled_join() const override {
+        return _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE ||
+               _join_distribution == TJoinDistributionType::COLOCATE;
+    }
+
 private:
     Status _do_evaluate(vectorized::Block& block, vectorized::VExprContextSPtrs& exprs,
                         RuntimeProfile::Counter& expr_call_timer,

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -214,6 +214,7 @@ public:
     // -1 means this operator doesn't have bucket shuffle keys.
     [[nodiscard]] virtual int get_num_bucket_shuffled_keys() const { return -1; }
     [[nodiscard]] virtual bool is_bucket_shuffled_join() const { return false; }
+    [[nodiscard]] virtual bool force_to_bucket_shuffled() const { return false; }
 
     [[nodiscard]] virtual bool can_terminate_early() { return false; }
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -211,6 +211,10 @@ public:
 
     virtual bool can_write() { return false; } // for sink
 
+    // -1 means this operator doesn't have bucket shuffle keys.
+    [[nodiscard]] virtual int get_num_bucket_shuffled_keys() const { return -1; }
+    [[nodiscard]] virtual bool is_bucket_shuffled_join() const { return false; }
+
     [[nodiscard]] virtual bool can_terminate_early() { return false; }
 
     /**

--- a/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
@@ -124,7 +124,7 @@ PartitionedAggSinkOperatorX::PartitionedAggSinkOperatorX(ObjectPool* pool, int o
                                                          const TPlanNode& tnode,
                                                          const DescriptorTbl& descs)
         : DataSinkOperatorX<PartitionedAggSinkLocalState>(operator_id, tnode.node_id) {
-    _agg_sink_operator = std::make_unique<AggSinkOperatorX>(pool, operator_id, tnode, descs);
+    _agg_sink_operator = std::make_unique<AggSinkOperatorX>(pool, operator_id, tnode, descs, false);
 }
 
 Status PartitionedAggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {

--- a/be/src/pipeline/exec/partitioned_aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_aggregation_sink_operator.h
@@ -315,6 +315,10 @@ public:
                                      DataSinkOperatorX<PartitionedAggSinkLocalState>::_name);
     }
 
+    int get_num_bucket_shuffled_keys() const override {
+        return _agg_sink_operator->get_num_bucket_shuffled_keys();
+    }
+
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1208,8 +1208,6 @@ Status PipelineXFragmentContext::_create_operator(ObjectPool* pool, const TPlanN
         sink->set_dests_id({op->operator_id()});
         RETURN_IF_ERROR(cur_pipe->set_sink(sink));
         RETURN_IF_ERROR(cur_pipe->sink_x()->init(tnode, _runtime_state.get()));
-
-        _should_be_bucket_shuffled = true;
         break;
     }
     case TPlanNodeType::INTERSECT_NODE: {
@@ -1283,7 +1281,8 @@ void PipelineXFragmentContext::_update_data_distribution_requirement(OperatorBas
                 _num_bucket_shuffled_keys != op->get_num_bucket_shuffled_keys();
         _num_bucket_shuffled_keys = op->get_num_bucket_shuffled_keys();
     }
-    _should_be_bucket_shuffled = _should_be_bucket_shuffled || op->is_bucket_shuffled_join();
+    _should_be_bucket_shuffled = _should_be_bucket_shuffled || op->is_bucket_shuffled_join() ||
+                                 op->force_to_bucket_shuffled();
 }
 
 template <bool is_intersect>

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1270,18 +1270,18 @@ Status PipelineXFragmentContext::_create_operator(ObjectPool* pool, const TPlanN
 // NOLINTEND(readability-function-cognitive-complexity)
 // NOLINTEND(readability-function-size)
 
+// We should use bucket shuffle local exchanger if one condition is met below:
+// 1. Operator is followed by a colocated Agg/Analytic operator with different `get_num_bucket_shuffled_keys`.
+// 2. Operator is followed by a colocated / bucket shuffled join.
 void PipelineXFragmentContext::_update_data_distribution_requirement(OperatorBase* op) {
     // `get_num_bucket_shuffled_keys` returns -1 means this operator doesn't have partition keys.
     if (op->get_num_bucket_shuffled_keys() > -1) {
-        // We should use bucket shuffle local exchanger if one condition is met below:
-        // 1. Operator is followed by a colocated Agg/Analytic operator with different `get_num_bucket_shuffled_keys`.
-        // 2. Operator is followed by a colocated / bucket shuffled join.
         _should_be_bucket_shuffled =
                 _should_be_bucket_shuffled ||
-                _num_bucket_shuffled_keys != op->get_num_bucket_shuffled_keys() ||
-                op->is_bucket_shuffled_join();
+                _num_bucket_shuffled_keys != op->get_num_bucket_shuffled_keys();
         _num_bucket_shuffled_keys = op->get_num_bucket_shuffled_keys();
     }
+    _should_be_bucket_shuffled = _should_be_bucket_shuffled || op->is_bucket_shuffled_join();
 }
 
 template <bool is_intersect>

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -789,7 +789,7 @@ Status PipelineXFragmentContext::_add_local_exchange_impl(
     case ExchangeType::HASH_SHUFFLE:
         shared_state->exchanger = ShuffleExchanger::create_unique(
                 std::max(cur_pipe->num_tasks(), _num_instances),
-                is_shuffled_hash_join && _total_instances > 0 ? _total_instances : _num_instances);
+                is_shuffled_hash_join ? _total_instances : _num_instances);
         break;
     case ExchangeType::BUCKET_HASH_SHUFFLE:
         shared_state->exchanger = BucketShuffleExchanger::create_unique(

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1208,6 +1208,8 @@ Status PipelineXFragmentContext::_create_operator(ObjectPool* pool, const TPlanN
         sink->set_dests_id({op->operator_id()});
         RETURN_IF_ERROR(cur_pipe->set_sink(sink));
         RETURN_IF_ERROR(cur_pipe->sink_x()->init(tnode, _runtime_state.get()));
+
+        _should_be_bucket_shuffled = true;
         break;
     }
     case TPlanNodeType::INTERSECT_NODE: {

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
@@ -239,6 +239,8 @@ private:
 
     // Total instance num running on all BEs
     int _total_instances = -1;
+
+    bool _has_bucket_shuffle_join = false;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
@@ -169,6 +169,8 @@ private:
 
     bool _enable_local_shuffle() const { return _runtime_state->enable_local_shuffle(); }
 
+    void _update_data_distribution_requirement(OperatorBase* op);
+
     OperatorXPtr _root_op = nullptr;
     // this is a [n * m] matrix. n is parallelism of pipeline engine and m is the number of pipelines.
     std::vector<std::vector<std::unique_ptr<PipelineXTask>>> _tasks;
@@ -240,7 +242,8 @@ private:
     // Total instance num running on all BEs
     int _total_instances = -1;
 
-    bool _has_bucket_shuffle_join = false;
+    int _num_bucket_shuffled_keys = -1;
+    bool _should_be_bucket_shuffled = false;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
## Proposed changes

For 1-phase Agg/Analytic operator, we prefer to use hash shuffle instead of bucket shuffle which is restricted by bucket distribution.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

