### PR TITLE
[fix](fe) Fix fe prometheus metric rest api npt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/CloudMetrics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/CloudMetrics.java
@@ -65,35 +65,35 @@ public class CloudMetrics {
 
         CLUSTER_REQUEST_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> {
             GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("rps", MetricUnit.NOUNIT,
-                    "request per second");
+                    "request per second", 0.0);
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
             return gauge;
         });
 
         CLUSTER_QUERY_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> {
             GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("qps", MetricUnit.NOUNIT,
-                    "query per second");
+                    "query per second", 0.0);
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
             return gauge;
         });
 
         CLUSTER_QUERY_ERR_RATE_GAUGE = new AutoMappedMetric<>(name -> {
             GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("query_err_rate", MetricUnit.NOUNIT,
-                    "query error rate");
+                    "query error rate", 0.0);
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
             return gauge;
         });
 
         CLUSTER_BACKEND_ALIVE = new AutoMappedMetric<>(name -> {
             GaugeMetricImpl<Integer> gauge  = new GaugeMetricImpl<Integer>("backend_alive", MetricUnit.NOUNIT,
-                    "backend alive or not");
+                    "backend alive or not", 0);
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
             return gauge;
         });
 
         CLUSTER_BACKEND_ALIVE_TOTAL = new AutoMappedMetric<>(name -> {
             GaugeMetricImpl<Integer> gauge  = new GaugeMetricImpl<Integer>("backend_alive_total", MetricUnit.NOUNIT,
-                    "backend alive num in cluster");
+                    "backend alive num in cluster", 0);
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
             return gauge;
         });

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/GaugeMetricImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/GaugeMetricImpl.java
@@ -19,8 +19,9 @@ package org.apache.doris.metric;
 
 public class GaugeMetricImpl<T> extends GaugeMetric<T> {
 
-    public GaugeMetricImpl(String name, MetricUnit unit, String description) {
+    public GaugeMetricImpl(String name, MetricUnit unit, String description, T defaultValue) {
         super(name, unit, description);
+        this.value = defaultValue;
     }
 
     private T value;

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -279,19 +279,15 @@ public final class MetricRepo {
 
         // qps, rps and error rate
         // these metrics should be set an init value, in case that metric calculator is not running
-        GAUGE_QUERY_PER_SECOND = new GaugeMetricImpl<>("qps", MetricUnit.NOUNIT, "query per second");
-        GAUGE_QUERY_PER_SECOND.setValue(0.0);
+        GAUGE_QUERY_PER_SECOND = new GaugeMetricImpl<>("qps", MetricUnit.NOUNIT, "query per second", 0.0);
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_QUERY_PER_SECOND);
-        GAUGE_REQUEST_PER_SECOND = new GaugeMetricImpl<>("rps", MetricUnit.NOUNIT, "request per second");
-        GAUGE_REQUEST_PER_SECOND.setValue(0.0);
+        GAUGE_REQUEST_PER_SECOND = new GaugeMetricImpl<>("rps", MetricUnit.NOUNIT, "request per second", 0.0);
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_REQUEST_PER_SECOND);
-        GAUGE_QUERY_ERR_RATE = new GaugeMetricImpl<>("query_err_rate", MetricUnit.NOUNIT, "query error rate");
+        GAUGE_QUERY_ERR_RATE = new GaugeMetricImpl<>("query_err_rate", MetricUnit.NOUNIT, "query error rate", 0.0);
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_QUERY_ERR_RATE);
-        GAUGE_QUERY_ERR_RATE.setValue(0.0);
         GAUGE_MAX_TABLET_COMPACTION_SCORE = new GaugeMetricImpl<>("max_tablet_compaction_score", MetricUnit.NOUNIT,
-                "max tablet compaction score of all backends");
+                "max tablet compaction score of all backends", 0L);
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_MAX_TABLET_COMPACTION_SCORE);
-        GAUGE_MAX_TABLET_COMPACTION_SCORE.setValue(0L);
 
         // query
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");
@@ -333,7 +329,7 @@ public final class MetricRepo {
                 "number of query instance begin"));
         USER_GAUGE_QUERY_INSTANCE_NUM = addLabeledMetrics("user", () ->
                 new GaugeMetricImpl<>("query_instance_num", MetricUnit.NOUNIT,
-                "number of running query instances of current user"));
+                "number of running query instances of current user", 0L));
         GaugeMetric<Long> queryInstanceNum = new GaugeMetric<Long>("query_instance_num",
                 MetricUnit.NOUNIT, "number of query instances of all current users") {
             @Override
@@ -471,7 +467,7 @@ public final class MetricRepo {
         };
         DORIS_METRIC_REGISTER.addMetrics(txnNum);
         DB_GAUGE_TXN_NUM = addLabeledMetrics("db", () ->
-                new GaugeMetricImpl<>("txn_num", MetricUnit.NOUNIT, "number of running transactions"));
+                new GaugeMetricImpl<>("txn_num", MetricUnit.NOUNIT, "number of running transactions", 0L));
         GaugeMetric<Long> publishTxnNum = new GaugeMetric<Long>("publish_txn_num", MetricUnit.NOUNIT,
                 "number of publish transactions") {
             @Override
@@ -481,7 +477,8 @@ public final class MetricRepo {
         };
         DORIS_METRIC_REGISTER.addMetrics(publishTxnNum);
         DB_GAUGE_PUBLISH_TXN_NUM = addLabeledMetrics("db",
-                () -> new GaugeMetricImpl<>("publish_txn_num", MetricUnit.NOUNIT, "number of publish transactions"));
+                () -> new GaugeMetricImpl<>("publish_txn_num", MetricUnit.NOUNIT,
+                "number of publish transactions", 0L));
         COUNTER_ROUTINE_LOAD_ROWS = new LongCounterMetric("routine_load_rows", MetricUnit.ROWS,
                 "total rows of routine load");
         DORIS_METRIC_REGISTER.addMetrics(COUNTER_ROUTINE_LOAD_ROWS);


### PR DESCRIPTION
```
java.lang.NullPointerException:
    Cannot invoke "Object.toString()" because the return value of
    "org.apache.doris.metric.Metric.getValue()" is null at
    org.apache.doris.metric.PrometheusMetricVisitor.visit(PrometheusMetricVisitor.java:168)
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

