### PR TITLE
[bug](ipv6) the ipv6 type should be uint128_t

### DIFF
--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -730,7 +730,7 @@ struct CppTypeTraits<FieldType::OLAP_FIELD_TYPE_IPV4> {
 };
 template <>
 struct CppTypeTraits<FieldType::OLAP_FIELD_TYPE_IPV6> {
-    using CppType = int128_t;
+    using CppType = uint128_t;
     using UnsignedCppType = uint128_t;
 };
 template <>

--- a/regression-test/data/datatype_p0/ip/test_ip_basic.out
+++ b/regression-test/data/datatype_p0/ip/test_ip_basic.out
@@ -63,6 +63,12 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 -- !sql8 --
 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 
+-- !sql8_2 --
+ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+-- !sql8_3 --
+ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
 -- !sql9 --
 \N	0
 0.0.0.0	1
@@ -354,3 +360,4 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff	4
 120.239.82.212	2a0c:3240::1
 121.25.82.29	2620:44:a000::1
 121.25.160.80	2001:418:0:5000::c2d
+

--- a/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
@@ -123,6 +123,8 @@ suite("test_ip_basic") {
     qt_sql6 "select ip_v6 from t0 order by ip_v6 limit 1 offset 1"
     qt_sql7 "select ip_v4 from t0 order by ip_v4 desc limit 1 offset 1"
     qt_sql8 "select ip_v6 from t0 order by ip_v6 desc limit 1 offset 1"
+    qt_sql8_2 "select ip_v6 from t0 order by ip_v6 desc limit 1 offset 1"
+    qt_sql8_3 "select ip_v6 from t0 order by ip_v6 desc limit 1 offset 1"
 
     // group by and agg
     qt_sql9 "select ip_v4, count(ip_v4) as cnt from t0 group by ip_v4 order by ip_v4"


### PR DESCRIPTION
## Proposed changes
the ipv6 type should be uint128_t, and max value is ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
if use int128_t type, it's will be min value.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

