### PR TITLE
[fix](agg) Fix nullptr access

### DIFF
--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -654,8 +654,11 @@ Status AggLocalState::close(RuntimeState* state) {
                                              // Do nothing
                                          },
                                          [&](auto& agg_method) {
-                                             COUNTER_SET(_hash_table_size_counter,
+                                             if (agg_method.hash_table) {
+                                                 COUNTER_SET(
+                                                         _hash_table_size_counter,
                                                          int64_t(agg_method.hash_table->size()));
+                                             }
                                          }},
                    _shared_state->agg_data->method_variant);
     }

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -48,7 +48,7 @@ struct MethodBaseInner {
     using Value = typename HashMap::value_type;
     using HashMapType = HashMap;
 
-    std::shared_ptr<HashMap> hash_table;
+    std::shared_ptr<HashMap> hash_table = nullptr;
     bool inited_iterator = false;
     Key* keys = nullptr;
     Arena arena;


### PR DESCRIPTION
## Proposed changes

*** Query id: 39d2f6f7794e4312-967cc108bc4c90d9 ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218048&logView=flowAware&focusLine=218048)  *** is nereids: 1 ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218049&logView=flowAware&focusLine=218049)  *** tablet id: 0 ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218050&logView=flowAware&focusLine=218050)  *** Aborted at 1714987567 (unix time) try "date -d @1714987567" if you are using GNU date ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218051&logView=flowAware&focusLine=218051)  *** Current BE git commitID: 5aa3da3 ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218052&logView=flowAware&focusLine=218052)  *** SIGSEGV address not mapped to object (@0x10) received by PID 290403 (TID 304778 OR 0x7fd77dc65700) from PID 16; stack trace: ***
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218053&logView=flowAware&focusLine=218053)   0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218054&logView=flowAware&focusLine=218054)   1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218055&logView=flowAware&focusLine=218055)   2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218056&logView=flowAware&focusLine=218056)   3# 0x00007FE192E40090 in /lib/x86_64-linux-gnu/libc.so.6
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218057&logView=flowAware&focusLine=218057)   4# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEON5doris10vectorized8OverloadIJZNS5_8pipeline13AggLocalState5closeEPNS5_12RuntimeStateEE3$_0ZNS9_5closeESB_E3$_1EEERSt7variantIJSt9monostateNS6_16MethodSerializedI9PHHashMapINS5_9StringRefEPc11DefaultHashISK_vELb0EEEENS6_15MethodOneNumberIhSJ_IhSL_SM_IhvELb0EEEENSQ_ItSJ_ItSL_SM_ItvELb0EEEENSQ_IjSJ_IjSL_9HashCRC32IjELb0EEEENSQ_ImSJ_ImSL_SX_ImELb0EEEENS6_19MethodStringNoCacheINS5_13StringHashMapISL_9AllocatorILb1ELb1ELb0EEEEEENSQ_INS6_7UInt128ESJ_IS1A_SL_SX_IS1A_ELb0EEEENSQ_IjSJ_IjSL_14HashMixWrapperIjSY_ELb0EEEENSQ_ImSJ_ImSL_S1E_ImS11_ELb0EEEENSQ_IS1A_SJ_IS1A_SL_S1E_IS1A_S1B_ELb0EEEENS6_26MethodSingleNullableColumnINSQ_IhNS6_15DataWithNullKeyISS_EEEEEENS1O_INSQ_ItNS1P_ISV_EEEEEENS1O_INSQ_IjNS1P_ISZ_EEEEEENS1O_INSQ_ImNS1P_IS12_EEEEEENS1O_INSQ_IjNS1P_IS1G_EEEEEENS1O_INSQ_ImNS1P_IS1J_EEEEEENS1O_INSQ_IS1A_NS1P_IS1C_EEEEEENS1O_INSQ_IS1A_NS1P_IS1M_EEEEEENS1O_INS14_INS1P_IS18_EEEEEENS6_15MethodKeysFixedIS12_Lb0EEENS2H_IS12_Lb1EEENS2H_IS1C_Lb0EEENS2H_IS1C_Lb1EEENS2H_ISJ_INS6_7UInt256ESL_SX_IS2M_ELb0EELb0EEENS2H_IS2O_Lb1EEENS2H_ISJ_INS6_7UInt136ESL_SX_IS2R_ELb0EELb0EEENS2H_IS2T_Lb1EEENS2H_IS1J_Lb0EEENS2H_IS1J_Lb1EEENS2H_IS1M_Lb0EEENS2H_IS1M_Lb1EEENS2H_ISJ_IS2M_SL_S1E_IS2M_S2N_ELb0EELb0EEENS2H_IS31_Lb1EEENS2H_ISJ_IS2R_SL_S1E_IS2R_S2S_ELb0EELb0EEENS2H_IS35_Lb1EEEEEEJEEESt16integer_sequenceImJLm1EEEE14__visit_invokeESF_S39_ at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218058&logView=flowAware&focusLine=218058)   5# doris::pipeline::AggLocalState::close(doris::RuntimeState*) at /root/doris/be/src/pipeline/exec/aggregation_source_operator.cpp:653
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218059&logView=flowAware&focusLine=218059)   6# doris::pipeline::OperatorXBase::close(doris::RuntimeState*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218060&logView=flowAware&focusLine=218060)   7# doris::pipeline::PipelineTask::close(doris::Status) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218061&logView=flowAware&focusLine=218061)   8# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /root/doris/be/src/pipeline/task_scheduler.cpp:91
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218062&logView=flowAware&focusLine=218062)   9# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:141
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218063&logView=flowAware&focusLine=218063)  10# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:551
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218064&logView=flowAware&focusLine=218064)  11# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218065&logView=flowAware&focusLine=218065)  12# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
[17:33:49 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/417594?buildTab=log&linesState=218066&logView=flowAware&focusLine=218066)  13# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

