### PR TITLE
[fix](clone) Fix clone and alter tablet use same tablet path

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -657,8 +657,7 @@ void DataDir::_perform_tablet_gc(const std::string& tablet_schema_hash_path, int
     if (!tablet || tablet->data_dir() != this) {
         if (tablet) {
             LOG(INFO) << "The tablet in path " << tablet_schema_hash_path
-                      << " is not same with the running one: " << tablet->data_dir()->_path << "/"
-                      << tablet->tablet_path()
+                      << " is not same with the running one: " << tablet->tablet_path()
                       << ", might be the old tablet after migration, try to move it to trash";
         }
         _engine.tablet_manager()->try_delete_unused_tablet_path(this, tablet_id, schema_hash,

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -939,8 +939,16 @@ Status DataDir::move_to_trash(const std::string& tablet_path) {
     }
 
     // 5. check parent dir of source file, delete it when empty
+    RETURN_IF_ERROR(delete_tablet_parent_path_if_empty(tablet_path));
+
+    return Status::OK();
+}
+
+Status DataDir::delete_tablet_parent_path_if_empty(const std::string& tablet_path) {
+    auto fs_tablet_path = io::Path(tablet_path);
     std::string source_parent_dir = fs_tablet_path.parent_path(); // tablet_id level
     std::vector<io::FileInfo> sub_files;
+    bool exists = true;
     RETURN_IF_ERROR(
             io::global_local_filesystem()->list(source_parent_dir, false, &sub_files, &exists));
     if (sub_files.empty()) {
@@ -948,7 +956,6 @@ Status DataDir::move_to_trash(const std::string& tablet_path) {
         // no need to exam return status
         RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(source_parent_dir));
     }
-
     return Status::OK();
 }
 

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -158,7 +158,7 @@ private:
 
     int _path_gc_step {0};
 
-    void _perform_tablet_gc(const std::string& tablet_schema_hash_path);
+    void _perform_tablet_gc(const std::string& tablet_schema_hash_path, int16_t shard_name);
 
     void _perform_rowset_gc(const std::string& tablet_schema_hash_path);
 

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -144,6 +144,8 @@ public:
     // Move tablet to trash.
     Status move_to_trash(const std::string& tablet_path);
 
+    static Status delete_tablet_parent_path_if_empty(const std::string& tablet_path);
+
 private:
     Status _init_cluster_id();
     Status _init_capacity_and_create_shards();

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1040,6 +1040,8 @@ Status StorageEngine::_do_sweep(const std::string& scan_root, const time_t& loca
             string path_name = sorted_path.string();
             if (difftime(local_now, mktime(&local_tm_create)) >= actual_expire) {
                 res = io::global_local_filesystem()->delete_directory(path_name);
+                LOG(INFO) << "do sweep delete directory " << path_name << " local_now " << local_now
+                          << "actual_expire " << actual_expire << " res " << res;
                 if (!res.ok()) {
                     continue;
                 }

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1134,12 +1134,7 @@ Status TabletManager::try_move_to_trash(TTabletId tablet_id, TSchemaHash schema_
 }
 
 Status TabletManager::start_trash_sweep() {
-    DBUG_EXECUTE_IF("TabletManager.start_trash_sweep.sleep", {
-        auto duration = std::chrono::milliseconds(dp->param("duration", 3600 * 1000));
-        LOG(INFO) << "in debug point TabletManager.start_trash_sweep.sleep "
-                  << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " s";
-        std::this_thread::sleep_for(duration);
-    });
+    DBUG_EXECUTE_IF("TabletManager.start_trash_sweep.sleep", DBUG_BLOCK);
     std::unique_lock<std::mutex> lock(_gc_tablets_lock, std::defer_lock);
     if (!lock.try_lock()) {
         return Status::OK();
@@ -1283,7 +1278,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                           << "tablet_id=" << tablet->tablet_id()
                           << ", schema_hash=" << tablet->schema_hash()
                           << ", delete tablet_path=" << tablet_path;
-                RETURN_IF_ERROR(io::global_local_filesystem()->delete_file(tablet_path));
+                RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_path));
                 return true;
             }
             LOG(WARNING) << "errors while load meta from store, skip this tablet. "

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1261,21 +1261,58 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
 Status TabletManager::register_transition_tablet(int64_t tablet_id, std::string reason) {
     tablets_shard& shard = _get_tablets_shard(tablet_id);
     std::lock_guard<std::mutex> lk(shard.lock_for_transition);
-    auto [it, can_do] = shard.tablets_under_transition.insert(std::pair(tablet_id, reason));
-    if (!can_do) {
-        LOG(INFO) << "tablet_id = " << tablet_id << "is doing " << it->second
-                  << " , add reason=" << reason;
-        return Status::InternalError<false>("{} failed try later, tablet_id={}", reason, tablet_id);
+    std::thread::id thread_id = std::this_thread::get_id();
+    if (auto search = shard.tablets_under_transition.find(tablet_id);
+        search == shard.tablets_under_transition.end()) {
+        // not found
+        shard.tablets_under_transition[tablet_id] = std::make_tuple(reason, thread_id, 1);
+        LOG(INFO) << "add tablet_id= " << tablet_id << " to map, reason=" << reason
+                  << " lock times=1 thread_id_in_map=" << thread_id;
+        return Status::OK();
+    } else {
+        // found
+        auto [r, thread_id_in_map, lock_times] = search->second;
+        if (thread_id != thread_id_in_map) {
+            // other thread, failed
+            LOG(INFO) << "tablet_id = " << tablet_id << " is doing " << r
+                      << " thread_id_in_map=" << thread_id_in_map << " , add reason=" << reason
+                      << " thread_id=" << thread_id;
+            return Status::InternalError<false>("{} failed try later, tablet_id={}", reason,
+                                                tablet_id);
+        }
+        shard.tablets_under_transition[tablet_id] =
+                std::make_tuple(r, thread_id_in_map, ++lock_times);
+        LOG(INFO) << "add tablet_id= " << tablet_id << " to map, reason=" << reason
+                  << " lock times=" << lock_times << " thread_id_in_map" << thread_id_in_map;
+        return Status::OK();
     }
-    LOG(INFO) << "add tablet_id= " << tablet_id << " to map, reason=" << reason;
-    return Status::OK();
 }
 
 void TabletManager::unregister_transition_tablet(int64_t tablet_id, std::string reason) {
     tablets_shard& shard = _get_tablets_shard(tablet_id);
     std::lock_guard<std::mutex> lk(shard.lock_for_transition);
-    shard.tablets_under_transition.erase(tablet_id);
-    LOG(INFO) << "erase tablet_id= " << tablet_id << " from map, reason=" << reason;
+    std::thread::id thread_id = std::this_thread::get_id();
+    if (auto search = shard.tablets_under_transition.find(tablet_id);
+        search == shard.tablets_under_transition.end()) {
+        // impossible, bug
+        DCHECK(false) << "tablet " << tablet_id
+                      << " must be found, before unreg must have been reg";
+    } else {
+        auto [r, thread_id_in_map, lock_times] = search->second;
+        if (thread_id_in_map != thread_id) {
+            // impossible, bug
+            DCHECK(false) << "tablet " << tablet_id << " unreg thread must same reg thread";
+        }
+        --lock_times;
+        if (lock_times != 0) {
+            LOG(INFO) << "erase tablet_id= " << tablet_id << " from map, reason=" << reason
+                      << " left=" << lock_times << " thread_id_in_map=" << thread_id_in_map;
+        } else {
+            shard.tablets_under_transition.erase(tablet_id);
+            LOG(INFO) << "erase tablet_id= " << tablet_id << " from map, reason=" << reason
+                      << " thread_id_in_map=" << thread_id_in_map;
+        }
+    }
 }
 
 void TabletManager::try_delete_unused_tablet_path(DataDir* data_dir, TTabletId tablet_id,

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -235,7 +235,7 @@ private:
         }
         mutable std::shared_mutex lock;
         tablet_map_t tablet_map;
-        mutable std::shared_mutex lock_for_transition;
+        std::mutex lock_for_transition;
         // tablet do clone, path gc, move to trash, disk migrate will record in tablets_under_transition
         std::map<int64_t, std::string> tablets_under_transition;
     };

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -237,7 +237,9 @@ private:
         tablet_map_t tablet_map;
         std::mutex lock_for_transition;
         // tablet do clone, path gc, move to trash, disk migrate will record in tablets_under_transition
-        std::map<int64_t, std::string> tablets_under_transition;
+        // tablet <reason, thread_id, lock_times>
+        std::map<int64_t, std::tuple<std::string, std::thread::id, int64_t>>
+                tablets_under_transition;
     };
 
     struct Partition {

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -176,6 +176,9 @@ public:
     bool update_tablet_partition_id(::doris::TPartitionId partition_id,
                                     ::doris::TTabletId tablet_id);
 
+    Status try_move_to_trash(TTabletId tablet_id, TSchemaHash schema_hash,
+                             const io::Path& tablet_path);
+
 private:
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -143,7 +143,8 @@ public:
     Status start_trash_sweep();
 
     void try_delete_unused_tablet_path(DataDir* data_dir, TTabletId tablet_id,
-                                       SchemaHash schema_hash, const std::string& schema_hash_path);
+                                       SchemaHash schema_hash, const std::string& schema_hash_path,
+                                       int16_t shard_id);
 
     void update_root_path_info(std::map<std::string, DataDirInfo>* path_map,
                                size_t* tablet_counter);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -49,6 +49,39 @@ class TCreateTabletReq;
 class TTablet;
 class TTabletInfo;
 
+class TabletSchemaPath {
+    private:
+        TTabletId tablet_id;
+        TSchemaHash schema_hash;
+        size_t path_hash;
+    public:
+        TabletSchemaPath() = default;
+        TabletSchemaPath(TTabletId tablet_id, TSchemaHash schema_hash, size_t path_hash) : tablet_id(tablet_id), schema_hash(schema_hash), path_hash(path_hash) {}
+        TabletSchemaPath(TabletSchemaPath&& scp) {
+            tablet_id = std::move(scp.tablet_id);
+            schema_hash = std::move(scp.schema_hash);
+            path_hash = std::move(scp.path_hash);
+        }
+                
+        bool operator==(const TabletSchemaPath& other) const {
+            return tablet_id == other.tablet_id && schema_hash == other.schema_hash && path_hash == other.path_hash;
+        }
+
+        bool operator<(const TabletSchemaPath& other) const {
+            if (tablet_id < other.tablet_id) {
+                return true;
+            } else if (tablet_id > other.tablet_id) {
+                return false;
+            } else if (schema_hash < other.schema_hash) {
+                return true;
+            } else if (schema_hash > other.schema_hash) {
+                return false;
+            } else {
+                return path_hash < other.path_hash;
+            }
+        }
+};
+
 // TabletManager provides get, add, delete tablet method for storage engine
 // NOTE: If you want to add a method that needs to hold meta-lock before you can call it,
 // please uniformly name the method in "xxx_unlocked()" mode
@@ -162,6 +195,13 @@ public:
     bool register_clone_tablet(int64_t tablet_id);
     void unregister_clone_tablet(int64_t tablet_id);
 
+    // return `true` if register success
+    std::pair<std::map<TabletSchemaPath, std::string>::iterator, bool> register_transition_tablet(int64_t tablet_id, TSchemaHash schema_hash, size_t path_hash, std::string reason);
+    void unregister_transition_tablet(int64_t tablet_id, TSchemaHash schema_hash, size_t path_hash);
+
+    std::pair<std::map<TabletSchemaPath, std::string>::iterator, bool> register_transition_tablet_nolock(int64_t tablet_id, TSchemaHash schema_hash, size_t path_hash, std::string reason);
+    void unregister_transition_tablet_nolock(int64_t tablet_id, TSchemaHash schema_hash, size_t path_hash);
+
     void get_tablets_distribution_on_different_disks(
             std::map<int64_t, std::map<DataDir*, int64_t>>& tablets_num_on_disk,
             std::map<int64_t, std::map<DataDir*, std::vector<TabletSize>>>& tablets_info_on_disk);
@@ -175,9 +215,6 @@ public:
 
     bool update_tablet_partition_id(::doris::TPartitionId partition_id,
                                     ::doris::TTabletId tablet_id);
-
-    Status try_move_to_trash(TTabletId tablet_id, TSchemaHash schema_hash,
-                             const io::Path& tablet_path);
 
 private:
     // Add a tablet pointer to StorageEngine
@@ -235,11 +272,14 @@ private:
         tablets_shard(tablets_shard&& shard) {
             tablet_map = std::move(shard.tablet_map);
             tablets_under_clone = std::move(shard.tablets_under_clone);
+            tablets_under_transition = std::move(shard.tablets_under_transition);
         }
         // protect tablet_map, tablets_under_clone and tablets_under_restore
         mutable std::shared_mutex lock;
         tablet_map_t tablet_map;
         std::set<int64_t> tablets_under_clone;
+        // tablet do clone, path gc, move to trash, disk migrate will record in tablets_under_transition
+        std::map<TabletSchemaPath, std::string> tablets_under_transition; 
     };
 
     struct Partition {

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -171,14 +171,14 @@ Status EngineCloneTask::_do_clone() {
     Status status = Status::OK();
     string src_file_path;
     TBackend src_host;
-    // Check local tablet exist or not
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(_clone_req.tablet_id);
-
     RETURN_IF_ERROR(
             _engine.tablet_manager()->register_transition_tablet(_clone_req.tablet_id, "clone"));
     Defer defer {[&]() {
         _engine.tablet_manager()->unregister_transition_tablet(_clone_req.tablet_id, "clone");
     }};
+
+    // Check local tablet exist or not
+    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(_clone_req.tablet_id);
 
     // The status of a tablet is not ready, indicating that it is a residual tablet after a schema
     // change failure. Clone a new tablet from remote be to overwrite it. This situation basically only

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -174,14 +174,10 @@ Status EngineCloneTask::_do_clone() {
     // Check local tablet exist or not
     TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(_clone_req.tablet_id);
 
-    TSchemaHash schema_hash = tablet->schema_hash();
-    size_t path_hash = tablet->data_dir()->path_hash();
-
-    RETURN_IF_ERROR(_engine.tablet_manager()->register_transition_tablet(
-            _clone_req.tablet_id, schema_hash, path_hash, "clone"));
+    RETURN_IF_ERROR(
+            _engine.tablet_manager()->register_transition_tablet(_clone_req.tablet_id, "clone"));
     Defer defer {[&]() {
-        _engine.tablet_manager()->unregister_transition_tablet(_clone_req.tablet_id, schema_hash,
-                                                               path_hash, "clone");
+        _engine.tablet_manager()->unregister_transition_tablet(_clone_req.tablet_id, "clone");
     }};
 
     // The status of a tablet is not ready, indicating that it is a residual tablet after a schema

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -269,6 +269,8 @@ Status EngineCloneTask::_do_clone() {
                       << ". signature: " << _signature;
             WARN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_dir),
                           "failed to delete useless clone dir ");
+            WARN_IF_ERROR(DataDir::delete_tablet_parent_path_if_empty(tablet_dir),
+                          "failed to delete parent dir");
         }};
 
         bool exists = true;

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -271,6 +271,17 @@ Status EngineCloneTask::_do_clone() {
                           "failed to delete useless clone dir ");
         }};
 
+        bool exists = true;
+        Status exists_st = io::global_local_filesystem()->exists(tablet_dir, &exists);
+        if (!exists_st) {
+            LOG(WARNING) << "cant get path=" << tablet_dir << " state, st=" << exists_st;
+            return exists_st;
+        }
+        if (exists) {
+            LOG(WARNING) << "before clone dest path=" << tablet_dir << " exist, remote it first";
+            RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_dir));
+        }
+
         bool allow_incremental_clone = false;
         RETURN_IF_ERROR_(status,
                          _make_and_download_snapshots(*store, tablet_dir, &src_host, &src_file_path,

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -263,6 +263,9 @@ Status EngineCloneTask::_do_clone() {
                                                   &store, _clone_req.partition_id));
         auto tablet_dir = fmt::format("{}/{}/{}", local_shard_root_path, _clone_req.tablet_id,
                                       _clone_req.schema_hash);
+        auto tablet_manager = _engine.tablet_manager();
+        RETURN_IF_ERROR(tablet_manager->try_move_to_trash(_clone_req.tablet_id,
+                                                          _clone_req.schema_hash, tablet_dir));
 
         Defer remove_useless_dir {[&] {
             if (status.ok()) {
@@ -281,7 +284,6 @@ Status EngineCloneTask::_do_clone() {
 
         LOG(INFO) << "clone copy done. src_host: " << src_host.host
                   << " src_file_path: " << src_file_path;
-        auto tablet_manager = _engine.tablet_manager();
         RETURN_IF_ERROR_(status, tablet_manager->load_tablet_from_dir(store, _clone_req.tablet_id,
                                                                       _clone_req.schema_hash,
                                                                       tablet_dir, false));

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -200,21 +200,16 @@ Status EngineStorageMigrationTask::_migrate() {
     int64_t tablet_id = _tablet->tablet_id();
     LOG(INFO) << "begin to process tablet migrate. "
               << "tablet_id=" << tablet_id << ", dest_store=" << _dest_store->path();
-    
+
     TSchemaHash schema_hash = _tablet->schema_hash();
     size_t path_hash = _tablet->data_dir()->path_hash();
 
-    auto [it, can_do] = _engine.tablet_manager()->register_transition_tablet(_tablet->tablet_id(), schema_hash, path_hash, "disk migrate");
-    if (!can_do) {
-        LOG(INFO) << "other op " << it->second << " effect this tablet_id = " << tablet_id << " schema_hash=" << schema_hash << " pash_hash=" << path_hash;
-        return Status::InternalError<false>("disk migrate tablet failed try later, tablet_id={}, schema_hash={}, path_hash={}", tablet_id, schema_hash, path_hash);
-    }
-    LOG(INFO) << "add tablet_id= " << tablet_id << " schema_hash=" << schema_hash << " path_hash=" << path_hash << " disk migrate tablet to map";
+    RETURN_IF_ERROR(_engine.tablet_manager()->register_transition_tablet(
+            _tablet->tablet_id(), schema_hash, path_hash, "disk migrate"));
     Defer defer {[&]() {
-        LOG(INFO) << "erase tablet_id= " << tablet_id << " schema_hash=" << schema_hash << " path_hash=" << path_hash << " disk migrate tablet from map";
-        _engine.tablet_manager()->unregister_transition_tablet(_tablet->tablet_id(), schema_hash, path_hash);
+        _engine.tablet_manager()->unregister_transition_tablet(_tablet->tablet_id(), schema_hash,
+                                                               path_hash, "disk migrate");
     }};
-
 
     DorisMetrics::instance()->storage_migrate_requests_total->increment(1);
     int32_t start_version = 0;

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -201,14 +201,11 @@ Status EngineStorageMigrationTask::_migrate() {
     LOG(INFO) << "begin to process tablet migrate. "
               << "tablet_id=" << tablet_id << ", dest_store=" << _dest_store->path();
 
-    TSchemaHash schema_hash = _tablet->schema_hash();
-    size_t path_hash = _tablet->data_dir()->path_hash();
-
-    RETURN_IF_ERROR(_engine.tablet_manager()->register_transition_tablet(
-            _tablet->tablet_id(), schema_hash, path_hash, "disk migrate"));
+    RETURN_IF_ERROR(_engine.tablet_manager()->register_transition_tablet(_tablet->tablet_id(),
+                                                                         "disk migrate"));
     Defer defer {[&]() {
-        _engine.tablet_manager()->unregister_transition_tablet(_tablet->tablet_id(), schema_hash,
-                                                               path_hash, "disk migrate");
+        _engine.tablet_manager()->unregister_transition_tablet(_tablet->tablet_id(),
+                                                               "disk migrate");
     }};
 
     DorisMetrics::instance()->storage_migrate_requests_total->increment(1);

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -322,6 +322,7 @@ Status EngineStorageMigrationTask::_migrate() {
     if (!res.ok()) {
         // we should remove the dir directly for avoid disk full of junk data, and it's safe to remove
         RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(full_path));
+        RETURN_IF_ERROR(DataDir::delete_tablet_parent_path_if_empty(full_path));
     }
     return res;
 }

--- a/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
+++ b/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
@@ -40,12 +40,10 @@ suite('test_drop_clone_tablet_path_race') {
                 if (result.size() == size) {
                     def version = result[0].Version
                     def state = result[0].State
-                    result.forEach {
-                         Assert.assertEquals(it.Version, version)
-                         Assert.assertEquals(it.State, state)
+                    succ = result.every { it.Version.equals(version) && it.State.equals(state) }
+                    if (succ) {
+                        break
                     }
-                    succ = true
-                    break
                 }
                 sleep(1000)
             }

--- a/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
+++ b/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.junit.Assert
+
+suite('test_drop_clone_tablet_path_race') {
+    if (isCloudMode()) {
+        return
+    }
+    def options = new ClusterOptions()
+    options.enableDebugPoints()
+    options.beNum = 3
+    
+    docker(options) {
+        def table = "t1"
+        sql """DROP TABLE IF EXISTS ${table}"""
+        sql """
+            CREATE TABLE `${table}` (
+            `id` int(11) NULL,
+            `name` varchar(255) NULL,
+            `score` int(11) SUM NULL
+            ) ENGINE=OLAP
+            AGGREGATE KEY(`id`, `name`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`id`) BUCKETS 10
+            PROPERTIES (
+                    'replication_num' = '3'
+            );
+        """
+
+        try {
+            // 10h
+            GetDebugPoint().enableDebugPointForAllBEs("TabletManager.start_trash_sweep.sleep", [duration:36000000])
+            for(int i= 0; i < 100; ++i) {
+                sql """INSERT INTO ${table} values (${i}, "${i}str", ${i} * 100)"""
+            }
+
+            sql """ALTER TABLE ${table} MODIFY PARTITION(${table}) SET ("replication_num" = "2")"""
+
+            sleep(60 * 1000)
+            boolean succ = false
+            for (int i = 0; i < 60; i++) {
+                def result = sql """SHOW TABLETS FROM ${table}"""
+                if (result.size() == 20) {
+                    succ = true
+                    break
+                }
+                sleep(1000)
+            }
+            Assert.assertTrue(succ)
+
+            sql """ALTER TABLE ${table} MODIFY PARTITION(${table}) SET ("replication_num" = "3")"""
+
+            sleep(60 * 1000)
+            succ = false
+            for (int i = 0; i < 60; i++) {
+                def result = sql """SHOW TABLETS FROM ${table}"""
+                if (result.size() == 30) {
+                    succ = true
+                    break
+                }
+                sleep(1000)
+            }
+            Assert.assertTrue(succ)
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs("TabletManager.start_trash_sweep.sleep")
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

The entire process is as follows:
1. Drop the tablet.
2. Successfully clone the tablet in full.
3. Start the incremental clone.
4. Start to move the tablet to the trash (the process of actually cleaning the data begins from step 1, where the tablet was dropped).
5. The incremental clone fails.
6. The incremental clone is successfully retried.

Step 4 moved the data that was just pulled from the full clone to the trash, leading to data loss.
The failure in step 5 of the incremental clone was also due to the deletion of the just-pulled snapshot data.

Fix：
When cloning, check the tablet status and determine if the tablet directory has already been moved to the trash directory. If it has not been moved to the trash, the clone thread should help move it to the trash directory.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

