### PR TITLE
[Enhancement](planner) Support string input for sql_select_limit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -115,9 +115,6 @@ public class VariableVarConverters {
 
         @Override
         public String decode(Long value) throws DdlException {
-            if (value == Long.MAX_VALUE) {
-                return String.valueOf(Long.MAX_VALUE);
-            }
             return String.valueOf(value);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -116,7 +116,7 @@ public class VariableVarConverters {
         @Override
         public String decode(Long value) throws DdlException {
             if (value == Long.MAX_VALUE) {
-                return "DEFAULT";
+                return String.valueOf(Long.MAX_VALUE);
             }
             return String.valueOf(value);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
@@ -48,6 +48,8 @@ public class VariableVarConverters {
         converters.put(SessionVariable.RUNTIME_FILTER_TYPE, runtimeFilterTypeConverter);
         ValidatePasswordPolicyConverter validatePasswordPolicyConverter = new ValidatePasswordPolicyConverter();
         converters.put(GlobalVariable.VALIDATE_PASSWORD_POLICY, validatePasswordPolicyConverter);
+        SqlSelectLimitConverter sqlSelectLimitConverter = new SqlSelectLimitConverter();
+        converters.put(SessionVariable.SQL_SELECT_LIMIT, sqlSelectLimitConverter);
     }
 
     public static Boolean hasConverter(String varName) {
@@ -93,6 +95,30 @@ public class VariableVarConverters {
         @Override
         public String decode(Long value) throws DdlException {
             return RuntimeFilterTypeHelper.decode(value);
+        }
+    }
+
+    // Converter to convert sql select limit variable
+    public static class SqlSelectLimitConverter implements VariableVarConverterI {
+        @Override
+        public Long encode(String value) throws DdlException {
+            if (value.equalsIgnoreCase("DEFAULT")) {
+                return Long.MAX_VALUE;
+            } else {
+                try {
+                    return Long.parseLong(value);
+                } catch (NumberFormatException e) {
+                    throw new DdlException("Invalid sql_select_limit value: " + value);
+                }
+            }
+        }
+
+        @Override
+        public String decode(Long value) throws DdlException {
+            if (value == Long.MAX_VALUE) {
+                return "DEFAULT";
+            }
+            return String.valueOf(value);
         }
     }
 

--- a/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
@@ -277,5 +277,19 @@ suite('test_default_limit', "arrow_flight_sql") {
             order by c.k1, baseall.k2 limit 8
         '''
         assertEquals(res.size(), 8)
+
+        // Test setting sql_select_limit with the string "DEFAULT"
+        sql 'set sql_select_limit = "DEFAULT"'
+        res = sql 'select * from baseall'
+        assertEquals(res.size(), 16)  // Expecting the default limit to show all rows
+
+        // Test setting sql_select_limit with an explicit numeric string
+        sql 'set sql_select_limit = "10"'
+        res = sql 'select * from baseall'
+        assertEquals(res.size(), 10)  // Expecting the limit to restrict the results to 10 rows
+
+        // Reset the sql_select_limit to no limit for further tests
+        sql 'set sql_select_limit = -1'
+
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Some MySQL JDBC Drivers will automatically send `set sql_select_limit='DEFAULT'`, where value is of String type. In order to avoid errors, I made it compatible

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

