### PR TITLE
[Chore](dependencies)bcprov-jdkon15 migration to bcprov-jdkon18

### DIFF
--- a/fe/be-java-extensions/java-common/pom.xml
+++ b/fe/be-java-extensions/java-common/pom.xml
@@ -38,6 +38,11 @@ under the License.
             <groupId>com.vesoft</groupId>
             <artifactId>client</artifactId>
         </dependency>
+        <!--vesoft client need bcprov-jdk18on-->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.doris</groupId>
             <artifactId>fe-common</artifactId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -668,20 +668,11 @@ under the License.
         <dependency>
             <groupId>com.aliyun.datalake</groupId>
             <artifactId>metastore-client-hive3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-openapi</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-util</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <!--metastore-client need bouncycastle-->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
 
         <!-- for fe recognize files stored on gcs -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -353,6 +353,8 @@ under the License.
         <arrow.vector.classifier>shade-format-flatbuffers</arrow.vector.classifier>
         <flatbuffers.version>1.12.0</flatbuffers.version>
         <jacoco.version>0.8.10</jacoco.version>
+        <!--bcpix jdk18-->
+        <bcpkix-jdk18.version>1.78.1</bcpkix-jdk18.version>
     </properties>
     <profiles>
         <profile>
@@ -1686,9 +1688,32 @@ under the License.
                 <version>${mariadb-java-client.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcpkix-jdk18.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.aliyun.datalake</groupId>
                 <artifactId>metastore-client-hive3</artifactId>
                 <version>${dlf-metastore-client-hive.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.aliyun</groupId>
+                        <artifactId>tea</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.aliyun</groupId>
+                        <artifactId>tea-openapi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.aliyun</groupId>
+                        <artifactId>tea-util</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>
@@ -1763,6 +1788,12 @@ under the License.
                 <groupId>com.vesoft</groupId>
                 <artifactId>client</artifactId>
                 <version>${vesoft.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Abstract
The bcprov-jdk15on library is primarily used for providing encryption and decryption algorithms. The vesoft-client and metastore-client-hive3 modules, which are dependencies of the FE module, both rely on bcprov-jdk15on to write keys and other objects to files. Additionally, the arrow-flight-jdbc module in version 2.1 also depends on this package. Migration to bcprov-jdkon18

Since bcprov-jdk15on is no longer being maintained and bcprov-jdkon18 is fully compatible with it, we can replace bcprov-jdk15on with bcprov-jdkon18. This will ensure continued support and security for our applications.

FYI https://www.bouncycastle.org/latest_releases.html
