### PR TITLE
[fix](auth)Stream load not have usage priv for workload group

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -207,6 +207,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
         ctx->db_id = result.db_id;
     }
     ctx->need_rollback = true;
+    ctx->auth.user_ip = result.host;
 
     return Status::OK();
 }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -207,7 +207,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
         ctx->db_id = result.db_id;
     }
     ctx->need_rollback = true;
-    if(result.host != "") {
+    if(result.__isset.host) {
         ctx->auth.user_ip = result.host;
     }
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -207,7 +207,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
         ctx->db_id = result.db_id;
     }
     ctx->need_rollback = true;
-    if(result.host != "") {
+    if (result.host != "") {
         ctx->auth.user_ip = result.host;
     }
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -207,7 +207,9 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
         ctx->db_id = result.db_id;
     }
     ctx->need_rollback = true;
-    ctx->auth.user_ip = result.host;
+    if(result.host != "") {
+        ctx->auth.user_ip = result.host;
+    }
 
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -110,7 +110,7 @@ public class StreamLoadHandler {
         ctx.setEnv(Env.getCurrentEnv());
         ctx.setQueryId(request.getLoadId());
         UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(),
-                "%");
+                request.getUserIp());
         ctx.setCurrentUserIdentity(userIdentity);
         ctx.setQualifiedUser(userIdentity.getQualifiedUser());
         ctx.setBackendId(request.getBackendId());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -109,8 +109,9 @@ public class StreamLoadHandler {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(Env.getCurrentEnv());
         ctx.setQueryId(request.getLoadId());
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(),
-                request.getUserIp());
+        String userIp = request.getUserIp();
+        String host = (StringUtils.isEmpty(userIp) || userIp.equals("null")) ? "%" : userIp;
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(), host);
         ctx.setCurrentUserIdentity(userIdentity);
         ctx.setQualifiedUser(userIdentity.getQualifiedUser());
         ctx.setBackendId(request.getBackendId());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -109,8 +109,10 @@ public class StreamLoadHandler {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(Env.getCurrentEnv());
         ctx.setQueryId(request.getLoadId());
-        ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(), "%"));
-        ctx.setQualifiedUser(request.getUser());
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(),
+                request.getUserIp());
+        ctx.setCurrentUserIdentity(userIdentity);
+        ctx.setQualifiedUser(userIdentity.getQualifiedUser());
         ctx.setBackendId(request.getBackendId());
         ctx.setThreadLocalInfo();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -110,7 +110,7 @@ public class StreamLoadHandler {
         ctx.setEnv(Env.getCurrentEnv());
         ctx.setQueryId(request.getLoadId());
         UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(),
-                request.getUserIp());
+                "%");
         ctx.setCurrentUserIdentity(userIdentity);
         ctx.setQualifiedUser(userIdentity.getQualifiedUser());
         ctx.setBackendId(request.getBackendId());

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1138,7 +1138,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         try {
             TLoadTxnBeginResult tmpRes = loadTxnBeginImpl(request, clientAddr);
             result.setTxnId(tmpRes.getTxnId()).setDbId(tmpRes.getDbId())
-                    .setCurrentUserIdent(tmpRes.getCurrentUserIdent());
+                    .setHost(tmpRes.getHost());
         } catch (DuplicatedRequestException e) {
             // this is a duplicate request, just return previous txn id
             LOG.warn("duplicate request for stream load. request id: {}, txn: {}", e.getDuplicatedRequestId(),

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1137,7 +1137,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         try {
             TLoadTxnBeginResult tmpRes = loadTxnBeginImpl(request, clientAddr);
-            result.setTxnId(tmpRes.getTxnId()).setDbId(tmpRes.getDbId());
+            result.setTxnId(tmpRes.getTxnId()).setDbId(tmpRes.getDbId())
+                    .setCurrentUserIdent(tmpRes.getCurrentUserIdent());
         } catch (DuplicatedRequestException e) {
             // this is a duplicate request, just return previous txn id
             LOG.warn("duplicate request for stream load. request id: {}, txn: {}", e.getDuplicatedRequestId(),
@@ -1165,6 +1166,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     private TLoadTxnBeginResult loadTxnBeginImpl(TLoadTxnBeginRequest request, String clientIp) throws UserException {
+        TLoadTxnBeginResult result = new TLoadTxnBeginResult();
         if (request.isSetAuthCode()) {
             // TODO(cmy): find a way to check
         } else if (Strings.isNullOrEmpty(request.getToken())) {
@@ -1172,6 +1174,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     request.getDb(),
                     request.getTbl(),
                     request.getUserIp(), PrivPredicate.LOAD);
+            result.setHost(userIdentity.getHost());
         } else {
             if (!checkToken(request.getToken())) {
                 throw new AuthenticationException("Invalid token: " + request.getToken());
@@ -1205,7 +1208,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 db.getId(), Lists.newArrayList(table.getId()), request.getLabel(), request.getRequestId(),
                 txnCoord,
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, -1, timeoutSecond);
-        TLoadTxnBeginResult result = new TLoadTxnBeginResult();
         result.setTxnId(txnId).setDbId(db.getId());
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1067,9 +1067,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return tableNames;
     }
 
-    private void checkSingleTablePasswordAndPrivs(String user, String passwd, String db, String tbl,
+    private UserIdentity checkSingleTablePasswordAndPrivs(String user, String passwd, String db, String tbl,
             String clientIp, PrivPredicate predicate) throws AuthenticationException {
-        checkPasswordAndPrivs(user, passwd, db, Lists.newArrayList(tbl), clientIp, predicate);
+        return checkPasswordAndPrivs(user, passwd, db, Lists.newArrayList(tbl), clientIp, predicate);
     }
 
     private void checkDbPasswordAndPrivs(String user, String passwd, String db, String clientIp,
@@ -1077,7 +1077,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         checkPasswordAndPrivs(user, passwd, db, null, clientIp, predicate);
     }
 
-    private void checkPasswordAndPrivs(String user, String passwd, String db, List<String> tables,
+    private UserIdentity checkPasswordAndPrivs(String user, String passwd, String db, List<String> tables,
             String clientIp, PrivPredicate predicate) throws AuthenticationException {
 
         final String fullUserName = ClusterNamespace.getNameFromFullName(user);
@@ -1093,7 +1093,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         "Access denied; you need (at least one of) the (" + predicate.toString()
                                 + ") privilege(s) for this operation");
             }
-            return;
+            return currentUser.get(0);
         }
 
         for (String tbl : tables) {
@@ -1105,6 +1105,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                                 + ") privilege(s) for this operation");
             }
         }
+        return currentUser.get(0);
     }
 
     private void checkPassword(String user, String passwd, String clientIp)
@@ -1167,7 +1168,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (request.isSetAuthCode()) {
             // TODO(cmy): find a way to check
         } else if (Strings.isNullOrEmpty(request.getToken())) {
-            checkSingleTablePasswordAndPrivs(request.getUser(), request.getPasswd(), request.getDb(),
+            UserIdentity userIdentity = checkSingleTablePasswordAndPrivs(request.getUser(), request.getPasswd(),
+                    request.getDb(),
                     request.getTbl(),
                     request.getUserIp(), PrivPredicate.LOAD);
         } else {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -608,6 +608,7 @@ struct TLoadTxnBeginResult {
     2: optional i64 txnId
     3: optional string job_status // if label already used, set status of existing job
     4: optional i64 db_id
+    5: optional Types.TUserIdentity current_user_ident
 }
 
 struct TBeginTxnRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -608,7 +608,7 @@ struct TLoadTxnBeginResult {
     2: optional i64 txnId
     3: optional string job_status // if label already used, set status of existing job
     4: optional i64 db_id
-    5: optional Types.TUserIdentity current_user_ident
+    5: optional string host
 }
 
 struct TBeginTxnRequest {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When requesting execution plans from FE through RPC, the client IP was previously used and changed to the matching user host.
For example, the previous version was' 82.157.43.14 ', and the later version after the modification was' 82.157.43%',
FE will directly build userIdentity using the brought IP.
Due to the possibility that only user a @'82.157.43.% 'may exist on FE and not a @'82.157.43.14', the user may not have permission.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

