### PR TITLE
[chore](cloud) Use c++20 and unleash endian check

### DIFF
--- a/cloud/CMakeLists.txt
+++ b/cloud/CMakeLists.txt
@@ -137,7 +137,7 @@ check_function_exists(sched_getcpu HAVE_SCHED_GETCPU)
 #  -fno-omit-frame-pointers: Keep frame pointer for functions in register
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall -Wno-sign-compare -pthread -Werror")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fstrict-aliasing -fno-omit-frame-pointer")
-set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=gnu++17 -D__STDC_FORMAT_MACROS")
+set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=gnu++20 -D__STDC_FORMAT_MACROS")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED")
 # Enable the cpu and heap profile of brpc

--- a/cloud/src/meta-service/doris_txn.cpp
+++ b/cloud/src/meta-service/doris_txn.cpp
@@ -17,6 +17,8 @@
 
 #include "doris_txn.h"
 
+#include <bit>
+
 namespace doris::cloud {
 
 int get_txn_id_from_fdb_ts(std::string_view fdb_vts, int64_t* txn_id) {
@@ -29,7 +31,8 @@ int get_txn_id_from_fdb_ts(std::string_view fdb_vts, int64_t* txn_id) {
     // byte addr 0 1 2 3 4 5 6 7  8 9
     int64_t ver = *reinterpret_cast<const int64_t*>(fdb_vts.data());
 
-    // static_assert(std::endian::little); // Since c++20
+    // TODO(gavin): implementation for big-endian or make it endian-independent
+    static_assert(std::endian::native == std::endian::little); // Since c++20
     // Convert big endian to little endian
     static auto to_little = [](int64_t v) {
         v = ((v & 0xffffffff00000000) >> 32) | ((v & 0x00000000ffffffff) << 32);

--- a/cloud/src/meta-service/txn_kv.cpp
+++ b/cloud/src/meta-service/txn_kv.cpp
@@ -19,11 +19,11 @@
 
 #include <bthread/countdown_event.h>
 #include <byteswap.h>
-#include <endian.h>
 #include <foundationdb/fdb_c_types.h>
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -420,9 +420,9 @@ bool Transaction::decode_atomic_int(std::string_view data, int64_t* val) {
 
     // ATTN: The FDB_MUTATION_TYPE_ADD stores integers in a little-endian representation.
     std::memcpy(val, data.data(), sizeof(*val));
-#if __BYTE_ORDER == __BIG_ENDIAN
-    *val = bswap_64(*val);
-#endif
+    if constexpr (std::endian::native == std::endian::big) {
+        *val = bswap_64(*val);
+    }
     return true;
 }
 


### PR DESCRIPTION
Use c++20 and unleash endian check to prevent misuse.