### PR TITLE
[improvement](statistics)Remove collect external table row count task.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -147,11 +147,6 @@ public class AnalysisInfo implements Writable {
     @SerializedName("message")
     public String message;
 
-    // True means this task is a table level task for external table.
-    // This kind of task is mainly to collect the number of rows of a table.
-    @SerializedName("externalTableLevelTask")
-    public final boolean externalTableLevelTask;
-
     @SerializedName("partitionOnly")
     public final boolean partitionOnly;
 
@@ -211,7 +206,7 @@ public class AnalysisInfo implements Writable {
             JobType jobType, AnalysisMode analysisMode, AnalysisMethod analysisMethod, AnalysisType analysisType,
             int samplePercent, long sampleRows, int maxBucketNum, long periodTimeInMs, String message,
             long lastExecTimeInMs, long timeCostInMs, AnalysisState state, ScheduleType scheduleType,
-            boolean isExternalTableLevelTask, boolean partitionOnly, boolean samplingPartition,
+            boolean partitionOnly, boolean samplingPartition,
             boolean isAllPartition, long partitionCount, CronExpression cronExpression, boolean forceFull,
             boolean usingSqlForPartitionColumn, long tblUpdateTime, long rowCount, boolean userInject,
             long updateRows, JobPriority priority) {
@@ -238,7 +233,6 @@ public class AnalysisInfo implements Writable {
         this.timeCostInMs = timeCostInMs;
         this.state = state;
         this.scheduleType = scheduleType;
-        this.externalTableLevelTask = isExternalTableLevelTask;
         this.partitionOnly = partitionOnly;
         this.samplingPartition = samplingPartition;
         this.isAllPartition = isAllPartition;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -53,7 +53,6 @@ public class AnalysisInfoBuilder {
     private AnalysisState state;
     private ScheduleType scheduleType;
     private String message = "";
-    private boolean externalTableLevelTask;
     private boolean partitionOnly;
     private boolean samplingPartition;
     private boolean isAllPartition;
@@ -94,7 +93,6 @@ public class AnalysisInfoBuilder {
         timeCostInMs = info.timeCostInMs;
         state = info.state;
         scheduleType = info.scheduleType;
-        externalTableLevelTask = info.externalTableLevelTask;
         partitionOnly = info.partitionOnly;
         samplingPartition = info.samplingPartition;
         isAllPartition = info.isAllPartition;
@@ -224,11 +222,6 @@ public class AnalysisInfoBuilder {
         return this;
     }
 
-    public AnalysisInfoBuilder setExternalTableLevelTask(boolean isTableLevel) {
-        this.externalTableLevelTask = isTableLevel;
-        return this;
-    }
-
     public AnalysisInfoBuilder setPartitionOnly(boolean isPartitionOnly) {
         this.partitionOnly = isPartitionOnly;
         return this;
@@ -293,7 +286,7 @@ public class AnalysisInfoBuilder {
         return new AnalysisInfo(jobId, taskId, taskIds, catalogId, dbId, tblId, jobColumns, partitionNames,
                 colName, indexId, jobType, analysisMode, analysisMethod, analysisType, samplePercent,
                 sampleRows, maxBucketNum, periodTimeInMs, message, lastExecTimeInMs, timeCostInMs, state, scheduleType,
-                externalTableLevelTask, partitionOnly, samplingPartition, isAllPartition, partitionCount,
+                partitionOnly, samplingPartition, isAllPartition, partitionCount,
                 cronExpression, forceFull, usingSqlForPartitionColumn, tblUpdateTime, rowCount, userInject, updateRows,
                 priority);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
@@ -75,12 +75,6 @@ public class AnalysisJob {
         markOneTaskDone();
     }
 
-    public synchronized void rowCountDone(BaseAnalysisTask task) {
-        queryingTask.remove(task);
-        queryFinished.add(task);
-        markOneTaskDone();
-    }
-
     protected void markOneTaskDone() {
         if (queryingTask.isEmpty()) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -46,7 +46,6 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogIf;
-import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -251,10 +250,6 @@ public class AnalysisManager implements Writable {
         boolean isSync = stmt.isSync();
         Map<Long, BaseAnalysisTask> analysisTaskInfos = new HashMap<>();
         createTaskForEachColumns(jobInfo, analysisTaskInfos, isSync);
-        if (!jobInfo.partitionOnly && stmt.isAllColumns()
-                && StatisticsUtil.isExternalTable(jobInfo.catalogId, jobInfo.dbId, jobInfo.tblId)) {
-            createTableLevelTaskForExternalTable(jobInfo, analysisTaskInfos, isSync);
-        }
         constructJob(jobInfo, analysisTaskInfos.values());
         if (isSync) {
             syncExecute(analysisTaskInfos.values());
@@ -372,7 +367,11 @@ public class AnalysisManager implements Writable {
         infoBuilder.setColName(stringJoiner.toString());
         infoBuilder.setTaskIds(Lists.newArrayList());
         infoBuilder.setTblUpdateTime(table.getUpdateTime());
-        infoBuilder.setRowCount(StatisticsUtil.isEmptyTable(table, analysisMethod) ? 0 : table.getRowCount());
+        // Empty table row count is 0. Call fetchRowCount() when getRowCount() returns <= 0,
+        // because getRowCount may return <= 0 if cached is not loaded. This is mainly for external table.
+        long rowCount = StatisticsUtil.isEmptyTable(table, analysisMethod) ? 0 :
+                (table.getRowCount() <= 0 ? table.fetchRowCount() : table.getRowCount());
+        infoBuilder.setRowCount(rowCount);
         TableStatsMeta tableStatsStatus = findTableStatsStatus(table.getId());
         infoBuilder.setUpdateRows(tableStatsStatus == null ? 0 : tableStatsStatus.updatedRows.get());
         infoBuilder.setPriority(JobPriority.MANUAL);
@@ -426,27 +425,6 @@ public class AnalysisManager implements Writable {
     public void logCreateAnalysisJob(AnalysisInfo analysisJob) {
         replayCreateAnalysisJob(analysisJob);
         Env.getCurrentEnv().getEditLog().logCreateAnalysisJob(analysisJob);
-    }
-
-    @VisibleForTesting
-    public void createTableLevelTaskForExternalTable(AnalysisInfo jobInfo,
-            Map<Long, BaseAnalysisTask> analysisTasks,
-            boolean isSync) throws DdlException {
-
-        if (jobInfo.analysisType == AnalysisType.HISTOGRAM) {
-            return;
-        }
-        AnalysisInfoBuilder colTaskInfoBuilder = new AnalysisInfoBuilder(jobInfo);
-        long taskId = Env.getCurrentEnv().getNextId();
-        AnalysisInfo analysisInfo = colTaskInfoBuilder.setIndexId(-1L).setLastExecTimeInMs(System.currentTimeMillis())
-                .setTaskId(taskId).setColName("TableRowCount").setExternalTableLevelTask(true).build();
-        analysisTasks.put(taskId, createTask(analysisInfo));
-        jobInfo.addTaskId(taskId);
-        if (isSync) {
-            // For sync job, don't need to persist, return here and execute it immediately.
-            return;
-        }
-        replayCreateAnalysisTask(analysisInfo);
     }
 
     public void updateTaskStatus(AnalysisInfo info, AnalysisState taskState, String message, long time) {
@@ -517,11 +495,6 @@ public class AnalysisManager implements Writable {
     @VisibleForTesting
     public void updateTableStats(AnalysisInfo jobInfo) {
         TableIf tbl = StatisticsUtil.findTable(jobInfo.catalogId, jobInfo.dbId, jobInfo.tblId);
-        // External Table only update table stats when all tasks finished.
-        // Because it needs to get the row count from the result of row count task.
-        if (tbl instanceof ExternalTable && !jobInfo.state.equals(AnalysisState.FINISHED)) {
-            return;
-        }
         TableStatsMeta tableStats = findTableStatsStatus(tbl.getId());
         if (tableStats == null) {
             updateTableStatsStatus(new TableStatsMeta(jobInfo.rowCount, jobInfo, tbl));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -178,10 +178,6 @@ public abstract class BaseAnalysisTask {
         db = dbObjects.db;
         tbl = dbObjects.table;
         tableSample = getTableSample();
-        // External Table level task doesn't contain a column. Don't need to do the column related analyze.
-        if (info.externalTableLevelTask) {
-            return;
-        }
         if (info.analysisType != null && (info.analysisType.equals(AnalysisType.FUNDAMENTALS)
                 || info.analysisType.equals(AnalysisType.HISTOGRAM))) {
             col = tbl.getColumn(info.colName);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
@@ -18,7 +18,6 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.ExternalTable;
@@ -37,10 +36,6 @@ import java.util.Set;
 
 public class ExternalAnalysisTask extends BaseAnalysisTask {
     private static final Logger LOG = LogManager.getLogger(ExternalAnalysisTask.class);
-
-    private static final String ANALYZE_TABLE_COUNT_TEMPLATE = "SELECT ROUND(COUNT(1) * ${scaleFactor}) as rowCount "
-            + "FROM `${catalogName}`.`${dbName}`.`${tblName}` ${sampleHints}";
-    private boolean isTableLevelTask;
     private boolean isPartitionOnly;
     private ExternalTable table;
 
@@ -50,7 +45,6 @@ public class ExternalAnalysisTask extends BaseAnalysisTask {
 
     public ExternalAnalysisTask(AnalysisInfo info) {
         super(info);
-        isTableLevelTask = info.externalTableLevelTask;
         isPartitionOnly = info.partitionOnly;
         table = (ExternalTable) tbl;
     }
@@ -59,33 +53,12 @@ public class ExternalAnalysisTask extends BaseAnalysisTask {
         if (killed) {
             return;
         }
-        if (isTableLevelTask) {
-            getTableStats();
-        } else {
-            getColumnStats();
-        }
+        getColumnStats();
     }
 
     // For test
     protected void setTable(ExternalTable table) {
         this.table = table;
-    }
-
-    /**
-     * Get table row count
-     */
-    private void getTableStats() {
-        Map<String, String> params = buildStatsParams(null);
-        Pair<Double, Long> sampleInfo = getSampleInfo();
-        params.put("scaleFactor", String.valueOf(sampleInfo.first));
-        List<ResultRow> columnResult =
-                StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
-                        .replace(ANALYZE_TABLE_COUNT_TEMPLATE));
-        String rowCount = columnResult.get(0).get(0);
-        Env.getCurrentEnv().getAnalysisManager()
-                .updateTableStatsStatus(
-                        new TableStatsMeta(Long.parseLong(rowCount), info, tbl));
-        job.rowCountDone(this);
     }
 
     // Get column stats

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -145,9 +145,7 @@ public class TableStatsMeta implements Writable {
         }
         jobType = analyzedJob.jobType;
         if (tableIf != null) {
-            if (tableIf instanceof OlapTable) {
-                rowCount = analyzedJob.rowCount;
-            }
+            rowCount = analyzedJob.rowCount;
             if (rowCount == 0 && AnalysisMethod.SAMPLE.equals(analyzedJob.analysisMethod)) {
                 return;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/JdbcAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/JdbcAnalysisTaskTest.java
@@ -20,13 +20,11 @@ package org.apache.doris.statistics;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.jdbc.JdbcExternalTable;
 import org.apache.doris.statistics.util.DBObjects;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
-import com.google.common.collect.ImmutableList;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -34,72 +32,7 @@ import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 public class JdbcAnalysisTaskTest {
-    @Test
-    public void testTableStats(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked JdbcExternalTable tableIf,
-            @Mocked AnalysisJob job)
-            throws Exception {
-        new Expectations() {
-            {
-                tableIf.getId();
-                result = 30001;
-                tableIf.getName();
-                result = "test";
-                catalogIf.getId();
-                result = 10001;
-                catalogIf.getName();
-                result = "jdbc";
-                databaseIf.getId();
-                result = 20001;
-                databaseIf.getFullName();
-                result = "mysql";
-            }
-        };
-
-        new MockUp<StatisticsUtil>() {
-            @Mock
-            public List<ResultRow> execStatisticQuery(String sql) {
-                Assertions.assertEquals("SELECT COUNT(1) as rowCount FROM `jdbc`.`mysql`.`test`", sql);
-                return ImmutableList.of(new ResultRow(ImmutableList.of("100")));
-            }
-
-            @Mock
-            public DBObjects convertIdToObjects(long catalogId, long dbId, long tblId) {
-                return new DBObjects(catalogIf, databaseIf, tableIf);
-            }
-        };
-
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void updateTableStatsStatus(TableStatsMeta tableStats) {
-                Assertions.assertEquals(100, tableStats.rowCount);
-            }
-        };
-
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public void update(AnalysisInfo analyzedJob, TableIf tableIf) {
-                //do nothing
-            }
-        };
-
-        AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
-        analysisInfoBuilder.setColName("col1");
-        analysisInfoBuilder.setJobType(AnalysisInfo.JobType.MANUAL);
-        analysisInfoBuilder.setExternalTableLevelTask(true);
-
-        JdbcAnalysisTask task = new JdbcAnalysisTask(analysisInfoBuilder.build());
-        task.col = new Column("col1", PrimitiveType.INT);
-        task.tbl = tableIf;
-        task.catalog = catalogIf;
-        task.db = databaseIf;
-        task.setJob(job);
-
-        task.doExecute();
-    }
-
     @Test
     public void testGetColumnStats(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked JdbcExternalTable tableIf)
             throws Exception {
@@ -144,7 +77,6 @@ public class JdbcAnalysisTaskTest {
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
         analysisInfoBuilder.setColName("col1");
         analysisInfoBuilder.setJobType(AnalysisInfo.JobType.MANUAL);
-        analysisInfoBuilder.setExternalTableLevelTask(false);
 
         JdbcAnalysisTask task = new JdbcAnalysisTask(analysisInfoBuilder.build());
         task.col = new Column("col1", PrimitiveType.INT);


### PR DESCRIPTION
Before, we would create an analyze task for external table to collect the row count of the table. But this is resource consuming and unnecessary. Because the planner doesn't use table row count, it fetch the row count from column row count. This pr is to remove this row count task for external table. 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

