### PR TITLE
[fix](tablet schedule) disable schedule need clear running tasks

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1872,7 +1872,7 @@ public class TabletScheduler extends MasterDaemon {
                     tabletCtx.setErrMsg("tablet scheduler is disabled");
                     cancelTablets.add(tabletCtx);
                 } else if (Config.disable_balance && tabletCtx.getType() == Type.BALANCE) {
-                    tabletCtxs.setErrMsg("balance is disabled");
+                    tabletCtx.setErrMsg("balance is disabled");
                     cancelTablets.add(tabletCtx);
                 } else if (tabletCtx.isTimeout()) {
                     tabletCtx.setErrMsg("timeout");

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1569,7 +1569,7 @@ public class TabletScheduler extends MasterDaemon {
         releaseTabletCtx(tabletCtx, state, status == Status.UNRECOVERABLE);
 
         // if check immediately, then no need to wait TabletChecker's 20s
-        if (state == TabletSchedCtx.State.FINISHED) {
+        if (state == TabletSchedCtx.State.FINISHED && !Config.disable_tablet_scheduler) {
             tryAddAfterFinished(tabletCtx);
         }
     }
@@ -1865,19 +1865,29 @@ public class TabletScheduler extends MasterDaemon {
      */
     public void handleRunningTablets() {
         // 1. remove the tablet ctx if timeout
-        List<TabletSchedCtx> timeoutTablets = Lists.newArrayList();
+        List<TabletSchedCtx> cancelTablets = Lists.newArrayList();
         synchronized (this) {
-            runningTablets.values().stream().filter(TabletSchedCtx::isTimeout).forEach(timeoutTablets::add);
+            for (TabletSchedCtx tabletCtx : runningTablets.values()) {
+                if (Config.disable_tablet_scheduler) {
+                    tabletCtx.setErrMsg("tablet scheduler is disabled");
+                    cancelTablets.add(tabletCtx);
+                } else if (Config.disable_balance && tabletCtx.getType() == Type.BALANCE) {
+                    tabletCtxs.setErrMsg("balance is disabled");
+                    cancelTablets.add(tabletCtx);
+                } else if (tabletCtx.isTimeout()) {
+                    tabletCtx.setErrMsg("timeout");
+                    cancelTablets.add(tabletCtx);
+                    stat.counterCloneTaskTimeout.incrementAndGet();
+                }
+            }
         }
 
         // 2. release ctx
-        timeoutTablets.forEach(t -> {
+        cancelTablets.forEach(t -> {
             // Set "resetReplicaState" to true because
-            // the timeout task should also be considered as UNRECOVERABLE,
+            // task should also be considered as UNRECOVERABLE,
             // so need to reset replica state.
-            t.setErrMsg("timeout");
-            finalizeTabletCtx(t, TabletSchedCtx.State.CANCELLED, Status.UNRECOVERABLE, "timeout");
-            stat.counterCloneTaskTimeout.incrementAndGet();
+            finalizeTabletCtx(t, TabletSchedCtx.State.CANCELLED, Status.UNRECOVERABLE, t.getErrMsg());
         });
     }
 


### PR DESCRIPTION
BUG:  when disable tablet schedule, the running task still remain until timeout.  Need set them fail when disable schedule.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

