### PR TITLE
[fix](IO) Fix async close's raii and lazily load jni's jvm max heap value

### DIFF
--- a/be/src/io/fs/broker_file_writer.h
+++ b/be/src/io/fs/broker_file_writer.h
@@ -48,20 +48,19 @@ public:
     Status appendv(const Slice* data, size_t data_cnt) override;
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override { return _cur_offset; }
-    FileWriterState closed() const override { return _close_state; }
+    State state() const override { return _state; }
     FileCacheAllocatorBuilder* cache_builder() const override { return nullptr; }
 
 private:
     Status _write(const uint8_t* buf, size_t buf_len, size_t* written_bytes);
     Status _close_impl();
 
-private:
     ExecEnv* _env = nullptr;
     const TNetworkAddress _address;
     Path _path;
     size_t _cur_offset = 0;
     TBrokerFD _fd;
-    FileWriterState _close_state {FileWriterState::OPEN};
+    State _state {State::OPENED};
 };
 
 } // end namespace io

--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -52,14 +52,13 @@ struct AsyncCloseStatusPack {
     std::future<Status> future;
 };
 
-enum class FileWriterState : uint8_t {
-    OPEN = 0,
-    ASYNC_CLOSING,
-    CLOSED,
-};
-
 class FileWriter {
 public:
+    enum class State : uint8_t {
+        OPENED = 0,
+        ASYNC_CLOSING,
+        CLOSED,
+    };
     FileWriter() = default;
     virtual ~FileWriter() = default;
 
@@ -78,7 +77,7 @@ public:
 
     virtual size_t bytes_appended() const = 0;
 
-    virtual FileWriterState closed() const = 0;
+    virtual State state() const = 0;
 
     virtual FileCacheAllocatorBuilder* cache_builder() const = 0;
 };

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -146,7 +146,7 @@ HdfsFileWriter::HdfsFileWriter(Path path, std::shared_ptr<HdfsHandler> handler, 
 HdfsFileWriter::~HdfsFileWriter() {
     if (_async_close_pack != nullptr) {
         // For thread safety
-        std::ignore = _async_close_pack->promise.get_future();
+        std::ignore = _async_close_pack->future.get();
         _async_close_pack = nullptr;
     }
     if (_hdfs_file) {

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -203,11 +203,11 @@ Status HdfsFileWriter::_acquire_jni_memory(size_t size) {
 }
 
 Status HdfsFileWriter::close(bool non_block) {
-    if (closed() == FileWriterState::CLOSED) {
+    if (state() == State::CLOSED) {
         return Status::InternalError("HdfsFileWriter already closed, file path {}, fs name {}",
                                      _path.native(), _fs_name);
     }
-    if (closed() == FileWriterState::ASYNC_CLOSING) {
+    if (state() == State::ASYNC_CLOSING) {
         if (non_block) {
             return Status::InternalError("Don't submit async close multi times");
         }
@@ -215,20 +215,20 @@ Status HdfsFileWriter::close(bool non_block) {
         _st = _async_close_pack->future.get();
         _async_close_pack = nullptr;
         // We should wait for all the pre async task to be finished
-        _close_state = FileWriterState::CLOSED;
+        _state = State::CLOSED;
         // The next time we call close() with no matter non_block true or false, it would always return the
         // '_st' value because this writer is already closed.
         return _st;
     }
     if (non_block) {
-        _close_state = FileWriterState::ASYNC_CLOSING;
+        _state = State::ASYNC_CLOSING;
         _async_close_pack = std::make_unique<AsyncCloseStatusPack>();
         _async_close_pack->future = _async_close_pack->promise.get_future();
         return ExecEnv::GetInstance()->non_block_close_thread_pool()->submit_func(
                 [&]() { _async_close_pack->promise.set_value(_close_impl()); });
     }
     _st = _close_impl();
-    _close_state = FileWriterState::CLOSED;
+    _state = State::CLOSED;
     return _st;
 }
 
@@ -405,7 +405,7 @@ Status HdfsFileWriter::_append(std::string_view content) {
 }
 
 Status HdfsFileWriter::appendv(const Slice* data, size_t data_cnt) {
-    if (_close_state != FileWriterState::OPEN) [[unlikely]] {
+    if (_state != State::OPENED) [[unlikely]] {
         return Status::InternalError("append to closed file: {}", _path.native());
     }
 

--- a/be/src/io/fs/hdfs_file_writer.h
+++ b/be/src/io/fs/hdfs_file_writer.h
@@ -48,7 +48,7 @@ public:
     Status appendv(const Slice* data, size_t data_cnt) override;
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override { return _bytes_appended; }
-    FileWriterState closed() const override { return _close_state; }
+    State state() const override { return _state; }
 
     Status close(bool non_block = false) override;
 
@@ -95,7 +95,7 @@ private:
     // We should make sure that close_impl's return value is consistent
     // So we need add one field to restore the value first time return by calling close_impl
     Status _st;
-    FileWriterState _close_state {FileWriterState::OPEN};
+    State _state {State::OPENED};
 };
 
 } // namespace io

--- a/be/src/io/fs/local_file_writer.h
+++ b/be/src/io/fs/local_file_writer.h
@@ -34,7 +34,7 @@ public:
     Status appendv(const Slice* data, size_t data_cnt) override;
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override;
-    FileWriterState closed() const override { return _close_state; }
+    State state() const override { return _state; }
 
     FileCacheAllocatorBuilder* cache_builder() const override { return nullptr; }
 
@@ -50,7 +50,7 @@ private:
     bool _dirty = false;
     const bool _sync_data = true;
     size_t _bytes_appended = 0;
-    FileWriterState _close_state {FileWriterState::OPEN};
+    State _state {State::OPENED};
 };
 
 } // namespace doris::io

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -105,7 +105,7 @@ S3FileWriter::S3FileWriter(std::shared_ptr<Aws::S3::S3Client> client, std::strin
 S3FileWriter::~S3FileWriter() {
     if (_async_close_pack != nullptr) {
         // For thread safety
-        std::ignore = _async_close_pack->promise.get_future();
+        std::ignore = _async_close_pack->future.get();
         _async_close_pack = nullptr;
     }
     // We won't do S3 abort operation in BE, we let s3 service do it own.

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -109,7 +109,7 @@ S3FileWriter::~S3FileWriter() {
         _async_close_pack = nullptr;
     }
     // We won't do S3 abort operation in BE, we let s3 service do it own.
-    if (closed() == FileWriterState::OPEN && !_failed) {
+    if (state() == State::OPENED && !_failed) {
         s3_bytes_written_total << _bytes_appended;
     }
     s3_file_being_written << -1;
@@ -157,11 +157,11 @@ void S3FileWriter::_wait_until_finish(std::string_view task_name) {
 }
 
 Status S3FileWriter::close(bool non_block) {
-    if (closed() == FileWriterState::CLOSED) {
+    if (state() == State::CLOSED) {
         return Status::InternalError("S3FileWriter already closed, file path {}, file key {}",
                                      _path.native(), _key);
     }
-    if (closed() == FileWriterState::ASYNC_CLOSING) {
+    if (state() == State::ASYNC_CLOSING) {
         if (non_block) {
             return Status::InternalError("Don't submit async close multi times");
         }
@@ -169,20 +169,20 @@ Status S3FileWriter::close(bool non_block) {
         _st = _async_close_pack->future.get();
         _async_close_pack = nullptr;
         // We should wait for all the pre async task to be finished
-        _close_state = FileWriterState::CLOSED;
+        _state = State::CLOSED;
         // The next time we call close() with no matter non_block true or false, it would always return the
         // '_st' value because this writer is already closed.
         return _st;
     }
     if (non_block) {
-        _close_state = FileWriterState::ASYNC_CLOSING;
+        _state = State::ASYNC_CLOSING;
         _async_close_pack = std::make_unique<AsyncCloseStatusPack>();
         _async_close_pack->future = _async_close_pack->promise.get_future();
         return ExecEnv::GetInstance()->non_block_close_thread_pool()->submit_func(
                 [&]() { _async_close_pack->promise.set_value(_close_impl()); });
     }
     _st = _close_impl();
-    _close_state = FileWriterState::CLOSED;
+    _state = State::CLOSED;
     return _st;
 }
 
@@ -242,7 +242,7 @@ Status S3FileWriter::_close_impl() {
 }
 
 Status S3FileWriter::appendv(const Slice* data, size_t data_cnt) {
-    if (closed() != FileWriterState::OPEN) [[unlikely]] {
+    if (state() != State::OPENED) [[unlikely]] {
         return Status::InternalError("append to closed file: {}", _path.native());
     }
 
@@ -470,7 +470,7 @@ Status S3FileWriter::_set_upload_to_remote_less_than_buffer_size() {
 }
 
 void S3FileWriter::_put_object(UploadFileBuffer& buf) {
-    DCHECK(closed() != FileWriterState::CLOSED) << fmt::format("state is {}", closed());
+    DCHECK(state() != State::CLOSED) << fmt::format("state is {}", state());
     Aws::S3::Model::PutObjectRequest request;
     request.WithBucket(_bucket).WithKey(_key);
     Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*buf.get_stream()));

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -54,7 +54,7 @@ public:
 
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override { return _bytes_appended; }
-    FileWriterState closed() const override { return _close_state; }
+    State state() const override { return _state; }
 
     FileCacheAllocatorBuilder* cache_builder() const override {
         return _cache_builder == nullptr ? nullptr : _cache_builder.get();
@@ -114,7 +114,7 @@ private:
     // this shortens the inconsistent time window.
     bool _used_by_s3_committer;
     std::unique_ptr<AsyncCloseStatusPack> _async_close_pack;
-    FileWriterState _close_state {FileWriterState::OPEN};
+    State _state {State::OPENED};
 };
 
 } // namespace io

--- a/be/src/io/fs/stream_sink_file_writer.cpp
+++ b/be/src/io/fs/stream_sink_file_writer.cpp
@@ -112,23 +112,23 @@ Status StreamSinkFileWriter::appendv(const Slice* data, size_t data_cnt) {
 }
 
 Status StreamSinkFileWriter::close(bool non_block) {
-    if (_close_state == FileWriterState::CLOSED) {
+    if (_state == State::CLOSED) {
         return Status::InternalError("StreamSinkFileWriter already closed, load id {}",
                                      print_id(_load_id));
     }
-    if (_close_state == FileWriterState::ASYNC_CLOSING) {
+    if (_state == State::ASYNC_CLOSING) {
         if (non_block) {
             return Status::InternalError("Don't submit async close multi times");
         }
         // Actucally the first time call to close(true) would return the value of _finalize, if it returned one
         // error status then the code would never call the second close(true)
-        _close_state = FileWriterState::CLOSED;
+        _state = State::CLOSED;
         return Status::OK();
     }
     if (non_block) {
-        _close_state = FileWriterState::ASYNC_CLOSING;
+        _state = State::ASYNC_CLOSING;
     } else {
-        _close_state = FileWriterState::CLOSED;
+        _state = State::CLOSED;
     }
     return _finalize();
 }

--- a/be/src/io/fs/stream_sink_file_writer.h
+++ b/be/src/io/fs/stream_sink_file_writer.h
@@ -46,7 +46,7 @@ public:
 
     size_t bytes_appended() const override { return _bytes_appended; }
 
-    FileWriterState closed() const override { return _close_state; }
+    State state() const override { return _state; }
 
     // FIXME(plat1ko): Maybe it's an inappropriate abstraction?
     const Path& path() const override {
@@ -68,7 +68,7 @@ private:
     int64_t _tablet_id;
     int32_t _segment_id;
     size_t _bytes_appended = 0;
-    FileWriterState _close_state {FileWriterState::OPEN};
+    State _state {State::OPENED};
 };
 
 } // namespace io

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -130,7 +130,7 @@ Status SegmentFileCollection::close() {
     }
 
     for (auto&& [_, writer] : _file_writers) {
-        if (writer->closed() != io::FileWriterState::CLOSED) {
+        if (writer->state() != io::FileWriter::State::CLOSED) {
             RETURN_IF_ERROR(writer->close());
         }
     }

--- a/be/src/runtime/load_stream_writer.cpp
+++ b/be/src/runtime/load_stream_writer.cpp
@@ -176,7 +176,7 @@ Status LoadStreamWriter::add_segment(uint32_t segid, const SegmentStatistics& st
     if (file_writer == nullptr) {
         return Status::Corruption("add_segment failed, file writer {} is destoryed", segid);
     }
-    if (file_writer->closed() != io::FileWriterState::CLOSED) {
+    if (file_writer->state() != io::FileWriter::State::CLOSED) {
         return Status::Corruption("add_segment failed, segment {} is not closed",
                                   file_writer->path().native());
     }
@@ -209,7 +209,7 @@ Status LoadStreamWriter::close() {
     }
 
     for (const auto& writer : _segment_file_writers) {
-        if (writer->closed() != io::FileWriterState::CLOSED) {
+        if (writer->state() != io::FileWriter::State::CLOSED) {
             return Status::Corruption("LoadStreamWriter close failed, segment {} is not closed",
                                       writer->path().native());
         }

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -209,12 +209,13 @@ Status JniLocalFrame::push(JNIEnv* env, int max_local_ref) {
 
 void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
     // The start_be.sh would set JAVA_OPTS
-    std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
+    std::string java_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     std::istringstream iss(java_opts);
     std::string opt;
     while (iss >> opt) {
         if (opt.find("-Xmx") == 0) {
             std::string xmxValue = opt.substr(4);
+            LOG_INFO("The max heap vaule is {}", xmxValue);
             char unit = xmxValue.back();
             xmxValue.pop_back();
             long long value = std::stoll(xmxValue);
@@ -247,6 +248,9 @@ size_t JniUtil::get_max_jni_heap_memory_size() {
 #if defined(USE_LIBHDFS3) || defined(BE_TEST)
     return std::numeric_limits<size_t>::max();
 #else
+    static std::once_flag parse_max_heap_memory_size_from_jvm_flag;
+    std::call_once(parse_max_heap_memory_size_from_jvm_flag, parse_max_heap_memory_size_from_jvm,
+                   tls_env_);
     return max_jvm_heap_memory_size_;
 #endif
 }
@@ -267,9 +271,6 @@ Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     // the hadoop libhdfs will do all the stuff
     SetEnvIfNecessary();
     tls_env_ = getJNIEnv();
-    if (nullptr != tls_env_) {
-        parse_max_heap_memory_size_from_jvm(tls_env_);
-    }
 #endif
     *env = tls_env_;
     return Status::OK();

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -208,14 +208,14 @@ Status JniLocalFrame::push(JNIEnv* env, int max_local_ref) {
 }
 
 void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
-    // The start_be.sh would set JAVA_OPTS
+    // The start_be.sh would set JAVA_OPTS inside LIBHDFS_OPTS
     std::string java_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     std::istringstream iss(java_opts);
     std::string opt;
     while (iss >> opt) {
         if (opt.find("-Xmx") == 0) {
             std::string xmxValue = opt.substr(4);
-            LOG_INFO("The max heap vaule is {}", xmxValue);
+            LOG(INFO) << "The max heap vaule is " << xmxValue;
             char unit = xmxValue.back();
             xmxValue.pop_back();
             long long value = std::stoll(xmxValue);

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -105,7 +105,7 @@ public:
         return _local_file_writer->appendv(data, data_cnt);
     }
 
-    io::FileWriterState closed() const override { return _local_file_writer->closed(); }
+    io::FileWriter::State state() const override { return _local_file_writer->state(); }
 
     size_t bytes_appended() const override { return _local_file_writer->bytes_appended(); }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

