### PR TITLE
[fix](config) for compatibility issue of log dir config

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1732,11 +1732,18 @@ std::vector<std::vector<std::string>> get_config_info() {
         std::vector<std::string> _config;
         _config.push_back(it.first);
 
+        std::string config_val = it.second;
+        // For compatibility, this PR #32933 change the log dir's config logic,
+        // and deprecate the `sys_log_dir` config.
+        if (it.first == "sys_log_dir" && config_val == "") {
+            config_val = std::getenv("DORIS_HOME") + "/log";
+        }
+
         _config.emplace_back(field_it->second.type);
         if (0 == strcmp(field_it->second.type, "bool")) {
-            _config.emplace_back(it.second == "1" ? "true" : "false");
+            _config.emplace_back(config_val == "1" ? "true" : "false");
         } else {
-            _config.push_back(it.second);
+            _config.push_back(config_val);
         }
         _config.emplace_back(field_it->second.valmutable ? "true" : "false");
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1736,7 +1736,7 @@ std::vector<std::vector<std::string>> get_config_info() {
         // For compatibility, this PR #32933 change the log dir's config logic,
         // and deprecate the `sys_log_dir` config.
         if (it.first == "sys_log_dir" && config_val == "") {
-            config_val = std::getenv("DORIS_HOME") + "/log";
+            config_val = fmt::format("{}/log", std::getenv("DORIS_HOME"));
         }
 
         _config.emplace_back(field_it->second.type);

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -376,7 +376,13 @@ public class ConfigBase {
             if (matcher == null || matcher.match(confKey)) {
                 List<String> config = Lists.newArrayList();
                 config.add(confKey);
-                config.add(getConfValue(f));
+                String value = getConfValue(f);
+                // For compatibility, this PR #32933 change the log dir's config logic,
+                // and deprecate the `sys_log_dir` config.
+                if (confKey.equals("sys_log_dir") && Strings.isNullOrEmpty(value)) {
+                    value = System.getenv("DORIS_HOME") + "/log";
+                }
+                config.add(value);
                 config.add(f.getType().getSimpleName());
                 config.add(String.valueOf(confField.mutable()));
                 config.add(String.valueOf(confField.masterOnly()));


### PR DESCRIPTION
## Proposed changes

PR #32933 change the config log dir logic, but result result empty `sys_log_dir` when calling
`/rest/v2/manager/node/configuration_info` rest API.

This PR make it compatible with old version, return the real log dir as `sys_log_dir`'s value in rest API


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

