### PR TITLE
[Fix](cloud) Fix concurrency bugs on creating auto partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -385,12 +385,17 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         }
         for (Table table : tableList) {
             OlapTable olapTable = (OlapTable) table;
-            olapTable.getPartitions().stream()
-                    .map(Partition::getBaseIndex)
-                    .map(MaterializedIndex::getTablets)
-                    .flatMap(Collection::stream)
-                    .map(Tablet::getId)
-                    .forEach(baseTabletIds::add);
+            try {
+                olapTable.readLock();
+                olapTable.getPartitions().stream()
+                        .map(Partition::getBaseIndex)
+                        .map(MaterializedIndex::getTablets)
+                        .flatMap(Collection::stream)
+                        .map(Tablet::getId)
+                        .forEach(baseTabletIds::add);
+            } finally {
+                olapTable.readUnlock();
+            }
         }
         Set<Long> tabletIds = tabletCommitInfos.stream().map(TabletCommitInfo::getTabletId).collect(Collectors.toSet());
         baseTabletIds.retainAll(tabletIds);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when there are multiple transactions try to create partitions in one table. they may meet:

```log
2024-04-25 17:54:34,025 WARN (thrift-server-pool-3|319) [FrontendServiceImpl.loadTxnCommit():1559] catch unknown result.
java.util.ConcurrentModificationException: null
	at java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1784) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
	at org.apache.doris.cloud.transaction.CloudGlobalTransactionMgr.getBaseTabletsFromTables(CloudGlobalTransactionMgr.java:393) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.cloud.transaction.CloudGlobalTransactionMgr.commitTransaction(CloudGlobalTransactionMgr.java:422) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.cloud.transaction.CloudGlobalTransactionMgr.commitTransaction(CloudGlobalTransactionMgr.java:323) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.cloud.transaction.CloudGlobalTransactionMgr.commitAndPublishTransaction(CloudGlobalTransactionMgr.java:749) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommitImpl(FrontendServiceImpl.java:1603) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.service.FrontendServiceImpl.loadTxnCommit(FrontendServiceImpl.java:1543) ~[doris-fe.jar:1.2-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor111.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60) ~[doris-fe.jar:1.2-SNAPSHOT]
	at jdk.proxy2.$Proxy35.loadTxnCommit(Unknown Source) ~[?:?]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3982) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.doris.thrift.FrontendService$Processor$loadTxnCommit.getResult(FrontendService.java:3962) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

**this should merge after run cloud p1 many times**

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

