### PR TITLE
[fix](planner)correlated predicate should include isnull predicate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -947,7 +947,8 @@ public class StmtRewriter {
      * query block (i.e. is not bound by the given 'tupleIds').
      */
     private static boolean isCorrelatedPredicate(Expr expr, List<TupleId> tupleIds) {
-        return (expr instanceof BinaryPredicate || expr instanceof SlotRef) && !expr.isBoundByTupleIds(tupleIds);
+        return (expr instanceof BinaryPredicate || expr instanceof SlotRef
+                || expr instanceof IsNullPredicate) && !expr.isBoundByTupleIds(tupleIds);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

pick from master https://github.com/apache/doris/pull/34833

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

