### PR TITLE
[Fix](executor)Fix stream load IP based auth Failed.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -152,7 +152,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 }
             } else {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity());
+                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity(), false);
             }
             if (tWgList.size() != 0) {
                 tExecPlanFragmentParams.setWorkloadGroups(tWgList);
@@ -185,7 +185,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 }
             } else {
                 tWgList = Env.getCurrentEnv().getWorkloadGroupMgr()
-                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity());
+                        .getWorkloadGroupByUser(routineLoadJob.getUserIdentity(), false);
             }
             if (tWgList.size() != 0) {
                 tExecPlanFragmentParams.setWorkloadGroups(tWgList);

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -233,13 +233,13 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
             if (groupName == null || groupName.isEmpty()) {
                 wg = nameToWorkloadGroup.get(DEFAULT_GROUP_NAME);
                 if (wg == null) {
-                    throw new RuntimeException("can not find normal workload group for routineload");
+                    throw new RuntimeException("can not find normal workload group for user " + user);
                 }
             } else {
                 wg = nameToWorkloadGroup.get(groupName);
                 if (wg == null) {
                     throw new UserException(
-                            "can not find workload group " + groupName + " for user " + user.getQualifiedUser());
+                            "can not find workload group " + groupName + " for user " + user);
                 }
             }
             if (checkAuth && !Env.getCurrentEnv().getAccessManager()

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1918,8 +1918,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             // mysql load request not carry user info, need fix it later.
             boolean hasUserName = !StringUtils.isEmpty(request.getUser());
             if (Config.enable_workload_group && hasUserName) {
-                UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(request.getUser(), "%");
-                tWorkloadGroupList = Env.getCurrentEnv().getWorkloadGroupMgr().getWorkloadGroupByUser(userIdentity);
+                tWorkloadGroupList = Env.getCurrentEnv().getWorkloadGroupMgr()
+                        .getWorkloadGroupByUser(ConnectContext.get()
+                                .getCurrentUserIdentity(), true);
             }
             if (!Strings.isNullOrEmpty(request.getLoadSql())) {
                 httpStreamPutImpl(request, result);


### PR DESCRIPTION
## Proposed changes
Currenty when be request Fe for a plan, Fe miss client's IP and using 'user@%' to auth for workload group, this may cause some user config IP based user auth failed, so we need to use real user's IP to to auth.
