### PR TITLE
[fix](group_commit) Wal reader should check block length to avoid reading empty block

### DIFF
--- a/be/src/olap/wal/wal_reader.cpp
+++ b/be/src/olap/wal/wal_reader.cpp
@@ -69,6 +69,9 @@ Status WalReader::read_block(PBlock& block) {
             file_reader->read_at(_offset, {row_len_buf, WalWriter::LENGTH_SIZE}, &bytes_read));
     _offset += WalWriter::LENGTH_SIZE;
     size_t block_len = decode_fixed64_le(row_len_buf);
+    if (block_len == 0) {
+        return Status::InternalError("fail to read wal {} ,block is empty", _file_name);
+    }
     // read block
     std::string block_buf;
     block_buf.resize(block_len);

--- a/be/src/olap/wal/wal_reader.cpp
+++ b/be/src/olap/wal/wal_reader.cpp
@@ -70,7 +70,7 @@ Status WalReader::read_block(PBlock& block) {
     _offset += WalWriter::LENGTH_SIZE;
     size_t block_len = decode_fixed64_le(row_len_buf);
     if (block_len == 0) {
-        return Status::InternalError("fail to read wal {} ,block is empty", _file_name);
+        return Status::DataQualityError("fail to read wal {} ,block is empty", _file_name);
     }
     // read block
     std::string block_buf;

--- a/be/src/vec/exec/format/wal/wal_reader.cpp
+++ b/be/src/vec/exec/format/wal/wal_reader.cpp
@@ -69,8 +69,8 @@ Status WalReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
     }
     int be_exec_version = pblock.has_be_exec_version() ? pblock.be_exec_version() : 0;
     if (!BeExecVersionManager::check_be_exec_version(be_exec_version)) {
-        return Status::InternalError("check be exec version fail when reading wal file {}",
-                                     _wal_path);
+        return Status::DataQualityError("check be exec version fail when reading wal file {}",
+                                        _wal_path);
     }
     vectorized::Block src_block;
     RETURN_IF_ERROR(src_block.deserialize(pblock));


### PR DESCRIPTION
## Proposed changes
reading empty block will make be core at deserialize wal file, becasue be exec version is unkow on empty wal file.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

