### PR TITLE
[branch-2.1](cherry-pick)fix refresh failed when not use db before create MTMV (#34…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
@@ -19,11 +19,12 @@ package org.apache.doris.mtmv;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.TableIf.TableType;
-import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.nereids.NereidsPlanner;
@@ -48,24 +49,52 @@ import java.util.Set;
 
 public class MTMVPlanUtil {
 
-    public static ConnectContext createMTMVContext(MTMV mtmv) throws AnalysisException {
+    public static ConnectContext createMTMVContext(MTMV mtmv) {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(Env.getCurrentEnv());
         ctx.setQualifiedUser(Auth.ADMIN_USER);
         ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
         ctx.getState().reset();
         ctx.setThreadLocalInfo();
-        CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr()
-                .getCatalogOrAnalysisException(mtmv.getEnvInfo().getCtlId());
-        ctx.changeDefaultCatalog(catalog.getName());
-        ctx.setDatabase(catalog.getDbOrAnalysisException(mtmv.getEnvInfo().getDbId()).getFullName());
         ctx.getSessionVariable().enableFallbackToOriginalPlanner = false;
+        ctx.getSessionVariable().enableNereidsDML = true;
         Optional<String> workloadGroup = mtmv.getWorkloadGroup();
         if (workloadGroup.isPresent()) {
             ctx.getSessionVariable().setWorkloadGroup(workloadGroup.get());
         }
-        ctx.getSessionVariable().enableNereidsDML = true;
+        // switch catalog;
+        CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(mtmv.getEnvInfo().getCtlId());
+        // if catalog not exist, it may not have any impact, so there is no error and it will be returned directly
+        if (catalog == null) {
+            return ctx;
+        }
+        ctx.changeDefaultCatalog(catalog.getName());
+        // use db
+        Optional<? extends DatabaseIf<? extends TableIf>> databaseIf = catalog.getDb(mtmv.getEnvInfo().getDbId());
+        // if db not exist, it may not have any impact, so there is no error and it will be returned directly
+        if (!databaseIf.isPresent()) {
+            return ctx;
+        }
+        ctx.setDatabase(databaseIf.get().getFullName());
         return ctx;
+    }
+
+    public static Pair<Boolean, String> checkEnvInfo(EnvInfo envInfo, ConnectContext ctx) {
+        if (envInfo.getCtlId() != ctx.getCurrentCatalog().getId()) {
+            return Pair.of(false, String.format(
+                    "The catalog selected when creating the materialized view was %s, "
+                            + "but now this catalog has been deleted. "
+                            + "Please recreate the materialized view.",
+                    envInfo.getCtlId()));
+        }
+        if (envInfo.getDbId() != ctx.getCurrentDbId()) {
+            return Pair.of(false, String.format(
+                    "The database selected when creating the materialized view was %s, "
+                            + "but now this database has been deleted. "
+                            + "Please recreate the materialized view.",
+                    envInfo.getDbId()));
+        }
+        return Pair.of(true, "");
     }
 
     public static MTMVRelation generateMTMVRelation(MTMV mtmv, ConnectContext ctx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/TableCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/TableCollector.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.visitor;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.TableIf.TableType;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.mtmv.MTMVPlanUtil;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -73,17 +72,8 @@ public class TableCollector extends DefaultPlanVisitor<Plan, TableCollectorConte
         if (!context.isExpand()) {
             return;
         }
-        try {
-            MTMVCache expandedMv = MTMVCache.from(mtmv, MTMVPlanUtil.createMTMVContext(mtmv));
-            expandedMv.getLogicalPlan().accept(this, context);
-        } catch (AnalysisException e) {
-            LOG.error(String.format(
-                    "table collector expand fail, mtmv name is %s, targetTableTypes is %s",
-                    mtmv.getName(), context.targetTableTypes), e);
-            throw new org.apache.doris.nereids.exceptions.AnalysisException(
-                    String.format("expand mv and collect table fail, mv name is %s, mv sql is %s",
-                            mtmv.getName(), mtmv.getQuerySql()), e);
-        }
+        MTMVCache expandedMv = MTMVCache.from(mtmv, MTMVPlanUtil.createMTMVContext(mtmv));
+        expandedMv.getLogicalPlan().accept(this, context);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
@@ -283,14 +283,14 @@ public class DecommissionBackendTest extends TestWithFeService {
                 + "DISTRIBUTED BY HASH(`c2`) BUCKETS 1\n"
                 + ";");
 
-        createMvByNereids("create materialized view db4.mv1 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
+        createMvByNereids("create materialized view db4.mv1 BUILD DEFERRED REFRESH COMPLETE ON MANUAL\n"
                 + "DISTRIBUTED BY RANDOM BUCKETS 1\n"
                 + "as "
                 + "select t1.c1, t2.c2, t2.k4 "
                 + "from db4.table1 t1 "
                 + "inner join db4.table2 t2 on t1.c1= t2.c2;");
 
-        createMvByNereids("create materialized view db4.mv2 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
+        createMvByNereids("create materialized view db4.mv2 BUILD DEFERRED REFRESH COMPLETE ON MANUAL\n"
                 + "DISTRIBUTED BY HASH(c1) BUCKETS 20 \n"
                 + "PROPERTIES ( 'colocate_with' = 'foo', 'replication_num' = '3' ) "
                 + "as "

--- a/regression-test/suites/mtmv_p0/test_env_db_dropped_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_env_db_dropped_mtmv.groovy
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_env_db_dropped_mtmv") {
+    def tableName = "t_test_env_db_dropped_mtmv_user"
+    def mvName = "test_env_db_dropped_mtmv"
+    def dbName1 = "test_env_db_dropped_mtmv_db1"
+    def dbName2 = "test_env_db_dropped_mtmv_db2"
+    sql """drop database if exists `${dbName1}`"""
+    sql """drop database if exists `${dbName2}`"""
+    sql """create database `${dbName1}`"""
+    sql """create database `${dbName2}`"""
+    sql """use `${dbName1}`"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${dbName2}.${tableName} (
+            event_day DATE,
+            id BIGINT,
+            username VARCHAR(20)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 10 
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+
+    sql """
+        CREATE MATERIALIZED VIEW ${dbName2}.${mvName}
+        BUILD DEFERRED REFRESH COMPLETE ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1') 
+        AS 
+        SELECT * FROM ${dbName2}.${tableName};
+    """
+    def jobName = getJobName(dbName2, mvName);
+
+    // table and mv in db2, so drop db1, should success
+    sql """drop database if exists `${dbName1}`"""
+    sql """
+            REFRESH MATERIALIZED VIEW ${dbName2}.${mvName} AUTO;
+        """
+    waitingMTMVTaskFinished(jobName)
+
+    sql """
+        DROP MATERIALIZED VIEW ${dbName2}.${mvName};
+    """
+
+    sql """create database `${dbName1}`"""
+    sql """use `${dbName1}`"""
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            event_day DATE,
+            id BIGINT,
+            username VARCHAR(20)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 10
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+    sql """
+        CREATE MATERIALIZED VIEW ${dbName2}.${mvName}
+        BUILD DEFERRED REFRESH COMPLETE ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS
+        SELECT * FROM ${tableName};
+    """
+    jobName = getJobName(dbName2, mvName);
+    sql """drop database if exists `${dbName1}`"""
+    // table in db1, has been dropped, will error
+    sql """
+            REFRESH MATERIALIZED VIEW ${dbName2}.${mvName} AUTO;
+        """
+    waitingMTMVTaskFinishedNotNeedSuccess(jobName)
+    def msg = sql """select ErrorMsg from tasks('type'='mv') where JobName = '${jobName}' order by CreateTime DESC limit 1"""
+    logger.info(msg.toString())
+    assertTrue(msg.toString().contains("has been deleted"))
+}


### PR DESCRIPTION
…431)

when create MTMV,we will save current ctl and db.

when refresh MTMV,will create an ConnectContext, and set same ctl, db to ctx

when db,ctx dropped, task will be failed.

But sometimes deleting a db does not actually have an impact, so changing it to not directly fail. If refreshing the data does cause an error, then giving the user an error message

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

