### PR TITLE
[bug](config) Fix modifying `label_num_threshold` does not take effect

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2555,10 +2555,12 @@ public class Config extends ConfigBase {
     public static int http_load_submitter_max_worker_threads = 2;
 
     @ConfField(mutable = true, masterOnly = true, description = {
-            "load label个数阈值，超过该个数后，对于已经完成导入作业或者任务，其label会被删除，被删除的 label 可以被重用。",
+            "load label个数阈值，超过该个数后，对于已经完成导入作业或者任务，"
+            + "其label会被删除，被删除的 label 可以被重用。 值为 -1 时，表示此阈值不生效。",
             "The threshold of load labels' number. After this number is exceeded, "
                     + "the labels of the completed import jobs or tasks will be deleted, "
-                    + "and the deleted labels can be reused."
+                    + "and the deleted labels can be reused. "
+                    + "When the value is -1, it indicates no threshold."
     })
     public static int label_num_threshold = 2000;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -170,8 +170,6 @@ public class DatabaseTransactionMgr {
 
     private long lockReportingThresholdMs = Config.lock_reporting_threshold_ms;
 
-    private long maxFinalTxnsNum = Long.MAX_VALUE;
-
     private void readLock() {
         this.transactionLock.readLock().lock();
     }
@@ -195,9 +193,6 @@ public class DatabaseTransactionMgr {
         this.env = env;
         this.idGenerator = idGenerator;
         this.editLog = env.getEditLog();
-        if (Config.label_num_threshold >= 0) {
-            this.maxFinalTxnsNum = Config.label_num_threshold;
-        }
     }
 
     public long getDbId() {
@@ -1920,7 +1915,7 @@ public class DatabaseTransactionMgr {
                 break;
             }
         }
-        while (finalStatusTransactionStateDeque.size() > maxFinalTxnsNum
+        while ((Config.label_num_threshold > 0 && finalStatusTransactionStateDeque.size() > Config.label_num_threshold)
                 && numOfClearedTransaction < left) {
             TransactionState transactionState = finalStatusTransactionStateDeque.getFirst();
             if (transactionState.getFinishTime() != -1) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

How to reproduce:

1、

```
MySQL [test]> admin set frontend config ("label_num_threshold" = "5");
Query OK, 0 rows affected (0.00 sec)
```

2、And insert 6 times into a table.

3、check the number of completed transactions.

```
MySQL [test]> show proc '/transactions/{db_id}';
+----------+--------+
| State    | Number |
+----------+--------+
| running  | 0      |
| finished | 6      |
+----------+--------+
2 rows in set (0.01 sec)
```

You can see that even if the history of completed transactions exceeds the threshold, they have not been cleared yet.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

