### PR TITLE
[fix][nereids] fix misunderstanding about bothSideShuffleKeysAreSameO…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -497,16 +497,10 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Boolean, Void> {
             boolean isSatisfy = true;
             for (int i = 0; i < shuffleSideOutputList.size() && isSatisfy; i++) {
                 ExprId shuffleSideExprId = shuffleSideOutputList.get(i);
-                boolean found = false;
-                for (int j = 0; j < notShuffleSideOutputList.size() && !found; j++) {
-                    ExprId notShuffleSideExprId = notShuffleSideOutputList.get(j);
-                    if (shuffleSideExprId.equals(notShuffleSideExprId)
-                            || shuffleSideOutput.getEquivalenceExprIdsOf(shuffleSideExprId)
-                            .contains(notShuffleSideExprId)) {
-                        found = true;
-                    }
-                }
-                if (!found) {
+                ExprId notShuffleSideExprId = notShuffleSideOutputList.get(i);
+                if (!(shuffleSideExprId.equals(notShuffleSideExprId)
+                        || shuffleSideOutput.getEquivalenceExprIdsOf(shuffleSideExprId)
+                        .contains(notShuffleSideExprId))) {
                     isSatisfy = false;
                 }
             }


### PR DESCRIPTION
## Proposed changes

Fix misunderstanding about bothSideShuffleKeysAreSameOrder, which originally should ensure the order of shuffle column lists.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

