### PR TITLE
[fix](memory) Fix build.sh thirdparty path error for jemalloc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,10 +30,8 @@ set -eo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 export DORIS_HOME="${ROOT}"
-export TP_DIR="${ROOT}/thirdparty"
-export TP_INSTALL_DIR="${TP_DIR:-.}/installed"
-export TP_INCLUDE_DIR="${TP_INSTALL_DIR}/include"
-export TP_LIB_DIR="${TP_INSTALL_DIR}/lib"
+export TP_INCLUDE_DIR="${DORIS_THIRDPARTY}/installed/include"
+export TP_LIB_DIR="${DORIS_THIRDPARTY}/installed/lib"
 
 . "${DORIS_HOME}/env.sh"
 

--- a/build.sh
+++ b/build.sh
@@ -356,7 +356,9 @@ if [[ -z "${USE_MEM_TRACKER}" ]]; then
         USE_MEM_TRACKER='OFF'
     fi
 fi
-if [[ -z "${USE_JEMALLOC}" ]]; then
+if [[ "${BUILD_TYPE,,}" == "asan" ]]; then
+    USE_JEMALLOC='OFF'
+elif [[ -z "${USE_JEMALLOC}" ]]; then
     USE_JEMALLOC='ON'
 fi
 if [[ ! -f "${TP_INCLUDE_DIR}/jemalloc/jemalloc_doris_with_prefix.h" ]]; then

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -875,6 +875,11 @@ build_rocksdb_jemalloc_with_prefix() {
     cp librocksdb.a "${TP_LIB_DIR}/librocksdb_jemalloc_with_prefix.a"
     cp -r include/rocksdb "${TP_INCLUDE_DIR}/rocksdb_jemalloc_with_prefix"
     strip_lib librocksdb_jemalloc_with_prefix.a
+    # for compatibility with previous doris version
+    rm -rf "${TP_LIB_DIR}/librocksdb.a"
+    rm -rf "${TP_INCLUDE_DIR}/rocksdb"
+    cp "${TP_LIB_DIR}/librocksdb_jemalloc_with_prefix.a" "${TP_LIB_DIR}/librocksdb.a"
+    cp -r "${TP_INCLUDE_DIR}/rocksdb_jemalloc_with_prefix" "${TP_INCLUDE_DIR}/rocksdb"
 }
 
 # cyrus_sasl
@@ -1866,10 +1871,10 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         thrift
         leveldb
         brpc
-        jemalloc_doris_with_prefix
-        rocksdb_jemalloc_with_prefix
         jemalloc_doris
         rocksdb
+        jemalloc_doris_with_prefix
+        rocksdb_jemalloc_with_prefix
         krb5 # before cyrus_sasl
         cyrus_sasl
         librdkafka


### PR DESCRIPTION
## Proposed changes

1. Fix build.sh thirdparty path error for jemalloc
2. fix jemalloc thirdparty is compatible with old code
3. if build_type=ASAN, compile without jemalloc, because asan not compatible with jemalloc without prefix
https://github.com/jemalloc/jemalloc/issues/2353
![image](https://github.com/apache/doris/assets/13197424/300e4064-12eb-42e9-b4b6-2a7499d5e51f)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

