### PR TITLE
[fix](Export) fix some issues of Export

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
@@ -384,6 +384,7 @@ public class ExportMgr {
         infoMap.put("tablet_num", job.getTabletsNum());
         infoMap.put("max_file_size", job.getMaxFileSize());
         infoMap.put("delete_existing_files", job.getDeleteExistingFiles());
+        infoMap.put("parallelism", job.getParallelism());
         infoMap.put("data_consistency", job.getDataConsistency());
         jobInfo.add(new Gson().toJson(infoMap));
         // path

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -249,9 +249,6 @@ public class ExportCommand extends Command implements ForwardWithSync {
         exportJob.setTableName(tblName);
         exportJob.setExportTable(table);
         exportJob.setTableId(table.getId());
-        if (ctx.getExecutor() != null) {
-            exportJob.setOrigStmt(ctx.getExecutor().getOriginStmt());
-        }
         // set partitions
         exportJob.setPartitionNames(this.partitionsNames);
         // set where expression

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -222,7 +222,7 @@ public class ConnectContext {
 
     private StatsErrorEstimator statsErrorEstimator;
 
-    private Map<String, String> resultAttachedInfo;
+    private Map<String, String> resultAttachedInfo = Maps.newHashMap();
 
     private String workloadGroupName = "";
     private Map<Long, Backend> insertGroupCommitTableToBeMap = new HashMap<>();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1.  Forbid rollback to the old optimizer in `Export` task. Since originStmt is empty, reverting to the old optimizer when the new optimizer is enabled is meaningless.

2. Display `parallelism` in 'show export'.

3. Create an initial Map for resultAttachedInfo to avoid NullPointerException.

4. Remove the originStmt added in this PR #31020, because the `Export` statement is underlying the Outfile statement, it cannot be treated as `OriginStmt`.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

