### PR TITLE
[fix](nereids)4 phase agg may lost parameter in some case

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
@@ -1766,7 +1766,7 @@ public class AggregateStrategies implements ImplementationRuleFactory {
                                 AggregateFunction nonDistinct = aggregateFunction
                                         .withDistinctAndChildren(false, ImmutableList.copyOf(aggChild));
                                 AggregateExpression nonDistinctAggExpr = new AggregateExpression(nonDistinct,
-                                        distinctLocalParam, aggregateFunction.child(0));
+                                        distinctLocalParam, aggregateFunction);
                                 return nonDistinctAggExpr;
                             } else {
                                 needUpdateSlot.add(aggregateFunction);

--- a/regression-test/suites/nereids_syntax_p0/agg_4_phase.groovy
+++ b/regression-test/suites/nereids_syntax_p0/agg_4_phase.groovy
@@ -56,4 +56,6 @@ suite("agg_4_phase") {
         contains ":VAGGREGATE (update serialize)"
     }
     qt_4phase (test_sql)
+
+    sql """select GROUP_CONCAT(distinct name, " ") from agg_4_phase_tbl;"""
 }


### PR DESCRIPTION
## Proposed changes

The last param of AggregateExpression's constructor should be agg function in phase 3 or 4-phase agg

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

