### PR TITLE
[improvement](hive)add the `queryid` to the temporary file path

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -1243,8 +1243,8 @@ public class HMSTransaction implements Transaction {
 
             if (!targetPath.equals(writePath)) {
                 Path path = new Path(targetPath);
-                String oldPartitionPath = new Path(path.getParent(),
-                        "_temp_" + queryId + "_" + path.getName()).toString();
+                String oldPartitionPath = new Path(
+                        path.getParent(), "_temp_" + queryId + "_" + path.getName()).toString();
                 Status status = wrapperRenameDirWithProfileSummary(
                         targetPath,
                         oldPartitionPath,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -1109,7 +1109,8 @@ public class HMSTransaction implements Transaction {
             String writePath = tableAndMore.getCurrentLocation();
             if (!targetPath.equals(writePath)) {
                 Path path = new Path(targetPath);
-                String oldTablePath = new Path(path.getParent(), "_temp_" + path.getName()).toString();
+                String oldTablePath = new Path(
+                        path.getParent(), "_temp_" + queryId + "_" + path.getName()).toString();
                 Status status = wrapperRenameDirWithProfileSummary(
                         targetPath,
                         oldTablePath,
@@ -1242,7 +1243,8 @@ public class HMSTransaction implements Transaction {
 
             if (!targetPath.equals(writePath)) {
                 Path path = new Path(targetPath);
-                String oldPartitionPath = new Path(path.getParent(), "_temp_" + path.getName()).toString();
+                String oldPartitionPath = new Path(path.getParent(),
+                        "_temp_" + queryId + "_" + path.getName()).toString();
                 Status status = wrapperRenameDirWithProfileSummary(
                         targetPath,
                         oldPartitionPath,


### PR DESCRIPTION
## Proposed changes

`_temp_<table_name>` to `_temp_<queryid>_<table_name>`.
Prevent users from having a table with the name `_temp_<table_name>`.

So as to partition temp dir

Issue #31442

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

