### PR TITLE
[fix](Nereids) empty set handle in fe should use result output

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -581,8 +581,7 @@ public class NereidsPlanner extends Planner {
             return Optional.of(resultSet);
         } else if (child instanceof PhysicalEmptyRelation) {
             List<Column> columns = Lists.newArrayList();
-            PhysicalEmptyRelation physicalEmptyRelation = (PhysicalEmptyRelation) physicalPlan.child(0);
-            for (int i = 0; i < physicalEmptyRelation.getProjects().size(); i++) {
+            for (int i = 0; i < physicalPlan.getOutput().size(); i++) {
                 NamedExpression output = physicalPlan.getOutput().get(i);
                 columns.add(new Column(output.getName(), output.getDataType().toCatalogDataType()));
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

