### PR TITLE
[profile](scan) add projection time in scaner

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -405,9 +405,11 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
         std::stringstream scanner_statistics;
         std::stringstream scanner_rows_read;
         std::stringstream scanner_wait_worker_time;
+        std::stringstream scanner_projection;
         scanner_statistics << "[";
         scanner_rows_read << "[";
         scanner_wait_worker_time << "[";
+        scanner_projection << "[";
         // Scanners can in 3 state
         //  state 1: in scanner context, not scheduled
         //  state 2: in scanner worker pool's queue, scheduled but not running
@@ -419,6 +421,9 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
             }
             // Add per scanner running time before close them
             scanner_statistics << PrettyPrinter::print(scanner->_scanner->get_time_cost_ns(),
+                                                       TUnit::TIME_NS)
+                               << ", ";
+            scanner_projection << PrettyPrinter::print(scanner->_scanner->projection_time(),
                                                        TUnit::TIME_NS)
                                << ", ";
             scanner_rows_read << PrettyPrinter::print(scanner->_scanner->get_rows_read(),
@@ -434,9 +439,11 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
         scanner_statistics << "]";
         scanner_rows_read << "]";
         scanner_wait_worker_time << "]";
+        scanner_projection << "]";
         _scanner_profile->add_info_string("PerScannerRunningTime", scanner_statistics.str());
         _scanner_profile->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
         _scanner_profile->add_info_string("PerScannerWaitTime", scanner_wait_worker_time.str());
+        _scanner_profile->add_info_string("PerScannerProjectionTime", scanner_projection.str());
     }
 
     _blocks_queue_added_cv.notify_one();

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -187,6 +187,7 @@ Status VScanner::_filter_output_block(Block* block) {
 
 Status VScanner::_do_projections(vectorized::Block* origin_block, vectorized::Block* output_block) {
     SCOPED_RAW_TIMER(&_per_scanner_timer);
+    SCOPED_RAW_TIMER(&_projection_timer);
 
     const size_t rows = origin_block->rows();
     if (rows == 0) {

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -109,6 +109,7 @@ public:
 
     int64_t get_time_cost_ns() const { return _per_scanner_timer; }
 
+    int64_t projection_time() const { return _projection_timer; }
     int64_t get_rows_read() const { return _num_rows_read; }
 
     bool is_init() const { return _is_init; }
@@ -237,6 +238,7 @@ protected:
 
     ScannerCounter _counter;
     int64_t _per_scanner_timer = 0;
+    int64_t _projection_timer = 0;
 
     bool _should_stop = false;
 };


### PR DESCRIPTION
## Proposed changes
```
 -  PerScannerRunningTime:  [1s194ms,  887.315ms,  1s049ms,  1s220ms,  1s209ms,  836.272ms,  1s105ms,  1s037ms,  1s063ms,  1s180ms,  1s191ms,  1s096ms,  883.761ms,  883.103ms,  1s023ms,  1s136ms,  904.661ms,  1s237ms,  1s116ms,  1s029ms,  932.601ms,  1s109ms,  1s184ms,  1s094ms,  1s256ms,  937.526ms,  1s143ms,  1s136ms,  1s047ms,  1s083ms,  940.786ms,  1s132ms,  1s055ms,  968.188ms,  1s024ms,  1s052ms,  1s045ms,  1s163ms,  1s134ms,  841.429ms,  1s064ms,  1s194ms,  1s126ms,  1s036ms,  1s012ms,  1s112ms,  1s219ms,  1s068ms,  ]
-  PerScannerProjectionTime:  [1s182ms,  850.468ms,  1s038ms,  1s164ms,  1s189ms,  825.352ms,  1s084ms,  1s017ms,  1s053ms,  1s168ms,  1s177ms,  1s058ms,  859.193ms,  833.417ms,  1s011ms,  1s122ms,  892.875ms,  1s228ms,  1s098ms,  1s006ms,  923.096ms,  1s096ms,  1s173ms,  1s079ms,  1s228ms,  927.629ms,  1s120ms,  1s099ms,  1s027ms,  1s052ms,  931.977ms,  1s099ms,  1s037ms,  949.553ms,  1s015ms,  1s042ms,  1s032ms,  1s143ms,  1s118ms,  828.954ms,  1s053ms,  1s182ms,  1s090ms,  1s022ms,  1s001ms,  1s096ms,  1s209ms,  1s057ms,  ]
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

