### PR TITLE
[fix](runtimefilter)slot comparison bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -389,7 +389,7 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         List<NamedExpression> output = setOperation.getOutputs();
         for (int j = 0; j < output.size(); j++) {
             NamedExpression expr = output.get(j);
-            if (expr.getName().equals(probeSlot.getName())) {
+            if (expr.getExprId().equals(probeSlot.getExprId())) {
                 projIndex = j;
                 break;
             }
@@ -397,10 +397,10 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         if (projIndex == -1) {
             return false;
         }
+        // probeExpr only has one input slot
         for (int i = 0; i < setOperation.children().size(); i++) {
             Map<Expression, Expression> map = Maps.newHashMap();
-            // probeExpr only has one input slot
-            map.put(ctx.probeExpr.getInputSlots().iterator().next(),
+            map.put(probeSlot,
                     setOperation.getRegularChildrenOutputs().get(i).get(projIndex));
             Expression newProbeExpr = ctx.probeExpr.accept(ExpressionVisitors.EXPRESSION_MAP_REPLACER, map);
             PushDownContext childPushDownContext = ctx.withNewProbeExpression(newProbeExpr);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
@@ -103,7 +103,7 @@ public class PhysicalCTEConsumer extends PhysicalRelation {
                     .stream().forEach(rf -> builder.append(" RF").append(rf.getId().asInt()));
         }
         return Utils.toSqlString("PhysicalCTEConsumer[" + id.asInt() + "]",
-                "stats", getStats(), "cteId", cteId, "RFs", builder);
+                "stats", getStats(), "cteId", cteId, "RFs", builder, "map", consumerToProducerSlotMap);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes
slot comparison should be based on exprId, not name

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

