### PR TITLE
[Chore](regression-test) adjust variant tpch/q09_trans.sql batch_size…

### DIFF
--- a/regression-test/suites/variant_p0/tpch/sql/q09_trans.sql
+++ b/regression-test/suites/variant_p0/tpch/sql/q09_trans.sql
@@ -1,6 +1,6 @@
 -- TABLES: part,SUPPLIER,lineitem,partsupp,orders,NATION
 -- ERROR: not stable
-SELECT  /*+SET_VAR(enable_fallback_to_original_planner=false) */
+SELECT  /*+SET_VAR(enable_fallback_to_original_planner=false,batch_size=2048) */
   NATION,
   O_YEAR,
   SUM(AMOUNT) AS SUM_PROFIT


### PR DESCRIPTION
… from default to 2048

since 50 may cause performance issue introduced by #33853(only happens in ASAN build)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

