### PR TITLE
[fix](hive) fix query external table make BE crash

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -339,7 +339,6 @@ public class ExternalFileScanNode extends ExternalScanNode {
             ParamCreateContext context = contexts.get(i);
             FileScanProviderIf scanProvider = scanProviders.get(i);
             setDefaultValueExprs(scanProvider, context);
-            setColumnPositionMappingForTextFile(scanProvider, context);
             finalizeParamsForLoad(context, analyzer);
             createScanRangeLocations(context, scanProvider);
             this.inputSplitsNum += scanProvider.getInputSplitNum();
@@ -358,6 +357,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
             if (scanProvider instanceof IcebergScanProvider) {
                 ((IcebergScanProvider) scanProvider).updateRequiredSlots(context);
             }
+            setColumnPositionMappingForTextFile(scanProvider, context);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

this sql make be crash:

`SELECT pk FROM (select round(col_num,2) as num,pk from hive.example_db.test) as tbl_1;`

because of TFileScanRangeParams.column_idxs is empty.

BE crash stack:
```
*** Query id: 91e7ebd6e5c44393-89c180fe4f0866db ***
*** Aborted at 1714407913 (unix time) try "date -d @1714407913" if you are using GNU date ***
*** Current BE git commitID: a7d2ef9 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 111768 (TID 0x7f8669d64700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) in /usr/local/service/doris/lib/be/doris_be
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 4# 0x00007F87833D9400 in /lib64/libc.so.6
 5# doris::vectorized::CsvReader::_fill_dest_columns(doris::Slice const&, doris::vectorized::Block*, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, unsigned long*) in /usr/local/service/doris/lib/be/doris_be
 6# doris::vectorized::CsvReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) in /usr/local/service/doris/lib/be/doris_be
 7# doris::vectorized::VFileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
 8# doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
 9# doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, doris::vectorized::VScanner*) in /usr/local/service/doris/lib/be/doris_be
10# doris::ThreadPool::dispatch_thread() in /usr/local/service/doris/lib/be/doris_be
11# doris::Thread::supervise_thread(void*) in /usr/local/service/doris/lib/be/doris_be
12# start_thread in /lib64/libpthread.so.0
13# __clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

