### PR TITLE
[improvement](cloud-merge) Enables concurrent file downloads

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -36,6 +36,7 @@ enum class DownloadType {
 };
 
 struct JobMeta {
+    JobMeta() = default;
     JobMeta(const TJobMeta& meta);
     DownloadType download_type;
     std::string be_ip;

--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -113,7 +113,11 @@ void FileCacheBlockDownloader::polling_download_task() {
         if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
                                                              task.atime)
                     .count() < hot_interval) {
-            download_blocks(task);
+            auto st = _workers->submit_func(
+                    [this, task_ = std::move(task)]() mutable { download_blocks(task_); });
+            if (!st.ok()) {
+                LOG(WARNING) << "submit download blocks failed: " << st;
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Slow warm up job because only single thread download files.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

