### PR TITLE
[test](case) add batch size in long time case 

### DIFF
--- a/regression-test/suites/nereids_rules_p0/mv/ssb/mv_ssb_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/ssb/mv_ssb_test.groovy
@@ -91,6 +91,7 @@ suite("mv_ssb_test") {
     sql "SET enable_fallback_to_original_planner=false"
     sql "SET enable_materialized_view_rewrite=true"
     sql "SET enable_nereids_timeout = false"
+    sql "SET BATCH_SIZE = 4064"
 
     def mv1_1 = """
             SELECT SUM(lo_extendedprice*lo_discount) AS


### PR DESCRIPTION
## Proposed changes

For even PRs, the batch size is set to 50, and this case runs for 50 minutes.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

