### PR TITLE
[improve](restore) Release useless info for the finished job to reduce mem usage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
@@ -788,6 +788,20 @@ public class BackupJobInfo implements Writable {
         return getBrief();
     }
 
+    public void releaseSnapshotInfo() {
+        tabletBeMap.clear();
+        tabletSnapshotPathMap.clear();
+        for (BackupOlapTableInfo tableInfo : backupOlapTableObjects.values()) {
+            for (BackupPartitionInfo partInfo : tableInfo.partitions.values()) {
+                for (BackupIndexInfo indexInfo : partInfo.indexes.values()) {
+                    for (BackupTabletInfo tabletInfo : indexInfo.sortedTabletInfoList) {
+                        tabletInfo.files.clear();
+                    }
+                }
+            }
+        }
+    }
+
     public static BackupJobInfo read(DataInput in) throws IOException {
         return BackupJobInfo.readFields(in);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreFileMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreFileMapping.java
@@ -156,6 +156,11 @@ public class RestoreFileMapping implements Writable {
         return mapping;
     }
 
+    public void clear() {
+        mapping.clear();
+        overwriteMap.clear();
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         out.writeInt(mapping.size());

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1804,6 +1804,8 @@ public class RestoreJob extends AbstractJob {
             releaseSnapshots();
 
             snapshotInfos.clear();
+            fileMapping.clear();
+            jobInfo.releaseSnapshotInfo();
 
             finishedTime = System.currentTimeMillis();
             state = RestoreJobState.FINISHED;
@@ -1996,6 +1998,9 @@ public class RestoreJob extends AbstractJob {
             releaseSnapshots();
 
             snapshotInfos.clear();
+            fileMapping.clear();
+            jobInfo.releaseSnapshotInfo();
+
             RestoreJobState curState = state;
             finishedTime = System.currentTimeMillis();
             state = RestoreJobState.CANCELLED;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The info about snapshot files is not visible in the result of `SHOW RESTORE`, but it costs a lot of memory.

![image](https://github.com/apache/doris/assets/7908062/bc02712d-3879-44d5-8b2b-bead6381919d)

Here is an example of a restore job about a large table, the main memory usage is in :

- jobInfo
  - backupOlapTableObjects
  - tabletBeMap
  - tabletSnapshotPathMap
- fileMapping
  - mapping
  - overwriteMap
  
This PR clear these fields when task is finished/cancelled, to reduce the memory usage.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

