### PR TITLE
[improve](disk) Not add disk to broken path list if disk is full and health check failed

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1217,6 +1217,8 @@ DEFINE_mBool(enable_injection_point, "false");
 
 DEFINE_mBool(ignore_schema_change_check, "false");
 
+DEFINE_mDouble(disk_health_check_full_threshold, "0.95");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1296,6 +1296,9 @@ DECLARE_mBool(enable_injection_point);
 
 DECLARE_mBool(ignore_schema_change_check);
 
+// When the disk health check fails, determine whether the health check failure is caused by a full disk
+DECLARE_mDouble(disk_health_check_full_threshold);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
If the disk is full and the disk health check fails, do not add the disk to the broken path list. If add the disk to broken path list the data on the full disk will can't be read.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

