### PR TITLE
[pipeline](fix) Logging blocking dependency if task is not cancelled

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -405,13 +405,12 @@ std::string PipelineTask::debug_string() {
                    print_id(_state->fragment_instance_id()));
 
     auto elapsed = (MonotonicNanos() - _fragment_context->create_time()) / 1000000000.0;
+    auto* cur_blocked_dep = _blocked_dep;
     fmt::format_to(debug_string_buffer,
                    "PipelineTask[this = {}, state = {}, dry run = {}, elapse time "
                    "= {}s], block dependency = {}, is running = {}\noperators: ",
                    (void*)this, get_state_name(_cur_state), _dry_run, elapsed,
-                   _blocked_dep && !_finished && !_state->is_cancelled()
-                           ? _blocked_dep->debug_string()
-                           : "NULL",
+                   cur_blocked_dep && !_finished ? cur_blocked_dep->debug_string() : "NULL",
                    is_running());
     for (size_t i = 0; i < _operators.size(); i++) {
         fmt::format_to(debug_string_buffer, "\n{}",

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -409,7 +409,9 @@ std::string PipelineTask::debug_string() {
                    "PipelineTask[this = {}, state = {}, dry run = {}, elapse time "
                    "= {}s], block dependency = {}, is running = {}\noperators: ",
                    (void*)this, get_state_name(_cur_state), _dry_run, elapsed,
-                   _blocked_dep && !_finished ? _blocked_dep->debug_string() : "NULL",
+                   _blocked_dep && !_finished && !_state->is_cancelled()
+                           ? _blocked_dep->debug_string()
+                           : "NULL",
                    is_running());
     for (size_t i = 0; i < _operators.size(); i++) {
         fmt::format_to(debug_string_buffer, "\n{}",


### PR DESCRIPTION
## Proposed changes

If thread 1 executes this pipeline task and finds it has been cancelled, it will clear the `_blocked_dep`. If at the same time FE cancel this pipeline task and logging `debug_string` before `_blocked_dep` is cleared, it will think  `_blocked_dep` is not nullptr and call `_blocked_dep->debug_string()`.

*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1715117028 (unix time) try "date -d @1715117028" if you are using GNU date ***
*** Current BE git commitID: dec5f0ca98 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 2952012 (TID 2955974 OR 0x7f92cac2e700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F9A91C770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F9A91C7002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F9A9A10D090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::pipeline::PipelineXTask::debug_string[abi:cxx11]() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:406
 6# doris::pipeline::PipelineXFragmentContext::debug_string[abi:cxx11]() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:1430
 7# doris::pipeline::PipelineXFragmentContext::cancel(doris::PPlanFragmentCancelReason const&, std::__cxx11::basic_string, std::allocator > const&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:146
 8# doris::QueryContext::cancel_pipeline_context(int, doris::PPlanFragmentCancelReason const&, std::__cxx11::basic_string, std::allocator > const&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/query_context.cpp:243
 9# doris::FragmentMgr::cancel_fragment(doris::TUniqueId const&, int, doris::PPlanFragmentCancelReason const&, std::__cxx11::basic_string, std::allocator > const&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:1072
10# doris::PInternalServiceImpl::cancel_plan_fragment(google::protobuf::RpcController*, doris::PCancelPlanFragmentRequest const*, doris::PCancelPlanFragmentResult*, google::protobuf::Closure*)::$_0::operator()() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/internal_service.cpp:593
11# void std::__invoke_impl(std::__invoke_other, doris::PInternalServiceImpl::cancel_plan_fragment(google::protobuf::RpcController*, doris::PCancelPlanFragmentRequest const*, doris::PCancelPlanFragmentResult*, google::protobuf::Closure*)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
12# std::enable_if, void>::type std::__invoke_r(doris::PInternalServiceImpl::cancel_plan_fragment(google::protobuf::RpcController*, doris::PCancelPlanFragmentRequest const*, doris::PCancelPlanFragmentResult*, google::protobuf::Closure*)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
13# std::_Function_handler::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
14# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
15# doris::WorkThreadPool::work_thread(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:158
16# void std::__invoke_impl::* const&)(int), doris::WorkThreadPool*&, int&>(std::__invoke_memfun_deref, void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
17# std::__invoke_result::* const&)(int), doris::WorkThreadPool*&, int&>::type std::__invoke::* const&)(int), doris::WorkThreadPool*&, int&>(void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
18# decltype (std::__invoke((*this)._M_pmf, std::forward*&>({parm#1}), std::forward({parm#1}))) std::_Mem_fn_base::*)(int), true>::operator()*&, int&>(doris::WorkThreadPool*&, int&) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:131
19# void std::__invoke_impl::*)(int)>&, doris::WorkThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
20# std::enable_if::*)(int)>&, doris::WorkThreadPool*&, int&>, void>::type std::__invoke_r::*)(int)>&, doris::WorkThreadPool*&, int&>(std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
21# void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
22# void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::operator()<>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
23# void std::__invoke_impl::*)(int)> (doris::WorkThreadPool*, int)>>(std::__invoke_other, std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
24# std::__invoke_result::*)(int)> (doris::WorkThreadPool*, int)>>::type std::__invoke::*)(int)> (doris::WorkThreadPool*, int)>>(std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
25# void std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253
26# std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)> > >::operator()() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260
27# std::thread::_State_impl::*)(int)> (doris::WorkThreadPool*, int)> > > >::_M_run() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211
28# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
29# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
30# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

