### PR TITLE
[chore](table property) forbid changing enable_single_replica_compaction property for mow table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2292,6 +2292,11 @@ public class SchemaChangeHandler extends AlterHandler {
             enableSingleCompaction = Boolean.parseBoolean(singleCompaction) ? 1 : 0;
         }
 
+        if (enableUniqueKeyMergeOnWrite && Boolean.parseBoolean(singleCompaction)) {
+            throw new UserException(
+                    "enable_single_replica_compaction property is not supported for merge-on-write table");
+        }
+
         String disableAutoCompactionBoolean = properties.get(PropertyAnalyzer.PROPERTIES_DISABLE_AUTO_COMPACTION);
         int disableAutoCompaction = -1; // < 0 means don't update
         if (disableAutoCompactionBoolean != null) {

--- a/regression-test/suites/compaction/test_table_level_compaction_policy.groovy
+++ b/regression-test/suites/compaction/test_table_level_compaction_policy.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_table_level_compaction_policy", "nonConcurrent") {
+suite("test_table_level_compaction_policy") {
     def tableName = "test_table_level_compaction_policy"
     sql """ DROP TABLE IF EXISTS ${tableName} """
 
@@ -257,7 +257,7 @@ suite("test_table_level_compaction_policy", "nonConcurrent") {
             );
     """
     sql """sync"""
-    
+
     test {
         sql """
             alter table  ${tableName} set ("enable_single_replica_compaction" = "true")


### PR DESCRIPTION
### BUG

For the 'mow' table, modifying the property 'enable single replica compaction' should fail.

### HOW TO FIX

![image](https://github.com/apache/doris/assets/76934516/ee8b3f2c-9893-45af-93b4-681e11c74b03)


