### PR TITLE
[bug](regexp) fix regexp function fallback to re2 failed

### DIFF
--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -296,12 +296,9 @@ Status FunctionLikeBase::hs_prepare(FunctionContext* context, const char* expres
 
     if (res != HS_SUCCESS) {
         *database = nullptr;
-        if (context) {
-            context->set_error("hs_compile regex pattern error");
-        }
+        hs_free_compile_error(compile_err);
         return Status::RuntimeError("hs_compile regex pattern error:" +
                                     std::string(compile_err->message));
-        hs_free_compile_error(compile_err);
     }
     hs_free_compile_error(compile_err);
 
@@ -309,9 +306,6 @@ Status FunctionLikeBase::hs_prepare(FunctionContext* context, const char* expres
         hs_free_database(*database);
         *database = nullptr;
         *scratch = nullptr;
-        if (context) {
-            context->set_error("hs_alloc_scratch allocate scratch space error");
-        }
         return Status::RuntimeError("hs_alloc_scratch allocate scratch space error");
     }
 

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -296,9 +296,10 @@ Status FunctionLikeBase::hs_prepare(FunctionContext* context, const char* expres
 
     if (res != HS_SUCCESS) {
         *database = nullptr;
+        auto error_msg = fmt::format("hs_compile regex pattern={}, error msg={}", expression,
+                                     compile_err->message);
         hs_free_compile_error(compile_err);
-        return Status::RuntimeError("hs_compile regex pattern error:" +
-                                    std::string(compile_err->message));
+        return Status::RuntimeError(error_msg);
     }
     hs_free_compile_error(compile_err);
 

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
@@ -22,6 +22,8 @@ It's true
 billie eillish
 
 -- !sql --
+
+-- !sql --
 billie eillish
 
 -- !sql --

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
@@ -40,6 +40,8 @@ suite("test_string_function_regexp") {
 
     qt_sql "SELECT k FROM ${tbName} WHERE k not regexp '^billie' ORDER BY k;"
     qt_sql "SELECT k FROM ${tbName} WHERE k not regexp 'ok\$' ORDER BY k;"
+    qt_sql "SELECT k FROM ${tbName} where (k regexp '[0]^[0-9]+.{0,1}[0-9]+\$') = 1;"
+
 
     // regexp as function
     qt_sql "SELECT k FROM ${tbName} WHERE regexp(k, '^billie') ORDER BY k;"


### PR DESCRIPTION
## Proposed changes

```
mysql [test_query_qa]>select k7 from baseall where (k7 regexp '[0]^[0-9]+.{0,1}[0-9]+$') = 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[CANCELLED][CANCELLED]UDF ERROR: hs_compile regex pattern error
```

before this sql exectue failed, as the hyperscan  report error: Embedded start anchors not supported.
But it's should be fallback to re2, when hyperscan failed, and this sql should be running normal.
```
mysql [test_query_qa]>select k7 from baseall where (k7 regexp '[0]^[0-9]+.{0,1}[0-9]+$') = 1;
Empty set (0.05 sec)
```


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

