### PR TITLE
[bugfix](multi catalog) fixed an issue in master where hive directory…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -362,7 +362,11 @@ public class HiveScanNode extends FileQueryScanNode {
         TFileTextScanRangeParams textParams = new TFileTextScanRangeParams();
         java.util.Map<String, String> delimiter = hmsTable.getRemoteTable().getSd().getSerdeInfo().getParameters();
         if (delimiter.containsKey(PROP_FIELD_DELIMITER)) {
-            textParams.setColumnSeparator(delimiter.get(PROP_FIELD_DELIMITER));
+            if (delimiter.get(PROP_FIELD_DELIMITER).length() == 0) {
+                textParams.setColumnSeparator(DEFAULT_FIELD_DELIMITER);
+            } else {
+                textParams.setColumnSeparator(delimiter.get(PROP_FIELD_DELIMITER));
+            }
         } else if (delimiter.containsKey(PROP_SEPARATOR_CHAR)) {
             textParams.setColumnSeparator(delimiter.get(PROP_SEPARATOR_CHAR));
         } else {


### PR DESCRIPTION
Fixed an issue in master where hive directory field separator was an empty string causing it to be core

## Proposed changes

cherry-pick from #34589

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

