### PR TITLE
[branch-2.0](regression test) fix test_decommission_with_replica_num_fail due to concurrent run cases

### DIFF
--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -50,6 +50,10 @@ suite('test_decommission_with_replica_num_fail') {
         }
     } finally {
         sql "CANCEL DECOMMISSION BACKEND '${targetBackend.Host}:${targetBackend.HeartbeatPort}'"
+        backends = sql_return_maparray('show backends')
+        for (def be : backends) {
+            logger.info("backend=${be}")
+        }
     }
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
 }

--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_decommission_with_replica_num_fail') {
+suite('test_decommission_with_replica_num_fail', 'nonConcurrent') {
     def tbl = 'test_decommission_with_replica_num_fail'
     def backends = sql_return_maparray('show backends')
     def replicaNum = 0

--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -43,6 +43,11 @@ suite('test_decommission_with_replica_num_fail', 'nonConcurrent') {
             "replication_num" = "${replicaNum}"
         );
     """
+
+    // fix set force_olap_table_replication_num
+    sql "ALTER TABLE ${tbl} SET ('default.replication_num' = '${replicaNum}')"
+    sql "ALTER TABLE ${tbl} MODIFY PARTITION (*) SET ('replication_num' = '${replicaNum}')"
+
     try {
         test {
             sql "ALTER SYSTEM DECOMMISSION BACKEND '${targetBackend.Host}:${targetBackend.HeartbeatPort}'"

--- a/regression-test/suites/node_p0/test_backend.groovy
+++ b/regression-test/suites/node_p0/test_backend.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_backend") {
+suite("test_backend", "nonConcurrent") {
     def address = "127.0.0.1"
     def notExistPort = 12346
 


### PR DESCRIPTION
FIX  test_decommission_with_replica_num_fail due to concurrent run with case test_backend, the later case will add backend then drop;

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

