### PR TITLE
[Feature](topn) support topn filter when olap scan node storage_no_merge is false

### DIFF
--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -217,10 +217,10 @@ Status OlapScanLocalState::_should_push_down_function_filter(
 }
 
 bool OlapScanLocalState::_should_push_down_common_expr() {
-    return state()->enable_common_expr_pushdown() && _storage_no_merge();
+    return state()->enable_common_expr_pushdown() && storage_no_merge();
 }
 
-bool OlapScanLocalState::_storage_no_merge() {
+bool OlapScanLocalState::storage_no_merge() {
     auto& p = _parent->cast<OlapScanOperatorX>();
     return (p._olap_scan_node.keyType == TKeysType::DUP_KEYS ||
             (p._olap_scan_node.keyType == TKeysType::UNIQUE_KEYS &&

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -78,9 +78,7 @@ private:
 
     bool _should_push_down_common_expr() override;
 
-    bool _storage_no_merge() override;
-
-    bool _push_down_topn() override { return true; }
+    bool storage_no_merge() override;
 
     Status _init_scanners(std::list<vectorized::VScannerSPtr>* scanners) override;
 

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -190,7 +190,7 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
         init_value_range(_slot_id_to_slot_desc[_colname_to_slot_id[colname]], type);
     }
 
-    if (!_push_down_topn()) {
+    if (!storage_no_merge()) {
         RETURN_IF_ERROR(_get_topn_filters(state));
     }
 
@@ -358,7 +358,7 @@ Status ScanLocalState<Derived>::_normalize_predicate(
             }
 
             if (pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE &&
-                (_is_key_column(slot->col_name()) || _storage_no_merge())) {
+                (_is_key_column(slot->col_name()) || storage_no_merge())) {
                 output_expr = nullptr;
                 return Status::OK();
             } else {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -158,9 +158,11 @@ class ScanLocalState : public ScanLocalStateBase {
 
     std::vector<Dependency*> dependencies() const override { return {_scan_dependency.get()}; }
 
-    std::vector<int> get_topn_filter_source_node_ids() {
+    const std::vector<int>& get_topn_filter_source_node_ids() {
         return _parent->cast<typename Derived::Parent>().topn_filter_source_node_ids;
     }
+
+    virtual bool storage_no_merge() { return false; }
 
 protected:
     template <typename LocalStateType>
@@ -175,8 +177,6 @@ protected:
     }
     virtual bool _should_push_down_common_expr() { return false; }
 
-    virtual bool _storage_no_merge() { return false; }
-    virtual bool _push_down_topn() { return false; }
     virtual bool _is_key_column(const std::string& col_name) { return false; }
     virtual vectorized::VScanNode::PushDownType _should_push_down_bloom_filter() {
         return vectorized::VScanNode::PushDownType::UNACCEPTABLE;

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -86,10 +86,10 @@ protected:
     PushDownType _should_push_down_is_null_predicate() override { return PushDownType::ACCEPTABLE; }
 
     bool _should_push_down_common_expr() override {
-        return _state->enable_common_expr_pushdown() && _storage_no_merge();
+        return _state->enable_common_expr_pushdown() && storage_no_merge();
     }
 
-    bool _storage_no_merge() override {
+    bool storage_no_merge() override {
         return (_olap_scan_node.keyType == TKeysType::DUP_KEYS ||
                 (_olap_scan_node.keyType == TKeysType::UNIQUE_KEYS &&
                  _olap_scan_node.__isset.enable_unique_key_merge_on_write &&

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -401,27 +401,26 @@ Status NewOlapScanner::_init_tablet_reader_params(
             _tablet_reader_params.filter_block_conjuncts = _conjuncts;
         }
 
-        if (((pipeline::OlapScanLocalState*)_local_state)->storage_no_merge()) {
-            // runtime predicate push down optimization for topn
-            if (!_parent && !((pipeline::OlapScanLocalState*)_local_state)
-                                     ->get_topn_filter_source_node_ids()
-                                     .empty()) {
-                // the new topn whitch support external table
-                _tablet_reader_params.topn_filter_source_node_ids =
-                        ((pipeline::OlapScanLocalState*)_local_state)
-                                ->get_topn_filter_source_node_ids();
-            } else {
-                _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
-                if (_tablet_reader_params.use_topn_opt) {
-                    if (olap_scan_node.__isset.topn_filter_source_node_ids) {
-                        // the 2.1 new multiple topn
-                        _tablet_reader_params.topn_filter_source_node_ids =
-                                olap_scan_node.topn_filter_source_node_ids;
+        // runtime predicate push down optimization for topn
+        if (!_parent && ((pipeline::OlapScanLocalState*)_local_state)->storage_no_merge() &&
+            !((pipeline::OlapScanLocalState*)_local_state)
+                     ->get_topn_filter_source_node_ids()
+                     .empty()) {
+            // the new topn whitch support external table
+            _tablet_reader_params.topn_filter_source_node_ids =
+                    ((pipeline::OlapScanLocalState*)_local_state)
+                            ->get_topn_filter_source_node_ids();
+        } else {
+            _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
+            if (_tablet_reader_params.use_topn_opt) {
+                if (olap_scan_node.__isset.topn_filter_source_node_ids) {
+                    // the 2.1 new multiple topn
+                    _tablet_reader_params.topn_filter_source_node_ids =
+                            olap_scan_node.topn_filter_source_node_ids;
 
-                    } else {
-                        // the 2.0 old topn
-                        _tablet_reader_params.topn_filter_source_node_ids = {0};
-                    }
+                } else {
+                    // the 2.0 old topn
+                    _tablet_reader_params.topn_filter_source_node_ids = {0};
                 }
             }
         }

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -401,25 +401,27 @@ Status NewOlapScanner::_init_tablet_reader_params(
             _tablet_reader_params.filter_block_conjuncts = _conjuncts;
         }
 
-        // runtime predicate push down optimization for topn
-        if (!_parent && !((pipeline::OlapScanLocalState*)_local_state)
-                                 ->get_topn_filter_source_node_ids()
-                                 .empty()) {
-            // the new topn whitch support external table
-            _tablet_reader_params.topn_filter_source_node_ids =
-                    ((pipeline::OlapScanLocalState*)_local_state)
-                            ->get_topn_filter_source_node_ids();
-        } else {
-            _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
-            if (_tablet_reader_params.use_topn_opt) {
-                if (olap_scan_node.__isset.topn_filter_source_node_ids) {
-                    // the 2.1 new multiple topn
-                    _tablet_reader_params.topn_filter_source_node_ids =
-                            olap_scan_node.topn_filter_source_node_ids;
+        if (((pipeline::OlapScanLocalState*)_local_state)->storage_no_merge()) {
+            // runtime predicate push down optimization for topn
+            if (!_parent && !((pipeline::OlapScanLocalState*)_local_state)
+                                     ->get_topn_filter_source_node_ids()
+                                     .empty()) {
+                // the new topn whitch support external table
+                _tablet_reader_params.topn_filter_source_node_ids =
+                        ((pipeline::OlapScanLocalState*)_local_state)
+                                ->get_topn_filter_source_node_ids();
+            } else {
+                _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
+                if (_tablet_reader_params.use_topn_opt) {
+                    if (olap_scan_node.__isset.topn_filter_source_node_ids) {
+                        // the 2.1 new multiple topn
+                        _tablet_reader_params.topn_filter_source_node_ids =
+                                olap_scan_node.topn_filter_source_node_ids;
 
-                } else {
-                    // the 2.0 old topn
-                    _tablet_reader_params.topn_filter_source_node_ids = {0};
+                    } else {
+                        // the 2.0 old topn
+                        _tablet_reader_params.topn_filter_source_node_ids = {0};
+                    }
                 }
             }
         }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -504,7 +504,7 @@ Status VScanNode::_normalize_predicate(const VExprSPtr& conjunct_expr_root, VExp
             }
 
             if (pdt == PushDownType::ACCEPTABLE &&
-                (_is_key_column(slot->col_name()) || _storage_no_merge())) {
+                (_is_key_column(slot->col_name()) || storage_no_merge())) {
                 output_expr = nullptr;
                 return Status::OK();
             } else {

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -242,7 +242,7 @@ protected:
 
     virtual bool _should_push_down_common_expr() { return false; }
 
-    virtual bool _storage_no_merge() { return false; }
+    virtual bool storage_no_merge() { return false; }
 
     virtual PushDownType _should_push_down_bloom_filter() { return PushDownType::UNACCEPTABLE; }
 


### PR DESCRIPTION
## Proposed changes
support topn filter when olap scan node storage_no_merge is false
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

