### PR TITLE
[compile](arm platform) fix compile in arm

### DIFF
--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -5,9 +5,11 @@ index 0cd213f..2514fcd 100644
 @@ -87,6 +87,8 @@ static int initparse(struct krb5int_dns_state *);
  
  #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
+ 
 +#if defined(__x86_64__)
 +__asm__(".symver __res_nsearch,__res_nsearch@GLIBC_2.2.5");
 +#endif
++
  /* Use res_ninit, res_nsearch, and res_ndestroy or res_nclose. */
  #define DECLARE_HANDLE(h) struct __res_state h
  #define INIT_HANDLE(h) (memset(&h, 0, sizeof(h)), res_ninit(&h) == 0)

--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -5,9 +5,10 @@ index 0cd213f..2514fcd 100644
 @@ -87,6 +87,8 @@ static int initparse(struct krb5int_dns_state *);
  
  #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
- 
+
++#if defined(__x86_64__)
 +__asm__(".symver __res_nsearch,__res_nsearch@GLIBC_2.2.5");
-+
++#endif
  /* Use res_ninit, res_nsearch, and res_ndestroy or res_nclose. */
  #define DECLARE_HANDLE(h) struct __res_state h
  #define INIT_HANDLE(h) (memset(&h, 0, sizeof(h)), res_ninit(&h) == 0)

--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -5,7 +5,6 @@ index 0cd213f..2514fcd 100644
 @@ -87,6 +87,8 @@ static int initparse(struct krb5int_dns_state *);
  
  #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
-
 +#if defined(__x86_64__)
 +__asm__(".symver __res_nsearch,__res_nsearch@GLIBC_2.2.5");
 +#endif


### PR DESCRIPTION
## Proposed changes
with #33314 , build thirdparty in arm will reports:
ld.lld: error: undefined symbol: __res_nsearch@GLIBC_2.2.5
referenced by dnsglue.c
dnsglue.o:(krb5int_dns_init) in archive ../../../lib/libkrb5.a

this pr try to fix it

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

