### PR TITLE
[refactor](fe status) unify fe status code and remove cancel reason

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -50,6 +50,7 @@ namespace ErrorCode {
     TStatusError(MEM_LIMIT_EXCEEDED, false);              \
     TStatusError(THRIFT_RPC_ERROR, true);                 \
     TStatusError(TIMEOUT, true);                          \
+    TStatusError(LIMIT_REACH, false);                     \
     TStatusError(TOO_MANY_TASKS, true);                   \
     TStatusError(UNINITIALIZED, false);                   \
     TStatusError(INCOMPLETE, false);                      \

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -412,7 +412,7 @@ void ExchangeSinkBuffer::_ended(InstanceLoId id) {
 
 void ExchangeSinkBuffer::_failed(InstanceLoId id, const std::string& err) {
     _is_finishing = true;
-    _context->cancel(err, Status::Cancelled(err));
+    _context->cancel(Status::Cancelled(err));
     _ended(id);
 }
 

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -169,7 +169,7 @@ bool PipelineFragmentContext::is_timeout(timespec now) const {
 // QueryCtx cancel will call fragment ctx cancel. And Also Fragment ctx's running
 // Method like exchange sink buffer will call query ctx cancel. If we add lock here
 // There maybe dead lock.
-void PipelineFragmentContext::cancel(const Status& reason) {
+void PipelineFragmentContext::cancel(const Status reason) {
     LOG_INFO("PipelineFragmentContext::cancel")
             .tag("query_id", print_id(_query_id))
             .tag("fragment_id", _fragment_id)
@@ -181,8 +181,8 @@ void PipelineFragmentContext::cancel(const Status& reason) {
             return;
         }
     }
-    _query_ctx->cancel(msg, reason, _fragment_id);
-    if (reason.is<ErrorCode::LIMIT_REACH>) {
+    _query_ctx->cancel(reason, _fragment_id);
+    if (reason.is<ErrorCode::LIMIT_REACH>()) {
         _is_report_on_cancel = false;
     } else {
         for (auto& id : _fragment_instance_ids) {
@@ -193,7 +193,7 @@ void PipelineFragmentContext::cancel(const Status& reason) {
     // For stream load the fragment's query_id == load id, it is set in FE.
     auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_id);
     if (stream_load_ctx != nullptr) {
-        stream_load_ctx->pipe->cancel(msg);
+        stream_load_ctx->pipe->cancel(reason.to_string());
     }
 
     // Cancel the result queue manager used by spark doris connector
@@ -1499,7 +1499,7 @@ void PipelineFragmentContext::close_if_prepare_failed(Status st) {
             close_a_pipeline();
         }
     }
-    _query_ctx->cancel(st.to_string(), st, _fragment_id);
+    _query_ctx->cancel(st, _fragment_id);
 }
 
 // If all pipeline tasks binded to the fragment instance are finished, then we could

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -169,8 +169,11 @@ bool PipelineFragmentContext::is_timeout(timespec now) const {
 // QueryCtx cancel will call fragment ctx cancel. And Also Fragment ctx's running
 // Method like exchange sink buffer will call query ctx cancel. If we add lock here
 // There maybe dead lock.
-void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
-                                     const std::string& msg) {
+void PipelineFragmentContext::cancel(const Status& reason) {
+    LOG_INFO("PipelineFragmentContext::cancel")
+            .tag("query_id", print_id(_query_id))
+            .tag("fragment_id", _fragment_id)
+            .tag("reason", reason.to_string());
     {
         std::lock_guard<std::mutex> l(_task_mutex);
         if (_closed_tasks == _total_tasks) {
@@ -178,16 +181,8 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
             return;
         }
     }
-    LOG_INFO("PipelineFragmentContext::cancel")
-            .tag("query_id", print_id(_query_id))
-            .tag("fragment_id", _fragment_id)
-            .tag("reason", reason)
-            .tag("error message", msg);
-    if (reason == PPlanFragmentCancelReason::TIMEOUT) {
-        LOG(WARNING) << "PipelineFragmentContext is cancelled due to timeout : " << debug_string();
-    }
-    _query_ctx->cancel(msg, Status::Cancelled(msg), _fragment_id);
-    if (reason == PPlanFragmentCancelReason::LIMIT_REACH) {
+    _query_ctx->cancel(msg, reason, _fragment_id);
+    if (reason.is<ErrorCode::LIMIT_REACH>) {
         _is_report_on_cancel = false;
     } else {
         for (auto& id : _fragment_instance_ids) {
@@ -1466,7 +1461,7 @@ Status PipelineFragmentContext::submit() {
             st = scheduler->schedule_task(t.get());
             if (!st) {
                 std::lock_guard<std::mutex> l(_status_lock);
-                cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "submit context fail");
+                cancel(Status::InternalError("submit context to executor fail"));
                 _total_tasks = submit_tasks;
                 break;
             }
@@ -1602,8 +1597,7 @@ Status PipelineFragmentContext::send_report(bool done) {
                              -1,
                              _runtime_state.get(),
                              [this](Status st) { return update_status(st); },
-                             [this](const PPlanFragmentCancelReason& reason,
-                                    const std::string& msg) { cancel(reason, msg); }};
+                             [this](const Status& reason) { cancel(reason); }};
 
     return _report_status_cb(
             req, std::dynamic_pointer_cast<PipelineFragmentContext>(shared_from_this()));

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -95,8 +95,7 @@ public:
 
     void set_is_report_success(bool is_report_success) { _is_report_success = is_report_success; }
 
-    void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
-                const std::string& msg = "");
+    void cancel(const Status& reason);
 
     // TODO: Support pipeline runtime filter
 

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -95,7 +95,7 @@ public:
 
     void set_is_report_success(bool is_report_success) { _is_report_success = is_report_success; }
 
-    void cancel(const Status& reason);
+    void cancel(const Status reason);
 
     // TODO: Support pipeline runtime filter
 

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -87,8 +87,7 @@ void _close_task(PipelineTask* task, Status exec_status) {
     // for pending finish now. So that could call close directly.
     Status status = task->close(exec_status);
     if (!status.ok()) {
-        task->fragment_context()->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
-                                         std::string(status.msg()));
+        task->fragment_context()->cancel(status);
     }
     task->finalize();
     task->set_running(false);
@@ -166,12 +165,17 @@ void TaskScheduler::_do_work(size_t index) {
             // LOG(WARNING)<< "task:\n"<<task->debug_string();
 
             // exec failed，cancel all fragment instance
+<<<<<<< HEAD
             fragment_ctx->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
                                  std::string(status.to_string_no_stack()));
             LOG(WARNING) << fmt::format("Pipeline task failed. query_id: {} reason: {}",
                                         print_id(task->query_context()->query_id()),
                                         status.to_string());
             _close_task(task, status);
+=======
+            fragment_ctx->cancel(status);
+            _close_task(task, PipelineTaskState::CANCELED, status);
+>>>>>>> 3c0e170471 (fix cancel reason)
             continue;
         }
         fragment_ctx->trigger_report_if_necessary();

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -165,17 +165,11 @@ void TaskScheduler::_do_work(size_t index) {
             // LOG(WARNING)<< "task:\n"<<task->debug_string();
 
             // exec failed，cancel all fragment instance
-<<<<<<< HEAD
-            fragment_ctx->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
-                                 std::string(status.to_string_no_stack()));
+            fragment_ctx->cancel(status);
             LOG(WARNING) << fmt::format("Pipeline task failed. query_id: {} reason: {}",
                                         print_id(task->query_context()->query_id()),
                                         status.to_string());
             _close_task(task, status);
-=======
-            fragment_ctx->cancel(status);
-            _close_task(task, PipelineTaskState::CANCELED, status);
->>>>>>> 3c0e170471 (fix cancel reason)
             continue;
         }
         fragment_ctx->trigger_report_if_necessary();

--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -103,8 +103,8 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
     }
     if (context != nullptr) {
         // first cancel the fragment instance, just ignore return status
-        _exec_env->fragment_mgr()->cancel_instance(context->fragment_instance_id,
-                                                   PPlanFragmentCancelReason::INTERNAL_ERROR);
+        _exec_env->fragment_mgr()->cancel_instance(
+                context->fragment_instance_id, Status::InternalError("cancelled by clear thread"));
         // clear the fragment instance's related result queue
         static_cast<void>(_exec_env->result_queue_mgr()->cancel(context->fragment_instance_id));
         LOG(INFO) << "close scan context: context id [ " << context_id << " ]";
@@ -144,8 +144,9 @@ void ExternalScanContextMgr::gc_expired_context() {
         }
         for (auto expired_context : expired_contexts) {
             // must cancel the fragment instance, otherwise return thrift transport TTransportException
-            _exec_env->fragment_mgr()->cancel_instance(expired_context->fragment_instance_id,
-                                                       PPlanFragmentCancelReason::INTERNAL_ERROR);
+            _exec_env->fragment_mgr()->cancel_instance(
+                    expired_context->fragment_instance_id,
+                    Status::InternalError("scan context is expired"));
             static_cast<void>(
                     _exec_env->result_queue_mgr()->cancel(expired_context->fragment_instance_id));
         }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -439,7 +439,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
             if (!rpc_status.ok()) {
                 // we need to cancel the execution of this fragment
                 static_cast<void>(req.update_fn(rpc_status));
-                req.cancel_fn(PPlanFragmentCancelReason::INTERNAL_ERROR, "report rpc fail");
+                req.cancel_fn(rpc_status);
                 return;
             }
             coord->reportExecStatus(res, params);
@@ -456,7 +456,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
                  print_id(req.fragment_instance_id), rpc_status.to_string());
         // we need to cancel the execution of this fragment
         static_cast<void>(req.update_fn(rpc_status));
-        req.cancel_fn(PPlanFragmentCancelReason::INTERNAL_ERROR, std::string(rpc_status.msg()));
+        req.cancel_fn(rpc_status);
     }
 }
 
@@ -469,8 +469,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<PlanFragmentExecutor> fragment_ex
 
     Status st = fragment_executor->execute();
     if (!st.ok()) {
-        fragment_executor->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
-                                  "fragment_executor execute failed");
+        fragment_executor->cancel(st);
     }
 
     std::shared_ptr<QueryContext> query_ctx = fragment_executor->get_query_ctx();
@@ -792,8 +791,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
             g_fragment_executing_count << -1;
             g_fragment_last_active_time.set_value(now);
         }
-        fragment_executor->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
-                                  "push plan fragment to thread pool failed");
+        fragment_executor->cancel(st);
         return Status::InternalError(
                 strings::Substitute("push plan fragment $0 to thread pool failed. err = $1, BE: $2",
                                     print_id(params.params.fragment_instance_id), st.to_string(),
@@ -924,8 +922,7 @@ std::shared_ptr<QueryContext> FragmentMgr::get_query_context(const TUniqueId& qu
     }
 }
 
-void FragmentMgr::cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
-                               const std::string& msg) {
+void FragmentMgr::cancel_query(const TUniqueId& query_id, const Status& reason) {
     std::shared_ptr<QueryContext> query_ctx;
     std::vector<TUniqueId> all_instance_ids;
     {
@@ -958,8 +955,7 @@ void FragmentMgr::cancel_query(const TUniqueId& query_id, const PPlanFragmentCan
     LOG(INFO) << "Query " << print_id(query_id) << " is cancelled and removed. Reason: " << msg;
 }
 
-void FragmentMgr::cancel_instance(const TUniqueId& instance_id,
-                                  const PPlanFragmentCancelReason& reason, const std::string& msg) {
+void FragmentMgr::cancel_instance(const TUniqueId& instance_id, const Status& reason) {
     std::shared_ptr<pipeline::PipelineFragmentContext> pipeline_ctx;
     std::shared_ptr<PlanFragmentExecutor> non_pipeline_ctx;
     {
@@ -987,15 +983,15 @@ void FragmentMgr::cancel_instance(const TUniqueId& instance_id,
     }
 
     if (pipeline_ctx != nullptr) {
-        pipeline_ctx->cancel(reason, msg);
+        pipeline_ctx->cancel(reason);
     } else if (non_pipeline_ctx != nullptr) {
         // calling PlanFragmentExecutor::cancel
-        non_pipeline_ctx->cancel(reason, msg);
+        non_pipeline_ctx->cancel(reason);
     }
 }
 
 void FragmentMgr::cancel_fragment(const TUniqueId& query_id, int32_t fragment_id,
-                                  const PPlanFragmentCancelReason& reason, const std::string& msg) {
+                                  const Status& reason) {
     std::unique_lock<std::mutex> lock(_lock);
     auto q_ctx_iter = _query_ctx_map.find(query_id);
     if (q_ctx_iter != _query_ctx_map.end()) {
@@ -1003,7 +999,7 @@ void FragmentMgr::cancel_fragment(const TUniqueId& query_id, int32_t fragment_id
         std::shared_ptr<QueryContext> q_ctx = q_ctx_iter->second;
         // the lock should only be used to protect the map, not scope query ctx
         lock.unlock();
-        WARN_IF_ERROR(q_ctx->cancel_pipeline_context(fragment_id, reason, msg),
+        WARN_IF_ERROR(q_ctx->cancel_pipeline_context(fragment_id, reason),
                       "fail to cancel fragment");
     } else {
         LOG(WARNING) << "Could not find the query id:" << print_id(query_id)
@@ -1090,7 +1086,9 @@ void FragmentMgr::cancel_worker() {
         // designed to count canceled fragment of non-pipeline query.
         timeout_canceled_fragment_count->increment(to_cancel.size());
         for (auto& id : to_cancel) {
-            cancel_instance(id, PPlanFragmentCancelReason::TIMEOUT);
+            cancel_instance(id,
+                            Status::Error<ErrorCode::TIMEOUT>(
+                                    "FragmentMgr cancel worker going to cancel timeout instance "));
             LOG(INFO) << "FragmentMgr cancel worker going to cancel timeout instance "
                       << print_id(id);
         }
@@ -1101,8 +1099,7 @@ void FragmentMgr::cancel_worker() {
         }
 
         for (const auto& qid : queries_to_cancel) {
-            cancel_query(qid, PPlanFragmentCancelReason::INTERNAL_ERROR,
-                         std::string("Coordinator dead."));
+            cancel_query(qid, Status::InternalError("Coordinator dead."));
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(1)));
     LOG(INFO) << "FragmentMgr cancel worker is going to exit.";

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -100,13 +100,13 @@ public:
                                            std::shared_ptr<pipeline::PipelineFragmentContext>&&);
 
     // Cancel instance (pipeline or nonpipeline).
-    void cancel_instance(const TUniqueId& instance_id, const Status& reason);
+    void cancel_instance(const TUniqueId instance_id, const Status reason);
     // Cancel fragment (only pipelineX).
     // {query id fragment} -> PipelineFragmentContext
-    void cancel_fragment(const TUniqueId& query_id, int32_t fragment_id, const Status& reason);
+    void cancel_fragment(const TUniqueId query_id, int32_t fragment_id, const Status reason);
 
     // Can be used in both version.
-    void cancel_query(const TUniqueId& query_id, const Status& reason);
+    void cancel_query(const TUniqueId query_id, const Status reason);
 
     void cancel_worker();
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -100,16 +100,13 @@ public:
                                            std::shared_ptr<pipeline::PipelineFragmentContext>&&);
 
     // Cancel instance (pipeline or nonpipeline).
-    void cancel_instance(const TUniqueId& instance_id, const PPlanFragmentCancelReason& reason,
-                         const std::string& msg = "");
+    void cancel_instance(const TUniqueId& instance_id, const Status& reason);
     // Cancel fragment (only pipelineX).
     // {query id fragment} -> PipelineFragmentContext
-    void cancel_fragment(const TUniqueId& query_id, int32_t fragment_id,
-                         const PPlanFragmentCancelReason& reason, const std::string& msg = "");
+    void cancel_fragment(const TUniqueId& query_id, int32_t fragment_id, const Status& reason);
 
     // Can be used in both version.
-    void cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
-                      const std::string& msg = "");
+    void cancel_query(const TUniqueId& query_id, const Status& reason);
 
     void cancel_worker();
 
@@ -156,9 +153,8 @@ public:
                                     TReportExecStatusParams* exec_status);
 
 private:
-    void cancel_unlocked_impl(const TUniqueId& id, const PPlanFragmentCancelReason& reason,
-                              const std::unique_lock<std::mutex>& state_lock, bool is_pipeline,
-                              const std::string& msg = "");
+    void cancel_unlocked_impl(const TUniqueId& id, const Status& reason,
+                              const std::unique_lock<std::mutex>& state_lock, bool is_pipeline);
 
     void _exec_actual(std::shared_ptr<PlanFragmentExecutor> fragment_executor,
                       const FinishCallback& cb);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -600,8 +600,8 @@ int64_t MemTrackerLimiter::free_top_memory_query(
                 continue;
             }
             ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-                    cancelled_queryid, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED,
-                    cancel_msg(min_pq.top().first, min_pq.top().second));
+                    cancelled_queryid, Status::MemoryLimitExceeded(cancel_msg(
+                                               min_pq.top().first, min_pq.top().second)));
 
             COUNTER_UPDATE(freed_memory_counter, min_pq.top().first);
             COUNTER_UPDATE(cancel_tasks_counter, 1);
@@ -728,8 +728,8 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(
             }
             int64_t query_mem = query_consumption[max_pq.top().second];
             ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-                    cancelled_queryid, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED,
-                    cancel_msg(query_mem, max_pq.top().second));
+                    cancelled_queryid,
+                    Status::MemoryLimitExceeded(cancel_msg(query_mem, max_pq.top().second)));
 
             usage_strings.push_back(fmt::format("{} memory used {} Bytes, overcommit ratio: {}",
                                                 max_pq.top().second, query_mem,

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -33,7 +33,7 @@ public:
     ~AsyncCancelQueryTask() override = default;
     void run() override {
         ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-                _query_id, PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED, _exceed_msg);
+                _query_id, Status::MemoryLimitExceeded(_exceed_msg));
     }
 
 private:

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -503,8 +503,7 @@ void PlanFragmentExecutor::send_report(bool done) {
             _backend_num,
             _runtime_state.get(),
             std::bind(&PlanFragmentExecutor::update_status, this, std::placeholders::_1),
-            std::bind(&PlanFragmentExecutor::cancel, this, std::placeholders::_1,
-                      std::placeholders::_2)};
+            std::bind(&PlanFragmentExecutor::cancel, this, std::placeholders::_1)};
     // This will send a report even if we are cancelled.  If the query completed correctly
     // but fragments still need to be cancelled (e.g. limit reached), the coordinator will
     // be waiting for a final report and profile.

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -538,7 +538,7 @@ void PlanFragmentExecutor::stop_report_thread() {
 
 void PlanFragmentExecutor::cancel(const Status& reason) {
     std::lock_guard<std::mutex> l(_status_lock);
-    LOG_INFO("PlanFragmentExecutor::cancel {} reason {} error msg {}",
+    LOG_INFO("PlanFragmentExecutor::cancel {} reason {}",
              PrintInstanceStandardInfo(query_id(), fragment_instance_id()), reason.to_string());
 
     // NOTE: Not need to check if already cancelled.

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -93,8 +93,8 @@ PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
           _opened(false),
           _closed(false),
           _is_report_success(false),
-          _is_report_on_cancel(true),
-          _cancel_reason(PPlanFragmentCancelReason::INTERNAL_ERROR) {
+          _is_report_on_cancel(true) {
+    _cancel_reason = Status::InternalError("");
     _report_thread_future = _report_thread_promise.get_future();
     _fragment_watcher.start();
     _query_statistics = std::make_shared<QueryStatistics>();
@@ -280,20 +280,10 @@ Status PlanFragmentExecutor::open() {
         // only retrieve the log.
         _runtime_state->log_error(status.to_string());
     }
-    if (status.is<CANCELLED>()) {
-        if (_cancel_reason == PPlanFragmentCancelReason::CALL_RPC_ERROR) {
-            status = Status::RuntimeError(_cancel_msg);
-        } else if (_cancel_reason == PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED) {
-            status = Status::MemoryLimitExceeded(_cancel_msg);
-        }
-    }
 
     {
         std::lock_guard<std::mutex> l(_status_lock);
         _status = status;
-        if (status.is<MEM_LIMIT_EXCEEDED>()) {
-            static_cast<void>(_runtime_state->set_mem_limit_exceeded(status.to_string()));
-        }
         if (_runtime_state->query_type() == TQueryType::EXTERNAL) {
             TUniqueId fragment_instance_id = _runtime_state->fragment_instance_id();
             _exec_env->result_queue_mgr()->update_queue_status(fragment_instance_id, status);
@@ -390,7 +380,7 @@ Status PlanFragmentExecutor::execute() {
         // if _need_wait_execution_trigger is true, which means this instance
         // is prepared but need to wait for the signal to do the rest execution.
         if (!_query_ctx->wait_for_start()) {
-            cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "wait fragment start timeout");
+            cancel(Status::InternalError("wait fragment start timeout"));
             return Status::OK();
         }
     }
@@ -407,8 +397,8 @@ Status PlanFragmentExecutor::execute() {
                                               print_id(_fragment_instance_id),
                                               print_id(_query_ctx->query_id())));
         if (!st.ok()) {
-            cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
-                   fmt::format("PlanFragmentExecutor open failed, reason: {}", st.to_string()));
+            cancel(Status::InternalError(
+                    fmt::format("PlanFragmentExecutor open failed, reason: {}", st.to_string())));
         }
         close();
     }
@@ -547,10 +537,10 @@ void PlanFragmentExecutor::stop_report_thread() {
     _report_thread_future.wait();
 }
 
-void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const std::string& msg) {
+void PlanFragmentExecutor::cancel(const Status& reason) {
     std::lock_guard<std::mutex> l(_status_lock);
     LOG_INFO("PlanFragmentExecutor::cancel {} reason {} error msg {}",
-             PrintInstanceStandardInfo(query_id(), fragment_instance_id()), reason, msg);
+             PrintInstanceStandardInfo(query_id(), fragment_instance_id()), reason.to_string());
 
     // NOTE: Not need to check if already cancelled.
     // Bug scenario: test_array_map_function.groovy:
@@ -558,24 +548,23 @@ void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const
 
     DCHECK(_prepared);
     _cancel_reason = reason;
-    if (reason == PPlanFragmentCancelReason::LIMIT_REACH) {
+    if (reason.is<ErrorCode::LIMIT_REACH>()) {
         _is_report_on_cancel = false;
     }
-    _cancel_msg = msg;
-    _runtime_state->set_is_cancelled(msg);
+    _runtime_state->set_is_cancelled(reason.to_string());
     // To notify wait_for_start()
     _query_ctx->set_ready_to_execute(true);
 
     // must close stream_mgr to avoid dead lock in Exchange Node
-    _exec_env->vstream_mgr()->cancel(_fragment_instance_id, Status::Cancelled(msg));
+    _exec_env->vstream_mgr()->cancel(_fragment_instance_id, reason);
     // Cancel the result queue manager used by spark doris connector
-    _exec_env->result_queue_mgr()->update_queue_status(_fragment_instance_id, Status::Aborted(msg));
+    _exec_env->result_queue_mgr()->update_queue_status(_fragment_instance_id, reason);
 #ifndef BE_TEST
     // Get pipe from new load stream manager and send cancel to it or the fragment may hang to wait read from pipe
     // For stream load the fragment's query_id == load id, it is set in FE.
     auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_ctx->query_id());
     if (stream_load_ctx != nullptr) {
-        stream_load_ctx->pipe->cancel(msg);
+        stream_load_ctx->pipe->cancel(reason.to_string());
     }
 #endif
     return;

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -125,8 +125,7 @@ public:
     void close();
 
     // Initiate cancellation. Must not be called until after prepare() returned.
-    void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
-                const std::string& msg = "");
+    void cancel(const Status& reason);
 
     // call these only after prepare()
     RuntimeState* runtime_state() { return _runtime_state.get(); }
@@ -237,8 +236,7 @@ private:
     MonotonicStopWatch _fragment_watcher;
 
     // Record the cancel information when calling the cancel() method, return it to FE
-    PPlanFragmentCancelReason _cancel_reason;
-    std::string _cancel_msg;
+    Status _cancel_reason;
 
     DescriptorTbl* _desc_tbl = nullptr;
 

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -62,7 +62,7 @@ struct ReportStatusRequest {
     int backend_num;
     RuntimeState* runtime_state;
     std::function<Status(Status)> update_fn;
-    std::function<void(const PPlanFragmentCancelReason&, const std::string&)> cancel_fn;
+    std::function<void(const Status&)> cancel_fn;
 };
 
 // Save the common components of fragments in a query.
@@ -107,10 +107,8 @@ public:
 
     [[nodiscard]] bool is_cancelled() const { return _is_cancelled.load(); }
 
-    void cancel_all_pipeline_context(const PPlanFragmentCancelReason& reason,
-                                     const std::string& msg);
-    Status cancel_pipeline_context(const int fragment_id, const PPlanFragmentCancelReason& reason,
-                                   const std::string& msg);
+    void cancel_all_pipeline_context(const Status& reason);
+    Status cancel_pipeline_context(const int fragment_id, const Status& reason);
     void set_pipeline_context(const int fragment_id,
                               std::shared_ptr<pipeline::PipelineFragmentContext> pip_ctx);
     void cancel(std::string msg, Status new_status, int fragment_id = -1);

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -111,7 +111,7 @@ public:
     Status cancel_pipeline_context(const int fragment_id, const Status& reason);
     void set_pipeline_context(const int fragment_id,
                               std::shared_ptr<pipeline::PipelineFragmentContext> pip_ctx);
-    void cancel(std::string msg, Status new_status, int fragment_id = -1);
+    void cancel(Status new_status, int fragment_id = -1);
 
     void set_exec_status(Status new_status) {
         if (new_status.ok()) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -374,17 +374,6 @@ std::string RuntimeState::cancel_reason() const {
     return _cancel_reason;
 }
 
-Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {
-    {
-        std::lock_guard<std::mutex> l(_process_status_lock);
-        if (_process_status.ok()) {
-            _process_status = Status::MemoryLimitExceeded(msg);
-        }
-    }
-    DCHECK(_process_status.is<MEM_LIMIT_EXCEEDED>());
-    return _process_status;
-}
-
 const int64_t MAX_ERROR_NUM = 50;
 
 Status RuntimeState::create_error_log_file() {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -230,14 +230,6 @@ public:
     int be_number(void) const { return _be_number; }
 
     // Sets _process_status with err_msg if no error has been set yet.
-    void set_process_status(const std::string& err_msg) {
-        std::lock_guard<std::mutex> l(_process_status_lock);
-        if (!_process_status.ok()) {
-            return;
-        }
-        _process_status = Status::InternalError(err_msg);
-    }
-
     void set_process_status(const Status& status) {
         if (status.ok()) {
             return;
@@ -248,12 +240,6 @@ public:
         }
         _process_status = status;
     }
-
-    // Sets _process_status to MEM_LIMIT_EXCEEDED.
-    // Subsequent calls to this will be no-ops. Returns _process_status.
-    // If 'msg' is non-nullptr, it will be appended to query_status_ in addition to the
-    // generic "Memory limit exceeded" error.
-    Status set_mem_limit_exceeded(const std::string& msg = "Memory limit exceeded");
 
     std::vector<std::string>& output_files() { return _output_files; }
 

--- a/be/src/runtime/workload_management/workload_action.cpp
+++ b/be/src/runtime/workload_management/workload_action.cpp
@@ -24,8 +24,7 @@ namespace doris {
 void WorkloadActionCancelQuery::exec(WorkloadQueryInfo* query_info) {
     LOG(INFO) << "[workload_schedule]workload scheduler cancel query " << query_info->query_id;
     ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-            query_info->tquery_id, PPlanFragmentCancelReason::INTERNAL_ERROR,
-            std::string("query canceled by workload scheduler"));
+            query_info->tquery_id, Status::InternalError("query canceled by workload scheduler"));
 }
 
 void WorkloadActionMoveQuery::exec(WorkloadQueryInfo* query_info) {

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -589,8 +589,8 @@ Status BaseBackendService::start_plan_fragment_execution(
 void BaseBackendService::cancel_plan_fragment(TCancelPlanFragmentResult& return_val,
                                               const TCancelPlanFragmentParams& params) {
     LOG(INFO) << "cancel_plan_fragment(): instance_id=" << print_id(params.fragment_instance_id);
-    _exec_env->fragment_mgr()->cancel_instance(params.fragment_instance_id,
-                                               PPlanFragmentCancelReason::INTERNAL_ERROR);
+    _exec_env->fragment_mgr()->cancel_instance(
+            params.fragment_instance_id, Status::InternalError("cancel message received from FE"));
 }
 
 void BaseBackendService::transmit_data(TTransmitDataResult& return_val,

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -571,36 +571,39 @@ void PInternalService::cancel_plan_fragment(google::protobuf::RpcController* /*c
         Status st = Status::OK();
 
         const bool has_cancel_reason = request->has_cancel_reason();
+        const bool has_cancel_status = request->has_cancel_status();
+        // During upgrade only LIMIT_REACH is used, other reason is changed to internal error
+        Status actual_cancel_status = Status::OK();
+        // Convert PPlanFragmentCancelReason to Status
+        if (has_cancel_status) {
+            // If fe set cancel status, then it is new FE now, should use cancel status.
+            actual_cancel_status = Status::create(request->cancel_status());
+        } else if (has_cancel_reason) {
+            // If fe not set cancel status, but set cancel reason, should convert cancel reason
+            // to cancel status here.
+            if (request->cancel_reason() == PPlanFragmentCancelReason::LIMIT_REACH) {
+                actual_cancel_status = Status::Error<ErrorCode::LIMIT_REACH>("limit reach");
+            } else {
+                // Use cancel reason as error message
+                actual_cancel_status = Status::InternalError(
+                        PPlanFragmentCancelReason_Name(request->cancel_reason()));
+            }
+        } else {
+            actual_cancel_status = Status::InternalError("unknown error");
+        }
+
         if (request->has_fragment_id()) {
             TUniqueId query_id;
             query_id.__set_hi(request->query_id().hi());
             query_id.__set_lo(request->query_id().lo());
-            LOG(INFO) << fmt::format(
-                    "Cancel query {}, reason: {}", print_id(query_id),
-                    has_cancel_reason ? PPlanFragmentCancelReason_Name(request->cancel_reason())
-                                      : "INTERNAL_ERROR");
-            // During upgrade only LIMIT_REACH is used, other reason is changed to internal error
-            Status actual_cancel_status = Status::OK();
-            if (has_cancel_reason) {
-                if (request->cancel_reason() == PPlanFragmentCancelReason::LIMIT_REACH) {
-                    actual_cancel_status = Status::Error<ErrorCode::LIMIT_REACH>();
-                } else {
-                    actual_cancel_status = Status::InternalError("");
-                }
-            } else {
-                if () {
-                }
-            }
+            LOG(INFO) << fmt::format("Cancel query {}, reason: {}", print_id(query_id),
+                                     actual_cancel_status.to_string());
             _exec_env->fragment_mgr()->cancel_fragment(query_id, request->fragment_id(),
                                                        actual_cancel_status);
         } else {
-            LOG(INFO) << fmt::format(
-                    "Cancel instance {}, reason: {}", print_id(tid),
-                    has_cancel_reason ? PPlanFragmentCancelReason_Name(request->cancel_reason())
-                                      : "INTERNAL_ERROR");
-            _exec_env->fragment_mgr()->cancel_instance(
-                    tid, has_cancel_reason ? request->cancel_reason()
-                                           : PPlanFragmentCancelReason::INTERNAL_ERROR);
+            LOG(INFO) << fmt::format("Cancel instance {}, reason: {}", print_id(tid),
+                                     actual_cancel_status.to_string());
+            _exec_env->fragment_mgr()->cancel_instance(tid, actual_cancel_status);
         }
 
         // TODO: the logic seems useless, cancel only return Status::OK. remove it

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -84,7 +84,7 @@ void FunctionContext::set_error(const char* error_msg) {
         ss << "UDF ERROR: " << error_msg;
 
         if (_state != nullptr) {
-            _state->set_process_status(ss.str());
+            _state->set_process_status(Status::InternalError(ss.str()));
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -38,6 +38,7 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.CatalogIf;
@@ -56,7 +57,6 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.plsql.Exec;
 import org.apache.doris.plsql.executor.PlSqlOperation;
 import org.apache.doris.plugin.audit.AuditEvent.AuditEventBuilder;
-import org.apache.doris.proto.Types;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.service.arrowflight.results.FlightSqlChannel;
 import org.apache.doris.statistics.ColumnStatistic;
@@ -65,6 +65,7 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TResultSinkType;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionEntry;
 import org.apache.doris.transaction.TransactionStatus;
@@ -902,7 +903,8 @@ public class ConnectContext {
         // cancelQuery by time out
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
-            executorRef.cancel(Types.PPlanFragmentCancelReason.TIMEOUT);
+            executorRef.cancel(new Status(TStatusCode.TIMEOUT,
+                    "query is timeout, killed by timeout checker"));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.qe;
 
-import org.apache.doris.proto.Types;
+import org.apache.doris.common.Status;
 import org.apache.doris.thrift.TNetworkAddress;
 
 import java.util.List;
@@ -28,7 +28,7 @@ public interface CoordInterface {
 
     public RowBatch getNext() throws Exception;
 
-    public void cancel(Types.PPlanFragmentCancelReason cancelReason);
+    public void cancel(Status cancelReason);
 
     // When call exec or get next data finished, should call this method to release
     // some resource.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1111,7 +1111,7 @@ public class Coordinator implements CoordInterface {
                     errMsg = operation + " failed. " + exception.getMessage();
                 }
                 queryStatus.updateStatus(TStatusCode.INTERNAL_ERROR, errMsg);
-                cancelInternal(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
+                cancelInternal(queryStatus);
                 switch (code) {
                     case TIMEOUT:
                         MetricRepo.BE_COUNTER_QUERY_RPC_FAILED.getOrAdd(triple.getLeft().brpcAddr.hostname)
@@ -1192,7 +1192,7 @@ public class Coordinator implements CoordInterface {
                     errMsg = operation + " failed. " + exception.getMessage();
                 }
                 queryStatus.updateStatus(TStatusCode.INTERNAL_ERROR, errMsg);
-                cancelInternal(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
+                cancelInternal(queryStatus);
                 switch (code) {
                     case TIMEOUT:
                         MetricRepo.BE_COUNTER_QUERY_RPC_FAILED.getOrAdd(triple.getLeft().brpcAddr.hostname)
@@ -1319,11 +1319,7 @@ public class Coordinator implements CoordInterface {
             }
 
             queryStatus.updateStatus(status.getErrorCode(), status.getErrorMsg());
-            if (status.getErrorCode() == TStatusCode.TIMEOUT) {
-                cancelInternal(Types.PPlanFragmentCancelReason.TIMEOUT);
-            } else {
-                cancelInternal(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
-            }
+            cancelInternal(queryStatus);
         } finally {
             lock.unlock();
         }
@@ -1385,7 +1381,7 @@ public class Coordinator implements CoordInterface {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("no block query, return num >= limit rows, need cancel");
                 }
-                cancelInternal(Types.PPlanFragmentCancelReason.LIMIT_REACH);
+                cancelInternal(new Status(TStatusCode.LIMIT_REACH, "query reach limit"));
             }
             if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().dryRunQuery) {
                 numReceivedRows = 0;
@@ -1402,7 +1398,7 @@ public class Coordinator implements CoordInterface {
     // We use a very conservative cancel strategy.
     // 0. If backends has zero process epoch, do not cancel. Zero process epoch usually arises in cluster upgrading.
     // 1. If process epoch is same, do not cancel. Means backends does not restart or die.
-    public boolean shouldCancel(List<Backend> currentBackends) {
+    public Status shouldCancel(List<Backend> currentBackends) {
         Map<Long, Backend> curBeMap = Maps.newHashMap();
         for (Backend be : currentBackends) {
             curBeMap.put(be.getId(), be);
@@ -1415,21 +1411,24 @@ public class Coordinator implements CoordInterface {
                 for (PipelineExecContext pipelineExecContext : pipelineExecContexts.values()) {
                     Backend be = curBeMap.get(pipelineExecContext.backend.getId());
                     if (be == null || !be.isAlive()) {
-                        LOG.warn("Backend {} not exists or dead, query {} should be cancelled",
+                        Status errorStatus = new Status(TStatusCode.CANCELLED,
+                                "Backend {} not exists or dead, query {} should be cancelled",
                                 pipelineExecContext.backend.toString(), DebugUtil.printId(queryId));
-                        return true;
+                        LOG.warn(errorStatus.getErrorMsg());
+                        return errorStatus;
                     }
 
                     // Backend process epoch changed, indicates that this be restarts, query should be cancelled.
                     // Check zero since during upgrading, older version oplog will not persistent be start time
                     // so newer version follower will get zero epoch when replaying oplog or snapshot
                     if (pipelineExecContext.beProcessEpoch != be.getProcessEpoch() && be.getProcessEpoch() != 0) {
-                        LOG.warn("Backend process epoch changed, previous {} now {}, "
-                                        + "means this be has already restarted, should cancel this coordinator,"
-                                        + " query id {}",
-                                        pipelineExecContext.beProcessEpoch, be.getProcessEpoch(),
-                                        DebugUtil.printId(queryId));
-                        return true;
+                        Status errorStatus = new Status(TStatusCode.CANCELLED,
+                                "Backend process epoch changed, previous {} now {}, "
+                                + "means this be has already restarted, should cancel this coordinator,"
+                                + "query id {}", pipelineExecContext.beProcessEpoch, be.getProcessEpoch(),
+                                DebugUtil.printId(queryId));
+                        LOG.warn(errorStatus.getErrorMsg());
+                        return errorStatus;
                     } else if (be.getProcessEpoch() == 0) {
                         LOG.warn("Backend {} has zero process epoch, maybe we are upgrading cluster?",
                                 be.toString());
@@ -1440,23 +1439,27 @@ public class Coordinator implements CoordInterface {
                 for (BackendExecStates beExecState : beToExecStates.values()) {
                     Backend be = curBeMap.get(beExecState.beId);
                     if (be == null || !be.isAlive()) {
-                        LOG.warn("Backend {} not exists or dead, query {} should be cancelled.",
+                        Status errorStatus = new Status(TStatusCode.CANCELLED,
+                                "Backend {} not exists or dead, query {} should be cancelled.",
                                 beExecState.beId, DebugUtil.printId(queryId));
-                        return true;
+                        LOG.warn(errorStatus.getErrorMsg());
+                        return errorStatus;
                     }
 
                     if (beExecState.beProcessEpoch != be.getProcessEpoch() && be.getProcessEpoch() != 0) {
-                        LOG.warn("Process epoch changed, previous {} now {}, means this be has already restarted, "
-                                        + "should cancel this coordinator, query id {}",
+                        Status errorStatus = new Status(TStatusCode.CANCELLED,
+                                "Process epoch changed, previous {} now {}, means this be has already restarted,"
+                                + "should cancel this coordinator, query id {}",
                                 beExecState.beProcessEpoch, be.getProcessEpoch(), DebugUtil.printId(queryId));
-                        return true;
+                        LOG.warn(errorStatus.getErrorMsg());
+                        return errorStatus;
                     } else if (be.getProcessEpoch() == 0) {
                         LOG.warn("Backend {} has zero process epoch, maybe we are upgrading cluster?", be.toString());
                     }
                 }
             }
 
-            return false;
+            return Status.OK;
         } finally {
             unlock();
         }
@@ -1466,15 +1469,19 @@ public class Coordinator implements CoordInterface {
     // fragment,
     // if any, as well as all plan fragments on remote nodes.
     public void cancel() {
-        cancel(Types.PPlanFragmentCancelReason.USER_CANCEL);
+        cancel(new Status(TStatusCode.CANCELLED, "query is cancelled by user"));
         if (queueToken != null) {
             queueToken.signalForCancel();
         }
     }
 
     @Override
-    public void cancel(Types.PPlanFragmentCancelReason cancelReason) {
+    public void cancel(Status cancelReason) {
         lock();
+        if (cancelReason.ok()) {
+            throw new RuntimeException("Should use correct cancel reason, but it is "
+                    + cancelReason.toString());
+        }
         try {
             if (!queryStatus.ok()) {
                 // Print an error stack here to know why send cancel again.
@@ -1482,7 +1489,7 @@ public class Coordinator implements CoordInterface {
                         + "so that send cancel to BE again",
                         DebugUtil.printId(queryId), queryStatus.toString(), new Exception());
             } else {
-                queryStatus.updateStatus(TStatusCode.CANCELLED, "cancelled");
+                queryStatus.updateStatus(cancelReason.getErrorCode(), cancelReason.getErrorMsg());
             }
             LOG.warn("Cancel execution of query {}, this is a outside invoke, cancelReason {}",
                     DebugUtil.printId(queryId), cancelReason.toString());
@@ -1510,7 +1517,7 @@ public class Coordinator implements CoordInterface {
         }
     }
 
-    private void cancelInternal(Types.PPlanFragmentCancelReason cancelReason) {
+    private void cancelInternal(Status cancelReason) {
         if (null != receiver) {
             receiver.cancel(cancelReason);
         }
@@ -1522,7 +1529,7 @@ public class Coordinator implements CoordInterface {
         cancelLatch();
     }
 
-    private void cancelRemoteFragmentsAsync(Types.PPlanFragmentCancelReason cancelReason) {
+    private void cancelRemoteFragmentsAsync(Status cancelReason) {
         if (enablePipelineEngine) {
             for (PipelineExecContext ctx : pipelineExecContexts.values()) {
                 ctx.cancelFragmentInstance(cancelReason);
@@ -3124,11 +3131,11 @@ public class Coordinator implements CoordInterface {
 
         // cancel the fragment instance.
         // return true if cancel success. Otherwise, return false
-        public synchronized void cancelFragmentInstance(Types.PPlanFragmentCancelReason cancelReason) {
+        public synchronized void cancelFragmentInstance(Status cancelReason) {
             LOG.warn("cancelRemoteFragments initiated={} done={} backend: {},"
                             + " fragment instance id={}, reason: {}",
                     this.initiated, this.done, backend.getId(),
-                    DebugUtil.printId(fragmentInstanceId()), cancelReason.name());
+                    DebugUtil.printId(fragmentInstanceId()), cancelReason.toString());
             try {
                 if (!this.initiated) {
                     return;
@@ -3143,7 +3150,7 @@ public class Coordinator implements CoordInterface {
                             + "fragment instance id={}, reason: {}",
                             this.hasCancelled, this.cancelInProcess,
                             this.initiated, this.done, backend.getId(),
-                            DebugUtil.printId(fragmentInstanceId()), cancelReason.name());
+                            DebugUtil.printId(fragmentInstanceId()), cancelReason.toString());
                     return;
                 }
                 try {
@@ -3175,7 +3182,7 @@ public class Coordinator implements CoordInterface {
                             LOG.warn("Failed to cancel query {} instance initiated={} done={} backend: {},"
                                     + "fragment instance id={}, reason: {}",
                                     DebugUtil.printId(queryId), initiated, done, backend.getId(),
-                                    DebugUtil.printId(fragmentInstanceId()), cancelReason.name(), t);
+                                    DebugUtil.printId(fragmentInstanceId()), cancelReason.toString(), t);
                         }
                     }, backendRpcCallbackExecutor);
                     cancelInProcess = true;
@@ -3316,13 +3323,13 @@ public class Coordinator implements CoordInterface {
 
         // Just send the cancel message to BE, not care about the result, because there is no retry
         // logic in upper logic.
-        private synchronized void cancelFragment(Types.PPlanFragmentCancelReason cancelReason) {
+        private synchronized void cancelFragment(Status cancelReason) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("cancelRemoteFragments initiated={} done={} backend: {},"
                         + " fragment id={} query={}, reason: {}",
                         this.initiated, this.done, backend.getId(),
                         this.fragmentId,
-                        DebugUtil.printId(queryId), cancelReason.name());
+                        DebugUtil.printId(queryId), cancelReason.toString());
             }
 
             if (this.hasCancelled || this.cancelInProcess) {
@@ -3360,7 +3367,7 @@ public class Coordinator implements CoordInterface {
                             LOG.warn("Failed to cancel query {} instance initiated={} done={} backend: {},"
                                     + "fragment id={}, reason: {}",
                                     DebugUtil.printId(queryId), initiated, done, backend.getId(),
-                                    fragmentId, cancelReason.name(), t);
+                                    fragmentId, cancelReason.toString(), t);
                         }
                     }, backendRpcCallbackExecutor);
                     cancelInProcess = true;
@@ -3378,13 +3385,13 @@ public class Coordinator implements CoordInterface {
 
         // Just send the cancel logic to BE, not care about the result, and there is no retry logic
         // in upper logic.
-        private synchronized void cancelInstance(Types.PPlanFragmentCancelReason cancelReason) {
+        private synchronized void cancelInstance(Status cancelReason) {
             for (TPipelineInstanceParams localParam : rpcParams.local_params) {
                 LOG.warn("cancelRemoteFragments initiated={} done={} backend:{},"
                         + " fragment instance id={} query={}, reason: {}",
                         this.initiated, this.done, backend.getId(),
                         DebugUtil.printId(localParam.fragment_instance_id),
-                        DebugUtil.printId(queryId), cancelReason.name());
+                        DebugUtil.printId(queryId), cancelReason.toString());
                 if (this.hasCancelled || this.cancelInProcess) {
                     LOG.info("fragment instance has already been cancelled {} or in process {}. "
                             + "initiated={} done={} backend:{},"
@@ -3392,7 +3399,7 @@ public class Coordinator implements CoordInterface {
                             this.hasCancelled, this.cancelInProcess,
                             this.initiated, this.done, backend.getId(),
                             DebugUtil.printId(localParam.fragment_instance_id),
-                            DebugUtil.printId(queryId), cancelReason.name());
+                            DebugUtil.printId(queryId), cancelReason.toString());
                     return;
                 }
                 try {
@@ -3424,7 +3431,7 @@ public class Coordinator implements CoordInterface {
                             LOG.warn("Failed to cancel query {} instance initiated={} done={} backend: {},"
                                     + "fragment instance id={}, reason: {}",
                                     DebugUtil.printId(queryId), initiated, done, backend.getId(),
-                                    DebugUtil.printId(localParam.fragment_instance_id), cancelReason.name(), t);
+                                    DebugUtil.printId(localParam.fragment_instance_id), cancelReason.toString(), t);
                         }
                     }, backendRpcCallbackExecutor);
                     cancelInProcess = true;
@@ -3437,7 +3444,7 @@ public class Coordinator implements CoordInterface {
         }
 
         /// TODO: refactor rpcParams
-        public synchronized void cancelFragmentInstance(Types.PPlanFragmentCancelReason cancelReason) {
+        public synchronized void cancelFragmentInstance(Status cancelReason) {
             if (!this.initiated) {
                 LOG.warn("Query {}, ccancel before initiated", DebugUtil.printId(queryId));
                 return;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExec.java
@@ -34,7 +34,6 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.InternalService.KeyTuple;
-import org.apache.doris.proto.Types;
 import org.apache.doris.rpc.BackendServiceProxy;
 import org.apache.doris.rpc.RpcException;
 import org.apache.doris.rpc.TCustomProtocolFactory;
@@ -202,7 +201,7 @@ public class PointQueryExec implements CoordInterface {
     }
 
     @Override
-    public void cancel(Types.PPlanFragmentCancelReason cancelReason) {
+    public void cancel(Status cancelReason) {
         // Do nothing
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.common.Status;
 import org.apache.doris.common.util.MasterDaemon;
-import org.apache.doris.proto.Types;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
@@ -36,10 +36,9 @@ public class QueryCancelWorker extends MasterDaemon {
         List<Backend> allBackends = systemInfoService.getAllBackends();
 
         for (Coordinator co : QeProcessorImpl.INSTANCE.getAllCoordinators()) {
-            if (co.shouldCancel(allBackends)) {
-                // TODO(zhiqiang): We need more clear cancel message, so that user can figure out what happened
-                //  by searching log.
-                co.cancel(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
+            Status status = co.shouldCancel(allBackends);
+            if (!status.ok()) {
+                co.cancel(status);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -19,6 +19,7 @@ package org.apache.doris.rpc;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.Status;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.planner.PlanFragmentId;
@@ -245,11 +246,12 @@ public class BackendServiceProxy {
     }
 
     public ListenableFuture<InternalService.PCancelPlanFragmentResult> cancelPlanFragmentAsync(TNetworkAddress address,
-            TUniqueId finstId, Types.PPlanFragmentCancelReason cancelReason) throws RpcException {
+            TUniqueId finstId, Status cancelReason) throws RpcException {
         final InternalService.PCancelPlanFragmentRequest pRequest =
                 InternalService.PCancelPlanFragmentRequest.newBuilder()
                         .setFinstId(Types.PUniqueId.newBuilder().setHi(finstId.hi).setLo(finstId.lo).build())
-                        .setCancelReason(cancelReason).build();
+                        .setCancelReason(cancelReason.getPCancelReason())
+                        .setCancelStatus(cancelReason.toPStatus()).build();
         try {
             final BackendServiceClient client = getProxy(address);
             return client.cancelPlanFragmentAsync(pRequest);
@@ -262,11 +264,12 @@ public class BackendServiceProxy {
 
     public ListenableFuture<InternalService.PCancelPlanFragmentResult> cancelPipelineXPlanFragmentAsync(
             TNetworkAddress address, PlanFragmentId fragmentId, TUniqueId queryId,
-            Types.PPlanFragmentCancelReason cancelReason) throws RpcException {
+            Status cancelReason) throws RpcException {
         final InternalService.PCancelPlanFragmentRequest pRequest = InternalService.PCancelPlanFragmentRequest
                 .newBuilder()
                 .setFinstId(Types.PUniqueId.newBuilder().setHi(0).setLo(0).build())
-                .setCancelReason(cancelReason)
+                .setCancelReason(cancelReason.getPCancelReason())
+                .setCancelStatus(cancelReason.toPStatus())
                 .setFragmentId(fragmentId.asInt())
                 .setQueryId(Types.PUniqueId.newBuilder().setHi(queryId.hi).setLo(queryId.lo).build()).build();
         try {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -248,6 +248,7 @@ message PCancelPlanFragmentRequest {
     optional PPlanFragmentCancelReason cancel_reason = 2;
     optional PUniqueId query_id = 3;
     optional int32 fragment_id = 4;
+    optional PStatus cancel_status = 5;
 };
 
 message PCancelPlanFragmentResult {

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -103,7 +103,6 @@ enum TStatusCode {
     TABLET_MISSING = 72,
 
     NOT_MASTER = 73,
-    LIMIT_REACH = 74,
 
     // used for cloud
     DELETE_BITMAP_LOCK_ERROR = 100,

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -43,6 +43,7 @@ enum TStatusCode {
     INTERNAL_ERROR                  = 6,
     THRIFT_RPC_ERROR                = 7,
     TIMEOUT                         = 8,
+    LIMIT_REACH                     = 9,  // Its ok to reuse this error code, because this error code is not used in 1.1
     //KUDU_NOT_ENABLED                = 9,  // Deprecated
     //KUDU_NOT_SUPPORTED_ON_OS        = 10, // Deprecated
     MEM_ALLOC_FAILED                = 11,

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -102,6 +102,7 @@ enum TStatusCode {
     TABLET_MISSING = 72,
 
     NOT_MASTER = 73,
+    LIMIT_REACH = 74,
 
     // used for cloud
     DELETE_BITMAP_LOCK_ERROR = 100,


### PR DESCRIPTION
## Proposed changes

Currently, we could not get real cancel reason because the status is very mess. In this PR I do following:
1. add new method in status.java, like be code. user could use new status to create an error status with formatted error message.
2. using TStatusCode as cancel reason.
3. TStatusCode should be part of errorcodes in status.h, so that we could unify the error code in FE and BE.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

