### PR TITLE
[fix] Process not destroy in DiskUtils df function

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
@@ -44,11 +44,13 @@ public class DiskUtils {
             return df;
         }
 
-        Process process;
+        Process process = null;
+        BufferedReader reader = null;
+        InputStream inputStream = null;
         try {
             process = Runtime.getRuntime().exec("df -k " + dir);
-            InputStream inputStream = process.getInputStream();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            inputStream = process.getInputStream();
+            reader = new BufferedReader(new InputStreamReader(inputStream));
             Df df = new Df();
             // Filesystem      1K-blocks       Used Available Use% Mounted on
             // /dev/sdc       5814186096 5814169712         0 100% /home/spy-sd/sdc
@@ -67,6 +69,18 @@ public class DiskUtils {
         } catch (IOException e) {
             log.info("failed to obtain disk information", e);
             return new Df();
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    log.info("failed to obtain disk information", e);
+                    return new Df();
+                }
+            }
         }
     }
 

--- a/fe/fe-common/src/test/java/org/apache/doris/common/io/DiskUtilsTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/io/DiskUtilsTest.java
@@ -23,28 +23,34 @@ import org.junit.Test;
 public class DiskUtilsTest {
     @Test
     public void testSiseFormat() {
-        long [] keys = new long[]{
-            1L,
-            1L * 1024,
-            1L * 1024 * 1024,
-            1L * 1024 * 1024 * 1024,
-            1L * 1024 * 1024 * 1024 * 1024,
-            1L * 1024 * 1024 * 1024 * 1024 * 1024,
-            1L * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+        long[] keys = new long[] {
+                1L,
+                1L * 1024,
+                1L * 1024 * 1024,
+                1L * 1024 * 1024 * 1024,
+                1L * 1024 * 1024 * 1024 * 1024,
+                1L * 1024 * 1024 * 1024 * 1024 * 1024,
+                1L * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
         };
 
-        String[] values = new String[]{
-            "1",
-            "1K",
-            "1M",
-            "1G",
-            "1T",
-            "1P",
-            "1024P",
+        String[] values = new String[] {
+                "1",
+                "1K",
+                "1M",
+                "1G",
+                "1T",
+                "1P",
+                "1024P",
         };
 
         for (int i = 0; i < values.length; i++) {
             Assert.assertEquals(values[i], DiskUtils.sizeFormat(keys[i]));
         }
+    }
+
+    @Test
+    public void testDf() {
+        DiskUtils.Df d = DiskUtils.df("/proc");
+        Assert.assertTrue(d.fileSystem.length() != 0);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DppScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DppScheduler.java
@@ -206,9 +206,10 @@ public class DppScheduler {
         List<String> hadoopRunCmdList = Util.shellSplit(hadoopRunCmd);
         String[] hadoopRunCmds = hadoopRunCmdList.toArray(new String[0]);
         BufferedReader errorReader = null;
+        Process p = null;
         long startTime = System.currentTimeMillis();
         try {
-            Process p = Runtime.getRuntime().exec(hadoopRunCmds);
+            p = Runtime.getRuntime().exec(hadoopRunCmds);
             errorReader = new BufferedReader(new InputStreamReader(p.getErrorStream()));
             for (int i = 0; i < 1000; i++) {
                 outputLine = errorReader.readLine();
@@ -226,7 +227,6 @@ public class DppScheduler {
                 if (outputLine.indexOf("Running job") != -1) {
                     String[] arr = outputLine.split(":");
                     etlJobId = arr[arr.length - 1].trim();
-                    p.destroy();
                     break;
                 }
             }
@@ -239,6 +239,9 @@ public class DppScheduler {
             Util.deleteDirectory(configDir);
             long endTime = System.currentTimeMillis();
             LOG.info("finished submit hadoop job: {}. cost: {} ms", jobId, endTime - startTime);
+            if (p != null) {
+                p.destroy();
+            }
             if (errorReader != null) {
                 try {
                     errorReader.close();

--- a/fe/fe-core/src/main/java/org/apache/doris/plsql/Exec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plsql/Exec.java
@@ -1944,11 +1944,12 @@ public class Exec extends org.apache.doris.nereids.PLParserBaseVisitor<Integer> 
     }
 
     public void execHost(ParserRuleContext ctx, String cmd) {
+        Process p = null;
         try {
             if (trace) {
                 trace(ctx, "HOST Command: " + cmd);
             }
-            Process p = Runtime.getRuntime().exec(cmd);
+            p = Runtime.getRuntime().exec(cmd);
             new StreamGobbler(p.getInputStream(), console).start();
             new StreamGobbler(p.getErrorStream(), console).start();
             int rc = p.waitFor();
@@ -1959,6 +1960,10 @@ public class Exec extends org.apache.doris.nereids.PLParserBaseVisitor<Integer> 
         } catch (Exception e) {
             setHostCode(1);
             signal(Signal.Type.SQLEXCEPTION);
+        } finally {
+            if (p != null) {
+                p.destroy();
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #34386

1) In DiskUtils df function
Added Process destroy and buffer read close in finally.
added UT to verify and cover the code change.
2) Process not destroy in plsql Exec
   fixed and reviewed.
3) Process not destroy DppScheduler
  fixed and reviewed

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

