### PR TITLE
[refactor](datalake) return the error status instead of static_cast<void>

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -413,8 +413,8 @@ void PrefetchBuffer::reset_offset(size_t offset) {
     } else {
         _exceed = false;
     }
-    static_cast<void>(ExecEnv::GetInstance()->buffered_reader_prefetch_thread_pool()->submit_func(
-            [buffer_ptr = shared_from_this()]() { buffer_ptr->prefetch_buffer(); }));
+    _prefetch_status = ExecEnv::GetInstance()->buffered_reader_prefetch_thread_pool()->submit_func(
+            [buffer_ptr = shared_from_this()]() { buffer_ptr->prefetch_buffer(); });
 }
 
 // only this function would run concurrently in another thread

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -173,7 +173,6 @@ public:
         for (char* box : _boxes) {
             delete[] box;
         }
-        static_cast<void>(close());
     }
 
     Status close() override {

--- a/be/src/olap/wal/wal_reader.cpp
+++ b/be/src/olap/wal/wal_reader.cpp
@@ -50,11 +50,8 @@ Status WalReader::init() {
 }
 
 Status WalReader::finalize() {
-    if (file_reader != nullptr) {
-        auto st = file_reader->close();
-        if (!st.ok()) {
-            LOG(WARNING) << "fail to close wal " << _file_name << " st= " << st.to_string();
-        }
+    if (file_reader) {
+        return file_reader->close();
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/avro/avro_jni_reader.cpp
+++ b/be/src/vec/exec/format/avro/avro_jni_reader.cpp
@@ -29,16 +29,12 @@ AvroJNIReader::AvroJNIReader(RuntimeState* state, RuntimeProfile* profile,
                              const TFileScanRangeParams& params,
                              const std::vector<SlotDescriptor*>& file_slot_descs,
                              const TFileRangeDesc& range)
-        : _file_slot_descs(file_slot_descs),
-          _state(state),
-          _profile(profile),
-          _params(params),
-          _range(range) {}
+        : JniReader(file_slot_descs, state, profile), _params(params), _range(range) {}
 
 AvroJNIReader::AvroJNIReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
                              const TFileRangeDesc& range,
                              const std::vector<SlotDescriptor*>& file_slot_descs)
-        : _file_slot_descs(file_slot_descs), _profile(profile), _params(params), _range(range) {}
+        : JniReader(file_slot_descs, nullptr, profile), _params(params), _range(range) {}
 
 AvroJNIReader::~AvroJNIReader() = default;
 

--- a/be/src/vec/exec/format/avro/avro_jni_reader.h
+++ b/be/src/vec/exec/format/avro/avro_jni_reader.h
@@ -28,8 +28,7 @@
 
 #include "common/status.h"
 #include "exec/olap_common.h"
-#include "vec/exec/format/generic_reader.h"
-#include "vec/exec/jni_connector.h"
+#include "vec/exec/format/jni_reader.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -48,7 +47,7 @@ namespace doris::vectorized {
 /**
  * Read avro-format file
  */
-class AvroJNIReader : public GenericReader {
+class AvroJNIReader : public JniReader {
     ENABLE_FACTORY_CREATOR(AvroJNIReader);
 
 public:
@@ -83,16 +82,10 @@ public:
 
     TypeDescriptor convert_to_doris_type(const rapidjson::Value& column_schema);
 
-    TypeDescriptor convert_complex_type(const rapidjson::Document::ConstObject child_schema);
-
 private:
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
-    RuntimeState* _state = nullptr;
-    RuntimeProfile* _profile = nullptr;
     const TFileScanRangeParams _params;
     const TFileRangeDesc _range;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range = nullptr;
-    std::unique_ptr<JniConnector> _jni_connector;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/jni_reader.cpp
+++ b/be/src/vec/exec/format/jni_reader.cpp
@@ -37,7 +37,7 @@ namespace doris::vectorized {
 
 MockJniReader::MockJniReader(const std::vector<SlotDescriptor*>& file_slot_descs,
                              RuntimeState* state, RuntimeProfile* profile)
-        : _file_slot_descs(file_slot_descs), _state(state), _profile(profile) {
+        : JniReader(file_slot_descs, state, profile) {
     std::ostringstream required_fields;
     std::ostringstream columns_types;
     std::vector<std::string> column_names;

--- a/be/src/vec/exec/format/jni_reader.h
+++ b/be/src/vec/exec/format/jni_reader.h
@@ -42,13 +42,35 @@ struct TypeDescriptor;
 
 namespace doris::vectorized {
 
+class JniReader : public GenericReader {
+public:
+    JniReader(const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
+              RuntimeProfile* profile)
+            : _file_slot_descs(file_slot_descs), _state(state), _profile(profile) {};
+
+    ~JniReader() override = default;
+
+    Status close() override {
+        if (_jni_connector) {
+            return _jni_connector->close();
+        }
+        return Status::OK();
+    }
+
+protected:
+    const std::vector<SlotDescriptor*>& _file_slot_descs;
+    RuntimeState* _state = nullptr;
+    RuntimeProfile* _profile = nullptr;
+    std::unique_ptr<JniConnector> _jni_connector;
+};
+
 /**
  * The demo usage of JniReader, showing how to read data from java scanner.
  * The java side is also a mock reader that provide values for each type.
  * This class will only be retained during the functional testing phase to verify that
  * the communication and data exchange with the jvm are correct.
  */
-class MockJniReader : public GenericReader {
+class MockJniReader : public JniReader {
 public:
     MockJniReader(const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
                   RuntimeProfile* profile);
@@ -63,6 +85,13 @@ public:
     Status init_reader(
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
 
+    Status close() override {
+        if (_jni_connector) {
+            return _jni_connector->close();
+        }
+        return Status::OK();
+    }
+
 protected:
     void _collect_profile_before_close() override {
         if (_jni_connector != nullptr) {
@@ -71,11 +100,7 @@ protected:
     }
 
 private:
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
-    RuntimeState* _state = nullptr;
-    RuntimeProfile* _profile = nullptr;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range;
-    std::unique_ptr<JniConnector> _jni_connector;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -165,6 +165,8 @@ public:
 
     Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
 
+    Status get_next_block_impl(Block* block, size_t* read_rows, bool* eof);
+
     void _fill_batch_vec(std::vector<orc::ColumnVectorBatch*>& result,
                          orc::ColumnVectorBatch* batch, int idx);
 
@@ -228,15 +230,19 @@ private:
 
     class ORCFilterImpl : public orc::ORCFilter {
     public:
-        ORCFilterImpl(OrcReader* orcReader) : orcReader(orcReader) {}
+        ORCFilterImpl(OrcReader* orcReader) : _orcReader(orcReader) {}
         ~ORCFilterImpl() override = default;
         void filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t size,
                     void* arg) const override {
-            static_cast<void>(orcReader->filter(data, sel, size, arg));
+            if (_status.ok()) {
+                _status = _orcReader->filter(data, sel, size, arg);
+            }
         }
+        Status get_status() { return _status; }
 
     private:
-        OrcReader* orcReader = nullptr;
+        mutable Status _status = Status::OK();
+        OrcReader* _orcReader = nullptr;
     };
 
     class StringDictFilterImpl : public orc::StringDictFilter {
@@ -247,17 +253,24 @@ private:
         virtual void fillDictFilterColumnNames(
                 std::unique_ptr<orc::StripeInformation> current_strip_information,
                 std::list<std::string>& column_names) const override {
-            static_cast<void>(_orc_reader->fill_dict_filter_column_names(
-                    std::move(current_strip_information), column_names));
+            if (_status.ok()) {
+                _status = _orc_reader->fill_dict_filter_column_names(
+                        std::move(current_strip_information), column_names);
+            }
         }
         virtual void onStringDictsLoaded(
                 std::unordered_map<std::string, orc::StringDictionary*>& column_name_to_dict_map,
                 bool* is_stripe_filtered) const override {
-            static_cast<void>(_orc_reader->on_string_dicts_loaded(column_name_to_dict_map,
-                                                                  is_stripe_filtered));
+            if (_status.ok()) {
+                _status = _orc_reader->on_string_dicts_loaded(column_name_to_dict_map,
+                                                              is_stripe_filtered);
+            }
         }
 
+        Status get_status() { return _status; }
+
     private:
+        mutable Status _status = Status::OK();
         OrcReader* _orc_reader = nullptr;
     };
 
@@ -596,7 +609,7 @@ private:
     // std::pair<col_name, slot_id>
     std::vector<std::pair<std::string, int>> _dict_filter_cols;
     std::shared_ptr<ObjectPool> _obj_pool;
-    std::unique_ptr<orc::StringDictFilter> _string_dict_filter;
+    std::unique_ptr<StringDictFilterImpl> _string_dict_filter;
     bool _dict_cols_has_converted = false;
     bool _has_complex_type = false;
     std::vector<orc::TypeKind>* _unsupported_pushdown_types;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -883,7 +883,7 @@ Status RowGroupReader::_rewrite_dict_predicates() {
         }
 
         // 4. Rewrite conjuncts.
-        static_cast<void>(_rewrite_dict_conjuncts(dict_codes, slot_id, dict_column->is_nullable()));
+        RETURN_IF_ERROR(_rewrite_dict_conjuncts(dict_codes, slot_id, dict_column->is_nullable()));
         ++it;
     }
     return Status::OK();

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -774,8 +774,8 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         auto& conjuncts = conjunct_iter->second;
         std::vector<int> skipped_page_range;
         const FieldSchema* col_schema = schema_desc.get_column(read_col);
-        static_cast<void>(page_index.collect_skipped_page_range(
-                &column_index, conjuncts, col_schema, skipped_page_range, *_ctz));
+        RETURN_IF_ERROR(page_index.collect_skipped_page_range(&column_index, conjuncts, col_schema,
+                                                              skipped_page_range, *_ctz));
         if (skipped_page_range.empty()) {
             continue;
         }
@@ -783,8 +783,8 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         RETURN_IF_ERROR(page_index.parse_offset_index(chunk, off_index_buff.data(), &offset_index));
         for (int page_id : skipped_page_range) {
             RowRange skipped_row_range;
-            static_cast<void>(page_index.create_skipped_row_range(offset_index, row_group.num_rows,
-                                                                  page_id, &skipped_row_range));
+            RETURN_IF_ERROR(page_index.create_skipped_row_range(offset_index, row_group.num_rows,
+                                                                page_id, &skipped_row_range));
             // use the union row range
             skipped_row_ranges.emplace_back(skipped_row_range);
         }
@@ -826,7 +826,7 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
 
 Status ParquetReader::_process_row_group_filter(const tparquet::RowGroup& row_group,
                                                 bool* filter_group) {
-    static_cast<void>(_process_column_stat_filter(row_group.columns, filter_group));
+    RETURN_IF_ERROR(_process_column_stat_filter(row_group.columns, filter_group));
     _init_chunk_dicts();
     RETURN_IF_ERROR(_process_dict_filter(filter_group));
     _init_bloom_filter();

--- a/be/src/vec/exec/format/table/hudi_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/hudi_jni_reader.cpp
@@ -43,11 +43,9 @@ HudiJniReader::HudiJniReader(const TFileScanRangeParams& scan_params,
                              const THudiFileDesc& hudi_params,
                              const std::vector<SlotDescriptor*>& file_slot_descs,
                              RuntimeState* state, RuntimeProfile* profile)
-        : _scan_params(scan_params),
-          _hudi_params(hudi_params),
-          _file_slot_descs(file_slot_descs),
-          _state(state),
-          _profile(profile) {
+        : JniReader(file_slot_descs, state, profile),
+          _scan_params(scan_params),
+          _hudi_params(hudi_params) {
     std::vector<std::string> required_fields;
     for (auto& desc : _file_slot_descs) {
         required_fields.emplace_back(desc->col_name());

--- a/be/src/vec/exec/format/table/hudi_jni_reader.h
+++ b/be/src/vec/exec/format/table/hudi_jni_reader.h
@@ -27,8 +27,7 @@
 
 #include "common/status.h"
 #include "exec/olap_common.h"
-#include "vec/exec/format/generic_reader.h"
-#include "vec/exec/jni_connector.h"
+#include "vec/exec/format/jni_reader.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -42,7 +41,7 @@ struct TypeDescriptor;
 
 namespace doris::vectorized {
 
-class HudiJniReader : public GenericReader {
+class HudiJniReader : public JniReader {
     ENABLE_FACTORY_CREATOR(HudiJniReader);
 
 public:
@@ -66,11 +65,7 @@ public:
 private:
     const TFileScanRangeParams& _scan_params;
     const THudiFileDesc& _hudi_params;
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
-    RuntimeState* _state;
-    RuntimeProfile* _profile;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range;
-    std::unique_ptr<JniConnector> _jni_connector;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/table/max_compute_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/max_compute_jni_reader.cpp
@@ -42,11 +42,9 @@ MaxComputeJniReader::MaxComputeJniReader(const MaxComputeTableDescriptor* mc_des
                                          const std::vector<SlotDescriptor*>& file_slot_descs,
                                          const TFileRangeDesc& range, RuntimeState* state,
                                          RuntimeProfile* profile)
-        : _max_compute_params(max_compute_params),
-          _file_slot_descs(file_slot_descs),
-          _range(range),
-          _state(state),
-          _profile(profile) {
+        : JniReader(file_slot_descs, state, profile),
+          _max_compute_params(max_compute_params),
+          _range(range) {
     _table_desc = mc_desc;
     std::ostringstream required_fields;
     std::ostringstream columns_types;

--- a/be/src/vec/exec/format/table/max_compute_jni_reader.h
+++ b/be/src/vec/exec/format/table/max_compute_jni_reader.h
@@ -28,8 +28,7 @@
 #include "common/status.h"
 #include "exec/olap_common.h"
 #include "runtime/descriptors.h"
-#include "vec/exec/format/generic_reader.h"
-#include "vec/exec/jni_connector.h"
+#include "vec/exec/format/jni_reader.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -49,7 +48,7 @@ namespace doris::vectorized {
  * This class will only be retained during the functional testing phase to verify that
  * the communication and data exchange with the jvm are correct.
  */
-class MaxComputeJniReader : public GenericReader {
+class MaxComputeJniReader : public JniReader {
     ENABLE_FACTORY_CREATOR(MaxComputeJniReader);
 
 public:
@@ -71,12 +70,8 @@ public:
 private:
     const MaxComputeTableDescriptor* _table_desc = nullptr;
     const TMaxComputeFileDesc& _max_compute_params;
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
     const TFileRangeDesc& _range;
-    RuntimeState* _state = nullptr;
-    RuntimeProfile* _profile = nullptr;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range = nullptr;
-    std::unique_ptr<JniConnector> _jni_connector = nullptr;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/table/paimon_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/paimon_jni_reader.cpp
@@ -40,7 +40,7 @@ const std::string PaimonJniReader::PAIMON_OPTION_PREFIX = "paimon_option_prefix.
 PaimonJniReader::PaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_descs,
                                  RuntimeState* state, RuntimeProfile* profile,
                                  const TFileRangeDesc& range)
-        : _file_slot_descs(file_slot_descs), _state(state), _profile(profile) {
+        : JniReader(file_slot_descs, state, profile) {
     std::vector<std::string> column_names;
     std::vector<std::string> column_types;
     for (auto& desc : _file_slot_descs) {

--- a/be/src/vec/exec/format/table/paimon_jni_reader.h
+++ b/be/src/vec/exec/format/table/paimon_jni_reader.h
@@ -26,9 +26,7 @@
 
 #include "common/status.h"
 #include "exec/olap_common.h"
-#include "vec/exec/format/generic_reader.h"
-#include "vec/exec/format/table/table_format_reader.h"
-#include "vec/exec/jni_connector.h"
+#include "vec/exec/format/jni_reader.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -48,7 +46,7 @@ namespace doris::vectorized {
  * This class will only be retained during the functional testing phase to verify that
  * the communication and data exchange with the jvm are correct.
  */
-class PaimonJniReader : public GenericReader {
+class PaimonJniReader : public JniReader {
     ENABLE_FACTORY_CREATOR(PaimonJniReader);
 
 public:
@@ -67,11 +65,7 @@ public:
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
 
 private:
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
-    RuntimeState* _state = nullptr;
-    RuntimeProfile* _profile = nullptr;
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range;
-    std::unique_ptr<JniConnector> _jni_connector;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/table/transactional_hive_reader.cpp
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.cpp
@@ -135,7 +135,7 @@ Status TransactionalHiveReader::init_row_filters(const TFileRangeDesc& range) {
         std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
                 partition_columns;
         std::unordered_map<std::string, VExprContextSPtr> missing_columns;
-        static_cast<void>(delete_reader.set_fill_columns(partition_columns, missing_columns));
+        RETURN_IF_ERROR(delete_reader.set_fill_columns(partition_columns, missing_columns));
 
         bool eof = false;
         while (!eof) {

--- a/be/src/vec/exec/format/table/trino_connector_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/trino_connector_jni_reader.cpp
@@ -42,7 +42,7 @@ const std::string TrinoConnectorJniReader::TRINO_CONNECTOR_OPTION_PREFIX =
 TrinoConnectorJniReader::TrinoConnectorJniReader(
         const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
         RuntimeProfile* profile, const TFileRangeDesc& range)
-        : _file_slot_descs(file_slot_descs), _state(state), _profile(profile) {
+        : JniReader(file_slot_descs, state, profile) {
     std::vector<std::string> column_names;
     for (const auto& desc : _file_slot_descs) {
         std::string field = desc->col_name();

--- a/be/src/vec/exec/format/table/trino_connector_jni_reader.h
+++ b/be/src/vec/exec/format/table/trino_connector_jni_reader.h
@@ -27,8 +27,7 @@
 
 #include "common/status.h"
 #include "exec/olap_common.h"
-#include "vec/exec/format/generic_reader.h"
-#include "vec/exec/jni_connector.h"
+#include "vec/exec/format/jni_reader.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -42,7 +41,7 @@ struct TypeDescriptor;
 
 namespace doris::vectorized {
 
-class TrinoConnectorJniReader : public GenericReader {
+class TrinoConnectorJniReader : public JniReader {
     ENABLE_FACTORY_CREATOR(TrinoConnectorJniReader);
 
 public:
@@ -63,9 +62,5 @@ public:
 
 private:
     Status _set_spi_plugins_dir();
-    const std::vector<SlotDescriptor*>& _file_slot_descs;
-    RuntimeState* _state;
-    RuntimeProfile* _profile;
-    std::unique_ptr<JniConnector> _jni_connector;
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/wal/wal_reader.cpp
+++ b/be/src/vec/exec/format/wal/wal_reader.cpp
@@ -30,12 +30,6 @@ WalReader::WalReader(RuntimeState* state) : _state(state) {
     _wal_id = state->wal_id();
 }
 
-WalReader::~WalReader() {
-    if (_wal_reader.get() != nullptr) {
-        static_cast<void>(_wal_reader->finalize());
-    }
-}
-
 Status WalReader::init_reader(const TupleDescriptor* tuple_descriptor) {
     _tuple_descriptor = tuple_descriptor;
     RETURN_IF_ERROR(_state->exec_env()->wal_mgr()->get_wal_path(_wal_id, _wal_path));

--- a/be/src/vec/exec/format/wal/wal_reader.h
+++ b/be/src/vec/exec/format/wal/wal_reader.h
@@ -26,11 +26,18 @@ struct ScannerCounter;
 class WalReader : public GenericReader {
 public:
     WalReader(RuntimeState* state);
-    ~WalReader() override;
+    ~WalReader() override = default;
     Status init_reader(const TupleDescriptor* tuple_descriptor);
     Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
+
+    Status close() override {
+        if (_wal_reader) {
+            return _wal_reader->finalize();
+        }
+        return Status::OK();
+    }
 
 private:
     RuntimeState* _state = nullptr;

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -65,10 +65,6 @@ namespace doris::vectorized {
     M(TypeIndex::DateTime, ColumnVector<Int64>, Int64)                 \
     M(TypeIndex::DateTimeV2, ColumnVector<UInt64>, UInt64)
 
-JniConnector::~JniConnector() {
-    static_cast<void>(close());
-}
-
 Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
     _state = state;
     _profile = profile;

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -208,8 +208,7 @@ public:
         _is_table_schema = true;
     }
 
-    /// Should release jni resources if other functions are failed.
-    ~JniConnector();
+    ~JniConnector() override = default;
 
     /**
      * Open java scanner, and get the following scanner methods by jni:

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -280,7 +280,7 @@ Status VJoinNodeBase::open(RuntimeState* state) {
 
     std::promise<Status> thread_status;
     try {
-        static_cast<void>(state->exec_env()->join_node_thread_pool()->submit_func(
+        RETURN_IF_ERROR(state->exec_env()->join_node_thread_pool()->submit_func(
                 [this, state, thread_status_p = &thread_status] {
                     this->_probe_side_open_thread(state, thread_status_p);
                 }));

--- a/be/src/vec/exec/scan/new_es_scanner.cpp
+++ b/be/src/vec/exec/scan/new_es_scanner.cpp
@@ -232,7 +232,7 @@ Status NewEsScanner::close(RuntimeState* state) {
     }
 
     if (_es_reader != nullptr) {
-        static_cast<void>(_es_reader->close());
+        RETURN_IF_ERROR(_es_reader->close());
     }
 
     RETURN_IF_ERROR(VScanner::close(state));

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -147,11 +147,27 @@ public:
             return;
         }
         if (new_max_thread_num >= cur_max_thread_num) {
-            static_cast<void>(_scan_thread_pool->set_max_threads(new_max_thread_num));
-            static_cast<void>(_scan_thread_pool->set_min_threads(new_min_thread_num));
+            Status st_max = _scan_thread_pool->set_max_threads(new_max_thread_num);
+            if (!st_max.ok()) {
+                LOG(WARNING) << "Failed to set max threads for scan thread pool: "
+                             << st_max.to_string();
+            }
+            Status st_min = _scan_thread_pool->set_min_threads(new_min_thread_num);
+            if (!st_min.ok()) {
+                LOG(WARNING) << "Failed to set min threads for scan thread pool: "
+                             << st_min.to_string();
+            }
         } else {
-            static_cast<void>(_scan_thread_pool->set_min_threads(new_min_thread_num));
-            static_cast<void>(_scan_thread_pool->set_max_threads(new_max_thread_num));
+            Status st_min = _scan_thread_pool->set_min_threads(new_min_thread_num);
+            if (!st_min.ok()) {
+                LOG(WARNING) << "Failed to set min threads for scan thread pool: "
+                             << st_min.to_string();
+            }
+            Status st_max = _scan_thread_pool->set_max_threads(new_max_thread_num);
+            if (!st_max.ok()) {
+                LOG(WARNING) << "Failed to set max threads for scan thread pool: "
+                             << st_max.to_string();
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Followup #34797
`static_cast<void>` has ignored the wrong status, some of them should make the query finished with error status, so replace `static_cast<void>`  with `RETURN_IF_ERROR`.

### Remaining Works
The following three scenarios need to be handled separately and cannot be simply replaced:
1. The outer function returns void;
2. Call status function inner constructors or destructors;
3. Call status function with best effort, and should ignore the wrong status.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

