### PR TITLE
[feature](Cloud) Implement gcs accessor for compatibility

### DIFF
--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -30,6 +30,8 @@
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/PutObjectRequest.h>
 
+#include <algorithm>
+#include <execution>
 #include <utility>
 
 #include "common/logging.h"
@@ -226,7 +228,21 @@ int S3Accessor::delete_objects(const std::vector<std::string>& relative_paths) {
 }
 
 int S3Accessor::delete_object(const std::string& relative_path) {
-    // TODO(cyx)
+    Aws::S3::Model::DeleteObjectRequest request;
+    auto key = get_key(relative_path);
+    request.WithBucket(conf_.bucket).WithKey(key);
+    auto outcome = SYNC_POINT_HOOK_RETURN_VALUE(s3_client_->DeleteObject(request),
+                                                "s3_client::delete_object", request);
+    if (!outcome.IsSuccess()) {
+        LOG_WARNING("failed to delete object")
+                .tag("endpoint", conf_.endpoint)
+                .tag("bucket", conf_.bucket)
+                .tag("key", key)
+                .tag("responseCode", static_cast<int>(outcome.GetError().GetResponseCode()))
+                .tag("error", outcome.GetError().GetMessage())
+                .tag("exception", outcome.GetError().GetExceptionName());
+        return -1;
+    }
     return 0;
 }
 
@@ -420,6 +436,21 @@ int S3Accessor::check_bucket_versioning() {
         return -1;
     }
     return 0;
+}
+
+int GcsAccessor::delete_objects(const std::vector<std::string>& relative_paths) {
+    std::vector<int> delete_rets(relative_paths.size());
+    std::transform(std::execution::par, relative_paths.begin(), relative_paths.end(),
+                   delete_rets.begin(),
+                   [this](const std::string& path) { return delete_object(path); });
+    int ret = 0;
+    for (int delete_ret : delete_rets) {
+        if (delete_ret != 0) {
+            ret = delete_ret;
+            break;
+        }
+    }
+    return ret;
 }
 
 #undef HELP_MACRO

--- a/cloud/src/recycler/s3_accessor.h
+++ b/cloud/src/recycler/s3_accessor.h
@@ -90,4 +90,13 @@ private:
     std::string path_;
 };
 
+class GcsAccessor final : public S3Accessor {
+public:
+    explicit GcsAccessor(S3Conf conf) : S3Accessor(std::move(conf)) {}
+    ~GcsAccessor() override = default;
+
+    // returns 0 for success otherwise error
+    int delete_objects(const std::vector<std::string>& relative_paths) override;
+};
+
 } // namespace doris::cloud

--- a/cloud/test/s3_accessor_test.cpp
+++ b/cloud/test/s3_accessor_test.cpp
@@ -672,7 +672,7 @@ TEST(S3AccessorTest, delete_object) {
 }
 
 TEST(S3AccessorTest, gcs_delete_objects) {
-    _mock_fs = std::make_unique<selectdb::MockAccessor>(selectdb::S3Conf {});
+    _mock_fs = std::make_unique<cloud::MockS3Accessor>(cloud::S3Conf {});
     _mock_client = std::make_unique<MockS3Client>();
     auto accessor = std::make_unique<GcsAccessor>(S3Conf {});
     auto sp = SyncPoint::get_instance();
@@ -704,7 +704,7 @@ TEST(S3AccessorTest, gcs_delete_objects) {
 }
 
 TEST(S3AccessorTest, gcs_delete_objects_error) {
-    _mock_fs = std::make_unique<selectdb::MockAccessor>(selectdb::S3Conf {});
+    _mock_fs = std::make_unique<cloud::MockS3Accessor>(cloud::S3Conf {});
     _mock_client = std::make_unique<MockS3Client>(std::make_unique<ErrorS3Client>());
     auto accessor = std::make_unique<GcsAccessor>(S3Conf {});
     auto sp = SyncPoint::get_instance();

--- a/cloud/test/s3_accessor_test.cpp
+++ b/cloud/test/s3_accessor_test.cpp
@@ -58,6 +58,8 @@ public:
             const Aws::S3::Model::ListObjectsV2Request& req) = 0;
     virtual Aws::S3::Model::DeleteObjectsOutcome DeleteObjects(
             const Aws::S3::Model::DeleteObjectsRequest& req) = 0;
+    virtual Aws::S3::Model::DeleteObjectOutcome DeleteObject(
+            const Aws::S3::Model::DeleteObjectRequest& req) = 0;
     virtual Aws::S3::Model::PutObjectOutcome PutObject(
             const Aws::S3::Model::PutObjectRequest& req) = 0;
     virtual Aws::S3::Model::HeadObjectOutcome HeadObject(
@@ -120,6 +122,13 @@ public:
             _mock_fs->delete_object(obj.GetKey());
         }
         return Aws::S3::Model::DeleteObjectsOutcome(std::move(result));
+    }
+
+    Aws::S3::Model::DeleteObjectOutcome DeleteObject(
+            const Aws::S3::Model::DeleteObjectRequest& req) override {
+        Aws::S3::Model::DeleteObjectResult result;
+        _mock_fs->delete_object(req.GetKey());
+        return Aws::S3::Model::DeleteObjectOutcome(std::move(result));
     }
 
     Aws::S3::Model::PutObjectOutcome PutObject(
@@ -207,6 +216,18 @@ public:
         return Aws::S3::Model::DeleteObjectsOutcome(std::move(err));
     }
 
+    Aws::S3::Model::DeleteObjectOutcome DeleteObject(
+            const Aws::S3::Model::DeleteObjectRequest& req) override {
+        if (!return_error_for_error_s3_client) {
+            return _correct_impl->DeleteObject(req);
+        }
+        auto err = Aws::Client::AWSError<Aws::S3::S3Errors>(Aws::S3::S3Errors::RESOURCE_NOT_FOUND,
+                                                            false);
+        err.SetResponseCode(Aws::Http::HttpResponseCode::NOT_FOUND);
+        // return -1
+        return Aws::S3::Model::DeleteObjectOutcome(std::move(err));
+    }
+
     Aws::S3::Model::PutObjectOutcome PutObject(
             const Aws::S3::Model::PutObjectRequest& req) override {
         if (!return_error_for_error_s3_client) {
@@ -267,6 +288,10 @@ public:
         return _impl->DeleteObjects(req);
     }
 
+    auto DeleteObject(const Aws::S3::Model::DeleteObjectRequest& req) {
+        return _impl->DeleteObject(req);
+    }
+
     auto PutObject(const Aws::S3::Model::PutObjectRequest& req) { return _impl->PutObject(req); }
 
     auto HeadObject(const Aws::S3::Model::HeadObjectRequest& req) { return _impl->HeadObject(req); }
@@ -303,6 +328,12 @@ static auto callbacks = std::array {
                           auto pair = *(std::pair<Aws::S3::Model::DeleteObjectsOutcome*,
                                                   Aws::S3::Model::DeleteObjectsRequest*>*)p;
                           *pair.first = (*_mock_client).DeleteObjects(*pair.second);
+                      }},
+        MockCallable {"s3_client::delete_object",
+                      [](void* p) {
+                          auto pair = *(std::pair<Aws::S3::Model::DeleteObjectOutcome*,
+                                                  Aws::S3::Model::DeleteObjectRequest*>*)p;
+                          *pair.first = (*_mock_client).DeleteObject(*pair.second);
                       }},
         MockCallable {"s3_client::put_object",
                       [](void* p) {
@@ -614,8 +645,7 @@ TEST(S3AccessorTest, exist_error) {
     ASSERT_EQ(-1, accessor->exist(prefix));
 }
 
-// function is not implemented
-TEST(S3AccessorTest, DISABLED_delete_object) {
+TEST(S3AccessorTest, delete_object) {
     _mock_fs = std::make_unique<cloud::MockS3Accessor>(cloud::S3Conf {});
     _mock_client = std::make_unique<MockS3Client>();
     auto accessor = std::make_unique<S3Accessor>(S3Conf {});
@@ -639,6 +669,75 @@ TEST(S3AccessorTest, DISABLED_delete_object) {
         ASSERT_EQ(0, accessor->delete_object(path));
         ASSERT_EQ(1, accessor->exist(path));
     }
+}
+
+TEST(S3AccessorTest, gcs_delete_objects) {
+    _mock_fs = std::make_unique<selectdb::MockAccessor>(selectdb::S3Conf {});
+    _mock_client = std::make_unique<MockS3Client>();
+    auto accessor = std::make_unique<GcsAccessor>(S3Conf {});
+    auto sp = SyncPoint::get_instance();
+    std::for_each(callbacks.begin(), callbacks.end(), [&](const MockCallable& mock_callback) {
+        sp->set_call_back(fmt::format("{}::pred", mock_callback.point_name),
+                          [](void* p) { *((bool*)p) = true; });
+        sp->set_call_back(mock_callback.point_name, mock_callback.func);
+    });
+    sp->enable_processing();
+    std::unique_ptr<int, std::function<void(int*)>> defer_log_statistics((int*)0x01, [&](int*) {
+        sp->disable_processing();
+        std::for_each(callbacks.begin(), callbacks.end(), [&](const MockCallable& mock_callback) {
+            sp->clear_call_back(mock_callback.point_name);
+        });
+    });
+    std::string prefix = "test_delete_object";
+    std::vector<std::string> paths;
+    size_t num = 300;
+    for (size_t i = 0; i < num; i++) {
+        auto path = fmt::format("{}{}", prefix, i);
+        _mock_fs->put_object(path, "");
+        paths.emplace_back(std::move(path));
+    }
+    ASSERT_EQ(0, accessor->delete_objects(paths));
+    for (size_t i = 0; i < num; i++) {
+        auto path = fmt::format("{}{}", prefix, i);
+        ASSERT_EQ(1, accessor->exist(path));
+    }
+}
+
+TEST(S3AccessorTest, gcs_delete_objects_error) {
+    _mock_fs = std::make_unique<selectdb::MockAccessor>(selectdb::S3Conf {});
+    _mock_client = std::make_unique<MockS3Client>(std::make_unique<ErrorS3Client>());
+    auto accessor = std::make_unique<GcsAccessor>(S3Conf {});
+    auto sp = SyncPoint::get_instance();
+    std::for_each(callbacks.begin(), callbacks.end(), [&](const MockCallable& mock_callback) {
+        sp->set_call_back(fmt::format("{}::pred", mock_callback.point_name),
+                          [](void* p) { *((bool*)p) = true; });
+        sp->set_call_back(mock_callback.point_name, mock_callback.func);
+    });
+    sp->enable_processing();
+    std::unique_ptr<int, std::function<void(int*)>> defer_log_statistics((int*)0x01, [&](int*) {
+        sp->disable_processing();
+        std::for_each(callbacks.begin(), callbacks.end(), [&](const MockCallable& mock_callback) {
+            sp->clear_call_back(mock_callback.point_name);
+        });
+        return_error_for_error_s3_client = false;
+    });
+    std::string prefix = "test_delete_objects";
+    std::vector<std::string> paths_first_half;
+    std::vector<std::string> paths_second_half;
+    size_t num = 300;
+    for (size_t i = 0; i < num; i++) {
+        auto path = fmt::format("{}{}", prefix, i);
+        _mock_fs->put_object(path, "");
+        if (i < 150) {
+            paths_first_half.emplace_back(std::move(path));
+        } else {
+            paths_second_half.emplace_back(std::move(path));
+        }
+    }
+    std::vector<std::string> empty;
+    ASSERT_EQ(0, accessor->delete_objects(empty));
+    return_error_for_error_s3_client = true;
+    ASSERT_EQ(-1, accessor->delete_objects(paths_first_half));
 }
 
 TEST(S3AccessorTest, delete_objects) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

GCP doesn't support `DeleteObjects` so we use parallel delete object for GCP.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

