### PR TITLE
[feature](MysqlResult) function write_column_to_mysql no longer handles the return value

### DIFF
--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -124,13 +124,13 @@ void MysqlRowBuffer<is_binary_format>::close_dynamic_mode() {
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::reserve(int64_t size) {
+void MysqlRowBuffer<is_binary_format>::reserve(int64_t size) {
     DCHECK(size > 0);
 
     int64_t need_size = size + (_pos - _buf);
 
     if (need_size <= _buf_size) {
-        return 0;
+        return;
     }
 
     int64_t alloc_size = std::max(need_size, _buf_size * 2);
@@ -146,8 +146,6 @@ int MysqlRowBuffer<is_binary_format>::reserve(int64_t size) {
     _pos = new_buf + offset;
     _buf = new_buf;
     _buf_size = alloc_size;
-
-    return 0;
 }
 
 template <typename T>
@@ -217,15 +215,14 @@ static char* add_decimal(const DecimalV2Value& data, int round_scale, char* pos,
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::append(const char* data, int64_t len) {
+void MysqlRowBuffer<is_binary_format>::append(const char* data, int64_t len) {
     reserve(len);
     memcpy(_pos, data, len);
     _pos += len;
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::append_var_string(const char* data, int64_t len) {
+void MysqlRowBuffer<is_binary_format>::append_var_string(const char* data, int64_t len) {
     /*
      The +9 comes from that strings of length longer than 16M require
      9 bytes to be stored (see net_store_length).
@@ -234,11 +231,10 @@ int MysqlRowBuffer<is_binary_format>::append_var_string(const char* data, int64_
     _pos = pack_vlen(_pos, len);
     memcpy(_pos, data, len);
     _pos += len;
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_tinyint(int8_t data) {
+void MysqlRowBuffer<is_binary_format>::push_tinyint(int8_t data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[1];
         _field_pos++;
@@ -248,11 +244,10 @@ int MysqlRowBuffer<is_binary_format>::push_tinyint(int8_t data) {
     // 1 for string trail, 1 for length, 1 for sign, other for digits
     reserve(3 + MAX_TINYINT_WIDTH);
     _pos = add_int(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_smallint(int16_t data) {
+void MysqlRowBuffer<is_binary_format>::push_smallint(int16_t data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[2];
         _field_pos++;
@@ -262,11 +257,10 @@ int MysqlRowBuffer<is_binary_format>::push_smallint(int16_t data) {
     // 1 for string trail, 1 for length, 1 for sign, other for digits
     reserve(3 + MAX_SMALLINT_WIDTH);
     _pos = add_int(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_int(int32_t data) {
+void MysqlRowBuffer<is_binary_format>::push_int(int32_t data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[4];
         _field_pos++;
@@ -276,11 +270,10 @@ int MysqlRowBuffer<is_binary_format>::push_int(int32_t data) {
     // 1 for string trail, 1 for length, 1 for sign, other for digits
     reserve(3 + MAX_INT_WIDTH);
     _pos = add_int(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_bigint(int64_t data) {
+void MysqlRowBuffer<is_binary_format>::push_bigint(int64_t data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[8];
         _field_pos++;
@@ -291,11 +284,10 @@ int MysqlRowBuffer<is_binary_format>::push_bigint(int64_t data) {
     reserve(3 + MAX_BIGINT_WIDTH);
 
     _pos = add_int(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_unsigned_bigint(uint64_t data) {
+void MysqlRowBuffer<is_binary_format>::push_unsigned_bigint(uint64_t data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[8];
         _field_pos++;
@@ -306,11 +298,10 @@ int MysqlRowBuffer<is_binary_format>::push_unsigned_bigint(uint64_t data) {
     reserve(4 + MAX_BIGINT_WIDTH);
 
     _pos = add_int(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_largeint(int128_t data) {
+void MysqlRowBuffer<is_binary_format>::push_largeint(int128_t data) {
     if (is_binary_format && !_dynamic_mode) {
         // large int as type string
         std::string value = LargeIntValue::to_string(data);
@@ -321,11 +312,10 @@ int MysqlRowBuffer<is_binary_format>::push_largeint(int128_t data) {
     reserve(3 + MAX_LARGEINT_WIDTH);
 
     _pos = add_largeint(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_float(float data) {
+void MysqlRowBuffer<is_binary_format>::push_float(float data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[4];
         _field_pos++;
@@ -336,11 +326,10 @@ int MysqlRowBuffer<is_binary_format>::push_float(float data) {
     reserve(3 + MAX_FLOAT_STR_LENGTH);
 
     _pos = add_float(data, _pos, _dynamic_mode, _faster_float_convert);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_double(double data) {
+void MysqlRowBuffer<is_binary_format>::push_double(double data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[8];
         _field_pos++;
@@ -350,11 +339,10 @@ int MysqlRowBuffer<is_binary_format>::push_double(double data) {
     // 1 for string trail, 1 for length, 1 for sign, other for digits
     reserve(3 + MAX_DOUBLE_STR_LENGTH);
     _pos = add_float(data, _pos, _dynamic_mode, _faster_float_convert);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_time(double data) {
+void MysqlRowBuffer<is_binary_format>::push_time(double data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[8];
         _field_pos++;
@@ -365,11 +353,10 @@ int MysqlRowBuffer<is_binary_format>::push_time(double data) {
     reserve(2 + MAX_TIME_WIDTH);
 
     _pos = add_time(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_timev2(double data, int scale) {
+void MysqlRowBuffer<is_binary_format>::push_timev2(double data, int scale) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[8];
         _field_pos++;
@@ -380,24 +367,23 @@ int MysqlRowBuffer<is_binary_format>::push_timev2(double data, int scale) {
     reserve(2 + MAX_TIME_WIDTH);
 
     _pos = add_timev2(data, _pos, _dynamic_mode, scale);
-    return 0;
 }
 
 template <bool is_binary_format>
 template <typename DateType>
-int MysqlRowBuffer<is_binary_format>::push_vec_datetime(DateType& data) {
+void MysqlRowBuffer<is_binary_format>::push_vec_datetime(DateType& data) {
     if (is_binary_format && !_dynamic_mode) {
         return push_datetime(data);
     }
 
     char buf[64];
     char* pos = data.to_string(buf);
-    return push_string(buf, pos - buf - 1);
+    push_string(buf, pos - buf - 1);
 }
 
 template <bool is_binary_format>
 template <typename DateType>
-int MysqlRowBuffer<is_binary_format>::push_datetime(const DateType& data) {
+void MysqlRowBuffer<is_binary_format>::push_datetime(const DateType& data) {
     if (is_binary_format && !_dynamic_mode) {
         char buff[12], *pos;
         size_t length;
@@ -434,34 +420,32 @@ int MysqlRowBuffer<is_binary_format>::push_datetime(const DateType& data) {
     reserve(2 + MAX_DATETIME_WIDTH);
 
     _pos = add_datetime(data, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_decimal(const DecimalV2Value& data, int round_scale) {
+void MysqlRowBuffer<is_binary_format>::push_decimal(const DecimalV2Value& data, int round_scale) {
     if (is_binary_format && !_dynamic_mode) {
         ++_field_pos;
     }
     // 1 for string trail, 1 for length, other for decimal str
     reserve(2 + MAX_DECIMAL_WIDTH);
     _pos = add_decimal(data, round_scale, _pos, _dynamic_mode);
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_ipv4(const IPv4Value& ipv4_val) {
+void MysqlRowBuffer<is_binary_format>::push_ipv4(const IPv4Value& ipv4_val) {
     auto ipv4_str = ipv4_val.to_string();
-    return push_string(ipv4_str.c_str(), ipv4_str.length());
+    push_string(ipv4_str.c_str(), ipv4_str.length());
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_ipv6(const IPv6Value& ipv6_val) {
+void MysqlRowBuffer<is_binary_format>::push_ipv6(const IPv6Value& ipv6_val) {
     auto ipv6_str = ipv6_val.to_string();
-    return push_string(ipv6_str.c_str(), ipv6_str.length());
+    push_string(ipv6_str.c_str(), ipv6_str.length());
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_string(const char* str, int64_t length) {
+void MysqlRowBuffer<is_binary_format>::push_string(const char* str, int64_t length) {
     if (is_binary_format && !_dynamic_mode) {
         ++_field_pos;
     }
@@ -472,14 +456,13 @@ int MysqlRowBuffer<is_binary_format>::push_string(const char* str, int64_t lengt
     }
     memcpy(_pos, str, length);
     _pos += length;
-    return 0;
 }
 
 template <bool is_binary_format>
-int MysqlRowBuffer<is_binary_format>::push_null() {
+void MysqlRowBuffer<is_binary_format>::push_null() {
     if (_dynamic_mode) {
         // for nested type
-        return 0;
+        return;
     }
 
     if constexpr (is_binary_format) {
@@ -489,13 +472,12 @@ int MysqlRowBuffer<is_binary_format>::push_null() {
         char* to = (char*)_buf + offset;
         *to = (char)((uchar)*to | (uchar)bit);
         _field_pos++;
-        return 0;
+        return;
     }
 
     reserve(1);
     int1store(_pos, 251);
     _pos += 1;
-    return 0;
 }
 
 template <bool is_binary_format>
@@ -510,15 +492,15 @@ char* MysqlRowBuffer<is_binary_format>::reserved(int64_t size) {
 template class MysqlRowBuffer<true>;
 template class MysqlRowBuffer<false>;
 
-template int MysqlRowBuffer<true>::push_vec_datetime<DateV2Value<DateV2ValueType>>(
+template void MysqlRowBuffer<true>::push_vec_datetime<DateV2Value<DateV2ValueType>>(
         DateV2Value<DateV2ValueType>& value);
-template int MysqlRowBuffer<true>::push_vec_datetime<DateV2Value<DateTimeV2ValueType>>(
+template void MysqlRowBuffer<true>::push_vec_datetime<DateV2Value<DateTimeV2ValueType>>(
         DateV2Value<DateTimeV2ValueType>& value);
-template int MysqlRowBuffer<true>::push_vec_datetime<VecDateTimeValue>(VecDateTimeValue& value);
-template int MysqlRowBuffer<false>::push_vec_datetime<DateV2Value<DateV2ValueType>>(
+template void MysqlRowBuffer<true>::push_vec_datetime<VecDateTimeValue>(VecDateTimeValue& value);
+template void MysqlRowBuffer<false>::push_vec_datetime<DateV2Value<DateV2ValueType>>(
         DateV2Value<DateV2ValueType>& value);
-template int MysqlRowBuffer<false>::push_vec_datetime<DateV2Value<DateTimeV2ValueType>>(
+template void MysqlRowBuffer<false>::push_vec_datetime<DateV2Value<DateTimeV2ValueType>>(
         DateV2Value<DateTimeV2ValueType>& value);
-template int MysqlRowBuffer<false>::push_vec_datetime<VecDateTimeValue>(VecDateTimeValue& value);
+template void MysqlRowBuffer<false>::push_vec_datetime<VecDateTimeValue>(VecDateTimeValue& value);
 
 } // namespace doris

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -65,26 +65,26 @@ public:
     void start_binary_row(uint32_t num_cols);
 
     // TODO(zhaochun): add signed/unsigned support
-    int push_tinyint(int8_t data);
-    int push_smallint(int16_t data);
-    int push_int(int32_t data);
-    int push_bigint(int64_t data);
-    int push_unsigned_bigint(uint64_t data);
-    int push_largeint(int128_t data);
-    int push_float(float data);
-    int push_double(double data);
-    int push_time(double data);
-    int push_timev2(double data, int scale);
+    void push_tinyint(int8_t data);
+    void push_smallint(int16_t data);
+    void push_int(int32_t data);
+    void push_bigint(int64_t data);
+    void push_unsigned_bigint(uint64_t data);
+    void push_largeint(int128_t data);
+    void push_float(float data);
+    void push_double(double data);
+    void push_time(double data);
+    void push_timev2(double data, int scale);
     template <typename DateType>
-    int push_datetime(const DateType& data);
-    int push_decimal(const DecimalV2Value& data, int round_scale);
-    int push_ipv4(const IPv4Value& ipv4_val);
-    int push_ipv6(const IPv6Value& ipv6_val);
-    int push_string(const char* str, int64_t length);
-    int push_null();
+    void push_datetime(const DateType& data);
+    void push_decimal(const DecimalV2Value& data, int round_scale);
+    void push_ipv4(const IPv4Value& ipv4_val);
+    void push_ipv6(const IPv6Value& ipv6_val);
+    void push_string(const char* str, int64_t length);
+    void push_null();
 
     template <typename DateType>
-    int push_vec_datetime(DateType& data);
+    void push_vec_datetime(DateType& data);
 
     // this function reserved size, change the pos step size, return old pos
     // Becareful when use the returned pointer.
@@ -131,13 +131,13 @@ public:
     void set_faster_float_convert(bool faster) { _faster_float_convert = faster; }
 
 private:
-    int reserve(int64_t size);
+    void reserve(int64_t size);
 
     // append data into buffer
-    int append(const char* data, int64_t len);
+    void append(const char* data, int64_t len);
     // the same as mysql net_store_data
     // the first few bytes is length, followed by data
-    int append_var_string(const char* data, int64_t len);
+    void append_var_string(const char* data, int64_t len);
 
     char* _pos = nullptr;
     char* _buf = nullptr;

--- a/be/src/vec/data_types/serde/data_type_array_serde.h
+++ b/be/src/vec/data_types/serde/data_type_array_serde.h
@@ -84,10 +84,10 @@ public:
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -101,8 +101,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 
     DataTypeSerDeSPtr nested_serde;
 };

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
@@ -103,9 +103,9 @@ void DataTypeBitMapSerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbV
 }
 
 template <bool is_binary_format>
-Status DataTypeBitMapSerDe::_write_column_to_mysql(const IColumn& column,
-                                                   MysqlRowBuffer<is_binary_format>& result,
-                                                   int row_idx, bool col_const) const {
+void DataTypeBitMapSerDe::_write_column_to_mysql(const IColumn& column,
+                                                 MysqlRowBuffer<is_binary_format>& result,
+                                                 int row_idx, bool col_const) const {
     auto& data_column = assert_cast<const ColumnBitmap&>(column);
     if (_return_object_as_string) {
         const auto col_index = index_check_const(row_idx, col_const);
@@ -113,26 +113,21 @@ Status DataTypeBitMapSerDe::_write_column_to_mysql(const IColumn& column,
         size_t size = bitmapValue.getSizeInBytes();
         std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
         bitmapValue.write_to(buf.get());
-        if (0 != result.push_string(buf.get(), size)) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(buf.get(), size);
     } else {
-        if (0 != result.push_null()) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_null();
     }
-    return Status::OK();
 }
 
-Status DataTypeBitMapSerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeBitMapSerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeBitMapSerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeBitMapSerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.h
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.h
@@ -74,10 +74,10 @@ public:
                                "read_column_from_arrow with type " + column.get_name());
     }
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -87,8 +87,8 @@ public:
 private:
     // Bitmap is binary data which is not shown by mysql.
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_date64_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_date64_serde.cpp
@@ -240,9 +240,9 @@ void DataTypeDate64SerDe::read_column_from_arrow(IColumn& column, const arrow::A
 }
 
 template <bool is_binary_format>
-Status DataTypeDate64SerDe::_write_column_to_mysql(const IColumn& column,
-                                                   MysqlRowBuffer<is_binary_format>& result,
-                                                   int row_idx, bool col_const) const {
+void DataTypeDate64SerDe::_write_column_to_mysql(const IColumn& column,
+                                                 MysqlRowBuffer<is_binary_format>& result,
+                                                 int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<Int64>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     auto time_num = data[col_index];
@@ -250,30 +250,23 @@ Status DataTypeDate64SerDe::_write_column_to_mysql(const IColumn& column,
     // _nesting_level >= 2 means this datetimev2 is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_vec_datetime(time_val))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_vec_datetime(time_val);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 
-Status DataTypeDate64SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeDate64SerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeDate64SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeDate64SerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_date64_serde.h
+++ b/be/src/vec/data_types/serde/data_type_date64_serde.h
@@ -61,10 +61,10 @@ public:
                                const cctz::time_zone& ctz) const override;
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -73,8 +73,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 
 class DataTypeDateTimeSerDe : public DataTypeDate64SerDe {

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
@@ -173,9 +173,9 @@ void DataTypeDateTimeV2SerDe::read_column_from_arrow(IColumn& column,
 }
 
 template <bool is_binary_format>
-Status DataTypeDateTimeV2SerDe::_write_column_to_mysql(const IColumn& column,
-                                                       MysqlRowBuffer<is_binary_format>& result,
-                                                       int row_idx, bool col_const) const {
+void DataTypeDateTimeV2SerDe::_write_column_to_mysql(const IColumn& column,
+                                                     MysqlRowBuffer<is_binary_format>& result,
+                                                     int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<UInt64>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     char buf[64];
@@ -185,30 +185,23 @@ Status DataTypeDateTimeV2SerDe::_write_column_to_mysql(const IColumn& column,
     // _nesting_level >= 2 means this datetimev2 is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_string(buf, pos - buf - 1))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_string(buf, pos - buf - 1);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 
-Status DataTypeDateTimeV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                      MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                      bool col_const) const {
+void DataTypeDateTimeV2SerDe::write_column_to_mysql(const IColumn& column,
+                                                    MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                    bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeDateTimeV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                      MysqlRowBuffer<false>& row_buffer,
-                                                      int row_idx, bool col_const) const {
+void DataTypeDateTimeV2SerDe::write_column_to_mysql(const IColumn& column,
+                                                    MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                    bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.h
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.h
@@ -65,10 +65,10 @@ public:
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -77,8 +77,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
     int scale;
 };
 } // namespace vectorized

--- a/be/src/vec/data_types/serde/data_type_datev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datev2_serde.cpp
@@ -116,9 +116,9 @@ void DataTypeDateV2SerDe::read_column_from_arrow(IColumn& column, const arrow::A
 }
 
 template <bool is_binary_format>
-Status DataTypeDateV2SerDe::_write_column_to_mysql(const IColumn& column,
-                                                   MysqlRowBuffer<is_binary_format>& result,
-                                                   int row_idx, bool col_const) const {
+void DataTypeDateV2SerDe::_write_column_to_mysql(const IColumn& column,
+                                                 MysqlRowBuffer<is_binary_format>& result,
+                                                 int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<UInt32>&>(column).get_data();
     auto col_index = index_check_const(row_idx, col_const);
     DateV2Value<DateV2ValueType> date_val =
@@ -126,30 +126,23 @@ Status DataTypeDateV2SerDe::_write_column_to_mysql(const IColumn& column,
     // _nesting_level >= 2 means this datetimev2 is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_vec_datetime(date_val))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_vec_datetime(date_val);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 
-Status DataTypeDateV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeDateV2SerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeDateV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeDateV2SerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_datev2_serde.h
+++ b/be/src/vec/data_types/serde/data_type_datev2_serde.h
@@ -62,10 +62,10 @@ public:
                                const cctz::time_zone& ctz) const override;
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -74,8 +74,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -205,37 +205,32 @@ void DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
 
 template <typename T>
 template <bool is_binary_format>
-Status DataTypeDecimalSerDe<T>::_write_column_to_mysql(const IColumn& column,
-                                                       MysqlRowBuffer<is_binary_format>& result,
-                                                       int row_idx, bool col_const) const {
+void DataTypeDecimalSerDe<T>::_write_column_to_mysql(const IColumn& column,
+                                                     MysqlRowBuffer<is_binary_format>& result,
+                                                     int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnDecimal<T>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     if constexpr (IsDecimalV2<T>) {
         DecimalV2Value decimal_val(data[col_index]);
         auto decimal_str = decimal_val.to_string(scale);
-        if (UNLIKELY(0 != result.push_string(decimal_str.c_str(), decimal_str.size()))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(decimal_str.c_str(), decimal_str.size());
     } else {
         auto length = data[col_index].to_string(buf, scale, scale_multiplier);
-        if (UNLIKELY(0 != result.push_string(buf, length))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(buf, length);
     }
-    return Status::OK();
 }
 
 template <typename T>
-Status DataTypeDecimalSerDe<T>::write_column_to_mysql(const IColumn& column,
-                                                      MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                      bool col_const) const {
+void DataTypeDecimalSerDe<T>::write_column_to_mysql(const IColumn& column,
+                                                    MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                    bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
 template <typename T>
-Status DataTypeDecimalSerDe<T>::write_column_to_mysql(const IColumn& column,
-                                                      MysqlRowBuffer<false>& row_buffer,
-                                                      int row_idx, bool col_const) const {
+void DataTypeDecimalSerDe<T>::write_column_to_mysql(const IColumn& column,
+                                                    MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                    bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.h
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.h
@@ -101,10 +101,10 @@ public:
                                const cctz::time_zone& ctz) const override;
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -113,8 +113,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 
     int scale;
     int precision;

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -153,9 +153,9 @@ void DataTypeHLLSerDe::write_column_to_arrow(const IColumn& column, const NullMa
 }
 
 template <bool is_binary_format>
-Status DataTypeHLLSerDe::_write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<is_binary_format>& result,
-                                                int row_idx, bool col_const) const {
+void DataTypeHLLSerDe::_write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<is_binary_format>& result, int row_idx,
+                                              bool col_const) const {
     auto& data_column = assert_cast<const ColumnHLL&>(column);
     if (_return_object_as_string) {
         const auto col_index = index_check_const(row_idx, col_const);
@@ -163,26 +163,21 @@ Status DataTypeHLLSerDe::_write_column_to_mysql(const IColumn& column,
         size_t size = hyperLogLog.max_serialized_size();
         std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
         hyperLogLog.serialize((uint8*)buf.get());
-        if (UNLIKELY(0 != result.push_string(buf.get(), size))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(buf.get(), size);
     } else {
-        if (UNLIKELY(0 != result.push_null())) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_null();
     }
-    return Status::OK();
 }
 
-Status DataTypeHLLSerDe::write_column_to_mysql(const IColumn& column,
-                                               MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                               bool col_const) const {
+void DataTypeHLLSerDe::write_column_to_mysql(const IColumn& column,
+                                             MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                             bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeHLLSerDe::write_column_to_mysql(const IColumn& column,
-                                               MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                               bool col_const) const {
+void DataTypeHLLSerDe::write_column_to_mysql(const IColumn& column,
+                                             MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                             bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_hll_serde.h
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.h
@@ -61,10 +61,10 @@ public:
                                "read_column_from_arrow with type " + column.get_name());
     }
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -74,8 +74,8 @@ public:
 private:
     // Hll is binary data which is not shown by mysql.
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_ipv4_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_ipv4_serde.cpp
@@ -26,39 +26,32 @@ namespace doris {
 namespace vectorized {
 
 template <bool is_binary_format>
-Status DataTypeIPv4SerDe::_write_column_to_mysql(const IColumn& column,
-                                                 MysqlRowBuffer<is_binary_format>& result,
-                                                 int row_idx, bool col_const) const {
+void DataTypeIPv4SerDe::_write_column_to_mysql(const IColumn& column,
+                                               MysqlRowBuffer<is_binary_format>& result,
+                                               int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<IPv4>&>(column).get_data();
     auto col_index = index_check_const(row_idx, col_const);
     IPv4Value ipv4_val(data[col_index]);
     // _nesting_level >= 2 means this datetimev2 is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_ipv4(ipv4_val))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_ipv4(ipv4_val);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 
-Status DataTypeIPv4SerDe::write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                bool col_const) const {
+void DataTypeIPv4SerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                              bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeIPv4SerDe::write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                bool col_const) const {
+void DataTypeIPv4SerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                              bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_ipv4_serde.h
+++ b/be/src/vec/data_types/serde/data_type_ipv4_serde.h
@@ -42,10 +42,10 @@ class DataTypeIPv4SerDe : public DataTypeNumberSerDe<IPv4> {
 public:
     DataTypeIPv4SerDe(int nesting_level = 1) : DataTypeNumberSerDe<IPv4>(nesting_level) {};
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
     Status serialize_one_cell_to_json(const IColumn& column, int row_num, BufferWritable& bw,
                                       FormatOptions& options) const override;
     Status deserialize_one_cell_from_json(IColumn& column, Slice& slice,
@@ -56,8 +56,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_ipv6_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_ipv6_serde.cpp
@@ -27,39 +27,32 @@ namespace doris {
 namespace vectorized {
 
 template <bool is_binary_format>
-Status DataTypeIPv6SerDe::_write_column_to_mysql(const IColumn& column,
-                                                 MysqlRowBuffer<is_binary_format>& result,
-                                                 int row_idx, bool col_const) const {
+void DataTypeIPv6SerDe::_write_column_to_mysql(const IColumn& column,
+                                               MysqlRowBuffer<is_binary_format>& result,
+                                               int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<IPv6>&>(column).get_data();
     auto col_index = index_check_const(row_idx, col_const);
     IPv6Value ipv6_val(data[col_index]);
     // _nesting_level >= 2 means this datetimev2 is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_ipv6(ipv6_val))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_ipv6(ipv6_val);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 
-Status DataTypeIPv6SerDe::write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                bool col_const) const {
+void DataTypeIPv6SerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                              bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeIPv6SerDe::write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                bool col_const) const {
+void DataTypeIPv6SerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                              bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_ipv6_serde.h
+++ b/be/src/vec/data_types/serde/data_type_ipv6_serde.h
@@ -45,10 +45,10 @@ class DataTypeIPv6SerDe : public DataTypeNumberSerDe<IPv6> {
 public:
     DataTypeIPv6SerDe(int nesting_level = 1) : DataTypeNumberSerDe<IPv6>(nesting_level) {};
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
     Status serialize_one_cell_to_json(const IColumn& column, int row_num, BufferWritable& bw,
                                       FormatOptions& options) const override;
     Status deserialize_one_cell_from_json(IColumn& column, Slice& slice,
@@ -59,8 +59,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -36,35 +36,30 @@ namespace doris {
 namespace vectorized {
 
 template <bool is_binary_format>
-Status DataTypeJsonbSerDe::_write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<is_binary_format>& result,
-                                                  int row_idx, bool col_const) const {
+void DataTypeJsonbSerDe::_write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<is_binary_format>& result,
+                                                int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnString&>(column);
     const auto col_index = index_check_const(row_idx, col_const);
     const auto jsonb_val = data.get_data_at(col_index);
     // jsonb size == 0 is NULL
     if (jsonb_val.data == nullptr || jsonb_val.size == 0) {
-        if (UNLIKELY(0 != result.push_null())) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_null();
     } else {
         std::string json_str = JsonbToJson::jsonb_to_json_string(jsonb_val.data, jsonb_val.size);
-        if (UNLIKELY(0 != result.push_string(json_str.c_str(), json_str.size()))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(json_str.c_str(), json_str.size());
     }
-    return Status::OK();
 }
 
-Status DataTypeJsonbSerDe::write_column_to_mysql(const IColumn& column,
-                                                 MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                 bool col_const) const {
+void DataTypeJsonbSerDe::write_column_to_mysql(const IColumn& column,
+                                               MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                               bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeJsonbSerDe::write_column_to_mysql(const IColumn& column,
-                                                 MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                 bool col_const) const {
+void DataTypeJsonbSerDe::write_column_to_mysql(const IColumn& column,
+                                               MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                               bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.h
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.h
@@ -37,10 +37,10 @@ class DataTypeJsonbSerDe : public DataTypeStringSerDe {
 public:
     DataTypeJsonbSerDe(int nesting_level = 1) : DataTypeStringSerDe(nesting_level) {};
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
     void write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                arrow::ArrayBuilder* array_builder, int start, int end,
                                const cctz::time_zone& ctz) const override;
@@ -71,8 +71,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_map_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_map_serde.cpp
@@ -395,9 +395,9 @@ void DataTypeMapSerDe::read_column_from_arrow(IColumn& column, const arrow::Arra
 }
 
 template <bool is_binary_format>
-Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
-                                                MysqlRowBuffer<is_binary_format>& result,
-                                                int row_idx, bool col_const) const {
+void DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<is_binary_format>& result, int row_idx,
+                                              bool col_const) const {
     auto& map_column = assert_cast<const ColumnMap&>(column);
     const IColumn& nested_keys_column = map_column.get_keys();
     const IColumn& nested_values_column = map_column.get_values();
@@ -406,76 +406,49 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
 
     const auto col_index = index_check_const(row_idx, col_const);
     result.open_dynamic_mode();
-    if (0 != result.push_string("{", 1)) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_string("{", 1);
     auto& offsets = map_column.get_offsets();
     for (auto j = offsets[col_index - 1]; j < offsets[col_index]; ++j) {
         if (j != offsets[col_index - 1]) {
-            if (0 != result.push_string(", ", 2)) {
-                return Status::InternalError("pack mysql buffer failed.");
-            }
+            result.push_string(", ", 2);
         }
         if (nested_keys_column.is_null_at(j)) {
-            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
-                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
-                return Status::InternalError("pack mysql buffer failed.");
-            }
+            result.push_string(NULL_IN_COMPLEX_TYPE.c_str(), strlen(NULL_IN_COMPLEX_TYPE.c_str()));
         } else {
             if (is_key_string) {
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
-                RETURN_IF_ERROR(
-                        key_serde->write_column_to_mysql(nested_keys_column, result, j, false));
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
+                result.push_string("\"", 1);
+                key_serde->write_column_to_mysql(nested_keys_column, result, j, false);
+                result.push_string("\"", 1);
             } else {
-                RETURN_IF_ERROR(
-                        key_serde->write_column_to_mysql(nested_keys_column, result, j, false));
+                key_serde->write_column_to_mysql(nested_keys_column, result, j, false);
             }
         }
-        if (0 != result.push_string(":", 1)) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(":", 1);
         if (nested_values_column.is_null_at(j)) {
-            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
-                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
-                return Status::InternalError("pack mysql buffer failed.");
-            }
+            result.push_string(NULL_IN_COMPLEX_TYPE.c_str(), strlen(NULL_IN_COMPLEX_TYPE.c_str()));
         } else {
             if (is_val_string) {
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
-                RETURN_IF_ERROR(
-                        value_serde->write_column_to_mysql(nested_values_column, result, j, false));
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
+                result.push_string("\"", 1);
+                value_serde->write_column_to_mysql(nested_values_column, result, j, false);
+                result.push_string("\"", 1);
             } else {
-                RETURN_IF_ERROR(
-                        value_serde->write_column_to_mysql(nested_values_column, result, j, false));
+                value_serde->write_column_to_mysql(nested_values_column, result, j, false);
             }
         }
     }
-    if (0 != result.push_string("}", 1)) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_string("}", 1);
     result.close_dynamic_mode();
-    return Status::OK();
 }
 
-Status DataTypeMapSerDe::write_column_to_mysql(const IColumn& column,
-                                               MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                               bool col_const) const {
+void DataTypeMapSerDe::write_column_to_mysql(const IColumn& column,
+                                             MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                             bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeMapSerDe::write_column_to_mysql(const IColumn& column,
-                                               MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                               bool col_const) const {
+void DataTypeMapSerDe::write_column_to_mysql(const IColumn& column,
+                                             MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                             bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_map_serde.h
+++ b/be/src/vec/data_types/serde/data_type_map_serde.h
@@ -77,10 +77,10 @@ public:
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -95,8 +95,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 
     DataTypeSerDeSPtr key_serde;
     DataTypeSerDeSPtr value_serde;

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -285,33 +285,29 @@ void DataTypeNullableSerDe::read_column_from_arrow(IColumn& column, const arrow:
 }
 
 template <bool is_binary_format>
-Status DataTypeNullableSerDe::_write_column_to_mysql(const IColumn& column,
-                                                     MysqlRowBuffer<is_binary_format>& result,
-                                                     int row_idx, bool col_const) const {
+void DataTypeNullableSerDe::_write_column_to_mysql(const IColumn& column,
+                                                   MysqlRowBuffer<is_binary_format>& result,
+                                                   int row_idx, bool col_const) const {
     auto& col = assert_cast<const ColumnNullable&>(column);
     auto& nested_col = col.get_nested_column();
     col_const = col_const || is_column_const(nested_col);
     const auto col_index = index_check_const(row_idx, col_const);
     if (col.has_null() && col.is_null_at(col_index)) {
-        if (UNLIKELY(0 != result.push_null())) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_null();
     } else {
-        RETURN_IF_ERROR(
-                nested_serde->write_column_to_mysql(nested_col, result, col_index, col_const));
+        nested_serde->write_column_to_mysql(nested_col, result, col_index, col_const);
     }
-    return Status::OK();
 }
 
-Status DataTypeNullableSerDe::write_column_to_mysql(const IColumn& column,
-                                                    MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                    bool col_const) const {
+void DataTypeNullableSerDe::write_column_to_mysql(const IColumn& column,
+                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                  bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeNullableSerDe::write_column_to_mysql(const IColumn& column,
-                                                    MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                    bool col_const) const {
+void DataTypeNullableSerDe::write_column_to_mysql(const IColumn& column,
+                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                  bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.h
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.h
@@ -74,10 +74,10 @@ public:
                                const cctz::time_zone& ctz) const override;
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -96,8 +96,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 
     DataTypeSerDeSPtr nested_serde;
 };

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -227,55 +227,49 @@ void DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
 
 template <typename T>
 template <bool is_binary_format>
-Status DataTypeNumberSerDe<T>::_write_column_to_mysql(const IColumn& column,
-                                                      MysqlRowBuffer<is_binary_format>& result,
-                                                      int row_idx, bool col_const) const {
-    int buf_ret = 0;
+void DataTypeNumberSerDe<T>::_write_column_to_mysql(const IColumn& column,
+                                                    MysqlRowBuffer<is_binary_format>& result,
+                                                    int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnType&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     if constexpr (std::is_same_v<T, Int8> || std::is_same_v<T, UInt8>) {
-        buf_ret = result.push_tinyint(data[col_index]);
+        result.push_tinyint(data[col_index]);
     } else if constexpr (std::is_same_v<T, Int16> || std::is_same_v<T, UInt16>) {
-        buf_ret = result.push_smallint(data[col_index]);
+        result.push_smallint(data[col_index]);
     } else if constexpr (std::is_same_v<T, Int32> || std::is_same_v<T, UInt32>) {
-        buf_ret = result.push_int(data[col_index]);
+        result.push_int(data[col_index]);
     } else if constexpr (std::is_same_v<T, Int64> || std::is_same_v<T, UInt64>) {
-        buf_ret = result.push_bigint(data[col_index]);
+        result.push_bigint(data[col_index]);
     } else if constexpr (std::is_same_v<T, Int128>) {
-        buf_ret = result.push_largeint(data[col_index]);
+        result.push_largeint(data[col_index]);
     } else if constexpr (std::is_same_v<T, float>) {
         if (std::isnan(data[col_index])) {
             // Handle NaN for float, we should push null value
-            buf_ret = result.push_null();
+            result.push_null();
         } else {
-            buf_ret = result.push_float(data[col_index]);
+            result.push_float(data[col_index]);
         }
     } else if constexpr (std::is_same_v<T, double>) {
         if (std::isnan(data[col_index])) {
             // Handle NaN for double, we should push null value
-            buf_ret = result.push_null();
+            result.push_null();
         } else {
-            buf_ret = result.push_double(data[col_index]);
+            result.push_double(data[col_index]);
         }
-    }
-    if (UNLIKELY(buf_ret != 0)) {
-        return Status::InternalError("pack mysql buffer failed.");
-    } else {
-        return Status::OK();
     }
 }
 
 template <typename T>
-Status DataTypeNumberSerDe<T>::write_column_to_mysql(const IColumn& column,
-                                                     MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                     bool col_const) const {
+void DataTypeNumberSerDe<T>::write_column_to_mysql(const IColumn& column,
+                                                   MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                   bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
 template <typename T>
-Status DataTypeNumberSerDe<T>::write_column_to_mysql(const IColumn& column,
-                                                     MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                     bool col_const) const {
+void DataTypeNumberSerDe<T>::write_column_to_mysql(const IColumn& column,
+                                                   MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                   bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_number_serde.h
+++ b/be/src/vec/data_types/serde/data_type_number_serde.h
@@ -85,10 +85,10 @@ public:
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -101,8 +101,8 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 
 template <typename T>

--- a/be/src/vec/data_types/serde/data_type_object_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_object_serde.cpp
@@ -37,25 +37,30 @@ namespace doris {
 
 namespace vectorized {
 
-Status DataTypeObjectSerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeObjectSerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                bool col_const) const {
     const auto& variant = assert_cast<const ColumnObject&>(column);
     if (!variant.is_finalized()) {
         const_cast<ColumnObject&>(variant).finalize();
     }
-    RETURN_IF_ERROR(variant.sanitize());
+    {
+        auto st = variant.sanitize();
+        if (!st.ok()) {
+            throw Exception(ErrorCode::INTERNAL_ERROR, st.msg());
+        }
+    }
     if (variant.is_scalar_variant()) {
         // Serialize scalar types, like int, string, array, faster path
         const auto& root = variant.get_subcolumn({});
-        RETURN_IF_ERROR(root->get_least_common_type_serde()->write_column_to_mysql(
-                root->get_finalized_column(), row_buffer, row_idx, col_const));
+        root->get_least_common_type_serde()->write_column_to_mysql(root->get_finalized_column(),
+                                                                   row_buffer, row_idx, col_const);
     } else {
         // Serialize hierarchy types to json format
         rapidjson::StringBuffer buffer;
         bool is_null = false;
         if (!variant.serialize_one_row_to_json_format(row_idx, &buffer, &is_null)) {
-            return Status::InternalError("Invalid json format");
+            throw Exception(ErrorCode::INTERNAL_ERROR, "Invalid json format");
         }
         if (is_null) {
             row_buffer.push_null();
@@ -63,7 +68,6 @@ Status DataTypeObjectSerDe::write_column_to_mysql(const IColumn& column,
             row_buffer.push_string(buffer.GetString(), buffer.GetLength());
         }
     }
-    return Status::OK();
 }
 
 void DataTypeObjectSerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result,

--- a/be/src/vec/data_types/serde/data_type_object_serde.h
+++ b/be/src/vec/data_types/serde/data_type_object_serde.h
@@ -80,13 +80,14 @@ public:
                                "read_column_from_arrow with type " + column.get_name());
     }
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override {
-        return Status::NotSupported("write_column_to_mysql with type " + column.get_name());
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override {
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "NotSupported write_column_to_mysql with type {}", column.get_name());
     }
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,

--- a/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
+++ b/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
@@ -111,12 +111,12 @@ public:
                                "read_column_from_arrow with type " + column.get_name());
     }
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override {
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override {
         return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
     }
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override {
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override {
         return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
     }
 
@@ -129,15 +129,15 @@ public:
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 
 // QuantileState is binary data which is not shown by mysql
 template <bool is_binary_format>
-Status DataTypeQuantileStateSerDe::_write_column_to_mysql(const IColumn& column,
-                                                          MysqlRowBuffer<is_binary_format>& result,
-                                                          int row_idx, bool col_const) const {
+void DataTypeQuantileStateSerDe::_write_column_to_mysql(const IColumn& column,
+                                                        MysqlRowBuffer<is_binary_format>& result,
+                                                        int row_idx, bool col_const) const {
     auto& data_column = reinterpret_cast<const ColumnQuantileState&>(column);
 
     if (_return_object_as_string) {
@@ -146,15 +146,10 @@ Status DataTypeQuantileStateSerDe::_write_column_to_mysql(const IColumn& column,
         size_t size = quantile_value.get_serialized_size();
         std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
         quantile_value.serialize((uint8_t*)buf.get());
-        if (0 != result.push_string(buf.get(), size)) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(buf.get(), size);
     } else {
-        if (0 != result.push_null()) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_null();
     }
-    return Status::OK();
 }
 
 } // namespace vectorized

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -250,11 +250,11 @@ public:
     virtual void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const = 0;
 
     // MySQL serializer and deserializer
-    virtual Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                         int row_idx, bool col_const) const = 0;
+    virtual void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                                       int row_idx, bool col_const) const = 0;
 
-    virtual Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                         int row_idx, bool col_const) const = 0;
+    virtual void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
+                                       int row_idx, bool col_const) const = 0;
     // Thrift serializer and deserializer
 
     // JSON serializer and deserializer

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -331,66 +331,50 @@ void DataTypeStructSerDe::read_column_from_arrow(IColumn& column, const arrow::A
 }
 
 template <bool is_binary_format>
-Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
-                                                   MysqlRowBuffer<is_binary_format>& result,
-                                                   int row_idx, bool col_const) const {
+void DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
+                                                 MysqlRowBuffer<is_binary_format>& result,
+                                                 int row_idx, bool col_const) const {
     auto& col = assert_cast<const ColumnStruct&>(column);
     const auto col_index = index_check_const(row_idx, col_const);
     result.open_dynamic_mode();
-    if (0 != result.push_string("{", 1)) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_string("{", 1);
     bool begin = true;
     for (size_t j = 0; j < elem_serdes_ptrs.size(); ++j) {
         if (!begin) {
-            if (0 != result.push_string(", ", 2)) {
-                return Status::InternalError("pack mysql buffer failed.");
-            }
+            result.push_string(", ", 2);
         }
 
         std::string col_name = "\"" + elem_names[j] + "\": ";
-        if (0 != result.push_string(col_name.c_str(), col_name.length())) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string(col_name.c_str(), col_name.length());
 
         if (col.get_column_ptr(j)->is_null_at(col_index)) {
-            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
-                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
-                return Status::InternalError("pack mysql buffer failed.");
-            }
+            result.push_string(NULL_IN_COMPLEX_TYPE.c_str(), strlen(NULL_IN_COMPLEX_TYPE.c_str()));
         } else {
             if (remove_nullable(col.get_column_ptr(j))->is_column_string()) {
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
-                RETURN_IF_ERROR(elem_serdes_ptrs[j]->write_column_to_mysql(
-                        col.get_column(j), result, col_index, false));
-                if (0 != result.push_string("\"", 1)) {
-                    return Status::InternalError("pack mysql buffer failed.");
-                }
+                result.push_string("\"", 1);
+                elem_serdes_ptrs[j]->write_column_to_mysql(col.get_column(j), result, col_index,
+                                                           false);
+                result.push_string("\"", 1);
             } else {
-                RETURN_IF_ERROR(elem_serdes_ptrs[j]->write_column_to_mysql(
-                        col.get_column(j), result, col_index, false));
+                elem_serdes_ptrs[j]->write_column_to_mysql(col.get_column(j), result, col_index,
+                                                           false);
             }
         }
         begin = false;
     }
-    if (UNLIKELY(0 != result.push_string("}", 1))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_string("}", 1);
     result.close_dynamic_mode();
-    return Status::OK();
 }
 
-Status DataTypeStructSerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeStructSerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 
-Status DataTypeStructSerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
+void DataTypeStructSerDe::write_column_to_mysql(const IColumn& column,
+                                                MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                                bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
 

--- a/be/src/vec/data_types/serde/data_type_struct_serde.h
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.h
@@ -152,10 +152,10 @@ public:
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
                                 int end, const cctz::time_zone& ctz) const override;
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -173,12 +173,12 @@ private:
     std::optional<size_t> try_get_position_by_name(const String& name) const;
 
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, bool return_object_data_as_binary,
-                                  std::vector<MysqlRowBuffer<is_binary_format>>& result,
-                                  int row_idx, int start, int end, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, bool return_object_data_as_binary,
+                                std::vector<MysqlRowBuffer<is_binary_format>>& result, int row_idx,
+                                int start, int end, bool col_const) const;
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 
     DataTypeSerDeSPtrs elem_serdes_ptrs;
     Strings elem_names;

--- a/be/src/vec/data_types/serde/data_type_time_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_time_serde.cpp
@@ -20,61 +20,51 @@ namespace doris {
 namespace vectorized {
 
 template <bool is_binary_format>
-Status DataTypeTimeSerDe::_write_column_to_mysql(const IColumn& column,
-                                                 MysqlRowBuffer<is_binary_format>& result,
-                                                 int row_idx, bool col_const) const {
+void DataTypeTimeSerDe::_write_column_to_mysql(const IColumn& column,
+                                               MysqlRowBuffer<is_binary_format>& result,
+                                               int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<Float64>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
-    if (UNLIKELY(0 != result.push_time(data[col_index]))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
-    return Status::OK();
+    result.push_time(data[col_index]);
 }
 
-Status DataTypeTimeSerDe::write_column_to_mysql(const IColumn& column,
+void DataTypeTimeSerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<true>& row_buffer, int row_idx,
+                                              bool col_const) const {
+    return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
+}
+
+void DataTypeTimeSerDe::write_column_to_mysql(const IColumn& column,
+                                              MysqlRowBuffer<false>& row_buffer, int row_idx,
+                                              bool col_const) const {
+    return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
+}
+
+void DataTypeTimeV2SerDe::write_column_to_mysql(const IColumn& column,
                                                 MysqlRowBuffer<true>& row_buffer, int row_idx,
                                                 bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
-
-Status DataTypeTimeSerDe::write_column_to_mysql(const IColumn& column,
+void DataTypeTimeV2SerDe::write_column_to_mysql(const IColumn& column,
                                                 MysqlRowBuffer<false>& row_buffer, int row_idx,
                                                 bool col_const) const {
     return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
 }
-
-Status DataTypeTimeV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<true>& row_buffer, int row_idx,
-                                                  bool col_const) const {
-    return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
-}
-Status DataTypeTimeV2SerDe::write_column_to_mysql(const IColumn& column,
-                                                  MysqlRowBuffer<false>& row_buffer, int row_idx,
-                                                  bool col_const) const {
-    return _write_column_to_mysql(column, row_buffer, row_idx, col_const);
-}
 template <bool is_binary_format>
-Status DataTypeTimeV2SerDe::_write_column_to_mysql(const IColumn& column,
-                                                   MysqlRowBuffer<is_binary_format>& result,
-                                                   int row_idx, bool col_const) const {
+void DataTypeTimeV2SerDe::_write_column_to_mysql(const IColumn& column,
+                                                 MysqlRowBuffer<is_binary_format>& result,
+                                                 int row_idx, bool col_const) const {
     auto& data = assert_cast<const ColumnVector<Float64>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     // _nesting_level >= 2 means this time is in complex type
     // and we should add double quotes
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    if (UNLIKELY(0 != result.push_timev2(data[col_index], scale))) {
-        return Status::InternalError("pack mysql buffer failed.");
-    }
+    result.push_timev2(data[col_index], scale);
     if (_nesting_level >= 2) {
-        if (UNLIKELY(0 != result.push_string("\"", 1))) {
-            return Status::InternalError("pack mysql buffer failed.");
-        }
+        result.push_string("\"", 1);
     }
-    return Status::OK();
 }
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_time_serde.h
+++ b/be/src/vec/data_types/serde/data_type_time_serde.h
@@ -34,29 +34,29 @@ class DataTypeTimeSerDe : public DataTypeNumberSerDe<Float64> {
 public:
     DataTypeTimeSerDe(int nesting_level = 1) : DataTypeNumberSerDe<Float64>(nesting_level) {};
 
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
 };
 class DataTypeTimeV2SerDe : public DataTypeNumberSerDe<Float64> {
 public:
     DataTypeTimeV2SerDe(int scale = 0, int nesting_level = 1)
             : DataTypeNumberSerDe<Float64>(nesting_level), scale(scale) {};
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer,
-                                 int row_idx, bool col_const) const override;
-    Status write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
-                                 int row_idx, bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<true>& row_buffer, int row_idx,
+                               bool col_const) const override;
+    void write_column_to_mysql(const IColumn& column, MysqlRowBuffer<false>& row_buffer,
+                               int row_idx, bool col_const) const override;
 
 private:
     template <bool is_binary_format>
-    Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
-                                  int row_idx, bool col_const) const;
+    void _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,
+                                int row_idx, bool col_const) const;
     int scale;
 };
 } // namespace vectorized

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -179,9 +179,9 @@ Status VMysqlResultWriter<is_binary_format>::write(Block& input_block) {
 
         for (size_t row_idx = 0; row_idx < num_rows; ++row_idx) {
             for (size_t col_idx = 0; col_idx < num_cols; ++col_idx) {
-                RETURN_IF_ERROR(arguments[col_idx].serde->write_column_to_mysql(
-                        *(arguments[col_idx].column), row_buffer, row_idx,
-                        arguments[col_idx].is_const));
+                arguments[col_idx].serde->write_column_to_mysql(*(arguments[col_idx].column),
+                                                                row_buffer, row_idx,
+                                                                arguments[col_idx].is_const);
             }
 
             // copy MysqlRowBuffer to Thrift

--- a/be/test/vec/data_types/datetime_round_test.cpp
+++ b/be/test/vec/data_types/datetime_round_test.cpp
@@ -105,8 +105,7 @@ static void serialization_checker(UInt32 scale, const std::string& input,
     EXPECT_TRUE(rt.ok());
     auto serde = std::dynamic_pointer_cast<DataTypeDateTimeV2SerDe>(datetime_ptr->get_serde());
     MysqlRowBuffer<false> mysql_rb;
-    rt = serde->write_column_to_mysql(*column, mysql_rb, 0, false);
-    EXPECT_TRUE(rt.ok());
+    serde->write_column_to_mysql(*column, mysql_rb, 0, false);
     auto elem_size = static_cast<uint8_t>(*mysql_rb.buf());
     if (elem_size != expected.size()) {
         std::cerr << "Left size " << elem_size << " right size " << expected.size() << " left str "


### PR DESCRIPTION
## Proposed changes

This is the first part of optimizing TupleConvertTime. When querying a large number of rows, Doris's speed tends to be slow.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

