### PR TITLE
[Refactor](executor) rename workload schedule policy to workload policy

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -62,7 +62,7 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
     std::unique_ptr<TopicListener> policy_listener =
             std::make_unique<WorkloadschedPolicyListener>(exec_env);
     LOG(INFO) << "Register workload scheduler policy listener";
-    _topic_subscriber->register_listener(doris::TTopicInfoType::type::WORKLOAD_SCHED_POLICY,
+    _topic_subscriber->register_listener(doris::TTopicInfoType::type::WORKLOAD_POLICY,
                                          std::move(policy_listener));
 
 #endif

--- a/be/src/agent/workload_sched_policy_listener.cpp
+++ b/be/src/agent/workload_sched_policy_listener.cpp
@@ -27,11 +27,11 @@ namespace doris {
 void WorkloadschedPolicyListener::handle_topic_info(const std::vector<TopicInfo>& topic_info_list) {
     std::map<uint64_t, std::shared_ptr<WorkloadSchedPolicy>> policy_map;
     for (const TopicInfo& topic_info : topic_info_list) {
-        if (!topic_info.__isset.workload_sched_policy) {
+        if (!topic_info.__isset.workload_policy) {
             continue;
         }
 
-        TWorkloadSchedPolicy tpolicy = topic_info.workload_sched_policy;
+        TWorkloadPolicy tpolicy = topic_info.workload_policy;
         // some metric or action can not exec in be, then need skip
         bool need_skip_current_policy = false;
 

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return SchemaRoutinesScanner::create_unique();
     case TSchemaTableType::SCH_USER:
         return SchemaUserScanner::create_unique();
-    case TSchemaTableType::SCH_WORKLOAD_SCHEDULE_POLICY:
+    case TSchemaTableType::SCH_WORKLOAD_POLICY:
         return SchemaWorkloadSchedulePolicyScanner::create_unique();
     default:
         return SchemaDummyScanner::create_unique();

--- a/be/src/exec/schema_scanner/schema_workload_sched_policy_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_workload_sched_policy_scanner.cpp
@@ -38,7 +38,7 @@ std::vector<SchemaScanner::ColumnDesc> SchemaWorkloadSchedulePolicyScanner::_s_t
 };
 
 SchemaWorkloadSchedulePolicyScanner::SchemaWorkloadSchedulePolicyScanner()
-        : SchemaScanner(_s_tbls_columns, TSchemaTableType::SCH_WORKLOAD_SCHEDULE_POLICY) {}
+        : SchemaScanner(_s_tbls_columns, TSchemaTableType::SCH_WORKLOAD_POLICY) {}
 
 SchemaWorkloadSchedulePolicyScanner::~SchemaWorkloadSchedulePolicyScanner() {}
 
@@ -59,7 +59,7 @@ Status SchemaWorkloadSchedulePolicyScanner::_get_workload_schedule_policy_block_
     schema_table_request_params.__set_current_user_ident(*_param->common_param->current_user_ident);
 
     TFetchSchemaTableDataRequest request;
-    request.__set_schema_table_name(TSchemaTableName::WORKLOAD_SCHEDULE_POLICY);
+    request.__set_schema_table_name(TSchemaTableName::WORKLOAD_POLICY);
     request.__set_schema_table_params(schema_table_request_params);
 
     TFetchSchemaTableDataResult result;

--- a/be/src/vec/exec/scan/vmeta_scanner.cpp
+++ b/be/src/vec/exec/scan/vmeta_scanner.cpp
@@ -234,7 +234,7 @@ Status VMetaScanner::_fetch_metadata(const TMetaScanRange& meta_scan_range) {
     case TMetadataType::FRONTENDS_DISKS:
         RETURN_IF_ERROR(_build_frontends_disks_metadata_request(meta_scan_range, &request));
         break;
-    case TMetadataType::WORKLOAD_SCHED_POLICY:
+    case TMetadataType::WORKLOAD_POLICY:
         RETURN_IF_ERROR(_build_workload_sched_policy_metadata_request(meta_scan_range, &request));
         break;
     case TMetadataType::CATALOGS:
@@ -368,7 +368,7 @@ Status VMetaScanner::_build_workload_sched_policy_metadata_request(
 
     // create TMetadataTableRequestParams
     TMetadataTableRequestParams metadata_table_params;
-    metadata_table_params.__set_metadata_type(TMetadataType::WORKLOAD_SCHED_POLICY);
+    metadata_table_params.__set_metadata_type(TMetadataType::WORKLOAD_POLICY);
     metadata_table_params.__set_current_user_ident(_user_identity);
 
     request->__set_metada_table_params(metadata_table_params);

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -56,8 +56,8 @@ import org.apache.doris.cloud.proto.Cloud.StagePB;
 import org.apache.doris.mysql.MysqlPassword;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.policy.PolicyTypeEnum;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadConditionMeta;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadActionMeta;
+import org.apache.doris.resource.workloadpolicy.WorkloadConditionMeta;
+import org.apache.doris.resource.workloadpolicy.WorkloadActionMeta;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -1417,9 +1417,9 @@ alter_stmt ::=
     {:
         RESULT = new AlterWorkloadGroupStmt(workloadGroupName, properties);
     :}
-    | KW_ALTER KW_WORKLOAD KW_SCHEDULE KW_POLICY ident_or_text:policyName opt_properties:properties
+    | KW_ALTER KW_WORKLOAD KW_POLICY ident_or_text:policyName opt_properties:properties
     {:
-        RESULT = new AlterWorkloadSchedPolicyStmt(policyName, properties);
+        RESULT = new AlterWorkloadPolicyStmt(policyName, properties);
     :}
     | KW_ALTER KW_ROUTINE KW_LOAD KW_FOR job_label:jobLabel opt_properties:jobProperties
       opt_datasource_properties:datasourceProperties
@@ -2007,9 +2007,9 @@ create_stmt ::=
         RESULT = new CreateWorkloadGroupStmt(ifNotExists, workloadGroupName, properties);
     :}
     /* workload schedule policy */
-    | KW_CREATE KW_WORKLOAD KW_SCHEDULE KW_POLICY opt_if_not_exists:ifNotExists ident_or_text:workloadPolicyName opt_conditions:conditions opt_actions:actions opt_properties:properties
+    | KW_CREATE KW_WORKLOAD KW_POLICY opt_if_not_exists:ifNotExists ident_or_text:workloadPolicyName opt_conditions:conditions opt_actions:actions opt_properties:properties
     {:
-        RESULT = new CreateWorkloadSchedPolicyStmt(ifNotExists, workloadPolicyName, conditions, actions, properties);
+        RESULT = new CreateWorkloadPolicyStmt(ifNotExists, workloadPolicyName, conditions, actions, properties);
     :}
     /* encryptkey */
     | KW_CREATE KW_ENCRYPTKEY opt_if_not_exists:ifNotExists encryptkey_name:keyName KW_AS STRING_LITERAL:keyString
@@ -3221,9 +3221,9 @@ drop_stmt ::=
     {:
         RESULT = new DropWorkloadGroupStmt(ifExists, workloadGroupName);
     :}
-    | KW_DROP KW_WORKLOAD KW_SCHEDULE KW_POLICY opt_if_exists:ifExists ident_or_text:policyName
+    | KW_DROP KW_WORKLOAD KW_POLICY opt_if_exists:ifExists ident_or_text:policyName
     {:
-        RESULT = new DropWorkloadSchedPolicyStmt(ifExists, policyName);
+        RESULT = new DropWorkloadPolicyStmt(ifExists, policyName);
     :}
     | KW_DROP KW_ENCRYPTKEY opt_if_exists:ifExists encryptkey_name:keyName
     {:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateWorkloadPolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateWorkloadPolicyStmt.java
@@ -25,13 +25,13 @@ import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadActionMeta;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadConditionMeta;
+import org.apache.doris.resource.workloadpolicy.WorkloadActionMeta;
+import org.apache.doris.resource.workloadpolicy.WorkloadConditionMeta;
 
 import java.util.List;
 import java.util.Map;
 
-public class CreateWorkloadSchedPolicyStmt extends DdlStmt {
+public class CreateWorkloadPolicyStmt extends DdlStmt {
 
     private final boolean ifNotExists;
     private final String policyName;
@@ -39,7 +39,7 @@ public class CreateWorkloadSchedPolicyStmt extends DdlStmt {
     private final List<WorkloadActionMeta> actions;
     private final Map<String, String> properties;
 
-    public CreateWorkloadSchedPolicyStmt(boolean ifNotExists, String policyName,
+    public CreateWorkloadPolicyStmt(boolean ifNotExists, String policyName,
             List<WorkloadConditionMeta> conditions, List<WorkloadActionMeta> actions, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.policyName = policyName;
@@ -62,7 +62,7 @@ public class CreateWorkloadSchedPolicyStmt extends DdlStmt {
         }
 
         // check name
-        FeNameFormat.checkWorkloadSchedPolicyName(policyName);
+        FeNameFormat.checkWorkloadPolicyName(policyName);
 
         if (conditions == null || conditions.size() < 1) {
             throw new DdlException("At least one condition needs to be specified");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropWorkloadPolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropWorkloadPolicyStmt.java
@@ -18,34 +18,32 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import java.util.Map;
+public class DropWorkloadPolicyStmt extends DdlStmt {
 
-public class AlterWorkloadSchedPolicyStmt extends DdlStmt {
+    private boolean ifExists;
+    private String policyName;
 
-    private final String policyName;
-    private final Map<String, String> properties;
-
-    public AlterWorkloadSchedPolicyStmt(String policyName, Map<String, String> properties) {
+    public DropWorkloadPolicyStmt(boolean ifExists, String policyName) {
+        this.ifExists = ifExists;
         this.policyName = policyName;
-        this.properties = properties;
+    }
+
+    public boolean isIfExists() {
+        return ifExists;
     }
 
     public String getPolicyName() {
         return policyName;
     }
 
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
+    @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
 
@@ -54,17 +52,14 @@ public class AlterWorkloadSchedPolicyStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
         }
 
-        if (properties == null || properties.isEmpty()) {
-            throw new AnalysisException("properties can't be null when alter workload schedule policy");
-        }
+        FeNameFormat.checkWorkloadPolicyName(policyName);
     }
 
     @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("ALTER WORKLOAD SCHEDULE POLICY ");
-        sb.append(policyName);
-        sb.append("PROPERTIES(").append(new PrintableMap<>(properties, " = ", true, false)).append(")");
+        sb.append("DROP ");
+        sb.append("WORKLOAD SCHEDULE POLICY '").append(policyName).append("' ");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SchemaTableType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SchemaTableType.java
@@ -76,8 +76,8 @@ public enum SchemaTableType {
     SCHE_USER("user", "user", TSchemaTableType.SCH_USER),
     SCH_PROCS_PRIV("procs_priv", "procs_priv", TSchemaTableType.SCH_PROCS_PRIV),
 
-    SCH_WORKLOAD_SCHEDULE_POLICY("WORKLOAD_SCHEDULE_POLICY", "WORKLOAD_SCHEDULE_POLICY",
-            TSchemaTableType.SCH_WORKLOAD_SCHEDULE_POLICY);
+    SCH_WORKLOAD_POLICY("WORKLOAD_POLICY", "WORKLOAD_POLICY",
+            TSchemaTableType.SCH_WORKLOAD_POLICY);
 
     private static final String dbName = "INFORMATION_SCHEMA";
     private static SelectList fullSelectLists;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -236,9 +236,9 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadRuntimeStatusMgr;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicyMgr;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicyPublisher;
+import org.apache.doris.resource.workloadpolicy.WorkloadPolicyMgr;
+import org.apache.doris.resource.workloadpolicy.WorkloadPolicyPublisher;
+import org.apache.doris.resource.workloadpolicy.WorkloadRuntimeStatusMgr;
 import org.apache.doris.scheduler.manager.TransientTaskManager;
 import org.apache.doris.scheduler.registry.ExportTaskRegister;
 import org.apache.doris.service.ExecuteEnv;
@@ -503,7 +503,7 @@ public class Env {
 
     private WorkloadGroupMgr workloadGroupMgr;
 
-    private WorkloadSchedPolicyMgr workloadSchedPolicyMgr;
+    private WorkloadPolicyMgr workloadPolicyMgr;
 
     private WorkloadRuntimeStatusMgr workloadRuntimeStatusMgr;
 
@@ -765,7 +765,7 @@ public class Env {
         this.statisticsJobAppender = new StatisticsJobAppender();
         this.globalFunctionMgr = new GlobalFunctionMgr();
         this.workloadGroupMgr = new WorkloadGroupMgr();
-        this.workloadSchedPolicyMgr = new WorkloadSchedPolicyMgr();
+        this.workloadPolicyMgr = new WorkloadPolicyMgr();
         this.workloadRuntimeStatusMgr = new WorkloadRuntimeStatusMgr();
         this.queryStats = new QueryStats();
         this.loadManagerAdapter = new LoadManagerAdapter();
@@ -870,8 +870,8 @@ public class Env {
         return workloadGroupMgr;
     }
 
-    public WorkloadSchedPolicyMgr getWorkloadSchedPolicyMgr() {
-        return workloadSchedPolicyMgr;
+    public WorkloadPolicyMgr getWorkloadPolicyMgr() {
+        return workloadPolicyMgr;
     }
 
     public WorkloadRuntimeStatusMgr getWorkloadRuntimeStatusMgr() {
@@ -1711,7 +1711,7 @@ public class Env {
 
         TopicPublisher wgPublisher = new WorkloadGroupPublisher(this);
         topicPublisherThread.addToTopicPublisherList(wgPublisher);
-        WorkloadSchedPolicyPublisher wpPublisher = new WorkloadSchedPolicyPublisher(this);
+        WorkloadPolicyPublisher wpPublisher = new WorkloadPolicyPublisher(this);
         topicPublisherThread.addToTopicPublisherList(wpPublisher);
         topicPublisherThread.start();
 
@@ -1742,7 +1742,7 @@ public class Env {
         dnsCache.start();
 
         workloadGroupMgr.startUpdateThread();
-        workloadSchedPolicyMgr.start();
+        workloadPolicyMgr.start();
         workloadRuntimeStatusMgr.start();
 
     }
@@ -2201,8 +2201,8 @@ public class Env {
         return checksum;
     }
 
-    public long loadWorkloadSchedPolicy(DataInputStream in, long checksum) throws IOException {
-        workloadSchedPolicyMgr = WorkloadSchedPolicyMgr.read(in);
+    public long loadWorkloadPolicy(DataInputStream in, long checksum) throws IOException {
+        workloadPolicyMgr = WorkloadPolicyMgr.read(in);
         LOG.info("finished replay workload sched policy from image");
         return checksum;
     }
@@ -2492,8 +2492,8 @@ public class Env {
         return checksum;
     }
 
-    public long saveWorkloadSchedPolicy(CountingDataOutputStream dos, long checksum) throws IOException {
-        Env.getCurrentEnv().getWorkloadSchedPolicyMgr().write(dos);
+    public long saveWorkloadPolicy(CountingDataOutputStream dos, long checksum) throws IOException {
+        Env.getCurrentEnv().getWorkloadPolicyMgr().write(dos);
         return checksum;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -499,8 +499,8 @@ public class SchemaTable extends Table {
                             .column("STATE", ScalarType.createVarchar(64))
                             .column("INFO", ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH))
                             .build()))
-            .put("workload_schedule_policy",
-                    new SchemaTable(SystemIdGenerator.getNextId(), "workload_schedule_policy", TableType.SCHEMA,
+            .put("workload_policy",
+                    new SchemaTable(SystemIdGenerator.getNextId(), "workload_policy", TableType.SCHEMA,
                             builder().column("ID", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("NAME", ScalarType.createVarchar(256))
                                     .column("CONDITION", ScalarType.createStringType())

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -143,7 +143,7 @@ public class FeNameFormat {
         checkCommonName("workload group", workloadGroupName);
     }
 
-    public static void checkWorkloadSchedPolicyName(String policyName) throws AnalysisException {
+    public static void checkWorkloadPolicyName(String policyName) throws AnalysisException {
         checkCommonName("workload schedule policy", policyName);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -89,7 +89,7 @@ import org.apache.doris.persist.DropPartitionInfo;
 import org.apache.doris.persist.DropResourceOperationLog;
 import org.apache.doris.persist.DropSqlBlockRuleOperationLog;
 import org.apache.doris.persist.DropWorkloadGroupOperationLog;
-import org.apache.doris.persist.DropWorkloadSchedPolicyOperatorLog;
+import org.apache.doris.persist.DropWorkloadPolicyOperatorLog;
 import org.apache.doris.persist.GlobalVarPersistInfo;
 import org.apache.doris.persist.HbPackage;
 import org.apache.doris.persist.LdapInfo;
@@ -127,7 +127,7 @@ import org.apache.doris.policy.DropPolicyLog;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicy;
+import org.apache.doris.resource.workloadpolicy.WorkloadPolicy;
 import org.apache.doris.statistics.AnalysisInfo;
 import org.apache.doris.statistics.NewPartitionLoadedEvent;
 import org.apache.doris.statistics.TableStatsMeta;
@@ -830,14 +830,14 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
-            case OperationType.OP_CREATE_WORKLOAD_SCHED_POLICY:
-            case OperationType.OP_ALTER_WORKLOAD_SCHED_POLICY: {
-                data = WorkloadSchedPolicy.read(in);
+            case OperationType.OP_CREATE_WORKLOAD_POLICY:
+            case OperationType.OP_ALTER_WORKLOAD_POLICY: {
+                data = WorkloadPolicy.read(in);
                 isRead = true;
                 break;
             }
-            case OperationType.OP_DROP_WORKLOAD_SCHED_POLICY: {
-                data = DropWorkloadSchedPolicyOperatorLog.read(in);
+            case OperationType.OP_DROP_WORKLOAD_POLICY: {
+                data = DropWorkloadPolicyOperatorLog.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropWorkloadPolicyOperatorLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropWorkloadPolicyOperatorLog.java
@@ -27,12 +27,12 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public class DropWorkloadSchedPolicyOperatorLog implements Writable {
+public class DropWorkloadPolicyOperatorLog implements Writable {
 
     @SerializedName(value = "id")
     private long id;
 
-    public DropWorkloadSchedPolicyOperatorLog(long id) {
+    public DropWorkloadPolicyOperatorLog(long id) {
         this.id = id;
     }
 
@@ -45,7 +45,7 @@ public class DropWorkloadSchedPolicyOperatorLog implements Writable {
         Text.writeString(out, GsonUtils.GSON.toJson(this));
     }
 
-    public static DropWorkloadSchedPolicyOperatorLog read(DataInput in) throws IOException {
-        return GsonUtils.GSON.fromJson(Text.readString(in), DropWorkloadSchedPolicyOperatorLog.class);
+    public static DropWorkloadPolicyOperatorLog read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), DropWorkloadPolicyOperatorLog.class);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -86,7 +86,7 @@ import org.apache.doris.policy.DropPolicyLog;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicy;
+import org.apache.doris.resource.workloadpolicy.WorkloadPolicy;
 import org.apache.doris.statistics.AnalysisInfo;
 import org.apache.doris.statistics.AnalysisJobInfo;
 import org.apache.doris.statistics.AnalysisManager;
@@ -1072,20 +1072,20 @@ public class EditLog {
                     env.getWorkloadGroupMgr().replayAlterWorkloadGroup(resource);
                     break;
                 }
-                case OperationType.OP_CREATE_WORKLOAD_SCHED_POLICY: {
-                    final WorkloadSchedPolicy policy = (WorkloadSchedPolicy) journal.getData();
-                    env.getWorkloadSchedPolicyMgr().replayCreateWorkloadSchedPolicy(policy);
+                case OperationType.OP_CREATE_WORKLOAD_POLICY: {
+                    final WorkloadPolicy policy = (WorkloadPolicy) journal.getData();
+                    env.getWorkloadPolicyMgr().replayCreateWorkloadPolicy(policy);
                     break;
                 }
-                case OperationType.OP_ALTER_WORKLOAD_SCHED_POLICY: {
-                    final WorkloadSchedPolicy policy = (WorkloadSchedPolicy) journal.getData();
-                    env.getWorkloadSchedPolicyMgr().replayAlterWorkloadSchedPolicy(policy);
+                case OperationType.OP_ALTER_WORKLOAD_POLICY: {
+                    final WorkloadPolicy policy = (WorkloadPolicy) journal.getData();
+                    env.getWorkloadPolicyMgr().replayAlterWorkloadPolicy(policy);
                     break;
                 }
-                case OperationType.OP_DROP_WORKLOAD_SCHED_POLICY: {
-                    final DropWorkloadSchedPolicyOperatorLog dropLog
-                            = (DropWorkloadSchedPolicyOperatorLog) journal.getData();
-                    env.getWorkloadSchedPolicyMgr().replayDropWorkloadSchedPolicy(dropLog.getId());
+                case OperationType.OP_DROP_WORKLOAD_POLICY: {
+                    final DropWorkloadPolicyOperatorLog dropLog
+                            = (DropWorkloadPolicyOperatorLog) journal.getData();
+                    env.getWorkloadPolicyMgr().replayDropWorkloadPolicy(dropLog.getId());
                     break;
                 }
                 case OperationType.OP_INIT_EXTERNAL_TABLE: {
@@ -1763,16 +1763,16 @@ public class EditLog {
         logEdit(OperationType.OP_DROP_WORKLOAD_GROUP, operationLog);
     }
 
-    public void logCreateWorkloadSchedPolicy(WorkloadSchedPolicy workloadSchedPolicy) {
-        logEdit(OperationType.OP_CREATE_WORKLOAD_SCHED_POLICY, workloadSchedPolicy);
+    public void logCreateWorkloadPolicy(WorkloadPolicy workloadSchedPolicy) {
+        logEdit(OperationType.OP_CREATE_WORKLOAD_POLICY, workloadSchedPolicy);
     }
 
-    public void logAlterWorkloadSchedPolicy(WorkloadSchedPolicy workloadSchedPolicy) {
-        logEdit(OperationType.OP_ALTER_WORKLOAD_SCHED_POLICY, workloadSchedPolicy);
+    public void logAlterWorkloadPolicy(WorkloadPolicy workloadSchedPolicy) {
+        logEdit(OperationType.OP_ALTER_WORKLOAD_POLICY, workloadSchedPolicy);
     }
 
-    public void dropWorkloadSchedPolicy(long policyId) {
-        logEdit(OperationType.OP_DROP_WORKLOAD_SCHED_POLICY, new DropWorkloadSchedPolicyOperatorLog(policyId));
+    public void dropWorkloadPolicy(long policyId) {
+        logEdit(OperationType.OP_DROP_WORKLOAD_POLICY, new DropWorkloadPolicyOperatorLog(policyId));
     }
 
     public void logAddPlsqlStoredProcedure(PlsqlStoredProcedure plsqlStoredProcedure) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -313,9 +313,9 @@ public class OperationType {
     public static final short OP_CREATE_WORKLOAD_GROUP = 410;
     public static final short OP_DROP_WORKLOAD_GROUP = 411;
     public static final short OP_ALTER_WORKLOAD_GROUP = 412;
-    public static final short OP_CREATE_WORKLOAD_SCHED_POLICY = 413;
-    public static final short OP_ALTER_WORKLOAD_SCHED_POLICY = 414;
-    public static final short OP_DROP_WORKLOAD_SCHED_POLICY = 415;
+    public static final short OP_CREATE_WORKLOAD_POLICY = 413;
+    public static final short OP_ALTER_WORKLOAD_POLICY = 414;
+    public static final short OP_DROP_WORKLOAD_POLICY = 415;
 
     // query stats 420 ~ 424
     public static final short OP_CLEAN_QUERY_STATS = 420;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaPersistMethod.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaPersistMethod.java
@@ -220,9 +220,9 @@ public class MetaPersistMethod {
                 break;
             case "workloadSchedPolicy":
                 metaPersistMethod.readMethod =
-                        Env.class.getDeclaredMethod("loadWorkloadSchedPolicy", DataInputStream.class, long.class);
+                        Env.class.getDeclaredMethod("loadWorkloadPolicy", DataInputStream.class, long.class);
                 metaPersistMethod.writeMethod =
-                        Env.class.getDeclaredMethod("saveWorkloadSchedPolicy", CountingDataOutputStream.class,
+                        Env.class.getDeclaredMethod("saveWorkloadPolicy", CountingDataOutputStream.class,
                                 long.class);
                 break;
             case "binlogs":

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -49,7 +49,7 @@ import org.apache.doris.analysis.AlterTableStmt;
 import org.apache.doris.analysis.AlterUserStmt;
 import org.apache.doris.analysis.AlterViewStmt;
 import org.apache.doris.analysis.AlterWorkloadGroupStmt;
-import org.apache.doris.analysis.AlterWorkloadSchedPolicyStmt;
+import org.apache.doris.analysis.AlterWorkloadPolicyStmt;
 import org.apache.doris.analysis.BackupStmt;
 import org.apache.doris.analysis.CancelAlterSystemStmt;
 import org.apache.doris.analysis.CancelAlterTableStmt;
@@ -84,7 +84,7 @@ import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.CreateUserStmt;
 import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.CreateWorkloadGroupStmt;
-import org.apache.doris.analysis.CreateWorkloadSchedPolicyStmt;
+import org.apache.doris.analysis.CreateWorkloadPolicyStmt;
 import org.apache.doris.analysis.DdlStmt;
 import org.apache.doris.analysis.DropAnalyzeJobStmt;
 import org.apache.doris.analysis.DropCatalogStmt;
@@ -103,7 +103,7 @@ import org.apache.doris.analysis.DropStatsStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.DropUserStmt;
 import org.apache.doris.analysis.DropWorkloadGroupStmt;
-import org.apache.doris.analysis.DropWorkloadSchedPolicyStmt;
+import org.apache.doris.analysis.DropWorkloadPolicyStmt;
 import org.apache.doris.analysis.GrantStmt;
 import org.apache.doris.analysis.InstallPluginStmt;
 import org.apache.doris.analysis.KillAnalysisJobStmt;
@@ -320,12 +320,12 @@ public class DdlExecutor {
             env.getWorkloadGroupMgr().createWorkloadGroup((CreateWorkloadGroupStmt) ddlStmt);
         } else if (ddlStmt instanceof DropWorkloadGroupStmt) {
             env.getWorkloadGroupMgr().dropWorkloadGroup((DropWorkloadGroupStmt) ddlStmt);
-        }  else if (ddlStmt instanceof CreateWorkloadSchedPolicyStmt) {
-            env.getWorkloadSchedPolicyMgr().createWorkloadSchedPolicy((CreateWorkloadSchedPolicyStmt) ddlStmt);
-        } else if (ddlStmt instanceof AlterWorkloadSchedPolicyStmt) {
-            env.getWorkloadSchedPolicyMgr().alterWorkloadSchedPolicy((AlterWorkloadSchedPolicyStmt) ddlStmt);
-        } else if (ddlStmt instanceof DropWorkloadSchedPolicyStmt) {
-            env.getWorkloadSchedPolicyMgr().dropWorkloadSchedPolicy((DropWorkloadSchedPolicyStmt) ddlStmt);
+        }  else if (ddlStmt instanceof CreateWorkloadPolicyStmt) {
+            env.getWorkloadPolicyMgr().createWorkloadPolicy((CreateWorkloadPolicyStmt) ddlStmt);
+        } else if (ddlStmt instanceof AlterWorkloadPolicyStmt) {
+            env.getWorkloadPolicyMgr().alterWorkloadPolicy((AlterWorkloadPolicyStmt) ddlStmt);
+        } else if (ddlStmt instanceof DropWorkloadPolicyStmt) {
+            env.getWorkloadPolicyMgr().dropWorkloadPolicy((DropWorkloadPolicyStmt) ddlStmt);
         } else if (ddlStmt instanceof CreateDataSyncJobStmt) {
             CreateDataSyncJobStmt createSyncJobStmt = (CreateDataSyncJobStmt) ddlStmt;
             SyncJobManager syncJobMgr = env.getSyncJobManager();

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -423,7 +423,7 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
         // A group with related policies should not be deleted.
         Long wgId = getWorkloadGroupIdByName(workloadGroupName);
         if (wgId != null) {
-            boolean groupHasPolicy = Env.getCurrentEnv().getWorkloadSchedPolicyMgr()
+            boolean groupHasPolicy = Env.getCurrentEnv().getWorkloadPolicyMgr()
                     .checkWhetherGroupHasPolicy(wgId.longValue());
             if (groupHasPolicy) {
                 throw new DdlException(

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadAction.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionCancelQuery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionCancelQuery.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.qe.QeProcessorImpl;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionMeta.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionSetSessionVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionSetSessionVar.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.analysis.SetStmt;
 import org.apache.doris.analysis.SetVar;

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadActionType.java
@@ -15,28 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
-import org.apache.doris.catalog.Env;
-import org.apache.doris.common.publish.TopicPublisher;
-import org.apache.doris.thrift.TPublishTopicRequest;
-import org.apache.doris.thrift.TTopicInfoType;
-import org.apache.doris.thrift.TopicInfo;
-
-import java.util.List;
-
-public class WorkloadSchedPolicyPublisher implements TopicPublisher {
-
-    private Env env;
-
-    public WorkloadSchedPolicyPublisher(Env env) {
-        this.env = env;
-    }
-
-    @Override
-    public void getTopicInfo(TPublishTopicRequest req) {
-        List<TopicInfo> list = env.getWorkloadSchedPolicyMgr().getPublishTopicInfoList();
-        req.putToTopicMap(TTopicInfoType.WORKLOAD_SCHED_POLICY, list);
-    }
-
+public enum WorkloadActionType {
+    CANCEL_QUERY, // cancel query
+    MOVE_QUERY_TO_GROUP, // move query from one wg group to another
+    SET_SESSION_VARIABLE
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadCondition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadCondition.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionBeScanBytes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionBeScanBytes.java
@@ -15,38 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 
-public class WorkloadConditionQueryTime implements WorkloadCondition {
+public class WorkloadConditionBeScanBytes implements WorkloadCondition {
 
     private long value;
+
     private WorkloadConditionOperator op;
 
-    public WorkloadConditionQueryTime(WorkloadConditionOperator op, long value) {
+    public WorkloadConditionBeScanBytes(WorkloadConditionOperator op, long value) {
         this.op = op;
         this.value = value;
     }
 
     @Override
     public boolean eval(String strValue) {
-        long inputLongValue = Long.parseLong(strValue);
-        return WorkloadConditionCompareUtils.compareInteger(op, inputLongValue, value);
+        // currently not support run in fe, so this condition never match
+        return false;
     }
 
-    public static WorkloadConditionQueryTime createWorkloadCondition(WorkloadConditionOperator op, String value)
+    public static WorkloadConditionBeScanBytes createWorkloadCondition(WorkloadConditionOperator op, String value)
             throws UserException {
         long longValue = Long.parseLong(value);
         if (longValue < 0) {
-            throw new UserException("invalid query time value, " + longValue + ", it requires >= 0");
+            throw new UserException("invalid scan bytes value, " + longValue + ", it requires >= 0");
         }
-        return new WorkloadConditionQueryTime(op, longValue);
+        return new WorkloadConditionBeScanBytes(op, longValue);
     }
 
     @Override
     public WorkloadMetricType getMetricType() {
-        return WorkloadMetricType.QUERY_TIME;
+        return WorkloadMetricType.BE_SCAN_BYTES;
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionBeScanRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionBeScanRows.java
@@ -15,17 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 
-public class WorkloadConditionBeScanBytes implements WorkloadCondition {
+public class WorkloadConditionBeScanRows implements WorkloadCondition {
 
     private long value;
 
     private WorkloadConditionOperator op;
 
-    public WorkloadConditionBeScanBytes(WorkloadConditionOperator op, long value) {
+    public WorkloadConditionBeScanRows(WorkloadConditionOperator op, long value) {
         this.op = op;
         this.value = value;
     }
@@ -36,17 +36,17 @@ public class WorkloadConditionBeScanBytes implements WorkloadCondition {
         return false;
     }
 
-    public static WorkloadConditionBeScanBytes createWorkloadCondition(WorkloadConditionOperator op, String value)
+    public static WorkloadConditionBeScanRows createWorkloadCondition(WorkloadConditionOperator op, String value)
             throws UserException {
         long longValue = Long.parseLong(value);
         if (longValue < 0) {
-            throw new UserException("invalid scan bytes value, " + longValue + ", it requires >= 0");
+            throw new UserException("invalid scan rows value, " + longValue + ", it requires >= 0");
         }
-        return new WorkloadConditionBeScanBytes(op, longValue);
+        return new WorkloadConditionBeScanRows(op, longValue);
     }
 
     @Override
     public WorkloadMetricType getMetricType() {
-        return WorkloadMetricType.BE_SCAN_BYTES;
+        return WorkloadMetricType.BE_SCAN_ROWS;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionCompareUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionCompareUtils.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionMeta.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionOperator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionOperator.java
@@ -15,16 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.thrift.TUniqueId;
-
-import java.util.Map;
-
-public class WorkloadQueryInfo {
-    String queryId = null;
-    TUniqueId tUniqueId = null;
-    ConnectContext context = null;
-    public Map<WorkloadMetricType, String> metricMap;
+public enum WorkloadConditionOperator {
+    EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAl
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionQueryTime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionQueryTime.java
@@ -15,38 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 
-public class WorkloadConditionBeScanRows implements WorkloadCondition {
+public class WorkloadConditionQueryTime implements WorkloadCondition {
 
     private long value;
-
     private WorkloadConditionOperator op;
 
-    public WorkloadConditionBeScanRows(WorkloadConditionOperator op, long value) {
+    public WorkloadConditionQueryTime(WorkloadConditionOperator op, long value) {
         this.op = op;
         this.value = value;
     }
 
     @Override
     public boolean eval(String strValue) {
-        // currently not support run in fe, so this condition never match
-        return false;
+        long inputLongValue = Long.parseLong(strValue);
+        return WorkloadConditionCompareUtils.compareInteger(op, inputLongValue, value);
     }
 
-    public static WorkloadConditionBeScanRows createWorkloadCondition(WorkloadConditionOperator op, String value)
+    public static WorkloadConditionQueryTime createWorkloadCondition(WorkloadConditionOperator op, String value)
             throws UserException {
         long longValue = Long.parseLong(value);
         if (longValue < 0) {
-            throw new UserException("invalid scan rows value, " + longValue + ", it requires >= 0");
+            throw new UserException("invalid query time value, " + longValue + ", it requires >= 0");
         }
-        return new WorkloadConditionBeScanRows(op, longValue);
+        return new WorkloadConditionQueryTime(op, longValue);
     }
 
     @Override
     public WorkloadMetricType getMetricType() {
-        return WorkloadMetricType.BE_SCAN_ROWS;
+        return WorkloadMetricType.QUERY_TIME;
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionUsername.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadConditionUsername.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.hbase.thirdparty.com.google.gson.annotations.SerializedName;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadMetricType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadMetricType.java
@@ -15,10 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
-public enum WorkloadActionType {
-    CANCEL_QUERY, // cancel query
-    MOVE_QUERY_TO_GROUP, // move query from one wg group to another
-    SET_SESSION_VARIABLE
+public enum WorkloadMetricType {
+    USERNAME, QUERY_TIME, BE_SCAN_ROWS, BE_SCAN_BYTES
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadPolicy.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
@@ -27,7 +27,7 @@ import org.apache.doris.thrift.TWorkloadAction;
 import org.apache.doris.thrift.TWorkloadActionType;
 import org.apache.doris.thrift.TWorkloadCondition;
 import org.apache.doris.thrift.TWorkloadMetricType;
-import org.apache.doris.thrift.TWorkloadSchedPolicy;
+import org.apache.doris.thrift.TWorkloadPolicy;
 import org.apache.doris.thrift.TopicInfo;
 
 import com.esotericsoftware.minlog.Log;
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
+public class WorkloadPolicy implements Writable, GsonPostProcessable {
 
     public static final String ENABLED = "enabled";
     public static final String PRIORITY = "priority";
@@ -97,7 +97,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
     private Boolean isFePolicy = null;
 
     // for ut
-    public WorkloadSchedPolicy() {
+    public WorkloadPolicy() {
     }
 
     // for ut
@@ -105,7 +105,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
         this.workloadConditionList = workloadConditionList;
     }
 
-    public WorkloadSchedPolicy(long id, String name, List<WorkloadCondition> workloadConditionList,
+    public WorkloadPolicy(long id, String name, List<WorkloadCondition> workloadConditionList,
             List<WorkloadAction> workloadActionList, Map<String, String> properties, List<Long> wgIdList) {
         this.id = id;
         this.name = name;
@@ -234,7 +234,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
         if (isFePolicy == null) {
             isFePolicy = false;
             for (WorkloadAction action : workloadActionList) {
-                if (WorkloadSchedPolicyMgr.FE_ACTION_SET.contains(action.getWorkloadActionType())) {
+                if (WorkloadPolicyMgr.FE_ACTION_SET.contains(action.getWorkloadActionType())) {
                     isFePolicy = true;
                     break;
                 }
@@ -244,7 +244,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
     }
 
     public TopicInfo toTopicInfo() {
-        TWorkloadSchedPolicy tPolicy = new TWorkloadSchedPolicy();
+        TWorkloadPolicy tPolicy = new TWorkloadPolicy();
         tPolicy.setId(id);
         tPolicy.setName(name);
         tPolicy.setVersion(version);
@@ -281,7 +281,7 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
         tPolicy.setActionList(actionList);
 
         TopicInfo topicInfo = new TopicInfo();
-        topicInfo.setWorkloadSchedPolicy(tPolicy);
+        topicInfo.setWorkloadPolicy(tPolicy);
 
         return topicInfo;
     }
@@ -292,9 +292,9 @@ public class WorkloadSchedPolicy implements Writable, GsonPostProcessable {
         Text.writeString(out, json);
     }
 
-    public static WorkloadSchedPolicy read(DataInput in) throws IOException {
+    public static WorkloadPolicy read(DataInput in) throws IOException {
         String json = Text.readString(in);
-        return GsonUtils.GSON.fromJson(json, WorkloadSchedPolicy.class);
+        return GsonUtils.GSON.fromJson(json, WorkloadPolicy.class);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadPolicyPublisher.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadPolicyPublisher.java
@@ -15,8 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
-public enum WorkloadConditionOperator {
-    EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAl
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.publish.TopicPublisher;
+import org.apache.doris.thrift.TPublishTopicRequest;
+import org.apache.doris.thrift.TTopicInfoType;
+import org.apache.doris.thrift.TopicInfo;
+
+import java.util.List;
+
+public class WorkloadPolicyPublisher implements TopicPublisher {
+
+    private Env env;
+
+    public WorkloadPolicyPublisher(Env env) {
+        this.env = env;
+    }
+
+    @Override
+    public void getTopicInfo(TPublishTopicRequest req) {
+        List<TopicInfo> list = env.getWorkloadPolicyMgr().getPublishTopicInfoList();
+        req.putToTopicMap(TTopicInfoType.WORKLOAD_POLICY, list);
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadQueryInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadQueryInfo.java
@@ -15,8 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
-public enum WorkloadMetricType {
-    USERNAME, QUERY_TIME, BE_SCAN_ROWS, BE_SCAN_BYTES
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.thrift.TUniqueId;
+
+import java.util.Map;
+
+public class WorkloadQueryInfo {
+    String queryId = null;
+    TUniqueId tUniqueId = null;
+    ConnectContext context = null;
+    public Map<WorkloadMetricType, String> metricMap;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadRuntimeStatusMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadpolicy/WorkloadRuntimeStatusMgr.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.resource.workloadschedpolicy;
+package org.apache.doris.resource.workloadpolicy;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -98,7 +98,7 @@ public class MetadataGenerator {
 
     private static final ImmutableMap<String, Integer> ROUTINE_INFO_COLUMN_TO_INDEX;
 
-    private static final ImmutableMap<String, Integer> WORKLOAD_SCHED_POLICY_COLUMN_TO_INDEX;
+    private static final ImmutableMap<String, Integer> WORKLOAD_POLICY_COLUMN_TO_INDEX;
 
     static {
         ImmutableMap.Builder<String, Integer> activeQueriesbuilder = new ImmutableMap.Builder();
@@ -121,11 +121,11 @@ public class MetadataGenerator {
         ROUTINE_INFO_COLUMN_TO_INDEX = routineInfoBuilder.build();
 
         ImmutableMap.Builder<String, Integer> policyBuilder = new ImmutableMap.Builder();
-        List<Column> policyColList = SchemaTable.TABLE_MAP.get("workload_schedule_policy").getFullSchema();
+        List<Column> policyColList = SchemaTable.TABLE_MAP.get("workload_policy").getFullSchema();
         for (int i = 0; i < policyColList.size(); i++) {
             policyBuilder.put(policyColList.get(i).getName().toLowerCase(), i);
         }
-        WORKLOAD_SCHED_POLICY_COLUMN_TO_INDEX = policyBuilder.build();
+        WORKLOAD_POLICY_COLUMN_TO_INDEX = policyBuilder.build();
 
     }
 
@@ -199,9 +199,9 @@ public class MetadataGenerator {
                 result = routineInfoMetadataResult(schemaTableParams);
                 columnIndex = ROUTINE_INFO_COLUMN_TO_INDEX;
                 break;
-            case WORKLOAD_SCHEDULE_POLICY:
+            case WORKLOAD_POLICY:
                 result = workloadSchedPolicyMetadataResult(schemaTableParams);
-                columnIndex = WORKLOAD_SCHED_POLICY_COLUMN_TO_INDEX;
+                columnIndex = WORKLOAD_POLICY_COLUMN_TO_INDEX;
                 break;
             default:
                 return errorResult("invalid schema table name.");
@@ -486,8 +486,8 @@ public class MetadataGenerator {
         }
 
         TUserIdentity tcurrentUserIdentity = params.getCurrentUserIdent();
-        List<List<String>> workloadPolicyList = Env.getCurrentEnv().getWorkloadSchedPolicyMgr()
-                .getWorkloadSchedPolicyTvfInfo(tcurrentUserIdentity);
+        List<List<String>> workloadPolicyList = Env.getCurrentEnv().getWorkloadPolicyMgr()
+                .getWorkloadPolicyTvfInfo(tcurrentUserIdentity);
         TFetchSchemaTableDataResult result = new TFetchSchemaTableDataResult();
         List<TRow> dataBatch = Lists.newArrayList();
         for (List<String> policyRow : workloadPolicyList) {

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/WorkloadSchedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/WorkloadSchedTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.doris.resource;
 
-import org.apache.doris.resource.workloadschedpolicy.WorkloadCondition;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadConditionOperator;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadConditionQueryTime;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadConditionUsername;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadMetricType;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadQueryInfo;
-import org.apache.doris.resource.workloadschedpolicy.WorkloadSchedPolicy;
+import org.apache.doris.resource.workloadpolicy.WorkloadCondition;
+import org.apache.doris.resource.workloadpolicy.WorkloadConditionOperator;
+import org.apache.doris.resource.workloadpolicy.WorkloadConditionQueryTime;
+import org.apache.doris.resource.workloadpolicy.WorkloadConditionUsername;
+import org.apache.doris.resource.workloadpolicy.WorkloadMetricType;
+import org.apache.doris.resource.workloadpolicy.WorkloadPolicy;
+import org.apache.doris.resource.workloadpolicy.WorkloadQueryInfo;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.GREATER, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -64,7 +64,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.GREATER_EQUAL, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -85,7 +85,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.EQUAL, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -106,7 +106,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.LESS, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -127,7 +127,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.LESS_EQUAl, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -148,7 +148,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition strCondition = new WorkloadConditionUsername(WorkloadConditionOperator.EQUAL, "root");
                 operatorList.add(strCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();
@@ -172,7 +172,7 @@ public class WorkloadSchedTest {
                 WorkloadCondition intCondition = new WorkloadConditionQueryTime(WorkloadConditionOperator.EQUAL, 100);
                 operatorList.add(intCondition);
 
-                WorkloadSchedPolicy workloadSchedPolicy1 = new WorkloadSchedPolicy();
+                WorkloadPolicy workloadSchedPolicy1 = new WorkloadPolicy();
                 workloadSchedPolicy1.setWorkloadConditionList(operatorList);
 
                 WorkloadQueryInfo queryInfo = new WorkloadQueryInfo();

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -249,7 +249,7 @@ struct TQueryIngestBinlogResult {
 enum TTopicInfoType {
     WORKLOAD_GROUP
     MOVE_QUERY_TO_GROUP
-    WORKLOAD_SCHED_POLICY
+    WORKLOAD_POLICY
 }
 
 struct TWorkloadGroupInfo {
@@ -298,7 +298,7 @@ struct TWorkloadAction {
     2: optional string action_args
 }
 
-struct TWorkloadSchedPolicy {
+struct TWorkloadPolicy {
     1: optional i64 id
     2: optional string name
     3: optional i32 version
@@ -311,7 +311,7 @@ struct TWorkloadSchedPolicy {
 
 struct TopicInfo {
     1: optional TWorkloadGroupInfo workload_group_info
-    2: optional TWorkloadSchedPolicy workload_sched_policy
+    2: optional TWorkloadPolicy workload_policy
 }
 
 struct TPublishTopicRequest {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -131,7 +131,7 @@ enum TSchemaTableType {
     SCH_WORKLOAD_GROUPS,
     SCH_USER,
     SCH_PROCS_PRIV,
-    SCH_WORKLOAD_SCHEDULE_POLICY;
+    SCH_WORKLOAD_POLICY;
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -947,7 +947,7 @@ enum TSchemaTableName {
   ACTIVE_QUERIES = 2, // db information_schema's table
   WORKLOAD_GROUPS = 3, // db information_schema's table
   ROUTINES_INFO = 4, // db information_schema's table
-  WORKLOAD_SCHEDULE_POLICY = 5,
+  WORKLOAD_POLICY = 5,
 }
 
 struct TMetadataTableRequestParams {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -716,7 +716,7 @@ enum TMetadataType {
   MATERIALIZED_VIEWS,
   JOBS,
   TASKS,
-  WORKLOAD_SCHED_POLICY
+  WORKLOAD_POLICY
 }
 
 enum TIcebergQueryType {

--- a/regression-test/data/external_table_p0/jdbc/test_mariadb_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mariadb_jdbc_catalog.out
@@ -59,7 +59,7 @@ triggers
 user_privileges
 views
 workload_groups
-workload_schedule_policy
+workload_policy
 
 -- !auto_default_t --
 0

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
@@ -223,7 +223,7 @@ triggers
 user_privileges
 views
 workload_groups
-workload_schedule_policy
+workload_policy
 
 -- !dt --
 2023-06-17T10:00	2023-06-17T10:00:01.100	2023-06-17T10:00:02.220	2023-06-17T10:00:03.333	2023-06-17T10:00:04.444400	2023-06-17T10:00:05.555550	2023-06-17T10:00:06.666666

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog_nereids.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog_nereids.out
@@ -191,7 +191,7 @@ triggers
 user_privileges
 views
 workload_groups
-workload_schedule_policy
+workload_policy
 
 -- !test_insert1 --
 doris1	18

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_driver5_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_driver5_catalog.out
@@ -233,7 +233,7 @@ triggers
 user_privileges
 views
 workload_groups
-workload_schedule_policy
+workload_policy
 
 -- !dt --
 2023-06-17T10:00	2023-06-17T10:00:01	2023-06-17T10:00:02	2023-06-17T10:00:03	2023-06-17T10:00:04	2023-06-17T10:00:05	2023-06-17T10:00:06

--- a/regression-test/suites/workload_manager_p0/test_workload_sched_policy.groovy
+++ b/regression-test/suites/workload_manager_p0/test_workload_sched_policy.groovy
@@ -19,23 +19,23 @@ suite("test_workload_sched_policy") {
 
     sql "set experimental_enable_nereids_planner = false;"
 
-    sql "drop workload schedule policy if exists test_cancel_policy;"
-    sql "drop workload schedule policy if exists set_action_policy;"
-    sql "drop workload schedule policy if exists fe_policy;"
-    sql "drop workload schedule policy if exists be_policy;"
+    sql "drop workload policy if exists test_cancel_policy;"
+    sql "drop workload policy if exists set_action_policy;"
+    sql "drop workload policy if exists fe_policy;"
+    sql "drop workload policy if exists be_policy;"
 
     // 1 create cancel policy
-    sql "create workload schedule policy test_cancel_policy " +
+    sql "create workload policy test_cancel_policy " +
             " conditions(query_time > 10) " +
             " actions(cancel_query) properties('enabled'='false'); "
 
     // 2 create set policy
-    sql "create workload schedule policy set_action_policy " +
+    sql "create workload policy set_action_policy " +
             "conditions(username='root') " +
             "actions(set_session_variable 'workload_group=normal') properties('enabled'='false');"
 
     // 3 create policy run in fe
-    sql "create workload schedule policy fe_policy " +
+    sql "create workload policy fe_policy " +
             "conditions(username='root') " +
             "actions(set_session_variable 'workload_group=normal') " +
             "properties( " +
@@ -44,7 +44,7 @@ suite("test_workload_sched_policy") {
             ");"
 
     // 4 create policy run in be
-    sql "create workload schedule policy be_policy " +
+    sql "create workload policy be_policy " +
             "conditions(query_time > 10) " +
             "actions(cancel_query) " +
             "properties( " +
@@ -52,46 +52,46 @@ suite("test_workload_sched_policy") {
             "'priority'='10' " +
             ");"
 
-    qt_select_policy_tvf "select name,condition,action,priority,enabled,version from information_schema.workload_schedule_policy where name in('be_policy','fe_policy','set_action_policy','test_cancel_policy') order by name;"
+    qt_select_policy_tvf "select name,condition,action,priority,enabled,version from information_schema. workload_policy where name in('be_policy','fe_policy','set_action_policy','test_cancel_policy') order by name;"
 
     // test_alter
-    sql "alter workload schedule policy fe_policy properties('priority'='2', 'enabled'='false');"
+    sql "alter workload policy fe_policy properties('priority'='2', 'enabled'='false');"
 
     // create failed check
     test {
-        sql "create workload schedule policy failed_policy " +
+        sql "create workload policy failed_policy " +
                 "conditions(abc > 123) actions(cancel_query);"
 
         exception "invalid metric name"
     }
 
     test {
-        sql "create workload schedule policy failed_policy " +
+        sql "create workload policy failed_policy " +
                 "conditions(query_time > 123) actions(abc);"
 
         exception "invalid action type"
     }
 
     test {
-        sql "alter workload schedule policy fe_policy properties('priority'='abc');"
+        sql "alter workload policy fe_policy properties('priority'='abc');"
 
         exception "invalid priority property value"
     }
 
     test {
-        sql "alter workload schedule policy fe_policy properties('enabled'='abc');"
+        sql "alter workload policy fe_policy properties('enabled'='abc');"
 
         exception "invalid enabled property value"
     }
 
     test {
-        sql "alter workload schedule policy fe_policy properties('priority'='10000');"
+        sql "alter workload policy fe_policy properties('priority'='10000');"
 
         exception "priority can only between"
     }
 
     test {
-        sql "create workload schedule policy conflict_policy " +
+        sql "create workload policy conflict_policy " +
                 "conditions (query_time > 0) " +
                 "actions(cancel_query, cancel_query);"
 
@@ -99,7 +99,7 @@ suite("test_workload_sched_policy") {
     }
 
     test {
-        sql "create workload schedule policy conflict_policy " +
+        sql "create workload policy conflict_policy " +
                 "conditions (username = 'root') " +
                 "actions(set_session_variable 'workload_group=normal', set_session_variable 'workload_group=abc');"
 
@@ -107,21 +107,21 @@ suite("test_workload_sched_policy") {
     }
 
     // drop
-    sql "drop workload schedule policy test_cancel_policy;"
-    sql "drop workload schedule policy set_action_policy;"
-    sql "drop workload schedule policy fe_policy;"
-    sql "drop workload schedule policy be_policy;"
+    sql "drop workload policy test_cancel_policy;"
+    sql "drop workload policy set_action_policy;"
+    sql "drop workload policy fe_policy;"
+    sql "drop workload policy be_policy;"
 
-    qt_select_policy_tvf_after_drop "select name,condition,action,priority,enabled,version from information_schema.workload_schedule_policy where name in('be_policy','fe_policy','set_action_policy','test_cancel_policy') order by name;"
+    qt_select_policy_tvf_after_drop "select name,condition,action,priority,enabled,version from information_schema. workload_policy where name in('be_policy','fe_policy','set_action_policy','test_cancel_policy') order by name;"
 
-    // test workload schedule policy
+    // test workload policy
     sql "ADMIN SET FRONTEND CONFIG ('workload_sched_policy_interval_ms' = '500');"
     sql """drop user if exists test_workload_sched_user"""
     sql """create user test_workload_sched_user identified by '12345'"""
     sql """grant ADMIN_PRIV on *.*.* to test_workload_sched_user"""
 
     // 1 create test_set_var_policy
-    sql "create workload schedule policy test_set_var_policy conditions(username='test_workload_sched_user')" +
+    sql "create workload policy test_set_var_policy conditions(username='test_workload_sched_user')" +
             "actions(set_session_variable 'parallel_pipeline_task_num=33');"
     def result1 = connect(user = 'test_workload_sched_user', password = '12345', url = context.config.jdbcUrl) {
         logger.info("begin sleep 15s to wait")
@@ -132,7 +132,7 @@ suite("test_workload_sched_policy") {
     assertEquals("33", result1[0][1])
 
     // 2 create test_set_var_policy2 with higher priority
-    sql "create workload schedule policy test_set_var_policy2 conditions(username='test_workload_sched_user') " +
+    sql "create workload policy test_set_var_policy2 conditions(username='test_workload_sched_user') " +
             "actions(set_session_variable 'parallel_pipeline_task_num=22') properties('priority'='10');"
     def result2 = connect(user = 'test_workload_sched_user', password = '12345', url = context.config.jdbcUrl) {
         Thread.sleep(3000)
@@ -142,7 +142,7 @@ suite("test_workload_sched_policy") {
     assertEquals("22", result2[0][1])
 
     // 3 disable test_set_var_policy2
-    sql "alter workload schedule policy test_set_var_policy2 properties('enabled'='false');"
+    sql "alter workload policy test_set_var_policy2 properties('enabled'='false');"
     def result3 = connect(user = 'test_workload_sched_user', password = '12345', url = context.config.jdbcUrl) {
         Thread.sleep(3000)
         sql "show variables like '%parallel_pipeline_task_num%';"
@@ -152,13 +152,13 @@ suite("test_workload_sched_policy") {
     
     sql "ADMIN SET FRONTEND CONFIG ('workload_sched_policy_interval_ms' = '10000');"
 
-    sql "drop workload schedule policy if exists test_set_var_policy;"
-    sql "drop workload schedule policy if exists test_set_var_policy2;"
+    sql "drop workload policy if exists test_set_var_policy;"
+    sql "drop workload policy if exists test_set_var_policy2;"
 
     sql "drop user if exists test_policy_user"
-    sql "drop workload schedule policy if exists test_cancel_query_policy"
-    sql "drop workload schedule policy if exists test_cancel_query_policy2"
-    sql "drop workload schedule policy if exists test_set_session"
+    sql "drop workload policy if exists test_cancel_query_policy"
+    sql "drop workload policy if exists test_cancel_query_policy2"
+    sql "drop workload policy if exists test_set_session"
     sql "drop workload group if exists policy_group;"
     sql "CREATE USER 'test_policy_user'@'%' IDENTIFIED BY '12345';"
     sql """grant SELECT_PRIV on *.*.* to test_policy_user;"""
@@ -166,9 +166,9 @@ suite("test_workload_sched_policy") {
     sql "create workload group if not exists policy_group2 properties ('cpu_share'='1024');"
     sql "GRANT USAGE_PRIV ON WORKLOAD GROUP 'policy_group' TO 'test_policy_user'@'%';"
     sql "GRANT USAGE_PRIV ON WORKLOAD GROUP 'policy_group2' TO 'test_policy_user'@'%';"
-    sql "create workload schedule policy test_cancel_query_policy conditions(query_time > 1000) actions(cancel_query) properties('workload_group'='policy_group')"
-    sql "create workload schedule policy test_cancel_query_policy2 conditions(query_time > 0, be_scan_rows>1) actions(cancel_query) properties('workload_group'='policy_group')"
-    sql "create workload schedule policy test_set_session conditions(username='test_policy_user') actions(set_session_variable 'parallel_pipeline_task_num=1')"
+    sql "create workload policy test_cancel_query_policy conditions(query_time > 1000) actions(cancel_query) properties('workload_group'='policy_group')"
+    sql "create workload policy test_cancel_query_policy2 conditions(query_time > 0, be_scan_rows>1) actions(cancel_query) properties('workload_group'='policy_group')"
+    sql "create workload policy test_set_session conditions(username='test_policy_user') actions(set_session_variable 'parallel_pipeline_task_num=1')"
 
     test {
         sql "drop workload group policy_group;"
@@ -176,31 +176,31 @@ suite("test_workload_sched_policy") {
     }
 
     test {
-        sql "alter workload schedule policy test_cancel_query_policy properties('workload_group'='invalid_gorup');"
+        sql "alter workload policy test_cancel_query_policy properties('workload_group'='invalid_gorup');"
         exception "unknown workload group"
     }
 
     // test alter policy property
     sql "drop user if exists test_alter_policy_user"
     sql "CREATE USER 'test_alter_policy_user'@'%' IDENTIFIED BY '12345';"
-    sql "drop workload schedule policy if exists test_alter_policy;"
-    sql "create workload schedule policy test_alter_policy conditions(username='test_alter_policy_user') actions(set_session_variable 'parallel_pipeline_task_num=0') properties('workload_group'='normal');"
-    qt_select_alter_1 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema.workload_schedule_policy where name='test_alter_policy'"
+    sql "drop workload policy if exists test_alter_policy;"
+    sql "create workload policy test_alter_policy conditions(username='test_alter_policy_user') actions(set_session_variable 'parallel_pipeline_task_num=0') properties('workload_group'='normal');"
+    qt_select_alter_1 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema. workload_policy where name='test_alter_policy'"
 
-    sql "alter workload schedule policy test_alter_policy properties('workload_group'='');"
-    qt_select_alter_2 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema.workload_schedule_policy where name='test_alter_policy'"
+    sql "alter workload policy test_alter_policy properties('workload_group'='');"
+    qt_select_alter_2 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema. workload_policy where name='test_alter_policy'"
 
-    sql "alter workload schedule policy test_alter_policy properties('enabled'='false');"
-    qt_select_alter_3 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema.workload_schedule_policy where name='test_alter_policy'"
+    sql "alter workload policy test_alter_policy properties('enabled'='false');"
+    qt_select_alter_3 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema. workload_policy where name='test_alter_policy'"
 
-    sql "alter workload schedule policy test_alter_policy properties('priority'='9');"
-    qt_select_alter_4 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema.workload_schedule_policy where name='test_alter_policy'"
+    sql "alter workload policy test_alter_policy properties('priority'='9');"
+    qt_select_alter_4 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema. workload_policy where name='test_alter_policy'"
 
-    sql "alter workload schedule policy test_alter_policy properties('workload_group'='normal');"
-    qt_select_alter_5 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema.workload_schedule_policy where name='test_alter_policy'"
+    sql "alter workload policy test_alter_policy properties('workload_group'='normal');"
+    qt_select_alter_5 "select name,condition,action,PRIORITY,ENABLED,VERSION,WORKLOAD_GROUP from information_schema. workload_policy where name='test_alter_policy'"
 
     sql "drop user test_alter_policy_user"
-    sql "drop workload schedule policy test_alter_policy"
+    sql "drop workload policy test_alter_policy"
 
     // daemon thread alter test
     def thread1 = new Thread({
@@ -217,14 +217,14 @@ suite("test_workload_sched_policy") {
                 if (curTime - lastTime > 20000) {
                     if (flag) {
                         connect(user = 'root', password = '', url = context.config.jdbcUrl) {
-                            sql "alter workload schedule policy test_cancel_query_policy properties('workload_group'='policy_group2');"
-                            sql "alter workload schedule policy test_cancel_query_policy2 properties('workload_group'='policy_group');"
+                            sql "alter workload policy test_cancel_query_policy properties('workload_group'='policy_group2');"
+                            sql "alter workload policy test_cancel_query_policy2 properties('workload_group'='policy_group');"
                         }
                         flag = false
                     } else {
                         connect(user = 'root', password = '', url = context.config.jdbcUrl) {
-                            sql "alter workload schedule policy test_cancel_query_policy properties('workload_group'='policy_group');"
-                            sql "alter workload schedule policy test_cancel_query_policy2 properties('workload_group'='policy_group2');"
+                            sql "alter workload policy test_cancel_query_policy properties('workload_group'='policy_group');"
+                            sql "alter workload policy test_cancel_query_policy2 properties('workload_group'='policy_group2');"
                         }
                         flag = true
                     }


### PR DESCRIPTION
Rename workload schedule policy to workload policy,  main changes are in the following aspects:
1 rename metadata class, this may cause upgrade failed if user config policy.
2 rename thrift class.
3 rename schema table from workload_schedule_policy to workload policy.