### PR TITLE
[opt](func) opt the revert_null_map performance

### DIFF
--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -303,9 +303,11 @@ inline static NullMap revert_null_map(const NullMap* null_bytemap, size_t start,
         return res;
     }
 
-    res.reserve(end - start);
-    for (size_t i = start; i < end; ++i) {
-        res.emplace_back(!(*null_bytemap)[i]);
+    res.resize(end - start);
+    auto* __restrict src_data = (*null_bytemap).data();
+    auto* __restrict res_data = res.data();
+    for (size_t i = 0; i < res.size(); ++i) {
+        res_data[i] = !src_data[i + start];
     }
     return res;
 }


### PR DESCRIPTION
## Proposed changes

```
2024-05-04T23:54:46+08:00
Running ./benchmark
Run on (96 X 3100.01 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 0.31, 1.20, 1.20
------------------------------------------------------
Benchmark            Time             CPU   Iterations
------------------------------------------------------
origin_test   10682025 ns     10682054 ns           55
simd_test       966283 ns       966286 ns          660
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

