### PR TITLE
[fix](fs) Close local file writer when downloading via broker fs

### DIFF
--- a/be/src/io/fs/broker_file_system.cpp
+++ b/be/src/io/fs/broker_file_system.cpp
@@ -419,7 +419,7 @@ Status BrokerFileSystem::download_impl(const Path& remote_file, const Path& loca
         RETURN_IF_ERROR(local_writer->append({read_buf.get(), read_len}));
     } // file_handler should be closed before calculating checksum
 
-    return Status::OK();
+    return local_writer->close();
 }
 
 std::string BrokerFileSystem::error_msg(const std::string& err) const {


### PR DESCRIPTION
## Proposed changes

Issue Number: ref #33303

The LocalFileWriter will remove the file if it was not closed during destruction, so the BrokerFileSystem::download_impl downloads the target file and removes it later.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

