### PR TITLE
[Improve] Estimated column reader memory to control segment cache

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1053,6 +1053,7 @@ DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
 // max number of segment cache, default -1 for backward compatibility fd_number*2/5
 DEFINE_mInt32(segment_cache_capacity, "-1");
+DEFINE_mInt32(each_segment_have_columns, "30");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1053,7 +1053,8 @@ DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
 // max number of segment cache, default -1 for backward compatibility fd_number*2/5
 DEFINE_mInt32(segment_cache_capacity, "-1");
-DEFINE_mInt32(each_segment_have_columns, "30");
+DEFINE_mInt32(estimated_num_columns_per_segment, "30");
+DEFINE_mInt32(estimated_mem_per_column_reader, "1024");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1055,6 +1055,8 @@ DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 DEFINE_mInt32(segment_cache_capacity, "-1");
 DEFINE_mInt32(estimated_num_columns_per_segment, "30");
 DEFINE_mInt32(estimated_mem_per_column_reader, "1024");
+// The value is calculate by storage_page_cache_limit * index_page_cache_percentage
+DEFINE_mInt32(segment_cache_memory_percentage, "2");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1099,7 +1099,8 @@ DECLARE_mInt32(schema_cache_sweep_time_sec);
 
 // max number of segment cache
 DECLARE_mInt32(segment_cache_capacity);
-DECLARE_mInt32(each_segment_have_columns);
+DECLARE_mInt32(estimated_num_columns_per_segment);
+DECLARE_mInt32(estimated_mem_per_column_reader);
 
 // enable binlog
 DECLARE_Bool(enable_feature_binlog);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1101,6 +1101,7 @@ DECLARE_mInt32(schema_cache_sweep_time_sec);
 DECLARE_mInt32(segment_cache_capacity);
 DECLARE_mInt32(estimated_num_columns_per_segment);
 DECLARE_mInt32(estimated_mem_per_column_reader);
+DECLARE_Int32(segment_cache_memory_percentage);
 
 // enable binlog
 DECLARE_Bool(enable_feature_binlog);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1099,6 +1099,7 @@ DECLARE_mInt32(schema_cache_sweep_time_sec);
 
 // max number of segment cache
 DECLARE_mInt32(segment_cache_capacity);
+DECLARE_mInt32(each_segment_have_columns);
 
 // enable binlog
 DECLARE_Bool(enable_feature_binlog);

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -408,6 +408,7 @@ Status Segment::_create_column_readers(const SegmentFooterPB& footer) {
         RETURN_IF_ERROR(ColumnReader::create(opts, footer.columns(iter->second), footer.num_rows(),
                                              _file_reader, &reader));
         _column_readers.emplace(column.unique_id(), std::move(reader));
+        _meta_mem_usage += config::estimated_mem_per_column_reader;
     }
 
     // init by column path

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -185,6 +185,8 @@ public:
         return safe;
     }
 
+    const TabletSchemaSPtr& tablet_schema() { return _tablet_schema; }
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, RowsetId rowset_id, TabletSchemaSPtr tablet_schema);

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -213,11 +213,11 @@ private:
     uint32_t _segment_id;
     uint32_t _num_rows;
 
-    // only for tracking memory use by segment meta data such as footer or index page.
+    // 1. Tracking memory use by segment meta data such as footer or index page.
+    // 2. Tracking memory use by segment column reader
     // The memory consumed by querying is tracked in segment iterator.
     // TODO: Segment::_meta_mem_usage Unknown value overflow, causes the value of SegmentMeta mem tracker
     // is similar to `-2912341218700198079`. So, temporarily put it in experimental type tracker.
-    // maybe have to use ColumnReader count as segment meta size.
     int64_t _meta_mem_usage;
 
     RowsetId _rowset_id;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -39,8 +39,9 @@ bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle*
 
 void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::CacheValue& value,
                           SegmentCacheHandle* handle) {
-    auto* lru_handle = LRUCachePolicy::insert(
-            key.encode(), &value, 1, value.segment->meta_mem_usage(), CachePriority::NORMAL);
+    auto* lru_handle =
+            LRUCachePolicy::insert(key.encode(), &value, value.segment->meta_mem_usage(),
+                                   value.segment->meta_mem_usage(), CachePriority::NORMAL);
     handle->push_segment(this, lru_handle);
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -81,7 +81,7 @@ public:
     };
 
     SegmentCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, capacity, LRUCacheType::NUMBER,
+            : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, capacity, LRUCacheType::SIZE,
                              config::tablet_rowset_stale_sweep_time_sec) {}
 
     // Lookup the given segment in the cache.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -488,7 +488,7 @@ Status ExecEnv::_init_mem_env() {
     }
     LOG(INFO) << "segment_cache_capacity <= fd_number * 2 / 5, fd_number: " << fd_number
               << " segment_cache_capacity: " << segment_cache_capacity;
-    _segment_loader = new SegmentLoader(segment_cache_capacity);
+    _segment_loader = new SegmentLoader(segment_cache_capacity * config::each_segment_have_columns);
 
     _schema_cache = new SchemaCache(config::schema_cache_capacity);
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -488,7 +488,9 @@ Status ExecEnv::_init_mem_env() {
     }
     LOG(INFO) << "segment_cache_capacity <= fd_number * 2 / 5, fd_number: " << fd_number
               << " segment_cache_capacity: " << segment_cache_capacity;
-    _segment_loader = new SegmentLoader(segment_cache_capacity * config::each_segment_have_columns);
+    _segment_loader =
+            new SegmentLoader(segment_cache_capacity * config::estimated_num_columns_per_segment *
+                              config::estimated_mem_per_column_reader);
 
     _schema_cache = new SchemaCache(config::schema_cache_capacity);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
If a segment has many columns, it will use a lot more memory than a segment with few columns, but it is not observable at present. So we estimated column reader memory to to control the memory.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

