### PR TITLE
[fix](Nereids) check pushDownContext validation after withNewProbeExpression()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -101,9 +101,14 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
             this.exprOrder = exprOrder;
             this.isNot = isNot;
             Expression expr = getSingleNumericSlotOrExpressionCoveredByCast(probeExpr);
+            /* finalTarget can be null if it is not a column from base table.
+            for example:
+            select * from T1 join (select 9 as x) T2 on T1.x=T2.x,
+            where the final target of T2.x is a constant
+            */
             if (expr instanceof Slot) {
                 probeSlot = (Slot) expr;
-                finalTarget = rfContext.getAliasTransferPair((Slot) probeSlot);
+                finalTarget = rfContext.getAliasTransferPair(probeSlot);
             } else {
                 finalTarget = null;
                 probeSlot = null;
@@ -290,6 +295,9 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         }
         for (Expression prob : probExprList) {
             PushDownContext ctxForChild = prob.equals(ctx.probeExpr) ? ctx : ctx.withNewProbeExpression(prob);
+            if (!ctxForChild.isValid()) {
+                continue;
+            }
             if (ctx.rfContext.isRelationUseByPlan(leftNode, ctxForChild.finalTarget.first)) {
                 pushed |= leftNode.accept(this, ctxForChild);
             }
@@ -356,8 +364,11 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
                 }
             }
         }
-
-        return project.child().accept(this, ctxProjectProbeExpr);
+        if (!ctxProjectProbeExpr.isValid()) {
+            return false;
+        } else {
+            return project.child().accept(this, ctxProjectProbeExpr);
+        }
     }
 
     @Override
@@ -394,7 +405,7 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
                  *   +--->select 0, 0
                  * push down context for "select 0, 0" is invalid
                  */
-                pushedDown |= setOperation.child(i).accept(this, ctx.withNewProbeExpression(newProbeExpr));
+                pushedDown |= setOperation.child(i).accept(this, childPushDownContext);
             }
         }
         return pushedDown;


### PR DESCRIPTION
## Proposed changes
when the runtime filter target to a constant, the PushDownContext.finalTarget is null.
in this case, do not pushdown runtime filter.
example:
select * from (select 1 as x from T1) T2 join T3 on T2.x=T3.x
when push down RF(T3.x->T2.x) inside  "select 1 as x from T1", the column x is a constant, and the pushDown stopped.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

