### PR TITLE
[fix](core) fix error sort in profile

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -348,7 +348,7 @@ Status PipelineFragmentContext::_build_pipeline_tasks(
     _total_tasks = 0;
     int target_size = request.local_params.size();
     _tasks.resize(target_size);
-    auto& pipeline_id_to_profile = _runtime_state->build_pipeline_profile(_pipelines.size());
+    auto pipeline_id_to_profile = _runtime_state->build_pipeline_profile(_pipelines.size());
 
     for (size_t i = 0; i < target_size; i++) {
         const auto& local_params = request.local_params[i];
@@ -1510,7 +1510,7 @@ void PipelineFragmentContext::_close_fragment_instance() {
         // After add the operation, the print out like that:
         // UNION_NODE (id=0):(Active: 56.720us, non-child: 82.53%)
         // We can easily know the exec node execute time without child time consumed.
-        for (const auto& runtime_profile_ptr : _runtime_state->pipeline_id_to_profile()) {
+        for (auto runtime_profile_ptr : _runtime_state->pipeline_id_to_profile()) {
             runtime_profile_ptr->pretty_print(&ss);
         }
 
@@ -1620,7 +1620,7 @@ PipelineFragmentContext::collect_realtime_profile_x() const {
     }
 
     // pipeline_id_to_profile is initialized in prepare stage
-    for (auto& pipeline_profile : _runtime_state->pipeline_id_to_profile()) {
+    for (auto pipeline_profile : _runtime_state->pipeline_id_to_profile()) {
         auto profile_ptr = std::make_shared<TRuntimeProfileTree>();
         pipeline_profile->to_thrift(profile_ptr.get());
         res.push_back(profile_ptr);

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -266,7 +266,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
             }
 
             if (enable_profile) {
-                for (auto& pipeline_profile : req.runtime_state->pipeline_id_to_profile()) {
+                for (auto pipeline_profile : req.runtime_state->pipeline_id_to_profile()) {
                     TDetailedReportParams detailed_param;
                     detailed_param.__isset.fragment_instance_id = false;
                     detailed_param.__isset.profile = true;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -557,26 +557,10 @@ bool RuntimeState::is_nereids() const {
 
 std::vector<std::shared_ptr<RuntimeProfile>> RuntimeState::pipeline_id_to_profile() {
     std::shared_lock lc(_pipeline_profile_lock);
-    std::vector<std::shared_ptr<RuntimeProfile>> pipelines_profile;
-    pipelines_profile.reserve(_pipeline_id_to_profile.size());
-    // The sort here won't change the structure of _pipeline_id_to_profile;
-    // it sorts the children of each element in sort_pipeline_id_to_profile,
-    // and these children are locked.
-    for (auto& pipeline_profile : _pipeline_id_to_profile) {
-        DCHECK(pipeline_profile);
-        // pipeline 0
-        //  pipeline task 0
-        //  pipeline task 1
-        //  pipleine task 2
-        //  .......
-        // sort by pipeline task total time
-        pipeline_profile->sort_children_by_total_time();
-        pipelines_profile.push_back(pipeline_profile);
-    }
-    return pipelines_profile;
+    return _pipeline_id_to_profile;
 }
 
-std::vector<std::shared_ptr<RuntimeProfile>>& RuntimeState::build_pipeline_profile(
+std::vector<std::shared_ptr<RuntimeProfile>> RuntimeState::build_pipeline_profile(
         std::size_t pipeline_size) {
     std::unique_lock lc(_pipeline_profile_lock);
     if (!_pipeline_id_to_profile.empty()) {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -581,7 +581,7 @@ public:
 
     std::vector<std::shared_ptr<RuntimeProfile>> pipeline_id_to_profile();
 
-    std::vector<std::shared_ptr<RuntimeProfile>>& build_pipeline_profile(std::size_t pipeline_size);
+    std::vector<std::shared_ptr<RuntimeProfile>> build_pipeline_profile(std::size_t pipeline_size);
 
     void set_task_execution_context(std::shared_ptr<TaskExecutionContext> context) {
         _task_execution_context_inited = true;

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -717,15 +717,4 @@ void RuntimeProfile::print_child_counters(const std::string& prefix,
     }
 }
 
-void RuntimeProfile::sort_children_by_total_time() {
-    std::lock_guard<std::mutex> l(_children_lock);
-    auto cmp = [](const std::pair<RuntimeProfile*, bool>& L,
-                  const std::pair<RuntimeProfile*, bool>& R) {
-        const RuntimeProfile* L_profile = L.first;
-        const RuntimeProfile* R_profile = R.first;
-        return L_profile->_counter_total_time.value() > R_profile->_counter_total_time.value();
-    };
-    std::sort(_children.begin(), _children.end(), cmp);
-}
-
 } // namespace doris

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -293,16 +293,6 @@ public:
     /// otherwise appended after other child profiles.
     RuntimeProfile* create_child(const std::string& name, bool indent = true, bool prepend = false);
 
-    // Sorts all children according to a custom comparator. Does not
-    // invalidate pointers to profiles.
-    template <class Compare>
-    void sort_childer(const Compare& cmp) {
-        std::lock_guard<std::mutex> l(_children_lock);
-        std::sort(_children.begin(), _children.end(), cmp);
-    }
-
-    void sort_children_by_total_time();
-
     // Merges the src profile into this one, combining counters that have an identical
     // path. Info strings from profiles are not merged. 'src' would be a const if it
     // weren't for locking.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -352,6 +352,7 @@ public class ExecutionProfile {
                     profile.setIsDone(true);
                 }
                 pipelineIdx++;
+                profile.sortChildren();
                 fragmentProfiles.get(params.fragment_id).addChild(profile);
             }
             // TODO ygl: is this right? there maybe multi Backends, what does


### PR DESCRIPTION
## Proposed changes
core
```
=================================================================
==2534984==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60c0034665f0 at pc 0x556b396b3c53 bp 0x7fb93a383920 sp 0x7fb93a383918
READ of size 8 at 0x60c0034665f0 thread T373 (FragmentInstanc)
    #0 0x556b396b3c52 in doris::RuntimeProfile::sort_children_by_total_time()::$_0::operator()(std::pair<doris::RuntimeProfile*, bool> const&, std::pair<doris::RuntimeProfile*, bool> const&) const /mnt/disk2/yanxuecheng/doris/be/src/util/runtime_profile.cpp:725:45
    #1 0x556b396b5c1f in bool __gnu_cxx::__ops::_Val_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>::operator()<std::pair<doris::RuntimeProfile*, bool>, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>>(std::pair<doris::RuntimeProfile*, bool>&, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/predefined_ops.h:240:16
    #2 0x556b396b58e8 in void std::__unguarded_linear_insert<__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Val_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>>(__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Val_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:1806:14
    #3 0x556b396b53d2 in void std::__insertion_sort<__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>>(__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:1834:6
    #4 0x556b396b0df0 in void std::__final_insertion_sort<__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>>(__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:1871:2
    #5 0x556b396b021d in void std::__sort<__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>>(__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__ops::_Iter_comp_iter<doris::RuntimeProfile::sort_children_by_total_time()::$_0>) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:1957:4
    #6 0x556b396afdc0 in void std::sort<__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, doris::RuntimeProfile::sort_children_by_total_time()::$_0>(__gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, __gnu_cxx::__normal_iterator<std::pair<doris::RuntimeProfile*, bool>*, std::vector<std::pair<doris::RuntimeProfile*, bool>, std::allocator<std::pair<doris::RuntimeProfile*, bool>>>>, doris::RuntimeProfile::sort_children_by_total_time()::$_0) /mnt/disk2/yanxuecheng/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:4875:7
    #7 0x556b396afa86 in doris::RuntimeProfile::sort_children_by_total_time() /mnt/disk2/yanxuecheng/doris/be/src/util/runtime_profile.cpp:728:5
    #8 0x556b38f4dad7 in doris::RuntimeState::pipeline_id_to_profile() /mnt/disk2/yanxuecheng/doris/be/src/runtime/runtime_state.cpp:573:27
    #9 0x556b38a68ad3 in doris::FragmentMgr::coordinator_callback(doris::ReportStatusRequest const&) /mnt/disk2/yanxuecheng/doris/be/src/runtime/fragment_mgr.cpp:269:66
    #10 0x556b38a9072c in doris::FragmentMgr::trigger_pipeline_context_report(doris::ReportStatusRequest, std::shared_ptr<doris::pipeline::PipelineFragmentContext>&&)::$_0::operator()() const /mnt/disk2/yanxuecheng/doris/be/src/runtime/fragment_mgr.cpp:201:9
 
```

error code 

```
void RuntimeProfile::sort_children_by_total_time() {
    std::lock_guard<std::mutex> l(_children_lock);
    auto cmp = [](const std::pair<RuntimeProfile*, bool>& L,
                  const std::pair<RuntimeProfile*, bool>& R) {
        const RuntimeProfile* L_profile = L.first;
        const RuntimeProfile* R_profile = R.first;
        return L_profile->_counter_total_time.value() > R_profile->_counter_total_time.value();
    };
    std::sort(_children.begin(), _children.end(), cmp);
}

```

reason like this https://stackoverflow.com/questions/52745026/heap-overflow-inside-custom-sort-function

"_counter_total_time" will change during sorting.


```
   Pipeline  :0    (host=TNetworkAddress(hostname:127.0.0.1,  port:9229)):
                PipelineTask  (index=7):(Active:  6s754ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  6s462ms
                PipelineTask  (index=0):(Active:  6s257ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s982ms
                PipelineTask  (index=5):(Active:  6s223ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s950ms
                PipelineTask  (index=2):(Active:  6s171ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s904ms
                PipelineTask  (index=6):(Active:  6s40ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s756ms
                PipelineTask  (index=3):(Active:  5s979ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s707ms
                PipelineTask  (index=1):(Active:  5s737ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  5s452ms
                PipelineTask  (index=4):(Active:  4s815ms,  %  non-child:  0.00%)
                      -  CoreChangeTimes:  0
                      -  ExecuteTime:  4s555ms

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

