### PR TITLE
[fix](merge-cloud) fix cloud autobucket num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
@@ -85,7 +85,7 @@ public class AutoBucketUtils {
 
     public static int getBucketsNum(long partitionSize) {
         int bucketsNumByPartitionSize = convertParitionSizeToBucketsNum(partitionSize);
-        int bucketsNumByBE = getBucketsNumByBEDisks();
+        int bucketsNumByBE = Config.isCloudMode() ? Integer.MAX_VALUE : getBucketsNumByBEDisks();
         int bucketsNum = Math.min(Config.autobucket_max_buckets, Math.min(bucketsNumByPartitionSize, bucketsNumByBE));
         int beNum = getBENum();
         logger.debug("AutoBucketsUtil: bucketsNumByPartitionSize {}, bucketsNumByBE {}, bucketsNum {}, beNum {}",
@@ -93,6 +93,7 @@ public class AutoBucketUtils {
         if (bucketsNum < bucketsNumByPartitionSize && bucketsNum < beNum) {
             bucketsNum = beNum;
         }
+        bucketsNum = Math.min(bucketsNum, Config.autobucket_max_buckets);
         logger.debug("AutoBucketsUtil: final bucketsNum {}", bucketsNum);
         return bucketsNum;
     }


### PR DESCRIPTION
BUG:  when calculate auto bucket num,  it will use function 'getBucketsNumByBEDisks' to calculate all backend left free disk sizes. But in cloud mode,  each backend's left disk size is not a right value, it's always equals 1.  So cloud auto bucket need to exclude this factor.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

