### PR TITLE
[Bug](topn) fix dcheck failed when  _tablet_reader_params.topn_filter_source_node…

### DIFF
--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -402,23 +402,12 @@ Status NewOlapScanner::_init_tablet_reader_params(
         }
 
         if (!_parent) {
+            // set push down topn filter
             _tablet_reader_params.topn_filter_source_node_ids =
                     ((pipeline::OlapScanLocalState*)_local_state)
                             ->get_topn_filter_source_node_ids(_state, true);
-        }
-
-        if (_tablet_reader_params.topn_filter_source_node_ids.empty()) {
-            // old topn logic
-            _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
-            if (_tablet_reader_params.use_topn_opt) {
-                if (olap_scan_node.__isset.topn_filter_source_node_ids) {
-                    _tablet_reader_params.topn_filter_source_node_ids =
-                            olap_scan_node.topn_filter_source_node_ids;
-
-                } else {
-                    _tablet_reader_params.topn_filter_source_node_ids = {0};
-                }
-            }
+            _tablet_reader_params.use_topn_opt =
+                    !_tablet_reader_params.topn_filter_source_node_ids.empty();
         }
     }
 


### PR DESCRIPTION
…_ids going into old topn logic

## Proposed changes
fix dcheck failed when  _tablet_reader_params.topn_filter_source_node_ids going into old topn logi
introduced by https://github.com/apache/doris/pull/34713

```cpp
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
1# 0x00007FC3765C6090 in /lib/x86_64-linux-gnu/libc.so.6
2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
4# 0x000055FB423A250D in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
5# 0x000055FB42394BAA in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
9# doris::QueryContext::get_runtime_predicate(int) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# doris::TabletReader::_init_conditions_param_except_leafnode_of_andnode(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:580
11# doris::TabletReader::_init_params(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:292
12# doris::TabletReader::init(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:127
13# doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/olap/block_reader.cpp:201
14# doris::vectorized::NewOlapScanner::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/new_olap_scanner.cpp:234
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

