### PR TITLE
[fix](SegComp) Don't call file writer close multi times for segcompaction

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -670,8 +670,11 @@ Status BetaRowsetWriter::_close_file_writers() {
         }
         RETURN_NOT_OK_STATUS_WITH_WARN(_segcompaction_rename_last_segments(),
                                        "rename last segments failed when build new rowset");
-        if (_segcompaction_worker->get_file_writer()) {
-            RETURN_NOT_OK_STATUS_WITH_WARN(_segcompaction_worker->get_file_writer()->close(),
+        // segcompaction worker would do file wrier's close function in compact_segments
+        if (auto& seg_comp_file_writer = _segcompaction_worker->get_file_writer();
+            nullptr != seg_comp_file_writer &&
+            seg_comp_file_writer->closed() != io::FileWriterState::CLOSED) {
+            RETURN_NOT_OK_STATUS_WITH_WARN(seg_comp_file_writer->close(),
                                            "close segment compaction worker failed");
         }
     }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -673,7 +673,7 @@ Status BetaRowsetWriter::_close_file_writers() {
         // segcompaction worker would do file wrier's close function in compact_segments
         if (auto& seg_comp_file_writer = _segcompaction_worker->get_file_writer();
             nullptr != seg_comp_file_writer &&
-            seg_comp_file_writer->closed() != io::FileWriterState::CLOSED) {
+            seg_comp_file_writer->state() != io::FileWrier::State::CLOSED) {
             RETURN_NOT_OK_STATUS_WITH_WARN(seg_comp_file_writer->close(),
                                            "close segment compaction worker failed");
         }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -673,7 +673,7 @@ Status BetaRowsetWriter::_close_file_writers() {
         // segcompaction worker would do file wrier's close function in compact_segments
         if (auto& seg_comp_file_writer = _segcompaction_worker->get_file_writer();
             nullptr != seg_comp_file_writer &&
-            seg_comp_file_writer->state() != io::FileWrier::State::CLOSED) {
+            seg_comp_file_writer->state() != io::FileWriter::State::CLOSED) {
             RETURN_NOT_OK_STATUS_WITH_WARN(seg_comp_file_writer->close(),
                                            "close segment compaction worker failed");
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

