### PR TITLE
[Enhencement](trino-connector) The trino-connector catalog supports pushdown predicates to the connector

### DIFF
--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
@@ -236,7 +236,7 @@ public class TrinoConnectorJniScanner extends JniScanner {
             Objects.requireNonNull(connectorPageSourceProvider,
                     String.format("Connector '%s' returned a null page source provider", catalogNameString));
         } catch (UnsupportedOperationException ignored) {
-            LOG.warn("exception when getPageSourceProvider: " + ignored.getMessage());
+            LOG.debug("exception when getPageSourceProvider: " + ignored.getMessage());
         }
 
         try {
@@ -249,7 +249,7 @@ public class TrinoConnectorJniScanner extends JniScanner {
             }
             connectorPageSourceProvider = new RecordPageSourceProvider(connectorRecordSetProvider);
         } catch (UnsupportedOperationException ignored) {
-            LOG.warn("exception when getRecordSetProvider: " + ignored.getMessage());
+            LOG.debug("exception when getRecordSetProvider: " + ignored.getMessage());
         }
 
         return connectorPageSourceProvider;
@@ -336,9 +336,6 @@ public class TrinoConnectorJniScanner extends JniScanner {
             trinoTypeList.add(columnMetadataList.get(index).getType());
             String hiveType = TrinoTypeToHiveTypeTranslator.fromTrinoTypeToHiveType(trinoTypeList.get(i));
             columnTypes[i] = ColumnType.parseType(fields[i], hiveType);
-
-            // LOG.info(String.format("Trino type: [%s], hive type: [%s], columnTypes: [%s].",
-            //         trinoTypeList.get(i), hiveType, columnTypes[i]));
         }
         super.types = columnTypes;
     }

--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
@@ -138,12 +138,12 @@ public class TrinoConnectorJniScanner extends JniScanner {
         connectorPredicateString = params.get("trino_connector_predicate");
         connectorTrascationHandleString = params.get("trino_connector_trascation_handle");
         if (LOG.isDebugEnabled()) {
-            LOG.debug("TrinoConnectorJniScanner connectorSplitString = " + connectorSplitString);
-            LOG.debug("TrinoConnectorJniScanner connectorTableHandleString = " + connectorTableHandleString);
-            LOG.debug("TrinoConnectorJniScanner connectorColumnHandleString = " + connectorColumnHandleString);
-            LOG.debug("TrinoConnectorJniScanner connectorColumnMetadataString = " + connectorColumnMetadataString);
-            LOG.debug("TrinoConnectorJniScanner connectorPredicateString = " + connectorPredicateString);
-            LOG.debug("TrinoConnectorJniScanner connectorTrascationHandleString = " + connectorTrascationHandleString);
+            LOG.debug("TrinoConnectorJniScanner connectorSplitString = " + connectorSplitString
+                    + " ; connectorTableHandleString = " + connectorTableHandleString
+                    + " ; connectorColumnHandleString = " + connectorColumnHandleString
+                    + " ; connectorColumnMetadataString = " + connectorColumnMetadataString
+                    + " ; connectorPredicateString = " + connectorPredicateString
+                    + " ; connectorTrascationHandleString = " + connectorTrascationHandleString);
         }
 
 

--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
@@ -36,10 +36,16 @@ import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.SimpleFormatter;
 
+// Noninstancetiable utility class
 public class TrinoConnectorPluginLoader {
     private static final Logger LOG = LogManager.getLogger(TrinoConnectorPluginLoader.class);
 
     private static String pluginsDir = EnvUtils.getDorisHome() + "/connectors";
+
+    // Suppress default constructor for noninstantiability
+    private TrinoConnectorPluginLoader() {
+        throw new AssertionError();
+    }
 
     private static class TrinoConnectorPluginLoad {
         private static FeaturesConfig featuresConfig = new FeaturesConfig();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonPredicateConverter.java
@@ -60,7 +60,7 @@ public class PaimonPredicateConverter {
         return list;
     }
 
-    public Predicate convertToPaimonExpr(Expr dorisExpr) {
+    private Predicate convertToPaimonExpr(Expr dorisExpr) {
         if (dorisExpr == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPluginLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPluginLoader.java
@@ -36,8 +36,14 @@ import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.SimpleFormatter;
 
+// Noninstancetiable utility class
 public class TrinoConnectorPluginLoader {
     private static final Logger LOG = LogManager.getLogger(TrinoConnectorPluginLoader.class);
+
+    // Suppress default constructor for noninstantiability
+    private TrinoConnectorPluginLoader() {
+        throw new AssertionError();
+    }
 
     private static class TrinoConnectorPluginLoad {
         private static FeaturesConfig featuresConfig = new FeaturesConfig();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorPredicateConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorPredicateConverter.java
@@ -1,0 +1,331 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.trinoconnector.source;
+
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.CastExpr;
+import org.apache.doris.analysis.CompoundPredicate;
+import org.apache.doris.analysis.DateLiteral;
+import org.apache.doris.analysis.DecimalLiteral;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.InPredicate;
+import org.apache.doris.analysis.IsNullPredicate;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.thrift.TExprOpcode;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.Type;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TimeZone;
+
+
+public class TrinoConnectorPredicateConverter {
+    private static final Logger LOG = LogManager.getLogger(TrinoConnectorPredicateConverter.class);
+    private final Map<String, ColumnHandle> trinoConnectorColumnHandleMap;
+
+    private final Map<String, ColumnMetadata> trinoConnectorColumnMetadataMap;
+
+    public TrinoConnectorPredicateConverter(Map<String, ColumnHandle> columnHandleMap,
+            Map<String, ColumnMetadata> columnMetadataMap) {
+        this.trinoConnectorColumnHandleMap = columnHandleMap;
+        this.trinoConnectorColumnMetadataMap = columnMetadataMap;
+    }
+
+    public Constraint convertToTrinoConnectorExpr(List<Expr> conjuncts) {
+        if (conjuncts.isEmpty()) {
+            return Constraint.alwaysTrue();
+        }
+        TupleDomain<ColumnHandle> summary = TupleDomain.all();
+        for (int i = 0; i < conjuncts.size(); ++i) {
+            TupleDomain<ColumnHandle> tmpSummary = convertToTrinoConnectorExpr(conjuncts.get(i));
+            summary = summary.intersect(tmpSummary);
+        }
+        return new Constraint(summary);
+    }
+
+    private TupleDomain<ColumnHandle> convertToTrinoConnectorExpr(Expr predicate) {
+        if (predicate instanceof CompoundPredicate) {
+            return compoundPredicateDesc((CompoundPredicate) predicate);
+        } else if (predicate instanceof InPredicate) {
+            return inPredicateDesc((InPredicate) predicate);
+        } else if (predicate instanceof BinaryPredicate) {
+            return binaryPredicateDesc((BinaryPredicate) predicate);
+        } else if (predicate instanceof IsNullPredicate) {
+            return isNullPredicateDesc((IsNullPredicate) predicate);
+        } else {
+            return TupleDomain.all();
+        }
+    }
+
+    private TupleDomain<ColumnHandle> compoundPredicateDesc(CompoundPredicate compoundPredicate) {
+        TupleDomain<ColumnHandle> left = convertToTrinoConnectorExpr(compoundPredicate.getChild(0));
+        Objects.requireNonNull(left, "left tupleDomain is null.");
+        switch (compoundPredicate.getOp()) {
+            case AND: {
+                TupleDomain<ColumnHandle> right = convertToTrinoConnectorExpr(compoundPredicate.getChild(1));
+                Objects.requireNonNull(right, "left tupleDomain is null.");
+                return left.intersect(right);
+            }
+            case OR: {
+                TupleDomain<ColumnHandle> right = convertToTrinoConnectorExpr(compoundPredicate.getChild(1));
+                Objects.requireNonNull(right, "left tupleDomain is null.");
+                return TupleDomain.columnWiseUnion(left, right);
+            }
+            case NOT:
+                return TupleDomain.all();
+            default:
+                return TupleDomain.all();
+        }
+    }
+
+    private TupleDomain<ColumnHandle> inPredicateDesc(InPredicate predicate) {
+        // Make sure the col slot is always first
+        SlotRef slotRef = convertExprToSlotRef(predicate.getChild(0));
+        if (slotRef == null) {
+            return TupleDomain.all();
+        }
+        String colName = slotRef.getColumnName();
+        Type type = trinoConnectorColumnMetadataMap.get(colName).getType();
+        List<Range> ranges = Lists.newArrayList();
+        for (int i = 1; i < predicate.getChildren().size(); i++) {
+            LiteralExpr literalExpr = convertExprToLiteral(predicate.getChild(i));
+            if (literalExpr == null) {
+                return TupleDomain.all();
+            }
+            try {
+                ranges.add(Range.equal(type,
+                        convertLiteralToDomainValues(type.getClass(), literalExpr)));
+            } catch (Exception e) {
+                LOG.warn("Can not convert literal to domain values, exception: {}", e.getMessage());
+                return TupleDomain.all();
+            }
+        }
+        Domain domain = Domain.create(ValueSet.ofRanges(ranges), false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+        return tupleDomain;
+    }
+
+    private TupleDomain<ColumnHandle> binaryPredicateDesc(BinaryPredicate predicate) {
+        // Make sure the col slot is always first
+        SlotRef slotRef = convertExprToSlotRef(predicate.getChild(0));
+        if (slotRef == null) {
+            return TupleDomain.all();
+        }
+        LiteralExpr literalExpr = convertExprToLiteral(predicate.getChild(1));
+        // literalExpr == null means predicate.getChild(1) is not a LiteralExpr or CastExpr
+        // such as where A.a < A.b
+        // predicate.getChild(1) is SlotRef, so we should return TupleDomain.all()
+        if (literalExpr == null) {
+            return TupleDomain.all();
+        }
+
+        String colName = slotRef.getColumnName();
+        Type type = trinoConnectorColumnMetadataMap.get(colName).getType();
+        try {
+            Domain domain = null;
+            TExprOpcode opcode = predicate.getOpcode();
+            switch (opcode) {
+                case EQ:
+                    domain = Domain.create(ValueSet.ofRanges(Range.equal(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), false);
+                    break;
+                case EQ_FOR_NULL:
+                    domain = Domain.create(ValueSet.ofRanges(Range.equal(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), true);
+                    break;
+                case NE:
+                    domain = Domain.create(ValueSet.all(type).subtract(ValueSet.ofRanges(Range.equal(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr)))), false);
+                    break;
+                case LT:
+                    domain = Domain.create(ValueSet.ofRanges(Range.lessThan(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), false);
+                    break;
+                case LE:
+                    domain = Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), false);
+                    break;
+                case GT:
+                    domain = Domain.create(ValueSet.ofRanges(Range.greaterThan(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), false);
+                    break;
+                case GE:
+                    domain = Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(type,
+                            convertLiteralToDomainValues(type.getClass(), literalExpr))), false);
+                    break;
+                case INVALID_OPCODE:
+                default:
+                    return TupleDomain.all();
+            }
+            return TupleDomain.withColumnDomains(ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+        } catch (AnalysisException e) {
+            LOG.warn("Can not convert doris literal expr to trino domain values, exception = {}.", e.getMessage());
+            return TupleDomain.all();
+        }
+    }
+
+    private TupleDomain<ColumnHandle> isNullPredicateDesc(IsNullPredicate predicate) {
+        Objects.requireNonNull(predicate.getChild(0), "The first child of IsNullPredicate is null.");
+        SlotRef slotRef = convertExprToSlotRef(predicate.getChild(0));
+        if (slotRef == null) {
+            return TupleDomain.all();
+        }
+        String colName = slotRef.getColumnName();
+        Type type = trinoConnectorColumnMetadataMap.get(colName).getType();
+        if (predicate.isNotNull()) {
+            return TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), Domain.notNull(type)));
+        }
+        return TupleDomain.withColumnDomains(
+                ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), Domain.onlyNull(type)));
+    }
+
+    /* Since different Trino types have different data formats stored in their Range,
+       we need to convert the data format stored in Doris's LiteralExpr to the corresponding Java data type
+       which can be recognized by the Trino Type Range.
+       The correspondence between different Trino types and the Java data types stored in their Range is as follows:
+
+        Trino Type                               Java Type
+
+        BooleanType                              boolean
+        TinyintType                              long
+        SmallintType                             long
+        IntegerType                              long
+        BigintType                               long
+        RealType                                 long
+        ShortDecimalType                         long
+        LongDecimalType                          io.trino.spi.type.Int128
+        CharType                                 io.airlift.slice.Slice
+        VarbinaryType                            io.airlift.slice.Slice
+        VarcharType                              io.airlift.slice.Slice
+        DateType                                 long
+        DoubleType                               double
+        TimeType                                 long
+        ShortTimestampType                       long
+        LongTimestampType                        io.trino.spi.type.LongTimestamp
+        ShortTimestampWithTimeZoneType           long
+        LongTimestampWithTimeZoneType            io.trino.spi.type.LongTimestampWithTimeZone
+        ArrayType                                io.trino.spi.block.Block
+        MapType                                  io.trino.spi.block.SqlMap
+        RowType                                  io.trino.spi.block.SqlRow*/
+    private Object convertLiteralToDomainValues(Class<? extends Type> type, LiteralExpr literalExpr) throws
+            AnalysisException {
+        switch (type.getSimpleName()) {
+            case "BooleanType":
+                return literalExpr.getRealValue();
+            case "TinyintType":
+            case "SmallintType":
+            case "IntegerType":
+            case "BigintType":
+            case "RealType":
+                return literalExpr.getLongValue();
+            case "ShortDecimalType": {
+                BigDecimal value = (BigDecimal) literalExpr.getRealValue();
+                BigDecimal tmpValue = new BigDecimal(Math.pow(10, DecimalLiteral.getBigDecimalScale(value)));
+                value = value.multiply(tmpValue);
+                return value.longValue();
+            }
+            case "LongDecimalType": {
+                BigDecimal value = (BigDecimal) literalExpr.getRealValue();
+                BigDecimal tmpValue = new BigDecimal(Math.pow(10, DecimalLiteral.getBigDecimalScale(value)));
+                value = value.multiply(tmpValue);
+                return Int128.valueOf(value.toBigIntegerExact());
+            }
+            case "CharType":
+            case "VarbinaryType":
+            case "VarcharType":
+                return Slices.utf8Slice((String) literalExpr.getRealValue());
+            case "DateType":
+                return ((DateLiteral) literalExpr).daynr() - new DateLiteral("1970-01-01").daynr();
+            case "DoubleType":
+                return literalExpr.getDoubleValue();
+            case "ShortTimestampType": {
+                DateLiteral dateLiteral = (DateLiteral) literalExpr;
+                return dateLiteral.unixTimestamp(TimeZone.getTimeZone(TimeUtils.UTC_TIME_ZONE)) * 1000
+                        + dateLiteral.getMicrosecond();
+            }
+            case "ShortTimestampWithTimeZoneType": {
+                DateLiteral dateLiteral = (DateLiteral) literalExpr;
+                return dateLiteral.unixTimestamp(TimeUtils.getTimeZone()) * 1000 + dateLiteral.getMicrosecond();
+            }
+            case "LongTimestampType": {
+                DateLiteral dateLiteral = (DateLiteral) literalExpr;
+                long epochMicros = dateLiteral.unixTimestamp(TimeZone.getTimeZone(TimeUtils.UTC_TIME_ZONE)) * 1000
+                        + dateLiteral.getMicrosecond();
+                return new LongTimestamp(epochMicros, 0);
+            }
+            case "LongTimestampWithTimeZoneType": {
+                DateLiteral dateLiteral = (DateLiteral) literalExpr;
+                long epochMicros = dateLiteral.unixTimestamp(TimeUtils.getTimeZone()) * 1000
+                        + dateLiteral.getMicrosecond();
+                return new LongTimestamp(epochMicros, 0);
+            }
+            case "TimeType":
+            case "ArrayType":
+            case "MapType":
+            case "RowType":
+            default:
+                return null;
+        }
+    }
+
+    private SlotRef convertExprToSlotRef(Expr expr) {
+        SlotRef slotRef = null;
+        if (expr instanceof SlotRef) {
+            slotRef = (SlotRef) expr;
+        } else if (expr instanceof CastExpr) {
+            if (expr.getChild(0) instanceof SlotRef) {
+                slotRef = (SlotRef) expr.getChild(0);
+            }
+        }
+        return slotRef;
+    }
+
+    private LiteralExpr convertExprToLiteral(Expr expr) {
+        LiteralExpr literalExpr = null;
+        if (expr instanceof LiteralExpr) {
+            literalExpr = (LiteralExpr) expr;
+        } else if (expr instanceof CastExpr) {
+            if (expr.getChild(0) instanceof LiteralExpr) {
+                literalExpr = (LiteralExpr) expr.getChild(0);
+            }
+        }
+        return literalExpr;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorPredicateConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorPredicateConverter.java
@@ -56,6 +56,8 @@ import java.util.TimeZone;
 
 public class TrinoConnectorPredicateConverter {
     private static final Logger LOG = LogManager.getLogger(TrinoConnectorPredicateConverter.class);
+
+    private static final String EPOCH_DATE = "1970-01-01";
     private final Map<String, ColumnHandle> trinoConnectorColumnHandleMap;
 
     private final Map<String, ColumnMetadata> trinoConnectorColumnMetadataMap;
@@ -265,7 +267,7 @@ public class TrinoConnectorPredicateConverter {
             case "VarcharType":
                 return Slices.utf8Slice((String) literalExpr.getRealValue());
             case "DateType":
-                return ((DateLiteral) literalExpr).daynr() - new DateLiteral("1970-01-01").daynr();
+                return ((DateLiteral) literalExpr).daynr() - new DateLiteral(EPOCH_DATE).daynr();
             case "DoubleType":
                 return literalExpr.getDoubleValue();
             case "ShortTimestampType": {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
@@ -45,6 +45,7 @@ import org.apache.doris.trinoconnector.TrinoColumnMetadata;
 import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.concurrent.Threads;
@@ -52,9 +53,13 @@ import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.block.BlockJsonSerde;
+import io.trino.metadata.BlockEncodingManager;
 import io.trino.metadata.HandleJsonModule;
 import io.trino.metadata.HandleResolver;
+import io.trino.metadata.InternalBlockEncodingSerde;
 import io.trino.plugin.base.TypeDeserializer;
+import io.trino.spi.block.Block;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
@@ -65,29 +70,38 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.transaction.IsolationLevel;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.split.BufferingSplitSource;
 import io.trino.split.ConnectorAwareSplitSource;
 import io.trino.split.SplitSource;
 import io.trino.type.InternalTypeManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 public class TrinoConnectorScanNode extends FileQueryScanNode {
+    private static final Logger LOG = LogManager.getLogger(TrinoConnectorScanNode.class);
     private static final int minScheduleSplitBatchSize = 10;
     private TrinoConnectorSource source = null;
     private ObjectMapperProvider objectMapperProvider;
 
-    // private static List<Predicate> predicates;
+    private ConnectorMetadata connectorMetadata;
+    private Constraint constraint;
 
     public TrinoConnectorScanNode(PlanNodeId id, TupleDescriptor desc, boolean needCheckColumnPriv) {
         super(id, desc, "TRINO_CONNECTOR_SCAN_NODE", StatisticalType.TRINO_CONNECTOR_SCAN_NODE, needCheckColumnPriv);
@@ -102,11 +116,15 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
                             table.getName()));
         }
 
-        source = new TrinoConnectorSource(desc, table);
-
         computeColumnsFilter();
         initBackendPolicy();
+        source = new TrinoConnectorSource(desc, table);
         initSchemaParams();
+
+        TrinoConnectorPredicateConverter trinoConnectorPredicateConverter = new TrinoConnectorPredicateConverter(
+                source.getTargetTable().getColumnHandleMap(),
+                source.getTargetTable().getColumnMetadataMap());
+        constraint = trinoConnectorPredicateConverter.convertToTrinoConnectorExpr(conjuncts);
     }
 
     @Override
@@ -117,16 +135,16 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
                 IsolationLevel.READ_UNCOMMITTED, true, true);
         source.setConnectorTransactionHandle(connectorTransactionHandle);
         ConnectorSession connectorSession = source.getTrinoSession().toConnectorSession(source.getCatalogHandle());
-        ConnectorMetadata connectorMetadata = connector.getMetadata(connectorSession, connectorTransactionHandle);
 
+        connectorMetadata = connector.getMetadata(connectorSession, connectorTransactionHandle);
         // 2. Begin query
         connectorMetadata.beginQuery(connectorSession);
+        applyPushDown(connectorSession);
 
         // 3. get splitSource
         SplitSource splitSource = getTrinoSplitSource(connector, source.getTrinoSession(), connectorTransactionHandle,
-                source.getTrinoConnectorExtTableHandle(),
-                DynamicFilter.EMPTY,
-                Constraint.alwaysTrue());
+                source.getTrinoConnectorTableHandle(),
+                DynamicFilter.EMPTY);
         // 4. get trino.Splits and convert it to doris.Splits
         List<Split> splits = Lists.newArrayList();
         while (!splitSource.isFinished()) {
@@ -137,9 +155,52 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         return splits;
     }
 
+    private void applyPushDown(ConnectorSession connectorSession) {
+        // push down predicate/filter
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> filterResult
+                = connectorMetadata.applyFilter(connectorSession, source.getTrinoConnectorTableHandle(), constraint);
+        if (filterResult.isPresent()) {
+            source.setTrinoConnectorTableHandle(filterResult.get().getHandle());
+        }
+
+        // push down limit
+        if (hasLimit()) {
+            long limit = getLimit();
+            Optional<LimitApplicationResult<ConnectorTableHandle>> limitResult
+                    = connectorMetadata.applyLimit(connectorSession, source.getTrinoConnectorTableHandle(), limit);
+            if (limitResult.isPresent()) {
+                source.setTrinoConnectorTableHandle(limitResult.get().getHandle());
+            }
+        }
+
+        // push down projection
+        // Map<String, ColumnHandle> columnHandleMap = source.getTargetTable().getColumnHandleMap();
+        // Map<String, ColumnHandle> assignments = Maps.newHashMap();
+        // if (source.getTargetTable().getName().equals("customer")) {
+        //     assignments.put("c_custkey", columnHandleMap.get("c_custkey"));
+        //     assignments.put("c_mktsegment", columnHandleMap.get("c_mktsegment"));
+        // } else if (source.getTargetTable().getName().equals("orders")) {
+        //     assignments.put("o_orderkey", columnHandleMap.get("o_orderkey"));
+        //     assignments.put("o_custkey", columnHandleMap.get("o_custkey"));
+        //     assignments.put("o_orderdate", columnHandleMap.get("o_orderdate"));
+        //     assignments.put("o_shippriority", columnHandleMap.get("o_shippriority"));
+        // } else if (source.getTargetTable().getName().equals("lineitem")) {
+        //     assignments.put("l_orderkey", columnHandleMap.get("l_orderkey"));
+        //     assignments.put("l_extendedprice", columnHandleMap.get("l_extendedprice"));
+        //     assignments.put("l_discount", columnHandleMap.get("l_discount"));
+        //     assignments.put("l_shipdate", columnHandleMap.get("l_shipdate"));
+        // }
+        // Optional<ProjectionApplicationResult<ConnectorTableHandle>> projectionResult
+        //         = connectorMetadata.applyProjection(connectorSession, source.getTrinoConnectorTableHandle(),
+        //         Lists.newArrayList(), assignments);
+        // if (projectionResult.isPresent()) {
+        //     source.setTrinoConnectorTableHandle(projectionResult.get().getHandle());
+        // }
+    }
+
     private SplitSource getTrinoSplitSource(Connector connector, Session session,
             ConnectorTransactionHandle connectorTransactionHandle, ConnectorTableHandle table,
-            DynamicFilter dynamicFilter, Constraint constraint) {
+            DynamicFilter dynamicFilter) {
         ConnectorSplitManager splitManager = connector.getSplitManager();
 
         if (!SystemSessionProperties.isAllowPushdownIntoConnectors(session)) {
@@ -147,7 +208,7 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         }
 
         ConnectorSession connectorSession = session.toConnectorSession(source.getCatalogHandle());
-        // TODO(ftw): here can not use table.getTransactionHandle
+        // Constraint is not used by Hive/BigQuery Connector
         ConnectorSplitSource connectorSplitSource = splitManager.getSplits(connectorTransactionHandle, connectorSession,
                 table, dynamicFilter, constraint);
 
@@ -183,8 +244,8 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         fileDesc.setDbName(source.getTargetTable().getDbName());
         fileDesc.setTrinoConnectorOptions(source.getCatalog().getTrinoConnectorProperties());
         fileDesc.setTableName(source.getTargetTable().getName());
-        fileDesc.setTrinoConnectorTableHandle(
-                encodeObjectToString(source.getTargetTable().getConnectorTableHandle(), objectMapperProvider));
+        fileDesc.setTrinoConnectorTableHandle(encodeObjectToString(
+                source.getTrinoConnectorTableHandle(), objectMapperProvider));
 
         Map<String, ColumnHandle> columnHandleMap = source.getTargetTable().getColumnHandleMap();
         Map<String, ColumnMetadata> columnMetadataMap = source.getTargetTable().getColumnMetadataMap();
@@ -220,7 +281,6 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
 
     private ObjectMapperProvider createObjectMapperProvider() {
         // mock ObjectMapperProvider
-        TypeManager typeManager = new InternalTypeManager(TrinoConnectorPluginLoader.getTypeRegistry());
         ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
         Set<Module> modules = new HashSet<Module>();
         HandleResolver handleResolver = TrinoConnectorPluginLoader.getHandleResolver();
@@ -233,9 +293,18 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         // modules.add(HandleJsonModule.tableExecuteHandleModule(handleResolver));
         // modules.add(HandleJsonModule.indexHandleModule(handleResolver));
         // modules.add(HandleJsonModule.partitioningHandleModule(handleResolver));
+        // modules.add(HandleJsonModule.tableFunctionHandleModule(handleResolver));
         objectMapperProvider.setModules(modules);
-        objectMapperProvider.setJsonDeserializers(
-                ImmutableMap.of(io.trino.spi.type.Type.class, new TypeDeserializer(typeManager)));
+
+        // set json deserializers
+        TypeManager typeManager = new InternalTypeManager(TrinoConnectorPluginLoader.getTypeRegistry());
+        InternalBlockEncodingSerde blockEncodingSerde = new InternalBlockEncodingSerde(new BlockEncodingManager(),
+                typeManager);
+        objectMapperProvider.setJsonSerializers(ImmutableMap.of(Block.class,
+                new BlockJsonSerde.Serializer(blockEncodingSerde)));
+        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(
+                Type.class, new TypeDeserializer(typeManager),
+                Block.class, new BlockJsonSerde.Deserializer(blockEncodingSerde)));
         return objectMapperProvider;
     }
 
@@ -258,11 +327,22 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         Map<String, ColumnMetadata> columnMetadataMap = source.getTargetTable().getColumnMetadataMap();
         Map<String, ColumnHandle> columnHandleMap = source.getTargetTable().getColumnHandleMap();
         List<ColumnHandle> columnHandles = new ArrayList<>();
+        // used for pushing down projection
+        Map<String, ColumnHandle> assignments = Maps.newHashMap();
         for (SlotDescriptor slotDescriptor : desc.getSlots()) {
             String colName = slotDescriptor.getColumn().getName();
+            assignments.put(colName, columnHandleMap.get(colName));
             if (columnMetadataMap.containsKey(colName)) {
                 columnHandles.add(columnHandleMap.get(colName));
             }
+        }
+
+        ConnectorSession connectorSession = source.getTrinoSession().toConnectorSession(source.getCatalogHandle());
+        Optional<ProjectionApplicationResult<ConnectorTableHandle>> projectionResult
+                = connectorMetadata.applyProjection(connectorSession, source.getTrinoConnectorTableHandle(),
+                Lists.newArrayList(), assignments);
+        if (projectionResult.isPresent()) {
+            source.setTrinoConnectorTableHandle(projectionResult.get().getHandle());
         }
 
         for (TScanRangeLocations tScanRangeLocations : scanRangeLocations) {
@@ -270,6 +350,8 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
             for (TFileRangeDesc tFileRangeDesc : ranges) {
                 tFileRangeDesc.table_format_params.trino_connector_params.setTrinoConnectorColumnHandles(
                         encodeObjectToString(columnHandles, objectMapperProvider));
+                tFileRangeDesc.table_format_params.trino_connector_params.setTrinoConnectorTableHandle(
+                        encodeObjectToString(source.getTrinoConnectorTableHandle(), objectMapperProvider));
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
@@ -171,7 +171,7 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("The TrinoConnectorTableHandle is " + source.getTrinoConnectorTableHandle()
-                    + "after pushing down.");
+                    + " after pushing down.");
         }
 
         // TODO(ftw): push down projection

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
@@ -138,14 +138,14 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         applyPushDown(connectorSession);
 
         // 3. get splitSource
-        SplitSource splitSource = getTrinoSplitSource(connector, source.getTrinoSession(), connectorTransactionHandle,
-                source.getTrinoConnectorTableHandle(),
-                DynamicFilter.EMPTY);
-        // 4. get trino.Splits and convert it to doris.Splits
         List<Split> splits = Lists.newArrayList();
-        while (!splitSource.isFinished()) {
-            for (io.trino.metadata.Split split : getNextSplitBatch(splitSource)) {
-                splits.add(new TrinoConnectorSplit(split.getConnectorSplit(), source.getConnectorName()));
+        try (SplitSource splitSource = getTrinoSplitSource(connector, source.getTrinoSession(),
+                connectorTransactionHandle, source.getTrinoConnectorTableHandle(), DynamicFilter.EMPTY)) {
+            // 4. get trino.Splits and convert it to doris.Splits
+            while (!splitSource.isFinished()) {
+                for (io.trino.metadata.Split split : getNextSplitBatch(splitSource)) {
+                    splits.add(new TrinoConnectorSplit(split.getConnectorSplit(), source.getConnectorName()));
+                }
             }
         }
         return splits;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorSource.java
@@ -39,14 +39,14 @@ public class TrinoConnectorSource {
     private final Connector connector;
     private final ConnectorName connectorName;
     private ConnectorTransactionHandle connectorTransactionHandle;
-    private final ConnectorTableHandle trinoConnectorExtTableHandle;
+    private ConnectorTableHandle trinoConnectorTableHandle;
 
     public TrinoConnectorSource(TupleDescriptor desc, TrinoConnectorExternalTable table) {
         this.desc = desc;
         this.trinoConnectorExtTable = table;
         this.trinoConnectorExternalCatalog = (TrinoConnectorExternalCatalog) table.getCatalog();
         this.catalogHandle = trinoConnectorExternalCatalog.getTrinoCatalogHandle();
-        this.trinoConnectorExtTableHandle = table.getConnectorTableHandle();
+        this.trinoConnectorTableHandle = table.getConnectorTableHandle();
         this.trinoSession = trinoConnectorExternalCatalog.getTrinoSession();
         this.connector = ((TrinoConnectorExternalCatalog) table.getCatalog()).getConnector();
         this.connectorName = ((TrinoConnectorExternalCatalog) table.getCatalog()).getConnectorName();
@@ -56,8 +56,8 @@ public class TrinoConnectorSource {
         return desc;
     }
 
-    public ConnectorTableHandle getTrinoConnectorExtTableHandle() {
-        return trinoConnectorExtTableHandle;
+    public ConnectorTableHandle getTrinoConnectorTableHandle() {
+        return trinoConnectorTableHandle;
     }
 
     public TrinoConnectorExternalTable getTargetTable() {
@@ -90,6 +90,10 @@ public class TrinoConnectorSource {
 
     public void setConnectorTransactionHandle(ConnectorTransactionHandle connectorTransactionHandle) {
         this.connectorTransactionHandle = connectorTransactionHandle;
+    }
+
+    public void setTrinoConnectorTableHandle(ConnectorTableHandle trinoConnectorExtTableHandle) {
+        this.trinoConnectorTableHandle = trinoConnectorExtTableHandle;
     }
 
     public ConnectorTransactionHandle getConnectorTransactionHandle() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPredicateTest.java
@@ -1,0 +1,688 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.trinoconnector;
+
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.BinaryPredicate.Operator;
+import org.apache.doris.analysis.BoolLiteral;
+import org.apache.doris.analysis.DateLiteral;
+import org.apache.doris.analysis.DecimalLiteral;
+import org.apache.doris.analysis.FloatLiteral;
+import org.apache.doris.analysis.InPredicate;
+import org.apache.doris.analysis.IntLiteral;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.NullLiteral;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.trinoconnector.source.TrinoConnectorPredicateConverter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+public class TrinoConnectorPredicateTest {
+
+    private static final ImmutableMap<String, ColumnHandle> trinoConnectorColumnHandleMap =
+             new ImmutableMap.Builder()
+                     .put("c_bool", new MockColumnHandle())
+                     .put("c_tinyint", new MockColumnHandle())
+                     .put("c_smallint", new MockColumnHandle())
+                     .put("c_int", new MockColumnHandle())
+                     .put("c_bigint", new MockColumnHandle())
+                     .put("c_real", new MockColumnHandle())
+                     .put("c_short_decimal", new MockColumnHandle())
+                     .put("c_long_decimal", new MockColumnHandle())
+                     .put("c_char", new MockColumnHandle())
+                     .put("c_varchar", new MockColumnHandle())
+                     .put("c_varbinary", new MockColumnHandle())
+                     .put("c_date", new MockColumnHandle())
+                     .put("c_double", new MockColumnHandle())
+                     .put("c_short_timestamp", new MockColumnHandle())
+                     // .put("c_short_timestamp_timezone", new MockColumnHandle())
+                     .put("c_long_timestamp", new MockColumnHandle())
+                     .put("c_long_timestamp_timezone", new MockColumnHandle())
+                     .build();
+
+    private static final ImmutableMap<String, ColumnMetadata> trinoConnectorColumnMetadataMap =
+            new ImmutableMap.Builder()
+                    .put("c_bool", new ColumnMetadata("c_bool", BooleanType.BOOLEAN))
+                    .put("c_tinyint", new ColumnMetadata("c_tinyint", TinyintType.TINYINT))
+                    .put("c_smallint", new ColumnMetadata("c_smallint", SmallintType.SMALLINT))
+                    .put("c_int", new ColumnMetadata("c_int", IntegerType.INTEGER))
+                    .put("c_bigint", new ColumnMetadata("c_bigint", BigintType.BIGINT))
+                    .put("c_real", new ColumnMetadata("c_real", RealType.REAL))
+                    .put("c_short_decimal", new ColumnMetadata("c_short_decimal",
+                            DecimalType.createDecimalType(9, 2)))
+                    .put("c_long_decimal", new ColumnMetadata("c_long_decimal",
+                            DecimalType.createDecimalType(38, 15)))
+                    .put("c_char", new ColumnMetadata("c_char", CharType.createCharType(128)))
+                    .put("c_varchar", new ColumnMetadata("c_varchar",
+                            VarcharType.createVarcharType(128)))
+                    .put("c_varbinary", new ColumnMetadata("c_varbinary", VarbinaryType.VARBINARY))
+                    .put("c_date", new ColumnMetadata("c_date", DateType.DATE))
+                    .put("c_double", new ColumnMetadata("c_double", DoubleType.DOUBLE))
+                    .put("c_short_timestamp", new ColumnMetadata("c_short_timestamp",
+                            TimestampType.TIMESTAMP_MICROS))
+                    // .put("c_short_timestamp_timezone", new ColumnMetadata("c_short_timestamp_timezone",
+                    //         TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS))
+                    .put("c_long_timestamp", new ColumnMetadata("c_long_timestamp",
+                            TimestampType.TIMESTAMP_PICOS))
+                    .put("c_long_timestamp_timezone", new ColumnMetadata("c_long_timestamp_timezone",
+                            TimestampWithTimeZoneType.TIMESTAMP_TZ_PICOS))
+                    .build();
+
+    private static TrinoConnectorPredicateConverter trinoConnectorPredicateConverter;
+
+    @BeforeClass
+    public static void before() throws AnalysisException {
+        trinoConnectorPredicateConverter = new TrinoConnectorPredicateConverter(
+                trinoConnectorColumnHandleMap,
+                trinoConnectorColumnMetadataMap);
+    }
+
+    @Test
+    public void testBinaryEqPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct equal binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    @Test
+    public void testBinaryEqualForNullPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct equal binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(Operator.EQ_FOR_NULL, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+
+        // test <=>
+        SlotRef intSlot = new SlotRef(new TableName("test_table"), "c_int");
+        NullLiteral nullLiteral = NullLiteral.create(Type.INT);
+        BinaryPredicate expr = new BinaryPredicate(Operator.EQ_FOR_NULL, intSlot, nullLiteral);
+        TupleDomain<ColumnHandle> testNullTupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                expr);
+        TupleDomain<ColumnHandle> expectNullTupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(trinoConnectorColumnHandleMap.get("c_int"), Domain.onlyNull(IntegerType.INTEGER)));
+        Assert.assertTrue(expectNullTupleDomain.contains(testNullTupleDomain));
+    }
+
+    @Test
+    public void testBinaryLessThanPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.lessThan(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct lessThan binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(Operator.LT, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    @Test
+    public void testBinaryLessEqualPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.lessThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct lessThanOrEqual binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(Operator.LE, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    @Test
+    public void testBinaryGreatThanPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.greaterThan(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct greaterThan binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(Operator.GT, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    @Test
+    public void testBinaryGreaterEqualPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.greaterThanOrEqual(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain domain = Domain.create(ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), domain));
+            expectTupleDomain.add(tupleDomain);
+        }
+
+        // test results, construct greaterThanOrEqual binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            BinaryPredicate expr = new BinaryPredicate(Operator.GE, slotRefs.get(i),
+                    literalList.get(i));
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectTupleDomain.size(); i++) {
+            Assert.assertTrue(expectTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    @Test
+    public void testInPredicate() throws AnalysisException {
+        // construct slotRefs and literalLists
+        List<SlotRef> slotRefs = mockSlotRefs();
+        List<LiteralExpr> literalList = mockLiteralExpr();
+
+        // expect results
+        List<TupleDomain<ColumnHandle>> expectInTupleDomain = Lists.newArrayList();
+        List<TupleDomain<ColumnHandle>> expectNotInTupleDomain = Lists.newArrayList();
+        ImmutableList<Range> expectRanges = new ImmutableList.Builder()
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bool").getType(), true))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_tinyint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_smallint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_int").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_bigint").getType(), 1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_real").getType(),
+                        Long.valueOf(Float.floatToIntBits(1.23f))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_double").getType(), 3.1415926456))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_decimal").getType(), 12345623L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_decimal").getType(),
+                        Int128.valueOf(new BigInteger("12345678901234567890123123"))))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_char").getType(),
+                        Slices.utf8Slice("trino connector char test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varchar").getType(),
+                        Slices.utf8Slice("trino connector varchar test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_varbinary").getType(),
+                        Slices.utf8Slice("trino connector varbinary test")))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_date").getType(), -1L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp").getType(),
+                        1000001L))
+                // .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_short_timestamp_timezone").getType(),
+                //         0L))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp").getType(),
+                        new LongTimestamp(1000001L, 0)))
+                .add(Range.equal(trinoConnectorColumnMetadataMap.get("c_long_timestamp_timezone").getType(),
+                        LongTimestampWithTimeZone.fromEpochMillisAndFraction(1000L, 1000000,
+                                TimeZoneKey.getTimeZoneKey("Asia/Shanghai"))))
+                .build();
+
+        for (int i = 0; i < slotRefs.size(); i++) {
+            final String colName = slotRefs.get(i).getColumnName();
+            Domain inDomain = Domain.create(
+                    ValueSet.ofRanges(Lists.newArrayList(expectRanges.get(i))), false);
+            Domain notInDomain = Domain.create(ValueSet.all(trinoConnectorColumnMetadataMap.get(colName).getType())
+                            .subtract(ValueSet.ofRanges(expectRanges.get(i))), false);
+            TupleDomain<ColumnHandle> inTupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), inDomain));
+            TupleDomain<ColumnHandle> notInTupleDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(trinoConnectorColumnHandleMap.get(colName), notInDomain));
+            expectInTupleDomain.add(inTupleDomain);
+            expectNotInTupleDomain.add(notInTupleDomain);
+        }
+
+        // test results, construct equal binary predicate
+        List<TupleDomain<ColumnHandle>> testTupleDomain = Lists.newArrayList();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            InPredicate expr = new InPredicate(slotRefs.get(i), literalList.get(i), false);
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectInTupleDomain.size(); i++) {
+            Assert.assertTrue(expectInTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+
+        testTupleDomain.clear();
+        for (int i = 0; i < slotRefs.size(); i++) {
+            InPredicate expr = new InPredicate(slotRefs.get(i), literalList.get(i), true);
+            TupleDomain<ColumnHandle> tupleDomain = trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(
+                    expr);
+            testTupleDomain.add(tupleDomain);
+        }
+        // verify if `testTupleDomain` is equal to `expectTupleDomain`.
+        for (int i = 0; i < expectNotInTupleDomain.size(); i++) {
+            Assert.assertTrue(expectNotInTupleDomain.get(i).contains(testTupleDomain.get(i)));
+        }
+    }
+
+    // @Test
+    // public void testCompoundPredicate() throws AnalysisException {
+    //     // construct slotRefs and literalLists
+    //     List<SlotRef> slotRefs = mockSlotRefs();
+    //     List<LiteralExpr> literalList = mockLiteralExpr();
+    //
+    //     // test results, construct equal binary predicate
+    //     List<Expr> validExprs = Lists.newArrayList();
+    //     for (int i = 0; i < slotRefs.size(); i++) {
+    //         BinaryPredicate expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, slotRefs.get(i),
+    //                 literalList.get(i));
+    //         validExprs.add(expr);
+    //     }
+    //
+    //     // AND
+    //     for (int i = 0; i < validExprs.size(); i++) {
+    //         for (int j = 0; j < validExprs.size(); j++) {
+    //             System.out.println("i = " + i + "; j = " + j);
+    //             CompoundPredicate andPredicate = new CompoundPredicate(CompoundPredicate.Operator.AND,
+    //                     validExprs.get(i), validExprs.get(j));
+    //             trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(andPredicate);
+    //         }
+    //     }
+    //
+    //     // OR
+    //     for (int i = 0; i < validExprs.size(); i++) {
+    //         for (int j = 0; j < validExprs.size(); j++) {
+    //             CompoundPredicate andPredicate = new CompoundPredicate(CompoundPredicate.Operator.OR,
+    //                     validExprs.get(i), validExprs.get(j));
+    //             trinoConnectorPredicateConverter.convertExprToTrinoTupleDomain(andPredicate);
+    //         }
+    //     }
+    // }
+
+    private List<SlotRef> mockSlotRefs() {
+        return new ImmutableList.Builder()
+                .add(new SlotRef(new TableName("test_table"), "c_bool"))
+
+                .add(new SlotRef(new TableName("test_table"), "c_tinyint"))
+                .add(new SlotRef(new TableName("test_table"), "c_smallint"))
+                .add(new SlotRef(new TableName("test_table"), "c_int"))
+                .add(new SlotRef(new TableName("test_table"), "c_bigint"))
+
+                .add(new SlotRef(new TableName("test_table"), "c_real"))
+                .add(new SlotRef(new TableName("test_table"), "c_double"))
+
+                .add(new SlotRef(new TableName("test_table"), "c_short_decimal"))
+                .add(new SlotRef(new TableName("test_table"), "c_long_decimal"))
+
+                .add(new SlotRef(new TableName("test_table"), "c_char"))
+                .add(new SlotRef(new TableName("test_table"), "c_varchar"))
+                .add(new SlotRef(new TableName("test_table"), "c_varbinary"))
+
+                .add(new SlotRef(new TableName("test_table"), "c_date"))
+                .add(new SlotRef(new TableName("test_table"), "c_short_timestamp"))
+                // .add(new SlotRef(new TableName("test_table"), "c_short_timestamp_timezone"))
+                .add(new SlotRef(new TableName("test_table"), "c_long_timestamp"))
+                .add(new SlotRef(new TableName("test_table"), "c_long_timestamp_timezone"))
+                .build();
+    }
+
+    private List<LiteralExpr> mockLiteralExpr() throws AnalysisException {
+        return new ImmutableList.Builder()
+                // boolean
+                .add(new BoolLiteral(true))
+                // Integer
+                .add(new IntLiteral(1, Type.TINYINT))
+                .add(new IntLiteral(1, Type.SMALLINT))
+                .add(new IntLiteral(1, Type.INT))
+                .add(new IntLiteral(1, Type.BIGINT))
+
+                .add(new FloatLiteral(1.23, Type.FLOAT)) // Real type
+                .add(new FloatLiteral(3.1415926456, Type.DOUBLE))
+
+                .add(new DecimalLiteral(new BigDecimal("123456.23")))
+                .add(new DecimalLiteral(new BigDecimal("12345678901234567890123.123")))
+
+                .add(new StringLiteral("trino connector char test"))
+                .add(new StringLiteral("trino connector varchar test"))
+                .add(new StringLiteral("trino connector varbinary test"))
+
+                .add(new DateLiteral("1969-12-31", Type.DATEV2))
+                .add(new DateLiteral("1970-01-01 00:00:01.000001", Type.DATETIMEV2))
+                // .add(new DateLiteral("1970-01-01 00:00:00.000000", Type.DATETIMEV2))
+                .add(new DateLiteral("1970-01-01 00:00:01.000001", Type.DATETIMEV2))
+                .add(new DateLiteral("1970-01-01 08:00:01.000001", Type.DATETIMEV2))
+                .build();
+    }
+
+    private static class MockColumnHandle implements ColumnHandle {
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The Trino connector SPI provides interfaces for filter pushdown, which can be utilized to push predicates down to the connector layer.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

