### PR TITLE
[opt](exec) opt const expr exec in set operator

### DIFF
--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -119,8 +119,7 @@ Status SetSinkOperatorX<is_intersect>::_extract_build_column(
     rows = is_all_const ? 1 : rows;
 
     for (size_t i = 0; i < _child_exprs.size(); ++i) {
-        int result_col_id = -1;
-        RETURN_IF_ERROR(_child_exprs[i]->execute(&block, &result_col_id));
+        int result_col_id = result_locs[i];
 
         if (is_all_const) {
             block.get_by_position(result_col_id).column =

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -86,7 +86,7 @@ Status SetSinkOperatorX<is_intersect>::_process_build_block(
 
     vectorized::materialize_block_inplace(block);
     vectorized::ColumnRawPtrs raw_ptrs(_child_exprs.size());
-    RETURN_IF_ERROR(_extract_build_column(local_state, block, raw_ptrs));
+    RETURN_IF_ERROR(_extract_build_column(local_state, block, raw_ptrs, rows));
 
     std::visit(
             [&](auto&& arg) {
@@ -108,20 +108,35 @@ Status SetSinkOperatorX<is_intersect>::_process_build_block(
 template <bool is_intersect>
 Status SetSinkOperatorX<is_intersect>::_extract_build_column(
         SetSinkLocalState<is_intersect>& local_state, vectorized::Block& block,
-        vectorized::ColumnRawPtrs& raw_ptrs) {
+        vectorized::ColumnRawPtrs& raw_ptrs, size_t& rows) {
+    std::vector<int> result_locs(_child_exprs.size(), -1);
+    bool is_all_const = true;
+
+    for (size_t i = 0; i < _child_exprs.size(); ++i) {
+        RETURN_IF_ERROR(_child_exprs[i]->execute(&block, &result_locs[i]));
+        is_all_const &= is_column_const(*block.get_by_position(result_locs[i]).column);
+    }
+    rows = is_all_const ? 1 : rows;
+
     for (size_t i = 0; i < _child_exprs.size(); ++i) {
         int result_col_id = -1;
         RETURN_IF_ERROR(_child_exprs[i]->execute(&block, &result_col_id));
 
-        block.get_by_position(result_col_id).column =
-                block.get_by_position(result_col_id).column->convert_to_full_column_if_const();
+        if (is_all_const) {
+            block.get_by_position(result_col_id).column =
+                    assert_cast<const vectorized::ColumnConst&>(
+                            *block.get_by_position(result_col_id).column)
+                            .get_data_column_ptr();
+        } else {
+            block.get_by_position(result_col_id).column =
+                    block.get_by_position(result_col_id).column->convert_to_full_column_if_const();
+        }
         if (local_state._shared_state->build_not_ignore_null[i]) {
             block.get_by_position(result_col_id).column =
                     make_nullable(block.get_by_position(result_col_id).column);
         }
 
-        const auto* column = block.get_by_position(result_col_id).column.get();
-        raw_ptrs[i] = column;
+        raw_ptrs[i] = block.get_by_position(result_col_id).column.get();
         DCHECK_GE(result_col_id, 0);
         local_state._shared_state->build_col_idx.insert({result_col_id, i});
     }

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -103,7 +103,8 @@ private:
     Status _process_build_block(SetSinkLocalState<is_intersect>& local_state,
                                 vectorized::Block& block, RuntimeState* state);
     Status _extract_build_column(SetSinkLocalState<is_intersect>& local_state,
-                                 vectorized::Block& block, vectorized::ColumnRawPtrs& raw_ptrs);
+                                 vectorized::Block& block, vectorized::ColumnRawPtrs& raw_ptrs,
+                                 size_t& rows);
 
     const int _cur_child_id;
     const int _child_quantity;

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -88,7 +88,7 @@ private:
     void hash_table_init();
     Status hash_table_build(RuntimeState* state);
     Status process_build_block(Block& block, RuntimeState* state);
-    Status extract_build_column(Block& block, ColumnRawPtrs& raw_ptrs);
+    Status extract_build_column(Block& block, ColumnRawPtrs& raw_ptrs, size_t& row_num);
     Status extract_probe_column(Block& block, ColumnRawPtrs& raw_ptrs, int child_id);
     void refresh_hash_table();
 


### PR DESCRIPTION
## Proposed changes

before:
```
(select 0 from lineorder) intersect (select null); 

cost: 14s
```

after:
```
(select 0 from lineorder) intersect (select null);

cost: 4s
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

