### PR TITLE
[improvement](statistics)Write audit log while doing drop stats.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -59,6 +59,7 @@ import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable.DLAType;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
+import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
@@ -153,9 +154,11 @@ public class StatisticsUtil {
     }
 
     public static QueryState execUpdate(String sql) throws Exception {
-        try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+        StmtExecutor stmtExecutor = null;
+        AutoCloseConnectContext r = StatisticsUtil.buildConnectContext();
+        try {
             r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
-            StmtExecutor stmtExecutor = new StmtExecutor(r.connectContext, sql);
+            stmtExecutor = new StmtExecutor(r.connectContext, sql);
             r.connectContext.setExecutor(stmtExecutor);
             stmtExecutor.execute();
             QueryState state = r.connectContext.getState();
@@ -163,6 +166,12 @@ public class StatisticsUtil {
                 throw new Exception(state.getErrorMessage());
             }
             return state;
+        } finally {
+            r.close();
+            if (stmtExecutor != null) {
+                AuditLogHelper.logAuditLog(r.connectContext, stmtExecutor.getOriginStmt().originStmt,
+                        stmtExecutor.getParsedStmt(), stmtExecutor.getQueryStatisticsForAuditLog(), true);
+            }
         }
     }
 


### PR DESCRIPTION
Add delete sql to audit log while doing drop stats and truncate table.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

