### PR TITLE
[feature](block) add check type in block data type and column 

### DIFF
--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -53,6 +53,13 @@ String IDataType::do_get_name() const {
     return get_family_name();
 }
 
+Status IDataType::_check_column_is_null(const IColumn* column) const {
+    if (column) {
+        return Status::OK();
+    }
+    return Status::InternalError("check failed in data type = {}", get_name());
+}
+
 void IDataType::update_avg_value_size_hint(const IColumn& column, double& avg_value_size_hint) {
     /// Update the average value size hint if amount of read rows isn't too small
     size_t row_size = column.size();

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -95,10 +95,21 @@ public:
 protected:
     virtual String do_get_name() const;
 
+    Status _check_column_is_null(const IColumn* column) const;
+
 public:
     /** Create empty column for corresponding type.
       */
     virtual MutableColumnPtr create_column() const = 0;
+    // check column type match datatype
+    virtual Status check_column_type(const IColumn* column) const = 0;
+
+    template <typename Type>
+    Status check_single_type(const IColumn* column) const {
+        const auto* col = check_and_get_column<Type>(column);
+        RETURN_IF_ERROR(_check_column_is_null(col));
+        return Status::OK();
+    }
 
     /** Create ColumnConst for corresponding type, with specified size and value.
       */

--- a/be/src/vec/data_types/data_type_agg_state.h
+++ b/be/src/vec/data_types/data_type_agg_state.h
@@ -109,6 +109,10 @@ public:
         return _agg_function->create_serialize_column();
     }
 
+    Status check_column_type(const IColumn* column) const override {
+        return _agg_serialized_type->check_column_type(column);
+    }
+
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
         return _agg_serialized_type->get_serde(nesting_level);
     };

--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -53,6 +53,13 @@ MutableColumnPtr DataTypeArray::create_column() const {
     return ColumnArray::create(nested->create_column(), ColumnArray::ColumnOffsets::create());
 }
 
+Status DataTypeArray::check_column_type(const IColumn* column) const {
+    const auto* col = check_and_get_column<ColumnArray>(column);
+    RETURN_IF_ERROR(_check_column_is_null(col));
+    RETURN_IF_ERROR(nested->check_column_type(&col->get_data()));
+    return Status::OK();
+}
+
 Field DataTypeArray::get_default() const {
     Array a;
     a.push_back(nested->get_default());

--- a/be/src/vec/data_types/data_type_array.h
+++ b/be/src/vec/data_types/data_type_array.h
@@ -75,6 +75,8 @@ public:
 
     MutableColumnPtr create_column() const override;
 
+    Status check_column_type(const IColumn* column) const override;
+
     Field get_default() const override;
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {

--- a/be/src/vec/data_types/data_type_bitmap.cpp
+++ b/be/src/vec/data_types/data_type_bitmap.cpp
@@ -19,6 +19,7 @@
 
 #include <utility>
 
+#include "common/status.h"
 #include "util/bitmap_value.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
@@ -92,6 +93,10 @@ const char* DataTypeBitMap::deserialize(const char* buf, IColumn* column,
 
 MutableColumnPtr DataTypeBitMap::create_column() const {
     return ColumnBitmap::create();
+}
+
+Status DataTypeBitMap::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnBitmap>(column);
 }
 
 void DataTypeBitMap::serialize_as_stream(const BitmapValue& cvalue, BufferWritable& buf) {

--- a/be/src/vec/data_types/data_type_bitmap.h
+++ b/be/src/vec/data_types/data_type_bitmap.h
@@ -72,6 +72,7 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool get_is_parametric() const override { return false; }
     bool have_subtypes() const override { return false; }

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -208,7 +208,15 @@ MutableColumnPtr DataTypeDecimal<T>::create_column() const {
         return ColumnType::create(0, scale);
     }
 }
-
+template <typename T>
+Status DataTypeDecimal<T>::check_column_type(const IColumn* column) const {
+    if constexpr (IsDecimalV2<T>) {
+        return check_single_type<ColumnDecimal128V2>(column);
+    } else {
+        return check_single_type<ColumnType>(column);
+    }
+    return Status::OK();
+}
 template <typename T>
 bool DataTypeDecimal<T>::parse_from_string(const std::string& str, T* res) const {
     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -223,6 +223,7 @@ public:
     }
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
     bool equals(const IDataType& rhs) const override;
 
     bool get_is_parametric() const override { return true; }

--- a/be/src/vec/data_types/data_type_fixed_length_object.cpp
+++ b/be/src/vec/data_types/data_type_fixed_length_object.cpp
@@ -72,4 +72,8 @@ MutableColumnPtr DataTypeFixedLengthObject::create_column() const {
     return ColumnType::create(0);
 }
 
+Status DataTypeFixedLengthObject::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnType>(column);
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_fixed_length_object.h
+++ b/be/src/vec/data_types/data_type_fixed_length_object.h
@@ -79,6 +79,7 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool get_is_parametric() const override { return false; }
     bool have_subtypes() const override { return false; }

--- a/be/src/vec/data_types/data_type_hll.cpp
+++ b/be/src/vec/data_types/data_type_hll.cpp
@@ -98,6 +98,10 @@ MutableColumnPtr DataTypeHLL::create_column() const {
     return ColumnHLL::create();
 }
 
+Status DataTypeHLL::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnHLL>(column);
+}
+
 void DataTypeHLL::serialize_as_stream(const HyperLogLog& cvalue, BufferWritable& buf) {
     auto& value = const_cast<HyperLogLog&>(cvalue);
     std::string memory_buffer(value.max_serialized_size(), '0');

--- a/be/src/vec/data_types/data_type_hll.h
+++ b/be/src/vec/data_types/data_type_hll.h
@@ -67,6 +67,7 @@ public:
     char* serialize(const IColumn& column, char* buf, int be_exec_version) const override;
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool get_is_parametric() const override { return false; }
     bool have_subtypes() const override { return false; }

--- a/be/src/vec/data_types/data_type_jsonb.cpp
+++ b/be/src/vec/data_types/data_type_jsonb.cpp
@@ -71,6 +71,10 @@ MutableColumnPtr DataTypeJsonb::create_column() const {
     return ColumnString::create();
 }
 
+Status DataTypeJsonb::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnString>(column);
+}
+
 bool DataTypeJsonb::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }

--- a/be/src/vec/data_types/data_type_jsonb.h
+++ b/be/src/vec/data_types/data_type_jsonb.h
@@ -66,6 +66,7 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int data_version) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     virtual Field get_default() const override {
         std::string default_json = "{}";

--- a/be/src/vec/data_types/data_type_map.cpp
+++ b/be/src/vec/data_types/data_type_map.cpp
@@ -253,6 +253,13 @@ MutableColumnPtr DataTypeMap::create_column() const {
                              ColumnArray::ColumnOffsets::create());
 }
 
+Status DataTypeMap::check_column_type(const IColumn* column) const {
+    const auto* map_column = check_and_get_column<ColumnMap>(column);
+    RETURN_IF_ERROR(_check_column_is_null(map_column));
+    RETURN_IF_ERROR(key_type->check_column_type(&map_column->get_keys()));
+    RETURN_IF_ERROR(value_type->check_column_type(&map_column->get_values()));
+    return Status::OK();
+}
 void DataTypeMap::to_pb_column_meta(PColumnMeta* col_meta) const {
     IDataType::to_pb_column_meta(col_meta);
     auto key_children = col_meta->add_children();

--- a/be/src/vec/data_types/data_type_map.h
+++ b/be/src/vec/data_types/data_type_map.h
@@ -76,6 +76,7 @@ public:
     const char* get_family_name() const override { return "Map"; }
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
     Field get_default() const override;
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {

--- a/be/src/vec/data_types/data_type_nothing.cpp
+++ b/be/src/vec/data_types/data_type_nothing.cpp
@@ -30,6 +30,10 @@ MutableColumnPtr DataTypeNothing::create_column() const {
     return ColumnNothing::create(0);
 }
 
+Status DataTypeNothing::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnNothing>(column);
+}
+
 char* DataTypeNothing::serialize(const IColumn& column, char* buf, int be_exec_version) const {
     LOG(FATAL) << "not support";
     __builtin_unreachable();

--- a/be/src/vec/data_types/data_type_nothing.h
+++ b/be/src/vec/data_types/data_type_nothing.h
@@ -61,6 +61,7 @@ public:
     }
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool equals(const IDataType& rhs) const override;
 

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -207,6 +207,13 @@ MutableColumnPtr DataTypeNullable::create_column() const {
     return ColumnNullable::create(nested_data_type->create_column(), ColumnUInt8::create());
 }
 
+Status DataTypeNullable::check_column_type(const IColumn* column) const {
+    const auto* col = check_and_get_column<ColumnNullable>(column);
+    RETURN_IF_ERROR(_check_column_is_null(col));
+    RETURN_IF_ERROR(nested_data_type->check_column_type(&col->get_nested_column()));
+    return Status::OK();
+}
+
 Field DataTypeNullable::get_default() const {
     return Null();
 }

--- a/be/src/vec/data_types/data_type_nullable.h
+++ b/be/src/vec/data_types/data_type_nullable.h
@@ -76,6 +76,7 @@ public:
     void to_pb_column_meta(PColumnMeta* col_meta) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     Field get_default() const override;
 

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -253,6 +253,11 @@ MutableColumnPtr DataTypeNumberBase<T>::create_column() const {
 }
 
 template <typename T>
+Status DataTypeNumberBase<T>::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnVector<T>>(column);
+}
+
+template <typename T>
 bool DataTypeNumberBase<T>::is_value_represented_by_integer() const {
     return std::is_integral_v<T>;
 }

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -138,6 +138,7 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool get_is_parametric() const override { return false; }
     bool have_subtypes() const override { return false; }

--- a/be/src/vec/data_types/data_type_object.h
+++ b/be/src/vec/data_types/data_type_object.h
@@ -63,6 +63,9 @@ public:
         return doris::FieldType::OLAP_FIELD_TYPE_VARIANT;
     }
     MutableColumnPtr create_column() const override { return ColumnObject::create(is_nullable); }
+    Status check_column_type(const IColumn* column) const override {
+        return check_single_type<ColumnObject>(column);
+    }
     bool is_object() const override { return true; }
     bool equals(const IDataType& rhs) const override;
     bool hasNullableSubcolumns() const { return is_nullable; }

--- a/be/src/vec/data_types/data_type_quantilestate.cpp
+++ b/be/src/vec/data_types/data_type_quantilestate.cpp
@@ -92,6 +92,10 @@ MutableColumnPtr DataTypeQuantileState::create_column() const {
     return ColumnQuantileState::create();
 }
 
+Status DataTypeQuantileState::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnQuantileState>(column);
+}
+
 void DataTypeQuantileState::serialize_as_stream(const QuantileState& cvalue, BufferWritable& buf) {
     auto& value = const_cast<QuantileState&>(cvalue);
     std::string memory_buffer;

--- a/be/src/vec/data_types/data_type_quantilestate.h
+++ b/be/src/vec/data_types/data_type_quantilestate.h
@@ -66,6 +66,7 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
 
     MutableColumnPtr create_column() const override;
+    Status check_column_type(const IColumn* column) const override;
 
     bool get_is_parametric() const override { return false; }
     bool have_subtypes() const override { return false; }

--- a/be/src/vec/data_types/data_type_string.cpp
+++ b/be/src/vec/data_types/data_type_string.cpp
@@ -70,6 +70,10 @@ MutableColumnPtr DataTypeString::create_column() const {
     return ColumnString::create();
 }
 
+Status DataTypeString::check_column_type(const IColumn* column) const {
+    return check_single_type<ColumnString>(column);
+}
+
 bool DataTypeString::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -70,6 +70,8 @@ public:
 
     MutableColumnPtr create_column() const override;
 
+    Status check_column_type(const IColumn* column) const override;
+
     Field get_default() const override;
 
     Field get_field(const TExprNode& node) const override {

--- a/be/src/vec/data_types/data_type_struct.h
+++ b/be/src/vec/data_types/data_type_struct.h
@@ -93,6 +93,8 @@ public:
 
     MutableColumnPtr create_column() const override;
 
+    Status check_column_type(const IColumn* column) const override;
+
     Field get_default() const override;
 
     Field get_field(const TExprNode& node) const override {

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -117,6 +117,8 @@ public:
                                                                      const Block&, Block*,
                                                                      bool do_projection = false);
 
+    Status check_column_data_type(vectorized::Block* block, int result_column_id);
+
     int get_last_result_column_id() const {
         DCHECK(_last_result_column_id != -1);
         return _last_result_column_id;


### PR DESCRIPTION
## Proposed changes

```
mysql [test]>select cast(j as int ) from test_json_not_null;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]error type in column , col name = (CAST j(JSONB) TO Int32) , expr expected type = Int32 , column expected type = Int32 , column is nullable = true , error type msg = check failed in data type = Int32
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

