### PR TITLE
[fix](Nereids) AnalyzeTblStmt should fail when disabling fallback_to_original_planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.AnalyzeTblStmt;
 import org.apache.doris.analysis.CreateTableAsSelectStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DeleteStmt;
@@ -315,7 +316,8 @@ public abstract class ConnectProcessor {
                 || s instanceof UpdateStmt
                 || s instanceof DeleteStmt
                 || s instanceof CreateTableAsSelectStmt
-                || s instanceof CreateTableStmt)) {
+                || s instanceof CreateTableStmt
+                || s instanceof AnalyzeTblStmt)) {
             String errMsg;
             Throwable exception = null;
             if (nereidsParseException != null) {


### PR DESCRIPTION
## Proposed changes

https://github.com/apache/doris/pull/32882 disable fallback_to_original_planner by default. I think we have not Implemented `AnalyzeTblStmt ` syntax in Nereids. Before we implement it in Nereids, We need to throw ex when turning off `fallback_to_original_planner`.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

