### PR TITLE
[refactor](jdbc catalog) split oceanbase jdbc executor

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -495,7 +495,8 @@ Status JdbcConnector::_check_type(SlotDescriptor* slot_desc, const std::string& 
         break;
     }
     case TYPE_DOUBLE: {
-        if (type_str != "java.lang.Double" && type_str != "java.math.BigDecimal") {
+        if (type_str != "java.lang.Double" && type_str != "java.math.BigDecimal" &&
+            type_str != "java.lang.String") {
             return Status::InternalError(error_msg);
         }
         break;

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorFactory.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorFactory.java
@@ -23,8 +23,10 @@ public class JdbcExecutorFactory {
     public static String getExecutorClass(TOdbcTableType type) {
         switch (type) {
             case MYSQL:
+            case OCEANBASE:
                 return "org/apache/doris/jdbc/MySQLJdbcExecutor";
             case ORACLE:
+            case OCEANBASE_ORACLE:
                 return "org/apache/doris/jdbc/OracleJdbcExecutor";
             case POSTGRESQL:
                 return "org/apache/doris/jdbc/PostgreSQLJdbcExecutor";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -75,7 +75,8 @@ public abstract class JdbcClient {
             case JdbcResource.MYSQL:
                 return new JdbcMySQLClient(jdbcClientConfig);
             case JdbcResource.OCEANBASE:
-                return new JdbcOceanBaseClient(jdbcClientConfig);
+                JdbcOceanBaseClient jdbcOceanBaseClient = new JdbcOceanBaseClient(jdbcClientConfig);
+                return jdbcOceanBaseClient.createClient(jdbcClientConfig);
             case JdbcResource.POSTGRESQL:
                 return new JdbcPostgreSQLClient(jdbcClientConfig);
             case JdbcResource.ORACLE:

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -65,6 +65,12 @@ public class JdbcMySQLClient extends JdbcClient {
         }
     }
 
+    protected JdbcMySQLClient(JdbcClientConfig jdbcClientConfig, String dbType) {
+        super(jdbcClientConfig);
+        convertDateToNull = isConvertDatetimeToNull(jdbcClientConfig);
+        this.dbType = dbType;
+    }
+
     @Override
     public List<String> getDatabaseNameList() {
         Connection conn = getConnection();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOceanBaseClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOceanBaseClient.java
@@ -27,15 +27,15 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 public class JdbcOceanBaseClient extends JdbcClient {
-    private JdbcClient currentClient;
 
     public JdbcOceanBaseClient(JdbcClientConfig jdbcClientConfig) {
         super(jdbcClientConfig);
+    }
 
+    public JdbcClient createClient(JdbcClientConfig jdbcClientConfig) throws JdbcClientException {
         Connection conn = null;
         Statement stmt = null;
         ResultSet rs = null;
-
         try {
             conn = super.getConnection();
             stmt = conn.createStatement();
@@ -43,16 +43,17 @@ public class JdbcOceanBaseClient extends JdbcClient {
             if (rs.next()) {
                 String compatibilityMode = rs.getString(2);
                 if ("MYSQL".equalsIgnoreCase(compatibilityMode)) {
-                    currentClient = new JdbcMySQLClient(jdbcClientConfig);
+                    return new JdbcMySQLClient(jdbcClientConfig, JdbcResource.OCEANBASE);
                 } else if ("ORACLE".equalsIgnoreCase(compatibilityMode)) {
-                    currentClient = new JdbcOracleClient(jdbcClientConfig);
                     setOracleMode();
+                    return new JdbcOracleClient(jdbcClientConfig, JdbcResource.OCEANBASE_ORACLE);
                 } else {
                     throw new JdbcClientException("Unsupported OceanBase compatibility mode: " + compatibilityMode);
                 }
+            } else {
+                throw new JdbcClientException("Failed to determine OceanBase compatibility mode");
             }
-        } catch (SQLException | JdbcClientException e) {
-            closeClient();
+        } catch (SQLException e) {
             throw new JdbcClientException("Failed to initialize JdbcOceanBaseClient", e.getMessage());
         } finally {
             close(rs, stmt, conn);
@@ -61,10 +62,11 @@ public class JdbcOceanBaseClient extends JdbcClient {
 
     @Override
     protected Type jdbcTypeToDoris(JdbcFieldSchema fieldSchema) {
-        return currentClient.jdbcTypeToDoris(fieldSchema);
+        throw new UnsupportedOperationException("JdbcOceanBaseClient does not support jdbcTypeToDoris");
     }
 
-    public void setOracleMode() {
+    private void setOracleMode() {
         this.dbType = JdbcResource.OCEANBASE_ORACLE;
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOracleClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOracleClient.java
@@ -38,6 +38,11 @@ public class JdbcOracleClient extends JdbcClient {
         super(jdbcClientConfig);
     }
 
+    protected JdbcOracleClient(JdbcClientConfig jdbcClientConfig, String dbType) {
+        super(jdbcClientConfig);
+        this.dbType = dbType;
+    }
+
     @Override
     public String getTestQuery() {
         return "SELECT 1 FROM dual";


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
Doris > select * from ob_mysql.test.all_types;
+-----------+------------+-------------+-------+----------+-----------+-----------+----------+---------+---------+----------+------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+------+---------+--------------+-------+--------------------------+----------------------------------------------------+-----------------+------+----------------------------+--------------+--------+
| tinyint_u | smallint_u | mediumint_u | int_u | bigint_u | decimal_u | double_u  | float_u  | boolean | tinyint | smallint | year | mediumint | int  | bigint | date       | timestamp                | datetime            | float    | double           | decimal | char | varchar | time         | text  | blob                     | json                                               | set             | bit  | binary                     | varbinary    | enum   |
+-----------+------------+-------------+-------+----------+-----------+-----------+----------+---------+---------+----------+------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+------+---------+--------------+-------+--------------------------+----------------------------------------------------+-----------------+------+----------------------------+--------------+--------+
|       201 |        301 |         401 |   501 | 601      |   3.14159 | 4.1415926 | 5.141592 |       1 |    -123 |     -301 | 2012 |      -401 | -501 |   -601 | 2012-10-30 | 2012-10-25 12:05:36.3457 | 2012-10-25 08:08:08 | -4.14145 |    -5.1400000001 | -6.1400 | row1 | line1   | 09:09:09.567 | text1 | 0x48656C6C6F20576F726C64 | {"age": 30, "city": "London", "name": "Alice"}     | Option1,Option3 | 0x2A | 0x48656C6C6F00000000000000 | 0x48656C6C6F | Value2 |
|       202 |        302 |         402 |   502 | 602      |   4.14159 | 5.1415926 | 6.141592 |       0 |    -124 |     -302 | 2013 |      -402 | -502 |   -602 | 2012-11-01 | 2012-10-26 02:08:39.3457 | 2013-10-26 08:09:18 | -5.14145 |    -6.1400000001 | -7.1400 | row2 | line2   | 09:11:09.567 | text2 | 0xE86F6C6C6F20576F726C67 | {"age": 18, "city": "ChongQing", "name": "Gaoxin"} | Option1,Option2 | 0x2F | 0x58676C6C6F00000000000000 | 0x88656C6C9F | Value3 |
|      NULL |        302 |        NULL |   502 | 602      |   4.14159 |      NULL | 6.141592 |    NULL |    -124 |     -302 | 2013 |      -402 | -502 |   -602 | NULL       | 2012-10-26 02:08:39.3457 | 2013-10-26 08:09:18 | -5.14145 |             NULL | -7.1400 | row2 | NULL    | 09:11:09.567 | text2 | 0xE86F6C6C6F20576F726C67 | NULL                                               | NULL            | 0x2F | NULL                       | 0x88656C6C9F | Value3 |
|       203 |        303 |         403 |   503 | 603      |   7.14159 | 8.1415926 | 9.141592 |       0 |    NULL |     -402 | 2017 |      -602 | -902 |  -1102 | 2012-11-02 | NULL                     | 2013-10-27 08:11:18 | -5.14145 | -6.1400000000001 | -7.1400 | row3 | line3   | 09:11:09.567 | text3 | 0xE86F6C6C6F20576F726C67 | {"age": 24, "city": "ChongQing", "name": "ChenQi"} | Option2         | 0x2F | 0x58676C6C6F00000000000000 | NULL         | Value1 |
+-----------+------------+-------------+-------+----------+-----------+-----------+----------+---------+---------+----------+------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+------+---------+--------------+-------+--------------------------+----------------------------------------------------+-----------------+------+----------------------------+--------------+--------+
4 rows in set (0.56 sec)

Doris > select * from ob_oracle.ZYK.TEST_ALL_TYPES;
+------+------+------+------------+------+------+--------+--------------------+------+--------------------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+---------+--------+---------+-------+--------+-------+-----------+---------------------+-------------------------+----------------------------+----------------------------+----------------------------+-------+-------------------+
| ID   | N1   | N2   | N3         | N4   | N5   | N6     | N7                 | N8   | N9                 | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       | COUNTRY | CITY   | ADDRESS | NAME  | NUM1   | NUM2  | NUM4      | T1                  | T2                      | T3                         | T4                         | T5                         | T6    | T7                |
+------+------+------+------------+------+------+--------+--------------------+------+--------------------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+---------+--------+---------+-------+--------+-------+-----------+---------------------+-------------------------+----------------------------+----------------------------+----------------------------+-------+-------------------+
| 1    | 111  | 123  | 7456123.89 | 573  | 34   | 673.43 | 34.126399993896484 |   60 | 23.231000900268555 |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 | 1       | china  | beijing | alice | 123.45 | 12300 | 0.0012345 | 2022-01-21 05:23:01 | 2019-11-12 20:33:57.999 | 2019-11-12 20:33:57.999998 | 2019-11-12 20:33:57.999996 | 2019-11-12 20:33:57.999997 | 223-9 | 12 10:23:1.123457 |
| 2    | NULL | NULL |       NULL | NULL | NULL |   NULL |               NULL | NULL |               NULL |           NULL |            NULL |       NULL |               NULL |           NULL |            NULL |       NULL | NULL                | NULL    | NULL   | NULL    | NULL  |   NULL |  NULL |      NULL | NULL                | NULL                    | NULL                       | NULL                       | NULL                       | NULL  | NULL              |
+------+------+------+------------+------+------+--------+--------------------+------+--------------------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+---------+--------+---------+-------+--------+-------+-----------+---------------------+-------------------------+----------------------------+----------------------------+----------------------------+-------+-------------------+
2 rows in set (0.35 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

