### PR TITLE
[feat](Nereids): compute func deps in logical plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
@@ -19,8 +19,10 @@ package org.apache.doris.nereids.properties;
 
 import org.apache.doris.nereids.trees.expressions.Slot;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -32,20 +34,33 @@ public class FuncDeps {
         final Set<Slot> dependencies;
 
         public FuncDepsItem(Set<Slot> determinants, Set<Slot> dependencies) {
-            this.determinants = determinants;
-            this.dependencies = dependencies;
+            this.determinants = ImmutableSet.copyOf(determinants);
+            this.dependencies = ImmutableSet.copyOf(dependencies);
         }
 
         @Override
         public String toString() {
             return String.format("%s -> %s", determinants, dependencies);
         }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof FuncDepsItem) {
+                return other.hashCode() == this.hashCode();
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(determinants, dependencies);
+        }
     }
 
-    private final List<FuncDepsItem> items;
+    private final Set<FuncDepsItem> items;
 
     FuncDeps() {
-        items = new ArrayList<>();
+        items = new HashSet<>();
     }
 
     public void addFuncItems(Set<Slot> determinants, Set<Slot> dependencies) {
@@ -54,6 +69,10 @@ public class FuncDeps {
 
     public int size() {
         return items.size();
+    }
+
+    public boolean isFuncDeps(Set<Slot> dominate, Set<Slot> dependency) {
+        return items.contains(new FuncDepsItem(dominate, dependency));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDepsDAG.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDepsDAG.java
@@ -66,6 +66,10 @@ public class FuncDepsDAG {
         this.dagItems = ImmutableList.copyOf(dagItems);
     }
 
+    public boolean isEmpty() {
+        return dagItems.isEmpty();
+    }
+
     /**
      * find all func deps
      */
@@ -150,5 +154,21 @@ public class FuncDepsDAG {
                 to.parents.add(from.index);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        for (DAGItem item : dagItems) {
+            for (int childIdx : item.children) {
+                sb.append(item.slots);
+                sb.append(" -> ");
+                sb.append(dagItems.get(childIdx).slots);
+                sb.append(", ");
+            }
+        }
+        sb.append("} ");
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDepsDG.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDepsDG.java
@@ -116,8 +116,10 @@ public class FuncDepsDG {
             Set<DGItem> visited, Set<DGItem> children) {
         for (int childIdx : root.children) {
             DGItem child = dgItems.get(childIdx);
-            if (!visited.contains(child) && validSlot.containsAll(child.slots)) {
-                children.add(child);
+            if (!visited.contains(child)) {
+                if (validSlot.containsAll(child.slots)) {
+                    children.add(child);
+                }
                 visited.add(child);
                 collectAllChildren(validSlot, child, visited, children);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
@@ -198,7 +198,8 @@ public class FunctionalDependencies {
         }
 
         /**
-         * add equal set in func deps
+         * add equal set in func deps.
+         * For equal Set {a1, a2, a3}, we will add (a1, a2) (a1, a3)
          */
         public void addDepsByEqualSet(Set<Slot> equalSet) {
             if (equalSet.size() < 2) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
@@ -78,7 +78,7 @@ public class FunctionalDependencies {
         return uniformSet.contains(slot);
     }
 
-    public boolean isUniform(ImmutableSet<Slot> slotSet) {
+    public boolean isUniform(Set<Slot> slotSet) {
         return !slotSet.isEmpty()
                 && (uniformSet.contains(slotSet) || slotSet.stream().allMatch(uniformSet::contains));
     }
@@ -288,11 +288,11 @@ public class FunctionalDependencies {
             return slots.contains(slot);
         }
 
-        public boolean contains(ImmutableSet<Slot> slotSet) {
+        public boolean contains(Set<Slot> slotSet) {
             if (slotSet.size() == 1) {
                 return slots.contains(slotSet.iterator().next());
             }
-            return slotSets.contains(slotSet);
+            return slotSets.contains(ImmutableSet.copyOf(slotSet));
         }
 
         public boolean containsAnySub(Set<Slot> slotSet) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
@@ -43,6 +43,7 @@ public class FunctionalDependencies {
     private final NestedSet uniqueSet;
     private final NestedSet uniformSet;
     private final ImmutableSet<FdItem> fdItems;
+    private final FuncDepsDAG fdDag;
 
     private final ImmutableEqualSet<Slot> equalSet;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FunctionalDependencies.java
@@ -41,28 +41,28 @@ public class FunctionalDependencies {
     public static final FunctionalDependencies EMPTY_FUNC_DEPS
             = new FunctionalDependencies(new NestedSet().toImmutable(),
                     new NestedSet().toImmutable(), new ImmutableSet.Builder<FdItem>().build(),
-                    ImmutableEqualSet.empty(), new FuncDepsDAG.Builder().build());
+                    ImmutableEqualSet.empty(), new FuncDepsDG.Builder().build());
     private final NestedSet uniqueSet;
     private final NestedSet uniformSet;
     private final ImmutableSet<FdItem> fdItems;
     private final ImmutableEqualSet<Slot> equalSet;
-    private final FuncDepsDAG fdDag;
+    private final FuncDepsDG fdDg;
 
     private FunctionalDependencies(NestedSet uniqueSet, NestedSet uniformSet, ImmutableSet<FdItem> fdItems,
-            ImmutableEqualSet<Slot> equalSet, FuncDepsDAG fdDag) {
+            ImmutableEqualSet<Slot> equalSet, FuncDepsDG fdDg) {
         this.uniqueSet = uniqueSet;
         this.uniformSet = uniformSet;
         this.fdItems = fdItems;
         this.equalSet = equalSet;
-        this.fdDag = fdDag;
+        this.fdDg = fdDg;
     }
 
     public boolean isEmpty() {
-        return uniformSet.isEmpty() && uniqueSet.isEmpty() && equalSet.isEmpty() && fdDag.isEmpty();
+        return uniformSet.isEmpty() && uniqueSet.isEmpty() && equalSet.isEmpty() && fdDg.isEmpty();
     }
 
     public boolean isDependent(Set<Slot> dominate, Set<Slot> dependency) {
-        return fdDag.findValidFuncDeps(Sets.union(dependency, dominate))
+        return fdDg.findValidFuncDeps(Sets.union(dependency, dominate))
                 .isFuncDeps(dominate, dependency);
     }
 
@@ -107,7 +107,7 @@ public class FunctionalDependencies {
     }
 
     public FuncDeps getAllValidFuncDeps(Set<Slot> validSlots) {
-        return fdDag.findValidFuncDeps(validSlots);
+        return fdDg.findValidFuncDeps(validSlots);
     }
 
     public boolean isEqualAndNotNotNull(Slot l, Slot r) {
@@ -125,7 +125,7 @@ public class FunctionalDependencies {
     @Override
     public String toString() {
         return String.format("FuncDeps[uniform:%s, unique:%s, fdItems:%s, equalSet:%s, funcDeps: %s]",
-                uniformSet, uniqueSet, fdItems, equalSet, fdDag);
+                uniformSet, uniqueSet, fdItems, equalSet, fdDg);
     }
 
     /**
@@ -136,14 +136,14 @@ public class FunctionalDependencies {
         private final NestedSet uniformSet;
         private ImmutableSet<FdItem> fdItems;
         private final ImmutableEqualSet.Builder<Slot> equalSetBuilder;
-        private final FuncDepsDAG.Builder fdDagBuilder;
+        private final FuncDepsDG.Builder fdDgBuilder;
 
         public Builder() {
             uniqueSet = new NestedSet();
             uniformSet = new NestedSet();
             fdItems = new ImmutableSet.Builder<FdItem>().build();
             equalSetBuilder = new ImmutableEqualSet.Builder<>();
-            fdDagBuilder = new FuncDepsDAG.Builder();
+            fdDgBuilder = new FuncDepsDG.Builder();
         }
 
         public Builder(FunctionalDependencies other) {
@@ -151,7 +151,7 @@ public class FunctionalDependencies {
             this.uniqueSet = new NestedSet(other.uniqueSet);
             this.fdItems = ImmutableSet.copyOf(other.fdItems);
             equalSetBuilder = new ImmutableEqualSet.Builder<>(other.equalSet);
-            fdDagBuilder = new FuncDepsDAG.Builder(other.fdDag);
+            fdDgBuilder = new FuncDepsDG.Builder(other.fdDg);
         }
 
         public void addUniformSlot(Slot slot) {
@@ -186,15 +186,15 @@ public class FunctionalDependencies {
             uniformSet.add(fd.uniformSet);
             uniqueSet.add(fd.uniqueSet);
             equalSetBuilder.addEqualSet(fd.equalSet);
-            fdDagBuilder.addDeps(fd.fdDag);
+            fdDgBuilder.addDeps(fd.fdDg);
         }
 
-        public void addFuncDepsDAG(FunctionalDependencies fd) {
-            fdDagBuilder.addDeps(fd.fdDag);
+        public void addFuncDepsDG(FunctionalDependencies fd) {
+            fdDgBuilder.addDeps(fd.fdDg);
         }
 
         public void addDeps(Set<Slot> dominate, Set<Slot> dependency) {
-            fdDagBuilder.addDeps(dominate, dependency);
+            fdDgBuilder.addDeps(dominate, dependency);
         }
 
         /**
@@ -209,8 +209,8 @@ public class FunctionalDependencies {
 
             while (iterator.hasNext()) {
                 Set<Slot> slotSet = ImmutableSet.of(iterator.next());
-                fdDagBuilder.addDeps(first, slotSet);
-                fdDagBuilder.addDeps(slotSet, first);
+                fdDgBuilder.addDeps(first, slotSet);
+                fdDgBuilder.addDeps(slotSet, first);
             }
         }
 
@@ -250,7 +250,7 @@ public class FunctionalDependencies {
 
         public FunctionalDependencies build() {
             return new FunctionalDependencies(uniqueSet.toImmutable(), uniformSet.toImmutable(),
-                    ImmutableSet.copyOf(fdItems), equalSetBuilder.build(), fdDagBuilder.build());
+                    ImmutableSet.copyOf(fdItems), equalSetBuilder.build(), fdDgBuilder.build());
         }
 
         public void pruneSlots(Set<Slot> outputSlots) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/BlockFuncDepsPropagation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/BlockFuncDepsPropagation.java
@@ -51,4 +51,9 @@ public interface BlockFuncDepsPropagation extends LogicalPlan {
     default void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         // don't generate
     }
+
+    @Override
+    default void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        // don't generate
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
@@ -74,6 +74,6 @@ public interface PropagateFuncDeps extends LogicalPlan {
 
     @Override
     default void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child(0).getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child(0).getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
@@ -71,4 +71,9 @@ public interface PropagateFuncDeps extends LogicalPlan {
     default void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    default void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child(0).getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -405,6 +405,6 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -402,4 +402,9 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -405,6 +405,6 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
@@ -154,6 +154,6 @@ public class LogicalAssertNumRows<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
@@ -151,4 +151,9 @@ public class LogicalAssertNumRows<CHILD_TYPE extends Plan> extends LogicalUnary<
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -220,4 +220,9 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         // don't generate any equal pair
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        // don't generate any equal pair
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
@@ -212,7 +212,7 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
@@ -211,6 +211,11 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
     }
 
     @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
+
+    @Override
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
@@ -165,7 +165,7 @@ public class LogicalExcept extends LogicalSetOperation {
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child(0).getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child(0).getLogicalProperties().getFunctionalDependencies());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> output = getOutput();
         List<? extends Slot> originalOutputs = regularChildrenOutputs.isEmpty()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
@@ -164,6 +164,20 @@ public class LogicalExcept extends LogicalSetOperation {
     }
 
     @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child(0).getLogicalProperties().getFunctionalDependencies());
+        Map<Slot, Slot> replaceMap = new HashMap<>();
+        List<Slot> output = getOutput();
+        List<? extends Slot> originalOutputs = regularChildrenOutputs.isEmpty()
+                ? child(0).getOutput()
+                : regularChildrenOutputs.get(0);
+        for (int i = 0; i < output.size(); i++) {
+            replaceMap.put(originalOutputs.get(i), output.get(i));
+        }
+        fdBuilder.replace(replaceMap);
+    }
+
+    @Override
     public void computeUniform(Builder fdBuilder) {
         fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
         Map<Slot, Slot> replaceMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
@@ -176,4 +176,9 @@ public class LogicalFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
             equalSlot.ifPresent(slotSlotPair -> fdBuilder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
         }
     }
+
+    @Override
+    public void computeFd(Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
@@ -179,6 +179,6 @@ public class LogicalFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
@@ -178,6 +178,6 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
 
     @Override
     public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
@@ -175,4 +175,9 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
@@ -149,6 +149,11 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     @Override
+    public void computeFd(Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
+
+    @Override
     public String toString() {
         return Utils.toSqlString("LogicalHaving", "predicates", getPredicate());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
@@ -150,7 +150,7 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
@@ -151,7 +151,7 @@ public class LogicalIntersect extends LogicalSetOperation {
     @Override
     public void computeFd(Builder fdBuilder) {
         for (Plan child : children) {
-            fdBuilder.addFuncDepsDAG(
+            fdBuilder.addFuncDepsDG(
                     child.getLogicalProperties().getFunctionalDependencies());
             replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
@@ -149,6 +149,15 @@ public class LogicalIntersect extends LogicalSetOperation {
     }
 
     @Override
+    public void computeFd(Builder fdBuilder) {
+        for (Plan child : children) {
+            fdBuilder.addFuncDepsDAG(
+                    child.getLogicalProperties().getFunctionalDependencies());
+            replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
+        }
+    }
+
+    @Override
     public ImmutableSet<FdItem> computeFdItems() {
         Set<NamedExpression> output = ImmutableSet.copyOf(getOutput());
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -716,10 +716,10 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     @Override
     public void computeFd(Builder fdBuilder) {
         if (!joinType.isLeftSemiOrAntiJoin()) {
-            fdBuilder.addFuncDepsDAG(right().getLogicalProperties().getFunctionalDependencies());
+            fdBuilder.addFuncDepsDG(right().getLogicalProperties().getFunctionalDependencies());
         }
         if (!joinType.isRightSemiOrAntiJoin()) {
-            fdBuilder.addFuncDepsDAG(left().getLogicalProperties().getFunctionalDependencies());
+            fdBuilder.addFuncDepsDG(left().getLogicalProperties().getFunctionalDependencies());
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -712,4 +712,14 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             }
         }
     }
+
+    @Override
+    public void computeFd(Builder fdBuilder) {
+        if (!joinType.isLeftSemiOrAntiJoin()) {
+            fdBuilder.addFuncDepsDAG(right().getLogicalProperties().getFunctionalDependencies());
+        }
+        if (!joinType.isRightSemiOrAntiJoin()) {
+            fdBuilder.addFuncDepsDAG(left().getLogicalProperties().getFunctionalDependencies());
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
@@ -186,4 +186,9 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
@@ -189,6 +189,6 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -173,4 +173,9 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
             }
         }
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        // don't generate
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
@@ -76,4 +76,6 @@ public interface LogicalPlan extends Plan {
     void computeUniform(FunctionalDependencies.Builder fdBuilder);
 
     void computeEqualSet(FunctionalDependencies.Builder fdBuilder);
+
+    void computeFd(FunctionalDependencies.Builder fdBuilder);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
@@ -19,12 +19,15 @@ package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.properties.FdItem;
 import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -64,8 +67,21 @@ public interface LogicalPlan extends Plan {
         computeUniform(fdBuilder);
         computeUnique(fdBuilder);
         computeEqualSet(fdBuilder);
+        computeFd(fdBuilder);
         ImmutableSet<FdItem> fdItems = computeFdItems();
         fdBuilder.addFdItems(fdItems);
+        for (Slot slot : getOutput()) {
+            Set<Slot> o = ImmutableSet.of(slot);
+            for (Set<Slot> uniqueSlot : fdBuilder.getAllUnique()) {
+                fdBuilder.addDeps(uniqueSlot, o);
+            }
+            for (Set<Slot> uniformSlot : fdBuilder.getAllUniform()) {
+                fdBuilder.addDeps(o, uniformSlot);
+            }
+        }
+        for (Set<Slot> equalSet : fdBuilder.calEqualSetList()) {
+            fdBuilder.addDepsByEqualSet(Sets.intersection(getOutputSet(), equalSet));
+        }
         return fdBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
@@ -72,9 +72,11 @@ public interface LogicalPlan extends Plan {
         fdBuilder.addFdItems(fdItems);
         for (Slot slot : getOutput()) {
             Set<Slot> o = ImmutableSet.of(slot);
+            // all slot dependents unique slot
             for (Set<Slot> uniqueSlot : fdBuilder.getAllUnique()) {
                 fdBuilder.addDeps(uniqueSlot, o);
             }
+            // uniform slot dependents all unique slot
             for (Set<Slot> uniformSlot : fdBuilder.getAllUniform()) {
                 fdBuilder.addDeps(o, uniformSlot);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -285,6 +285,6 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -282,4 +282,9 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         }
         fdBuilder.pruneSlots(getOutputSet());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -212,6 +212,6 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -209,4 +209,9 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -204,7 +204,7 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 
     public void setRelationId(RelationId relationId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -202,6 +202,11 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
         fdBuilder.replace(replaceMap);
     }
 
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
+
     public void setRelationId(RelationId relationId) {
         this.relationId = relationId;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
@@ -189,7 +189,7 @@ public class LogicalTopN<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
@@ -188,6 +188,11 @@ public class LogicalTopN<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
     }
 
     @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
+
+    @Override
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getFunctionalDependencies().getFdItems();
         if (getLimit() == 1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
@@ -258,6 +258,11 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
     }
 
     @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        // don't generate
+    }
+
+    @Override
     public ImmutableSet<FdItem> computeFdItems() {
         Set<NamedExpression> output = ImmutableSet.copyOf(getOutput());
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -155,6 +155,6 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -152,4 +152,9 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -333,6 +333,6 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -330,4 +330,9 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
         fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
     }
+
+    @Override
+    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+        fdBuilder.addFuncDepsDAG(child().getLogicalProperties().getFunctionalDependencies());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
@@ -88,6 +88,22 @@ public class ImmutableEqualSet<T> {
             }
         }
 
+        /**
+         * Calculate all equal set
+         */
+        public List<Set<T>> calEqualSetList() {
+            parent.replaceAll((s, v) -> findRoot(s));
+            return parent.values()
+                    .stream()
+                    .distinct()
+                    .map(a -> {
+                        T ra = parent.get(a);
+                        return parent.keySet().stream()
+                                .filter(t -> parent.get(t).equals(ra))
+                                .collect(ImmutableSet.toImmutableSet());
+                    }).collect(ImmutableList.toImmutableList());
+        }
+
         public void addEqualSet(ImmutableEqualSet<T> equalSet) {
             this.parent.putAll(equalSet.root);
         }
@@ -116,6 +132,10 @@ public class ImmutableEqualSet<T> {
         return root.keySet().stream()
                 .filter(t -> root.get(t).equals(ra) && !t.equals(a))
                 .collect(ImmutableSet.toImmutableSet());
+    }
+
+    public boolean isEmpty() {
+        return root.isEmpty();
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDAGTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDAGTest.java
@@ -28,40 +28,40 @@ import org.junit.jupiter.api.Test;
 class FuncDepsDAGTest {
     @Test
     void testBasic() {
-        FuncDepsDAG dag = new FuncDepsDAG();
+        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
-        FuncDeps res = dag.findValidFuncDeps(Sets.newHashSet(s1, s2));
+        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
         Assertions.assertEquals(1, res.size());
     }
 
     @Test
     void testTrans() {
-        FuncDepsDAG dag = new FuncDepsDAG();
+        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
         dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
-        FuncDeps res = dag.findValidFuncDeps(Sets.newHashSet(s1, s3));
+        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s3));
         Assertions.assertEquals(1, res.size());
     }
 
     @Test
     void testCircle() {
-        FuncDepsDAG dag = new FuncDepsDAG();
+        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s1));
-        FuncDeps res = dag.findValidFuncDeps(Sets.newHashSet(s1, s2));
+        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
         Assertions.assertEquals(2, res.size());
     }
 
     @Test
     void testTree() {
-        FuncDepsDAG dag = new FuncDepsDAG();
+        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
@@ -69,7 +69,7 @@ class FuncDepsDAGTest {
         dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));
-        FuncDeps res = dag.findValidFuncDeps(Sets.newHashSet(s1, s4, s3));
+        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s4, s3));
         Assertions.assertEquals(2, res.size());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
@@ -45,6 +45,7 @@ class FuncDepsDGTest {
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s3));
+        System.out.println(res);
         Assertions.assertEquals(1, res.size());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
@@ -25,51 +25,51 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class FuncDepsDAGTest {
+class FuncDepsDGTest {
     @Test
     void testBasic() {
-        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
+        FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
-        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
+        dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
+        FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
         Assertions.assertEquals(1, res.size());
     }
 
     @Test
     void testTrans() {
-        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
+        FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
-        dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
-        dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
-        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s3));
+        dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
+        dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
+        FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s3));
         Assertions.assertEquals(1, res.size());
     }
 
     @Test
     void testCircle() {
-        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
+        FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
-        dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s1));
-        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
+        dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
+        dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s1));
+        FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
         Assertions.assertEquals(2, res.size());
     }
 
     @Test
     void testTree() {
-        FuncDepsDAG.Builder dag = new FuncDepsDAG.Builder();
+        FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
         Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
         Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
         Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
         Slot s4 = new SlotReference("s4", IntegerType.INSTANCE);
-        dag.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
-        dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
-        dag.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));
-        FuncDeps res = dag.build().findValidFuncDeps(Sets.newHashSet(s1, s4, s3));
+        dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
+        dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
+        dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));
+        FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s4, s3));
         Assertions.assertEquals(2, res.size());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsTest.java
@@ -1,0 +1,233 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.properties;
+
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+class FuncDepsTest extends TestWithFeService {
+    Slot slot1 = new SlotReference("1", IntegerType.INSTANCE, false);
+    Slot slot2 = new SlotReference("2", IntegerType.INSTANCE, false);
+    Slot slot3 = new SlotReference("1", IntegerType.INSTANCE, false);
+    Slot slot4 = new SlotReference("1", IntegerType.INSTANCE, false);
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        createTable("create table test.agg (\n"
+                + "id int not null,\n"
+                + "id2 int replace not null,\n"
+                + "name varchar(128) replace not null )\n"
+                + "AGGREGATE KEY(id)\n"
+                + "distributed by hash(id) buckets 10\n"
+                + "properties('replication_num' = '1');");
+        createTable("create table test.uni (\n"
+                + "id int not null,\n"
+                + "id2 int not null,\n"
+                + "name varchar(128) not null)\n"
+                + "UNIQUE KEY(id)\n"
+                + "distributed by hash(id) buckets 10\n"
+                + "properties('replication_num' = '1');");
+        connectContext.setDatabase("test");
+    }
+
+    @Test
+    void testAgg() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg group by id, id2")
+                .getPlan();
+        Set<Slot> output = ImmutableSet.copyOf(plan.getOutputSet());
+        System.out.println(plan.getLogicalProperties()
+                .getFunctionalDependencies().getAllValidFuncDeps(output));
+        Assertions.assertTrue(
+                plan.getLogicalProperties()
+                .getFunctionalDependencies().getAllValidFuncDeps(output)
+                        .isFuncDeps(output, ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+    @Test
+    void testTopNLimit() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg group by id, id2 order by id limit 1")
+                .getPlan();
+        Set<Slot> output = ImmutableSet.copyOf(plan.getOutputSet());
+        System.out.println(plan.getLogicalProperties()
+                .getFunctionalDependencies().getAllValidFuncDeps(output));
+        Assertions.assertTrue(
+                plan.getLogicalProperties()
+                        .getFunctionalDependencies().getAllValidFuncDeps(output)
+                        .isFuncDeps(output, ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+    @Test
+    void testSetOp() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg where id2 = id intersect select id, id2 from agg")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+        plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg where id2 = id except select id, id2 from agg")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+        plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg where id2 = id union all select id, id2 from agg")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isEmpty());
+        plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg union all select id, id2 from agg where id2 = id")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isEmpty());
+    }
+
+    @Test
+    void testFilterHaving() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg where id = 1")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+        plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from agg  group by id, id2 having id = 1")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+    @Test
+    void testGenerate() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from  agg lateral view explode([1,2,3]) tmp1 as e1")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+    }
+
+    @Test
+    void testJoin() {
+        // inner join
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select uni.id, agg.id, agg.id2 from agg join uni "
+                        + "where agg.id = uni.id")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(2))));
+
+        // foj
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t1.id, t1.id2, t2.id, t2.id2 "
+                        + "from uni as t1 full outer join uni as t2 on t1.id2 = t2.id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
+
+        // loj
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t1.id, t1.id2, t2.id, t2.id2 "
+                        + "from uni as t1 left outer join uni as t2 on t1.id2 = t2.id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
+
+        // roj
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t1.id, t1.id2, t2.id, t2.id2 "
+                        + "from uni as t1 right outer join uni as t2 on t1.id2 = t2.id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
+    }
+
+    @Test
+    void testOneRowRelation() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select 1, 1")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+    @Test
+    void testProject() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id as o1, id as o2, id2 as o4, 1 as c1, 1 as c2 from uni where id = id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+    }
+
+    @Test
+    void testSubQuery() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2 from (select id, id2 from agg where id = id2) t")
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+    @Test
+    void testWindow() {
+        // partition by uniform
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select id, id2, row_number() over(partition by id) from agg where id = id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+                .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FunctionalDependenciesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FunctionalDependenciesTest.java
@@ -138,14 +138,14 @@ class FunctionalDependenciesTest extends TestWithFeService {
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUniform(plan.getOutputSet()));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg full outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutputSet()));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id from agg left outer join uni "
@@ -298,8 +298,10 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select name from agg where id = 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUniform(plan.getOutputSet()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
@@ -135,8 +135,8 @@ class UniformTest extends TestWithFeService {
                 .analyze("select id from agg lateral view explode([1,2,3]) tmp1 as e1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUniform(plan.getOutputSet()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
@@ -185,19 +185,19 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from agg lateral view explode([1,2,3]) tmp1 as e1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
     }
 
     @Test
     void testJoin() {
         // foj doesn't propagate any
         Plan plan = PlanChecker.from(connectContext)
-                .analyze("select * from agg full outer join uni "
+                .analyze("select agg.id from agg full outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutputSet()));
 
         // loj propagate unique when right is unique
         plan = PlanChecker.from(connectContext)
@@ -205,7 +205,7 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg left outer join uni "
                         + "on agg.id = uni.id")
@@ -220,7 +220,9 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(1)));
+
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg right outer join uni "
                         + "on agg.id = uni.id")
@@ -271,28 +273,22 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id < uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id or agg.name > uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isEmpty());
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id and agg.name > uni.name")


### PR DESCRIPTION
## Proposed changes

This pull request introduces several improvements to the handling of function dependencies and resolves a bug in the LogicalUnion Node:

1. Introduce a direct graph data structure to efficiently store and manage function dependencies. This enhancement allows for better organization and faster access to the dependencies between functions.

2. Implement the computation of function dependencies within each plan. By analyzing the relationships and dependencies among functions in each plan, we can optimize the execution order and identify potential optimizations.

3. Extend the function dependency handling by utilizing unique slots and uniform slots. This extension enables more precise tracking of dependencies, taking into account the specific characteristics of each slot type. It improves the accuracy and reliability of the dependency analysis.

4. Fix a bug discovered in the LogicalUnion Node. The issue has been identified and resolved, ensuring the correct functionality of the node in the presence of function dependencies.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

