### PR TITLE
[Feat](Job) Job supports task execution statistics

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -51,6 +51,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -58,7 +59,11 @@ import java.util.stream.Collectors;
 @Data
 @Log4j2
 public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C>, Writable {
-
+    public static final ImmutableList<Column> COMMON_SCHEMA = ImmutableList.of(
+            new Column("SucceedTaskCount", ScalarType.createStringType()),
+            new Column("FailedTaskCount", ScalarType.createStringType()),
+            new Column("CanceledTaskCount", ScalarType.createStringType())
+            );
     @SerializedName(value = "jid")
     private Long jobId;
 
@@ -91,6 +96,16 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
 
     @SerializedName(value = "sql")
     String executeSql;
+
+
+    @SerializedName(value = "stc")
+    private AtomicLong succeedTaskCount = new AtomicLong(0);
+
+    @SerializedName(value = "ftc")
+    private AtomicLong failedTaskCount = new AtomicLong(0);
+
+    @SerializedName(value = "ctc")
+    private AtomicLong canceledTaskCount = new AtomicLong(0);
 
     public AbstractJob() {
     }
@@ -142,6 +157,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
             task.cancel();
         }
         runningTasks = new CopyOnWriteArrayList<>();
+        logUpdateOperation();
     }
 
     private static final ImmutableList<String> TITLE_NAMES =
@@ -290,14 +306,18 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
 
     @Override
     public void onTaskFail(T task) throws JobException {
+        failedTaskCount.incrementAndGet();
         updateJobStatusIfEnd(false);
         runningTasks.remove(task);
+        logUpdateOperation();
     }
 
     @Override
     public void onTaskSuccess(T task) throws JobException {
+        succeedTaskCount.incrementAndGet();
         updateJobStatusIfEnd(true);
         runningTasks.remove(task);
+        logUpdateOperation();
 
     }
 
@@ -309,12 +329,15 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         }
         switch (executeType) {
             case ONE_TIME:
+                updateJobStatus(JobStatus.FINISHED);
+                this.finishTimeMs = System.currentTimeMillis();
+                break;
             case INSTANT:
                 this.finishTimeMs = System.currentTimeMillis();
                 if (taskSuccess) {
-                    Env.getCurrentEnv().getJobManager().getJob(jobId).updateJobStatus(JobStatus.FINISHED);
+                    updateJobStatus(JobStatus.FINISHED);
                 } else {
-                    Env.getCurrentEnv().getJobManager().getJob(jobId).updateJobStatus(JobStatus.STOPPED);
+                    updateJobStatus(JobStatus.STOPPED);
                 }
                 break;
             case RECURRING:
@@ -322,7 +345,8 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
                 if (null != timerDefinition.getEndTimeMs()
                         && timerDefinition.getEndTimeMs() < System.currentTimeMillis()
                         + timerDefinition.getIntervalUnit().getIntervalMs(timerDefinition.getInterval())) {
-                    Env.getCurrentEnv().getJobManager().getJob(jobId).updateJobStatus(JobStatus.FINISHED);
+                    this.finishTimeMs = System.currentTimeMillis();
+                    updateJobStatus(JobStatus.FINISHED);
                 }
                 break;
             default:
@@ -360,6 +384,9 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         trow.addToColumnValue(new TCell().setStringVal(jobStatus.name()));
         trow.addToColumnValue(new TCell().setStringVal(executeSql));
         trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(createTimeMs)));
+        trow.addToColumnValue(new TCell().setStringVal(String.valueOf(succeedTaskCount.get())));
+        trow.addToColumnValue(new TCell().setStringVal(String.valueOf(failedTaskCount.get())));
+        trow.addToColumnValue(new TCell().setStringVal(String.valueOf(canceledTaskCount.get())));
         trow.addToColumnValue(new TCell().setStringVal(comment));
         return trow;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -37,6 +37,7 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
@@ -52,11 +53,12 @@ public class InsertTask extends AbstractTask {
     public static final ImmutableList<Column> SCHEMA = ImmutableList.of(
             new Column("TaskId", ScalarType.createStringType()),
             new Column("JobId", ScalarType.createStringType()),
+            new Column("JobName", ScalarType.createStringType()),
             new Column("Label", ScalarType.createStringType()),
             new Column("Status", ScalarType.createStringType()),
             new Column("ErrorMsg", ScalarType.createStringType()),
-            new Column("CreateTimeMs", ScalarType.createStringType()),
-            new Column("FinishTimeMs", ScalarType.createStringType()),
+            new Column("CreateTime", ScalarType.createStringType()),
+            new Column("FinishTime", ScalarType.createStringType()),
             new Column("TrackingUrl", ScalarType.createStringType()),
             new Column("LoadStatistic", ScalarType.createStringType()),
             new Column("User", ScalarType.createStringType()));
@@ -64,7 +66,7 @@ public class InsertTask extends AbstractTask {
     public static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
 
     static {
-        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder();
+        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder<>();
         for (int i = 0; i < SCHEMA.size(); i++) {
             builder.put(SCHEMA.get(i).getName().toLowerCase(), i);
         }
@@ -77,6 +79,7 @@ public class InsertTask extends AbstractTask {
     private ConnectContext ctx;
     private String sql;
     private String currentDb;
+    @SerializedName(value = "uif")
     private UserIdentity userIdentity;
     private LoadStatistic loadStatistic;
     private AtomicBoolean isCanceled = new AtomicBoolean(false);
@@ -211,42 +214,51 @@ public class InsertTask extends AbstractTask {
     }
 
     @Override
-    public TRow getTvfInfo() {
+    public TRow getTvfInfo(String jobName) {
         TRow trow = new TRow();
         if (jobInfo == null) {
             // if task not start, load job is null,return pending task show info
-            return getPendingTaskTVFInfo();
+            return getPendingTaskTVFInfo(jobName);
         }
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(jobInfo.getId())));
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(getJobId())));
-        trow.addToColumnValue(new TCell().setStringVal(labelName));
+        trow.addToColumnValue(new TCell().setStringVal(jobName));
+        trow.addToColumnValue(new TCell().setStringVal(getJobId() + LABEL_SPLITTER + getTaskId()));
         trow.addToColumnValue(new TCell().setStringVal(jobInfo.getState().name()));
         // err msg
-        String errMsg = "";
+        String errorMsg = "";
         if (failMsg != null) {
-            errMsg = "type:" + failMsg.getCancelType() + "; msg:" + failMsg.getMsg();
+            errorMsg = failMsg.getMsg();
         }
-        trow.addToColumnValue(new TCell().setStringVal(errMsg));
+        if (StringUtils.isNotBlank(getErrMsg())) {
+            errorMsg = getErrMsg();
+        }
+        trow.addToColumnValue(new TCell().setStringVal(errorMsg));
         // create time
-        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getCreateTimestamp())));
+        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(getCreateTimeMs())));
         // load end time
-        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(jobInfo.getFinishTimestamp())));
+        trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(getFinishTimeMs())));
         // tracking url
         trow.addToColumnValue(new TCell().setStringVal(trackingUrl));
-        if (null != loadStatistic) {
-            trow.addToColumnValue(new TCell().setStringVal(loadStatistic.toJson()));
+        if (null != jobInfo.getLoadStatistic()) {
+            trow.addToColumnValue(new TCell().setStringVal(jobInfo.getLoadStatistic().toJson()));
         } else {
             trow.addToColumnValue(new TCell().setStringVal(""));
         }
-        trow.addToColumnValue(new TCell().setStringVal(userIdentity.getQualifiedUser()));
+        if (userIdentity == null) {
+            trow.addToColumnValue(new TCell().setStringVal(""));
+        } else {
+            trow.addToColumnValue(new TCell().setStringVal(userIdentity.getQualifiedUser()));
+        }
         return trow;
     }
 
     // if task not start, load job is null,return pending task show info
-    private TRow getPendingTaskTVFInfo() {
+    private TRow getPendingTaskTVFInfo(String jobName) {
         TRow trow = new TRow();
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(getTaskId())));
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(getJobId())));
+        trow.addToColumnValue(new TCell().setStringVal(jobName));
         trow.addToColumnValue(new TCell().setStringVal(getJobId() + LABEL_SPLITTER + getTaskId()));
         trow.addToColumnValue(new TCell().setStringVal(getStatus().name()));
         trow.addToColumnValue(new TCell().setStringVal(""));

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -299,11 +299,11 @@ public class MTMVTask extends AbstractTask {
     }
 
     @Override
-    public TRow getTvfInfo() {
+    public TRow getTvfInfo(String jobName) {
         TRow trow = new TRow();
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(super.getTaskId())));
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(super.getJobId())));
-        trow.addToColumnValue(new TCell().setStringVal(super.getJobName()));
+        trow.addToColumnValue(new TCell().setStringVal(jobName));
         String dbName = "";
         String mvName = "";
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -267,8 +267,7 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
      **/
     public void replayUpdateJob(T job) {
         jobMap.put(job.getJobId(), job);
-        log.info(new LogBuilder(LogKey.SCHEDULER_JOB, job.getJobId())
-                .add("msg", "replay update scheduler job").build());
+        job.logUpdateOperation();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -29,8 +29,6 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.PatternMatcherWrapper;
 import org.apache.doris.common.io.Writable;
-import org.apache.doris.common.util.LogBuilder;
-import org.apache.doris.common.util.LogKey;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.job.base.AbstractJob;
 import org.apache.doris.job.common.JobStatus;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
@@ -196,7 +196,7 @@ public class JobScheduler<T extends AbstractJob<?, C>, C> implements Closeable {
     }
 
     private void clearEndJob(T job) {
-        if (job.getFinishTimeMs() + FINISHED_JOB_CLEANUP_THRESHOLD_TIME_MS < System.currentTimeMillis()) {
+        if (job.getFinishTimeMs() + FINISHED_JOB_CLEANUP_THRESHOLD_TIME_MS > System.currentTimeMillis()) {
             return;
         }
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
@@ -63,7 +63,7 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
-    public void onFail(String msg) throws JobException {
+    public void onFail() throws JobException {
         status = TaskStatus.FAILED;
         if (!isCallable()) {
             return;
@@ -72,12 +72,13 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
-    public void onFail() throws JobException {
+    public void onFail(String errMsg) throws JobException {
         if (TaskStatus.CANCELED.equals(status)) {
             return;
         }
         status = TaskStatus.FAILED;
         setFinishTimeMs(System.currentTimeMillis());
+        setErrMsg(errMsg);
         if (!isCallable()) {
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/Task.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/Task.java
@@ -70,5 +70,5 @@ public interface Task {
      * get info for tvf `tasks`
      * @return TRow
      */
-    TRow getTvfInfo();
+    TRow getTvfInfo(String jobName);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -809,7 +809,7 @@ public class MetadataGenerator {
             }
             List<AbstractTask> tasks = job.queryAllTasks();
             for (AbstractTask task : tasks) {
-                TRow tvfInfo = task.getTvfInfo();
+                TRow tvfInfo = task.getTvfInfo(job.getJobName());
                 if (tvfInfo != null) {
                     dataBatch.add(tvfInfo);
                 }

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -118,13 +118,11 @@ suite("test_base_insert_job") {
      """
     
     Thread.sleep(2000)
-    def onceJob = sql """ select id,ExecuteSql from jobs("type"="insert") where Name like '%${jobName}%' and ExecuteType='ONE_TIME' """
+    def onceJob = sql """ select SucceedTaskCount from jobs("type"="insert") where Name like '%${jobName}%' and ExecuteType='ONE_TIME' """
     assert onceJob.size() == 1
-    def onceJobId = onceJob.get(0).get(0);
-    def onceJobSql = onceJob.get(0).get(1);
-    println onceJobSql
-    // test cancel task
-    def datas = sql """select status,taskid from tasks("type"="insert") where jobid= ${onceJobId}"""
+    //check succeed task count
+    assert '1' == onceJob.get(0).get(0)
+    def datas = sql """select status,taskid from tasks("type"="insert") where jobName= '${jobName}'"""
     println datas
     assert datas.size() == 1
     assert datas.get(0).get(0) == "FINISHED"
@@ -154,7 +152,7 @@ suite("test_base_insert_job") {
         DROP JOB IF EXISTS where jobname =  '${jobName}'
     """
     sql """
-          CREATE JOB ${jobName}  ON SCHEDULE every 1 second   comment 'test for test&68686781jbjbhj//ncsa' DO insert into ${tableName}  values  ('2023-07-19',5, 1001);
+          CREATE JOB ${jobName}  ON SCHEDULE every 1 second starts current_timestamp  comment 'test for test&68686781jbjbhj//ncsa' DO insert into ${tableName}  values  ('2023-07-19',5, 1001);
      """
 
     Thread.sleep(2000)
@@ -162,15 +160,12 @@ suite("test_base_insert_job") {
     sql """
         PAUSE JOB where jobname =  '${jobName}'
     """
-    def job = sql """ select id,ExecuteSql from jobs("type"="insert") where Name like '%${jobName}%'  """
-    assert job.size() == 1
-    def jobId = job.get(0).get(0);
-    def tasks = sql """ select status from tasks("type"="insert") where jobid= ${jobId}  """
+    def tasks = sql """ select status from tasks("type"="insert") where JobName= '${jobName}'  """
     sql """
         RESUME JOB where jobname =  '${jobName}'
     """
     Thread.sleep(2500)
-    def afterResumeTasks = sql """ select status from tasks("type"="insert") where jobid= ${jobId}  """
+    def afterResumeTasks = sql """ select status from tasks("type"="insert") where JobName= '${jobName}'   """
     println afterResumeTasks
     assert afterResumeTasks.size() >tasks.size
     // assert same job name


### PR DESCRIPTION
## Changes

### Task metadata add jobName
```sql
mysql> desc  function tasks("type"="insert");;
+---------------+------+------+-------+---------+-------+
| Field         | Type | Null | Key   | Default | Extra |
+---------------+------+------+-------+---------+-------+
| TaskId        | TEXT | No   | false | NULL    | NONE  |
| JobId         | TEXT | No   | false | NULL    | NONE  |
| JobName       | TEXT | No   | false | NULL    | NONE  |
| Label         | TEXT | No   | false | NULL    | NONE  |
| Status        | TEXT | No   | false | NULL    | NONE  |
| ErrorMsg      | TEXT | No   | false | NULL    | NONE  |
| CreateTime    | TEXT | No   | false | NULL    | NONE  |
| FinishTime    | TEXT | No   | false | NULL    | NONE  |
| TrackingUrl   | TEXT | No   | false | NULL    | NONE  |
| LoadStatistic | TEXT | No   | false | NULL    | NONE  |
| User          | TEXT | No   | false | NULL    | NONE  |
+---------------+------+------+-------+---------+-------+
11 row
```
### Failed tasks cannot be displayed. 
We use a LoadManager to store task execution information, but failed tasks are not stored. Since the entire lifecycle of a task includes the Load Manager, it must be managed throughout the entire Job Manager.
### Job metadata add succeedCount, failedCount, canceledCount
```sql
mysql> desc  function jobs("type"="insert");
+-------------------+------+------+-------+---------+-------+
| Field             | Type | Null | Key   | Default | Extra |
+-------------------+------+------+-------+---------+-------+
| Id                | TEXT | No   | false | NULL    | NONE  |
| Name              | TEXT | No   | false | NULL    | NONE  |
| Definer           | TEXT | No   | false | NULL    | NONE  |
| ExecuteType       | TEXT | No   | false | NULL    | NONE  |
| RecurringStrategy | TEXT | No   | false | NULL    | NONE  |
| Status            | TEXT | No   | false | NULL    | NONE  |
| ExecuteSql        | TEXT | No   | false | NULL    | NONE  |
| CreateTime        | TEXT | No   | false | NULL    | NONE  |
| SucceedTaskCount  | TEXT | No   | false | NULL    | NONE  |
| FailedTaskCount   | TEXT | No   | false | NULL    | NONE  |
| CanceledTaskCount | TEXT | No   | false | NULL    | NONE  |
| Comment           | TEXT | No   | false | NULL    | NONE  |
+-------------------+------+------+-------+---------+-------+
12 rows in set (0.01 sec)
```
We have added the fields SucceedTaskCount, FailedTaskCount, and CancelTaskCount. Users want to be able to view the execution status of tasks, so we included these fields.
## Compatibility:
### Upgrade
Upgrading smoothly without any compatibility issues.
### Rollback
However, if you upgrade to this new version and then roll back to the old version, the new version's tasks will not be displayed. The new version deprecates the old task storage method, and the old tasks will be migrated to the new task storage. Therefore, when rolling back to the old version, the tasks generated by the new version will not be visible. However, tasks are primarily responsible for task execution and have a short lifespan, so it will not have a significant impact on users.