### PR TITLE
[fix](csv-reader) fix column split error when there is escape character

### DIFF
--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
@@ -143,13 +143,12 @@ void EncloseCsvLineReaderContext::_on_normal(const uint8_t* start, size_t& len) 
 }
 
 void EncloseCsvLineReaderContext::_on_pre_match_enclose(const uint8_t* start, size_t& len) {
-    bool should_escape = false;
     do {
         do {
             if (start[_idx] == _escape) [[unlikely]] {
-                should_escape = !should_escape;
-            } else if (should_escape) [[unlikely]] {
-                should_escape = false;
+                _should_escape = !_should_escape;
+            } else if (_should_escape) [[unlikely]] {
+                _should_escape = false;
             } else if (start[_idx] == _enclose) [[unlikely]] {
                 _state.forward_to(ReaderState::MATCH_ENCLOSE);
                 ++_idx;

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
@@ -135,6 +135,7 @@ public:
 
     inline void refresh_impl() {
         _idx = 0;
+        _should_escape = false;
         _result = nullptr;
         _column_sep_positions.clear();
         _state.reset();
@@ -168,6 +169,7 @@ private:
     const size_t _column_sep_len;
 
     size_t _idx = 0;
+    bool _should_escape = false;
 
     const std::string _column_sep;
     std::vector<size_t> _column_sep_positions;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
A row of data happened to have an escape character truncated, mistaking the next character for an enclose, resulting in a delimitation error.

**for example:** 
origin data
```
1,2,3,"{~"title~": ~"abced~", ~"id~": 1, ~"name~": ~"user1~", ~"email~": ~"user1@example.com~"}"
```
curl  --location-trusted -u root: -T data -H "format:csv" -H "column_separator:," -H "format:csv" -H 'enclose:"' -H "trim_double_quotes:true" -H 'escape:~' http://127.0.0.1:8040/api/test/load_test_2/_stream_load

Truncated when a row of data is read
```
1,2,3,"{~"title~": ~"abced~", ~"id~": 1, ~"name~": ~
"user1~", ~"email~": ~"user1@example.com~"}"
```
The quotation  before `user1` is considered an enclose character.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

