### PR TITLE
[improvement](mtmv) Optimize the nested materialized view performance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -416,7 +416,9 @@ public class Memo {
             throw new IllegalStateException("Insert a plan into targetGroup but differ in logicalproperties");
         }
         // TODO Support sync materialized view in the future
-        if (plan instanceof CatalogRelation && ((CatalogRelation) plan).getTable() instanceof MTMV) {
+        if (plan instanceof LogicalPlan && plan instanceof CatalogRelation
+                && ((CatalogRelation) plan).getTable() instanceof MTMV
+                && !plan.getGroupExpression().isPresent()) {
             refreshVersion.incrementAndGet();
         }
         Optional<GroupExpression> groupExpr = plan.getGroupExpression();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/StructInfoMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/StructInfoMap.java
@@ -59,7 +59,7 @@ public class StructInfoMap {
             return structInfo;
         }
         if (groupExpressionMap.isEmpty() || !groupExpressionMap.containsKey(tableMap)) {
-            refresh(group, memo.getRefreshVersion(), foldTableMap);
+            refresh(group, memo.getRefreshVersion());
             group.getstructInfoMap().setRefreshVersion(memo.getRefreshVersion());
         }
         if (groupExpressionMap.containsKey(tableMap)) {
@@ -118,7 +118,10 @@ public class StructInfoMap {
      * @param group the root group
      *
      */
-    public void refresh(Group group, long refreshVersion, BitSet targetBitSet) {
+    public void refresh(Group group, long memoVersion) {
+        if (memoVersion == group.getstructInfoMap().refreshVersion) {
+            return;
+        }
         Set<Integer> refreshedGroup = new HashSet<>();
         for (GroupExpression groupExpression : group.getLogicalExpressions()) {
             List<Set<BitSet>> childrenTableMap = new LinkedList<>();
@@ -129,10 +132,9 @@ public class StructInfoMap {
             }
             for (Group child : groupExpression.children()) {
                 StructInfoMap childStructInfoMap = child.getstructInfoMap();
-                if (!refreshedGroup.contains(child.getGroupId().asInt())
-                        && refreshVersion != childStructInfoMap.getRefreshVersion()) {
-                    childStructInfoMap.refresh(child, refreshVersion, targetBitSet);
-                    childStructInfoMap.setRefreshVersion(refreshVersion);
+                if (!refreshedGroup.contains(child.getGroupId().asInt())) {
+                    childStructInfoMap.refresh(child, memoVersion);
+                    childStructInfoMap.setRefreshVersion(memoVersion);
                 }
                 refreshedGroup.add(child.getGroupId().asInt());
                 childrenTableMap.add(child.getstructInfoMap().getTableMaps());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -150,8 +150,7 @@ public class MaterializedViewUtils {
             StructInfoMap structInfoMap = ownerGroup.getstructInfoMap();
             if (cascadesContext.getMemo().getRefreshVersion() != structInfoMap.getRefreshVersion()
                     || structInfoMap.getTableMaps().isEmpty()) {
-                structInfoMap.refresh(ownerGroup, cascadesContext.getMemo().getRefreshVersion(),
-                        materializedViewTableSet);
+                structInfoMap.refresh(ownerGroup, cascadesContext.getMemo().getRefreshVersion());
                 structInfoMap.setRefreshVersion(cascadesContext.getMemo().getRefreshVersion());
             }
             Set<BitSet> queryTableSets = structInfoMap.getTableMaps();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
@@ -50,7 +50,7 @@ class StructInfoMapTest extends SqlTestBase {
         Group root = c1.getMemo().getRoot();
         Set<BitSet> tableMaps = root.getstructInfoMap().getTableMaps();
         Assertions.assertTrue(tableMaps.isEmpty());
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
+        root.getstructInfoMap().refresh(root, 1);
         Assertions.assertEquals(1, tableMaps.size());
         new MockUp<MTMVRelationManager>() {
             @Mock
@@ -76,7 +76,7 @@ class StructInfoMapTest extends SqlTestBase {
                 .optimize()
                 .printlnBestPlanTree();
         root = c1.getMemo().getRoot();
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
+        root.getstructInfoMap().refresh(root, 1);
         tableMaps = root.getstructInfoMap().getTableMaps();
         Assertions.assertEquals(2, tableMaps.size());
         dropMvByNereids("drop materialized view mv1");
@@ -97,8 +97,8 @@ class StructInfoMapTest extends SqlTestBase {
         Group root = c1.getMemo().getRoot();
         Set<BitSet> tableMaps = root.getstructInfoMap().getTableMaps();
         Assertions.assertTrue(tableMaps.isEmpty());
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
+        root.getstructInfoMap().refresh(root, 1);
+        root.getstructInfoMap().refresh(root, 1);
         Assertions.assertEquals(1, tableMaps.size());
         new MockUp<MTMVRelationManager>() {
             @Mock
@@ -124,8 +124,8 @@ class StructInfoMapTest extends SqlTestBase {
                 .optimize()
                 .printlnBestPlanTree();
         root = c1.getMemo().getRoot();
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
+        root.getstructInfoMap().refresh(root, 1);
+        root.getstructInfoMap().refresh(root, 1);
         tableMaps = root.getstructInfoMap().getTableMaps();
         Assertions.assertEquals(2, tableMaps.size());
         dropMvByNereids("drop materialized view mv1");
@@ -162,7 +162,7 @@ class StructInfoMapTest extends SqlTestBase {
                 .rewrite()
                 .optimize();
         Group root = c1.getMemo().getRoot();
-        root.getstructInfoMap().refresh(root, 1, new BitSet());
+        root.getstructInfoMap().refresh(root, 1);
         StructInfoMap structInfoMap = root.getstructInfoMap();
         Assertions.assertEquals(2, structInfoMap.getTableMaps().size());
         BitSet mvMap = structInfoMap.getTableMaps().stream()


### PR DESCRIPTION
## Proposed changes

Record increase refersh version more accurately.
The refreshVersion in the memo will increase when mv rewrite successfully.
In query rewrite, if refresh version is different from the current struct info map in group , will refresh the group struct info or not.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

