### PR TITLE
[compile](arm platform) fix compile error in arm

### DIFF
--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -1,8 +1,8 @@
 diff --git a/src/lib/krb5/os/dnsglue.c b/src/lib/krb5/os/dnsglue.c
-index 0cd213f..2514fcd 100644
+index 0cd213f..db35532 100644
 --- a/src/lib/krb5/os/dnsglue.c
 +++ b/src/lib/krb5/os/dnsglue.c
-@@ -87,6 +87,8 @@ static int initparse(struct krb5int_dns_state *);
+@@ -87,6 +87,10 @@ static int initparse(struct krb5int_dns_state *);
  
  #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
  

--- a/thirdparty/patches/krb5-1.19.patch
+++ b/thirdparty/patches/krb5-1.19.patch
@@ -6,7 +6,9 @@ index 0cd213f..2514fcd 100644
  
  #elif HAVE_RES_NINIT && HAVE_RES_NSEARCH
  
++#if defined(__x86_64__)
 +__asm__(".symver __res_nsearch,__res_nsearch@GLIBC_2.2.5");
++#endif
 +
  /* Use res_ninit, res_nsearch, and res_ndestroy or res_nclose. */
  #define DECLARE_HANDLE(h) struct __res_state h


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
with #33314 , build thirdparty in arm will reports:
ld.lld: error: undefined symbol: __res_nsearch@GLIBC_2.2.5
referenced by dnsglue.c
dnsglue.o:(krb5int_dns_init) in archive ../../../lib/libkrb5.a

this pr try to fix it

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

