### PR TITLE
[improvement](mtmv) Materialization context and mtmv decoupling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
@@ -42,9 +42,10 @@ import com.google.common.collect.ImmutableList;
  */
 public class MTMVCache {
 
-    // the materialized view plan which should be optimized by the same rules to query
+    // The materialized view plan which should be optimized by the same rules to query
+    // and will remove top sink and unused sort
     private final Plan logicalPlan;
-    // for stable output order, we should use original plan
+    // The original plan of mv def sql
     private final Plan originalPlan;
 
     public MTMVCache(Plan logicalPlan, Plan originalPlan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -236,14 +236,14 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
             // Rewrite query by view
             rewrittenPlan = rewriteQueryByView(matchMode, queryStructInfo, viewStructInfo, viewToQuerySlotMapping,
                     rewrittenPlan, materializationContext);
-            if (rewrittenPlan == null) {
-                continue;
-            }
             rewrittenPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
                     childContext -> {
                         Rewriter.getWholeTreeRewriter(childContext).execute();
                         return childContext.getRewritePlan();
                     }, rewrittenPlan, queryPlan);
+            if (rewrittenPlan == null) {
+                continue;
+            }
             // check the partitions used by rewritten plan is valid or not
             Multimap<Pair<MTMVPartitionInfo, PartitionInfo>, Partition> invalidPartitionsQueryUsed =
                     calcUsedInvalidMvPartitions(rewrittenPlan, materializationContext, cascadesContext);
@@ -286,9 +286,10 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 }
                 // For rewrittenPlan which contains materialized view should remove invalid partition ids
                 List<Plan> children = Lists.newArrayList(
-                        rewrittenPlan.accept(new InvalidPartitionRemover(), Pair.of(materializationContext.getMTMV(),
-                                invalidPartitionsQueryUsed.values().stream()
-                                        .map(Partition::getId).collect(Collectors.toSet()))),
+                        rewrittenPlan.accept(new InvalidPartitionRemover(), Pair.of(
+                                materializationContext.getMaterializationQualifier(),
+                                invalidPartitionsQueryUsed.values().stream().map(Partition::getId)
+                                        .collect(Collectors.toSet()))),
                         StructInfo.addFilterOnTableScan(queryPlan, filterOnOriginPlan, cascadesContext));
                 // Union query materialized view and source table
                 rewrittenPlan = new LogicalUnion(Qualifier.ALL,
@@ -386,40 +387,43 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
             Plan rewrittenPlan,
             MaterializationContext materializationContext,
             CascadesContext cascadesContext) {
-        // check partition is valid or not
-        MTMV mtmv = materializationContext.getMTMV();
-        PartitionInfo mvPartitionInfo = mtmv.getPartitionInfo();
-        if (PartitionType.UNPARTITIONED.equals(mvPartitionInfo.getType())) {
-            // if not partition, if rewrite success, it means mv is available
-            return ImmutableMultimap.of();
+        if (materializationContext instanceof AsyncMaterializationContext) {
+            // check partition is valid or not
+            MTMV mtmv = ((AsyncMaterializationContext) materializationContext).getMtmv();
+            PartitionInfo mvPartitionInfo = mtmv.getPartitionInfo();
+            if (PartitionType.UNPARTITIONED.equals(mvPartitionInfo.getType())) {
+                // if not partition, if rewrite success, it means mv is available
+                return ImmutableMultimap.of();
+            }
+            // check mv related table partition is valid or not
+            MTMVPartitionInfo mvCustomPartitionInfo = mtmv.getMvPartitionInfo();
+            BaseTableInfo relatedPartitionTable = mvCustomPartitionInfo.getRelatedTableInfo();
+            if (relatedPartitionTable == null) {
+                return ImmutableMultimap.of();
+            }
+            // get mv valid partitions
+            Set<Long> mvDataValidPartitionIdSet = MTMVRewriteUtil.getMTMVCanRewritePartitions(mtmv,
+                            cascadesContext.getConnectContext(), System.currentTimeMillis()).stream()
+                    .map(Partition::getId)
+                    .collect(Collectors.toSet());
+            // get partitions query used
+            Set<Long> mvPartitionSetQueryUsed = rewrittenPlan.collectToList(node -> node instanceof LogicalOlapScan
+                            && Objects.equals(((CatalogRelation) node).getTable().getName(), mtmv.getName()))
+                    .stream()
+                    .map(node -> ((LogicalOlapScan) node).getSelectedPartitionIds())
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+            // get invalid partition ids
+            Set<Long> invalidMvPartitionIdSet = new HashSet<>(mvPartitionSetQueryUsed);
+            invalidMvPartitionIdSet.removeAll(mvDataValidPartitionIdSet);
+            ImmutableMultimap.Builder<Pair<MTMVPartitionInfo, PartitionInfo>, Partition> invalidPartitionMapBuilder =
+                    ImmutableMultimap.builder();
+            Pair<MTMVPartitionInfo, PartitionInfo> partitionInfo = Pair.of(mvCustomPartitionInfo, mvPartitionInfo);
+            invalidMvPartitionIdSet.forEach(invalidPartitionId ->
+                    invalidPartitionMapBuilder.put(partitionInfo, mtmv.getPartition(invalidPartitionId)));
+            return invalidPartitionMapBuilder.build();
         }
-        // check mv related table partition is valid or not
-        MTMVPartitionInfo mvCustomPartitionInfo = mtmv.getMvPartitionInfo();
-        BaseTableInfo relatedPartitionTable = mvCustomPartitionInfo.getRelatedTableInfo();
-        if (relatedPartitionTable == null) {
-            return ImmutableMultimap.of();
-        }
-        // get mv valid partitions
-        Set<Long> mvDataValidPartitionIdSet = MTMVRewriteUtil.getMTMVCanRewritePartitions(mtmv,
-                        cascadesContext.getConnectContext(), System.currentTimeMillis()).stream()
-                .map(Partition::getId)
-                .collect(Collectors.toSet());
-        // get partitions query used
-        Set<Long> mvPartitionSetQueryUsed = rewrittenPlan.collectToList(node -> node instanceof LogicalOlapScan
-                        && Objects.equals(((CatalogRelation) node).getTable().getName(), mtmv.getName()))
-                .stream()
-                .map(node -> ((LogicalOlapScan) node).getSelectedPartitionIds())
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-        // get invalid partition ids
-        Set<Long> invalidMvPartitionIdSet = new HashSet<>(mvPartitionSetQueryUsed);
-        invalidMvPartitionIdSet.removeAll(mvDataValidPartitionIdSet);
-        ImmutableMultimap.Builder<Pair<MTMVPartitionInfo, PartitionInfo>, Partition> invalidPartitionMapBuilder =
-                ImmutableMultimap.builder();
-        Pair<MTMVPartitionInfo, PartitionInfo> partitionInfo = Pair.of(mvCustomPartitionInfo, mvPartitionInfo);
-        invalidMvPartitionIdSet.forEach(invalidPartitionId ->
-                        invalidPartitionMapBuilder.put(partitionInfo, mtmv.getPartition(invalidPartitionId)));
-        return invalidPartitionMapBuilder.build();
+        return ImmutableMultimap.of();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
@@ -90,7 +90,7 @@ public class AsyncMaterializationContext extends MaterializationContext {
         if (!(relation instanceof PhysicalCatalogRelation)) {
             return false;
         }
-       return ((PhysicalCatalogRelation) relation).getTable() instanceof MTMV;
+        return ((PhysicalCatalogRelation) relation).getTable() instanceof MTMV;
     }
 
     public Plan getMvScanPlan() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
@@ -24,12 +24,17 @@ import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.exploration.mv.mapping.ExpressionMapping;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.algebra.Relation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalCatalogRelation;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.Multimap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Async context for query rewrite by materialized view
@@ -60,6 +65,32 @@ public class AsyncMaterializationContext extends MaterializationContext {
     @Override
     List<String> getMaterializationQualifier() {
         return this.mtmv.getFullQualifiers();
+    }
+
+    @Override
+    String getStringInfo() {
+        StringBuilder failReasonBuilder = new StringBuilder("[").append("\n");
+        for (Map.Entry<ObjectId, Collection<Pair<String, String>>> reasonEntry : this.failReason.asMap().entrySet()) {
+            failReasonBuilder
+                    .append("\n")
+                    .append("ObjectId : ").append(reasonEntry.getKey()).append(".\n");
+            for (Pair<String, String> reason : reasonEntry.getValue()) {
+                failReasonBuilder.append("Summary : ").append(reason.key()).append(".\n")
+                        .append("Reason : ").append(reason.value()).append(".\n");
+            }
+        }
+        failReasonBuilder.append("\n").append("]");
+        return Utils.toSqlString("MaterializationContext[" + getMaterializationQualifier() + "]",
+                "rewriteSuccess", this.success,
+                "failReason", failReasonBuilder.toString());
+    }
+
+    @Override
+    boolean isFinalChosen(Relation relation) {
+        if (!(relation instanceof PhysicalCatalogRelation)) {
+            return false;
+        }
+       return ((PhysicalCatalogRelation) relation).getTable() instanceof MTMV;
     }
 
     public Plan getMvScanPlan() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AsyncMaterializationContext.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.exploration.mv;
+
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.rules.exploration.mv.mapping.ExpressionMapping;
+import org.apache.doris.nereids.trees.plans.ObjectId;
+import org.apache.doris.nereids.trees.plans.Plan;
+
+import com.google.common.collect.Multimap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * Async context for query rewrite by materialized view
+ */
+public class AsyncMaterializationContext extends MaterializationContext {
+
+    private static final Logger LOG = LogManager.getLogger(AsyncMaterializationContext.class);
+    private final MTMV mtmv;
+
+    /**
+     * MaterializationContext, this contains necessary info for query rewriting by mv
+     */
+    public AsyncMaterializationContext(MTMV mtmv, Plan mvPlan, Plan mvOriginalPlan, List<Table> baseTables,
+            List<Table> baseViews, CascadesContext cascadesContext) {
+        super(mvPlan, mvOriginalPlan, MaterializedViewUtils.generateMvScanPlan(mtmv, cascadesContext), cascadesContext);
+        this.mtmv = mtmv;
+    }
+
+    public MTMV getMtmv() {
+        return mtmv;
+    }
+
+    @Override
+    Plan doGenerateMvPlan(CascadesContext cascadesContext) {
+        return MaterializedViewUtils.generateMvScanPlan(this.mtmv, cascadesContext);
+    }
+
+    @Override
+    List<String> getMaterializationQualifier() {
+        return this.mtmv.getFullQualifiers();
+    }
+
+    public Plan getMvScanPlan() {
+        return mvScanPlan;
+    }
+
+    public List<Table> getBaseTables() {
+        return baseTables;
+    }
+
+    public List<Table> getBaseViews() {
+        return baseViews;
+    }
+
+    public ExpressionMapping getMvExprToMvScanExprMapping() {
+        return mvExprToMvScanExprMapping;
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public Plan getMvPlan() {
+        return mvPlan;
+    }
+
+    public Multimap<ObjectId, Pair<String, String>> getFailReason() {
+        return failReason;
+    }
+
+    public boolean isEnableRecordFailureDetail() {
+        return enableRecordFailureDetail;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+        this.failReason.clear();
+    }
+
+    public StructInfo getStructInfo() {
+        return structInfo;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -265,8 +265,8 @@ public abstract class MaterializationContext {
         builder.append("\nMaterializedViewRewriteSuccessAndChose:\n");
         if (!chosenMaterializationQualifiers.isEmpty()) {
             builder.append("  Names: ");
-            chosenMaterializationQualifiers.forEach(chosenMaterializationQualifier ->
-                    builder.append(String.join("-", chosenMaterializationQualifier)).append(", "));
+            chosenMaterializationQualifiers.forEach(materializationQualifier ->
+                    builder.append(generateQualifierName(materializationQualifier)).append(", "));
         }
         // rewrite success but not chosen
         builder.append("\nMaterializedViewRewriteSuccessButNotChose:\n");
@@ -276,8 +276,8 @@ public abstract class MaterializationContext {
                 .collect(Collectors.toSet());
         if (!rewriteSuccessButNotChoseQualifiers.isEmpty()) {
             builder.append("  Names: ");
-            rewriteSuccessButNotChoseQualifiers.forEach(chosenMaterializationQualifier ->
-                    builder.append(String.join("-", chosenMaterializationQualifier)).append(", "));
+            rewriteSuccessButNotChoseQualifiers.forEach(materializationQualifier ->
+                    builder.append(generateQualifierName(materializationQualifier)).append(", "));
         }
         // rewrite fail
         builder.append("\nMaterializedViewRewriteFail:");
@@ -286,12 +286,16 @@ public abstract class MaterializationContext {
                 Set<String> failReasonSet =
                         ctx.getFailReason().values().stream().map(Pair::key).collect(ImmutableSet.toImmutableSet());
                 builder.append("\n")
-                        .append("  Name: ").append(ctx.getMaterializationQualifier())
+                        .append("  Name: ").append(generateQualifierName(ctx.getMaterializationQualifier()))
                         .append("\n")
                         .append("  FailSummary: ").append(String.join(", ", failReasonSet));
             }
         }
         return builder.toString();
+    }
+
+    private static String generateQualifierName(List<String> qualifiers) {
+        return String.join("-", qualifiers);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -295,7 +295,7 @@ public abstract class MaterializationContext {
     }
 
     private static String generateQualifierName(List<String> qualifiers) {
-        return String.join("-", qualifiers);
+        return String.join("#", qualifiers);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -203,6 +203,9 @@ public class MaterializedViewUtils {
             CascadesContext cascadesContext,
             Function<CascadesContext, Plan> planRewriter,
             Plan rewrittenPlan, Plan originPlan) {
+        if (originPlan == null || rewrittenPlan == null) {
+            return null;
+        }
         if (originPlan.getOutputSet().size() != rewrittenPlan.getOutputSet().size()) {
             return rewrittenPlan;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/StructInfo.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.rules.exploration.mv;
 
-import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.TableIf;
@@ -643,11 +642,11 @@ public class StructInfo {
     /**
      * Add predicates on base table when materialized view scan contains invalid partitions
      */
-    public static class InvalidPartitionRemover extends DefaultPlanRewriter<Pair<MTMV, Set<Long>>> {
+    public static class InvalidPartitionRemover extends DefaultPlanRewriter<Pair<List<String>, Set<Long>>> {
         // materialized view scan is always LogicalOlapScan, so just handle LogicalOlapScan
         @Override
-        public Plan visitLogicalOlapScan(LogicalOlapScan olapScan, Pair<MTMV, Set<Long>> context) {
-            if (olapScan.getTable().getName().equals(context.key().getName())) {
+        public Plan visitLogicalOlapScan(LogicalOlapScan olapScan, Pair<List<String>, Set<Long>> context) {
+            if (olapScan.getTable().getFullQualifiers().equals(context.key())) {
                 List<Long> selectedPartitionIds = olapScan.getSelectedPartitionIds();
                 return olapScan.withSelectedPartitionIds(selectedPartitionIds.stream()
                         .filter(partitionId -> !context.value().contains(partitionId))


### PR DESCRIPTION
## Proposed changes

Decoupling the `MTMV` from the materialization context.
Change `MaterializationContext` to abstract which is the materialization desc.
It now has `AsyncMaterializationContext` sub class, can also has other type of `MaterializationContext` such as 
`SyncMaterializationContext` and so on.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

