### PR TITLE
[opt](Nereids) normalize column name of output file

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -43,8 +43,10 @@ import org.apache.doris.nereids.rules.expression.rules.FunctionBinder;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.DefaultValueSlot;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Substring;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
@@ -58,6 +60,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalTableSink;
 import org.apache.doris.nereids.trees.plans.logical.UnboundLogicalSink;
+import org.apache.doris.nereids.trees.plans.visitor.InferPlanOutputAlias;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
@@ -66,6 +69,7 @@ import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -83,12 +87,19 @@ public class BindSink implements AnalysisRuleFactory {
     public List<Rule> buildRules() {
         return ImmutableList.of(
                 RuleType.BINDING_INSERT_TARGET_TABLE.build(unboundTableSink().thenApply(this::bindOlapTableSink)),
-                RuleType.BINDING_INSERT_FILE.build(
-                        logicalFileSink().when(s -> s.getOutputExprs().isEmpty())
-                                .then(fileSink -> fileSink.withOutputExprs(
-                                        fileSink.child().getOutput().stream()
-                                                .map(NamedExpression.class::cast)
-                                                .collect(ImmutableList.toImmutableList())))
+                RuleType.BINDING_INSERT_FILE.build(logicalFileSink().when(s -> s.getOutputExprs().isEmpty())
+                        .then(fileSink -> {
+                            ImmutableListMultimap.Builder<ExprId, Integer> exprIdToIndexMapBuilder =
+                                    ImmutableListMultimap.builder();
+                            List<Slot> childOutput = fileSink.child().getOutput();
+                            for (int index = 0; index < childOutput.size(); index++) {
+                                exprIdToIndexMapBuilder.put(childOutput.get(index).getExprId(), index);
+                            }
+                            InferPlanOutputAlias aliasInfer = new InferPlanOutputAlias(childOutput);
+                            List<NamedExpression> output = aliasInfer.infer(fileSink.child(),
+                                    exprIdToIndexMapBuilder.build());
+                            return fileSink.withOutputExprs(output);
+                        })
                 ),
                 // TODO: bind hive taget table
                 RuleType.BINDING_INSERT_HIVE_TABLE.build(unboundHiveTableSink().thenApply(this::bindHiveTableSink))

--- a/regression-test/data/export_p0/outfile/outfile_expr/test_outfile_expr_generate_col_name.out
+++ b/regression-test/data/export_p0/outfile/outfile_expr/test_outfile_expr_generate_col_name.out
@@ -36,7 +36,7 @@ false
 false
 
 -- !desc_s3 --
-__binary_predicate_0	BOOLEAN	Yes	false	\N	NONE
+__greater_than_0	BOOLEAN	Yes	false	\N	NONE
 
 -- !select_base1 --
 10
@@ -72,7 +72,7 @@ __max_0	INT	Yes	false	\N	NONE
 9	id not exist
 
 -- !desc_s3 --
-__case_expr_1	TEXT	Yes	false	\N	NONE
+__case_when_1	TEXT	Yes	false	\N	NONE
 id	INT	Yes	false	\N	NONE
 
 -- !select_base1 --
@@ -100,10 +100,10 @@ id	INT	Yes	false	\N	NONE
 9	1	string	27	false	5	true	1
 
 -- !desc_s3 --
-__arithmetic_expr_5	INT	Yes	false	\N	NONE
-__arithmetic_expr_7	BIGINT	Yes	false	\N	NONE
-__binary_predicate_4	BOOLEAN	Yes	false	\N	NONE
-__cast_expr_3	BIGINT	Yes	false	\N	NONE
+__add_5	INT	Yes	false	\N	NONE
+__bit_or_7	INT	Yes	false	\N	NONE
+__cast_3	BIGINT	Yes	false	\N	NONE
+__greater_than_4	BOOLEAN	Yes	false	\N	NONE
 __in_predicate_6	BOOLEAN	Yes	false	\N	NONE
 __literal_1	INT	Yes	false	\N	NONE
 __literal_2	TEXT	Yes	false	\N	NONE
@@ -134,9 +134,9 @@ id	INT	Yes	false	\N	NONE
 2566	888	9999
 
 -- !desc_s3 --
-__cast_expr_0	TEXT	Yes	false	\N	NONE
-__cast_expr_1	BIGINT	Yes	false	\N	NONE
-__cast_expr_2	TEXT	Yes	false	\N	NONE
+__cast_0	TEXT	Yes	false	\N	NONE
+__cast_1	BIGINT	Yes	false	\N	NONE
+__cast_2	TEXT	Yes	false	\N	NONE
 
 -- !select_base1 --
 false
@@ -163,7 +163,7 @@ false
 false
 
 -- !desc_s3 --
-__binary_predicate_0	BOOLEAN	Yes	false	\N	NONE
+__greater_than_0	BOOLEAN	Yes	false	\N	NONE
 
 -- !select_base1 --
 10
@@ -199,7 +199,7 @@ __max_0	INT	Yes	false	\N	NONE
 9	id not exist
 
 -- !desc_s3 --
-__case_expr_1	VARCHAR(65533)	Yes	false	\N	NONE
+__case_when_1	TEXT	Yes	false	\N	NONE
 id	INT	Yes	false	\N	NONE
 
 -- !select_base1 --
@@ -227,13 +227,13 @@ id	INT	Yes	false	\N	NONE
 9	1	string	27	false	5	true	1
 
 -- !desc_s3 --
-__arithmetic_expr_5	SMALLINT	Yes	false	\N	NONE
-__arithmetic_expr_7	BIGINT	Yes	false	\N	NONE
-__binary_predicate_4	BOOLEAN	Yes	false	\N	NONE
-__cast_expr_3	BIGINT	Yes	false	\N	NONE
+__add_5	SMALLINT	Yes	false	\N	NONE
+__bit_or_7	TINYINT	Yes	false	\N	NONE
+__cast_3	BIGINT	Yes	false	\N	NONE
+__greater_than_4	BOOLEAN	Yes	false	\N	NONE
 __in_predicate_6	BOOLEAN	Yes	false	\N	NONE
 __literal_1	TINYINT	Yes	false	\N	NONE
-__literal_2	VARCHAR(65533)	Yes	false	\N	NONE
+__literal_2	VARCHAR(6)	Yes	false	\N	NONE
 id	INT	Yes	false	\N	NONE
 
 -- !select_base1 --
@@ -261,7 +261,7 @@ id	INT	Yes	false	\N	NONE
 2566	888	9999
 
 -- !desc_s3 --
-__cast_expr_0	TEXT	Yes	false	\N	NONE
-__cast_expr_1	BIGINT	Yes	false	\N	NONE
-__cast_expr_2	TEXT	Yes	false	\N	NONE
+__cast_0	TEXT	Yes	false	\N	NONE
+__cast_1	BIGINT	Yes	false	\N	NONE
+__cast_2	TEXT	Yes	false	\N	NONE
 

--- a/regression-test/suites/export_p0/outfile/outfile_expr/test_outfile_expr_generate_col_name.groovy
+++ b/regression-test/suites/export_p0/outfile/outfile_expr/test_outfile_expr_generate_col_name.groovy
@@ -22,9 +22,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 suite("test_outfile_expr_generate_col_name", "p0") {
-    // close nereids
-    sql """ set enable_nereids_planner=false """
-
     String ak = getS3AK()
     String sk = getS3SK()
     String s3_endpoint = getS3Endpoint()


### PR DESCRIPTION
when do export to output file, normalize column name.
For example

> SELECT 1 > 2 INTO OUTFILE "..."

the column name of 1 > 2 will be __greater_than_0