### PR TITLE
[Opt](func) opt the percentile func performance

### DIFF
--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -70,8 +70,11 @@ private:
  *    f. shrink some function's nullable mode.
  *    g. do local merge of remote runtime filter
  *    h. "now": ALWAYS_NOT_NULLABLE -> DEPEND_ON_ARGUMENTS
+ *
+ * 5: start from doris 2.1.4
+ *    a. change the impl of percentile
 */
-constexpr inline int BeExecVersionManager::max_be_exec_version = 4;
+constexpr inline int BeExecVersionManager::max_be_exec_version = 5;
 constexpr inline int BeExecVersionManager::min_be_exec_version = 0;
 
 /// functional

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_percentile.h"
+
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/helpers.h"
+
+namespace doris::vectorized {
+
+template <bool is_nullable>
+AggregateFunctionPtr create_aggregate_function_percentile_approx(const std::string& name,
+                                                                 const DataTypes& argument_types,
+                                                                 const bool result_is_nullable) {
+    const DataTypePtr& argument_type = remove_nullable(argument_types[0]);
+    WhichDataType which(argument_type);
+    if (which.idx != TypeIndex::Float64) {
+        return nullptr;
+    }
+    if (argument_types.size() == 1) {
+        return creator_without_type::create<AggregateFunctionPercentileApproxMerge<is_nullable>>(
+                remove_nullable(argument_types), result_is_nullable);
+    }
+    if (argument_types.size() == 2) {
+        return creator_without_type::create<
+                AggregateFunctionPercentileApproxTwoParams<is_nullable>>(
+                remove_nullable(argument_types), result_is_nullable);
+    }
+    if (argument_types.size() == 3) {
+        return creator_without_type::create<
+                AggregateFunctionPercentileApproxThreeParams<is_nullable>>(
+                remove_nullable(argument_types), result_is_nullable);
+    }
+    return nullptr;
+}
+
+void register_aggregate_function_percentile(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function_both("percentile",
+                                   creator_without_type::creator<AggregateFunctionPercentile>);
+    factory.register_function_both("percentile_array",
+                                   creator_without_type::creator<AggregateFunctionPercentileArray>);
+}
+
+void register_aggregate_function_percentile_approx(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function("percentile_approx",
+                              create_aggregate_function_percentile_approx<false>, false);
+    factory.register_function("percentile_approx",
+                              create_aggregate_function_percentile_approx<true>, true);
+}
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -1,0 +1,473 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <boost/iterator/iterator_facade.hpp>
+#include <cmath>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "util/counts.h"
+#include "util/tdigest.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_vector.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/pod_array_fwd.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_array.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/io/io_helper.h"
+
+namespace doris::vectorized {
+
+class Arena;
+class BufferReadable;
+
+struct PercentileApproxState {
+    static constexpr double INIT_QUANTILE = -1.0;
+    PercentileApproxState() = default;
+    ~PercentileApproxState() = default;
+
+    void init(double compression = 10000) {
+        if (!init_flag) {
+            //https://doris.apache.org/zh-CN/sql-reference/sql-functions/aggregate-functions/percentile_approx.html#description
+            //The compression parameter setting range is [2048, 10000].
+            //If the value of compression parameter is not specified set, or is outside the range of [2048, 10000],
+            //will use the default value of 10000
+            if (compression < 2048 || compression > 10000) {
+                compression = 10000;
+            }
+            digest = TDigest::create_unique(compression);
+            compressions = compression;
+            init_flag = true;
+        }
+    }
+
+    void write(BufferWritable& buf) const {
+        write_binary(init_flag, buf);
+        if (!init_flag) {
+            return;
+        }
+
+        write_binary(target_quantile, buf);
+        write_binary(compressions, buf);
+        uint32_t serialize_size = digest->serialized_size();
+        std::string result(serialize_size, '0');
+        DCHECK(digest.get() != nullptr);
+        digest->serialize((uint8_t*)result.c_str());
+
+        write_binary(result, buf);
+    }
+
+    void read(BufferReadable& buf) {
+        read_binary(init_flag, buf);
+        if (!init_flag) {
+            return;
+        }
+
+        read_binary(target_quantile, buf);
+        read_binary(compressions, buf);
+        std::string str;
+        read_binary(str, buf);
+        digest = TDigest::create_unique(compressions);
+        digest->unserialize((uint8_t*)str.c_str());
+    }
+
+    double get() const {
+        if (init_flag) {
+            return digest->quantile(target_quantile);
+        } else {
+            return std::nan("");
+        }
+    }
+
+    void merge(const PercentileApproxState& rhs) {
+        if (!rhs.init_flag) {
+            return;
+        }
+        if (init_flag) {
+            DCHECK(digest.get() != nullptr);
+            digest->merge(rhs.digest.get());
+        } else {
+            digest = TDigest::create_unique(compressions);
+            digest->merge(rhs.digest.get());
+            init_flag = true;
+        }
+        if (target_quantile == PercentileApproxState::INIT_QUANTILE) {
+            target_quantile = rhs.target_quantile;
+        }
+    }
+
+    void add(double source, double quantile) {
+        digest->add(source);
+        target_quantile = quantile;
+    }
+
+    void reset() {
+        target_quantile = INIT_QUANTILE;
+        init_flag = false;
+        digest = TDigest::create_unique(compressions);
+    }
+
+    bool init_flag = false;
+    std::unique_ptr<TDigest> digest;
+    double target_quantile = INIT_QUANTILE;
+    double compressions = 10000;
+};
+
+class AggregateFunctionPercentileApprox
+        : public IAggregateFunctionDataHelper<PercentileApproxState,
+                                              AggregateFunctionPercentileApprox> {
+public:
+    AggregateFunctionPercentileApprox(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<PercentileApproxState,
+                                           AggregateFunctionPercentileApprox>(argument_types_) {}
+
+    String get_name() const override { return "percentile_approx"; }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeFloat64>());
+    }
+
+    void reset(AggregateDataPtr __restrict place) const override {
+        AggregateFunctionPercentileApprox::data(place).reset();
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        AggregateFunctionPercentileApprox::data(place).merge(
+                AggregateFunctionPercentileApprox::data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        AggregateFunctionPercentileApprox::data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        AggregateFunctionPercentileApprox::data(place).read(buf);
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        ColumnNullable& nullable_column = assert_cast<ColumnNullable&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            nullable_column.insert_default();
+        } else {
+            auto& col = assert_cast<ColumnVector<Float64>&>(nullable_column.get_nested_column());
+            col.get_data().push_back(result);
+            nullable_column.get_null_map_data().push_back(0);
+        }
+    }
+};
+
+// only for merge
+template <bool is_nullable>
+class AggregateFunctionPercentileApproxMerge : public AggregateFunctionPercentileApprox {
+public:
+    AggregateFunctionPercentileApproxMerge(const DataTypes& argument_types_)
+            : AggregateFunctionPercentileApprox(argument_types_) {}
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena*) const override {
+        LOG(FATAL) << "AggregateFunctionPercentileApproxMerge do not support add()";
+        __builtin_unreachable();
+    }
+};
+
+template <bool is_nullable>
+class AggregateFunctionPercentileApproxTwoParams : public AggregateFunctionPercentileApprox {
+public:
+    AggregateFunctionPercentileApproxTwoParams(const DataTypes& argument_types_)
+            : AggregateFunctionPercentileApprox(argument_types_) {}
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena*) const override {
+        if constexpr (is_nullable) {
+            double column_data[2] = {0, 0};
+
+            for (int i = 0; i < 2; ++i) {
+                const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
+                if (nullable_column == nullptr) { //Not Nullable column
+                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
+                    column_data[i] = column.get_float64(row_num);
+                } else if (!nullable_column->is_null_at(
+                                   row_num)) { // Nullable column && Not null data
+                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
+                            nullable_column->get_nested_column());
+                    column_data[i] = column.get_float64(row_num);
+                } else { // Nullable column && null data
+                    if (i == 0) {
+                        return;
+                    }
+                }
+            }
+
+            this->data(place).init();
+            this->data(place).add(column_data[0], column_data[1]);
+
+        } else {
+            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
+            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
+
+            this->data(place).init();
+            this->data(place).add(sources.get_float64(row_num), quantile.get_float64(row_num));
+        }
+    }
+};
+
+template <bool is_nullable>
+class AggregateFunctionPercentileApproxThreeParams : public AggregateFunctionPercentileApprox {
+public:
+    AggregateFunctionPercentileApproxThreeParams(const DataTypes& argument_types_)
+            : AggregateFunctionPercentileApprox(argument_types_) {}
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena*) const override {
+        if constexpr (is_nullable) {
+            double column_data[3] = {0, 0, 0};
+
+            for (int i = 0; i < 3; ++i) {
+                const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
+                if (nullable_column == nullptr) { //Not Nullable column
+                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
+                    column_data[i] = column.get_float64(row_num);
+                } else if (!nullable_column->is_null_at(
+                                   row_num)) { // Nullable column && Not null data
+                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
+                            nullable_column->get_nested_column());
+                    column_data[i] = column.get_float64(row_num);
+                } else { // Nullable column && null data
+                    if (i == 0) {
+                        return;
+                    }
+                }
+            }
+
+            this->data(place).init(column_data[2]);
+            this->data(place).add(column_data[0], column_data[1]);
+
+        } else {
+            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
+            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
+            const auto& compression = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
+
+            this->data(place).init(compression.get_float64(row_num));
+            this->data(place).add(sources.get_float64(row_num), quantile.get_float64(row_num));
+        }
+    }
+};
+
+struct PercentileState {
+    mutable std::vector<Counts> vec_counts;
+    std::vector<double> vec_quantile {-1};
+    bool inited_flag = false;
+
+    void write(BufferWritable& buf) const {
+        write_binary(inited_flag, buf);
+        int size_num = vec_quantile.size();
+        write_binary(size_num, buf);
+        for (const auto& quantile : vec_quantile) {
+            write_binary(quantile, buf);
+        }
+        for (auto& counts : vec_counts) {
+            counts.serialize(buf);
+        }
+    }
+
+    void read(BufferReadable& buf) {
+        read_binary(inited_flag, buf);
+        int size_num = 0;
+        read_binary(size_num, buf);
+        double data = 0.0;
+        vec_quantile.clear();
+        for (int i = 0; i < size_num; ++i) {
+            read_binary(data, buf);
+            vec_quantile.emplace_back(data);
+        }
+        vec_counts.clear();
+        vec_counts.resize(size_num);
+        for (int i = 0; i < size_num; ++i) {
+            vec_counts[i].unserialize(buf);
+        }
+    }
+
+    void add(int64_t source, const PaddedPODArray<Float64>& quantiles, int arg_size) {
+        if (!inited_flag) {
+            vec_counts.resize(arg_size);
+            vec_quantile.resize(arg_size, -1);
+            inited_flag = true;
+            for (int i = 0; i < arg_size; ++i) {
+                vec_quantile[i] = quantiles[i];
+            }
+        }
+        for (int i = 0; i < arg_size; ++i) {
+            vec_counts[i].increment(source, 1);
+        }
+    }
+
+    void merge(const PercentileState& rhs) {
+        if (!rhs.inited_flag) {
+            return;
+        }
+        int size_num = rhs.vec_quantile.size();
+        if (!inited_flag) {
+            vec_counts.resize(size_num);
+            vec_quantile.resize(size_num, -1);
+            inited_flag = true;
+        }
+
+        for (int i = 0; i < size_num; ++i) {
+            if (vec_quantile[i] == -1.0) {
+                vec_quantile[i] = rhs.vec_quantile[i];
+            }
+            vec_counts[i].merge(const_cast<Counts*>(&(rhs.vec_counts[i])));
+        }
+    }
+
+    void reset() {
+        vec_counts.clear();
+        vec_quantile.clear();
+        inited_flag = false;
+    }
+
+    double get() const { return vec_counts[0].terminate(vec_quantile[0]); }
+
+    void insert_result_into(IColumn& to) const {
+        auto& column_data = assert_cast<ColumnVector<Float64>&>(to).get_data();
+        for (int i = 0; i < vec_counts.size(); ++i) {
+            column_data.push_back(vec_counts[i].terminate(vec_quantile[i]));
+        }
+    }
+};
+
+class AggregateFunctionPercentile final
+        : public IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentile> {
+public:
+    AggregateFunctionPercentile(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentile>(
+                      argument_types_) {}
+
+    String get_name() const override { return "percentile"; }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
+
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena*) const override {
+        const auto& sources = assert_cast<const ColumnVector<Int64>&>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
+        AggregateFunctionPercentile::data(place).add(sources.get_int(row_num), quantile.get_data(),
+                                                     1);
+    }
+
+    void reset(AggregateDataPtr __restrict place) const override {
+        AggregateFunctionPercentile::data(place).reset();
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        AggregateFunctionPercentile::data(place).merge(AggregateFunctionPercentile::data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        AggregateFunctionPercentile::data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        AggregateFunctionPercentile::data(place).read(buf);
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& col = assert_cast<ColumnVector<Float64>&>(to);
+        col.insert_value(AggregateFunctionPercentile::data(place).get());
+    }
+};
+
+class AggregateFunctionPercentileArray final
+        : public IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentileArray> {
+public:
+    AggregateFunctionPercentileArray(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentileArray>(
+                      argument_types_) {}
+
+    String get_name() const override { return "percentile_array"; }
+
+    DataTypePtr get_return_type() const override {
+        return std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeFloat64>()));
+    }
+
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena*) const override {
+        const auto& sources = assert_cast<const ColumnVector<Int64>&>(*columns[0]);
+        const auto& quantile_array = assert_cast<const ColumnArray&>(*columns[1]);
+        const auto& offset_column_data = quantile_array.get_offsets();
+        const auto& nested_column =
+                assert_cast<const ColumnNullable&>(quantile_array.get_data()).get_nested_column();
+        const auto& nested_column_data = assert_cast<const ColumnVector<Float64>&>(nested_column);
+
+        AggregateFunctionPercentileArray::data(place).add(
+                sources.get_int(row_num), nested_column_data.get_data(),
+                offset_column_data.data()[row_num] - offset_column_data[(ssize_t)row_num - 1]);
+    }
+
+    void reset(AggregateDataPtr __restrict place) const override {
+        AggregateFunctionPercentileArray::data(place).reset();
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        AggregateFunctionPercentileArray::data(place).merge(
+                AggregateFunctionPercentileArray::data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        AggregateFunctionPercentileArray::data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        AggregateFunctionPercentileArray::data(place).read(buf);
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_nested_col = to_arr.get_data();
+        if (to_nested_col.is_nullable()) {
+            auto col_null = reinterpret_cast<ColumnNullable*>(&to_nested_col);
+            AggregateFunctionPercentileArray::data(place).insert_result_into(
+                    col_null->get_nested_column());
+            col_null->get_null_map_data().resize_fill(col_null->get_nested_column().size(), 0);
+        } else {
+            AggregateFunctionPercentileArray::data(place).insert_result_into(to_nested_col);
+        }
+        to_arr.get_offsets().push_back(to_nested_col.size());
+    }
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
@@ -22,43 +22,15 @@
 
 namespace doris::vectorized {
 
-template <bool is_nullable>
-AggregateFunctionPtr create_aggregate_function_percentile_approx(const std::string& name,
-                                                                 const DataTypes& argument_types,
-                                                                 const bool result_is_nullable) {
-    const DataTypePtr& argument_type = remove_nullable(argument_types[0]);
-    WhichDataType which(argument_type);
-    if (which.idx != TypeIndex::Float64) {
-        return nullptr;
-    }
-    if (argument_types.size() == 1) {
-        return creator_without_type::create<AggregateFunctionPercentileApproxMerge<is_nullable>>(
-                remove_nullable(argument_types), result_is_nullable);
-    }
-    if (argument_types.size() == 2) {
-        return creator_without_type::create<
-                AggregateFunctionPercentileApproxTwoParams<is_nullable>>(
-                remove_nullable(argument_types), result_is_nullable);
-    }
-    if (argument_types.size() == 3) {
-        return creator_without_type::create<
-                AggregateFunctionPercentileApproxThreeParams<is_nullable>>(
-                remove_nullable(argument_types), result_is_nullable);
-    }
-    return nullptr;
-}
-
-void register_aggregate_function_percentile(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function_both("percentile",
-                                   creator_without_type::creator<AggregateFunctionPercentile>);
-    factory.register_function_both("percentile_array",
-                                   creator_without_type::creator<AggregateFunctionPercentileArray>);
-}
-
-void register_aggregate_function_percentile_approx(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("percentile_approx",
-                              create_aggregate_function_percentile_approx<false>, false);
-    factory.register_function("percentile_approx",
-                              create_aggregate_function_percentile_approx<true>, true);
+void register_aggregate_function_percentile_old(AggregateFunctionSimpleFactory& factory) {
+    factory.register_alternative_function(
+            "percentile", creator_without_type::creator<AggregateFunctionPercentileOld>);
+    factory.register_alternative_function(
+            "percentile", creator_without_type::creator<AggregateFunctionPercentileOld>, true);
+    factory.register_alternative_function(
+            "percentile_array", creator_without_type::creator<AggregateFunctionPercentileArrayOld>);
+    factory.register_alternative_function(
+            "percentile_array", creator_without_type::creator<AggregateFunctionPercentileArrayOld>,
+            true);
 }
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -55,241 +55,8 @@ class BufferWritable;
 
 namespace doris::vectorized {
 
-struct PercentileApproxState {
-    static constexpr double INIT_QUANTILE = -1.0;
-    PercentileApproxState() = default;
-    ~PercentileApproxState() = default;
-
-    void init(double compression = 10000) {
-        if (!init_flag) {
-            //https://doris.apache.org/zh-CN/sql-reference/sql-functions/aggregate-functions/percentile_approx.html#description
-            //The compression parameter setting range is [2048, 10000].
-            //If the value of compression parameter is not specified set, or is outside the range of [2048, 10000],
-            //will use the default value of 10000
-            if (compression < 2048 || compression > 10000) {
-                compression = 10000;
-            }
-            digest = TDigest::create_unique(compression);
-            compressions = compression;
-            init_flag = true;
-        }
-    }
-
-    void write(BufferWritable& buf) const {
-        write_binary(init_flag, buf);
-        if (!init_flag) {
-            return;
-        }
-
-        write_binary(target_quantile, buf);
-        write_binary(compressions, buf);
-        uint32_t serialize_size = digest->serialized_size();
-        std::string result(serialize_size, '0');
-        DCHECK(digest.get() != nullptr);
-        digest->serialize((uint8_t*)result.c_str());
-
-        write_binary(result, buf);
-    }
-
-    void read(BufferReadable& buf) {
-        read_binary(init_flag, buf);
-        if (!init_flag) {
-            return;
-        }
-
-        read_binary(target_quantile, buf);
-        read_binary(compressions, buf);
-        std::string str;
-        read_binary(str, buf);
-        digest = TDigest::create_unique(compressions);
-        digest->unserialize((uint8_t*)str.c_str());
-    }
-
-    double get() const {
-        if (init_flag) {
-            return digest->quantile(target_quantile);
-        } else {
-            return std::nan("");
-        }
-    }
-
-    void merge(const PercentileApproxState& rhs) {
-        if (!rhs.init_flag) {
-            return;
-        }
-        if (init_flag) {
-            DCHECK(digest.get() != nullptr);
-            digest->merge(rhs.digest.get());
-        } else {
-            digest = TDigest::create_unique(compressions);
-            digest->merge(rhs.digest.get());
-            init_flag = true;
-        }
-        if (target_quantile == PercentileApproxState::INIT_QUANTILE) {
-            target_quantile = rhs.target_quantile;
-        }
-    }
-
-    void add(double source, double quantile) {
-        digest->add(source);
-        target_quantile = quantile;
-    }
-
-    void reset() {
-        target_quantile = INIT_QUANTILE;
-        init_flag = false;
-        digest = TDigest::create_unique(compressions);
-    }
-
-    bool init_flag = false;
-    std::unique_ptr<TDigest> digest;
-    double target_quantile = INIT_QUANTILE;
-    double compressions = 10000;
-};
-
-class AggregateFunctionPercentileApprox
-        : public IAggregateFunctionDataHelper<PercentileApproxState,
-                                              AggregateFunctionPercentileApprox> {
-public:
-    AggregateFunctionPercentileApprox(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<PercentileApproxState,
-                                           AggregateFunctionPercentileApprox>(argument_types_) {}
-
-    String get_name() const override { return "percentile_approx"; }
-
-    DataTypePtr get_return_type() const override {
-        return make_nullable(std::make_shared<DataTypeFloat64>());
-    }
-
-    void reset(AggregateDataPtr __restrict place) const override {
-        AggregateFunctionPercentileApprox::data(place).reset();
-    }
-
-    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
-               Arena*) const override {
-        AggregateFunctionPercentileApprox::data(place).merge(
-                AggregateFunctionPercentileApprox::data(rhs));
-    }
-
-    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
-        AggregateFunctionPercentileApprox::data(place).write(buf);
-    }
-
-    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
-                     Arena*) const override {
-        AggregateFunctionPercentileApprox::data(place).read(buf);
-    }
-
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        ColumnNullable& nullable_column = assert_cast<ColumnNullable&>(to);
-        double result = AggregateFunctionPercentileApprox::data(place).get();
-
-        if (std::isnan(result)) {
-            nullable_column.insert_default();
-        } else {
-            auto& col = assert_cast<ColumnVector<Float64>&>(nullable_column.get_nested_column());
-            col.get_data().push_back(result);
-            nullable_column.get_null_map_data().push_back(0);
-        }
-    }
-};
-
-// only for merge
-template <bool is_nullable>
-class AggregateFunctionPercentileApproxMerge : public AggregateFunctionPercentileApprox {
-public:
-    AggregateFunctionPercentileApproxMerge(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
-    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
-             Arena*) const override {
-        LOG(FATAL) << "AggregateFunctionPercentileApproxMerge do not support add()";
-        __builtin_unreachable();
-    }
-};
-
-template <bool is_nullable>
-class AggregateFunctionPercentileApproxTwoParams : public AggregateFunctionPercentileApprox {
-public:
-    AggregateFunctionPercentileApproxTwoParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
-    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
-             Arena*) const override {
-        if constexpr (is_nullable) {
-            double column_data[2] = {0, 0};
-
-            for (int i = 0; i < 2; ++i) {
-                const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
-                if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
-                    column_data[i] = column.get_float64(row_num);
-                } else if (!nullable_column->is_null_at(
-                                   row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
-                            nullable_column->get_nested_column());
-                    column_data[i] = column.get_float64(row_num);
-                } else { // Nullable column && null data
-                    if (i == 0) {
-                        return;
-                    }
-                }
-            }
-
-            this->data(place).init();
-            this->data(place).add(column_data[0], column_data[1]);
-
-        } else {
-            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-
-            this->data(place).init();
-            this->data(place).add(sources.get_float64(row_num), quantile.get_float64(row_num));
-        }
-    }
-};
-
-template <bool is_nullable>
-class AggregateFunctionPercentileApproxThreeParams : public AggregateFunctionPercentileApprox {
-public:
-    AggregateFunctionPercentileApproxThreeParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
-    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
-             Arena*) const override {
-        if constexpr (is_nullable) {
-            double column_data[3] = {0, 0, 0};
-
-            for (int i = 0; i < 3; ++i) {
-                const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
-                if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
-                    column_data[i] = column.get_float64(row_num);
-                } else if (!nullable_column->is_null_at(
-                                   row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
-                            nullable_column->get_nested_column());
-                    column_data[i] = column.get_float64(row_num);
-                } else { // Nullable column && null data
-                    if (i == 0) {
-                        return;
-                    }
-                }
-            }
-
-            this->data(place).init(column_data[2]);
-            this->data(place).add(column_data[0], column_data[1]);
-
-        } else {
-            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-            const auto& compression = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
-
-            this->data(place).init(compression.get_float64(row_num));
-            this->data(place).add(sources.get_float64(row_num), quantile.get_float64(row_num));
-        }
-    }
-};
-
-struct PercentileState {
-    std::vector<Counts> vec_counts;
+struct OldPercentileState {
+    std::vector<OldCounts> vec_counts;
     std::vector<double> vec_quantile {-1};
     bool inited_flag = false;
 
@@ -341,7 +108,7 @@ struct PercentileState {
         }
     }
 
-    void merge(const PercentileState& rhs) {
+    void merge(const OldPercentileState& rhs) {
         if (!rhs.inited_flag) {
             return;
         }
@@ -376,11 +143,11 @@ struct PercentileState {
     }
 };
 
-class AggregateFunctionPercentile final
-        : public IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentile> {
+class AggregateFunctionPercentileOld final
+        : public IAggregateFunctionDataHelper<OldPercentileState, AggregateFunctionPercentileOld> {
 public:
-    AggregateFunctionPercentile(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentile>(
+    AggregateFunctionPercentileOld(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<OldPercentileState, AggregateFunctionPercentileOld>(
                       argument_types_) {}
 
     String get_name() const override { return "percentile"; }
@@ -391,39 +158,41 @@ public:
              Arena*) const override {
         const auto& sources = assert_cast<const ColumnVector<Int64>&>(*columns[0]);
         const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-        AggregateFunctionPercentile::data(place).add(sources.get_int(row_num), quantile.get_data(),
-                                                     1);
+        AggregateFunctionPercentileOld::data(place).add(sources.get_int(row_num),
+                                                        quantile.get_data(), 1);
     }
 
     void reset(AggregateDataPtr __restrict place) const override {
-        AggregateFunctionPercentile::data(place).reset();
+        AggregateFunctionPercentileOld::data(place).reset();
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
                Arena*) const override {
-        AggregateFunctionPercentile::data(place).merge(AggregateFunctionPercentile::data(rhs));
+        AggregateFunctionPercentileOld::data(place).merge(
+                AggregateFunctionPercentileOld::data(rhs));
     }
 
     void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
-        AggregateFunctionPercentile::data(place).write(buf);
+        AggregateFunctionPercentileOld::data(place).write(buf);
     }
 
     void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
                      Arena*) const override {
-        AggregateFunctionPercentile::data(place).read(buf);
+        AggregateFunctionPercentileOld::data(place).read(buf);
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnVector<Float64>&>(to);
-        col.insert_value(AggregateFunctionPercentile::data(place).get());
+        col.insert_value(AggregateFunctionPercentileOld::data(place).get());
     }
 };
 
-class AggregateFunctionPercentileArray final
-        : public IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentileArray> {
+class AggregateFunctionPercentileArrayOld final
+        : public IAggregateFunctionDataHelper<OldPercentileState,
+                                              AggregateFunctionPercentileArrayOld> {
 public:
-    AggregateFunctionPercentileArray(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<PercentileState, AggregateFunctionPercentileArray>(
+    AggregateFunctionPercentileArrayOld(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<OldPercentileState, AggregateFunctionPercentileArrayOld>(
                       argument_types_) {}
 
     String get_name() const override { return "percentile_array"; }
@@ -441,28 +210,28 @@ public:
                 assert_cast<const ColumnNullable&>(quantile_array.get_data()).get_nested_column();
         const auto& nested_column_data = assert_cast<const ColumnVector<Float64>&>(nested_column);
 
-        AggregateFunctionPercentileArray::data(place).add(
+        AggregateFunctionPercentileArrayOld::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),
                 offset_column_data.data()[row_num] - offset_column_data[(ssize_t)row_num - 1]);
     }
 
     void reset(AggregateDataPtr __restrict place) const override {
-        AggregateFunctionPercentileArray::data(place).reset();
+        AggregateFunctionPercentileArrayOld::data(place).reset();
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
                Arena*) const override {
-        AggregateFunctionPercentileArray::data(place).merge(
-                AggregateFunctionPercentileArray::data(rhs));
+        AggregateFunctionPercentileArrayOld::data(place).merge(
+                AggregateFunctionPercentileArrayOld::data(rhs));
     }
 
     void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
-        AggregateFunctionPercentileArray::data(place).write(buf);
+        AggregateFunctionPercentileArrayOld::data(place).write(buf);
     }
 
     void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
                      Arena*) const override {
-        AggregateFunctionPercentileArray::data(place).read(buf);
+        AggregateFunctionPercentileArrayOld::data(place).read(buf);
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
@@ -470,11 +239,11 @@ public:
         auto& to_nested_col = to_arr.get_data();
         if (to_nested_col.is_nullable()) {
             auto col_null = reinterpret_cast<ColumnNullable*>(&to_nested_col);
-            AggregateFunctionPercentileArray::data(place).insert_result_into(
+            AggregateFunctionPercentileArrayOld::data(place).insert_result_into(
                     col_null->get_nested_column());
             col_null->get_null_map_data().resize_fill(col_null->get_nested_column().size(), 0);
         } else {
-            AggregateFunctionPercentileArray::data(place).insert_result_into(to_nested_col);
+            AggregateFunctionPercentileArrayOld::data(place).insert_result_into(to_nested_col);
         }
         to_arr.get_offsets().push_back(to_nested_col.size());
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
@@ -54,6 +54,7 @@ void register_aggregate_function_approx_count_distinct(AggregateFunctionSimpleFa
 void register_aggregate_function_group_array_intersect(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_group_concat(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_percentile(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_percentile_old(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_window_funnel(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_retention(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_percentile_approx(AggregateFunctionSimpleFactory& factory);
@@ -95,6 +96,7 @@ AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
         register_aggregate_function_topn(instance);
         register_aggregate_function_approx_count_distinct(instance);
         register_aggregate_function_percentile(instance);
+        register_aggregate_function_percentile_old(instance);
         register_aggregate_function_percentile_approx(instance);
         register_aggregate_function_window_funnel(instance);
         register_aggregate_function_retention(instance);

--- a/be/src/vec/common/string_buffer.hpp
+++ b/be/src/vec/common/string_buffer.hpp
@@ -30,17 +30,18 @@ public:
     explicit BufferWritable(ColumnString& vector)
             : _data(vector.get_chars()), _offsets(vector.get_offsets()) {}
 
-    inline void write(const char* data, int len) {
+    void write(const char* data, size_t len) {
         _data.insert(data, data + len);
         _now_offset += len;
     }
-    inline void write(char c) {
+
+    void write(char c) {
         const char* p = &c;
         _data.insert(p, p + 1);
         _now_offset += 1;
     }
 
-    inline void commit() {
+    void commit() {
         ColumnString::check_chars_length(_offsets.back() + _now_offset, 0);
         _offsets.push_back(_offsets.back() + _now_offset);
         _now_offset = 0;
@@ -70,13 +71,13 @@ public:
     explicit BufferReadable(StringRef&& ref) : _data(ref.data) {}
     ~BufferReadable() = default;
 
-    inline StringRef read(int len) {
+    StringRef read(size_t len) {
         StringRef ref(_data, len);
         _data += len;
         return ref;
     }
 
-    inline void read(char* data, int len) {
+    void read(char* data, int len) {
         memcpy(data, _data, len);
         _data += len;
     }

--- a/be/src/vec/functions/simple_function_factory.h
+++ b/be/src/vec/functions/simple_function_factory.h
@@ -108,8 +108,8 @@ class SimpleFunctionFactory {
     using Creator = std::function<FunctionBuilderPtr()>;
     using FunctionCreators = phmap::flat_hash_map<std::string, Creator>;
     using FunctionIsVariadic = phmap::flat_hash_set<std::string>;
-    /// @TEMPORARY: for be_exec_version=4
-    constexpr static int NEWEST_VERSION_FUNCTION_SUBSTITUTE = 4;
+    /// @TEMPORARY: for be_exec_version=5
+    constexpr static int NEWEST_VERSION_FUNCTION_SUBSTITUTE = 5;
 
 public:
     void register_function(const std::string& name, const Creator& ptr) {
@@ -148,7 +148,7 @@ public:
     /// @TEMPORARY: for be_exec_version=3
     template <class Function>
     void register_alternative_function() {
-        static std::string suffix {"_old_for_version_before_4_0"};
+        static std::string suffix {"_old_for_version_before_5_0"};
         function_to_replace[Function::name] = Function::name + suffix;
         register_function(Function::name + suffix, &createDefaultFunction<Function>);
     }
@@ -192,7 +192,7 @@ private:
     FunctionCreators function_creators;
     FunctionIsVariadic function_variadic_set;
     std::unordered_map<std::string, std::string> function_alias;
-    /// @TEMPORARY: for be_exec_version=3. replace function to old version.
+    /// @TEMPORARY: for be_exec_version=4. replace function to old version.
     std::unordered_map<std::string, std::string> function_to_replace;
 
     template <typename Function>
@@ -200,7 +200,7 @@ private:
         return std::make_shared<DefaultFunctionBuilder>(Function::create());
     }
 
-    /// @TEMPORARY: for be_exec_version=3
+    /// @TEMPORARY: for be_exec_version=4
     void temporary_function_update(int fe_version_now, std::string& name) {
         // replace if fe is old version.
         if (fe_version_now < NEWEST_VERSION_FUNCTION_SUBSTITUTE &&

--- a/be/test/util/counts_test.cpp
+++ b/be/test/util/counts_test.cpp
@@ -42,12 +42,16 @@ TEST_F(TCountsTest, TotalTest) {
 
     double result = counts.terminate(0.2);
     EXPECT_EQ(1, result);
-    uint8_t* writer = new uint8_t[counts.serialized_size()];
-    uint8_t* type_reader = writer;
-    counts.serialize(writer);
+
+    auto cs = vectorized::ColumnString::create();
+    vectorized::BufferWritable bw(*cs);
+    counts.serialize(bw);
+    bw.commit();
 
     Counts other;
-    other.unserialize(type_reader);
+    StringRef res(cs->get_chars().data(), cs->get_chars().size());
+    vectorized::BufferReadable br(res);
+    other.unserialize(br);
     double result1 = other.terminate(0.2);
     EXPECT_EQ(result, result1);
 
@@ -61,7 +65,6 @@ TEST_F(TCountsTest, TotalTest) {
     counts.merge(&other1);
     // 1 1 1 1 2 5 7 7 9 9 10 19 50 50 50 99 99 100 100 100
     EXPECT_EQ(counts.terminate(0.3), 6.4);
-    delete[] writer;
 }
 
 } // namespace doris

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1773,7 +1773,7 @@ public class Config extends ConfigBase {
      * Max data version of backends serialize block.
      */
     @ConfField(mutable = false)
-    public static int max_be_exec_version = 4;
+    public static int max_be_exec_version = 5;
 
     /**
      * Min data version of backends serialize block.


### PR DESCRIPTION
## Proposed changes


Before：
```
select app_name ,PERCENTILE(duration, 0.5), count() from test group by 1;
+---------------+-------------------------------------------+----------+
| app_name      | percentile(duration, cast(0.5 as DOUBLE)) | count(*) |
+---------------+-------------------------------------------+----------+
| ddd   |                       -2453840367977893.5 |  3562878 |
| bbb |                        2927619961908628.5 |  3561875 |
| NULL          |                   -1.3121945030076114e+16 |   375247 |
+---------------+-------------------------------------------+----------+
3 rows in set (10.75 sec)
```

After：
```
select app_name ,PERCENTILE(duration, 0.5), count() from test group by 1;
+---------------+-------------------------------------------+----------+
| app_name      | percentile(duration, cast(0.5 as DOUBLE)) | count(*) |
+---------------+-------------------------------------------+----------+
| ddd   |                       -2453840367977893.5 |  3562878 |
| bbb |                        2927619961908628.5 |  3561875 |
| NULL          |                   -1.3121945030076114e+16 |   375247 |
+---------------+-------------------------------------------+----------+
3 rows in set (0.75 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

