### PR TITLE
[fix](catalog) fix potential catalog cache dead lock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -226,9 +226,7 @@ public abstract class ExternalCatalog
         initLocalObjects();
         if (!initialized) {
             if (useMetaCache.get()) {
-                if (metaCache != null) {
-                    metaCache.invalidateAll();
-                } else {
+                if (metaCache == null) {
                     metaCache = Env.getCurrentEnv().getExtMetaCacheMgr().buildMetaCache(
                             name,
                             OptionalLong.of(86400L),
@@ -345,7 +343,6 @@ public abstract class ExternalCatalog
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
                 ExternalDatabase<? extends ExternalTable> db = idToDb.get(dbId);
-                db.setUnInitialized(invalidCacheInInit);
                 tmpIdToDb.put(dbId, db);
                 initCatalogLog.addRefreshDb(dbId);
             } else {
@@ -379,6 +376,15 @@ public abstract class ExternalCatalog
         this.initialized = false;
         synchronized (this.propLock) {
             this.convertedProperties = null;
+        }
+        if (useMetaCache.isPresent()) {
+            if (useMetaCache.get() && metaCache != null) {
+                metaCache.invalidateAll();
+            } else if (!useMetaCache.get()) {
+                for (ExternalDatabase<? extends ExternalTable> db : idToDb.values()) {
+                    db.setUnInitialized(invalidCache);
+                }
+            }
         }
         this.invalidCacheInInit = invalidCache;
         if (invalidCache) {
@@ -587,7 +593,6 @@ public abstract class ExternalCatalog
             // Because replyInitCatalog can only be called when `use_meta_cache` is false.
             // And if `use_meta_cache` is false, getDbForReplay() will not return null
             Preconditions.checkNotNull(db.get());
-            db.get().setUnInitialized(invalidCacheInInit);
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -118,6 +118,15 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     public void setUnInitialized(boolean invalidCache) {
         this.initialized = false;
         this.invalidCacheInInit = invalidCache;
+        if (extCatalog.getUseMetaCache().isPresent()) {
+            if (extCatalog.getUseMetaCache().get() && metaCache != null) {
+                metaCache.invalidateAll();
+            } else if (!extCatalog.getUseMetaCache().get()) {
+                for (T table : idToTbl.values()) {
+                    table.unsetObjectCreated();
+                }
+            }
+        }
         if (invalidCache) {
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDbCache(extCatalog.getId(), name);
         }
@@ -131,9 +140,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         extCatalog.makeSureInitialized();
         if (!initialized) {
             if (extCatalog.getUseMetaCache().get()) {
-                if (metaCache != null) {
-                    metaCache.invalidateAll();
-                } else {
+                if (metaCache == null) {
                     metaCache = Env.getCurrentEnv().getExtMetaCacheMgr().buildMetaCache(
                             name,
                             OptionalLong.of(86400L),
@@ -175,7 +182,6 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             // So we need add a validation here to avoid table(s) not found, this is just a temporary solution
             // because later we will remove all the logics about InitCatalogLog/InitDatabaseLog.
             if (table.isPresent()) {
-                table.get().unsetObjectCreated();
                 tmpTableNameToId.put(table.get().getName(), table.get().getId());
                 tmpIdToTbl.put(table.get().getId(), table.get());
             }
@@ -206,7 +212,6 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                     tblId = tableNameToId.get(tableName);
                     tmpTableNameToId.put(tableName, tblId);
                     T table = idToTbl.get(tblId);
-                    table.unsetObjectCreated();
                     tmpIdToTbl.put(tblId, table);
                     initDatabaseLog.addRefreshTable(tblId);
                 } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
@@ -91,7 +91,7 @@ public class RefreshDbTest extends TestWithFeService {
         }
         long l3 = db1.getLastUpdateTime();
         Assertions.assertTrue(l3 == l2);
-        Assertions.assertTrue(table.isObjectCreated());
+        Assertions.assertFalse(table.isObjectCreated());
         test1.getDbNullable("db1").getTables();
         Assertions.assertFalse(table.isObjectCreated());
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/RefreshCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/RefreshCatalogTest.java
@@ -144,7 +144,7 @@ public class RefreshCatalogTest extends TestWithFeService {
         // not triggered init method
         long l3 = test2.getLastUpdateTime();
         Assertions.assertTrue(l3 == l2);
-        Assertions.assertTrue(table.isObjectCreated());
+        Assertions.assertFalse(table.isObjectCreated());
         test2.getDbNullable("db1").getTables();
         // Assertions.assertFalse(table.isObjectCreated());
         try {


### PR DESCRIPTION
## Proposed changes

Do not invalid cache when initializing catalog or database.
Because it may cause dead lock.

1. ExternalSchemaCache.getSchema [lock schema cache entry]
2. Call catalog init [lock catalog lock]
3. Catalog init will try invalidate cache (include ExternalSchemaCache)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

