### PR TITLE
[branch-2.0](resource)fix check available fail when s3 aws_token is set and reset as, sk faild on be.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1196,6 +1196,7 @@ void TaskWorkerPool::_push_storage_policy_worker_thread_callback() {
                 S3Conf s3_conf;
                 s3_conf.ak = std::move(resource.s3_storage_param.ak);
                 s3_conf.sk = std::move(resource.s3_storage_param.sk);
+                s3_conf.token = std::move(resource.s3_storage_param.token);
                 s3_conf.endpoint = std::move(resource.s3_storage_param.endpoint);
                 s3_conf.region = std::move(resource.s3_storage_param.region);
                 s3_conf.prefix = std::move(resource.s3_storage_param.root_path);
@@ -1211,7 +1212,7 @@ void TaskWorkerPool::_push_storage_policy_worker_thread_callback() {
                     st = io::S3FileSystem::create(s3_conf, std::to_string(resource.id), &fs);
                 } else {
                     fs = std::static_pointer_cast<io::S3FileSystem>(existed_resource.fs);
-                    fs->set_conf(s3_conf);
+                    st = fs->set_conf(s3_conf);
                 }
                 if (!st.ok()) {
                     LOG(WARNING) << "update s3 resource failed: " << st;

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -96,6 +96,29 @@ namespace io {
     RETURN_IF_ERROR(get_key(path, &key));
 #endif
 
+// Guarded by external lock.
+Status S3FileSystem::set_conf(S3Conf s3_conf) {
+    if (s3_conf.ak == _s3_conf.ak && s3_conf.sk == _s3_conf.sk && s3_conf.token == _s3_conf.token) {
+        return Status::OK(); // Same conf
+    }
+
+    auto reset_conf = _s3_conf;
+    reset_conf.ak = s3_conf.ak;
+    reset_conf.sk = s3_conf.sk;
+    reset_conf.token = s3_conf.token;
+    auto client = S3ClientFactory::instance().create(s3_conf);
+    if (!client) {
+        return Status::InternalError("failed to init s3 client with {}", _s3_conf.to_string());
+    }
+
+    {
+        std::lock_guard lock(_client_mu);
+        _client = std::move(client);
+    }
+    _s3_conf = std::move(reset_conf);
+    return Status::OK();
+}
+
 Status S3FileSystem::create(S3Conf s3_conf, std::string id, std::shared_ptr<S3FileSystem>* fs) {
     (*fs).reset(new S3FileSystem(std::move(s3_conf), std::move(id)));
     return (*fs)->connect();

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -59,7 +59,7 @@ public:
     static Status create(S3Conf s3_conf, std::string id, std::shared_ptr<S3FileSystem>* fs);
     ~S3FileSystem() override;
     // Guarded by external lock.
-    void set_conf(S3Conf s3_conf) { _s3_conf = std::move(s3_conf); }
+    Status set_conf(S3Conf s3_conf);
 
     std::shared_ptr<Aws::S3::S3Client> get_client() const {
         std::lock_guard lock(_client_mu);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -104,7 +104,8 @@ public class S3Resource extends Resource {
         properties.putIfAbsent(S3Properties.REGION, region);
         String ak = properties.get(S3Properties.ACCESS_KEY);
         String sk = properties.get(S3Properties.SECRET_KEY);
-        CloudCredentialWithEndpoint credential = new CloudCredentialWithEndpoint(pingEndpoint, region, ak, sk);
+        String token = properties.get(S3Properties.SESSION_TOKEN);
+        CloudCredentialWithEndpoint credential = new CloudCredentialWithEndpoint(pingEndpoint, region, ak, sk, token);
 
         if (needCheck) {
             String bucketName = properties.get(S3Properties.BUCKET);
@@ -125,6 +126,7 @@ public class S3Resource extends Resource {
         Map<String, String> propertiesPing = new HashMap<>();
         propertiesPing.put(S3Properties.Env.ACCESS_KEY, credential.getAccessKey());
         propertiesPing.put(S3Properties.Env.SECRET_KEY, credential.getSecretKey());
+        propertiesPing.put(S3Properties.Env.TOKEN, credential.getSessionToken());
         propertiesPing.put(S3Properties.Env.ENDPOINT, credential.getEndpoint());
         propertiesPing.put(S3Properties.Env.REGION, credential.getRegion());
         propertiesPing.put(PropertyConverter.USE_PATH_STYLE,
@@ -189,6 +191,10 @@ public class S3Resource extends Resource {
         writeLock();
         for (Map.Entry<String, String> kv : properties.entrySet()) {
             replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+            if (kv.getKey().equals(S3Properties.Env.TOKEN)
+                    || kv.getKey().equals(S3Properties.SESSION_TOKEN)) {
+                this.properties.put(kv.getKey(), kv.getValue());
+            }
         }
         ++version;
         writeUnlock();
@@ -198,11 +204,13 @@ public class S3Resource extends Resource {
     private CloudCredentialWithEndpoint getS3PingCredentials(Map<String, String> properties) {
         String ak = properties.getOrDefault(S3Properties.ACCESS_KEY, this.properties.get(S3Properties.ACCESS_KEY));
         String sk = properties.getOrDefault(S3Properties.SECRET_KEY, this.properties.get(S3Properties.SECRET_KEY));
+        String token = properties.getOrDefault(S3Properties.SESSION_TOKEN,
+                this.properties.get(S3Properties.SESSION_TOKEN));
         String endpoint = properties.getOrDefault(S3Properties.ENDPOINT, this.properties.get(S3Properties.ENDPOINT));
         String pingEndpoint = "http://" + endpoint;
         String region = S3Properties.getRegionOfEndpoint(pingEndpoint);
         properties.putIfAbsent(S3Properties.REGION, region);
-        return new CloudCredentialWithEndpoint(pingEndpoint, region, ak, sk);
+        return new CloudCredentialWithEndpoint(pingEndpoint, region, ak, sk, token);
     }
 
     private boolean isNeedCheck(Map<String, String> newProperties) {
@@ -232,7 +240,9 @@ public class S3Resource extends Resource {
             // it's dangerous to show password in show odbc resource,
             // so we use empty string to replace the real password
             if (entry.getKey().equals(S3Properties.Env.SECRET_KEY)
-                    || entry.getKey().equals(S3Properties.SECRET_KEY)) {
+                    || entry.getKey().equals(S3Properties.SECRET_KEY)
+                    || entry.getKey().equals(S3Properties.Env.TOKEN)
+                    || entry.getKey().equals(S3Properties.SESSION_TOKEN)) {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), "******"));
             } else {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
@@ -253,6 +253,7 @@ public class S3Properties extends BaseProperties {
         s3Info.setRegion(properties.get(S3Properties.REGION));
         s3Info.setAk(properties.get(S3Properties.ACCESS_KEY));
         s3Info.setSk(properties.get(S3Properties.SECRET_KEY));
+        s3Info.setToken(properties.get(S3Properties.SESSION_TOKEN));
 
         s3Info.setRootPath(properties.get(S3Properties.ROOT_PATH));
         s3Info.setBucket(properties.get(S3Properties.BUCKET));

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -71,6 +71,7 @@ struct TS3StorageParam {
     8: optional string root_path
     9: optional string bucket
     10: optional bool use_path_style = false
+    11: optional string token
 }
 
 struct TStoragePolicy {

--- a/regression-test/suites/cold_heat_separation/policy/alter.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/alter.groovy
@@ -39,6 +39,7 @@ suite("alter_policy") {
             "AWS_ROOT_PATH" = "path/to/rootaaaa",
             "AWS_ACCESS_KEY" = "bbba",
             "AWS_SECRET_KEY" = "aaaa",
+            "AWS_TOKEN" = "session_token",
             "AWS_MAX_CONNECTIONS" = "50",
             "AWS_REQUEST_TIMEOUT_MS" = "3000",
             "AWS_CONNECTION_TIMEOUT_MS" = "1000",
@@ -68,6 +69,10 @@ suite("alter_policy") {
 
         def alter_result_succ_7 = try_sql """
             ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_REQUEST_TIMEOUT_MS" = "7777");
+        """
+
+        def alter_result_succ_8 = try_sql """
+            ALTER RESOURCE "${resource_name}" PROPERTIES("AWS_TOKEN" = "new_session_token");
         """
 
         // errCode = 2, detailMessage = current not support modify property : AWS_REGION
@@ -112,6 +117,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -133,6 +139,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "10101010")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_TOKEN
+        assertEquals(show_alter_result[10][3], "******")
     }
 
     def check_alter_resource_result_with_policy = { resource_name ->
@@ -151,6 +159,7 @@ suite("alter_policy") {
         // [has_resouce_policy_alter, s3, AWS_REQUEST_TIMEOUT_MS, 7777],
         // [has_resouce_policy_alter, s3, AWS_ROOT_PATH, path/to/rootaaaa],
         // [has_resouce_policy_alter, s3, AWS_SECRET_KEY, ******],
+        // [has_resouce_policy_alter, s3, AWS_TOKEN, ******],
         // [has_resouce_policy_alter, s3, id, {id}],
         // [has_resouce_policy_alter, s3, type, s3]
         // [has_resouce_policy_alter, s3, version, {version}]]
@@ -172,6 +181,8 @@ suite("alter_policy") {
         assertEquals(show_alter_result[8][3], "path/to/rootaaaa")
         // AWS_SECRET_KEY
         assertEquals(show_alter_result[9][3], "******")
+        // AWS_TOKEN
+        assertEquals(show_alter_result[10][3], "******")
     }
 
 


### PR DESCRIPTION
Issue Number: close #xxx

ref https://github.com/apache/doris/pull/34057, fix same issue on branch 2.0

fe return 'S3 can't use, return "please check your properties" when AWS_TOKEN is set
When altering the AK/SK resource, S3 client did not reset