### PR TITLE
[Enhancement] FE/BE print the node start time at startup

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -237,7 +237,7 @@ if [[ -f "${pidfile}" ]]; then
 fi
 
 chmod 550 "${DORIS_HOME}/lib/doris_be"
-echo "Start Time: $(date), Node uptime: $(uptime)" >> "${LOG_DIR}/be.out"
+echo "Start Time: $(date), Node uptime: $(uptime)" >>"${LOG_DIR}/be.out"
 
 if [[ ! -f '/bin/limit3' ]]; then
     LIMIT=''

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -237,7 +237,7 @@ if [[ -f "${pidfile}" ]]; then
 fi
 
 chmod 550 "${DORIS_HOME}/lib/doris_be"
-echo "Start time: $(date)" >>"${LOG_DIR}/be.out"
+echo "Start Time: $(date), Node uptime: $(uptime)" >> "${LOG_DIR}/be.out"
 
 if [[ ! -f '/bin/limit3' ]]; then
     LIMIT=''

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -239,7 +239,7 @@ if [[ -n "${JACOCO_COVERAGE_OPT}" ]]; then
     coverage_opt="${JACOCO_COVERAGE_OPT}"
 fi
 
-echo "Start Time: $(date), Node uptime: $(uptime)" >> "${LOG_DIR}/fe.out"
+echo "Start Time: $(date), Node uptime: $(uptime)" >>"${LOG_DIR}/fe.out"
 
 if [[ "${HELPER}" != "" ]]; then
     # change it to '-helper' to be compatible with code in Frontend

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -239,7 +239,7 @@ if [[ -n "${JACOCO_COVERAGE_OPT}" ]]; then
     coverage_opt="${JACOCO_COVERAGE_OPT}"
 fi
 
-date >>"${LOG_DIR}/fe.out"
+echo "Start Time: $(date), Node uptime: $(uptime)" >> "${LOG_DIR}/fe.out"
 
 if [[ "${HELPER}" != "" ]]; then
     # change it to '-helper' to be compatible with code in Frontend


### PR DESCRIPTION
## Proposed changes
When FE/BE restarts we cannot know if FE/BE restarted due to node restart or process restart

Issue Number: close #35003 

Add node uptime to FE/BE out file during startup

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

