### PR TITLE
[feature](Cloud) Try to do memory limit control for hdfs write

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1257,7 +1257,7 @@ DEFINE_Int64(num_s3_file_upload_thread_pool_max_thread, "64");
 // The max ratio for ttl cache's size
 DEFINE_mInt64(max_ttl_cache_ratio, "90");
 // The maximum jvm heap usage ratio for hdfs write workload
-DEFINE_mDouble(max_hdfs_jni_heap_usage_ratio, "0.7");
+DEFINE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio, "0.7");
 // The sleep milliseconds duration when hdfs write exceeds the maximum usage
 DEFINE_mInt64(hdfs_jni_write_sleep_milliseconds, "300");
 // The max retry times when hdfs write failed

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1262,8 +1262,6 @@ DEFINE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio, "0.5");
 DEFINE_mInt64(hdfs_jni_write_sleep_milliseconds, "300");
 // The max retry times when hdfs write failed
 DEFINE_mInt64(hdfs_jni_write_max_retry_time, "3");
-// The max inflight hdfs writer
-DEFINE_mInt64(max_inflight_hdfs_write_connection, "100");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1044,7 +1044,7 @@ DEFINE_mInt64(s3_write_buffer_size, "5242880");
 // Log interval when doing s3 upload task
 DEFINE_mInt32(s3_file_writer_log_interval_second, "60");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
-DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "4"); // 4MB
+DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "1"); // 4MB
 
 //disable shrink memory by default
 DEFINE_mBool(enable_shrink_memory, "false");
@@ -1262,6 +1262,8 @@ DEFINE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio, "0.7");
 DEFINE_mInt64(hdfs_jni_write_sleep_milliseconds, "300");
 // The max retry times when hdfs write failed
 DEFINE_mInt64(hdfs_jni_write_max_retry_time, "3");
+// The max inflight hdfs writer
+DEFINE_mInt64(max_inflight_hdfs_write_connection, "100");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1256,6 +1256,12 @@ DEFINE_Int64(num_s3_file_upload_thread_pool_min_thread, "16");
 DEFINE_Int64(num_s3_file_upload_thread_pool_max_thread, "64");
 // The max ratio for ttl cache's size
 DEFINE_mInt64(max_ttl_cache_ratio, "90");
+// The maximum jvm heap usage ratio for hdfs write workload
+DEFINE_mDouble(max_hdfs_jni_heap_usage_ratio, "0.7");
+// The sleep milliseconds duration when hdfs write exceeds the maximum usage
+DEFINE_mInt64(hdfs_jni_write_sleep_milliseconds, "300");
+// The max retry times when hdfs write failed
+DEFINE_mInt64(hdfs_jni_write_max_retry_time, "3");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1044,7 +1044,7 @@ DEFINE_mInt64(s3_write_buffer_size, "5242880");
 // Log interval when doing s3 upload task
 DEFINE_mInt32(s3_file_writer_log_interval_second, "60");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
-DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "1"); // 4MB
+DEFINE_mInt64(hdfs_write_batch_buffer_size_mb, "1"); // 1MB
 
 //disable shrink memory by default
 DEFINE_mBool(enable_shrink_memory, "false");
@@ -1257,7 +1257,7 @@ DEFINE_Int64(num_s3_file_upload_thread_pool_max_thread, "64");
 // The max ratio for ttl cache's size
 DEFINE_mInt64(max_ttl_cache_ratio, "90");
 // The maximum jvm heap usage ratio for hdfs write workload
-DEFINE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio, "0.7");
+DEFINE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio, "0.5");
 // The sleep milliseconds duration when hdfs write exceeds the maximum usage
 DEFINE_mInt64(hdfs_jni_write_sleep_milliseconds, "300");
 // The max retry times when hdfs write failed

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1338,8 +1338,6 @@ DECLARE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio);
 DECLARE_mInt64(hdfs_jni_write_sleep_milliseconds);
 // The max retry times when hdfs write failed
 DECLARE_mInt64(hdfs_jni_write_max_retry_time);
-// The max inflight hdfs writer
-DECLARE_mInt64(max_inflight_hdfs_write_connection);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1332,6 +1332,12 @@ DECLARE_Int64(num_s3_file_upload_thread_pool_min_thread);
 DECLARE_Int64(num_s3_file_upload_thread_pool_max_thread);
 // The max ratio for ttl cache's size
 DECLARE_mInt64(max_ttl_cache_ratio);
+// The maximum jvm heap usage ratio for hdfs write workload
+DECLARE_mDouble(max_hdfs_jni_heap_usage_ratio);
+// The sleep milliseconds duration when hdfs write exceeds the maximum usage
+DECLARE_mInt64(hdfs_jni_write_sleep_milliseconds);
+// The max retry times when hdfs write failed
+DECLARE_mInt64(hdfs_jni_write_max_retry_time);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1333,7 +1333,7 @@ DECLARE_Int64(num_s3_file_upload_thread_pool_max_thread);
 // The max ratio for ttl cache's size
 DECLARE_mInt64(max_ttl_cache_ratio);
 // The maximum jvm heap usage ratio for hdfs write workload
-DECLARE_mDouble(max_hdfs_jni_heap_usage_ratio);
+DECLARE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio);
 // The sleep milliseconds duration when hdfs write exceeds the maximum usage
 DECLARE_mInt64(hdfs_jni_write_sleep_milliseconds);
 // The max retry times when hdfs write failed

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1338,6 +1338,8 @@ DECLARE_mDouble(max_hdfs_wirter_jni_heap_usage_ratio);
 DECLARE_mInt64(hdfs_jni_write_sleep_milliseconds);
 // The max retry times when hdfs write failed
 DECLARE_mInt64(hdfs_jni_write_max_retry_time);
+// The max inflight hdfs writer
+DECLARE_mInt64(max_inflight_hdfs_write_connection);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -104,7 +104,7 @@ public:
         std::unique_lock lck {cur_memory_latch};
         size_t origin_size = cur_memory_comsuption;
         cur_memory_comsuption -= memory_size;
-        if (cur_memory_comsuption <= max_usage() && origin_size > max_usage()) {
+        if (cur_memory_comsuption < max_usage() && origin_size > max_usage()) {
             cv.notify_all();
         }
 #endif

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -87,8 +87,9 @@ static constexpr size_t CLIENT_WRITE_PACKET_SIZE = 64 * 1024; // 64 KB
 class HdfsWriteMemUsageRecorder {
 public:
     HdfsWriteMemUsageRecorder()
-            : max_jvm_heap_size(JniUtil::get_max_jni_heap_memory_size()),
-              cur_memory_comsuption(0) {}
+            : max_jvm_heap_size(JniUtil::get_max_jni_heap_memory_size()), cur_memory_comsuption(0) {
+        LOG_INFO("the max jvm heap size is {}", max_jvm_heap_size);
+    }
     ~HdfsWriteMemUsageRecorder() = default;
     size_t max_usage() const {
         return static_cast<size_t>(max_jvm_heap_size *

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <filesystem>
 #include <ostream>
+#include <random>
 #include <string>
 #include <thread>
 #include <utility>

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -98,7 +98,7 @@ public:
         size_t origin_size = cur_memory_comsuption;
         cur_memory_comsuption -= memory_size;
         if (cur_memory_comsuption <= max_usage() && origin_size > max_usage()) {
-            cv.notify_one();
+            cv.notify_all();
         }
 #endif
     }

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -68,11 +68,11 @@ public:
 #ifdef USE_LIBHDFS3
         return Status::OK();
 #endif
-        for (int retry_time = config::hsfs_jni_write_max_retry_time; retry_time != 0;
+        for (int retry_time = config::hdfs_jni_write_max_retry_time; retry_time != 0;
              retry_time--) {
             if (cur_memory_comsuption + memory_size > max_usage()) {
                 std::this_thread::sleep_for(
-                        std::chrono::milliseconds(config::max_hdfs_jni_write_sleep_milliseconds));
+                        std::chrono::milliseconds(config::hdfs_jni_write_sleep_milliseconds));
                 continue;
             }
             cur_memory_comsuption.fetch_add(memory_size);

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -97,20 +97,25 @@ public:
     Status acquire_memory(size_t memory_size) {
 #ifdef USE_LIBHDFS3
         return Status::OK();
-#endif
+#elif BE_TEST
+        return Status::OK();
+#else
         if (cur_memory_comsuption + memory_size > max_usage()) {
             return Status::InternalError("Run out of Jni jvm heap space, current limit size is {}",
                                          max_usage());
         }
         cur_memory_comsuption.fetch_add(memory_size);
         return Status::OK();
+#endif
     }
 
     void release_memory(size_t memory_size) {
 #ifdef USE_LIBHDFS3
         return;
-#endif
+#elif BE_TEST
+#else
         cur_memory_comsuption.fetch_sub(memory_size);
+#endif
     }
 
 private:

--- a/be/src/io/fs/hdfs_file_writer.h
+++ b/be/src/io/fs/hdfs_file_writer.h
@@ -62,6 +62,8 @@ private:
     Status append_hdfs_file(std::string_view content);
     void _write_into_local_file_cache();
     Status _append(std::string_view content);
+    void _flush_and_reset_approximate_jni_buffer_size();
+    Status _acquire_jni_memory(size_t size);
 
     Path _path;
     std::shared_ptr<HdfsHandler> _hdfs_handler = nullptr;
@@ -87,6 +89,7 @@ private:
         std::string _batch_buffer;
     };
     BatchBuffer _batch_buffer;
+    size_t _approximate_jni_buffer_size = 0;
 };
 
 } // namespace io

--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -75,6 +75,7 @@ bvar::LatencyRecorder hdfs_create_dir_latency("hdfs_create_dir");
 bvar::LatencyRecorder hdfs_open_latency("hdfs_open");
 bvar::LatencyRecorder hdfs_close_latency("hdfs_close");
 bvar::LatencyRecorder hdfs_flush_latency("hdfs_flush");
+bvar::LatencyRecorder hdfs_hflush_latency("hdfs_hflush");
 bvar::LatencyRecorder hdfs_hsync_latency("hdfs_hsync");
 }; // namespace hdfs_bvar
 

--- a/be/src/io/hdfs_util.h
+++ b/be/src/io/hdfs_util.h
@@ -46,6 +46,7 @@ extern bvar::LatencyRecorder hdfs_create_dir_latency;
 extern bvar::LatencyRecorder hdfs_open_latency;
 extern bvar::LatencyRecorder hdfs_close_latency;
 extern bvar::LatencyRecorder hdfs_flush_latency;
+extern bvar::LatencyRecorder hdfs_hflush_latency;
 extern bvar::LatencyRecorder hdfs_hsync_latency;
 }; // namespace hdfs_bvar
 

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -153,7 +153,7 @@ const std::string GetDorisJNIClasspathOption() {
         if (JNI_OK != res) {
             DCHECK(false) << "Failed to create JVM, code= " << res;
         }
-        
+
     } else {
         CHECK_EQ(rv, 0) << "Could not find any created Java VM";
         CHECK_EQ(num_vms, 1) << "No VMs returned";
@@ -207,8 +207,9 @@ Status JniLocalFrame::push(JNIEnv* env, int max_local_ref) {
 
 void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
     jclass cls = env->FindClass("java/lang/management/MemoryPoolMXBean");
-    jmethodID mid = env->GetStaticMethodID(cls, "getPlatformMXBean", 
-                       "(Ljavax/management/MBeanServerConnection;)Ljava/lang/management/MemoryPoolMXBean;");
+    jmethodID mid = env->GetStaticMethodID(
+            cls, "getPlatformMXBean",
+            "(Ljavax/management/MBeanServerConnection;)Ljava/lang/management/MemoryPoolMXBean;");
     jobject bean = env->CallStaticObjectMethod(cls, mid, NULL);
 
     jclass beanClass = env->GetObjectClass(bean);

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -244,9 +244,7 @@ void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
 }
 
 size_t JniUtil::get_max_jni_heap_memory_size() {
-#ifdef USE_LIBHDFS3
-    return std::numeric_limits<size_t>::max();
-#elif defined BE_TEST
+#if defined(USE_LIBHDFS3) || defined(BE_TEST)
     return std::numeric_limits<size_t>::max();
 #else
     return max_jvm_heap_memory_size_;

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -248,7 +248,7 @@ size_t JniUtil::get_max_jni_heap_memory_size() {
 #else
     return max_jvm_heap_memory_size_;
 #endif
-
+}
 
 Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     DCHECK(!tls_env_) << "Call GetJNIEnv() fast path";

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -237,6 +237,9 @@ void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
             }
         }
     }
+    if (0 == max_jvm_heap_memory_size_) {
+        LOG(FATAL) << "the max_jvm_heap_memory_size_ is " << max_jvm_heap_memory_size_;
+    }
     LOG(INFO) << "the max_jvm_heap_memory_size_ is " << max_jvm_heap_memory_size_;
 }
 

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -237,6 +237,7 @@ void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
             }
         }
     }
+    LOG(INFO) << "the max_jvm_heap_memory_size_ is " << max_jvm_heap_memory_size_;
 }
 
 size_t JniUtil::get_max_jni_heap_memory_size() {

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -174,6 +174,7 @@ jmethodID JniUtil::get_jvm_threads_id_ = nullptr;
 jmethodID JniUtil::get_jmx_json_ = nullptr;
 jobject JniUtil::jni_scanner_loader_obj_ = nullptr;
 jmethodID JniUtil::jni_scanner_loader_method_ = nullptr;
+jlong JniUtil::max_jvm_heap_memory_size_ = 0;
 
 Status JniUtfCharGuard::create(JNIEnv* env, jstring jstr, JniUtfCharGuard* out) {
     DCHECK(jstr != nullptr);

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -248,7 +248,7 @@ size_t JniUtil::get_max_jni_heap_memory_size() {
 #else
     return max_jvm_heap_memory_size_;
 #endif
-}
+
 
 Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     DCHECK(!tls_env_) << "Call GetJNIEnv() fast path";

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -241,7 +241,6 @@ void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
 }
 
 size_t JniUtil::get_max_jni_heap_memory_size() {
-    return max_jvm_heap_memory_size_;
 #ifdef USE_LIBHDFS3
     return std::numeric_limits<size_t>::max();
 #elif defined BE_TEST

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -84,7 +84,7 @@ public:
     static Status get_jni_scanner_class(JNIEnv* env, const char* classname, jclass* loaded_class);
     static jobject convert_to_java_map(JNIEnv* env, const std::map<std::string, std::string>& map);
     static std::map<std::string, std::string> convert_to_cpp_map(JNIEnv* env, jobject map);
-    static size_t get_max_jni_heap_memory_size()  { return max_jvm_heap_memory_size_;}
+    static size_t get_max_jni_heap_memory_size() { return max_jvm_heap_memory_size_; }
 
 private:
     static void parse_max_heap_memory_size_from_jvm(JNIEnv* env);

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -84,7 +84,7 @@ public:
     static Status get_jni_scanner_class(JNIEnv* env, const char* classname, jclass* loaded_class);
     static jobject convert_to_java_map(JNIEnv* env, const std::map<std::string, std::string>& map);
     static std::map<std::string, std::string> convert_to_cpp_map(JNIEnv* env, jobject map);
-    static size_t get_max_jni_heap_memory_size() { return max_jvm_heap_memory_size_; }
+    static size_t get_max_jni_heap_memory_size();
 
 private:
     static void parse_max_heap_memory_size_from_jvm(JNIEnv* env);

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -84,8 +84,10 @@ public:
     static Status get_jni_scanner_class(JNIEnv* env, const char* classname, jclass* loaded_class);
     static jobject convert_to_java_map(JNIEnv* env, const std::map<std::string, std::string>& map);
     static std::map<std::string, std::string> convert_to_cpp_map(JNIEnv* env, jobject map);
+    static size_t get_max_jni_heap_memory_size()  { return max_jvm_heap_memory_size_;}
 
 private:
+    static void parse_max_heap_memory_size_from_jvm(JNIEnv* env);
     static Status GetJNIEnvSlowPath(JNIEnv** env);
     static Status init_jni_scanner_loader(JNIEnv* env);
 
@@ -103,6 +105,7 @@ private:
     static jmethodID jni_scanner_loader_method_;
     // Thread-local cache of the JNIEnv for this thread.
     static __thread JNIEnv* tls_env_;
+    static jlong max_jvm_heap_memory_size_;
 };
 
 /// Helper class for lifetime management of chars from JNI, releasing JNI chars when


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In practice, we've found that if the import frequency to HDFS is too fast, it can cause an OutOfMemoryError (OOM) in the JVM started by the JNI. For this, we should have a method to monitor how much JVM memory is currently being used.

The HdfsWriteRateLimit class increments a recorded value during hdfsWrite when writing to HDFS. When hdfsCloseFile is called, all related memory in the JVM will be invalidated, so the recorded value can be decreased at that time. However, if the current usage exceeds the maximum set by the user, the current write will sleep. If the number of sleeps exceeds the number specified by the user, then the current write is considered to have failed.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

