### PR TITLE
[Fix](executor)Fix workload thread start failed when follower convert to master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1741,7 +1741,7 @@ public class Env {
 
         dnsCache.start();
 
-        workloadGroupMgr.startUpdateThread();
+        workloadGroupMgr.start();
         workloadSchedPolicyMgr.start();
         workloadRuntimeStatusMgr.start();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -19,7 +19,6 @@ package org.apache.doris.resource.workloadgroup;
 
 import org.apache.doris.analysis.AlterWorkloadGroupStmt;
 import org.apache.doris.analysis.CreateWorkloadGroupStmt;
-import org.apache.doris.analysis.DropWorkloadGroupStmt;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -187,38 +186,6 @@ public class WorkloadGroupMgrTest {
             Assert.fail();
         } catch (UserException e) {
             Assert.assertTrue(e.getMessage().contains("does not exist"));
-        }
-    }
-
-    @Test
-    public void testDropWorkloadGroup() throws UserException {
-        Config.enable_workload_group = true;
-        ConnectContext context = new ConnectContext();
-        WorkloadGroupMgr workloadGroupMgr = new WorkloadGroupMgr();
-        Map<String, String> properties = Maps.newHashMap();
-        properties.put(WorkloadGroup.CPU_SHARE, "10");
-        properties.put(WorkloadGroup.MEMORY_LIMIT, "30%");
-        String name = "g1";
-        CreateWorkloadGroupStmt createStmt = new CreateWorkloadGroupStmt(false, name, properties);
-        workloadGroupMgr.createWorkloadGroup(createStmt);
-        context.getSessionVariable().setWorkloadGroup(name);
-        Assert.assertEquals(1, workloadGroupMgr.getWorkloadGroup(context).size());
-
-        DropWorkloadGroupStmt dropStmt = new DropWorkloadGroupStmt(false, name);
-        workloadGroupMgr.dropWorkloadGroup(dropStmt);
-        try {
-            context.getSessionVariable().setWorkloadGroup(name);
-            workloadGroupMgr.getWorkloadGroup(context);
-            Assert.fail();
-        } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("does not exist"));
-        }
-
-        DropWorkloadGroupStmt dropDefaultStmt = new DropWorkloadGroupStmt(false, WorkloadGroupMgr.DEFAULT_GROUP_NAME);
-        try {
-            workloadGroupMgr.dropWorkloadGroup(dropDefaultStmt);
-        } catch (DdlException e) {
-            Assert.assertTrue(e.getMessage().contains("is not allowed"));
         }
     }
 

--- a/regression-test/data/workload_manager_p0/test_curd_wlg.out
+++ b/regression-test/data/workload_manager_p0/test_curd_wlg.out
@@ -9,6 +9,15 @@
 normal	20	50%	true	2147483647	0	0	1%	16	
 test_group	10	10%	true	2147483647	0	0	-1	-1	
 
+-- !show_del_wg_1 --
+normal	20	50%	true	2147483647	0	0	1%	16	
+test_drop_wg	10	0%	true	2147483647	0	0	-1	-1	
+test_group	10	10%	true	2147483647	0	0	-1	-1	
+
+-- !show_del_wg_2 --
+normal	20	50%	true	2147483647	0	0	1%	16	
+test_group	10	10%	true	2147483647	0	0	-1	-1	
+
 -- !mem_limit_1 --
 2
 

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -70,6 +70,7 @@ enable_job_schedule_second_for_test = true
 
 enable_workload_group = true
 publish_topic_info_interval_ms = 1000
+workload_sched_policy_interval_ms = 1000
 
 disable_decimalv2 = false
 disable_datev1 = false

--- a/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
+++ b/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
@@ -128,6 +128,12 @@ suite("test_crud_wlg") {
 
     qt_show_1 "select name,cpu_share,memory_limit,enable_memory_overcommit,max_concurrency,max_queue_size,queue_timeout,cpu_hard_limit,scan_thread_num,tag from information_schema.workload_groups where name in ('normal','test_group') order by name;"
 
+    // test drop workload group
+    sql "create workload group if not exists test_drop_wg properties ('cpu_share'='10')"
+    qt_show_del_wg_1 "select name,cpu_share,memory_limit,enable_memory_overcommit,max_concurrency,max_queue_size,queue_timeout,cpu_hard_limit,scan_thread_num,tag from information_schema.workload_groups where name in ('normal','test_group','test_drop_wg') order by name;"
+    sql "drop workload group test_drop_wg"
+    qt_show_del_wg_2 "select name,cpu_share,memory_limit,enable_memory_overcommit,max_concurrency,max_queue_size,queue_timeout,cpu_hard_limit,scan_thread_num,tag from information_schema.workload_groups where name in ('normal','test_group','test_drop_wg') order by name;"
+
     // test memory_limit
     test {
         sql "alter workload group test_group properties ( 'memory_limit'='100%' );"


### PR DESCRIPTION
## Proposed changes
<img width="1117" alt="image" src="https://github.com/apache/doris/assets/12951030/ac24413c-d52d-49a9-a90a-da364320ef94">
When follower fe convert to master fe，a non-master daemon thread may be started duplicately. this may throw a exception.
