### PR TITLE
[feature](ddl) Support CREATE DB with COMMENT

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -92,8 +92,10 @@ public final class FeMetaVersion {
     public static final int VERSION_134 = 134;
     // For mate gson
     public static final int VERSION_135 = 135;
+    // support db comment
+    public static final int VERSION_136 = 136;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_135;
+    public static final int VERSION_CURRENT = VERSION_136;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1837,13 +1837,13 @@ opt_intermediate_type ::=
 // Create Statement
 create_stmt ::=
     /* Database */
-    KW_CREATE KW_DATABASE opt_if_not_exists:ifNotExists db_name:db opt_properties:properties
+    KW_CREATE KW_DATABASE opt_if_not_exists:ifNotExists db_name:db opt_comment:dbComment opt_properties:properties
     {:
-        RESULT = new CreateDbStmt(ifNotExists, db, properties);
+        RESULT = new CreateDbStmt(ifNotExists, db, properties, dbComment);
     :}
-    | KW_CREATE KW_SCHEMA opt_if_not_exists:ifNotExists db_name:db
+    | KW_CREATE KW_SCHEMA opt_if_not_exists:ifNotExists db_name:db opt_comment:dbComment
     {:
-        RESULT = new CreateDbStmt(ifNotExists, db, null);
+        RESULT = new CreateDbStmt(ifNotExists, db, null, dbComment);
     :}
     /* Catalog */
     | KW_CREATE KW_CATALOG opt_if_not_exists:ifNotExists ident:catalogName opt_comment:comment opt_properties:properties

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateDbStmt.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
@@ -37,12 +38,18 @@ public class CreateDbStmt extends DdlStmt {
     private String ctlName;
     private String dbName;
     private Map<String, String> properties;
+    private String comment;
 
-    public CreateDbStmt(boolean ifNotExists, DbName dbName, Map<String, String> properties) {
+    public CreateDbStmt(boolean ifNotExists, DbName dbName, Map<String, String> properties, String comment) {
         this.ifNotExists = ifNotExists;
         this.ctlName = dbName.getCtl();
         this.dbName = dbName.getDb();
         this.properties = properties == null ? new HashMap<>() : properties;
+        this.comment = Strings.nullToEmpty(comment);
+    }
+
+    public CreateDbStmt(boolean ifNotExists, DbName dbName, Map<String, String> properties) {
+        this(ifNotExists, dbName, properties, null);
     }
 
     public String getFullDbName() {
@@ -59,6 +66,10 @@ public class CreateDbStmt extends DdlStmt {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public String getComment() {
+        return comment;
     }
 
     @Override
@@ -86,6 +97,9 @@ public class CreateDbStmt extends DdlStmt {
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("CREATE DATABASE ").append("`").append(dbName).append("`");
+        if (!Strings.isNullOrEmpty(comment)) {
+            stringBuilder.append("\nCOMMENT \"").append(comment).append("\"");
+        }
         if (properties.size() > 0) {
             stringBuilder.append("\nPROPERTIES (\n");
             stringBuilder.append(new PrintableMap<>(properties, "=", true, true, false));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
@@ -70,6 +70,10 @@ public interface DatabaseIf<T extends TableIf> {
 
     DatabaseProperty getDbProperties();
 
+    String getDbComment();
+
+    String getDbComment(boolean escapeQuota);
+
     boolean isTableExist(String tableName);
 
     List<T> getTables();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.internal.LinkedTreeMap;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -320,6 +321,16 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public DatabaseProperty getDbProperties() {
         return dbProperties;
+    }
+
+    @Override
+    public String getDbComment() {
+        return StringUtils.EMPTY;
+    }
+
+    @Override
+    public String getDbComment(boolean escapeQuota) {
+        return StringUtils.EMPTY;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -420,6 +420,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         Database db = new Database(id, fullDbName);
         // check and analyze database properties before create database
         db.setDbProperties(new DatabaseProperty(properties));
+        db.setDbComment(stmt.getComment());
 
         if (!tryLock(false)) {
             throw new DdlException("Failed to acquire catalog lock. Try again");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1098,6 +1098,9 @@ public class ShowExecutor {
         } else {
             DatabaseIf db = catalog.getDbOrAnalysisException(showStmt.getDb());
             sb.append("CREATE DATABASE `").append(ClusterNamespace.getNameFromFullName(showStmt.getDb())).append("`");
+            if (!Strings.isNullOrEmpty(db.getDbComment())) {
+                sb.append("\nCOMMENT \"").append(db.getDbComment()).append("\"");
+            }
             if (db.getDbProperties().getProperties().size() > 0) {
                 sb.append("\nPROPERTIES (\n");
                 sb.append(new PrintableMap<>(db.getDbProperties().getProperties(), "=", true, true, false));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
@@ -54,6 +54,15 @@ public class CreateDbStmtTest {
         Assert.assertEquals("CREATE DATABASE `test`", dbStmt.toString());
     }
 
+    @Test
+    public void testAnalyzeWithComment() throws UserException {
+        CreateDbStmt dbStmt = new CreateDbStmt(false,
+                new DbName(null, "test"), null, "this is comment");
+        dbStmt.analyze(analyzer);
+        Assert.assertEquals("testCluster:test", dbStmt.getFullDbName());
+        Assert.assertEquals("CREATE DATABASE `testCluster:test` COMMENT \"this is comment\"", dbStmt.toString());
+    }
+
     @Test(expected = AnalysisException.class)
     public void testAnalyzeWithException() throws UserException {
         CreateDbStmt stmt = new CreateDbStmt(false, new DbName("", ""), null);


### PR DESCRIPTION
When create a database, add support for comment, which explains something about the database so that people who see it know what it is and what it does. CREATE DATABASE [IF NOT EXISTS] db_name COMMENT database_comment [PROPERTIES ("key"="value", ...)]; Add database's comment to the result of the SHOW CREATE DATABASE statement.