### PR TITLE
[improvement](mtmv) Optimize the nested materialized view rewrite performance cherry pick

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -411,6 +411,9 @@ public class Memo {
             Preconditions.checkState(groupExpressions.containsKey(groupExpr.get()));
             return CopyInResult.of(false, groupExpr.get());
         }
+        if (targetGroup != null) {
+            targetGroup.getstructInfoMap().setRefreshed(false);
+        }
         List<Group> childrenGroups = Lists.newArrayList();
         for (int i = 0; i < plan.children().size(); i++) {
             // skip useless project.
@@ -559,6 +562,7 @@ public class Memo {
         if (source == root) {
             root = destination;
         }
+        destination.getstructInfoMap().setRefreshed(false);
         groups.remove(source.getGroupId());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
@@ -443,10 +443,18 @@ public class StructInfo {
         }
     }
 
+    /** Judge if source contains all target */
     public static boolean containsAll(BitSet source, BitSet target) {
-        BitSet intersection = (BitSet) source.clone();
-        intersection.and(target);
-        return intersection.equals(target);
+        if (source.size() < target.size()) {
+            return false;
+        }
+        for (int i = target.nextSetBit(0); i >= 0; i = target.nextSetBit(i + 1)) {
+            boolean contains = source.get(i);
+            if (!contains) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
 (#34050)

Optimize the nested materialized view rewrite performance when exists many join This is brought by #33362

## Proposed changes

pr: https://github.com/apache/doris/pull/34050
commit id: e86c599a

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

