### PR TITLE
[Opt] multi table func exec performance

### DIFF
--- a/be/src/pipeline/exec/table_function_operator.cpp
+++ b/be/src/pipeline/exec/table_function_operator.cpp
@@ -192,12 +192,12 @@ Status TableFunctionLocalState::get_expanded_block(RuntimeState* state,
             }
 
             DCHECK_LE(1, p._fn_num);
-            _current_row_insert_times += _fns[p._fn_num - 1]->get_value(
-                    columns[p._child_slots.size()],
+            auto repeat_times = _fns[p._fn_num - 1]->get_value(
+                    columns[p._child_slots.size() + p._fn_num - 1],
                     state->batch_size() - columns[p._child_slots.size()]->size());
+            _current_row_insert_times += repeat_times;
             for (int i = 0; i < p._fn_num - 1; i++) {
-                _fns[i]->get_same_many_values(columns[i + p._child_slots.size()],
-                                              _current_row_insert_times);
+                _fns[i]->get_same_many_values(columns[i + p._child_slots.size()], repeat_times);
             }
         }
     }

--- a/be/src/pipeline/exec/table_function_operator.cpp
+++ b/be/src/pipeline/exec/table_function_operator.cpp
@@ -190,16 +190,14 @@ Status TableFunctionLocalState::get_expanded_block(RuntimeState* state,
             if (skip_child_row = _is_inner_and_empty(); skip_child_row) {
                 continue;
             }
-            if (p._fn_num == 1) {
-                _current_row_insert_times += _fns[0]->get_value(
-                        columns[p._child_slots.size()],
-                        state->batch_size() - columns[p._child_slots.size()]->size());
-            } else {
-                for (int i = 0; i < p._fn_num; i++) {
-                    _fns[i]->get_value(columns[i + p._child_slots.size()]);
-                }
-                _current_row_insert_times++;
-                _fns[p._fn_num - 1]->forward();
+
+            DCHECK_LE(1, p._fn_num);
+            _current_row_insert_times += _fns[p._fn_num - 1]->get_value(
+                    columns[p._child_slots.size()],
+                    state->batch_size() - columns[p._child_slots.size()]->size());
+            for (int i = 0; i < p._fn_num - 1; i++) {
+                _fns[i]->get_same_many_values(columns[i + p._child_slots.size()],
+                                              _current_row_insert_times);
             }
         }
     }

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -199,12 +199,12 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
             }
 
             DCHECK_LE(1, _fn_num);
-            _current_row_insert_times += _fns[_fn_num - 1]->get_value(
+            auto repeat_times = _fns[_fn_num - 1]->get_value(
                     columns[_child_slots.size()],
                     state->batch_size() - columns[_child_slots.size()]->size());
+            _current_row_insert_times += repeat_times;
             for (int i = 0; i < _fn_num - 1; i++) {
-                _fns[i]->get_same_many_values(columns[i + _child_slots.size()],
-                                              _current_row_insert_times);
+                _fns[i]->get_same_many_values(columns[i + _child_slots.size()], repeat_times);
             }
         }
     }

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -197,16 +197,14 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
             if (skip_child_row = _is_inner_and_empty(); skip_child_row) {
                 continue;
             }
-            if (_fn_num == 1) {
-                _current_row_insert_times += _fns[0]->get_value(
-                        columns[_child_slots.size()],
-                        state->batch_size() - columns[_child_slots.size()]->size());
-            } else {
-                for (int i = 0; i < _fn_num; i++) {
-                    _fns[i]->get_value(columns[i + _child_slots.size()]);
-                }
-                _current_row_insert_times++;
-                _fns[_fn_num - 1]->forward();
+
+            DCHECK_LE(1, _fn_num);
+            _current_row_insert_times += _fns[_fn_num - 1]->get_value(
+                    columns[_child_slots.size()],
+                    state->batch_size() - columns[_child_slots.size()]->size());
+            for (int i = 0; i < _fn_num - 1; i++) {
+                _fns[i]->get_same_many_values(columns[i + _child_slots.size()],
+                                              _current_row_insert_times);
             }
         }
     }

--- a/be/src/vec/exprs/table_function/table_function.h
+++ b/be/src/vec/exprs/table_function/table_function.h
@@ -53,7 +53,7 @@ public:
         _cur_offset = 0;
     }
 
-    virtual void get_value(MutableColumnPtr& column) = 0;
+    virtual void get_same_many_values(MutableColumnPtr& column, int length = 0) = 0;
     virtual int get_value(MutableColumnPtr& column, int max_step) = 0;
 
     virtual Status close() { return Status::OK(); }

--- a/be/src/vec/exprs/table_function/udf_table_function.cpp
+++ b/be/src/vec/exprs/table_function/udf_table_function.cpp
@@ -153,20 +153,20 @@ void UDFTableFunction::process_close() {
     _array_offset = 0;
 }
 
-void UDFTableFunction::get_value(MutableColumnPtr& column) {
+void UDFTableFunction::get_same_many_values(MutableColumnPtr& column, int length) {
     size_t pos = _array_offset + _cur_offset;
     if (current_empty() || (_array_column_detail.nested_nullmap_data &&
                             _array_column_detail.nested_nullmap_data[pos])) {
-        column->insert_default();
+        column->insert_many_defaults(length);
     } else {
         if (_is_nullable) {
             auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
             auto nested_column = nullable_column->get_nested_column_ptr();
             auto nullmap_column = nullable_column->get_null_map_column_ptr();
-            nested_column->insert_from(*_array_column_detail.nested_col, pos);
-            assert_cast<ColumnUInt8*>(nullmap_column.get())->insert_default();
+            nested_column->insert_many_from(*_array_column_detail.nested_col, pos, length);
+            assert_cast<ColumnUInt8*>(nullmap_column.get())->insert_many_defaults(length);
         } else {
-            column->insert_from(*_array_column_detail.nested_col, pos);
+            column->insert_many_from(*_array_column_detail.nested_col, pos, length);
         }
     }
 }

--- a/be/src/vec/exprs/table_function/udf_table_function.h
+++ b/be/src/vec/exprs/table_function/udf_table_function.h
@@ -38,7 +38,7 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
     Status close() override {
         if (_jni_ctx) {

--- a/be/src/vec/exprs/table_function/vexplode.cpp
+++ b/be/src/vec/exprs/table_function/vexplode.cpp
@@ -71,20 +71,20 @@ void VExplodeTableFunction::process_close() {
     _array_offset = 0;
 }
 
-void VExplodeTableFunction::get_value(MutableColumnPtr& column) {
+void VExplodeTableFunction::get_same_many_values(MutableColumnPtr& column, int length) {
     size_t pos = _array_offset + _cur_offset;
     if (current_empty() || (_detail.nested_nullmap_data && _detail.nested_nullmap_data[pos])) {
-        column->insert_default();
+        column->insert_many_defaults(length);
     } else {
         if (_is_nullable) {
             assert_cast<ColumnNullable*>(column.get())
                     ->get_nested_column_ptr()
-                    ->insert_from(*_detail.nested_col, pos);
+                    ->insert_many_from(*_detail.nested_col, pos, length);
             assert_cast<ColumnUInt8*>(
                     assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
-                    ->insert_default();
+                    ->insert_many_defaults(length);
         } else {
-            column->insert_from(*_detail.nested_col, pos);
+            column->insert_many_from(*_detail.nested_col, pos, length);
         }
     }
 }

--- a/be/src/vec/exprs/table_function/vexplode.h
+++ b/be/src/vec/exprs/table_function/vexplode.h
@@ -43,7 +43,7 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
@@ -71,19 +71,19 @@ void VExplodeBitmapTableFunction::forward(int step) {
     TableFunction::forward(step);
 }
 
-void VExplodeBitmapTableFunction::get_value(MutableColumnPtr& column) {
+void VExplodeBitmapTableFunction::get_same_many_values(MutableColumnPtr& column, int length) {
     if (current_empty()) {
-        column->insert_default();
+        column->insert_many_defaults(length);
     } else {
         if (_is_nullable) {
             assert_cast<ColumnInt64*>(
                     assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
-                    ->insert_value(**_cur_iter);
+                    ->fill(**_cur_iter, length);
             assert_cast<ColumnUInt8*>(
                     assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
-                    ->insert_default();
+                    ->insert_many_defaults(length);
         } else {
-            assert_cast<ColumnInt64*>(column.get())->insert_value(**_cur_iter);
+            assert_cast<ColumnInt64*>(column.get())->fill(**_cur_iter, length);
         }
     }
 }

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -42,7 +42,7 @@ public:
     ~VExplodeBitmapTableFunction() override = default;
 
     void reset() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
     void forward(int step = 1) override;

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -44,8 +44,10 @@ struct ParsedData {
         _values_null_flag.clear();
     }
     virtual int set_output(rapidjson::Document& document, int value_size) = 0;
-    virtual void insert_result_from_parsed_data(MutableColumnPtr& column, int max_step,
-                                                int64_t cur_offset) = 0;
+    virtual void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                                int max_step) = 0;
+    virtual void insert_many_same_value_from_parsed_data(MutableColumnPtr& column,
+                                                         int64_t cur_offset, int length) = 0;
     const char* get_null_flag_address(int cur_offset) {
         return reinterpret_cast<const char*>(_values_null_flag.data() + cur_offset);
     }
@@ -88,11 +90,19 @@ struct ParsedDataInt : public ParsedData<int64_t> {
         }
         return value_size;
     }
-    void insert_result_from_parsed_data(MutableColumnPtr& column, int max_step,
-                                        int64_t cur_offset) override {
+
+    void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                        int max_step) override {
         assert_cast<ColumnInt64*>(column.get())
                 ->insert_many_raw_data(
                         reinterpret_cast<const char*>(_backup_data.data() + cur_offset), max_step);
+    }
+
+    void insert_many_same_value_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                                 int length) override {
+        assert_cast<ColumnInt64*>(column.get())
+                ->insert_many_raw_data(
+                        reinterpret_cast<const char*>(_backup_data.data() + cur_offset), length);
     }
 };
 
@@ -112,20 +122,36 @@ struct ParsedDataDouble : public ParsedData<double> {
         }
         return value_size;
     }
-    void insert_result_from_parsed_data(MutableColumnPtr& column, int max_step,
-                                        int64_t cur_offset) override {
+
+    void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                        int max_step) override {
         assert_cast<ColumnFloat64*>(column.get())
                 ->insert_many_raw_data(
                         reinterpret_cast<const char*>(_backup_data.data() + cur_offset), max_step);
     }
+
+    void insert_many_same_value_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                                 int length) override {
+        assert_cast<ColumnFloat64*>(column.get())
+                ->insert_many_raw_data(
+                        reinterpret_cast<const char*>(_backup_data.data() + cur_offset), length);
+    }
 };
 
 struct ParsedDataStringBase : public ParsedData<std::string> {
-    void insert_result_from_parsed_data(MutableColumnPtr& column, int max_step,
-                                        int64_t cur_offset) override {
+    void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                        int max_step) override {
         assert_cast<ColumnString*>(column.get())
                 ->insert_many_strings(_data_string_ref.data() + cur_offset, max_step);
     }
+
+    void insert_many_same_value_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
+                                                 int length) override {
+        assert_cast<ColumnString*>(column.get())
+                ->insert_many_data(_data_string_ref[cur_offset].data,
+                                   _data_string_ref[cur_offset].size, length);
+    }
+
     void reset() override {
         ParsedData<std::string>::reset();
         _data_string_ref.clear();
@@ -236,11 +262,12 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
-    void insert_values_into_column(MutableColumnPtr& column, int max_step);
 
 private:
+    void _insert_same_many_values_into_column(MutableColumnPtr& column, int max_step);
+    void _insert_values_into_column(MutableColumnPtr& column, int max_step);
     DataImpl _parsed_data;
     ColumnPtr _text_column;
 };

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -101,8 +101,7 @@ struct ParsedDataInt : public ParsedData<int64_t> {
     void insert_many_same_value_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
                                                  int length) override {
         assert_cast<ColumnInt64*>(column.get())
-                ->insert_many_raw_data(
-                        reinterpret_cast<const char*>(_backup_data.data() + cur_offset), length);
+                ->insert_raw_integers(_backup_data[cur_offset], length);
     }
 };
 
@@ -133,8 +132,7 @@ struct ParsedDataDouble : public ParsedData<double> {
     void insert_many_same_value_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
                                                  int length) override {
         assert_cast<ColumnFloat64*>(column.get())
-                ->insert_many_raw_data(
-                        reinterpret_cast<const char*>(_backup_data.data() + cur_offset), length);
+                ->insert_raw_integers(_backup_data[cur_offset], length);
     }
 };
 

--- a/be/src/vec/exprs/table_function/vexplode_map.h
+++ b/be/src/vec/exprs/table_function/vexplode_map.h
@@ -57,7 +57,7 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -92,19 +92,20 @@ void VExplodeNumbersTableFunction::process_close() {
     _value_column = nullptr;
 }
 
-void VExplodeNumbersTableFunction::get_value(MutableColumnPtr& column) {
+void VExplodeNumbersTableFunction::get_same_many_values(MutableColumnPtr& column, int length) {
     if (current_empty()) {
-        column->insert_default();
+        column->insert_many_defaults(length);
     } else {
         if (_is_nullable) {
             assert_cast<ColumnInt32*>(
                     assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
-                    ->insert_value(_cur_offset);
+                    ->insert_many_raw_data(reinterpret_cast<const char*>(&_cur_offset), length);
             assert_cast<ColumnUInt8*>(
                     assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
-                    ->insert_default();
+                    ->insert_many_defaults(length);
         } else {
-            assert_cast<ColumnInt32*>(column.get())->insert_value(_cur_offset);
+            assert_cast<ColumnInt32*>(column.get())
+                    ->insert_many_raw_data(reinterpret_cast<const char*>(&_cur_offset), length);
         }
     }
 }

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -99,13 +99,12 @@ void VExplodeNumbersTableFunction::get_same_many_values(MutableColumnPtr& column
         if (_is_nullable) {
             assert_cast<ColumnInt32*>(
                     assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
-                    ->insert_many_raw_data(reinterpret_cast<const char*>(&_cur_offset), length);
+                    ->insert_raw_integers(_cur_offset, length);
             assert_cast<ColumnUInt8*>(
                     assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
                     ->insert_many_defaults(length);
         } else {
-            assert_cast<ColumnInt32*>(column.get())
-                    ->insert_many_raw_data(reinterpret_cast<const char*>(&_cur_offset), length);
+            assert_cast<ColumnInt32*>(column.get())->insert_raw_integers(_cur_offset, length);
         }
     }
 }

--- a/be/src/vec/exprs/table_function/vexplode_numbers.h
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.h
@@ -44,7 +44,7 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override {
         max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
         if (_is_const) {

--- a/be/src/vec/exprs/table_function/vexplode_split.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_split.cpp
@@ -125,11 +125,11 @@ void VExplodeSplitTableFunction::process_close() {
     _delimiter = {};
 }
 
-void VExplodeSplitTableFunction::get_value(MutableColumnPtr& column) {
+void VExplodeSplitTableFunction::get_same_many_values(MutableColumnPtr& column, int length) {
     if (current_empty()) {
-        column->insert_default();
+        column->insert_many_defaults(length);
     } else {
-        column->insert_data(_backup[_cur_offset].data, _backup[_cur_offset].size);
+        column->insert_many_data(_backup[_cur_offset].data, _backup[_cur_offset].size, length);
     }
 }
 

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -45,7 +45,7 @@ public:
     Status process_init(Block* block, RuntimeState* state) override;
     void process_row(size_t row_idx) override;
     void process_close() override;
-    void get_value(MutableColumnPtr& column) override;
+    void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
 private:

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -364,7 +364,7 @@ Block* process_table_function(TableFunction* fn, Block* input_block,
         }
 
         do {
-            fn->get_value(column);
+            fn->get_same_many_values(column, 1);
             fn->forward();
         } while (!fn->eos());
     }


### PR DESCRIPTION
## Proposed changes

before：
```
[regression_test_query_p0_sql_functions_table_function]>select count(*) from test_lv_str                         lateral view explode_numbers(10000) tmp1 as e1                         lateral view explode_numbers(10000) tmp2 as e2;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (2.32 sec)

```

after:
```
[regression_test_query_p0_sql_functions_table_function]>select count(*) from test_lv_str                         lateral view explode_numbers(10000) tmp1 as e1                         lateral view explode_numbers(10000) tmp2 as e2;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (0.36 sec)

```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

