### PR TITLE
[fix](nereids)LogicalPlanDeepCopier will lost some info when coping logical relation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
@@ -88,7 +88,7 @@ public class UnboundOneRowRelation extends LogicalRelation implements Unbound, O
 
     @Override
     public UnboundOneRowRelation withRelationId(RelationId relationId) {
-        throw new RuntimeException("should not call UnboundOneRowRelation's withRelationId method");
+        throw new UnboundException("should not call UnboundOneRowRelation's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
@@ -87,6 +87,11 @@ public class UnboundOneRowRelation extends LogicalRelation implements Unbound, O
     }
 
     @Override
+    public UnboundOneRowRelation withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call UnboundOneRowRelation's withRelationId method");
+    }
+
+    @Override
     public List<Slot> computeOutput() {
         throw new UnboundException("output");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
@@ -144,6 +144,11 @@ public class UnboundRelation extends LogicalRelation implements Unbound, BlockFu
     }
 
     @Override
+    public UnboundRelation withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call UnboundRelation's withRelationId method");
+    }
+
+    @Override
     public List<Slot> computeOutput() {
         throw new UnboundException("output");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
@@ -145,7 +145,7 @@ public class UnboundRelation extends LogicalRelation implements Unbound, BlockFu
 
     @Override
     public UnboundRelation withRelationId(RelationId relationId) {
-        throw new RuntimeException("should not call UnboundRelation's withRelationId method");
+        throw new UnboundException("should not call UnboundRelation's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
@@ -103,7 +103,7 @@ public class UnboundTVFRelation extends LogicalRelation implements TVFRelation, 
 
     @Override
     public UnboundTVFRelation withRelationId(RelationId relationId) {
-        throw new RuntimeException("should not call UnboundTVFRelation's withRelationId method");
+        throw new UnboundException("should not call UnboundTVFRelation's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
@@ -102,6 +102,11 @@ public class UnboundTVFRelation extends LogicalRelation implements TVFRelation, 
     }
 
     @Override
+    public UnboundTVFRelation withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call UnboundTVFRelation's withRelationId method");
+    }
+
+    @Override
     public String toString() {
         return Utils.toSqlString("UnboundTVFRelation",
                 "functionName", functionName,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -177,6 +177,9 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
     @Override
     public Plan visitLogicalDeferMaterializeOlapScan(LogicalDeferMaterializeOlapScan deferMaterializeOlapScan,
             DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(deferMaterializeOlapScan.getRelationId())) {
+            return context.getRelationReplaceMap().get(deferMaterializeOlapScan.getRelationId());
+        }
         LogicalOlapScan newScan = (LogicalOlapScan) visitLogicalOlapScan(
                 deferMaterializeOlapScan.getLogicalOlapScan(), context);
         Set<ExprId> newSlotIds = deferMaterializeOlapScan.getDeferMaterializeSlotIds().stream()
@@ -184,7 +187,10 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .collect(ImmutableSet.toImmutableSet());
         SlotReference newRowId = (SlotReference) ExpressionDeepCopier.INSTANCE
                 .deepCopy(deferMaterializeOlapScan.getColumnIdSlot(), context);
-        return new LogicalDeferMaterializeOlapScan(newScan, newSlotIds, newRowId);
+        LogicalDeferMaterializeOlapScan newMaterializeOlapScan =
+                new LogicalDeferMaterializeOlapScan(newScan, newSlotIds, newRowId);
+        context.putRelation(newMaterializeOlapScan.getRelationId(), newMaterializeOlapScan);
+        return newMaterializeOlapScan;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -39,14 +39,17 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalCTEProducer;
 import org.apache.doris.nereids.trees.plans.logical.LogicalDeferMaterializeOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalDeferMaterializeTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEsScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalExcept;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalGenerate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
 import org.apache.doris.nereids.trees.plans.logical.LogicalIntersect;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJdbcScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOdbcScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
@@ -202,6 +205,51 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         updateReplaceMapWithOutput(fileScan, newFileScan, context.exprIdReplaceMap);
         context.putRelation(fileScan.getRelationId(), newFileScan);
         return newFileScan;
+    }
+
+    @Override
+    public Plan visitLogicalJdbcScan(LogicalJdbcScan jdbcScan, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(jdbcScan.getRelationId())) {
+            return context.getRelationReplaceMap().get(jdbcScan.getRelationId());
+        }
+        Set<Expression> conjuncts = jdbcScan.getConjuncts().stream()
+                .map(p -> ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
+                .collect(ImmutableSet.toImmutableSet());
+        LogicalJdbcScan newJdbcScan = jdbcScan.withConjuncts(conjuncts)
+                .withRelationId(StatementScopeIdGenerator.newRelationId());
+        updateReplaceMapWithOutput(jdbcScan, newJdbcScan, context.exprIdReplaceMap);
+        context.putRelation(jdbcScan.getRelationId(), newJdbcScan);
+        return newJdbcScan;
+    }
+
+    @Override
+    public Plan visitLogicalOdbcScan(LogicalOdbcScan odbcScan, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(odbcScan.getRelationId())) {
+            return context.getRelationReplaceMap().get(odbcScan.getRelationId());
+        }
+        Set<Expression> conjuncts = odbcScan.getConjuncts().stream()
+                .map(p -> ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
+                .collect(ImmutableSet.toImmutableSet());
+        LogicalOdbcScan newOdbcScan = odbcScan.withConjuncts(conjuncts)
+                .withRelationId(StatementScopeIdGenerator.newRelationId());
+        updateReplaceMapWithOutput(odbcScan, newOdbcScan, context.exprIdReplaceMap);
+        context.putRelation(odbcScan.getRelationId(), newOdbcScan);
+        return newOdbcScan;
+    }
+
+    @Override
+    public Plan visitLogicalEsScan(LogicalEsScan esScan, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(esScan.getRelationId())) {
+            return context.getRelationReplaceMap().get(esScan.getRelationId());
+        }
+        Set<Expression> conjuncts = esScan.getConjuncts().stream()
+                .map(p -> ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
+                .collect(ImmutableSet.toImmutableSet());
+        LogicalEsScan newEsScan = esScan.withConjuncts(conjuncts)
+                .withRelationId(StatementScopeIdGenerator.newRelationId());
+        updateReplaceMapWithOutput(esScan, newEsScan, context.exprIdReplaceMap);
+        context.putRelation(esScan.getRelationId(), newEsScan);
+        return newEsScan;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -39,27 +39,23 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalCTEProducer;
 import org.apache.doris.nereids.trees.plans.logical.LogicalDeferMaterializeOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalDeferMaterializeTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
-import org.apache.doris.nereids.trees.plans.logical.LogicalEsScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalExcept;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalGenerate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
 import org.apache.doris.nereids.trees.plans.logical.LogicalIntersect;
-import org.apache.doris.nereids.trees.plans.logical.LogicalJdbcScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
-import org.apache.doris.nereids.trees.plans.logical.LogicalOdbcScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
-import org.apache.doris.nereids.trees.plans.logical.LogicalSchemaScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
-import org.apache.doris.nereids.trees.plans.logical.LogicalTVFRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.trees.plans.logical.LogicalWindow;
@@ -86,19 +82,43 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
     }
 
     @Override
+    public Plan visitLogicalRelation(LogicalRelation logicalRelation, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(logicalRelation.getRelationId())) {
+            return context.getRelationReplaceMap().get(logicalRelation.getRelationId());
+        }
+        LogicalRelation newRelation =
+                logicalRelation.withRelationId(StatementScopeIdGenerator.newRelationId());
+        updateReplaceMapWithOutput(logicalRelation, newRelation, context.exprIdReplaceMap);
+        context.putRelation(newRelation.getRelationId(), newRelation);
+        return newRelation;
+    }
+
+    @Override
     public Plan visitLogicalEmptyRelation(LogicalEmptyRelation emptyRelation, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(emptyRelation.getRelationId())) {
+            return context.getRelationReplaceMap().get(emptyRelation.getRelationId());
+        }
         List<NamedExpression> newProjects = emptyRelation.getProjects().stream()
                 .map(p -> (NamedExpression) ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalEmptyRelation(StatementScopeIdGenerator.newRelationId(), newProjects);
+        LogicalEmptyRelation newEmptyRelation =
+                new LogicalEmptyRelation(StatementScopeIdGenerator.newRelationId(), newProjects);
+        context.putRelation(emptyRelation.getRelationId(), newEmptyRelation);
+        return newEmptyRelation;
     }
 
     @Override
     public Plan visitLogicalOneRowRelation(LogicalOneRowRelation oneRowRelation, DeepCopierContext context) {
+        if (context.getRelationReplaceMap().containsKey(oneRowRelation.getRelationId())) {
+            return context.getRelationReplaceMap().get(oneRowRelation.getRelationId());
+        }
         List<NamedExpression> newProjects = oneRowRelation.getProjects().stream()
                 .map(p -> (NamedExpression) ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalOneRowRelation(StatementScopeIdGenerator.newRelationId(), newProjects);
+        LogicalOneRowRelation newOneRowRelation =
+                new LogicalOneRowRelation(StatementScopeIdGenerator.newRelationId(), newProjects);
+        context.putRelation(newOneRowRelation.getRelationId(), newOneRowRelation);
+        return newOneRowRelation;
     }
 
     @Override
@@ -155,28 +175,6 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
     }
 
     @Override
-    public Plan visitLogicalOlapScan(LogicalOlapScan olapScan, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(olapScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(olapScan.getRelationId());
-        }
-        LogicalOlapScan newOlapScan;
-        if (olapScan.getManuallySpecifiedPartitions().isEmpty()) {
-            newOlapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
-                    olapScan.getTable(), olapScan.getQualifier(), olapScan.getSelectedTabletIds(),
-                    olapScan.getHints(), olapScan.getTableSample());
-        } else {
-            newOlapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
-                    olapScan.getTable(), olapScan.getQualifier(),
-                    olapScan.getManuallySpecifiedPartitions(), olapScan.getSelectedTabletIds(),
-                    olapScan.getHints(), olapScan.getTableSample());
-        }
-        newOlapScan.getOutput();
-        context.putRelation(olapScan.getRelationId(), newOlapScan);
-        updateReplaceMapWithOutput(olapScan, newOlapScan, context.exprIdReplaceMap);
-        return newOlapScan;
-    }
-
-    @Override
     public Plan visitLogicalDeferMaterializeOlapScan(LogicalDeferMaterializeOlapScan deferMaterializeOlapScan,
             DeepCopierContext context) {
         LogicalOlapScan newScan = (LogicalOlapScan) visitLogicalOlapScan(
@@ -190,78 +188,18 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
     }
 
     @Override
-    public Plan visitLogicalSchemaScan(LogicalSchemaScan schemaScan, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(schemaScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(schemaScan.getRelationId());
-        }
-        LogicalSchemaScan newSchemaScan = new LogicalSchemaScan(StatementScopeIdGenerator.newRelationId(),
-                schemaScan.getTable(), schemaScan.getQualifier());
-        updateReplaceMapWithOutput(schemaScan, newSchemaScan, context.exprIdReplaceMap);
-        context.putRelation(schemaScan.getRelationId(), newSchemaScan);
-        return newSchemaScan;
-    }
-
-    @Override
     public Plan visitLogicalFileScan(LogicalFileScan fileScan, DeepCopierContext context) {
         if (context.getRelationReplaceMap().containsKey(fileScan.getRelationId())) {
             return context.getRelationReplaceMap().get(fileScan.getRelationId());
         }
-        LogicalFileScan newFileScan = new LogicalFileScan(StatementScopeIdGenerator.newRelationId(),
-                fileScan.getTable(), fileScan.getQualifier(), fileScan.getTableSample());
-        updateReplaceMapWithOutput(fileScan, newFileScan, context.exprIdReplaceMap);
-        context.putRelation(fileScan.getRelationId(), newFileScan);
         Set<Expression> conjuncts = fileScan.getConjuncts().stream()
                 .map(p -> ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
                 .collect(ImmutableSet.toImmutableSet());
-        return newFileScan.withConjuncts(conjuncts);
-    }
-
-    @Override
-    public Plan visitLogicalTVFRelation(LogicalTVFRelation tvfRelation, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(tvfRelation.getRelationId())) {
-            return context.getRelationReplaceMap().get(tvfRelation.getRelationId());
-        }
-        LogicalTVFRelation newTVFRelation = new LogicalTVFRelation(StatementScopeIdGenerator.newRelationId(),
-                tvfRelation.getFunction());
-        updateReplaceMapWithOutput(tvfRelation, newTVFRelation, context.exprIdReplaceMap);
-        context.putRelation(tvfRelation.getRelationId(), newTVFRelation);
-        return newTVFRelation;
-    }
-
-    @Override
-    public Plan visitLogicalJdbcScan(LogicalJdbcScan jdbcScan, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(jdbcScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(jdbcScan.getRelationId());
-        }
-        LogicalJdbcScan newJdbcScan = new LogicalJdbcScan(StatementScopeIdGenerator.newRelationId(),
-                jdbcScan.getTable(), jdbcScan.getQualifier());
-        updateReplaceMapWithOutput(jdbcScan, newJdbcScan, context.exprIdReplaceMap);
-        context.putRelation(jdbcScan.getRelationId(), newJdbcScan);
-        return newJdbcScan;
-    }
-
-    @Override
-    public Plan visitLogicalOdbcScan(LogicalOdbcScan odbcScan, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(odbcScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(odbcScan.getRelationId());
-        }
-        LogicalOdbcScan newOdbcScan = new LogicalOdbcScan(StatementScopeIdGenerator.newRelationId(),
-                odbcScan.getTable(), odbcScan.getQualifier());
-        updateReplaceMapWithOutput(odbcScan, newOdbcScan, context.exprIdReplaceMap);
-        context.putRelation(odbcScan.getRelationId(), newOdbcScan);
-        return newOdbcScan;
-    }
-
-    @Override
-    public Plan visitLogicalEsScan(LogicalEsScan esScan, DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(esScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(esScan.getRelationId());
-        }
-        LogicalEsScan newEsScan = new LogicalEsScan(StatementScopeIdGenerator.newRelationId(),
-                esScan.getTable(), esScan.getQualifier());
-        updateReplaceMapWithOutput(esScan, newEsScan, context.exprIdReplaceMap);
-        context.putRelation(esScan.getRelationId(), newEsScan);
-        return newEsScan;
+        LogicalFileScan newFileScan = fileScan.withConjuncts(conjuncts)
+                .withRelationId(StatementScopeIdGenerator.newRelationId());
+        updateReplaceMapWithOutput(fileScan, newFileScan, context.exprIdReplaceMap);
+        context.putRelation(fileScan.getRelationId(), newFileScan);
+        return newFileScan;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -89,7 +89,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         LogicalRelation newRelation =
                 logicalRelation.withRelationId(StatementScopeIdGenerator.newRelationId());
         updateReplaceMapWithOutput(logicalRelation, newRelation, context.exprIdReplaceMap);
-        context.putRelation(newRelation.getRelationId(), newRelation);
+        context.putRelation(logicalRelation.getRelationId(), newRelation);
         return newRelation;
     }
 
@@ -117,7 +117,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .collect(ImmutableList.toImmutableList());
         LogicalOneRowRelation newOneRowRelation =
                 new LogicalOneRowRelation(StatementScopeIdGenerator.newRelationId(), newProjects);
-        context.putRelation(newOneRowRelation.getRelationId(), newOneRowRelation);
+        context.putRelation(oneRowRelation.getRelationId(), newOneRowRelation);
         return newOneRowRelation;
     }
 
@@ -177,9 +177,6 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
     @Override
     public Plan visitLogicalDeferMaterializeOlapScan(LogicalDeferMaterializeOlapScan deferMaterializeOlapScan,
             DeepCopierContext context) {
-        if (context.getRelationReplaceMap().containsKey(deferMaterializeOlapScan.getRelationId())) {
-            return context.getRelationReplaceMap().get(deferMaterializeOlapScan.getRelationId());
-        }
         LogicalOlapScan newScan = (LogicalOlapScan) visitLogicalOlapScan(
                 deferMaterializeOlapScan.getLogicalOlapScan(), context);
         Set<ExprId> newSlotIds = deferMaterializeOlapScan.getDeferMaterializeSlotIds().stream()
@@ -189,7 +186,6 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .deepCopy(deferMaterializeOlapScan.getColumnIdSlot(), context);
         LogicalDeferMaterializeOlapScan newMaterializeOlapScan =
                 new LogicalDeferMaterializeOlapScan(newScan, newSlotIds, newRowId);
-        context.putRelation(newMaterializeOlapScan.getRelationId(), newMaterializeOlapScan);
         return newMaterializeOlapScan;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
@@ -143,6 +143,11 @@ public class LogicalCTEConsumer extends LogicalRelation implements BlockFuncDeps
     }
 
     @Override
+    public LogicalCTEConsumer withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call LogicalCTEConsumer's withRelationId method");
+    }
+
+    @Override
     public List<Slot> computeOutput() {
         return ImmutableList.copyOf(producerToConsumerOutputMap.values());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -128,6 +129,11 @@ public class LogicalDeferMaterializeOlapScan extends LogicalCatalogRelation impl
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.isEmpty(), "LogicalDeferMaterializeOlapScan should have no child");
         return this;
+    }
+
+    @Override
+    public LogicalDeferMaterializeOlapScan withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call LogicalDeferMaterializeOlapScan's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -82,6 +82,11 @@ public class LogicalEmptyRelation extends LogicalRelation
     }
 
     @Override
+    public LogicalEmptyRelation withRelationId(RelationId relationId) {
+        return new LogicalEmptyRelation(relationId, projects, Optional.empty(), Optional.empty());
+    }
+
+    @Override
     public List<Slot> computeOutput() {
         return projects.stream()
                 .map(NamedExpression::toSlot)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -83,7 +83,7 @@ public class LogicalEmptyRelation extends LogicalRelation
 
     @Override
     public LogicalEmptyRelation withRelationId(RelationId relationId) {
-        return new LogicalEmptyRelation(relationId, projects, Optional.empty(), Optional.empty());
+        throw new RuntimeException("should not call LogicalEmptyRelation's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
@@ -84,8 +84,14 @@ public class LogicalEsScan extends LogicalCatalogRelation {
     }
 
     public LogicalEsScan withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalEsScan(relationId, (ExternalTable) table, qualifier, groupExpression,
+        return new LogicalEsScan(relationId, (ExternalTable) table, qualifier, Optional.empty(),
                 Optional.of(getLogicalProperties()), conjuncts);
+    }
+
+    @Override
+    public LogicalEsScan withRelationId(RelationId relationId) {
+        return new LogicalEsScan(relationId, (ExternalTable) table, qualifier, Optional.empty(),
+                Optional.empty(), conjuncts);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -109,13 +109,19 @@ public class LogicalFileScan extends LogicalCatalogRelation {
     }
 
     public LogicalFileScan withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier, groupExpression,
+        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier, Optional.empty(),
                 Optional.of(getLogicalProperties()), conjuncts, selectedPartitions, tableSample);
     }
 
     public LogicalFileScan withSelectedPartitions(SelectedPartitions selectedPartitions) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier, groupExpression,
+        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier, Optional.empty(),
                 Optional.of(getLogicalProperties()), conjuncts, selectedPartitions, tableSample);
+    }
+
+    @Override
+    public LogicalFileScan withRelationId(RelationId relationId) {
+        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier, Optional.empty(),
+                Optional.empty(), conjuncts, selectedPartitions, tableSample);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
@@ -82,7 +82,7 @@ public class LogicalJdbcScan extends LogicalCatalogRelation {
     }
 
     public LogicalJdbcScan withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalJdbcScan(relationId, table, qualifier, groupExpression,
+        return new LogicalJdbcScan(relationId, table, qualifier, Optional.empty(),
             Optional.of(getLogicalProperties()), conjuncts);
     }
 
@@ -90,6 +90,11 @@ public class LogicalJdbcScan extends LogicalCatalogRelation {
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return new LogicalJdbcScan(relationId, table, qualifier, groupExpression, logicalProperties, conjuncts);
+    }
+
+    @Override
+    public LogicalJdbcScan withRelationId(RelationId relationId) {
+        return new LogicalJdbcScan(relationId, table, qualifier, Optional.empty(), Optional.empty(), conjuncts);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOdbcScan.java
@@ -78,7 +78,7 @@ public class LogicalOdbcScan extends LogicalCatalogRelation {
     }
 
     public LogicalOdbcScan withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalOdbcScan(relationId, table, qualifier, groupExpression,
+        return new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(),
                 Optional.of(getLogicalProperties()), conjuncts);
     }
 
@@ -86,6 +86,11 @@ public class LogicalOdbcScan extends LogicalCatalogRelation {
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return new LogicalOdbcScan(relationId, table, qualifier, groupExpression, logicalProperties, conjuncts);
+    }
+
+    @Override
+    public LogicalOdbcScan withRelationId(RelationId relationId) {
+        return new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(), Optional.empty(), conjuncts);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -317,7 +317,7 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
                 Optional.empty(), Optional.empty(),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
-                hints, cacheSlotWithSlotName, tableSample, directMvScan, projectPulledUp);
+                hints, Maps.newHashMap(), tableSample, directMvScan, projectPulledUp);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -313,9 +313,10 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
 
     @Override
     public LogicalOlapScan withRelationId(RelationId relationId) {
+        // we have to set partitionPruned to false, so that mtmv rewrite can prevent deadlock when rewriting union
         return new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.empty(),
-                selectedPartitionIds, partitionPruned, selectedTabletIds,
+                selectedPartitionIds, false, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, Maps.newHashMap(), tableSample, directMvScan, projectPulledUp);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -312,6 +312,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     }
 
     @Override
+    public LogicalOlapScan withRelationId(RelationId relationId) {
+        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+                Optional.empty(), Optional.empty(),
+                selectedPartitionIds, partitionPruned, selectedTabletIds,
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
+                hints, cacheSlotWithSlotName, tableSample, directMvScan, projectPulledUp);
+    }
+
+    @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalOlapScan(this, context);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -91,7 +91,7 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
 
     @Override
     public LogicalOneRowRelation withRelationId(RelationId relationId) {
-        return new LogicalOneRowRelation(relationId, projects, Optional.empty(), Optional.empty());
+        throw new RuntimeException("should not call LogicalOneRowRelation's withRelationId method");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -90,6 +90,11 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     @Override
+    public LogicalOneRowRelation withRelationId(RelationId relationId) {
+        return new LogicalOneRowRelation(relationId, projects, Optional.empty(), Optional.empty());
+    }
+
+    @Override
     public List<Slot> computeOutput() {
         return projects.stream()
                 .map(NamedExpression::toSlot)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRelation.java
@@ -83,6 +83,8 @@ public abstract class LogicalRelation extends LogicalLeaf implements Relation {
         return relationId;
     }
 
+    public abstract LogicalRelation withRelationId(RelationId relationId);
+
     @Override
     public JSONObject toJson() {
         JSONObject logicalRelation = super.toJson();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
@@ -66,6 +66,11 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
     }
 
     @Override
+    public LogicalSchemaScan withRelationId(RelationId relationId) {
+        return new LogicalSchemaScan(relationId, table, qualifier, Optional.empty(), Optional.empty());
+    }
+
+    @Override
     public String toString() {
         return Utils.toSqlString("LogicalSchemaScan");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
@@ -68,6 +68,11 @@ public class LogicalTVFRelation extends LogicalRelation implements TVFRelation, 
     }
 
     @Override
+    public LogicalTVFRelation withRelationId(RelationId relationId) {
+        return new LogicalTVFRelation(relationId, function, Optional.empty(), Optional.empty());
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTestScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTestScan.java
@@ -71,6 +71,11 @@ public class LogicalTestScan extends LogicalCatalogRelation {
     }
 
     @Override
+    public LogicalTestScan withRelationId(RelationId relationId) {
+        throw new RuntimeException("should not call LogicalTestScan's withRelationId method");
+    }
+
+    @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalTestScan(this, context);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -122,6 +123,11 @@ public class RewriteTopDownJobTest {
         public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
                 Optional<LogicalProperties> logicalProperties, List<Plan> children) {
             return new LogicalBoundRelation(table, qualifier, groupExpression, logicalProperties);
+        }
+
+        @Override
+        public LogicalBoundRelation withRelationId(RelationId relationId) {
+            throw new RuntimeException("should not call LogicalBoundRelation's withRelationId method");
         }
     }
 }


### PR DESCRIPTION
1. add withRelationId to LogicalRelation. LogicalPlanDeepCopier use this method to do deep copy
2. remove redundant code and add common method visitLogicalRelation for relations to do deep copy by default

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

