### PR TITLE
[fix](memory) Fix page cache memory tracker consumption in prune

### DIFF
--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -111,7 +111,7 @@ public:
                 : LRUCachePolicy(CachePolicy::CacheType::DATA_PAGE_CACHE, capacity,
                                  LRUCacheType::SIZE, config::data_page_cache_stale_sweep_time_sec,
                                  num_shards) {
-            init_mem_tracker_by_allocator();
+            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
         }
     };
 
@@ -121,7 +121,7 @@ public:
                 : LRUCachePolicy(CachePolicy::CacheType::INDEXPAGE_CACHE, capacity,
                                  LRUCacheType::SIZE, config::index_page_cache_stale_sweep_time_sec,
                                  num_shards) {
-            init_mem_tracker_by_allocator();
+            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
         }
     };
 
@@ -131,7 +131,7 @@ public:
                 : LRUCachePolicy(CachePolicy::CacheType::PK_INDEX_PAGE_CACHE, capacity,
                                  LRUCacheType::SIZE,
                                  config::pk_index_page_cache_stale_sweep_time_sec, num_shards) {
-            init_mem_tracker_by_allocator();
+            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
         }
     };
 

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -101,8 +101,30 @@ public:
     virtual void prune_all(bool force) = 0;
 
     CacheType type() { return _type; }
+    void init_mem_tracker(const std::string& type_name) {
+        _mem_tracker =
+                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
+                                             ExecEnv::GetInstance()->details_mem_tracker_set());
+    }
     MemTracker* mem_tracker() { return _mem_tracker.get(); }
-    int64_t mem_consumption() { return _mem_tracker->consumption(); }
+    void init_mem_tracker_by_allocator(const std::string& type_name) {
+        _mem_tracker_by_allocator = MemTrackerLimiter::create_shared(
+                MemTrackerLimiter::Type::GLOBAL,
+                fmt::format("{}[{}](AllocByAllocator)", type_string(_type), type_name));
+    }
+    std::shared_ptr<MemTrackerLimiter> mem_tracker_by_allocator() const {
+        DCHECK(_mem_tracker_by_allocator != nullptr);
+        return _mem_tracker_by_allocator;
+    }
+    int64_t mem_consumption() {
+        if (_mem_tracker_by_allocator != nullptr) {
+            return _mem_tracker_by_allocator->consumption();
+        } else if (_mem_tracker != nullptr) {
+            return _mem_tracker->consumption();
+        }
+        LOG(FATAL) << "__builtin_unreachable";
+        __builtin_unreachable();
+    }
     bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 
@@ -117,15 +139,10 @@ protected:
         _cost_timer = ADD_TIMER(_profile, "CostTime");
     }
 
-    void init_mem_tracker(const std::string& type_name) {
-        _mem_tracker =
-                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
-                                             ExecEnv::GetInstance()->details_mem_tracker_set());
-    }
-
     CacheType _type;
 
     std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker_by_allocator;
 
     std::unique_ptr<RuntimeProfile> _profile;
     RuntimeProfile::Counter* _prune_stale_number_counter = nullptr;

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -91,17 +91,6 @@ public:
         }
     }
 
-    void init_mem_tracker_by_allocator() {
-        _mem_tracker_by_allocator = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::GLOBAL,
-                fmt::format("{}[{}](AllocByAllocator)", type_string(_type),
-                            lru_cache_type_string(_lru_cache_type)));
-    }
-    std::shared_ptr<MemTrackerLimiter> mem_tracker_by_allocator() const {
-        DCHECK(_mem_tracker_by_allocator != nullptr);
-        return _mem_tracker_by_allocator;
-    }
-
     // Insert and cache value destroy will be manually consume tracking_bytes to mem tracker.
     // If lru cache is LRUCacheType::SIZE, tracking_bytes usually equal to charge.
     Cache::Handle* insert(const CacheKey& key, void* value, size_t charge, size_t tracking_bytes,
@@ -214,7 +203,6 @@ private:
     // compatible with ShardedLRUCache usage, but will not actually cache.
     std::shared_ptr<Cache> _cache;
     LRUCacheType _lru_cache_type;
-    std::shared_ptr<MemTrackerLimiter> _mem_tracker_by_allocator;
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

when process memory exceed limit, page cache may not prune in time.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

