### PR TITLE
[test](fix) Fix test check fail when test nested mv hit

### DIFF
--- a/regression-test/suites/nereids_rules_p0/mv/nested_mtmv/nested_mtmv.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested_mtmv/nested_mtmv.groovy
@@ -279,7 +279,11 @@ suite("nested_mtmv") {
         """
     explain {
         sql("${query_stmt_2}")
-        contains "${mv_level4_name}(${mv_level4_name})"
+        check {result ->
+            // both mv_level4_name and mv_level3_name can be rewritten successfully
+            result.contains("${mv_level4_name}(${mv_level4_name})")
+                    || result.contains("${mv_level3_name}(${mv_level3_name})")
+        }
     }
     compare_res(query_stmt_2 + " order by 1,2,3,4,5,6,7")
 


### PR DESCRIPTION
## Proposed changes

if mv3 is def as following:
`select c1, c2, c3 from t1;`

mv4 is def as following:
`select c1, c2 from mv3;`

when query is 
`select c1, c2 from t1;`

the mv3 and mv4 both can be rewritten successfully 

 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

