### PR TITLE
[bugfix](hive)fix testcase for viewfs

### DIFF
--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -41,10 +41,13 @@ Status create_hdfs_fs(const THdfsParams& hdfs_params, const std::string& fs_name
     return Status::OK();
 }
 
-uint64 hdfs_hash_code(const THdfsParams& hdfs_params) {
+uint64 hdfs_hash_code(const THdfsParams& hdfs_params, const std::string& fs_name) {
     uint64 hash_code = 0;
-    hash_code ^= Fingerprint(hdfs_params.fs_name);
-    if (hdfs_params.__isset.user) {
+    // The specified fsname is used first.
+    // If there is no specified fsname, the default fsname is used
+    if (!fs_name.empty()) {
+        hash_code ^= Fingerprint(fs_name);
+    } else if (hdfs_params.__isset.user) {
         hash_code ^= Fingerprint(hdfs_params.user);
     }
     if (hdfs_params.__isset.hdfs_kerberos_principal) {
@@ -104,7 +107,7 @@ void HdfsHandlerCache::_clean_oldest() {
 
 Status HdfsHandlerCache::get_connection(const THdfsParams& hdfs_params, const std::string& fs_name,
                                         std::shared_ptr<HdfsHandler>* fs_handle) {
-    uint64 hash_code = hdfs_hash_code(hdfs_params);
+    uint64 hash_code = hdfs_hash_code(hdfs_params, fs_name);
     {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _cache.find(hash_code);


### PR DESCRIPTION
## Proposed changes

The specified `fsname` is used first, and if there is no `fsname`, the default `fsname` is used.
Because we create an HDFS cache based on the actual `fsname`.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

