### PR TITLE
[fix](load) acquire latest token instead of oldest token in TokenManager

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
@@ -53,16 +53,20 @@ public class TokenManager {
     public void start() {
         this.tokenQueue = EvictingQueue.create(Config.token_queue_size);
         // init one token to avoid async issue.
-        this.tokenQueue.offer(generateNewToken());
+        this.addNewToken(generateNewToken());
         this.tokenGenerator = Executors.newScheduledThreadPool(1,
                 new CustomThreadFactory("token-generator"));
-        this.tokenGenerator.scheduleAtFixedRate(() -> tokenQueue.offer(generateNewToken()), 0,
+        this.tokenGenerator.scheduleAtFixedRate(() -> this.addNewToken(generateNewToken()), 0,
                 Config.token_generate_period_hour, TimeUnit.HOURS);
     }
 
+    private void addNewToken(String token) {
+        tokenQueue.offer(token);
+        latestToken = token;
+    }
+
     private String generateNewToken() {
-        latestToken = UUID.randomUUID().toString();
-        return latestToken;
+        return UUID.randomUUID().toString();
     }
 
     public String acquireToken() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
@@ -44,6 +44,7 @@ public class TokenManager {
 
     private  int thriftTimeoutMs = 300 * 1000;
     private  EvictingQueue<String> tokenQueue;
+    private  String latestToken;
     private  ScheduledExecutorService tokenGenerator;
 
     public TokenManager() {
@@ -60,12 +61,13 @@ public class TokenManager {
     }
 
     private String generateNewToken() {
-        return UUID.randomUUID().toString();
+        latestToken = UUID.randomUUID().toString();
+        return latestToken;
     }
 
     public String acquireToken() throws UserException {
         if (Env.getCurrentEnv().isMaster() || FeConstants.runningUnitTest) {
-            return tokenQueue.peek();
+            return latestToken;
         } else {
             try {
                 return acquireTokenFromMaster();


### PR DESCRIPTION
## Proposed changes

Previously, `TokenManager` always returns the oldest token, which may expire soon.
This PR changes it to return the latest token instead.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

