### PR TITLE
[fix](txn insert) Txn insert stuck if execute on observer fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -1161,7 +1161,7 @@ public class NativeInsertStmt extends InsertStmt {
 
     @Override
     public RedirectStatus getRedirectStatus() {
-        if (isExplain() || isGroupCommit()) {
+        if (isExplain() || isGroupCommit() || (ConnectContext.get() != null && ConnectContext.get().isTxnModel())) {
             return RedirectStatus.NO_FORWARD;
         } else {
             return RedirectStatus.FORWARD_WITH_SYNC;

--- a/regression-test/suites/insert_p0/insert_group_commit_into.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into.groovy
@@ -47,7 +47,7 @@ suite("insert_group_commit_into") {
                 return true
             }
             retry++
-            if (retry >= 10) {
+            if (retry >= 20) {
                 return false
             }
         }


### PR DESCRIPTION
## Proposed changes

When client use txn insert in legacy planner and connect to observer fe, it will stuck. 
Because the packet is null and fe does not return to client.
The reason of packet is null is that the statement does not forward to master.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

