### PR TITLE
[Bug](runtime-filter) release rf count dependency when query canceled

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1301,16 +1301,16 @@ void IRuntimeFilter::set_filter_timer(std::shared_ptr<pipeline::RuntimeFilterTim
     _filter_timer.push_back(timer);
 }
 
-void IRuntimeFilter::set_dependency(pipeline::CountedFinishDependency* dependency) {
+void IRuntimeFilter::set_dependency(std::shared_ptr<pipeline::Dependency> dependency) {
     _dependency = dependency;
-    _dependency->add();
+    ((pipeline::CountedFinishDependency*)_dependency.get())->add();
     CHECK(_dependency);
 }
 
 void IRuntimeFilter::set_synced_size(uint64_t global_size) {
     _synced_size = global_size;
     if (_dependency) {
-        _dependency->sub();
+        ((pipeline::CountedFinishDependency*)_dependency.get())->sub();
     }
 }
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -70,7 +70,6 @@ struct SharedRuntimeFilterContext;
 
 namespace pipeline {
 class RuntimeFilterTimer;
-struct CountedFinishDependency;
 } // namespace pipeline
 
 enum class RuntimeFilterType {
@@ -366,7 +365,7 @@ public:
 
     void set_synced_size(uint64_t global_size);
 
-    void set_dependency(pipeline::CountedFinishDependency* dependency);
+    void set_dependency(std::shared_ptr<pipeline::Dependency> dependency);
 
     int64_t get_synced_size() const { return _synced_size; }
 
@@ -453,7 +452,7 @@ protected:
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
     int64_t _synced_size = -1;
-    pipeline::CountedFinishDependency* _dependency = nullptr;
+    std::shared_ptr<pipeline::Dependency> _dependency;
 };
 
 // avoid expose RuntimePredicateWrapper

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -42,7 +42,7 @@ public:
     }
 
     Status send_filter_size(RuntimeState* state, uint64_t hash_table_size,
-                            pipeline::CountedFinishDependency* dependency) {
+                            std::shared_ptr<pipeline::Dependency> dependency) {
         if (_runtime_filters.empty()) {
             return Status::OK();
         }

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -212,6 +212,7 @@ public:
     using SharedState = FakeSharedState;
     CountedFinishDependency(int id, int node_id, std::string name, QueryContext* query_ctx)
             : FinishDependency(id, node_id, name, query_ctx) {}
+    using Dependency::is_blocked_by;
 
     void add() {
         std::unique_lock<std::mutex> l(_mtx);

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -207,12 +207,11 @@ public:
     [[nodiscard]] Dependency* is_blocked_by(PipelineTask* task) override;
 };
 
-struct CountedFinishDependency final : public FinishDependency {
+struct CountedFinishDependency final : public Dependency {
 public:
     using SharedState = FakeSharedState;
     CountedFinishDependency(int id, int node_id, std::string name, QueryContext* query_ctx)
-            : FinishDependency(id, node_id, name, query_ctx) {}
-    using Dependency::is_blocked_by;
+            : Dependency(id, node_id, name, query_ctx) {}
 
     void add() {
         std::unique_lock<std::mutex> l(_mtx);

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -211,7 +211,7 @@ struct CountedFinishDependency final : public Dependency {
 public:
     using SharedState = FakeSharedState;
     CountedFinishDependency(int id, int node_id, std::string name, QueryContext* query_ctx)
-            : Dependency(id, node_id, name, query_ctx) {}
+            : Dependency(id, node_id, name, true, query_ctx) {}
 
     void add() {
         std::unique_lock<std::mutex> l(_mtx);

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -557,7 +557,7 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
 
         RETURN_IF_ERROR(local_state._runtime_filter_slots->send_filter_size(
                 state, local_state._shared_state->build_block->rows(),
-                (CountedFinishDependency*)(local_state._finish_dependency.get())));
+                local_state._finish_dependency));
         RETURN_IF_ERROR(
                 local_state.process_build_block(state, (*local_state._shared_state->build_block)));
         if (_shared_hashtable_controller) {

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1821,7 +1821,6 @@ private:
     }
 
     WrapperType create_unsupport_wrapper(const String error_msg) const {
-        LOG(WARNING) << error_msg;
         return [error_msg](FunctionContext* /*context*/, Block& /*block*/,
                            const ColumnNumbers& /*arguments*/, const size_t /*result*/,
                            size_t /*input_rows_count*/) {


### PR DESCRIPTION
## Proposed changes
release rf count dependency when query canceled

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

