### PR TITLE
[opt](file-scanner) print current path when encountering error

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -290,6 +290,15 @@ Status VFileScanner::open(RuntimeState* state) {
     return Status::OK();
 }
 
+Status VFileScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof) {
+    Status st = _get_block_wrapped(state, block, eof);
+    if (!st.ok()) {
+        // add cur path in error msg for easy debugging
+        return std::move(st.prepend("cur path: " + get_current_scan_range_name() + ". "));
+    }
+    return st;
+}
+
 // For query:
 //                              [exist cols]  [non-exist cols]  [col from path]  input  output
 //                              A     B    C  D                 E
@@ -309,7 +318,7 @@ Status VFileScanner::open(RuntimeState* state) {
 // _fill_columns_from_path      -     -    -  -                 x                x      -
 // _fill_missing_columns        -     -    -  x                 -                x      -
 // _convert_to_output_block     -     -    -  -                 -                -      x
-Status VFileScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof) {
+Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool* eof) {
     do {
         RETURN_IF_CANCELLED(state);
         if (_cur_reader == nullptr || _cur_reader_eof) {

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -88,6 +88,8 @@ public:
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) override;
 
+    Status _get_block_wrapped(RuntimeState* state, Block* block, bool* eof);
+
     Status _get_next_reader();
 
     // TODO: cast input block columns type to string.


### PR DESCRIPTION
## Proposed changes

Like this:
```
mysql> select * from text_deflate;
ERROR 1105 (HY000): errCode = 2, detailMessage = (172.21.0.101)[CANCELLED][INTERNAL_ERROR]cur path: hdfs://ns/usr/hive/warehouse/yytest.db/text_deflate/test2.snappy. Compressed file has been truncated, which is not allowed
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

