### PR TITLE
[fix](colocate) fix colocate join fail caused by subquery when nereids disabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -844,12 +844,14 @@ public class HashJoinNode extends JoinNodeBase {
     }
 
     SlotRef getMappedInputSlotRef(SlotRef slotRef) {
-        if (outputSmap != null) {
-            Expr mappedExpr = outputSmap.mappingForRhsExpr(slotRef);
-            if (mappedExpr != null && mappedExpr instanceof SlotRef) {
+        if (childOutputSMap != null) {
+            Expr mappedExpr = childOutputSMap.mappingForRhsExpr(slotRef);
+            if (mappedExpr != null && mappedExpr instanceof SlotRef
+                    && !nullableTupleIds.contains(((SlotRef) mappedExpr).getDesc().getParent().getId())) {
                 return (SlotRef) mappedExpr;
             } else {
-                if (outputSmap.containsMappingFor(slotRef)) {
+                if (childOutputSMap.containsMappingFor(slotRef)
+                        && !nullableTupleIds.contains(slotRef.getDesc().getParent().getId())) {
                     return slotRef;
                 } else {
                     return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JoinNodeBase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JoinNodeBase.java
@@ -60,6 +60,7 @@ public abstract class JoinNodeBase extends PlanNode {
     protected TupleDescriptor vOutputTupleDesc;
     protected ExprSubstitutionMap vSrcToOutputSMap;
     protected List<TupleDescriptor> vIntermediateTupleDescList;
+    protected ExprSubstitutionMap childOutputSMap;
 
     public JoinNodeBase(PlanNodeId id, String planNodeName, StatisticalType statisticalType,
             PlanNode outer, PlanNode inner, TableRef innerRef) {
@@ -259,6 +260,8 @@ public abstract class JoinNodeBase extends PlanNode {
         }
         // 4. change the outputSmap
         outputSmap = ExprSubstitutionMap.composeAndReplace(outputSmap, srcTblRefToOutputTupleSmap, analyzer);
+        childOutputSMap = new ExprSubstitutionMap(outputSmap.getLhs(), outputSmap.getRhs());
+        childOutputSMap.substituteLhs(getCombinedChildSmap(), analyzer);
     }
 
     @Override

--- a/regression-test/suites/correctness_p0/test_colocate_join.groovy
+++ b/regression-test/suites/correctness_p0/test_colocate_join.groovy
@@ -181,6 +181,12 @@ suite("test_colocate_join") {
         contains "2:VHASH JOIN\n  |  join op: INNER JOIN(COLOCATE[])[]"
     }
 
+    explain {
+        sql("select a.id,a.name,t1.id,t1.name,cid,cname from test_colo1 a join (select b.id,b.name,c.id as cid,c.name as cname from test_colo2 b left join test_colo3 c on b.id = c.id and b.name = c.name) t1 on a.id=t1.id and a.name= t1.name;")
+        contains "4:VHASH JOIN\n  |  join op: INNER JOIN(COLOCATE[])[]"
+        contains "3:VHASH JOIN\n  |    |  join op: LEFT OUTER JOIN(COLOCATE[])[]"
+    }
+
     /* test join same table but hit different rollup, should disable colocate join */
     sql """ DROP TABLE IF EXISTS `test_query_colocate`;"""
 


### PR DESCRIPTION
## Proposed changes

this [pr](https://github.com/apache/doris/pull/15140/files) fix three tables doing colocate join, but it does not deal with subquery case as follow
```
select a.id,a.name,t1.id,t1.name,cid,cname from test_colo1 a join (select b.id,b.name,c.id as cid,c.name as cname from test_colo2 b left join test_colo3 c on b.id = c.id and b.name = c.name) t1 on a.id=t1.id and a.name= t1.name;

```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

