### PR TITLE
[branch-2.1](resource)fix check available fail when s3 aws_token is set and reset as, sk faild on be.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1248,6 +1248,7 @@ void push_storage_policy_callback(StorageEngine& engine, const TAgentTaskRequest
             S3Conf s3_conf;
             s3_conf.ak = std::move(resource.s3_storage_param.ak);
             s3_conf.sk = std::move(resource.s3_storage_param.sk);
+            s3_conf.token = std::move(resource.s3_storage_param.token);
             s3_conf.endpoint = std::move(resource.s3_storage_param.endpoint);
             s3_conf.region = std::move(resource.s3_storage_param.region);
             s3_conf.prefix = std::move(resource.s3_storage_param.root_path);
@@ -1263,7 +1264,7 @@ void push_storage_policy_callback(StorageEngine& engine, const TAgentTaskRequest
                 st = io::S3FileSystem::create(s3_conf, std::to_string(resource.id), &fs);
             } else {
                 fs = std::static_pointer_cast<io::S3FileSystem>(existed_resource.fs);
-                fs->set_conf(s3_conf);
+                st = fs->set_conf(s3_conf);
             }
             if (!st.ok()) {
                 LOG(WARNING) << "update s3 resource failed: " << st;

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -97,6 +97,30 @@ namespace io {
     RETURN_IF_ERROR(get_key(path, &key));
 #endif
 
+// Guarded by external lock.
+Status S3FileSystem::set_conf(S3Conf s3_conf) {
+    if (s3_conf.ak == _s3_conf.ak && s3_conf.sk == _s3_conf.sk && 
+        s3_conf.token == _s3_conf.token) {
+        return Status::OK(); // Same conf
+    }
+
+    auto reset_conf = _s3_conf;
+    reset_conf.ak = s3_conf.ak;
+    reset_conf.sk = s3_conf.sk;
+    reset_conf.token = s3_conf.token;
+    auto client = S3ClientFactory::instance().create(s3_conf);
+    if (!client) {
+        return Status::InternalError("failed to init s3 client with {}", _s3_conf.to_string());
+    }
+
+    {
+        std::lock_guard lock(_client_mu);
+        _client = std::move(client);
+    }
+    _s3_conf = std::move(reset_conf);
+    return Status::OK();
+}
+
 std::string S3FileSystem::full_path(std::string_view key) const {
     return fmt::format("{}/{}/{}", _s3_conf.endpoint, _s3_conf.bucket, key);
 }

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -99,8 +99,7 @@ namespace io {
 
 // Guarded by external lock.
 Status S3FileSystem::set_conf(S3Conf s3_conf) {
-    if (s3_conf.ak == _s3_conf.ak && s3_conf.sk == _s3_conf.sk && 
-        s3_conf.token == _s3_conf.token) {
+    if (s3_conf.ak == _s3_conf.ak && s3_conf.sk == _s3_conf.sk && s3_conf.token == _s3_conf.token) {
         return Status::OK(); // Same conf
     }
 

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -59,7 +59,7 @@ public:
     static Status create(S3Conf s3_conf, std::string id, std::shared_ptr<S3FileSystem>* fs);
     ~S3FileSystem() override;
     // Guarded by external lock.
-    void set_conf(S3Conf s3_conf) { _s3_conf = std::move(s3_conf); }
+    Status set_conf(S3Conf s3_conf);
     const S3Conf& s3_conf() const { return _s3_conf; }
 
     std::shared_ptr<Aws::S3::S3Client> get_client() const {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
@@ -261,6 +261,7 @@ public class S3Properties extends BaseProperties {
         s3Info.setRegion(properties.get(S3Properties.REGION));
         s3Info.setAk(properties.get(S3Properties.ACCESS_KEY));
         s3Info.setSk(properties.get(S3Properties.SECRET_KEY));
+        s3Info.setToken(properties.get(S3Properties.SESSION_TOKEN));
 
         s3Info.setRootPath(properties.get(S3Properties.ROOT_PATH));
         s3Info.setBucket(properties.get(S3Properties.BUCKET));

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -73,6 +73,7 @@ struct TS3StorageParam {
     8: optional string root_path
     9: optional string bucket
     10: optional bool use_path_style = false
+    11: optional string token
 }
 
 struct TStoragePolicy {

--- a/regression-test/suites/cold_heat_separation/policy/alter.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/alter.groovy
@@ -39,6 +39,7 @@ suite("alter_policy") {
             "AWS_ROOT_PATH" = "path/to/rootaaaa",
             "AWS_ACCESS_KEY" = "bbba",
             "AWS_SECRET_KEY" = "aaaa",
+            "AWS_TOKEN" = "session_token",
             "AWS_MAX_CONNECTIONS" = "50",
             "AWS_REQUEST_TIMEOUT_MS" = "3000",
             "AWS_CONNECTION_TIMEOUT_MS" = "1000",
@@ -68,6 +69,10 @@ suite("alter_policy") {
 
         def alter_result_succ_7 = try_sql """
             ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_REQUEST_TIMEOUT_MS" = "7777");
+        """
+
+        def alter_result_succ_8 = try_sql """
+            ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_TOKEN" = "new_session_token");
         """
 
         // errCode = 2, detailMessage = current not support modify property : AWS_REGION
@@ -112,6 +117,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -133,6 +139,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "10101010")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_TOKEN
+        assertEquals(show_alter_result[10][3], "******")
     }
 
     def check_alter_resource_result_with_policy = { resource_name ->
@@ -151,6 +159,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -172,6 +181,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "path/to/rootaaaa")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_TOKEN
+        assertEquals(show_alter_result[10][3], "******")
     }
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

ref #34057, fix same issue on branch 2.1

1. fe return 'S3 can't use, return "please check your properties" when AWS_TOKEN is set
2. When altering the AK/SK resource, S3 client did not reset

