### PR TITLE
[refine](profile) format pipeline WaitForDependencyTime

### DIFF
--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -68,14 +68,13 @@ Status ExchangeLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     const auto& queues = stream_recvr->sender_queues();
     deps.resize(queues.size());
     metrics.resize(queues.size());
-    static const std::string timer_name = "WaitForDependencyTime";
-    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, timer_name, 1);
+    ADD_LABEL_COUNTER_WITH_LEVEL(_runtime_profile, WaitForDependencyTime, 1);
     for (size_t i = 0; i < queues.size(); i++) {
         deps[i] = Dependency::create_shared(_parent->operator_id(), _parent->node_id(),
                                             "SHUFFLE_DATA_DEPENDENCY", state->get_query_ctx());
         queues[i]->set_dependency(deps[i]);
-        metrics[i] = _runtime_profile->add_nonzero_counter(fmt::format("WaitForData{}", i),
-                                                           TUnit ::TIME_NS, timer_name, 1);
+        metrics[i] = _runtime_profile->add_nonzero_counter(
+                fmt::format("WaitForData{}", i), TUnit ::TIME_NS, WaitForDependencyTime, 1);
     }
 
     return Status::OK();

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -422,8 +422,8 @@ Status PipelineXLocalState<SharedStateArg>::init(RuntimeState* state, LocalState
             _shared_state = info.le_state_map.at(_parent->operator_id()).first.get();
 
             _dependency = _shared_state->get_dep_by_channel_id(info.task_idx);
-            _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
-                    _runtime_profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
+            ADD_LABEL_COUNTER_WITH_LEVEL(_runtime_profile, WaitForDependencyTime, 1);
+            _wait_for_dependency_timer = add_dependency_timer(_dependency->name());
         } else if (info.shared_state) {
             // For UnionSourceOperator without children, there is no shared state.
             _shared_state = info.shared_state->template cast<SharedStateArg>();
@@ -431,8 +431,8 @@ Status PipelineXLocalState<SharedStateArg>::init(RuntimeState* state, LocalState
             _dependency = _shared_state->create_source_dependency(
                     _parent->operator_id(), _parent->node_id(), _parent->get_name(),
                     state->get_query_ctx());
-            _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
-                    _runtime_profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
+            ADD_LABEL_COUNTER_WITH_LEVEL(_runtime_profile, WaitForDependencyTime, 1);
+            _wait_for_dependency_timer = add_dependency_timer(_dependency->name());
         }
     }
 
@@ -510,8 +510,8 @@ Status PipelineXSinkLocalState<SharedState>::init(RuntimeState* state, LocalSink
                     _parent->dests_id().front(), _parent->node_id(), _parent->get_name(),
                     state->get_query_ctx());
         }
-        _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
-                _profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
+        ADD_LABEL_COUNTER_WITH_LEVEL(_profile, WaitForDependencyTime, 1);
+        _wait_for_dependency_timer = add_dependency_timer(_dependency->name());
     } else {
         _dependency = nullptr;
     }
@@ -591,9 +591,8 @@ Status AsyncWriterSink<Writer, Parent>::init(RuntimeState* state, LocalSinkState
     _async_writer_dependency = AsyncWriterDependency::create_shared(
             _parent->operator_id(), _parent->node_id(), state->get_query_ctx());
     _writer->set_dependency(_async_writer_dependency.get(), _finish_dependency.get());
-
-    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
-            _profile, "WaitForDependency[" + _async_writer_dependency->name() + "]Time", 1);
+    ADD_LABEL_COUNTER_WITH_LEVEL(_profile, WaitForDependencyTime, 1);
+    _wait_for_dependency_timer = add_dependency_timer(_async_writer_dependency->name());
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -61,7 +61,7 @@ using OperatorXPtr = std::shared_ptr<OperatorXBase>;
 using OperatorXs = std::vector<OperatorXPtr>;
 
 using DataSinkOperatorXPtr = std::shared_ptr<DataSinkOperatorXBase>;
-
+static const std::string WaitForDependencyTime = "WaitForDependencyTime";
 // This struct is used only for initializing local state.
 struct LocalStateInfo {
     RuntimeProfile* parent_profile = nullptr;
@@ -188,7 +188,9 @@ public:
     [[nodiscard]] virtual std::string debug_string(int indentation_level = 0) const = 0;
 
     virtual std::vector<Dependency*> dependencies() const { return {nullptr}; }
-
+    RuntimeProfile::Counter* add_dependency_timer(const std::string& name) {
+        return ADD_CHILD_TIMER_WITH_LEVEL(_runtime_profile, name, WaitForDependencyTime, 1);
+    }
     // override in Scan
     virtual Dependency* finishdependency() { return nullptr; }
     //  override in Scan  MultiCastSink
@@ -359,6 +361,10 @@ public:
     RuntimeProfile::Counter* rows_input_counter() { return _rows_input_counter; }
     RuntimeProfile::Counter* exec_time_counter() { return _exec_timer; }
     virtual std::vector<Dependency*> dependencies() const { return {nullptr}; }
+
+    RuntimeProfile::Counter* add_dependency_timer(const std::string& name) {
+        return ADD_CHILD_TIMER_WITH_LEVEL(_profile, name, WaitForDependencyTime, 1);
+    }
 
     // override in exchange sink , AsyncWriterSink
     virtual Dependency* finishdependency() { return nullptr; }

--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -35,8 +35,6 @@ Status ResultSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info)
     RETURN_IF_ERROR(Base::init(state, info));
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_init_timer);
-    static const std::string timer_name = "WaitForDependencyTime";
-    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_profile, timer_name, 1);
     auto fragment_instance_id = state->fragment_instance_id();
 
     _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -71,8 +71,8 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     _scan_dependency =
             Dependency::create_shared(_parent->operator_id(), _parent->node_id(),
                                       _parent->get_name() + "_DEPENDENCY", state->get_query_ctx());
-    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
-            _runtime_profile, "WaitForDependency[" + _scan_dependency->name() + "]Time", 1);
+    ADD_LABEL_COUNTER_WITH_LEVEL(_runtime_profile, WaitForDependencyTime, 1);
+    _wait_for_dependency_timer = add_dependency_timer(_scan_dependency->name());
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_init_timer);
     auto& p = _parent->cast<typename Derived::Parent>();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
@@ -67,7 +67,7 @@ public class AggCounter extends Counter {
                     + RuntimeProfile.MIN_TIME_PRE
                     + RuntimeProfile.printCounter(min.getValue(), min.getType());
             return infoString;
-        } else {
+        } else if (!isNoneType()) {
             Counter avg = new Counter(sum.getType(), sum.getValue());
             avg.divValue(number);
             String infoString = ""
@@ -80,6 +80,8 @@ public class AggCounter extends Counter {
                     + RuntimeProfile.MIN_TIME_PRE
                     + RuntimeProfile.printCounter(min.getValue(), min.getType());
             return infoString;
+        } else {
+            return RuntimeProfile.printCounter(0, getType());
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Counter.java
@@ -95,6 +95,11 @@ public class Counter {
         return ttype == TUnit.TIME_MS || ttype == TUnit.TIME_NS || ttype == TUnit.TIME_S;
     }
 
+    public boolean isNoneType() {
+        TUnit ttype = TUnit.findByValue(type);
+        return ttype == TUnit.NONE;
+    }
+
     public long getLevel() {
         return this.level;
     }


### PR DESCRIPTION
## Proposed changes

before
```
                          EXCHANGE_OPERATOR  (id=41):
                                -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                    -  WaitForData0:  avg  12s120ms,  max  12s120ms,  min  12s120ms
                          AGGREGATION_OPERATOR  (id=36):
                                -  WaitForDependency[AGGREGATION_OPERATOR_DEPENDENCY]Time:  avg  12s117ms,  max  12s118ms,  min  12s117ms
```

now

```
                          EXCHANGE_OPERATOR  (id=5):
                                -  WaitForDependencyTime:  
                                    -  WaitForData0:  avg  996.715ms,  max  996.715ms,  min  996.715ms
                          AGGREGATION_OPERATOR  (id=6):
                                -  WaitForDependencyTime:  
                                    -  AGGREGATION_OPERATOR_DEPENDENCY:  avg  996.569ms,  max  996.569ms,  min  996.569ms
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

