### PR TITLE
Buf fix in be broker module.

### DIFF
--- a/be/src/io/fs/broker_file_system.cpp
+++ b/be/src/io/fs/broker_file_system.cpp
@@ -416,7 +416,7 @@ Status BrokerFileSystem::download_impl(const Path& remote_file, const Path& loca
         RETURN_IF_ERROR(local_writer->append({read_buf.get(), read_len}));
     } // file_handler should be closed before calculating checksum
 
-    return Status::OK();
+    return local_writer->close();
 }
 
 Status BrokerFileSystem::read_file(const TBrokerFD& fd, size_t offset, size_t bytes_req,

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -338,7 +338,9 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             }
             // remove file which will be downloaded now.
             // this file will be added to local_files if it be downloaded successfully.
-            local_files.erase(find);
+            if (find != local_files.end()) {
+                local_files.erase(find);
+            }
             RETURN_IF_ERROR(_remote_fs->download(full_remote_file, full_local_file));
 
             // 3. check md5 of the downloaded file


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
This pr contains tow small bug fix about snapshop_loader and broker module.

1. Uncheckd erase action of vector may cause be run failure of core dump.
2. Close the local file writer after data has been wrote.
