### PR TITLE
[Fix](catalog)Upgrade hive-catalog-shade to 2.0.2 to solve the problem that DLF cannot be used normally

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -684,26 +684,6 @@ under the License.
             </exclusions>
         </dependency>
 
-        <!-- for aliyun dlf -->
-        <dependency>
-            <groupId>com.aliyun.datalake</groupId>
-            <artifactId>metastore-client-hive3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-openapi</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-util</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- for fe recognize files stored on gcs -->
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -228,7 +228,7 @@ under the License.
         <doris.home>${fe.dir}/../</doris.home>
         <revision>1.2-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <doris.hive.catalog.shade.version>2.0.1</doris.hive.catalog.shade.version>
+        <doris.hive.catalog.shade.version>2.0.2</doris.hive.catalog.shade.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!--plugin parameters-->
@@ -330,7 +330,6 @@ under the License.
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
         <mariadb-java-client.version>3.0.9</mariadb-java-client.version>
-        <dlf-metastore-client-hive.version>0.2.14</dlf-metastore-client-hive.version>
         <hadoop.version>3.3.6</hadoop.version>
         <joda.version>2.8.1</joda.version>
         <project.scm.id>github</project.scm.id>
@@ -1500,11 +1499,6 @@ under the License.
                 <groupId>org.mariadb.jdbc</groupId>
                 <artifactId>mariadb-java-client</artifactId>
                 <version>${mariadb-java-client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aliyun.datalake</groupId>
-                <artifactId>metastore-client-hive3</artifactId>
-                <version>${dlf-metastore-client-hive.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
## Proposed changes
The exception stack encountered when using DLF is as follows:

This is because hive-catalog-sahde incorrectly renamed dlf-related packages, causing it to fail to run normally.
```
 java.lang.ClassCastException: class org.apache.hadoop.hive.metastore.api.NoSuchObjectException cannot be cast to class org.apache.thrift.TException
```
https://github.com/apache/doris-shade/pull/44