### PR TITLE
[Fix](compile) Fix clang-18 and libc++ compile problems

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -157,6 +157,7 @@ set(BOOST_VERSION "1.81.0")
 
 if (NOT APPLE)
     find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS system date_time)
+    find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS system container)
 else()
     find_package(Boost ${BOOST_VERSION} COMPONENTS system date_time)
     find_package(Boost ${BOOST_VERSION} COMPONENTS system container)
@@ -290,12 +291,11 @@ if (COMPILER_CLANG)
                         -Wno-implicit-float-conversion
                         -Wno-implicit-int-conversion
                         -Wno-sign-conversion
+                        -Wno-missing-field-initializers
+                        -Wno-unused-const-variable
                         -Wno-shorten-64-to-32)
     if (USE_LIBCPP)
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)
-        if (NOT OS_MACOSX)
-            add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-lstdc++>)
-        endif()
         add_definitions(-DUSE_LIBCPP)
     endif()
 endif ()
@@ -509,6 +509,7 @@ find_package(absl)
 # add it here first.
 set(COMMON_THIRDPARTY
     Boost::date_time
+    Boost::container
     ${COMMON_THIRDPARTY}
 )
 
@@ -551,7 +552,6 @@ endif()
 if (OS_MACOSX)
     set(COMMON_THIRDPARTY
         ${COMMON_THIRDPARTY}
-        Boost::container
         bfd
         iberty
         intl
@@ -595,9 +595,11 @@ if (NOT OS_MACOSX)
         ${DORIS_DEPENDENCIES}
         -static-libstdc++
         -static-libgcc
-        -lstdc++fs
         -lresolv
     )
+    if (NOT (USE_LIBCPP AND COMPILER_CLANG))
+        set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -lstdc++fs)
+    endif()
 else()
     set(DORIS_LINK_LIBS
         ${DORIS_LINK_LIBS}

--- a/be/src/cloud/cloud_tablet_hotspot.cpp
+++ b/be/src/cloud/cloud_tablet_hotspot.cpp
@@ -89,20 +89,20 @@ void TabletHotspot::get_top_n_hot_partition(std::vector<THotTableMessage>* hot_t
                 hot_partition.qpd = std::max(hot_partition.qpd, counter->qpd());
                 hot_partition.qpw = std::max(hot_partition.qpw, counter->qpw());
                 hot_partition.last_access_time =
-                        std::max(hot_partition.last_access_time,
-                                 std::chrono::duration_cast<std::chrono::seconds>(
-                                         counter->last_access_time.time_since_epoch())
-                                         .count());
+                        std::max<int64_t>(hot_partition.last_access_time,
+                                          std::chrono::duration_cast<std::chrono::seconds>(
+                                                  counter->last_access_time.time_since_epoch())
+                                                  .count());
             } else if (counter->qpw() != 0) {
                 auto& hot_partition = week_hot_partitions[std::make_pair(
                         counter->table_id, counter->index_id)][counter->partition_id];
                 hot_partition.qpd = 0;
                 hot_partition.qpw = std::max(hot_partition.qpw, counter->qpw());
                 hot_partition.last_access_time =
-                        std::max(hot_partition.last_access_time,
-                                 std::chrono::duration_cast<std::chrono::seconds>(
-                                         counter->last_access_time.time_since_epoch())
-                                         .count());
+                        std::max<int64_t>(hot_partition.last_access_time,
+                                          std::chrono::duration_cast<std::chrono::seconds>(
+                                                  counter->last_access_time.time_since_epoch())
+                                                  .count());
             }
         }
     });

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -157,7 +157,7 @@ void BlockFileCache::remove_query_context(const TUniqueId& query_id) {
     std::lock_guard cache_lock(_mutex);
     const auto& query_iter = _query_map.find(query_id);
 
-    if (query_iter != _query_map.end() && query_iter->second.unique()) {
+    if (query_iter != _query_map.end() && query_iter->second.use_count() <= 1) {
         _query_map.erase(query_iter);
     }
 }

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -332,6 +332,8 @@ TEST_F(ThreadPoolTest, TestDeadlocks) {
     const char* death_msg = "doris::ThreadPool::check_not_pool_thread_unlocked()";
 #elif defined(__APPLE__)
     const char* death_msg = "pthread_start";
+#elif defined(__clang__) && defined(USE_LIBCPP)
+    const char* death_msg = "doris::ThreadPool::check_not_pool_thread_unlocked()";
 #else
     const char* death_msg =
             "_ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_"

--- a/cloud/CMakeLists.txt
+++ b/cloud/CMakeLists.txt
@@ -165,7 +165,7 @@ if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
 endif()
 
 if (USE_LIBCPP AND COMPILER_CLANG)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++ -lstdc++")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++")
     add_definitions(-DUSE_LIBCPP)
 endif()
 
@@ -335,11 +335,13 @@ set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
     ${DORIS_DEPENDENCIES}
     -static-libstdc++
     -static-libgcc
-    -lstdc++fs
     -lresolv
     -L${DORIS_JAVA_HOME}/lib/server
     -ljvm
 )
+if (NOT (USE_LIBCPP AND COMPILER_CLANG))
+    set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -lstdc++fs)
+endif()
 
 if (USE_JEMALLOC)
     set(MALLOCLIB jemalloc)

--- a/cloud/src/common/encryption_util.cpp
+++ b/cloud/src/common/encryption_util.cpp
@@ -632,8 +632,8 @@ static int generate_random_root_key(TxnKv* txn_kv, KmsClient* kms_client, std::s
 
     // 3. otherwise, generate a random data key in memory
     std::mt19937 rnd(time(nullptr));
-    std::uniform_int_distribution<char> dist(std::numeric_limits<char>::min(),
-                                             std::numeric_limits<char>::max());
+    std::uniform_int_distribution<short> dist(std::numeric_limits<char>::min(),
+                                              std::numeric_limits<char>::max());
     std::string root_key_plaintext(32, '0');
     for (char& i : root_key_plaintext) {
         i = (char)dist(rnd);

--- a/cloud/src/recycler/checker.cpp
+++ b/cloud/src/recycler/checker.cpp
@@ -127,8 +127,9 @@ int Checker::start() {
             long enqueue_time_s = 0;
             {
                 std::unique_lock lock(mtx_);
-                pending_instance_cond_.wait(
-                        lock, [&]() { return !pending_instance_queue_.empty() || stopped(); });
+                pending_instance_cond_.wait(lock, [&]() -> bool {
+                    return !pending_instance_queue_.empty() || stopped();
+                });
                 if (stopped()) {
                     return;
                 }

--- a/cloud/src/recycler/checker.h
+++ b/cloud/src/recycler/checker.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#if defined(USE_LIBCPP) && _LIBCPP_ABI_VERSION <= 1
+#define _LIBCPP_ABI_INCOMPLETE_TYPES_IN_DEQUE
+#endif
 #include <atomic>
 #include <condition_variable>
 #include <deque>

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -376,7 +376,11 @@ int GcsAccessor::delete_prefix_impl(const std::string& path_prefix, int64_t expi
 
 int GcsAccessor::delete_files(const std::vector<std::string>& paths) {
     std::vector<int> delete_rets(paths.size());
+#ifdef USE_LIBCPP
+    std::transform(paths.begin(), paths.end(), delete_rets.begin(),
+#else
     std::transform(std::execution::par, paths.begin(), paths.end(), delete_rets.begin(),
+#endif
                    [this](const std::string& path) {
                        LOG_INFO("delete file").tag("uri", to_uri(path));
                        return delete_file(path);

--- a/cloud/test/codec_test.cpp
+++ b/cloud/test/codec_test.cpp
@@ -35,8 +35,8 @@ TEST(CodecTest, StringCodecTest) {
     std::mt19937 gen(std::random_device("/dev/urandom")());
     const int max_len = (2 << 16) + 10086;
     std::uniform_int_distribution<int> rd_len(0, max_len);
-    std::uniform_int_distribution<char> rd_char(std::numeric_limits<char>::min(),
-                                                std::numeric_limits<char>::max());
+    std::uniform_int_distribution<short> rd_char(std::numeric_limits<char>::min(),
+                                                 std::numeric_limits<char>::max());
 
     int ret = -1;
 

--- a/common/cpp/s3_rate_limiter.cpp
+++ b/common/cpp/s3_rate_limiter.cpp
@@ -24,10 +24,8 @@
 #include <thread>
 #if defined(__APPLE__)
 #include <ctime>
-#define CURRENT_TIME std::chrono::system_clock::now()
-#else
-#define CURRENT_TIME std::chrono::high_resolution_clock::now()
 #endif
+#define CURRENT_TIME std::chrono::system_clock::now()
 
 namespace doris {
 // Just 10^6.

--- a/run-cloud-ut.sh
+++ b/run-cloud-ut.sh
@@ -160,6 +160,14 @@ if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
     GLIBC_COMPATIBILITY=ON
 fi
 
+if [[ -z "${USE_LIBCPP}" ]]; then
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_LIBCPP='OFF'
+    else
+        USE_LIBCPP='ON'
+    fi
+fi
+
 if [[ -z "${USE_DWARF}" ]]; then
     USE_DWARF=OFF
 fi
@@ -176,6 +184,7 @@ find . -name "*.gcda" -exec rm {} \;
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DMAKE_TEST=ON \
     -DGLIBC_COMPATIBILITY="${GLIBC_COMPATIBILITY}" \
+    -DUSE_LIBCPP="${USE_LIBCPP}" \
     -DUSE_DWARF="${USE_DWARF}" \
     -DUSE_MEM_TRACKER=ON \
     -DUSE_JEMALLOC=OFF \
@@ -204,6 +213,8 @@ fi
 echo "**********************************"
 echo "   Running MetaService Unit Test  "
 echo "**********************************"
+
+export ASAN_OPTIONS=detect_container_overflow=0
 
 # test binary output dir
 cd test

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -627,7 +627,7 @@ build_bzip() {
     check_if_source_exist "${BZIP_SOURCE}"
     cd "${TP_SOURCE_DIR}/${BZIP_SOURCE}"
 
-    make -j "${PARALLEL}" install PREFIX="${TP_INSTALL_DIR}"
+    make -j "${PARALLEL}" install PREFIX="${TP_INSTALL_DIR}" CFLAGS="-fPIC"
 }
 
 # lzo2
@@ -1735,7 +1735,7 @@ build_libuuid() {
     check_if_source_exist "${LIBUUID_SOURCE}"
     cd "${TP_SOURCE_DIR}/${LIBUUID_SOURCE}"
     CC=gcc ./configure --prefix="${TP_INSTALL_DIR}" --disable-shared --enable-static
-    make -j "${PARALLEL}"
+    make -j "${PARALLEL}" CFLAGS="-fPIC"
     make install
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Fix clang-18 and libc++ compile problems

unique() of shared_ptr is deprecated in clang-18, it's not a strict implementation, can use use_count() instead.
And fixed some other compie errors in both using clang-18 and libc++.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

