### PR TITLE
[fix](jdbc catalog) Fix ClassLoader Scope in JdbcExecutor Initialization

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -309,13 +309,13 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
         try {
             ClassLoader parent = getClass().getClassLoader();
             ClassLoader classLoader = UdfUtils.getClassLoader(config.getJdbcDriverUrl(), parent);
+            Thread.currentThread().setContextClassLoader(classLoader);
             hikariDataSource = JdbcDataSource.getDataSource().getSource(hikariDataSourceKey);
             if (hikariDataSource == null) {
                 synchronized (hikariDataSourceLock) {
                     hikariDataSource = JdbcDataSource.getDataSource().getSource(hikariDataSourceKey);
                     if (hikariDataSource == null) {
                         long start = System.currentTimeMillis();
-                        Thread.currentThread().setContextClassLoader(classLoader);
                         HikariDataSource ds = new HikariDataSource();
                         ds.setDriverClassName(config.getJdbcDriverClass());
                         ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(config.getJdbcUrl()));

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/DefaultJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/DefaultJdbcExecutor.java
@@ -353,13 +353,13 @@ public class DefaultJdbcExecutor {
             } else {
                 ClassLoader parent = getClass().getClassLoader();
                 ClassLoader classLoader = UdfUtils.getClassLoader(config.getJdbcDriverUrl(), parent);
+                Thread.currentThread().setContextClassLoader(classLoader);
                 hikariDataSource = JdbcDataSource.getDataSource().getSource(hikariDataSourceKey);
                 if (hikariDataSource == null) {
                     synchronized (hikariDataSourceLock) {
                         hikariDataSource = JdbcDataSource.getDataSource().getSource(hikariDataSourceKey);
                         if (hikariDataSource == null) {
                             long start = System.currentTimeMillis();
-                            Thread.currentThread().setContextClassLoader(classLoader);
                             HikariDataSource ds = new HikariDataSource();
                             ds.setDriverClassName(config.getJdbcDriverClass());
                             ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(config.getJdbcUrl()));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

We should set the classloader at the beginning of initializing the connection instead of creating a new connection pool, because the new connection pool will be created based on whether there is a connection pool in the cache.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

