### PR TITLE
[fix](move-memtable) change brpc connection type to single

### DIFF
--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -111,7 +111,8 @@ public:
 
     std::shared_ptr<T> get_new_client_no_cache(const std::string& host_port,
                                                const std::string& protocol = "baidu_std",
-                                               const std::string& connect_type = "") {
+                                               const std::string& connect_type = "",
+                                               const std::string& connection_group = "") {
         brpc::ChannelOptions options;
         if constexpr (std::is_same_v<T, PFunctionService_Stub>) {
             options.protocol = config::function_service_protocol;
@@ -120,6 +121,9 @@ public:
         }
         if (connect_type != "") {
             options.connection_type = connect_type;
+        }
+        if (connection_group != "") {
+            options.connection_group = connection_group;
         }
         options.connect_timeout_ms = 2000;
         options.max_retry = 10;

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -175,9 +175,9 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
         *request.add_tablets() = tablet;
     }
     POpenLoadStreamResponse response;
-    // use "pooled" connection to avoid conflicts between streaming rpc and regular rpc,
-    // see: https://github.com/apache/brpc/issues/392
-    const auto& stub = client_cache->get_new_client_no_cache(host_port, "baidu_std", "pooled");
+    // set load_id as connection_group to distinguish different streaming connections
+    const auto& stub = client_cache->get_new_client_no_cache(host_port, "baidu_std", "single",
+                                                             print_id(_load_id));
     stub->open_load_stream(&cntl, &request, &response, nullptr);
     for (const auto& resp : response.tablet_schemas()) {
         auto tablet_schema = std::make_unique<TabletSchema>();

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -176,8 +176,8 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     }
     POpenLoadStreamResponse response;
     // set load_id as connection_group to distinguish different streaming connections
-    const auto& stub = client_cache->get_new_client_no_cache(host_port, "baidu_std", "single",
-                                                             "streaming");
+    const auto& stub =
+            client_cache->get_new_client_no_cache(host_port, "baidu_std", "single", "streaming");
     stub->open_load_stream(&cntl, &request, &response, nullptr);
     for (const auto& resp : response.tablet_schemas()) {
         auto tablet_schema = std::make_unique<TabletSchema>();

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -175,7 +175,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
         *request.add_tablets() = tablet;
     }
     POpenLoadStreamResponse response;
-    // set load_id as connection_group to distinguish different streaming connections
+    // set connection_group "streaming" to distinguish with non-streaming connections
     const auto& stub =
             client_cache->get_new_client_no_cache(host_port, "baidu_std", "single", "streaming");
     stub->open_load_stream(&cntl, &request, &response, nullptr);

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -177,7 +177,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     POpenLoadStreamResponse response;
     // set load_id as connection_group to distinguish different streaming connections
     const auto& stub = client_cache->get_new_client_no_cache(host_port, "baidu_std", "single",
-                                                             print_id(_load_id));
+                                                             "streaming");
     stub->open_load_stream(&cntl, &request, &response, nullptr);
     for (const auto& resp : response.tablet_schemas()) {
         auto tablet_schema = std::make_unique<TabletSchema>();


### PR DESCRIPTION
## Proposed changes

Previously, we use "pooled" connection to distinguish streaming connections
with non-streaming connections.

According to brpc docs [connection-type][1]:

> Max number of pooled connections from one client to one server is limited
> by -max_connection_pool_size.
>
> Note the number is not same as “max number of connections”.
> New connections are always created when there’s no idle ones in the pool;
> the returned connections are closed immediately when the pool already
> has max_connection_pool_size connections.

If there are too many connections, the connection will be closed immediately
once the initial `open_load_stream` rpc has finished. Causing the stream
to be closed in the meantime. Subsequent writes to the stream will encounter
"StreamWrite failed, err=22".

This PR changes brpc connection type to `"single"` for streaming connections.
And set brpc connection group to `"streaming"` to distinguish connections.

[1]: https://brpc.apache.org/docs/client/basics/#connection-type

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

