### PR TITLE
[fix](load) fix repeatedly open tablets_channel when tablets_channel already cancelled

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -129,8 +129,9 @@ void TabletsChannel::_init_profile(RuntimeProfile* profile) {
 
 Status BaseTabletsChannel::open(const PTabletWriterOpenRequest& request) {
     std::lock_guard<std::mutex> l(_lock);
-    if (_state == kOpened) {
-        // Normal case, already open by other sender
+    // if _state is kOpened, it's a normal case, already open by other sender
+    // if _state is kFinished, already cancelled by other sender
+    if (_state == kOpened || _state == kFinished) {
         return Status::OK();
     }
     LOG(INFO) << "open tablets channel: " << _key << ", tablets num: " << request.tablets().size()


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
```
F20240506 01:01:14.788642 4129046 tablets_channel.cpp:479] Check failed: _tablet_writers.size() == tablet_cnt (64 vs. 0)
*** Check failure stack trace: ***
    @     0x5648cdf21916  google::LogMessage::SendToLog()
    @     0x5648cdf1e360  google::LogMessage::Flush()
    @     0x5648cdf22159  google::LogMessageFatal::~LogMessageFatal()
    @     0x56489db05232  doris::BaseTabletsChannel::_open_all_writers()
    @     0x56489db03af4  doris::BaseTabletsChannel::open()
    @     0x56489d730007  doris::LoadChannel::open()
    @     0x56489d7169f3  doris::LoadChannelMgr::open()
    @     0x56489dd57c07  doris::PInternalService::tablet_writer_open()::$_0::operator()()
    @     0x56489dd57477  std::__invoke_impl<>()
    @     0x56489dd573e9 
```
The execution time of multiple instances is different. The tablets_channel has already been cancelled, and the open operation of a certain instance has only come.   The open operation was repeated, causing the DCheck to fail.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

