### PR TITLE
[BugFix](StoragePolicy) fix modify partition's storage policy with different resource issue succeed with execption

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -826,14 +826,15 @@ public class Alter {
             // 4.3 modify partition storage policy
             // can set multi times storage policy
             String currentStoragePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);
+
+            // 4.4 analyze new properties
+            DataProperty newDataProperty = PropertyAnalyzer.analyzeDataProperty(modifiedProperties, dataProperty);
+
             if (!currentStoragePolicy.equals("")) {
                 // check currentStoragePolicy resource exist.
                 Env.getCurrentEnv().getPolicyMgr().checkStoragePolicyExist(currentStoragePolicy);
                 partitionInfo.setStoragePolicy(partition.getId(), currentStoragePolicy);
             }
-
-            // 4.4 analyze new properties
-            DataProperty newDataProperty = PropertyAnalyzer.analyzeDataProperty(modifiedProperties, dataProperty);
 
             // 1. date property
             if (newDataProperty != null) {


### PR DESCRIPTION
## Proposed changes

version: 2.0.9

when we try to modify a partition's storage policy which have different resource with the previous one, we get error message "currently do not support change origin storage policy to another one with different resource",  but the modification same also succeed!


expect:
the modification fail with "currently do not support change origin storage policy to another one with different resource". 



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

