### PR TITLE
[fix](insert) fix forget to abort txn when insert checkStrictMode failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -163,16 +163,14 @@ public abstract class AbstractInsertExecutor {
         }
     }
 
-    private boolean checkStrictMode() {
+    private void checkStrictMode() throws Exception {
         // if in strict mode, insert will fail if there are filtered rows
         if (ctx.getSessionVariable().getEnableInsertStrict()) {
             if (filteredRows > 0) {
-                ctx.getState().setError(ErrorCode.ERR_FAILED_WHEN_INSERT,
-                        "Insert has filtered data in strict mode, tracking_url=" + coordinator.getTrackingUrl());
-                return false;
+                ErrorReport.reportDdlException("Insert has filtered data in strict mode",
+                        ErrorCode.ERR_FAILED_WHEN_INSERT);
             }
         }
-        return true;
     }
 
     /**
@@ -182,9 +180,7 @@ public abstract class AbstractInsertExecutor {
         beforeExec();
         try {
             execImpl(executor, jobId);
-            if (!checkStrictMode()) {
-                return;
-            }
+            checkStrictMode();
             int retryTimes = 0;
             while (retryTimes < Config.mow_insert_into_commit_retry_times) {
                 try {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
we need to abort the transaction  when checkStrictMode failed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

