### PR TITLE
[chore](InjectPoint) Log when entering injection point

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -131,7 +131,7 @@ bvar::LatencyRecorder g_cloud_commit_txn_resp_redirect_latency("cloud_table_stat
 class MetaServiceProxy {
 public:
     static Status get_client(std::shared_ptr<MetaService_Stub>* stub) {
-        SYNC_POINT_RETURN_WITH_VALUE("MetaServiceProxy::get_client", Status::OK(), stub);
+        TEST_SYNC_POINT_RETURN_WITH_VALUE("MetaServiceProxy::get_client", Status::OK(), stub);
         return get_pooled_client(stub);
     }
 

--- a/be/src/common/sync_point.h
+++ b/be/src/common/sync_point.h
@@ -228,12 +228,12 @@ auto try_any_cast_ret(std::vector<std::any>& any) {
 namespace doris::config {
 extern bool enable_injection_point;
 }
-# define TEST_INJECTION_POINT(x) if (doris::config::enable_injection_point) { SYNC_POINT(x); }
-# define TEST_IDX_INJECTION_POINT(x, index) if (doris::config::enable_injection_point) { IDX_SYNC_POINT(x, index); }
-# define TEST_INJECTION_POINT_CALLBACK(x, ...) if (doris::config::enable_injection_point) { SYNC_POINT_CALLBACK(x, __VA_ARGS__); }
-# define TEST_INJECTION_POINT_SINGLETON() if (doris::config::enable_injection_point) { SYNC_POINT_SINGLETON(); }
-# define TEST_INJECTION_POINT_RETURN_WITH_VALUE(x, default_ret_val, ...) if (doris::config::enable_injection_point) { SYNC_POINT_RETURN_WITH_VALUE(x, default_ret_val, __VA_ARGS__); }
-# define TEST_INJECTION_POINT_RETURN_WITH_VOID(x, ...) if (doris::config::enable_injection_point) { SYNC_POINT_RETURN_WITH_VOID(x, __VA_ARGS__); }
+# define TEST_INJECTION_POINT(x) if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); SYNC_POINT(x); }
+# define TEST_IDX_INJECTION_POINT(x, index) if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); IDX_SYNC_POINT(x, index); }
+# define TEST_INJECTION_POINT_CALLBACK(x, ...) if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); SYNC_POINT_CALLBACK(x, __VA_ARGS__); }
+# define TEST_INJECTION_POINT_SINGLETON() if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); SYNC_POINT_SINGLETON(); }
+# define TEST_INJECTION_POINT_RETURN_WITH_VALUE(x, default_ret_val, ...) if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); SYNC_POINT_RETURN_WITH_VALUE(x, default_ret_val, __VA_ARGS__); }
+# define TEST_INJECTION_POINT_RETURN_WITH_VOID(x, ...) if (doris::config::enable_injection_point) { LOG_INFO("enter inject point {}", x); SYNC_POINT_RETURN_WITH_VOID(x, __VA_ARGS__); }
 #endif // ENABLE_INJECTION_POINT
 
 // clang-format on

--- a/be/src/http/action/config_action.cpp
+++ b/be/src/http/action/config_action.cpp
@@ -62,7 +62,7 @@ void ConfigAction::handle_show_config(HttpRequest* req) {
 
     writer.StartArray();
     for (const auto& _config : config_info) {
-        if (conf_item != nullptr || conf_item != "") {
+        if (conf_item != nullptr || !conf_item.empty()) {
             if (_config[0] == conf_item) {
                 writer.StartArray();
                 for (const std::string& config_filed : _config) {

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -185,11 +185,11 @@ Status HdfsFileWriter::append_hdfs_file(std::string_view content) {
             written_bytes =
                     hdfsWrite(_hdfs_handler->hdfs_fs, _hdfs_file, content.data(), content.size());
             {
-                [[maybe_unused]] Status error_ret = Status::InternalError(
-                        "write hdfs failed. fs_name: {}, path: {}, error: size exceeds", _fs_name,
-                        _path.native());
-                TEST_INJECTION_POINT_RETURN_WITH_VALUE("HdfsFileWriter::append_hdfs_file_error",
-                                                       error_ret);
+                TEST_INJECTION_POINT_RETURN_WITH_VALUE(
+                        "HdfsFileWriter::append_hdfs_file_error",
+                        Status::InternalError(
+                                "write hdfs failed. fs_name: {}, path: {}, error: inject error",
+                                _fs_name, _path.native()));
             }
         }
         if (written_bytes < 0) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Previously, there were two ways to trigger the inject points: triggered via HTTP and triggered by opening the inject point configuration in BE. The former could print out the information of the injected points, while the latter did not have any information, making it inconvenient for debugging. Therefore, this PR added some necessary logs to the latter.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

