### PR TITLE
[fix](memory) Fix BE compile in Mac with no prefix Jemalloc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -372,7 +372,12 @@ if [[ ! -f "${TP_INCLUDE_DIR}/jemalloc/jemalloc_doris_with_prefix.h" ]]; then
     fi
 else
     if [[ -z "${USE_JEMALLOC_HOOK}" ]]; then
-        USE_JEMALLOC_HOOK='OFF'
+        if [[ "$(uname -s)" != 'Darwin' ]]; then
+            USE_JEMALLOC_HOOK='OFF'
+        else
+            # compile jemalloc on mac have default prefix `je_`, so default use prefix jemalloc to ensure code uniformity.
+            USE_JEMALLOC_HOOK='ON'
+        fi
     fi
     # update jemalloc prefix
     rm -rf "${TP_INCLUDE_DIR}/jemalloc/jemalloc.h"


### PR DESCRIPTION
## Proposed changes

compile jemalloc on mac have default prefix `je_`, so default use prefix jemalloc to ensure code uniformity.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

