### PR TITLE
[fix](regression test) fix unstable case auto bucket test

### DIFF
--- a/regression-test/suites/autobucket/test_autobucket.groovy
+++ b/regression-test/suites/autobucket/test_autobucket.groovy
@@ -65,8 +65,8 @@ suite("test_autobucket") {
     sql "ADMIN SET FRONTEND CONFIG ('autobucket_min_buckets' = '1')"
     sql "drop table if exists autobucket_test_min_buckets"
 
-    // set max to 4
-    sql "ADMIN SET FRONTEND CONFIG ('autobucket_max_buckets' = '4')"
+    // set max to 1
+    sql "ADMIN SET FRONTEND CONFIG ('autobucket_max_buckets' = '1')"
     sql "drop table if exists autobucket_test_max_buckets"
     result = sql """
         CREATE TABLE `autobucket_test_max_buckets` (
@@ -84,7 +84,7 @@ suite("test_autobucket") {
     result = sql "show partitions from autobucket_test_max_buckets"
     logger.info("${result}")
     // XXX: buckets at pos(8), next maybe impl by sql meta
-    assertEquals(Integer.valueOf(result.get(0).get(8)), 4)
+    assertEquals(Integer.valueOf(result.get(0).get(8)), 1) //equals max bucket
     // set back to default
     sql "ADMIN SET FRONTEND CONFIG ('autobucket_max_buckets' = '128')"
     sql "drop table if exists autobucket_test_max_buckets"


### PR DESCRIPTION
bucket num = min(partition_size/1G,   avaible disk /50 GB + 1)

sometimes, the pipeline test backend's available disk  < 50GB,  then the test will failed.

Considering this case is only to test autobucket_max_buckets,  we set autobucket_max_buckets=1 to torrent with any available disk size.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

