### PR TITLE
[bugfix](multi catalog) fixed an issue where the hive catalog field d…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
@@ -368,7 +368,11 @@ public class HiveScanNode extends FileQueryScanNode {
         TFileTextScanRangeParams textParams = new TFileTextScanRangeParams();
         java.util.Map<String, String> delimiter = hmsTable.getRemoteTable().getSd().getSerdeInfo().getParameters();
         if (delimiter.containsKey(PROP_FIELD_DELIMITER)) {
-            textParams.setColumnSeparator(delimiter.get(PROP_FIELD_DELIMITER));
+            if (delimiter.get(PROP_FIELD_DELIMITER).length() == 0) {
+                textParams.setColumnSeparator(DEFAULT_FIELD_DELIMITER);
+            } else {
+                textParams.setColumnSeparator(delimiter.get(PROP_FIELD_DELIMITER));
+            }
         } else if (delimiter.containsKey(PROP_SEPARATOR_CHAR)) {
             textParams.setColumnSeparator(delimiter.get(PROP_SEPARATOR_CHAR));
         } else {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
fixed an issue where the hive catalog field delimiter is an empty string, causing it to be core
1、hive build statement
```
CREATE TABLE `hive_q1`(
  `id` int, 
  `name` string)
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' 
WITH SERDEPROPERTIES ( 
  'field.delim'='', 
  'serialization.format'='') 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.mapred.TextInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
LOCATION
  'hdfs://HDFSxxxxx/usr/hive/warehouse/hive_q1'
TBLPROPERTIES (
  'transient_lastDdlTime'='1715175063')
```

2、problem
`When the field.delim attribute value is an empty string, the be core dumps because of the separator problem`

3、be stack
```
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) in /usr/local/service/doris/lib/be/doris_be
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/jdk/jre/lib/amd64/server/libjvm.so
 4# 0x00007F75D264E400 in /lib64/libc.so.6
 5# __memset_sse2 in /lib64/libc.so.6
 6# doris::vectorized::PlainCsvTextFieldSplitter::_split_field_multi_char(doris::Slice const&, std::vector<doris::Slice, std::allocator<doris::Slice> >*) in /usr/local/service/doris/lib/be/doris_be
 7# doris::vectorized::CsvReader::_line_split_to_values(doris::Slice const&, bool*) in /usr/local/service/doris/lib/be/doris_be
 8# doris::vectorized::CsvReader::_fill_dest_columns(doris::Slice const&, doris::vectorized::Block*, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, unsigned long*) in /usr/local/service/doris/lib/be/doris_be
 9# doris::vectorized::CsvReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) in /usr/local/service/doris/lib/be/doris_be
10# doris::vectorized::VFileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
11# doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
12# doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, std::shared_ptr<doris::vectorized::VScanner>) in /usr/local/service/doris/lib/be/doris_be
13# std::_Function_handler<void (), doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::$_1::operator()() const::{lambda()#4}>::_M_invoke(std::_Any_data const&) in /usr/local/service/doris/lib/be/doris_be
14# doris::WorkThreadPool<true>::work_thread(int) in /usr/local/service/doris/lib/be/doris_be
15# execute_native_thread_routine in /usr/local/service/doris/lib/be/doris_be
16# start_thread in /lib64/libpthread.so.0
17# __clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

