### PR TITLE
[improve](shcema change)fix alter table faild when  modify multiple columns with column changed positions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -474,7 +474,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 found = true;
             }
             if (hasColPos) {
-                if (col.getName().equalsIgnoreCase(columnPos.getLastCol())) {
+                if (col.getNonShadowName().equalsIgnoreCase(columnPos.getLastCol())) {
                     lastColIndex = i;
                 }
             } else {
@@ -605,7 +605,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
             if (hasColPos) {
-                if (col.getName().equalsIgnoreCase(columnPos.getLastCol())) {
+                if (col.getNonShadowName().equalsIgnoreCase(columnPos.getLastCol())) {
                     lastColIndex = i;
                 }
             } else {

--- a/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
+++ b/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_alter_muti_modify_column') {
+    def tbl = 'test_alter_muti_modify_column_tbl'
+    sql "DROP TABLE IF EXISTS ${tbl} FORCE"
+    sql """
+        CREATE TABLE ${tbl} (
+            `id` BIGINT NOT NULL,
+            `v1` BIGINT NULL,
+            `v2` VARCHAR(128) NULL,
+            `v3` VARCHAR(128) NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"quit
+        );
+    """
+
+    sql """
+        ALTER TABLE ${tbl} 
+        MODIFY COLUMN `v2` VARCHAR(512) NULL AFTER `v1`,
+        MODIFY COLUMN `v3` VARCHAR(512) NULL AFTER `v2`;
+    """
+
+    def result = sql """ show create table ${tbl} """
+    def createTbl = result[0][1].toString()
+    assertTrue(createTbl.indexOf("`v2` VARCHAR(512) NULL") > 0)
+    assertTrue(createTbl.indexOf("`v3` VARCHAR(512) NULL") > 0)
+
+    sql "DROP TABLE IF EXISTS ${tbl} FORCE"
+}

--- a/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
+++ b/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
@@ -33,15 +33,40 @@ suite('test_alter_muti_modify_column') {
     """
 
     sql """
+        INSERT INTO ${tbl} VALUES
+        (1, 10, 'abc', 'def'),
+        (2, 20, 'xyz', 'uvw'),
+        (3, 30, 'pqr', 'lmn');
+    """
+
+    // Check data before ALTER TABLE
+    def resultBefore = sql """ SELECT * FROM ${tbl} ORDER BY id """
+    assertEquals(3, resultBefore.size())
+    assertEquals([1, 10, 'abc', 'def'], resultBefore[0])
+    assertEquals([2, 20, 'xyz', 'uvw'], resultBefore[1])
+    assertEquals([3, 30, 'pqr', 'lmn'], resultBefore[2])
+
+    sql """
         ALTER TABLE ${tbl} 
         MODIFY COLUMN `v2` VARCHAR(512) NULL AFTER `v1`,
         MODIFY COLUMN `v3` VARCHAR(512) NULL AFTER `v2`;
     """
 
-    def result = sql """ show create table ${tbl} """
-    def createTbl = result[0][1].toString()
+    // Wait for ALTER TABLE to take effect
+    Thread.sleep(5000)
+
+    // Check table structure after ALTER TABLE
+    def resultCreate = sql """ SHOW CREATE TABLE ${tbl} """
+    def createTbl = resultCreate[0][1].toString()
     assertTrue(createTbl.indexOf("`v2` VARCHAR(512) NULL") > 0)
     assertTrue(createTbl.indexOf("`v3` VARCHAR(512) NULL") > 0)
+
+    // Check data after ALTER TABLE
+    def resultAfter = sql """ SELECT * FROM ${tbl} ORDER BY id """
+    assertEquals(3, resultAfter.size())
+    assertEquals([1, 10, 'abc', 'def'], resultAfter[0])
+    assertEquals([2, 20, 'xyz', 'uvw'], resultAfter[1])
+    assertEquals([3, 30, 'pqr', 'lmn'], resultAfter[2])
 
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
 }

--- a/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
+++ b/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
@@ -39,12 +39,20 @@ suite('test_alter_muti_modify_column') {
         (3, 30, 'pqr', 'lmn');
     """
 
+    def expectedResults = [
+        [1, 10, 'abc', 'def'],
+        [2, 20, 'xyz', 'uvw'],
+        [3, 30, 'pqr', 'lmn']
+    ]
+
     // Check data before ALTER TABLE
     def resultBefore = sql """ SELECT * FROM ${tbl} ORDER BY id """
-    assertEquals(3, resultBefore.size())
-    assertEquals([1, 10, 'abc', 'def'], resultBefore[0])
-    assertEquals([2, 20, 'xyz', 'uvw'], resultBefore[1])
-    assertEquals([3, 30, 'pqr', 'lmn'], resultBefore[2])
+    assertEquals(expectedResults.size(), resultBefore.size())
+    for (int i = 0; i < expectedResults.size(); i++) {
+        for (int j = 0; j < expectedResults[i].size(); j++) {
+            assertEquals(expectedResults[i][j], resultBefore[i][j])
+        }
+    }
 
     sql """
         ALTER TABLE ${tbl} 
@@ -63,10 +71,12 @@ suite('test_alter_muti_modify_column') {
 
     // Check data after ALTER TABLE
     def resultAfter = sql """ SELECT * FROM ${tbl} ORDER BY id """
-    assertEquals(3, resultAfter.size())
-    assertEquals([1, 10, 'abc', 'def'], resultAfter[0])
-    assertEquals([2, 20, 'xyz', 'uvw'], resultAfter[1])
-    assertEquals([3, 30, 'pqr', 'lmn'], resultAfter[2])
+    assertEquals(expectedResults.size(), resultAfter.size())
+    for (int i = 0; i < expectedResults.size(); i++) {
+        for (int j = 0; j < expectedResults[i].size(); j++) {
+            assertEquals(expectedResults[i][j], resultAfter[i][j])
+        }
+    }
 
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
 }

--- a/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
+++ b/regression-test/suites/alter_p0/test_alter_muti_modify_column.groovy
@@ -28,7 +28,7 @@ suite('test_alter_muti_modify_column') {
         UNIQUE KEY(`id`)
         DISTRIBUTED BY HASH(`id`) BUCKETS 1
         PROPERTIES (
-        "replication_allocation" = "tag.location.default: 1"quit
+            "replication_allocation" = "tag.location.default: 1"
         );
     """
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when try to modify multiple columns with changed positions, attempting to modify a column that has already been moved will result in a 'column not found' error.

CREATE TABLE `test` (
`id` BIGINT NOT NULL,
`v1` BIGINT NULL,
`v2` VARCHAR(128) NULL,
`v3` VARCHAR(128) NULL
 ) ENGINE=OLAP
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1
 PROPERTIES (
 "replication_allocation" = "tag.location.default: 1"
 );
Query OK, 0 rows affected (0.00 sec)

ALTER TABLE `test` MODIFY COLUMN `v2` VARCHAR(512) NULL AFTER `v1`, MODIFY COLUMN `v3` VARCHAR(512) NULL AFTER `v2`;
ERROR 1105 (HY000): errCode = 2, detailMessage = Column[v2] does not exists

when column datatype change, shadow prefix will be add to column name, we can use NonShadowName to find this column.