### PR TITLE
[fix](be-ut) Fix annoying error message when using run-be-ut.sh

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -276,7 +276,7 @@ rm -f "${UDF_RUNTIME_DIR}"/*
 # clean all gcda file
 while read -r gcda_file; do
     rm "${gcda_file}"
-done < <(find "${DORIS_TEST_BINARY_DIR}" -name "*gcda")
+done < <(find "${CMAKE_BUILD_DIR}" -name "*gcda")
 
 # prepare gtest output dir
 GTEST_OUTPUT_DIR="${CMAKE_BUILD_DIR}/gtest_output"


### PR DESCRIPTION
The garbage gcda file are not removed before running ut, this makes console full of error message.


![img_v3_02ap_e873d9f3-82dc-42de-bd0e-b44c8f7ad06g](https://github.com/apache/doris/assets/42906151/85bdf823-b3a9-45f3-965b-a934deaaf598)

