### PR TITLE
[test](case) add original planner case 

### DIFF
--- a/regression-test/suites/correctness_p0/test_xor_pred.groovy
+++ b/regression-test/suites/correctness_p0/test_xor_pred.groovy
@@ -40,10 +40,20 @@ suite("test_xor_pred") {
         select k1,k2 , k1 xor k2, not (k1 xor k2) from dbxor order by k1,k2;
     """
 
+    // xor only support bool  
     test {
+        sql """set enable_nereids_planner=true;"""
         sql """
             select 1 xor 0;
         """
-        exception("Can not find the compatibility function signature: xor(TINYINT, TINYINT)")
+        exception("errCode")
+    }
+
+    test {
+        sql """set enable_nereids_planner=false;"""
+        sql """
+            select 1 xor 0;
+        """
+        exception("errCode")
     }
 }


### PR DESCRIPTION
## Proposed changes


The original intention behind this case is to indicate that XOR only accepts boolean parameters, but it might fall back to the old planner, which produces different error messages from the nereids planner.
```
Exception:
java.lang.IllegalStateException: TestAction failed, sql:
select 1 xor 0;
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

