### PR TITLE
[enhance](Cloud) Add one create vault property to control if use this vault as default vault

### DIFF
--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -773,6 +773,7 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
             txn->put(vault_key, vault.SerializeAsString());
             if (request->has_set_as_default_storage_vault() &&
                 request->set_as_default_storage_vault()) {
+                response->set_default_storage_vault_replaced(instance.has_default_storage_vault_id());
                 set_default_vault_log_helper(instance, vault.name(), vault.id());
                 instance.set_default_storage_vault_id(vault.id());
                 instance.set_default_storage_vault_name(vault.name());
@@ -789,6 +790,7 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
         }
         if (request->has_set_as_default_storage_vault() &&
             request->set_as_default_storage_vault()) {
+            response->set_default_storage_vault_replaced(instance.has_default_storage_vault_id());
             set_default_vault_log_helper(instance, *instance.storage_vault_names().rbegin(),
                                          *instance.resource_ids().rbegin());
             instance.set_default_storage_vault_id(*instance.resource_ids().rbegin());
@@ -832,6 +834,7 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
         }
         auto pos = name_itr - instance.storage_vault_names().begin();
         auto id_itr = instance.resource_ids().begin() + pos;
+        response->set_default_storage_vault_replaced(instance.has_default_storage_vault_id());
         set_default_vault_log_helper(instance, name, *id_itr);
         instance.set_default_storage_vault_id(*id_itr);
         instance.set_default_storage_vault_name(name);

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -763,6 +763,16 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
             instance.add_obj_info()->CopyFrom(last_item);
             LOG_INFO("Instance {} tries to put obj info", instance.instance_id());
         } else if (request->op() == AlterObjStoreInfoRequest::ADD_S3_VAULT) {
+            if (instance.storage_vault_names().end() !=
+                std::find_if(instance.storage_vault_names().begin(),
+                             instance.storage_vault_names().end(),
+                             [&](const std::string& candidate_name) {
+                                 return candidate_name == request->vault().name();
+                             })) {
+                code = MetaServiceCode::ALREADY_EXISTED;
+                msg = fmt::format("vault_name={} already created", request->vault().name());
+                return;
+            }
             StorageVaultPB vault;
             vault.set_id(last_item.id());
             vault.set_name(request->vault().name());

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -773,7 +773,8 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
             txn->put(vault_key, vault.SerializeAsString());
             if (request->has_set_as_default_storage_vault() &&
                 request->set_as_default_storage_vault()) {
-                response->set_default_storage_vault_replaced(instance.has_default_storage_vault_id());
+                response->set_default_storage_vault_replaced(
+                        instance.has_default_storage_vault_id());
                 set_default_vault_log_helper(instance, vault.name(), vault.id());
                 instance.set_default_storage_vault_id(vault.id());
                 instance.set_default_storage_vault_name(vault.name());

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -757,6 +757,11 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
             vault.mutable_obj_info()->MergeFrom(last_item);
             auto vault_key = storage_vault_key({instance.instance_id(), last_item.id()});
             txn->put(vault_key, vault.SerializeAsString());
+            if (request->has_set_as_default_storage_vault() &&
+                request->set_as_default_storage_vault()) {
+                instance.set_default_storage_vault_id(vault.id());
+                instance.set_default_storage_vault_name(vault.name());
+            }
         }
     } break;
     case AlterObjStoreInfoRequest::ADD_HDFS_INFO: {
@@ -764,6 +769,11 @@ void MetaServiceImpl::alter_obj_store_info(google::protobuf::RpcController* cont
                     instance, txn.get(), const_cast<StorageVaultPB&>(request->vault()), code, msg);
             ret != 0) {
             return;
+        }
+        if (request->has_set_as_default_storage_vault() &&
+            request->set_as_default_storage_vault()) {
+            instance.set_default_storage_vault_id(*instance.resource_ids().rbegin());
+            instance.set_default_storage_vault_name(*instance.storage_vault_names().rbegin());
         }
         break;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -37,10 +37,12 @@ import java.util.Map;
 // PROPERTIES (key1 = value1, ...)
 public class CreateStorageVaultStmt extends DdlStmt {
     private static final String TYPE = "type";
+    private static final String SET_AS_DEFAULT = "set_as_default";
 
     private final boolean ifNotExists;
     private final String vaultName;
     private final Map<String, String> properties;
+    private boolean setAsDefault;
     private StorageVault.StorageVaultType vaultType;
 
     public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
@@ -52,6 +54,10 @@ public class CreateStorageVaultStmt extends DdlStmt {
 
     public boolean isIfNotExists() {
         return ifNotExists;
+    }
+
+    public boolean setAsDefault() {
+        return setAsDefault;
     }
 
     public String getStorageVaultName() {
@@ -102,6 +108,7 @@ public class CreateStorageVaultStmt extends DdlStmt {
         if (type == null) {
             throw new AnalysisException("Storage Vault type can't be null");
         }
+        setAsDefault = Boolean.parseBoolean(properties.getOrDefault(SET_AS_DEFAULT, "false"));
         setStorageVaultType(StorageVault.StorageVaultType.fromString(type));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -67,8 +67,8 @@ public class HdfsStorageVault extends StorageVault {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
-    public HdfsStorageVault(String name, boolean ifNotExists) {
-        super(name, StorageVault.StorageVaultType.HDFS, ifNotExists);
+    public HdfsStorageVault(String name, boolean ifNotExists, boolean setAsDefault) {
+        super(name, StorageVault.StorageVaultType.HDFS, ifNotExists, setAsDefault);
         properties = Maps.newHashMap();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -56,8 +56,9 @@ public class S3StorageVault extends StorageVault {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
-    public S3StorageVault(String name, boolean ifNotExists, CreateResourceStmt stmt) throws DdlException {
-        super(name, StorageVault.StorageVaultType.S3, ifNotExists);
+    public S3StorageVault(String name, boolean ifNotExists,
+            boolean setAsDefault, CreateResourceStmt stmt) throws DdlException {
+        super(name, StorageVault.StorageVaultType.S3, ifNotExists, setAsDefault);
         resource = Resource.fromStmt(stmt);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -63,6 +63,7 @@ public abstract class StorageVault {
     protected StorageVaultType type;
     protected String id;
     private boolean ifNotExists;
+    private boolean setAsDefault;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
@@ -85,10 +86,11 @@ public abstract class StorageVault {
     public StorageVault() {
     }
 
-    public StorageVault(String name, StorageVaultType type, boolean ifNotExists) {
+    public StorageVault(String name, StorageVaultType type, boolean ifNotExists, boolean setAsDefault) {
         this.name = name;
         this.type = type;
         this.ifNotExists = ifNotExists;
+        this.setAsDefault = setAsDefault;
     }
 
     public static StorageVault fromStmt(CreateStorageVaultStmt stmt) throws DdlException, UserException {
@@ -97,6 +99,10 @@ public abstract class StorageVault {
 
     public boolean ifNotExists() {
         return this.ifNotExists;
+    }
+
+    public boolean setAsDefault() {
+        return this.setAsDefault;
     }
 
 
@@ -120,17 +126,18 @@ public abstract class StorageVault {
         StorageVaultType type = stmt.getStorageVaultType();
         String name = stmt.getStorageVaultName();
         boolean ifNotExists = stmt.isIfNotExists();
+        boolean setAsDefault = stmt.setAsDefault();
         StorageVault vault;
         switch (type) {
             case HDFS:
-                vault = new HdfsStorageVault(name, ifNotExists);
+                vault = new HdfsStorageVault(name, ifNotExists, setAsDefault);
                 vault.modifyProperties(stmt.getProperties());
                 break;
             case S3:
                 CreateResourceStmt resourceStmt =
                         new CreateResourceStmt(false, ifNotExists, name, stmt.getProperties());
                 resourceStmt.analyzeResourceType();
-                vault = new S3StorageVault(name, ifNotExists, resourceStmt);
+                vault = new S3StorageVault(name, ifNotExists, setAsDefault, resourceStmt);
                 break;
             default:
                 throw new DdlException("Unknown StorageVault type: " + type);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -166,8 +166,9 @@ public class StorageVaultMgr {
                         hdfsStorageVault.getName(), response);
                 throw new DdlException(response.getStatus().getMsg());
             }
-            LOG.info("Succeed to create hdfs vault {}, id {}",
-                    hdfsStorageVault.getName(), response.getStorageVaultId());
+            LOG.info("Succeed to create hdfs vault {}, id {}, origin default vault replaced {}",
+                    hdfsStorageVault.getName(), response.getStorageVaultId(),
+                            response.getDefaultStorageVaultReplaced());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());
@@ -208,8 +209,8 @@ public class StorageVaultMgr {
                 LOG.warn("failed to alter storage vault response: {} ", response);
                 throw new DdlException(response.getStatus().getMsg());
             }
-            LOG.info("Succeed to create s3 vault {}, id {}",
-                    s3StorageVault.getName(), response.getStorageVaultId());
+            LOG.info("Succeed to create s3 vault {}, id {}, origin default vault replaced {}",
+                    s3StorageVault.getName(), response.getStorageVaultId(), response.getDefaultStorageVaultReplaced());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -158,12 +158,16 @@ public class StorageVaultMgr {
                     MetaServiceProxy.getInstance().alterObjStoreInfo(requestBuilder.build());
             if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
                     && hdfsStorageVault.ifNotExists()) {
+                LOG.info("Hdfs vault {} already existed", hdfsStorageVault.getName());
                 return;
             }
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
-                LOG.warn("failed to alter storage vault response: {} ", response);
+                LOG.warn("failed to create hdfs storage vault, vault name {}, response: {} ",
+                        hdfsStorageVault.getName(), response);
                 throw new DdlException(response.getStatus().getMsg());
             }
+            LOG.info("Succeed to create hdfs vault {}, id {}",
+                    hdfsStorageVault.getName(), response.getStorageVaultId());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());
@@ -197,12 +201,15 @@ public class StorageVaultMgr {
                     MetaServiceProxy.getInstance().alterObjStoreInfo(requestBuilder.build());
             if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
                     && s3StorageVault.ifNotExists()) {
+                LOG.info("S3 vault {} already existed", s3StorageVault.getName());
                 return;
             }
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
                 LOG.warn("failed to alter storage vault response: {} ", response);
                 throw new DdlException(response.getStatus().getMsg());
             }
+            LOG.info("Succeed to create s3 vault {}, id {}",
+                    s3StorageVault.getName(), response.getStorageVaultId());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -152,6 +152,7 @@ public class StorageVaultMgr {
                 = Cloud.AlterObjStoreInfoRequest.newBuilder();
         requestBuilder.setOp(Cloud.AlterObjStoreInfoRequest.Operation.ADD_HDFS_INFO);
         requestBuilder.setVault(alterHdfsInfoBuilder.build());
+        requestBuilder.setSetAsDefaultStorageVault(vault.setAsDefault());
         try {
             Cloud.AlterObjStoreInfoResponse response =
                     MetaServiceProxy.getInstance().alterObjStoreInfo(requestBuilder.build());
@@ -190,6 +191,7 @@ public class StorageVaultMgr {
         alterObjVaultBuilder.setName(s3StorageVault.getName());
         alterObjVaultBuilder.setObjInfo(objBuilder.build());
         requestBuilder.setVault(alterObjVaultBuilder.build());
+        requestBuilder.setSetAsDefaultStorageVault(vault.setAsDefault());
         try {
             Cloud.AlterObjStoreInfoResponse response =
                     MetaServiceProxy.getInstance().alterObjStoreInfo(requestBuilder.build());

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -158,7 +158,7 @@ public class HdfsStorageVaultTest {
                 return resp.build();
             }
         };
-        StorageVault vault = new HdfsStorageVault("name", true);
+        StorageVault vault = new HdfsStorageVault("name", true, false);
         vault.modifyProperties(ImmutableMap.of(
                 "type", "hdfs",
                 "path", "abs/"));
@@ -201,7 +201,7 @@ public class HdfsStorageVaultTest {
                 return resp.build();
             }
         };
-        StorageVault vault = new HdfsStorageVault("name", true);
+        StorageVault vault = new HdfsStorageVault("name", true, false);
         Assertions.assertThrows(DdlException.class,
                 () -> {
                     mgr.setDefaultStorageVault(new SetDefaultStorageVaultStmt("non_existent"));

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -788,6 +788,7 @@ message AlterObjStoreInfoRequest {
 message AlterObjStoreInfoResponse {
     optional MetaServiceResponseStatus status = 1;
     optional string storage_vault_id = 2;
+    optional bool default_storage_vault_replaced = 3;
 }
 
 message UpdateAkSkRequest {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -782,6 +782,7 @@ message AlterObjStoreInfoRequest {
     optional ObjectStoreInfoPB obj = 2;
     optional Operation op = 3;
     optional StorageVaultPB vault = 4;
+    optional bool set_as_default_storage_vault = 5;
 }
 
 message AlterObjStoreInfoResponse {

--- a/regression-test/suites/vaults/create/create.groovy
+++ b/regression-test/suites/vaults/create/create.groovy
@@ -129,6 +129,28 @@ suite("create_vault") {
         """
     }, "already created")
 
+    sql """
+        CREATE TABLE IF NOT EXISTS create_table_use_s3_vault (
+                C_CUSTKEY     INTEGER NOT NULL,
+                C_NAME        INTEGER NOT NULL
+                )
+                DUPLICATE KEY(C_CUSTKEY, C_NAME)
+                DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 1
+                PROPERTIES (
+                "replication_num" = "1",
+                "storage_vault_name" = "create_s3_vault"
+                )
+    """
+
+    sql """
+        insert into create_table_use_s3_vault values(1,1);
+    """
+
+    sql """
+        select * from create_table_use_s3_vault;
+    """
+
+
     def vaults_info = try_sql """
         show storage vault
     """

--- a/regression-test/suites/vaults/create/create.groovy
+++ b/regression-test/suites/vaults/create/create.groovy
@@ -78,12 +78,12 @@ suite("create_vault") {
                 )
     """
 
-    def create_stmt = """
+    String create_stmt = sql """
         show create table create_table_use_vault
     """
 
     logger.info("the create table stmt is ${create_stmt}")
-    assertTrue(create_stmt.contains("\"storage_vault_name\" = \"create_hdfs_vault\""))
+    assertTrue(create_stmt.contains("create_hdfs_vault"))
 
     expectExceptionLike({
         sql """

--- a/regression-test/suites/vaults/default/default.groovy
+++ b/regression-test/suites/vaults/default/default.groovy
@@ -64,7 +64,7 @@ suite("default_vault") {
         def name = vaults_info[i][0]
         if (name.equals("create_s3_vault_for_default")) {
             // isDefault is true
-            assertTrue(vaults_info[i][3])
+            assertEquals(vaults_info[i][3], "true")
         }
     }
 

--- a/regression-test/suites/vaults/default/default.groovy
+++ b/regression-test/suites/vaults/default/default.groovy
@@ -40,6 +40,36 @@ suite("default_vault") {
     }, "supply")
 
     sql """
+        CREATE STORAGE VAULT IF NOT EXISTS create_s3_vault_for_default
+        PROPERTIES (
+        "type"="S3",
+        "s3.endpoint"="${getS3Endpoint()}",
+        "s3.region" = "${getS3Region()}",
+        "s3.access_key" = "${getS3AK()}",
+        "s3.secret_key" = "${getS3SK()}",
+        "s3.root.path" = "ssb_sf1_p2_s3",
+        "s3.bucket" = "${getS3BucketName()}",
+        "s3.external_endpoint" = "",
+        "provider" = "${getS3Provider()}",
+        "set_as_default" = "true"
+        );
+    """
+
+    def vaults_info = sql """
+        show storage vault
+    """
+
+    // check if create_s3_vault_for_default is set as default
+    for (int i = 0; i < vaults_info.size(); i++) {
+        def name = vaults_info[i][0]
+        if (name.equals("create_s3_vault_for_default")) {
+            // isDefault is true
+            assertTrue(vaults_info[i][3])
+        }
+    }
+
+
+    sql """
         set built_in_storage_vault as default storage vault
     """
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

branch-4.0 needs

Now user can specify whether they want use this vault as default storage vault when they create this vault no matter using sql or http action.

```sql
CREATE STORAGE VAULT IF NOT EXISTS create_s3_vault_for_default
        PROPERTIES (
        "type"="S3",
        "s3.endpoint"="${getS3Endpoint()}",
        "s3.region" = "${getS3Region()}",
        "s3.access_key" = "${getS3AK()}",
        "s3.secret_key" = "${getS3SK()}",
        "s3.root.path" = "ssb_sf1_p2_s3",
        "s3.bucket" = "${getS3BucketName()}",
        "s3.external_endpoint" = "",
        "provider" = "${getS3Provider()}",
        "set_as_default" = "true"
        );
        
 mysql> show storage vault;
+------------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| StorageVaultName       | StorageVaultId | Propeties                                                                                                                                                                                                                                                                                                                                       | IsDefault |
+------------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| built_in_storage_vault | 1              | build_conf { fs_name: "hdfs://127.0.0.1:8020" } prefix: "_AC8CA03E-B5C1-15E2-21D3-D49FB527FE1D"                                                                                                                                                                                                                                                 | false     |
| s3_vault               | 2              | ctime: 1714138950 mtime: 1714138950 ak: "AKIDAE2aqpY0B7oFPIvHMBj01lFSO3RYOxFH" sk: "xxxxxxx" bucket: "doris-build-1308700295" prefix: "ssb_sf1_p2_s3" endpoint: "http://cos.ap-beijing.myqcloud.com" region: "ap-beijing" provider: COS external_endpoint: "" encryption_info { encryption_method: "AES_256_ECB" key_id: 1 } sse_enabled: false | true      |
+------------------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
2 rows in set (0.01 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

