### PR TITLE
[fix](nereids-Branch-2.1) fix bug: try to prune a not-exist rf

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -353,7 +354,7 @@ public class RuntimeFilterContext {
     }
 
     public List<ExprId> getTargetExprIdByFilterJoin(AbstractPhysicalJoin join) {
-        return joinToTargetExprId.get(join);
+        return joinToTargetExprId.getOrDefault(join, new ArrayList<>());
     }
 
     public SlotReference getCorrespondingOlapSlotReference(SlotReference slot) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
@@ -155,7 +155,7 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
             context.getRuntimeFilterContext().addEffectiveSrcNode(join, childType);
         } else {
             List<ExprId> exprIds = rfContext.getTargetExprIdByFilterJoin(join);
-            if (exprIds != null && !exprIds.isEmpty()) {
+            if (!exprIds.isEmpty()) {
                 boolean isEffective = false;
                 for (Expression expr : join.getEqualToConjuncts()) {
                     if (isEffectiveRuntimeFilter((EqualTo) expr, join)) {


### PR DESCRIPTION
if join right side is cte, we do not generate rf.
in rf prune process, we try to prune a not existed rf, whose right side is cte

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

