### PR TITLE
[fix](compaction) generate single compaction and cumu(base) compaction tablets simultaneously.

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -894,7 +894,7 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
         // So that we can update the max_compaction_score metric.
         if (!data_dir->reach_capacity_limit(0)) {
             uint32_t disk_max_score = 0;
-            auto tablets = _tablet_manager->find_best_tablet_to_compaction(
+            auto tablets = _tablet_manager->find_best_tablets_to_compaction(
                     compaction_type, data_dir,
                     compaction_type == CompactionType::CUMULATIVE_COMPACTION
                             ? copied_cumu_map[data_dir]

--- a/be/src/olap/single_replica_compaction.h
+++ b/be/src/olap/single_replica_compaction.h
@@ -37,6 +37,8 @@ public:
     Status prepare_compact() override;
     Status execute_compact() override;
 
+    inline CompactionType real_compact_type() const { return _compaction_type; }
+
 protected:
     std::string_view compaction_name() const override { return "single replica compaction"; }
     ReaderType compaction_type() const override {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1328,6 +1328,12 @@ bool StorageEngine::get_peer_replica_info(int64_t tablet_id, TReplicaInfo* repli
 }
 
 bool StorageEngine::should_fetch_from_peer(int64_t tablet_id) {
+#ifdef BE_TEST
+    if (tablet_id % 2 == 0) {
+        return true;
+    }
+    return false;
+#endif
     TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1708,6 +1708,9 @@ void Tablet::execute_single_replica_compaction(SingleReplicaCompaction& compacti
         set_last_single_compaction_failure_status(res.to_string());
         if (res.is<CANCELLED>()) {
             DorisMetrics::instance()->single_compaction_request_cancelled->increment(1);
+            // "CANCELLED" indicates that the peer has not performed compaction,
+            // wait for the peer to perform compaction
+            set_skip_compaction(true, compaction.real_compact_type(), UnixSeconds());
             VLOG_CRITICAL << "Cannel fetching from the remote peer. res=" << res
                           << ", tablet=" << tablet_id();
         } else {

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -716,7 +716,7 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
     result->__set_tablet_stat_list(*local_cache);
 }
 
-std::vector<TabletSharedPtr> TabletManager::find_best_tablet_to_compaction(
+std::vector<TabletSharedPtr> TabletManager::find_best_tablets_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
         const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
         const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -803,7 +803,8 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablets_to_compaction(
         picked_tablet.emplace_back(std::move(best_tablet));
     }
 
-    if (best_single_compact_tablet != nullptr) {
+    // pick single compaction tablet needs the highest score
+    if (best_single_compact_tablet != nullptr && single_compact_highest_score >= highest_score) {
         VLOG_CRITICAL << "Found the best tablet for single compaction. "
                       << "compaction_type=" << compaction_type_str
                       << ", tablet_id=" << best_single_compact_tablet->tablet_id()

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -725,7 +725,7 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablet_to_compaction(
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
     uint32_t highest_score = 0;
-    // find the
+    // find the single compaction tablet
     uint32_t single_compact_highest_score = 0;
     TabletSharedPtr best_tablet;
     TabletSharedPtr best_single_compact_tablet;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -793,14 +793,14 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablet_to_compaction(
     };
 
     for_each_tablet(handler, filter_all_tablets);
-    std::vector<TabletSharedPtr> res;
+    std::vector<TabletSharedPtr> picked_tablet;
     if (best_tablet != nullptr) {
         VLOG_CRITICAL << "Found the best tablet for compaction. "
                       << "compaction_type=" << compaction_type_str
                       << ", tablet_id=" << best_tablet->tablet_id() << ", path=" << data_dir->path()
                       << ", highest_score=" << highest_score
                       << ", fetch from peer: " << best_tablet->should_fetch_from_peer();
-        res.emplace_back(std::move(best_tablet));
+        picked_tablet.emplace_back(std::move(best_tablet));
     }
 
     if (best_single_compact_tablet != nullptr) {
@@ -810,11 +810,11 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablet_to_compaction(
                       << ", path=" << data_dir->path()
                       << ", highest_score=" << single_compact_highest_score << ", fetch from peer: "
                       << best_single_compact_tablet->should_fetch_from_peer();
-        res.emplace_back(std::move(best_single_compact_tablet));
+        picked_tablet.emplace_back(std::move(best_single_compact_tablet));
     }
     *score = highest_score > single_compact_highest_score ? highest_score
                                                           : single_compact_highest_score;
-    return res;
+    return picked_tablet;
 }
 
 Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id,

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -73,7 +73,10 @@ public:
     // If `is_drop_table_or_partition` is true, we need to remove all remote rowsets in this tablet.
     Status drop_tablet(TTabletId tablet_id, TReplicaId replica_id, bool is_drop_table_or_partition);
 
-    TabletSharedPtr find_best_tablet_to_compaction(
+    // Find two tablets.
+    // One with the highest score to execute single compaction,
+    // the other with the highest score to execute cumu or base compaction.
+    std::vector<TabletSharedPtr> find_best_tablet_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
             const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -76,6 +76,9 @@ public:
     // Find two tablets.
     // One with the highest score to execute single compaction,
     // the other with the highest score to execute cumu or base compaction.
+    // Single compaction needs to be completed successfully after the peer completes it.
+    // We need to generate two types of tasks separately to avoid continuously generating
+    // single compaction tasks for the tablet.
     std::vector<TabletSharedPtr> find_best_tablets_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -76,7 +76,7 @@ public:
     // Find two tablets.
     // One with the highest score to execute single compaction,
     // the other with the highest score to execute cumu or base compaction.
-    std::vector<TabletSharedPtr> find_best_tablet_to_compaction(
+    std::vector<TabletSharedPtr> find_best_tablets_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
             const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -430,7 +430,7 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
             CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
                     CUMULATIVE_TIME_SERIES_POLICY);
     uint32_t score = 0;
-    auto compact_tablets = _tablet_mgr->find_best_tablet_to_compaction(
+    auto compact_tablets = _tablet_mgr->find_best_tablets_to_compaction(
             CompactionType::CUMULATIVE_COMPACTION, _data_dir, cumu_set, &score,
             cumulative_compaction_policies);
     EXPECT_TRUE(compact_tablets.size() == 1);
@@ -444,7 +444,7 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
         create_tablet(id, true, rowset_size++);
     }
 
-    compact_tablets = _tablet_mgr->find_best_tablet_to_compaction(
+    compact_tablets = _tablet_mgr->find_best_tablets_to_compaction(
             CompactionType::CUMULATIVE_COMPACTION, _data_dir, cumu_set, &score,
             cumulative_compaction_policies);
     EXPECT_TRUE(compact_tablets.size() == 2);

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -453,6 +453,15 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
     ASSERT_EQ(compact_tablets[1]->tablet_id(), 20);
     ASSERT_EQ(score, 23);
 
+    create_tablet(21, false, rowset_size++);
+
+    compact_tablets = _tablet_mgr->find_best_tablets_to_compaction(
+            CompactionType::CUMULATIVE_COMPACTION, _data_dir, cumu_set, &score,
+            cumulative_compaction_policies);
+    ASSERT_EQ(compact_tablets.size(), 1);
+    ASSERT_EQ(compact_tablets[0]->tablet_id(), 21);
+    ASSERT_EQ(score, 24);
+
     // drop all tablets
     for (int64_t id = 1; id <= 20; ++id) {
         Status drop_st = _tablet_mgr->drop_tablet(id, id * 10, false);

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -32,10 +32,15 @@
 #include "common/status.h"
 #include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
+#include "olap/cumulative_compaction_policy.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/data_dir.h"
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
 #include "olap/options.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
 #include "olap/tablet_manager.h"
@@ -333,6 +338,121 @@ TEST_F(TabletMgrTest, GetRowsetId) {
         RowsetId id;
         EXPECT_FALSE(_tablet_mgr->get_rowset_id_from_path(path, &id));
     }
+}
+
+TEST_F(TabletMgrTest, FindTabletWithCompact) {
+    auto create_tablet = [this](int64_t tablet_id, bool enable_single_compact, int rowset_size) {
+        std::vector<TColumn> cols;
+        TColumn col1;
+        col1.column_type.type = TPrimitiveType::SMALLINT;
+        col1.__set_column_name("col1");
+        col1.__set_is_key(true);
+        cols.push_back(col1);
+
+        TColumn col2;
+        col2.column_type.type = TPrimitiveType::INT;
+        col2.__set_column_name(SEQUENCE_COL);
+        col2.__set_is_key(false);
+        col2.__set_aggregation_type(TAggregationType::REPLACE);
+        cols.push_back(col2);
+
+        TColumn col3;
+        col3.column_type.type = TPrimitiveType::INT;
+        col3.__set_column_name("v1");
+        col3.__set_is_key(false);
+        col3.__set_aggregation_type(TAggregationType::REPLACE);
+        cols.push_back(col3);
+
+        RuntimeProfile profile("CreateTablet");
+        TTabletSchema tablet_schema;
+        tablet_schema.__set_short_key_column_count(1);
+        tablet_schema.__set_schema_hash(3333);
+        tablet_schema.__set_keys_type(TKeysType::UNIQUE_KEYS);
+        tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        tablet_schema.__set_columns(cols);
+        tablet_schema.__set_sequence_col_idx(1);
+        tablet_schema.__set_enable_single_replica_compaction(enable_single_compact);
+        TCreateTabletReq create_tablet_req;
+        create_tablet_req.__set_tablet_schema(tablet_schema);
+        create_tablet_req.__set_tablet_id(tablet_id);
+        create_tablet_req.__set_version(1);
+        create_tablet_req.__set_replica_id(tablet_id * 10);
+        std::vector<DataDir*> data_dirs;
+        data_dirs.push_back(_data_dir);
+        Status create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs, &profile);
+        ASSERT_TRUE(create_st.ok()) << create_st;
+
+        TabletSharedPtr tablet = _tablet_mgr->get_tablet(tablet_id);
+        EXPECT_TRUE(tablet != nullptr);
+        // check dir exist
+        bool dir_exist = false;
+        EXPECT_TRUE(io::global_local_filesystem()->exists(tablet->tablet_path(), &dir_exist).ok());
+        EXPECT_TRUE(dir_exist);
+        // check meta has this tablet
+        TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
+        Status check_meta_st =
+                TabletMetaManager::get_meta(_data_dir, tablet_id, 3333, new_tablet_meta);
+        EXPECT_TRUE(check_meta_st == Status::OK());
+        // insert into rowset
+        auto create_rowset = [=](int64_t start, int64 end) {
+            auto rowset_meta = std::make_shared<RowsetMeta>();
+            Version version(start, end);
+            rowset_meta->set_version(version);
+            rowset_meta->set_tablet_id(tablet->tablet_id());
+            rowset_meta->set_tablet_uid(tablet->tablet_uid());
+            rowset_meta->set_rowset_id(k_engine->next_rowset_id());
+            return std::make_shared<BetaRowset>(tablet->tablet_schema(), tablet->tablet_path(),
+                                                std::move(rowset_meta));
+        };
+        auto st = tablet->init();
+        ASSERT_TRUE(st.ok()) << st;
+        for (int i = 2; i <= rowset_size; ++i) {
+            auto rs = create_rowset(i, i);
+            auto st = tablet->add_inc_rowset(rs);
+            ASSERT_TRUE(st.ok()) << st;
+        }
+    };
+
+    int rowset_size = 5;
+
+    // create 10 tablets
+    for (int64_t id = 1; id <= 10; ++id) {
+        create_tablet(id, false, rowset_size++);
+    }
+
+    // create 10 tablets enable single compact
+    // 5 tablets do cumu compaction, 5 tablets do single compaction
+    // if BE_TEST is defined, tablet_id % 2 == 0 means that tablet needs to do single compact
+    for (int64_t id = 11; id <= 20; ++id) {
+        create_tablet(id, true, rowset_size++);
+    }
+
+    std::unordered_set<TTabletId> cumu_set;
+    std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>
+            cumulative_compaction_policies;
+    cumulative_compaction_policies[CUMULATIVE_SIZE_BASED_POLICY] =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_SIZE_BASED_POLICY);
+    cumulative_compaction_policies[CUMULATIVE_TIME_SERIES_POLICY] =
+            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy(
+                    CUMULATIVE_TIME_SERIES_POLICY);
+    uint32_t score = 0;
+    auto compact_tablets = _tablet_mgr->find_best_tablet_to_compaction(
+            CompactionType::CUMULATIVE_COMPACTION, _data_dir, cumu_set, &score,
+            cumulative_compaction_policies);
+    EXPECT_TRUE(compact_tablets.size() == 2);
+    EXPECT_TRUE(compact_tablets[0]->tablet_id() == 19);
+    EXPECT_TRUE(compact_tablets[1]->tablet_id() == 20);
+    EXPECT_TRUE(score == 23);
+
+    // drop all tablets
+    for (int64_t id = 1; id <= 20; ++id) {
+        Status drop_st = _tablet_mgr->drop_tablet(id, id * 10, false);
+        EXPECT_TRUE(drop_st == Status::OK());
+    }
+
+    Status trash_st = _tablet_mgr->start_trash_sweep();
+    EXPECT_TRUE(trash_st == Status::OK());
 }
 
 } // namespace doris


### PR DESCRIPTION
## BUG
Each time a compaction task was generated, either a single compaction or a cumu (base) compaction tablet.
Because there is no matched version available to pull from the peer, it keeps generating single compaction tasks, cumu (base) compaction tasks cannot be generated.

## HOW TO FIX
1. When single compaction fails to complete,  skip the compaction task for this tablet temporarily.
2. Each time a compaction task is generated, create two tasks: one for single compaction and one for cumu(base) compaction.




