### PR TITLE
[Fix](Planner) fix date_xxx functions without complete function signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -103,6 +103,11 @@ public class FEFunctions {
         return daysAdd(date, day);
     }
 
+    @FEFunction(name = "date_add", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral dateAddDate(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, day);
+    }
+
     @FEFunction(name = "date_add", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral dateAddDateV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         return daysAdd(date, day);
@@ -134,6 +139,12 @@ public class FEFunctions {
         return dateLiteral.plusYears((int) year.getLongValue());
     }
 
+    @FEFunction(name = "years_add", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral yearsAddDate(LiteralExpr date, LiteralExpr year) throws AnalysisException {
+        DateLiteral dateLiteral = (DateLiteral) date;
+        return dateLiteral.plusYears((int) year.getLongValue());
+    }
+
     @FEFunction(name = "years_add", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral yearsAddDateV2(LiteralExpr date, LiteralExpr year) throws AnalysisException {
         DateLiteral dateLiteral = (DateLiteral) date;
@@ -152,6 +163,12 @@ public class FEFunctions {
         return dateLiteral.plusMonths((int) month.getLongValue());
     }
 
+    @FEFunction(name = "months_add", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral monthsAddDate(LiteralExpr date, LiteralExpr month) throws AnalysisException {
+        DateLiteral dateLiteral = (DateLiteral) date;
+        return dateLiteral.plusMonths((int) month.getLongValue());
+    }
+
     @FEFunction(name = "months_add", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral monthsAddDateV2(LiteralExpr date, LiteralExpr month) throws AnalysisException {
         DateLiteral dateLiteral = (DateLiteral) date;
@@ -166,6 +183,12 @@ public class FEFunctions {
 
     @FEFunction(name = "days_add", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")
     public static DateLiteral daysAdd(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        DateLiteral dateLiteral = (DateLiteral) date;
+        return dateLiteral.plusDays((int) day.getLongValue());
+    }
+
+    @FEFunction(name = "days_add", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral daysAddDate(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         DateLiteral dateLiteral = (DateLiteral) date;
         return dateLiteral.plusDays((int) day.getLongValue());
     }
@@ -223,13 +246,38 @@ public class FEFunctions {
         return dateAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 
+    @FEFunction(name = "date_sub", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral dateSubDate(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
     @FEFunction(name = "date_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral dateSubDateV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         return dateAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 
+    @FEFunction(name = "date_sub", argTypes = { "DATETIMEV2", "INT" }, returnType = "DATETIMEV2")
+    public static DateLiteral dateSubDateTimeV2(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
     @FEFunction(name = "years_sub", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")
     public static DateLiteral yearsSub(LiteralExpr date, LiteralExpr year) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) year.getLongValue()));
+    }
+
+    @FEFunction(name = "years_sub", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral yearsSubDate(LiteralExpr date, LiteralExpr year) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) year.getLongValue()));
+    }
+
+    @FEFunction(name = "years_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
+    public static DateLiteral yearsSubDateV2(LiteralExpr date, LiteralExpr year) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) year.getLongValue()));
+    }
+
+    @FEFunction(name = "years_sub", argTypes = { "DATETIMEV2", "INT" }, returnType = "DATETIMEV2")
+    public static DateLiteral yearsSubDateTimeV2(LiteralExpr date, LiteralExpr year) throws AnalysisException {
         return yearsAdd(date, new IntLiteral(-(int) year.getLongValue()));
     }
 
@@ -238,8 +286,28 @@ public class FEFunctions {
         return monthsAdd(date, new IntLiteral(-(int) month.getLongValue()));
     }
 
+    @FEFunction(name = "months_sub", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral monthsSubDate(LiteralExpr date, LiteralExpr month) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+    }
+
+    @FEFunction(name = "months_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
+    public static DateLiteral monthsSubDateV2(LiteralExpr date, LiteralExpr month) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+    }
+
+    @FEFunction(name = "months_sub", argTypes = { "DATETIMEV2", "INT" }, returnType = "DATETIMEV2")
+    public static DateLiteral monthsSubDateTimeV2(LiteralExpr date, LiteralExpr month) throws AnalysisException {
+        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+    }
+
     @FEFunction(name = "days_sub", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")
     public static DateLiteral daysSub(LiteralExpr date, LiteralExpr day) throws AnalysisException {
+        return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
+    }
+
+    @FEFunction(name = "days_sub", argTypes = { "DATE", "INT" }, returnType = "DATE")
+    public static DateLiteral daysSubDate(LiteralExpr date, LiteralExpr day) throws AnalysisException {
         return daysAdd(date, new IntLiteral(-(int) day.getLongValue()));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -288,17 +288,17 @@ public class FEFunctions {
 
     @FEFunction(name = "months_sub", argTypes = { "DATE", "INT" }, returnType = "DATE")
     public static DateLiteral monthsSubDate(LiteralExpr date, LiteralExpr month) throws AnalysisException {
-        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+        return monthsAdd(date, new IntLiteral(-(int) month.getLongValue()));
     }
 
     @FEFunction(name = "months_sub", argTypes = { "DATEV2", "INT" }, returnType = "DATEV2")
     public static DateLiteral monthsSubDateV2(LiteralExpr date, LiteralExpr month) throws AnalysisException {
-        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+        return monthsAdd(date, new IntLiteral(-(int) month.getLongValue()));
     }
 
     @FEFunction(name = "months_sub", argTypes = { "DATETIMEV2", "INT" }, returnType = "DATETIMEV2")
     public static DateLiteral monthsSubDateTimeV2(LiteralExpr date, LiteralExpr month) throws AnalysisException {
-        return yearsAdd(date, new IntLiteral(-(int) month.getLongValue()));
+        return monthsAdd(date, new IntLiteral(-(int) month.getLongValue()));
     }
 
     @FEFunction(name = "days_sub", argTypes = { "DATETIME", "INT" }, returnType = "DATETIME")

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -239,6 +239,51 @@ suite("test_date_function") {
         contains "2025-01-16"
     }
 
+    explain {
+        sql """select * from ${tableName} where test_datetime >= date_sub('2024-01-16',INTERVAL 1 day);"""
+        contains "2024-01-15"
+    }
+
+    explain {
+        sql """select * from ${tableName} where test_datetime >= months_sub('2024-02-16',1);"""
+        contains "2024-01-16"
+    }
+    explain {
+        sql """select * from ${tableName} where test_datetime >= years_sub('2024-01-16',1);"""
+        contains "2023-01-16"
+    }
+
+    explain {
+        sql """select * from ${tableName} where test_datetime >= date_add(cast('2024-01-16' as DATE),INTERVAL 1 day);"""
+        contains "2024-01-17"
+    }
+    explain {
+        sql """select * from ${tableName} where test_datetime >= adddate(cast('2024-01-16' as DATE),INTERVAL 1 day);"""
+        contains "2024-01-17"
+    }
+    explain {
+        sql """select * from ${tableName} where test_datetime >= months_add(cast('2024-01-16' as DATE),1);"""
+        contains "2024-02-16"
+    }
+    explain {
+        sql """select * from ${tableName} where test_datetime >= years_add(cast('2024-01-16' as DATE),1);"""
+        contains "2025-01-16"
+    }
+
+    explain {
+        sql """select * from ${tableName} where test_datetime >= date_sub(cast('2024-01-16' as DATE),INTERVAL 1 day);"""
+        contains "2024-01-15"
+    }
+
+    explain {
+        sql """select * from ${tableName} where test_datetime >= months_sub(cast('2024-02-16' as DATE),1);"""
+        contains "2024-01-16"
+    }
+    explain {
+        sql """select * from ${tableName} where test_datetime >= years_sub(cast('2024-01-16' as DATE),1);"""
+        contains "2023-01-16"
+    }
+
     // DATE_FORMAT
     sql """ truncate table ${tableName} """
     sql """ insert into ${tableName} values ("2009-10-04 22:23:00") """


### PR DESCRIPTION
## Proposed changes

pick from master #34761

Problem:
When using current_date as input of functions like date_sub, fold constant would failed cause of missing of function signature
in Planner
Solved:
Add complete function signature of functions like date_sub

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

