### PR TITLE
[fix](replication_allocation) fix two problems for force_olap_table_replication_allocation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -636,7 +636,8 @@ public class DynamicPartitionUtil {
 
         // check replication_allocation first, then replciation_num
         ReplicaAllocation replicaAlloc = null;
-        if (properties.containsKey(DynamicPartitionProperty.REPLICATION_ALLOCATION)) {
+        if (!Config.force_olap_table_replication_allocation.isEmpty()
+                || properties.containsKey(DynamicPartitionProperty.REPLICATION_ALLOCATION)) {
             replicaAlloc = PropertyAnalyzer.analyzeReplicaAllocation(properties, "dynamic_partition");
             properties.remove(DynamicPartitionProperty.REPLICATION_ALLOCATION);
             analyzedProperties.put(DynamicPartitionProperty.REPLICATION_ALLOCATION, replicaAlloc.toCreateStmt());

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -169,9 +169,10 @@ public class UserPropertyMgr implements Writable {
         Set<Tag> tags = existProperty.getCopiedResourceTags();
         // only root and admin can return empty tag.
         // empty tag means user can access all backends.
-        // for normal user, if tag is empty, use default tag.
+        // for normal user, if tag is empty and not set force_olap_table_replication_allocation, use default tag.
         if (tags.isEmpty() && !(qualifiedUser.equalsIgnoreCase(Auth.ROOT_USER)
-                || qualifiedUser.equalsIgnoreCase(Auth.ADMIN_USER))) {
+                || qualifiedUser.equalsIgnoreCase(Auth.ADMIN_USER))
+                && Config.force_olap_table_replication_allocation.isEmpty()) {
             tags = Sets.newHashSet(Tag.DEFAULT_BACKEND_TAG);
         }
         return tags;


### PR DESCRIPTION
follow https://github.com/apache/doris/pull/32916

there are two problem:

1. create table failed while only dynamic_partition.replication_num is set, 
2. normal user(exclude root and admin) can not read and write, because of there default `resource_tag.location = default`

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

