### PR TITLE
[enhance](Cloud) Add GCP enum for ObjectStoreInfoPB

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/RemoteBase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/RemoteBase.java
@@ -140,6 +140,7 @@ public abstract class RemoteBase {
         switch (obj.provider) {
             case OSS:
                 return new OssRemote(obj);
+            case GCP:
             case S3:
                 return new S3Remote(obj);
             case COS:

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -176,6 +176,7 @@ message ObjectStoreInfoPB {
         COS = 2;
         OBS = 3;
         BOS = 4;
+        GCP = 5;
     }
     optional int64 ctime = 1;
     optional int64 mtime = 2;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This pr is part of GCP support for Cloud Doris. We should implement one GCPRemote Class for Copy Into Support. It would be one future work since it would require GCP SDK support in FE.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

