### PR TITLE
[fix](outfile)Fixed orcOutputStream.close() throwing an exception during destruction causing the program to hang.

### DIFF
--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -62,7 +62,16 @@ VOrcOutputStream::VOrcOutputStream(doris::io::FileWriter* file_writer)
 
 VOrcOutputStream::~VOrcOutputStream() {
     if (!_is_closed) {
-        close();
+        try {
+            close();
+        } catch (...) {
+            /*
+         * Under normal circumstances, close() will be called first, and then the destructor will be called.
+         * If the task is canceled, close() will not be executed, but the destructor will be called directly,
+         * which will cause the be core.When the task is canceled, since the log file has been written during
+         * close(), no operation is performed here.
+         */
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

sql:
```
select * from outfile_exception_test t ORDER BY user_id
into outfile "s3://test-outfile-exception-no-exists/test_outfile/exp_"
format as orc
properties(
    "s3.endpoint" = "xxxxxxxx",
    "s3.region" = "xxxx",
    "s3.access_key"= "xx",
    "s3.secret_key" = "xxx"
);
```

When the sql is executed normally, the close() function of `VOrcOutputStream` will be called first, and then the destructor will be called. If there is a problem with SQL, the close function will throw an exception to return the error to the user. If the task is canceled, the destructor will be called directly, and then the close() function will be executed, causing the system to hang.


<!--Describe your changes.-->

Since close() writes to the log file, I just need to catch the exception in the destructor.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

