### PR TITLE
[feature](ui) web profile download use plain text

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -59,6 +59,15 @@ public class QueryProfileController extends BaseController {
         return ResponseEntityBuilder.ok(profile);
     }
 
+    @RequestMapping(path = "/query_profile/text/{" + ID + "}", method = RequestMethod.GET)
+    public Object profileText(@PathVariable(value = ID) String id) {
+        String queryProfileStr = ProfileManager.getInstance().getProfile(id);
+        if (queryProfileStr == null) {
+            return "query id " + id + " not found";
+        }
+        return queryProfileStr;
+    }
+
     @RequestMapping(path = "/query_profile", method = RequestMethod.GET)
     public Object query() {
         Map<String, Object> result = Maps.newHashMap();

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -76,6 +76,30 @@ export function queryProfile<T>(data: any): Promise<Result<T>> {
     return request(LocalUrl, data);
 }
 
+//query_profileText
+export function queryProfileText(data: any): Promise<string> {
+    let LocalUrl = '/rest/v1/query_profile/';
+    if (data.path) {
+        LocalUrl = `/rest/v1/query_profile/text/${data.path}`;
+    }
+    const headers = new Headers();
+    headers.append('Accept', 'text/plain');
+
+    return fetch(LocalUrl, {
+        method: 'GET',
+        headers: headers
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.text();
+        })
+        .catch(error => {
+            console.error('Error fetching data:', error);
+            return '';
+        });
+}
 //session
 export function getSession<T>(data: any): Promise<Result<T>> {
     return request('/rest/v1/session', data);

--- a/ui/src/pages/query-profile/index.tsx
+++ b/ui/src/pages/query-profile/index.tsx
@@ -19,7 +19,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, Col, Row, Typography, Space } from 'antd';
-import { queryProfile } from 'Src/api/api';
+import { queryProfile,queryProfileText } from 'Src/api/api';
 import Table from 'Src/components/table';
 import { useHistory } from 'react-router-dom';
 import { Result } from '@src/interfaces/http.interface';
@@ -70,24 +70,13 @@ export default function QueryProfile(params: any) {
                                 <Button
                                     size="small"
                                     onClick={() => {
-                                        queryProfile<any>({
+                                        queryProfileText<any>({
                                             path: row['Profile ID'],
                                         }).then((profileDetailRes) => {
-                                            if (
-                                                profileDetailRes &&
-                                                profileDetailRes.msg ===
-                                                    'success'
-                                            ) {
-                                                if (
-                                                    !profileDetailRes.data
-                                                        .column_names
-                                                ) {
-                                                    download(
-                                                        profileDetailRes.data,
-                                                        row['Profile ID']
-                                                    );
-                                                }
-                                            }
+                                            download(
+                                                profileDetailRes,
+                                                row['Profile ID']
+                                            );
                                         });
                                     }}
                                 >


### PR DESCRIPTION
## Proposed changes

download the plain text of the profile, reduce the overhead of  string replace , converting JSON format.
```java
    @RequestMapping(path = "/query_profile/{" + ID + "}", method = RequestMethod.GET)
    public Object profile(@PathVariable(value = ID) String id) {
        String profile = ProfileManager.getInstance().getProfile(id);
        if (profile == null) {
            return ResponseEntityBuilder.okWithCommonError("ID " + id + " does not exist");
        }
        profile = profile.replaceAll("\n", "</br>");
        profile = profile.replaceAll(" ", "&nbsp;&nbsp;");
        return ResponseEntityBuilder.ok(profile);
    }
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

