### PR TITLE
[bugfix](insert) fix cherry pick : redundant branch judgment

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2698,10 +2698,7 @@ public class StmtExecutor {
         ConnectContext.get().setSkipAuth(true);
         try {
             InsertOverwriteTableStmt iotStmt = (InsertOverwriteTableStmt) this.parsedStmt;
-            if (iotStmt.isAutoDetectPartition()) {
-                // insert overwrite table auto detect which partitions need to replace
-                handleAutoOverwritePartition(iotStmt);
-            } else if (iotStmt.getPartitionNames().size() == 0) {
+            if (iotStmt.getPartitionNames().size() == 0) {
                 // insert overwrite table
                 handleOverwriteTable(iotStmt);
             } else if (iotStmt.isAutoDetectPartition()) {


### PR DESCRIPTION
## Proposed changes

follow #33523

Redundant branch judgment.
The superfluous branch judgment that will be obtained in `isAutoDetectPartition` to get `getPartitionNames` is null, resulting in NPE.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

