### PR TITLE
[Fix](regression-test) Fix test_hive_write_type regression test.

### DIFF
--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
@@ -197,7 +197,7 @@ suite("test_hive_write_type", "p0,external,hive,external_docker,external_docker_
             } catch (Exception e) {
                 log.info(e.getMessage())
                 // BE err msg need use string contains to check
-                assertTrue(e.getMessage().contains("[E-124]Arithmetic overflow, convert failed from 1234567, expected data is [-999999, 999999]"))
+                assertTrue(e.getMessage().contains("Arithmetic overflow, convert failed from 1234567, expected data is [-999999, 999999]"))
             }
 
             try {
@@ -208,7 +208,7 @@ suite("test_hive_write_type", "p0,external,hive,external_docker,external_docker_
                 """
             } catch (Exception e) {
                 log.info(e.getMessage())
-                assertTrue(e.getMessage().contains("[E-124]Arithmetic overflow, convert failed from 1234567, expected data is [-999999, 999999]"))
+                assertTrue(e.getMessage().contains("Arithmetic overflow, convert failed from 1234567, expected data is [-999999, 999999]"))
             }
 
             test {


### PR DESCRIPTION
## Proposed changes

[Fix] (regression-test) Fix test_hive_write_type regression test.
Because #34397 changed error code of `ARITHMETIC_OVERFLOW_ERRROR`, so the error msg is not expected in the test.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

