### PR TITLE
[opt](Nereids) let behavior of function char same with legacy planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Char.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Char.java
@@ -18,9 +18,11 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.StringType;
@@ -43,6 +45,18 @@ public class Char extends ScalarFunction
 
     public Char(Expression... varArgs) {
         super("char", varArgs);
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        if (!(child(0) instanceof StringLikeLiteral)) {
+            throw new AnalysisException("char charset name must be a constant: " + child(0).toSql());
+        }
+        StringLikeLiteral stringLiteral = (StringLikeLiteral) child(0);
+        if (!"utf8".equalsIgnoreCase(stringLiteral.getStringValue())) {
+            throw new AnalysisException(
+                    "char function currently only support charset name 'utf8': " + child(0).toSql());
+        }
     }
 
     /**

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -285,9 +285,6 @@ suite("test_string_function", "arrow_flight_sql") {
     qt_sql "select substring_index(\"prefix_string\", \"_\", null);"
     qt_sql "select substring_index(\"prefix_string\", \"__\", -1);"
 
-    sql 'set enable_nereids_planner=true'
-    sql 'set enable_fallback_to_original_planner=false'
-
     qt_sql "select elt(0, \"hello\", \"doris\");"
     qt_sql "select elt(1, \"hello\", \"doris\");"
     qt_sql "select elt(2, \"hello\", \"doris\");"
@@ -297,15 +294,10 @@ suite("test_string_function", "arrow_flight_sql") {
     qt_sql "select sub_replace(\"doris\",\"***\",1,2);"
 
     // test function char
-    sql 'set enable_nereids_planner=false'
-    def success = false
-    try {
+    test {
         sql """ select char(68 using abc); """
-        success = true
-    } catch (Exception e) {
-        assertTrue(e.getMessage().contains("only support charset name 'utf8'"), e.getMessage())
+        exception "only support charset name 'utf8'"
     }
-    assertFalse(success)
 
     // const
     qt_sql_func_char_const1 """ select char(68); """


### PR DESCRIPTION
1. first argument must be string like literal
2. only support utf-8 charset
