### PR TITLE
Fix broken links in CONTRIBUTING guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Any questions, you can contact us to get timely answers, including dev mail list
 For the first time in Doris community, you can:
 
 * Follow [Doris GitHub](https://github.com/apache/doris)
-* Subscribe to our [mailing list](./docs/en/community/subscribe-mail-list.md);
+* Subscribe to our [mailing list](https://doris.apache.org/community/subscribe-mail-list/);
 * Join Doris [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
 
 Learn the development trends of Doris project in time and give your opinions on the topics you are concerned about.
@@ -58,18 +58,18 @@ Browse the document, you can deepen your understanding of Doris, can also help y
 
 If you are interested in improving the quality of documents, whether it is revising the address of a page, correcting a link, and writing a better introductory document, we are very welcome!
 
-Most of our documents are written in Markdown format, and you can modify and submit document changes directly through `docs/` in [GitHub](https://github.com/apache/doris). If you submit code changes, you can refer to [Pull Request](./docs/en/community/how-to-contribute/pull-request.md).
+Most of our documents are written in Markdown format, and you can modify and submit document changes directly through `docs/` in [GitHub](https://github.com/apache/doris). If you submit code changes, you can refer to [Pull Request](https://doris.apache.org/community/how-to-contribute/pull-request/).
 
 ## If a Bug or problem is found
 
 If a Bug or problem is found, you can directly raise a new Issue through GitHub's [Issues](https://github.com/apache/doris/issues/new/choose), and we will have someone deal with it regularly.
 
-You can also fix it yourself by reading the analysis code (of course, it's better to talk to us before that, maybe someone has fixed the same problem) and submit a [Pull Request](./docs/en/community/how-to-contribute/pull-request.md).
+You can also fix it yourself by reading the analysis code (of course, it's better to talk to us before that, maybe someone has fixed the same problem) and submit a [Pull Request](https://doris.apache.org/community/how-to-contribute/pull-request/).
 
 ## Modify the code and submit PR (Pull Request)
 
-You can download the code, compile and install it, deploy and run it for a try (refer to the [compilation document](./docs/en/installing/compilation.md)) to see if it works as you expected. If you have problems, you can contact us directly, ask questions or fix them by reading and analyzing the source code.
+You can download the code, compile and install it, deploy and run it for a try (refer to the [compilation guides](https://doris.apache.org/docs/dev/install/source-install/compilation-with-docker)) to see if it works as you expected. If you have problems, you can contact us directly, ask questions or fix them by reading and analyzing the source code.
 
 Whether it's fixing Bugs or adding Features, we're all very welcome. If you want to submit code to Doris, you need to create a new branch for your submitted code from the fork code library on GitHub to your project space, add the source project upstream, and submit PR.
 
-About how to submit a PR refer to [Pull Request](./docs/en/community/how-to-contribute/pull-request.md).
+About how to submit a PR refer to [Pull Request](https://doris.apache.org/community/how-to-contribute/pull-request/).

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -32,7 +32,7 @@ under the License.
 初次来到 Doris 社区，您可以：
 
 * 关注 Doris [GitHub 代码库](https://github.com/apache/doris)
-* 订阅我们的 [邮件列表](./docs/zh-CN/community/subscribe-mail-list.md)；
+* 订阅我们的 [邮件列表](https://doris.apache.org/zh-CN/community/subscribe-mail-list/)；
 * 加入 Doris 的 [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
 
 通过以上方式及时了解 Doris 项目的开发动态并为您关注的话题发表意见。
@@ -58,17 +58,17 @@ under the License.
 
 如果您对改进文档的质量感兴趣，不论是修订一个页面的地址、更正一个链接、以及写一篇更优秀的入门文档，我们都非常欢迎！
 
-我们的文档大多数是使用 Markdown 格式编写的，您可以直接通过在 [GitHub](https://github.com/apache/doris) 中的 `docs/` 中修改并提交文档变更。如果提交代码变更，可以参阅 [Pull Request](./docs/zh-CN/community/how-to-contribute/pull-request.md)。
+我们的文档大多数是使用 Markdown 格式编写的，您可以直接通过在 [GitHub](https://github.com/apache/doris) 中的 `docs/` 中修改并提交文档变更。如果提交代码变更，可以参阅 [Pull Request](https://doris.apache.org/zh-CN/community/how-to-contribute/pull-request/)。
 
 ## 如果发现了一个 Bug 或问题
 
 如果发现了一个 Bug 或问题，您可以直接通过 GitHub 的 [Issues](https://github.com/apache/doris/issues/new/choose) 提一个新的 Issue，我们会有人定期处理。
 
-您也可以通过阅读分析代码自己修复（当然在这之前最好能和我们交流下，或许已经有人在修复同样的问题了），然后提交一个 [Pull Request](./docs/zh-CN/community/how-to-contribute/pull-request.md)。
+您也可以通过阅读分析代码自己修复（当然在这之前最好能和我们交流下，或许已经有人在修复同样的问题了），然后提交一个 [Pull Request](https://doris.apache.org/zh-CN/community/how-to-contribute/pull-request/)。
 
 ## 修改代码和提交PR（Pull Request）
 
-您可以下载代码，编译安装，部署运行试一试（可以参考 [编译文档](./docs/zh-CN/installing/compilation.md)），看看是否与您预想的一样工作。如果有问题，您可以直接联系我们，提 Issue 或者通过阅读和分析源代码自己修复。
+您可以下载代码，编译安装，部署运行试一试（可以参考 [编译文档](https://doris.apache.org/zh-CN/docs/dev/install/source-install/compilation-with-docker/)），看看是否与您预想的一样工作。如果有问题，您可以直接联系我们，提 Issue 或者通过阅读和分析源代码自己修复。
 
 无论是修复 Bug 还是增加 Feature，我们都非常欢迎。如果您希望给 Doris 提交代码，您需要从 GitHub 上 fork 代码库至您的项目空间下，为您提交的代码创建一个新的分支，添加源项目为upstream，并提交PR。
-提交PR的方式可以参考文档 [Pull Request](./docs/zh-CN/community/how-to-contribute/pull-request.md)。
+提交PR的方式可以参考文档 [Pull Request](https://doris.apache.org/zh-CN/community/how-to-contribute/pull-request/)。


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The links to internal markdown pages were broken. Replace them with the public urls.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

