### PR TITLE
[fix](nereids)do not push rf through cteAnchor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -33,6 +33,8 @@ import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalCTEAnchor;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalCTEProducer;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
@@ -432,4 +434,14 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         return false;
     }
 
+    @Override
+    public Boolean visitPhysicalCTEAnchor(PhysicalCTEAnchor<? extends Plan, ? extends Plan> anchor,
+            PushDownContext ctx) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitPhysicalCTEProducer(PhysicalCTEProducer<? extends Plan> cteProducer, PushDownContext ctx) {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -228,7 +228,10 @@ public class PhysicalNestedLoopJoin<
         } else {
             otherJoinConjuncts.forEach(expr -> builder.append(expr.shapeInfo()));
         }
-
+        if (!runtimeFilters.isEmpty()) {
+            builder.append(" build RFs:").append(runtimeFilters.stream()
+                    .map(rf -> rf.shapeInfo()).collect(Collectors.joining(";")));
+        }
         return builder.toString();
     }
 

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.out
@@ -24,16 +24,14 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF5 wr_order_number->[ws_order_number]
 ----------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------PhysicalProject
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[web_returns] apply RFs: RF6
 ----------------------PhysicalProject
 ------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF7 ws_order_number->[ws_order_number,ws_order_number]
 --------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF3 web_site_sk->[ws_web_site_sk]
 ------------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_ship_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_ship_date_sk]


### PR DESCRIPTION
## Proposed changes
pick from master #34744

Or_expansion rule create a CTEAnchor inside plan tree, and there are some columns above anchor sharing the same ExprId with columns under anchor. This mislead runtime pushdown visitor.
Solution:
when detect anchor inside plan tree, do not push rf through it.
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

