### PR TITLE
[fix](regression test) make case test_decommission_with_replica_num_fail nonConcurrent

### DIFF
--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -16,6 +16,10 @@
 // under the License.
 
 suite('test_decommission_with_replica_num_fail', 'nonConcurrent') {
+    if (isCloudMode()) {
+        return
+    }
+
     def tbl = 'test_decommission_with_replica_num_fail'
     def backends = sql_return_maparray('show backends')
     def replicaNum = 0

--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -15,11 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_decommission_with_replica_num_fail') {
-    if (isCloudMode()) {
-        return
-    }
-
+suite('test_decommission_with_replica_num_fail', 'nonConcurrent') {
     def tbl = 'test_decommission_with_replica_num_fail'
     def backends = sql_return_maparray('show backends')
     def replicaNum = 0

--- a/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
+++ b/regression-test/suites/alter_p0/test_decommission_with_replica_num_fail.groovy
@@ -59,6 +59,10 @@ suite('test_decommission_with_replica_num_fail') {
         }
     } finally {
         sql "CANCEL DECOMMISSION BACKEND '${targetBackend.Host}:${targetBackend.HeartbeatPort}'"
+        backends = sql_return_maparray('show backends')
+        for (def be : backends) {
+            logger.info("backend=${be}")
+        }
     }
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
 }


### PR DESCRIPTION
make case test_decommission_with_replica_num_fail nonConcurrent because it will decommission then cancel one backend.  It may affect other cases.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

