### PR TITLE
[Fix](outfile) Fix the timing of setting the `_is_closed` flag in Parquet/ORC writer

### DIFF
--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -77,8 +77,8 @@ VOrcOutputStream::~VOrcOutputStream() {
 
 void VOrcOutputStream::close() {
     if (!_is_closed) {
+        Defer defer {[this] { _is_closed = true; }};
         Status st = _file_writer->close();
-        _is_closed = true;
         if (!st.ok()) {
             LOG(WARNING) << "close orc output stream failed: " << st;
             throw std::runtime_error(st.to_string());

--- a/be/src/vec/runtime/vparquet_transformer.cpp
+++ b/be/src/vec/runtime/vparquet_transformer.cpp
@@ -99,15 +99,14 @@ arrow::Result<int64_t> ParquetOutputStream::Tell() const {
 }
 
 arrow::Status ParquetOutputStream::Close() {
-    if (_is_closed) {
-        return arrow::Status::OK();
+    if (!_is_closed) {
+        Defer defer {[this] { _is_closed = true; }};
+        Status st = _file_writer->close();
+        if (!st.ok()) {
+            LOG(WARNING) << "close parquet output stream failed: " << st;
+            return arrow::Status::IOError(st.to_string());
+        }
     }
-    Status st = _file_writer->close();
-    if (!st.ok()) {
-        LOG(WARNING) << "close parquet output stream failed: " << st;
-        return arrow::Status::IOError(st.to_string());
-    }
-    _is_closed = true;
     return arrow::Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In parquet_transformer.cpp:
If `_file_writer->close()` returns an error, then `_is_closed = true` will not be executed.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

