### PR TITLE
[fix](mtmv)use isManagedTable instead of check table type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -841,7 +841,7 @@ public class Analyzer {
                 .getDbOrAnalysisException(tableName.getDb());
         TableIf table = database.getTableOrAnalysisException(tableName.getTbl());
 
-        if (table.getType() == TableType.OLAP && (((OlapTable) table).getState() == OlapTableState.RESTORE
+        if (table.isManagedTable() && (((OlapTable) table).getState() == OlapTableState.RESTORE
                 || ((OlapTable) table).getState() == OlapTableState.RESTORE_WITH_LOAD)) {
             Boolean isNotRestoring = ((OlapTable) table).getPartitions().stream()
                     .filter(partition -> partition.getState() == PartitionState.RESTORE).collect(Collectors.toList())

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -30,7 +30,6 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.AnalysisException;
@@ -1086,7 +1085,7 @@ public class SelectStmt extends QueryStmt {
                 break;
             }
             long rowCount = 0;
-            if (tblRef.getTable().getType() == TableType.OLAP) {
+            if (tblRef.getTable().isManagedTable()) {
                 rowCount = ((OlapTable) (tblRef.getTable())).getRowCount();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("tableName={} rowCount={}", tblRef.getAlias(), rowCount);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -808,7 +808,7 @@ public class RestoreJob extends AbstractJob {
 
             // generate create replica task for all restored tables
             for (Table restoreTbl : restoredTbls) {
-                if (restoreTbl.getType() == TableType.OLAP) {
+                if (restoreTbl.isManagedTable()) {
                     OlapTable restoreOlapTable = (OlapTable) restoreTbl;
                     for (Partition restorePart : restoreOlapTable.getPartitions()) {
                         createReplicas(db, batchTask, restoreOlapTable, restorePart);
@@ -1941,7 +1941,7 @@ public class RestoreJob extends AbstractJob {
                 LOG.info("remove restored table when cancelled: {}", restoreTbl.getName());
                 if (db.writeLockIfExist()) {
                     try {
-                        if (restoreTbl.getType() == TableType.OLAP) {
+                        if (restoreTbl.isManagedTable()) {
                             OlapTable restoreOlapTable = (OlapTable) restoreTbl;
                             restoreOlapTable.writeLock();
                             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -808,7 +808,7 @@ public class RestoreJob extends AbstractJob {
 
             // generate create replica task for all restored tables
             for (Table restoreTbl : restoredTbls) {
-                if (restoreTbl.isManagedTable()) {
+                if (restoreTbl.getType() == TableType.OLAP) {
                     OlapTable restoreOlapTable = (OlapTable) restoreTbl;
                     for (Partition restorePart : restoreOlapTable.getPartitions()) {
                         createReplicas(db, batchTask, restoreOlapTable, restorePart);
@@ -1941,7 +1941,7 @@ public class RestoreJob extends AbstractJob {
                 LOG.info("remove restored table when cancelled: {}", restoreTbl.getName());
                 if (db.writeLockIfExist()) {
                     try {
-                        if (restoreTbl.isManagedTable()) {
+                        if (restoreTbl.getType() == TableType.OLAP) {
                             OlapTable restoreOlapTable = (OlapTable) restoreTbl;
                             restoreOlapTable.writeLock();
                             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -112,7 +112,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     }
 
     private void addRecycledTabletsForTable(Set<Long> recycledTabletSet, Table table) {
-        if (table.getType() == TableType.OLAP) {
+        if (table.isManagedTable()) {
             OlapTable olapTable = (OlapTable) table;
             Collection<Partition> allPartitions = olapTable.getAllPartitions();
             for (Partition partition : allPartitions) {
@@ -321,7 +321,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
 
             Table table = tableInfo.getTable();
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
             }
             iterator.remove();
@@ -352,7 +352,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 long tableId = table.getId();
 
                 if (isExpire(tableId, currentTimeMs)) {
-                    if (table.getType() == TableType.OLAP || table.getType() == TableType.MATERIALIZED_VIEW) {
+                    if (table.isManagedTable()) {
                         Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
                     }
 
@@ -434,7 +434,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 continue;
             }
             Table table = tableInfo.getTable();
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
             }
 
@@ -455,7 +455,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             return;
         }
         Table table = tableInfo.getTable();
-        if (table.getType() == TableType.OLAP) {
+        if (table.isManagedTable()) {
             Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, true);
         }
         LOG.info("replay erase table[{}]", tableId);
@@ -732,7 +732,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                         throw new DdlException("Table name[" + newTableName + "] is already used");
                     }
 
-                    if (table.getType() == TableType.OLAP) {
+                    if (table.isManagedTable()) {
                         // olap table should also check if any rollup has same name as "newTableName"
                         ((OlapTable) table).checkAndSetName(newTableName, false);
                     } else {
@@ -756,7 +756,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 Env.getCurrentEnv().getEditLog().logRecoverTable(recoverInfo);
             }
             // Only olap table need recover dynamic partition, other table like jdbc odbc view.. do not need it
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 DynamicPartitionUtil.registerOrRemoveDynamicPartitionTable(db.getId(), (OlapTable) table, isReplay);
             }
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -696,8 +696,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
 
         if (table.getType() == TableType.MATERIALIZED_VIEW) {
-            throw new DdlException("Can not recover materialized view '" + tableName + "' or table id '" + tableId + "' in "
-                    + db.getFullName());
+            throw new DdlException("Can not recover materialized view '" + tableName + "' or table id '"
+                    + tableId + "' in " + db.getFullName());
         }
 
         innerRecoverTable(db, table, tableName, newTableName, null, false);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -641,14 +641,17 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
             RecycleTableInfo tableInfo = entry.getValue();
             if (tableInfo.getDbId() != dbId || !tableNames.contains(tableInfo.getTable().getName())
-                    || !tableIds.contains(tableInfo.getTable().getId())
-                    || tableInfo.getTable().getType() == TableType.MATERIALIZED_VIEW) {
+                    || !tableIds.contains(tableInfo.getTable().getId())) {
                 continue;
             }
 
             Table table = tableInfo.getTable();
-            db.registerTable(table);
-            LOG.info("recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
+            if (table.getType() == TableType.OLAP) {
+                db.registerTable(table);
+                LOG.info("recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
+            } else {
+                LOG.info("ignore recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
+            }
             iterator.remove();
             idToRecycleTime.remove(table.getId());
             tableNames.remove(table.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -913,7 +913,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         // idToTable
         for (RecycleTableInfo tableInfo : idToTable.values()) {
             Table table = tableInfo.getTable();
-            if (table.getType() != TableType.OLAP) {
+            if (!table.isManagedTable()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -296,7 +296,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         }
 
         for (Table table : tables) {
-            if (table.getType() != TableType.OLAP) {
+            if (!table.isManagedTable()) {
                 continue;
             }
 
@@ -317,7 +317,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         try {
             long usedReplicaCount = 0;
             for (Table table : this.idToTable.values()) {
-                if (table.getType() != TableType.OLAP) {
+                if (!table.isManagedTable()) {
                     continue;
                 }
 
@@ -562,7 +562,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         readLock();
         try {
             for (Table table : idToTable.values()) {
-                if (table.getType() != TableType.OLAP) {
+                if (!table.isManagedTable()) {
                     continue;
                 }
                 OlapTable olapTable = (OlapTable) table;
@@ -888,7 +888,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
             if (newBinlogConfig.isEnable() && !oldBinlogConfig.isEnable()) {
                 // check all tables binlog enable is true
                 for (Table table : idToTable.values()) {
-                    if (table.getType() != TableType.OLAP) {
+                    if (!table.isManagedTable()) {
                         continue;
                     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3927,7 +3927,7 @@ public class Env {
             }
             List<Table> tableList = db.getTables();
             for (Table table : tableList) {
-                if (table.getType() != TableType.OLAP) {
+                if (!table.isManagedTable()) {
                     continue;
                 }
 
@@ -6010,7 +6010,7 @@ public class Env {
         }
 
         for (Table table : tables) {
-            if (table.getType() != TableType.OLAP) {
+            if (!table.isManagedTable()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3240,7 +3240,7 @@ public class Env {
             }
             // There MUST BE 2 space in front of each column description line
             // sqlalchemy requires this to parse SHOW CREATE TABLE stmt.
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 sb.append("  ").append(
                         column.toSql(((OlapTable) table).getKeysType() == KeysType.UNIQUE_KEYS, true));
             } else {
@@ -4425,7 +4425,7 @@ public class Env {
                     throw new DdlException("Table name[" + newTableName + "] is already used");
                 }
 
-                if (table.getType() == TableType.OLAP) {
+                if (table.isManagedTable()) {
                     // olap table should also check if any rollup has same name as "newTableName"
                     ((OlapTable) table).checkAndSetName(newTableName, false);
                 } else {
@@ -5495,7 +5495,7 @@ public class Env {
         List<ReplicaPersistInfo> replicaPersistInfos = backendTabletsInfo.getReplicaPersistInfos();
         for (ReplicaPersistInfo info : replicaPersistInfos) {
             OlapTable olapTable = (OlapTable) getInternalCatalog().getDb(info.getDbId())
-                    .flatMap(db -> db.getTable(info.getTableId())).filter(t -> t.getType() == TableType.OLAP)
+                    .flatMap(db -> db.getTable(info.getTableId())).filter(t -> t.isManagedTable())
                     .orElse(null);
             if (olapTable == null) {
                 continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
@@ -349,7 +348,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             }
             // 3. update CloudPartition
             OlapTable olapTable = (OlapTable) env.getInternalCatalog().getDb(dbId)
-                    .flatMap(db -> db.getTable(tableId)).filter(t -> t.getType() == TableType.OLAP)
+                    .flatMap(db -> db.getTable(tableId)).filter(t -> t.isManagedTable())
                     .orElse(null);
             if (olapTable == null) {
                 continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexInfoProcDir.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.qe.SessionVariable;
 
@@ -60,7 +59,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
         result.setNames(TITLE_NAMES);
         table.readLock();
         try {
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 OlapTable olapTable = (OlapTable) table;
 
                 // indices order
@@ -122,7 +121,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
         try {
             List<Column> schema = null;
             Set<String> bfColumns = null;
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 OlapTable olapTable = (OlapTable) table;
                 schema = olapTable.getSchemaByIndexId(idxId);
                 if (schema == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/RemoteIndexSchemaProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/RemoteIndexSchemaProcDir.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.FetchRemoteTabletSchemaUtil;
@@ -88,7 +87,7 @@ public class RemoteIndexSchemaProcDir implements ProcDirInterface {
         List<Partition> partitions = Lists.newArrayList();
         table.readLock();
         try {
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 OlapTable olapTable = (OlapTable) table;
                 for (String partitionName : partitionNameList) {
                     Partition partition = olapTable.getPartition(partitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 
@@ -90,7 +89,7 @@ public class StatisticProcNode implements ProcNodeInterface {
 
             this.db.getTables().stream().filter(Objects::nonNull).forEach(t -> {
                 ++tableNum;
-                if (t.getType() == TableType.OLAP) {
+                if (t.isManagedTable()) {
                     OlapTable olapTable = (OlapTable) t;
                     olapTable.readLock();
                     try {

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/ConsistencyChecker.java
@@ -25,7 +25,6 @@ import org.apache.doris.catalog.MetaObject;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
@@ -268,7 +267,7 @@ public class ConsistencyChecker extends MasterDaemon {
                 // sort tables
                 Queue<MetaObject> tableQueue = new PriorityQueue<>(Math.max(tables.size(), 1), COMPARATOR);
                 for (Table table : tables) {
-                    if (table.getType() != TableType.OLAP) {
+                    if (!table.isManagedTable()) {
                         continue;
                     }
                     tableQueue.add(table);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -965,7 +965,8 @@ public class InternalCatalog implements CatalogIf<Database> {
             // drop all temp partitions of this table, so that there is no temp partitions in recycle bin,
             // which make things easier.
             ((OlapTable) table).dropAllTempPartitions();
-        } else if (table.getType() == TableType.MATERIALIZED_VIEW) {
+        }
+        if (table.getType() == TableType.MATERIALIZED_VIEW) {
             Env.getCurrentEnv().getMtmvService().deregisterMTMV((MTMV) table);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -961,7 +961,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             long recycleTime) {
         if (table.getType() == TableType.ELASTICSEARCH) {
             esRepository.deRegisterTable(table.getId());
-        } else if (table.getType() == TableType.OLAP) {
+        } else if (table.isManagedTable()) {
             // drop all temp partitions of this table, so that there is no temp partitions in recycle bin,
             // which make things easier.
             ((OlapTable) table).dropAllTempPartitions();
@@ -1208,7 +1208,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             List<String> createTableStmt = Lists.newArrayList();
             table.readLock();
             try {
-                if (table.getType() == TableType.OLAP) {
+                if (table.isManagedTable()) {
                     if (!CollectionUtils.isEmpty(stmt.getRollupNames())) {
                         OlapTable olapTable = (OlapTable) table;
                         for (String rollupIndexName : stmt.getRollupNames()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1400,7 +1400,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         try {
             Table table = db.getTableOrDdlException(tableName);
 
-            if (table.getType() != TableType.OLAP && table.getType() != TableType.MATERIALIZED_VIEW) {
+            if (!table.isManagedTable()) {
                 throw new DdlException("Only support create partition from a OLAP table");
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -307,7 +307,7 @@ public class ShowAction extends RestBaseController {
             // sort by table name
             List<Table> tables = db.getTables();
             for (Table table : tables) {
-                if (table.getType() != TableType.OLAP) {
+                if (!table.isManagedTable()) {
                     continue;
                 }
                 table.readLock();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -352,7 +352,7 @@ public class ShowAction extends RestBaseController {
         Map<String, Long> oneEntry = Maps.newHashMap();
         if (table.getType() == TableType.VIEW || table.getType() == TableType.ODBC) {
             oneEntry.put(table.getName(), 0L);
-        } else if (table.getType() == TableType.OLAP) {
+        } else if (table.isManagedTable()) {
             table.readLock();
             try {
                 long tableSize = ((OlapTable) table).getDataSize(singleReplica);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/StorageTypeCheckAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/StorageTypeCheckAction.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -64,7 +63,7 @@ public class StorageTypeCheckAction extends RestBaseController {
         Map<String, Map<String, String>> result = Maps.newHashMap();
         List<Table> tbls = db.getTables();
         for (Table tbl : tbls) {
-            if (tbl.getType() != TableType.OLAP) {
+            if (!tbl.isManagedTable()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -270,7 +270,7 @@ public class ExportJob implements Writable {
                 if (exportTable.getType() == TableType.VIEW) {
                     // view table
                     generateViewOrExternalTableOutfile(qualifiedTableName);
-                } else if (exportTable.getType() == TableType.OLAP) {
+                } else if (exportTable.isManagedTable()) {
                     // olap table
                     generateOlapTableOutfile(qualifiedTableName);
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.load.ExportFailMsg.CancelType;
@@ -90,7 +89,7 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
                 throw new JobException("Export executor has been canceled, task id: {}", taskId);
             }
             // check the version of tablets, skip if the consistency is in partition level.
-            if (exportJob.getExportTable().getType() == TableType.OLAP && !exportJob.isPartitionConsistency()) {
+            if (exportJob.getExportTable().isManagedTable() && !exportJob.isPartitionConsistency()) {
                 try {
                     Database db = Env.getCurrentEnv().getInternalCatalog().getDbOrAnalysisException(
                             exportJob.getTableName().getDb());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropMTMVInfo.java
@@ -69,7 +69,7 @@ public class DropMTMVInfo {
      */
     public DropTableStmt translateToLegacyStmt() {
         TableName tableName = mvName.transferToTableName();
-        DropTableStmt dropTableStmt = new DropTableStmt(ifExists, tableName, false);
+        DropTableStmt dropTableStmt = new DropTableStmt(ifExists, tableName, true);
         dropTableStmt.setMaterializedView(true);
         return dropTableStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/query/IndexStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/query/IndexStats.java
@@ -20,7 +20,6 @@ package org.apache.doris.statistics.query;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.util.Util;
 
 import com.google.common.collect.ImmutableMap;
@@ -138,7 +137,7 @@ public class IndexStats {
      */
     public Map<String, Map> getStats(boolean summary) {
         List<Column> indexColumns;
-        if (table.getType() == TableType.OLAP) {
+        if (table.isManagedTable()) {
             OlapTable olapTable = (OlapTable) table;
             indexColumns = olapTable.getSchemaByIndexId(indexId);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/query/TableStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/query/TableStats.java
@@ -20,7 +20,6 @@ package org.apache.doris.statistics.query;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.collect.ImmutableMap;
@@ -126,7 +125,7 @@ public class TableStats {
         Map<String, Map> stat = new HashMap<>();
         stat.put("summary", ImmutableMap.of("query", getQueryStats()));
         Map<String, Map> dstat = new HashMap<>();
-        if (table.getType() == TableType.OLAP) {
+        if (table.isManagedTable()) {
             OlapTable olapTable = (OlapTable) table;
             for (Map.Entry<String, Long> entry : olapTable.getIndexNameToId().entrySet()) {
                 if (indexStats.containsKey(entry.getValue())) {

--- a/regression-test/suites/mtmv_p0/test_recover_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_recover_mtmv.groovy
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Assert;
+
+suite("test_recover_mtmv") {
+    def tableName = "t_test_recover_mtmv_user"
+    def mvName = "test_recover_mtmv"
+    def dbName = "regression_test_mtmv_p0"
+    def dbName1 = "test_recover_mtmv_db";
+    sql """drop table if exists `${tableName}`"""
+    sql """drop database if exists `${dbName1}`"""
+    sql """
+        CREATE TABLE IF NOT EXISTS `${tableName}` (
+            event_day DATE,
+            id BIGINT,
+            username VARCHAR(20)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 10 
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH COMPLETE ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS 
+        SELECT * FROM ${tableName};
+    """
+
+    // test recover partition of MTMV
+    try {
+        sql """
+            RECOVER PARTITION p1 FROM ${mvName};
+        """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // test recover mv
+     sql """
+            DROP MATERIALIZED VIEW ${mvName}
+        """
+    try {
+        sql """
+            recover table ${mvName};
+        """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    sql """create database `${dbName1}`"""
+
+    sql """
+        CREATE MATERIALIZED VIEW ${dbName1}.${mvName}
+        BUILD DEFERRED REFRESH COMPLETE ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS
+        SELECT * FROM ${tableName};
+    """
+
+    sql """drop database if exists `${dbName1}`"""
+
+    sql """recover database ${dbName1};"""
+
+    def result =  sql """show tables from ${dbName1};"""
+    log.info(result)
+    assertEquals(0, result.size())
+
+    sql """drop database if exists `${dbName1}`"""
+    sql """drop table if exists `${tableName}`"""
+}

--- a/regression-test/suites/mtmv_p0/test_recover_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_recover_mtmv.groovy
@@ -85,7 +85,7 @@ suite("test_recover_mtmv") {
     sql """recover database ${dbName1};"""
 
     def result =  sql """show tables from ${dbName1};"""
-    log.info(result)
+    log.info(result.toString())
     assertEquals(0, result.size())
 
     sql """drop database if exists `${dbName1}`"""


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The TableType of olap table is `OLAP`, and the TableType of materialized view is `MATERIALIZED_VIEW`. Many functions of olap are required for materialized views, but many previous functions filtered out materialized views by determining whether the TableType is `OLAP` and need to be changed to using `TableIf.isManagedTable()` to determine

not allow recycle mv
not allow recycle partition in mv
will ignore mv when recycle db

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

