### PR TITLE
[env](thrift) Generate move constructors and assignment operators.

### DIFF
--- a/gensrc/thrift/Makefile
+++ b/gensrc/thrift/Makefile
@@ -31,7 +31,7 @@ all: ${GEN_OBJECTS} ${OBJECTS}
 
 $(shell mkdir -p ${BUILD_DIR}/gen_java)
 
-THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen cpp -out ${BUILD_DIR}/gen_cpp --allow-64bit-consts -strict
+THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen cpp:moveable_types -out ${BUILD_DIR}/gen_cpp --allow-64bit-consts -strict
 THRIFT_JAVA_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen java:fullcamel -out ${BUILD_DIR}/gen_java --allow-64bit-consts -strict
 
 ${BUILD_DIR}/gen_cpp:


### PR DESCRIPTION
## Proposed changes


For structures like the profile, which might be large, we require move constructors and assignment operators.

before
```
class TCounter : public virtual ::apache::thrift::TBase {
 public:
  TCounter(const TCounter&);
  TCounter& operator=(const TCounter&);
```

now

```
class TCounter : public virtual ::apache::thrift::TBase {
 public:
  TCounter(const TCounter&);
  TCounter(TCounter&&) noexcept;
  TCounter& operator=(const TCounter&);
  TCounter& operator=(TCounter&&) noexcept;
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

