### PR TITLE
[fix](session) fix select * from variables system table

### DIFF
--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -41,8 +41,7 @@ std::vector<SchemaScanner::ColumnDesc> SchemaVariablesScanner::_s_vars_columns =
         {"VARIABLE_NAME", TYPE_VARCHAR, sizeof(StringRef), false},
         {"VARIABLE_VALUE", TYPE_VARCHAR, sizeof(StringRef), false},
         {"DEFAULT_VALUE", TYPE_VARCHAR, sizeof(StringRef), false},
-        {"CHANGED", TYPE_VARCHAR, sizeof(StringRef), false}
-};
+        {"CHANGED", TYPE_VARCHAR, sizeof(StringRef), false}};
 
 SchemaVariablesScanner::SchemaVariablesScanner(TVarType::type type)
         : SchemaScanner(_s_vars_columns, TSchemaTableType::SCH_VARIABLES), _type(type) {}

--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -40,6 +40,8 @@ std::vector<SchemaScanner::ColumnDesc> SchemaVariablesScanner::_s_vars_columns =
         //   name,       type,          size
         {"VARIABLE_NAME", TYPE_VARCHAR, sizeof(StringRef), false},
         {"VARIABLE_VALUE", TYPE_VARCHAR, sizeof(StringRef), false},
+        {"DEFAULT_VALUE", TYPE_VARCHAR, sizeof(StringRef), false},
+        {"CHANGED", TYPE_VARCHAR, sizeof(StringRef), false}
 };
 
 SchemaVariablesScanner::SchemaVariablesScanner(TVarType::type type)
@@ -94,7 +96,7 @@ Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
         std::vector<StringRef> strs(row_num);
         int idx = 0;
         for (auto& it : _var_result.variables) {
-            strs[idx] = StringRef(it.first.c_str(), it.first.size());
+            strs[idx] = StringRef(it[0].c_str(), it[0].size());
             datas[idx] = strs.data() + idx;
             ++idx;
         }
@@ -105,11 +107,33 @@ Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
         std::vector<StringRef> strs(row_num);
         int idx = 0;
         for (auto& it : _var_result.variables) {
-            strs[idx] = StringRef(it.second.c_str(), it.second.size());
+            strs[idx] = StringRef(it[1].c_str(), it[1].size());
             datas[idx] = strs.data() + idx;
             ++idx;
         }
         RETURN_IF_ERROR(fill_dest_column_for_range(block, 1, datas));
+    }
+    // default value
+    {
+        std::vector<StringRef> strs(row_num);
+        int idx = 0;
+        for (auto& it : _var_result.variables) {
+            strs[idx] = StringRef(it[2].c_str(), it[2].size());
+            datas[idx] = strs.data() + idx;
+            ++idx;
+        }
+        RETURN_IF_ERROR(fill_dest_column_for_range(block, 2, datas));
+    }
+    // changed
+    {
+        std::vector<StringRef> strs(row_num);
+        int idx = 0;
+        for (auto& it : _var_result.variables) {
+            strs[idx] = StringRef(it[3].c_str(), it[3].size());
+            datas[idx] = strs.data() + idx;
+            ++idx;
+        }
+        RETURN_IF_ERROR(fill_dest_column_for_range(block, 3, datas));
     }
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -957,18 +957,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TShowVariableResult showVariables(TShowVariableRequest params) throws TException {
         TShowVariableResult result = new TShowVariableResult();
-        Map<String, String> map = Maps.newHashMap();
-        result.setVariables(map);
+        List<List<String>> vars = Lists.newArrayList();
+        result.setVariables(vars);
         // Find connect
         ConnectContext ctx = exeEnv.getScheduler().getContext((int) params.getThreadId());
         if (ctx == null) {
             return result;
         }
-        List<List<String>> rows = VariableMgr.dump(SetType.fromThrift(params.getVarType()), ctx.getSessionVariable(),
-                null);
-        for (List<String> row : rows) {
-            map.put(row.get(0), row.get(1));
-        }
+        vars = VariableMgr.dump(SetType.fromThrift(params.getVarType()), ctx.getSessionVariable(), null);
+        result.setVariables(vars);
         return result;
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -105,7 +105,7 @@ struct TShowVariableRequest {
 
 // Results of a call to describeTable()
 struct TShowVariableResult {
-    1: required map<string, string> variables
+    1: required list<list<string>> variables
 }
 
 // Valid table file formats

--- a/regression-test/data/variable_p0/set_and_unset_variable.out
+++ b/regression-test/data/variable_p0/set_and_unset_variable.out
@@ -135,6 +135,9 @@ deprecated_enable_local_exchange	true	true	0
 show_hidden_columns	false	false	0
 
 -- !cmd --
+show_hidden_columns	false	false	0
+
+-- !cmd --
 0
 
 -- !cmd --
@@ -157,6 +160,9 @@ experimental_enable_agg_state	false	false	0
 
 -- !cmd --
 deprecated_enable_local_exchange	true	true	0
+
+-- !cmd --
+show_hidden_columns	false	false	0
 
 -- !cmd --
 show_hidden_columns	false	false	0

--- a/regression-test/suites/variable_p0/set_and_unset_variable.groovy
+++ b/regression-test/suites/variable_p0/set_and_unset_variable.groovy
@@ -73,6 +73,8 @@ suite("set_and_unset_variable") {
     qt_cmd """show session variables like 'deprecated_enable_local_exchange'"""
     qt_cmd """show session variables like 'show_hidden_columns'"""
 
+    qt_cmd """select * from information_schema.session_variables where variable_name = 'show_hidden_columns'"""
+
     // test UNSET GLOBAL VARIABLE ALL
     qt_cmd """set global runtime_filter_type='BLOOM_FILTER'"""
     qt_cmd """set global experimental_enable_agg_state='true'"""
@@ -83,6 +85,8 @@ suite("set_and_unset_variable") {
     qt_cmd """show global variables like 'experimental_enable_agg_state'"""
     qt_cmd """show global variables like 'deprecated_enable_local_exchange'"""
     qt_cmd """show global variables like 'show_hidden_columns'"""
+
+    qt_cmd """select * from information_schema.global_variables where variable_name = 'show_hidden_columns'"""
 
     // test read_only
     qt_cmd """show variables like 'read_only'"""


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

after #23017, information_schema.session_variables and information_schema.global_variables had 2 new columns, but SchemaVariablesScanner just 2 columns. when select * from *_variables,will get 'no match column for this column' error

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

