### PR TITLE
[Refactor](Sink) Remove is_append mode in table sink

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -85,10 +85,7 @@ public:
 
     Status init();
 
-    Status write(const vectorized::Block* block, const std::vector<int>& row_idxs,
-                 bool is_append = false);
-
-    Status append(const vectorized::Block* block);
+    Status write(const vectorized::Block* block, const std::vector<int>& row_idxs);
 
     // flush the last memtable to flush queue, must call it before build_rowset()
     Status close();

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -188,8 +188,7 @@ public:
                _flush_mem_tracker->consumption();
     }
     // insert tuple from (row_pos) to (row_pos+num_rows)
-    void insert(const vectorized::Block* block, const std::vector<int>& row_idxs,
-                bool is_append = false);
+    void insert(const vectorized::Block* block, const std::vector<int>& row_idxs);
 
     void shrink_memtable_by_agg();
 

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -229,7 +229,7 @@ public:
 
     Status open_wait();
 
-    Status add_block(vectorized::Block* block, const Payload* payload, bool is_append = false);
+    Status add_block(vectorized::Block* block, const Payload* payload);
 
     int try_send_and_fetch_status(RuntimeState* state,
                                   std::unique_ptr<ThreadPoolToken>& thread_pool_token);


### PR DESCRIPTION
Remove the is_append mode from the sink component due to the following reasons:

1. The performance improvement from this mode is relatively minor, approximately 10%, as demonstrated in previous benchmarks.
2. The mode complicates maintenance. It requires a separate data writing path to avoid copying, which increases complexity and poses a risk of potential data loss.

I've already test the compability with previous version

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

