### PR TITLE
[fix](createTableLike) fix syntax error for CreateTableLikeStmt with partition properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.ListUtil;
+import org.apache.doris.common.util.PropertyAnalyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -249,7 +250,7 @@ public class ListPartitionInfo extends PartitionInfo {
 
             Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
                 if (!p.equals("")) {
-                    sb.append("PROPERTIES (\"STORAGE POLICY\" = \"");
+                    sb.append(" (\"" + PropertyAnalyzer.PROPERTIES_STORAGE_POLICY + "\" = \"");
                     sb.append(p).append("\")");
                 }
             });

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SinglePartitionDesc;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.RangeUtils;
 
 import com.google.common.base.Preconditions;
@@ -299,7 +300,7 @@ public class RangePartitionInfo extends PartitionInfo {
 
             Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
                 if (!p.equals("")) {
-                    sb.append("PROPERTIES (\"STORAGE POLICY\" = \"");
+                    sb.append(" (\"" + PropertyAnalyzer.PROPERTIES_STORAGE_POLICY + "\" = \"");
                     sb.append(p).append("\")");
                 }
             });


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
case:
create a partitioned table and set partition storage policy
`CREATE TABLE table1
    (
        k1 DATE,
        k2 INT,
        V1 VARCHAR(2048) REPLACE
    ) PARTITION BY RANGE (k1) (
        PARTITION p1 VALUES LESS THAN ("2022-01-01") ("storage_policy" = "test_policy")
    ) DISTRIBUTED BY HASH(k2) BUCKETS 1
    PROPERTIES (
        "replication_num"="1"
    );`

then create a new table table2 : `create table table2 like table1`, get a syntax error：
<img width="1092" alt="image" src="https://github.com/apache/doris/assets/50550370/a83c48d0-bed1-4529-a672-e123ce994af6">

<!--Describe your changes.-->
change partition sql string to match create table syntax.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

