### PR TITLE
[fix](test)Add wait for full compaction

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_index_compaction_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_index_compaction_fault_injection.groovy
@@ -240,6 +240,9 @@ suite("test_index_compaction_failure_injection", "nonConcurrent") {
         logger.info("trigger_full_compaction_on_tablets normally")
         trigger_full_compaction_on_tablets.call(tablets)
 
+        // wait for full compaction done
+        wait_full_compaction_done.call(tablets)
+
         // after full compaction, there is only 1 rowset.
         rowsetCount = get_rowset_count.call(tablets);
         if (isCloudMode) {


### PR DESCRIPTION
## Proposed changes

`test_index_compaction_fault_injection` case is unstable. 
Add wait to check full compaction is done before assert.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

