### PR TITLE
[fix](Nereids) rewritten mv should check output set and should not return null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -203,9 +203,8 @@ public class MaterializedViewUtils {
             CascadesContext cascadesContext,
             Function<CascadesContext, Plan> planRewriter,
             Plan rewrittenPlan, Plan originPlan) {
-        List<Slot> originOutputs = originPlan.getOutput();
-        if (originOutputs.size() != rewrittenPlan.getOutput().size()) {
-            return null;
+        if (originPlan.getOutputSet().size() != rewrittenPlan.getOutputSet().size()) {
+            return rewrittenPlan;
         }
         // After RBO, slot order may change, so need originSlotToRewrittenExprId which record
         // origin plan slot order


### PR DESCRIPTION
1. we should check output set, since we will remove top project and result output size will diff with its child output size if there are dup slot in result list
2. should not return null, instead we should return rewritten plan itself, because we will use return result in many place and do not check null at all
