### PR TITLE
[fix](compaction)fix test case to compatible with 3 replicas

### DIFF
--- a/regression-test/suites/compaction/test_time_series_compaction_policy.groovy
+++ b/regression-test/suites/compaction/test_time_series_compaction_policy.groovy
@@ -23,12 +23,6 @@ suite("test_time_series_compaction_polciy", "p0") {
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
 
-    def set_be_config = { key, value ->
-        for (String backend_id: backendId_to_backendIP.keySet()) {
-            def (code, out, err) = update_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), key, value)
-            logger.info("update config: code=" + code + ", out=" + out + ", err=" + err)
-        }
-    }
     def trigger_cumulative_compaction_on_tablets = { tablets ->
         for (def tablet : tablets) {
             String tablet_id = tablet.TabletId
@@ -80,121 +74,91 @@ suite("test_time_series_compaction_polciy", "p0") {
         }
         return rowsetCount
     }
-    def compaction_keep_invisible_version_min_count = 50
-    def compaction_keep_invisible_version_max_count = 500
 
-    try {
-        String backend_id
-        backend_id = backendId_to_backendIP.keySet()[0]
-        def (code, out, err) = show_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id))
-        logger.info("Show config: code=" + code + ", out=" + out + ", err=" + err)
-        assertEquals(code, 0)
-        def configList = parseJson(out.trim())
-        assert configList instanceof List
+    sql """ DROP TABLE IF EXISTS ${tableName}; """
+    sql """
+        CREATE TABLE ${tableName} (
+            `id` int(11) NULL,
+            `name` varchar(255) NULL,
+            `hobbies` text NULL,
+            `score` int(11) NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES ( "replication_num" = "1", "disable_auto_compaction" = "true", "compaction_policy" = "time_series");
+    """
+    // insert 16 lines, BUCKETS = 2
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+    
+    qt_sql_1 """ select count() from ${tableName} """
 
-        for (Object ele in (List) configList) {
-            assert ele instanceof List<String>
-            if (((List<String>) ele)[0] == "compaction_keep_invisible_version_min_count") {
-                compaction_keep_invisible_version_min_count = ((List<String>) ele)[2]
-            } else if (((List<String>) ele)[0] == "compaction_keep_invisible_version_max_count") {
-                compaction_keep_invisible_version_max_count = ((List<String>) ele)[2]
-            }
+    //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
+    def tablets = sql_return_maparray """ show tablets from ${tableName}; """
+
+    int replicaNum = 1
+    def dedup_tablets = deduplicate_tablets(tablets)
+    if (dedup_tablets.size() > 0) {
+        replicaNum = Math.round(tablets.size() / dedup_tablets.size())
+        if (replicaNum != 1 && replicaNum != 3) {
+            assert(false)
         }
-        logger.info("compaction_keep_invisible_version_min_count is: " + compaction_keep_invisible_version_min_count)
-        logger.info("compaction_keep_invisible_version_max_count is: " + compaction_keep_invisible_version_max_count)
-
-        // set_be_config("compaction_keep_invisible_version_min_count", "0");
-        // set_be_config("compaction_keep_invisible_version_max_count", "0");
-
-        sql """ DROP TABLE IF EXISTS ${tableName}; """
-        sql """
-            CREATE TABLE ${tableName} (
-                `id` int(11) NULL,
-                `name` varchar(255) NULL,
-                `hobbies` text NULL,
-                `score` int(11) NULL
-            ) ENGINE=OLAP
-            DUPLICATE KEY(`id`)
-            COMMENT 'OLAP'
-            DISTRIBUTED BY HASH(`id`) BUCKETS 2
-            PROPERTIES ( "replication_num" = "1", "disable_auto_compaction" = "true", "compaction_policy" = "time_series");
-        """
-        // insert 16 lines, BUCKETS = 2
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-        
-        qt_sql_1 """ select count() from ${tableName} """
-
-        //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
-        def tablets = sql_return_maparray """ show tablets from ${tableName}; """
-
-        int replicaNum = 1
-        def dedup_tablets = deduplicate_tablets(tablets)
-        if (dedup_tablets.size() > 0) {
-            replicaNum = Math.round(tablets.size() / dedup_tablets.size())
-            if (replicaNum != 1 && replicaNum != 3) {
-                assert(false)
-            }
-        }
-        
-        // BUCKETS = 2
-        // before cumulative compaction, there are 17 * 2 = 34 rowsets.
-        int rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 34 * replicaNum)
-
-        // trigger cumulative compactions for all tablets in table
-        trigger_cumulative_compaction_on_tablets.call(tablets)
-
-        // wait for cumulative compaction done
-        wait_cumulative_compaction_done.call(tablets)
-
-        // after cumulative compaction, there is only 26 rowset.
-        // 5 consecutive empty versions are merged into one empty version
-        // 34 - 2*4 = 26
-        rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 26 * replicaNum)
-
-        // trigger cumulative compactions for all tablets in ${tableName}
-        trigger_cumulative_compaction_on_tablets.call(tablets)
-
-        // wait for cumulative compaction done
-        wait_cumulative_compaction_done.call(tablets)
-
-        // after cumulative compaction, there is only 22 rowset.
-        // 26 - 4 = 22
-        rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 22 * replicaNum)
-
-        qt_sql_2 """ select count() from ${tableName}"""
-        sql """ alter table ${tableName} set ("time_series_compaction_file_count_threshold"="10")"""
-        sql """sync"""
-        // trigger cumulative compactions for all tablets in ${tableName}
-        trigger_cumulative_compaction_on_tablets.call(tablets)
-
-        // wait for cumulative compaction done
-        wait_cumulative_compaction_done.call(tablets)
-
-        // after cumulative compaction, there is only 11 rowset.
-        rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 11 * replicaNum)
-        qt_sql_3 """ select count() from ${tableName}"""
-    } finally {
-        set_be_config("compaction_keep_invisible_version_min_count", compaction_keep_invisible_version_min_count);
-        set_be_config("compaction_keep_invisible_version_max_count", compaction_keep_invisible_version_max_count);
     }
     
+    // BUCKETS = 2
+    // before cumulative compaction, there are 17 * 2 = 34 rowsets.
+    int rowsetCount = get_rowset_count.call(tablets);
+    assert (rowsetCount == 34 * replicaNum)
+
+    // trigger cumulative compactions for all tablets in table
+    trigger_cumulative_compaction_on_tablets.call(tablets)
+
+    // wait for cumulative compaction done
+    wait_cumulative_compaction_done.call(tablets)
+
+    // after cumulative compaction, there is only 26 rowset.
+    // 5 consecutive empty versions are merged into one empty version
+    // 34 - 2*4 = 26
+    rowsetCount = get_rowset_count.call(tablets);
+    assert (rowsetCount == 26 * replicaNum)
+
+    // trigger cumulative compactions for all tablets in ${tableName}
+    trigger_cumulative_compaction_on_tablets.call(tablets)
+
+    // wait for cumulative compaction done
+    wait_cumulative_compaction_done.call(tablets)
+
+    // after cumulative compaction, there is only 22 rowset.
+    // 26 - 4 = 22
+    rowsetCount = get_rowset_count.call(tablets);
+    assert (rowsetCount == 22 * replicaNum)
+
+    qt_sql_2 """ select count() from ${tableName}"""
+    sql """ alter table ${tableName} set ("time_series_compaction_file_count_threshold"="10")"""
+    sql """sync"""
+    // trigger cumulative compactions for all tablets in ${tableName}
+    trigger_cumulative_compaction_on_tablets.call(tablets)
+
+    // wait for cumulative compaction done
+    wait_cumulative_compaction_done.call(tablets)
+
+    // after cumulative compaction, there is only 11 rowset.
+    rowsetCount = get_rowset_count.call(tablets);
+    assert (rowsetCount == 11 * replicaNum)
+    qt_sql_3 """ select count() from ${tableName}"""
 }

--- a/regression-test/suites/compaction/test_time_series_compaction_policy.groovy
+++ b/regression-test/suites/compaction/test_time_series_compaction_policy.groovy
@@ -23,6 +23,12 @@ suite("test_time_series_compaction_polciy", "p0") {
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
 
+    def set_be_config = { key, value ->
+        for (String backend_id: backendId_to_backendIP.keySet()) {
+            def (code, out, err) = update_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), key, value)
+            logger.info("update config: code=" + code + ", out=" + out + ", err=" + err)
+        }
+    }
     def trigger_cumulative_compaction_on_tablets = { tablets ->
         for (def tablet : tablets) {
             String tablet_id = tablet.TabletId
@@ -74,88 +80,121 @@ suite("test_time_series_compaction_polciy", "p0") {
         }
         return rowsetCount
     }
+    def compaction_keep_invisible_version_min_count = 50
+    def compaction_keep_invisible_version_max_count = 500
 
-    // String backend_id;
-    // backend_id = backendId_to_backendIP.keySet()[0]
-    // def (code, out, err) = show_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id))
+    try {
+        String backend_id
+        backend_id = backendId_to_backendIP.keySet()[0]
+        def (code, out, err) = show_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id))
+        logger.info("Show config: code=" + code + ", out=" + out + ", err=" + err)
+        assertEquals(code, 0)
+        def configList = parseJson(out.trim())
+        assert configList instanceof List
+
+        for (Object ele in (List) configList) {
+            assert ele instanceof List<String>
+            if (((List<String>) ele)[0] == "compaction_keep_invisible_version_min_count") {
+                compaction_keep_invisible_version_min_count = ((List<String>) ele)[2]
+            } else if (((List<String>) ele)[0] == "compaction_keep_invisible_version_max_count") {
+                compaction_keep_invisible_version_max_count = ((List<String>) ele)[2]
+            }
+        }
+        logger.info("compaction_keep_invisible_version_min_count is: " + compaction_keep_invisible_version_min_count)
+        logger.info("compaction_keep_invisible_version_max_count is: " + compaction_keep_invisible_version_max_count)
+
+        // set_be_config("compaction_keep_invisible_version_min_count", "0");
+        // set_be_config("compaction_keep_invisible_version_max_count", "0");
+
+        sql """ DROP TABLE IF EXISTS ${tableName}; """
+        sql """
+            CREATE TABLE ${tableName} (
+                `id` int(11) NULL,
+                `name` varchar(255) NULL,
+                `hobbies` text NULL,
+                `score` int(11) NULL
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`id`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`id`) BUCKETS 2
+            PROPERTIES ( "replication_num" = "1", "disable_auto_compaction" = "true", "compaction_policy" = "time_series");
+        """
+        // insert 16 lines, BUCKETS = 2
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
+        
+        qt_sql_1 """ select count() from ${tableName} """
+
+        //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
+        def tablets = sql_return_maparray """ show tablets from ${tableName}; """
+
+        int replicaNum = 1
+        def dedup_tablets = deduplicate_tablets(tablets)
+        if (dedup_tablets.size() > 0) {
+            replicaNum = Math.round(tablets.size() / dedup_tablets.size())
+            if (replicaNum != 1 && replicaNum != 3) {
+                assert(false)
+            }
+        }
+        
+        // BUCKETS = 2
+        // before cumulative compaction, there are 17 * 2 = 34 rowsets.
+        int rowsetCount = get_rowset_count.call(tablets);
+        assert (rowsetCount == 34 * replicaNum)
+
+        // trigger cumulative compactions for all tablets in table
+        trigger_cumulative_compaction_on_tablets.call(tablets)
+
+        // wait for cumulative compaction done
+        wait_cumulative_compaction_done.call(tablets)
+
+        // after cumulative compaction, there is only 26 rowset.
+        // 5 consecutive empty versions are merged into one empty version
+        // 34 - 2*4 = 26
+        rowsetCount = get_rowset_count.call(tablets);
+        assert (rowsetCount == 26 * replicaNum)
+
+        // trigger cumulative compactions for all tablets in ${tableName}
+        trigger_cumulative_compaction_on_tablets.call(tablets)
+
+        // wait for cumulative compaction done
+        wait_cumulative_compaction_done.call(tablets)
+
+        // after cumulative compaction, there is only 22 rowset.
+        // 26 - 4 = 22
+        rowsetCount = get_rowset_count.call(tablets);
+        assert (rowsetCount == 22 * replicaNum)
+
+        qt_sql_2 """ select count() from ${tableName}"""
+        sql """ alter table ${tableName} set ("time_series_compaction_file_count_threshold"="10")"""
+        sql """sync"""
+        // trigger cumulative compactions for all tablets in ${tableName}
+        trigger_cumulative_compaction_on_tablets.call(tablets)
+
+        // wait for cumulative compaction done
+        wait_cumulative_compaction_done.call(tablets)
+
+        // after cumulative compaction, there is only 11 rowset.
+        rowsetCount = get_rowset_count.call(tablets);
+        assert (rowsetCount == 11 * replicaNum)
+        qt_sql_3 """ select count() from ${tableName}"""
+    } finally {
+        set_be_config("compaction_keep_invisible_version_min_count", compaction_keep_invisible_version_min_count);
+        set_be_config("compaction_keep_invisible_version_max_count", compaction_keep_invisible_version_max_count);
+    }
     
-    // logger.info("Show config: code=" + code + ", out=" + out + ", err=" + err)
-    // assertEquals(code, 0)
-
-    sql """ DROP TABLE IF EXISTS ${tableName}; """
-    sql """
-        CREATE TABLE ${tableName} (
-            `id` int(11) NULL,
-            `name` varchar(255) NULL,
-            `hobbies` text NULL,
-            `score` int(11) NULL
-        ) ENGINE=OLAP
-        DUPLICATE KEY(`id`)
-        COMMENT 'OLAP'
-        DISTRIBUTED BY HASH(`id`) BUCKETS 2
-        PROPERTIES ( "replication_num" = "1", "disable_auto_compaction" = "true", "compaction_policy" = "time_series");
-    """
-    // insert 16 lines, BUCKETS = 2
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-    sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-    sql """ INSERT INTO ${tableName} VALUES (100, "andy", "andy love apple", 100); """
-    
-    qt_sql_1 """ select count() from ${tableName} """
-
-    //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
-    def tablets = sql_return_maparray """ show tablets from ${tableName}; """
-    // BUCKETS = 2
-    // before cumulative compaction, there are 17 * 2 = 34 rowsets.
-    int rowsetCount = get_rowset_count.call(tablets);
-    assert (rowsetCount == 34)
-
-    // trigger cumulative compactions for all tablets in table
-    trigger_cumulative_compaction_on_tablets.call(tablets)
-
-    // wait for cumulative compaction done
-    wait_cumulative_compaction_done.call(tablets)
-
-    // after cumulative compaction, there is only 26 rowset.
-    // 5 consecutive empty versions are merged into one empty version
-    // 34 - 2*4 = 26
-    rowsetCount = get_rowset_count.call(tablets);
-    assert (rowsetCount == 26)
-
-    // trigger cumulative compactions for all tablets in ${tableName}
-    trigger_cumulative_compaction_on_tablets.call(tablets)
-
-    // wait for cumulative compaction done
-    wait_cumulative_compaction_done.call(tablets)
-
-    // after cumulative compaction, there is only 22 rowset.
-    // 26 - 4 = 22
-    rowsetCount = get_rowset_count.call(tablets);
-    assert (rowsetCount == 22)
-
-    qt_sql_2 """ select count() from ${tableName}"""
-    sql """ alter table ${tableName} set ("time_series_compaction_file_count_threshold"="10")"""
-    sql """sync"""
-    // trigger cumulative compactions for all tablets in ${tableName}
-    trigger_cumulative_compaction_on_tablets.call(tablets)
-
-    // wait for cumulative compaction done
-    wait_cumulative_compaction_done.call(tablets)
-
-    // after cumulative compaction, there is only 11 rowset.
-    rowsetCount = get_rowset_count.call(tablets);
-    assert (rowsetCount == 11)
-    qt_sql_3 """ select count() from ${tableName}"""
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Although the table was created with 1 replica, some tests set force_olap_table_replication_num=3.
Test cases must accommodate this situation.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

