### PR TITLE
[fix](autobucket) calc bucket num exclude today's partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -201,7 +201,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         for (Map.Entry<Long, PartitionItem> idToItem : idToItems) {
             Partition partition = table.getPartition(idToItem.getKey());
             // exclude current partition because its data isn't enough one week/day/hour.
-            if (partition != null && partition.getName() != nowPartitionName && artition.getVisibleVersion() >= 2) {
+            if (partition != null && !partition.getName().equals(nowPartitionName)
+                    && partition.getVisibleVersion() >= 2) {
                 partitionSizeArray.add(partition.getAllDataSize(true));
             }
         }


### PR DESCRIPTION
BUG:  when calculate auto bucketnum,  should skip today's partition because its data is not enough one day. For example:    at 00:01,  user first insert one row into today's partition. Then the dynamic partition scheduler will try to create tomorrow's partition. It then use existing partitions to calculate bucket num. Even if today partition has data, but it's rather short time,  so need to exclude it.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

