### PR TITLE
[enhance](Backup) Obscure the secret key for show backup's repository stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -743,8 +743,12 @@ public class Repository implements Writable {
         stmtBuilder.append("\"");
 
         stmtBuilder.append("\nPROPERTIES\n(");
-        stmtBuilder.append(new PrintableMap<>(this.getRemoteFileSystem().getProperties(), " = ",
-                true, true, true));
+        Map<String, String> properties = new HashMap();
+        properties.putAll(this.getRemoteFileSystem().getProperties());
+        // WE should not return the acturl secret key to user for safety consideration
+        properties.putIfAbsent(S3Properties.SECRET_KEY, "xxxxxx");
+        properties.putIfAbsent(S3Properties.Env.SECRET_KEY, "xxxxxx");
+        stmtBuilder.append(new PrintableMap<>(properties, " = ", true, true, true));
         stmtBuilder.append("\n)");
         return stmtBuilder.toString();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The original implementation would return the actual secret key for the repository which is not consider safe

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

