### PR TITLE
[Fix](hive-writer) Fix hive partition update file size and remove redundant column names.

### DIFF
--- a/be/src/vec/sink/writer/vhive_partition_writer.h
+++ b/be/src/vec/sink/writer/vhive_partition_writer.h
@@ -92,7 +92,6 @@ private:
     TUpdateMode::type _update_mode;
 
     size_t _row_count = 0;
-    size_t _input_size_in_bytes = 0;
 
     const VExprContextSPtrs& _vec_output_expr_ctxs;
     const VExprContextSPtrs& _write_output_expr_ctxs;


### PR DESCRIPTION
## Proposed changes

Issue Number: #31442

[Fix] (hive-writer) Fix hive partition update file size and remove redundant column names.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

