### PR TITLE
[fix](profile)  Fix reporting the profile while building the pipeline profile.

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -348,17 +348,7 @@ Status PipelineFragmentContext::_build_pipeline_tasks(
     _total_tasks = 0;
     int target_size = request.local_params.size();
     _tasks.resize(target_size);
-    auto& pipeline_id_to_profile = _runtime_state->pipeline_id_to_profile();
-    DCHECK(pipeline_id_to_profile.empty());
-    pipeline_id_to_profile.resize(_pipelines.size());
-    {
-        size_t pip_idx = 0;
-        for (auto& pipeline_profile : pipeline_id_to_profile) {
-            pipeline_profile =
-                    std::make_unique<RuntimeProfile>("Pipeline : " + std::to_string(pip_idx));
-            pip_idx++;
-        }
-    }
+    auto& pipeline_id_to_profile = _runtime_state->build_pipeline_profile(_pipelines.size());
 
     for (size_t i = 0; i < target_size; i++) {
         const auto& local_params = request.local_params[i];

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -556,4 +556,44 @@ bool RuntimeState::is_nereids() const {
     return _query_ctx->is_nereids();
 }
 
+std::vector<std::shared_ptr<RuntimeProfile>> RuntimeState::pipeline_id_to_profile() {
+    std::shared_lock lc(_pipeline_profile_lock);
+    std::vector<std::shared_ptr<RuntimeProfile>> pipelines_profile;
+    pipelines_profile.reserve(_pipeline_id_to_profile.size());
+    // The sort here won't change the structure of _pipeline_id_to_profile;
+    // it sorts the children of each element in sort_pipeline_id_to_profile,
+    // and these children are locked.
+    for (auto& pipeline_profile : _pipeline_id_to_profile) {
+        DCHECK(pipeline_profile);
+        // pipeline 0
+        //  pipeline task 0
+        //  pipeline task 1
+        //  pipleine task 2
+        //  .......
+        // sort by pipeline task total time
+        pipeline_profile->sort_children_by_total_time();
+        pipelines_profile.push_back(pipeline_profile);
+    }
+    return pipelines_profile;
+}
+
+std::vector<std::shared_ptr<RuntimeProfile>>& RuntimeState::build_pipeline_profile(
+        std::size_t pipeline_size) {
+    std::unique_lock lc(_pipeline_profile_lock);
+    if (!_pipeline_id_to_profile.empty()) {
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "build_pipeline_profile can only be called once.");
+    }
+    _pipeline_id_to_profile.resize(pipeline_size);
+    {
+        size_t pip_idx = 0;
+        for (auto& pipeline_profile : _pipeline_id_to_profile) {
+            pipeline_profile =
+                    std::make_shared<RuntimeProfile>("Pipeline : " + std::to_string(pip_idx));
+            pip_idx++;
+        }
+    }
+    return _pipeline_id_to_profile;
+}
+
 } // end namespace doris


### PR DESCRIPTION
## Proposed changes

This error occurs because the profile is being reported while still in the build process.
1. Using a shared pointer  in _pipeline_id_to_profile
2. Return a copy when get pipeline profile 
3. Add a lock in build pipeline profile 

```
start BE in local mode
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1714226889 (unix time) try "date -d @1714226889" if you are using GNU date ***
*** Current BE git commitID: 53c62a4f03 ***
*** SIGSEGV address not mapped to object (@0x270) received by PID 3343430 (TID 3344068 OR 0x7ff93a2bc700) from PID 624; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/zhaochangle/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /mnt/disk1/zhaochangle/jdk-17.0.2/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/disk1/zhaochangle/jdk-17.0.2/lib/server/libjvm.so
 3# 0x00007FFA7FA77B50 in /lib64/libc.so.6
 4# doris::RuntimeProfile::sort_children_by_total_time() at /mnt/disk1/zhaochangle/doris/be/src/util/runtime_profile.cpp:728
 5# doris::FragmentMgr::coordinator_callback(doris::ReportStatusRequest const&) at /mnt/disk1/zhaochangle/doris/be/src/runtime/fragment_mgr.cpp:269
 6# std::_Function_handler<void (), doris::FragmentMgr::trigger_pipeline_context_report(doris::ReportStatusRequest, std::shared_ptr<doris::pipeline::PipelineFragmentContext>&&)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk1/zhaochangle/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
 7# doris::ThreadPool::dispatch_thread() in /mnt/disk1/zhaochangle/doris/output_perf/be/lib/doris_be
 8# doris::Thread::supervise_thread(void*) at /mnt/disk1/zhaochangle/doris/be/src/util/thread.cpp:499
 9# start_thread in /lib64/libpthread.so.0
10# __clone in /lib64/libc.so.6
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

