### PR TITLE
[fix](nereids) Push max rf into cte

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/IdGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/IdGenerator.java
@@ -34,4 +34,8 @@ public abstract class IdGenerator<IdType extends Id<IdType>> {
     }
 
     public abstract IdType getNextId();
+
+    public int getCurrentId() {
+        return nextId;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -573,7 +573,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                     RuntimeFilter filter = new RuntimeFilter(generator.getNextId(),
                             rf.getSrcExpr(), targetList, targetExpressions, rf.getType(), rf.getExprOrder(),
                             rf.getBuilderNode(), buildSideNdv, rf.isBloomFilterSizeCalculatedByNdv(),
-                            cteNode);
+                            rf.gettMinMaxType(), cteNode);
                     targetNodes.forEach(node -> node.addAppliedRuntimeFilter(filter));
                     for (Slot slot : targetList) {
                         ctx.setTargetExprIdToFilter(slot.getExprId(), filter);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
@@ -58,11 +58,11 @@ public class RuntimeFilter {
      */
     public RuntimeFilter(RuntimeFilterId id, Expression src, List<Slot> targets, List<Expression> targetExpressions,
                          TRuntimeFilterType type, int exprOrder, AbstractPhysicalJoin builderNode, long buildSideNdv,
-                         boolean bloomFilterSizeCalculatedByNdv,
+                         boolean bloomFilterSizeCalculatedByNdv, TMinMaxRuntimeFilterType tMinMaxType,
                          PhysicalRelation scan) {
         this(id, src, targets, targetExpressions, type, exprOrder,
                 builderNode, false, buildSideNdv, bloomFilterSizeCalculatedByNdv,
-                TMinMaxRuntimeFilterType.MIN_MAX, scan);
+                tMinMaxType, scan);
     }
 
     public RuntimeFilter(RuntimeFilterId id, Expression src, List<Slot> targets, List<Expression> targetExpressions,


### PR DESCRIPTION
## Proposed changes
when push single side min-max runtime filter into cte, the signel side info is missing

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

