### PR TITLE
[fix](shuffle) compensate num rows filtered in ExchangeNode

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -636,6 +636,9 @@ Status ExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
                                               _tablet_finder->num_filtered_rows());
         _state->update_num_rows_load_unselected(
                 _tablet_finder->num_immutable_partition_filtered_rows());
+        // sink won't see those filtered rows, we should compensate here
+        _state->set_num_rows_load_total(_state->num_rows_load_filtered() +
+                                        _state->num_rows_load_unselected());
     }
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);


### PR DESCRIPTION
## Proposed changes

Currently the success load rows is calculated by:

```
num_success_rows = num_total_rows - num_filtered_rows - num_unselected_rows.
```

When shuffle is on, ExchangeNode may filter some rows and increase `num_filtered_rows` and `num_unselected_rows`.
And OlapTableSink is unaware of those rows and won't count them in `num_total_rows`.

This PR fixes this problem by compensating filtered rows and unselected rows in ExchangeNode.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

