### PR TITLE
[Improvement](sort) insert data by batch on VSortedRunMerger::get_next

### DIFF
--- a/be/src/vec/columns/column.cpp
+++ b/be/src/vec/columns/column.cpp
@@ -46,6 +46,13 @@ void IColumn::insert_from(const IColumn& src, size_t n) {
     insert(src[n]);
 }
 
+void IColumn::insert_from_multi_column(const std::vector<const IColumn*>& srcs,
+                                       std::vector<size_t> positions) {
+    for (size_t i = 0; i < srcs.size(); ++i) {
+        insert_from(*srcs[i], positions[i]);
+    }
+}
+
 void IColumn::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                           IColumn::Permutation& perms, EqualRange& range, bool last_column) const {
     sorter->sort_column(static_cast<const IColumn&>(*this), flags, perms, range, last_column);

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -241,6 +241,9 @@ public:
         }
     }
 
+    virtual void insert_from_multi_column(const std::vector<const IColumn*>& srcs,
+                                          std::vector<size_t> positions);
+
     /// Appends a batch elements from other column with the same type
     /// indices_begin + indices_end represent the row indices of column src
     virtual void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,

--- a/be/src/vec/common/sort/partition_sorter.cpp
+++ b/be/src/vec/common/sort/partition_sorter.cpp
@@ -189,7 +189,7 @@ Status PartitionSorter::partition_sort_read(Block* output_block, bool* eos, int 
             break;
         }
 
-        if (!current->isLast()) {
+        if (!current->is_last()) {
             current->next();
             priority_queue.push(current);
         }

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -128,7 +128,7 @@ Status MergeSorterState::_merge_sort_read_impl(int batch_size, doris::vectorized
             offset_--;
         }
 
-        if (!current->isLast()) {
+        if (!current->is_last()) {
             current->next();
             priority_queue_.push(current);
         }

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -163,8 +163,8 @@ struct MergeSortCursorImpl {
         rows = all_columns[0]->size();
     }
 
-    bool isFirst() const { return pos == 0; }
-    bool isLast() const { return pos + 1 >= rows; }
+    bool is_first() const { return pos == 0; }
+    bool is_last() const { return pos + 1 >= rows; }
     void next() { ++pos; }
 
     virtual bool has_next_block() { return false; }

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -288,15 +288,14 @@ template <bool is_binary_format>
 Status DataTypeNullableSerDe::_write_column_to_mysql(const IColumn& column,
                                                      MysqlRowBuffer<is_binary_format>& result,
                                                      int row_idx, bool col_const) const {
-    auto& col = assert_cast<const ColumnNullable&>(column);
-    auto& nested_col = col.get_nested_column();
-    col_const = col_const || is_column_const(nested_col);
+    const auto& col = assert_cast<const ColumnNullable&>(column);
     const auto col_index = index_check_const(row_idx, col_const);
     if (col.has_null() && col.is_null_at(col_index)) {
         if (UNLIKELY(0 != result.push_null())) {
             return Status::InternalError("pack mysql buffer failed.");
         }
     } else {
+        const auto& nested_col = col.get_nested_column();
         RETURN_IF_ERROR(
                 nested_serde->write_column_to_mysql(nested_col, result, col_index, col_const));
     }

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -233,12 +233,7 @@ bool VSortedRunMerger::next_heap(MergeSortCursor& current) {
         return true;
     }
 
-    if (_pipeline_engine_enabled) {
-        // need to check sender is readable again before the next reading.
-        _pending_cursor = current.impl;
-    } else if (has_next_block(current)) {
-        _priority_queue.push(current);
-    }
+    _pending_cursor = current.impl;
     return false;
 }
 

--- a/be/src/vec/runtime/vsorted_run_merger.h
+++ b/be/src/vec/runtime/vsorted_run_merger.h
@@ -93,6 +93,10 @@ protected:
     // Times calls to get the next batch of rows from the input run.
     RuntimeProfile::Counter* _get_next_block_timer = nullptr;
 
+    std::vector<size_t> _indexs;
+    std::vector<Block*> _block_addrs;
+    std::vector<const IColumn*> _column_addrs;
+
 private:
     void init_timers(RuntimeProfile* profile);
 


### PR DESCRIPTION
## Proposed changes
insert data by batch on VSortedRunMerger::get_next

before: 
Total:  1s564ms
MergeGetNext:  291.125ms
AppendBatchTime:  982.993ms
                              -  ResultSendTime:  191.916ms
                              -  TupleConvertTime:  776.347ms
                
after:     
Total:  1s306ms
MergeGetNext:  204.96ms
AppendBatchTime:  798.66ms
                              -  ResultSendTime:  149.435ms
                              -  TupleConvertTime:  636.668ms
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

