### PR TITLE
[fix](function) json_object can not input null value 

### DIFF
--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -619,6 +619,7 @@ struct ExecuteReducer {
 struct FunctionJsonArrayImpl {
     static constexpr auto name = "json_array";
 
+    static constexpr auto must_not_null = false;
     template <int flag>
     using Reducer = ExecuteReducer<flag, FunctionJsonArrayImpl>;
 
@@ -654,7 +655,7 @@ struct FunctionJsonArrayImpl {
 
 struct FunctionJsonObjectImpl {
     static constexpr auto name = "json_object";
-
+    static constexpr auto must_not_null = true;
     template <int flag>
     using Reducer = ExecuteReducer<flag, FunctionJsonObjectImpl>;
 
@@ -743,6 +744,9 @@ public:
                 data_columns.push_back(assert_cast<const ColumnString*>(column_ptrs.back().get()));
             }
         }
+        if (SpecificImpl::must_not_null) {
+            RETURN_IF_ERROR(check_keys_all_not_null(nullmaps, input_rows_count, arguments.size()));
+        }
         execute(data_columns, *assert_cast<ColumnString*>(result_column.get()), input_rows_count,
                 nullmaps);
         block.get_by_position(result).column = std::move(result_column);
@@ -773,6 +777,24 @@ public:
             objects[i].Accept(writer);
             result_column.insert_data(buf.GetString(), buf.GetSize());
         }
+    }
+
+    static Status check_keys_all_not_null(const std::vector<const ColumnUInt8*>& nullmaps, int size,
+                                          size_t args) {
+        for (int i = 0; i < args; i += 2) {
+            const auto* null_map = nullmaps[i];
+            if (null_map) {
+                const bool not_null_num =
+                        simd::count_zero_num((int8_t*)null_map->get_data().data(), size);
+                if (not_null_num < size) {
+                    return Status::InternalError(
+                            "function {} can not input null value , JSON documents may not contain "
+                            "NULL member names.",
+                            name);
+                }
+            }
+        }
+        return Status::OK();
     }
 };
 

--- a/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_object.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_object.groovy
@@ -41,5 +41,9 @@ suite("test_query_json_object", "query") {
     sql "insert into ${tableName} values(4,null,null,'test','2022-01-01 11:11:11');"
     sql "insert into ${tableName} values(5,1,true,'test','2022-01-01 11:11:11');"
     qt_sql1 "select json_object('k0',k0,'k1',k1,'k2',k2,'k3',k3,'k4',k4,'k5', null,'k6','k6') from ${tableName} order by k0;"
+    test {
+        sql """select k0,json_object(k3,123) from ${tableName} order by k0;"""
+        exception "[CANCELLED][INTERNAL_ERROR] function json_object can not input null value , JSON documents may not contain NULL member names."
+    }
     sql "DROP TABLE ${tableName};"
 }


### PR DESCRIPTION
## Proposed changes
Evaluates a (possibly empty) list of key-value pairs and returns a JSON object containing those pairs. An error occurs if any key name is NULL or the number of arguments is odd.

```
mysql [test2]>select * from test;
+------+------+
| id   | str  |
+------+------+
|    1 | NULL |
+------+------+
1 row in set (0.06 sec)

mysql [test2]>select json_object(str,id) from test;
+----------------------------------------------------+
| json_object(str, cast(id as VARCHAR(65533)), '62') |
+----------------------------------------------------+
| {"":1}                                             |
+----------------------------------------------------+
1 row in set (0.12 sec)
```

now 

```
mysql [test2]>select json_object(str,id) from test;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CANCELLED][INTERNAL_ERROR] function json_object can not input null value , JSON documents may not contain NULL member names.
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

