### PR TITLE
[chore](ga) add large file checker

### DIFF
--- a/.github/workflows/lfs-warning.yml
+++ b/.github/workflows/lfs-warning.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: 'Check Large File'
+
+on: [push, pull_request_target]
+
+jobs:
+  large-file-checker:
+    name: "Check large file"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Check Large File
+        uses: ./.github/actions/lfs-warning
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filesizelimit: 1MB

--- a/.github/workflows/lfs-warning.yml
+++ b/.github/workflows/lfs-warning.yml
@@ -26,12 +26,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check Large File
+      
+      - name: "Checkout lfs-warning commit"
+        run: |
+          rm -rf ./.github/actions/lfs-warning
+          git clone https://github.com/ppremk/lfs-warning .github/actions/lfs-warning
+          pushd .github/actions/lfs-warning &>/dev/null
+          git checkout 4b98a8a5e6c429c23c34eee02d71553bca216425
+          popd &>/dev/null
+
+      - name: "Check Large File"
         uses: ./.github/actions/lfs-warning
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           filesizelimit: 1MB
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,9 @@
 [submodule ".github/actions/ccache-action"]
 	path = .github/actions/ccache-action
 	url = https://github.com/hendrikmuhs/ccache-action
+[submodule ".github/actions/lfs-warning"]
+	path = .github/actions/lfs-warning
+	url = https://github.com/ppremk/lfs-warning
 [submodule "be/src/apache-orc"]
 	path = be/src/apache-orc
 	url = https://github.com/apache/doris-thirdparty.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule ".github/actions/ccache-action"]
 	path = .github/actions/ccache-action
 	url = https://github.com/hendrikmuhs/ccache-action
-[submodule ".github/actions/lfs-warning"]
-	path = .github/actions/lfs-warning
-	url = https://github.com/ppremk/lfs-warning
 [submodule "be/src/apache-orc"]
 	path = be/src/apache-orc
 	url = https://github.com/apache/doris-thirdparty.git


### PR DESCRIPTION
## Proposed changes

Add a action to check if the PR contains large file.
To avoid merge large file in to code base

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

