### PR TITLE
[enhance](Cloud) Use http action to fetch instance's enable storage vault field instead of using regression's conf

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -69,7 +69,6 @@ class Config {
     public String realDataPath
     public String cacheDataPath
     public boolean enableCacheData
-    public boolean enableStorageVault
     public String pluginPath
     public String sslCertificatePath
     public String dorisComposePath
@@ -165,7 +164,6 @@ class Config {
             String realDataPath,
             String cacheDataPath,
             Boolean enableCacheData,
-            Boolean enableStorageVault,
             String testGroups,
             String excludeGroups,
             String testSuites, 
@@ -218,7 +216,6 @@ class Config {
         this.realDataPath = realDataPath
         this.cacheDataPath = cacheDataPath
         this.enableCacheData = enableCacheData
-        this.enableStorageVault = enableStorageVault
         this.testGroups = testGroups
         this.excludeGroups = excludeGroups
         this.testSuites = testSuites
@@ -273,7 +270,6 @@ class Config {
         config.realDataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(realDataOpt, config.realDataPath))
         config.cacheDataPath = cmd.getOptionValue(cacheDataOpt, config.cacheDataPath)
         config.enableCacheData = Boolean.parseBoolean(cmd.getOptionValue(enableCacheDataOpt, config.enableCacheData.toString()))
-        config.enableStorageVault = Boolean.parseBoolean(cmd.getOptionValue(enableStorageVaultOpt, config.enableStorageVault.toString()))
         config.pluginPath = FileUtils.getCanonicalPath(cmd.getOptionValue(pluginOpt, config.pluginPath))
         config.sslCertificatePath = FileUtils.getCanonicalPath(cmd.getOptionValue(sslCertificateOpt, config.sslCertificatePath))
         config.dorisComposePath = FileUtils.getCanonicalPath(config.dorisComposePath)
@@ -498,7 +494,6 @@ class Config {
             configToString(obj.realDataPath),
             configToString(obj.cacheDataPath),
             configToBoolean(obj.enableCacheData),
-            configToBoolean(obj.enableStorageVault),
             configToString(obj.testGroups),
             configToString(obj.excludeGroups),
             configToString(obj.testSuites),
@@ -722,11 +717,6 @@ class Config {
         if (config.enableCacheData == null) {
             config.enableCacheData = true
             log.info("Set enableCacheData to '${config.enableCacheData}' because not specify.".toString())
-        }
-
-        if (config.enableStorageVault == null) {
-            config.enableStorageVault = true
-            log.info("Set enableStorageVault to '${config.enableStorageVault}' because not specify.".toString())
         }
 
         if (config.pluginPath == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -52,7 +52,6 @@ class ConfigOptions {
     static Option realDataOpt
     static Option cacheDataOpt
     static Option enableCacheDataOpt
-    static Option enableStorageVaultOpt
     static Option pluginOpt
     static Option sslCertificateOpt
     static Option imageOpt
@@ -183,14 +182,6 @@ class ConfigOptions {
                 .type(String.class)
                 .longOpt("enableCacheData")
                 .desc("enable caches data for stream load from s3")
-                .build()
-        enableStorageVaultOpt = Option.builder("ESV")
-                .argName("enableStorageVault")
-                .required(false)
-                .hasArg(true)
-                .type(String.class)
-                .longOpt("enableStorageVault")
-                .desc("does cloud mode enable storage vault")
                 .build()
         pluginOpt = Option.builder("plugin")
                 .argName("pluginPath")

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1123,7 +1123,25 @@ class Suite implements GroovyInterceptable {
     }
 
     boolean enableStoragevault() {
-        return isCloudMode() && context.config.enableStorageVault;
+        def getInstanceInfo = { check_func ->
+            httpTest {
+                endpoint context.config.metaServiceHttpAddress
+                uri "/MetaService/http/get_instance?token=${token}&instance_id=${context.config.instanceId}"
+                op "get"
+                check check_func
+            }
+        }
+        boolean enableStorageVault = false;
+        getInstanceInfo.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                def json = parseJson(body)
+                if (json.instance.enableStorageVault == "true") {
+                    enableStorageVault = true;
+                }
+                
+        }
+        return enableStorageVault;
     }
 
     String getFeConfig(String key) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1136,7 +1136,7 @@ class Suite implements GroovyInterceptable {
             respCode, body ->
                 assertEquals("${respCode}".toString(), "200")
                 def json = parseJson(body)
-                if (json.instance.enableStorageVault == "true") {
+                if (json.result.containsKey("enableStorageVault") && json.result.enableStorageVault == "true") {
                     enableStorageVault = true;
                 }
                 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1125,8 +1125,9 @@ class Suite implements GroovyInterceptable {
     boolean enableStoragevault() {
         if (context.config.metaServiceHttpAddress == null || context.config.metaServiceHttpAddress.isEmpty() ||
                 context.config.metaServiceHttpAddress == null || context.config.metaServiceHttpAddress.isEmpty() ||
-                    context.config.instanceId == null || context.config.instanceId.isEmpty()) {
-                        return false;
+                    context.config.instanceId == null || context.config.instanceId.isEmpty() ||
+                        context.config.metaServiceToken == null || context.config.metaServiceToken.isEmpty()) {
+            return false;
         }
         def getInstanceInfo = { check_func ->
             httpTest {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1123,10 +1123,15 @@ class Suite implements GroovyInterceptable {
     }
 
     boolean enableStoragevault() {
+        if (context.config.metaServiceHttpAddress == null || context.config.metaServiceHttpAddress.isEmpty() ||
+                context.config.metaServiceHttpAddress == null || context.config.metaServiceHttpAddress.isEmpty() ||
+                    context.config.instanceId == null || context.config.instanceId.isEmpty()) {
+                        return false;
+        }
         def getInstanceInfo = { check_func ->
             httpTest {
                 endpoint context.config.metaServiceHttpAddress
-                uri "/MetaService/http/get_instance?token=${token}&instance_id=${context.config.instanceId}"
+                uri "/MetaService/http/get_instance?token=${context.config.metaServiceToken}&instance_id=${context.config.instanceId}"
                 op "get"
                 check check_func
             }
@@ -1134,7 +1139,10 @@ class Suite implements GroovyInterceptable {
         boolean enableStorageVault = false;
         getInstanceInfo.call() {
             respCode, body ->
-                assertEquals("${respCode}".toString(), "200")
+                String respCodeValue = "${respCode}".toString();
+                if (!respCodeValue.equals("200")) {
+                    return;
+                }
                 def json = parseJson(body)
                 if (json.result.containsKey("enableStorageVault") && json.result.enableStorageVault == "true") {
                     enableStorageVault = true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Formerly i tried to use conf to control if the case of storage vault should be skipped or not. It's proved to be error prone and 
is easy to forget set the correct value. So i use the http action to directly fetch the instance's status to do this check.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

