### PR TITLE
[fix](load) skip sending cancel rpc if VNodeChannel is not inited

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -846,6 +846,10 @@ void VNodeChannel::cancel(const std::string& cancel_msg) {
     // we don't need to wait last rpc finished, cause closure's release/reset will join.
     // But do we need brpc::StartCancel(call_id)?
     _cancel_with_msg(cancel_msg);
+    // if not inited, _stub will be nullptr, skip sending cancel rpc
+    if (!_inited) {
+        return;
+    }
 
     auto request = std::make_shared<PTabletWriterCancelRequest>();
     request->set_allocated_id(&_parent->_load_id);


### PR DESCRIPTION
## Proposed changes

Fix the following coredump

```cpp
Core was generated by `/mnt/hdd01/DorisCloudS3Stress/cluster0/be/lib/doris_be'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  pthread_sigmask (how=2, newmask=<optimized out>, oldmask=0x0) at pthread_sigmask.c:48
48      pthread_sigmask.c: No such file or directory.
[Current thread is 1 (Thread 0x7fdbf91f1700 (LWP 3649251))]
(gdb) bt
#0  pthread_sigmask (how=2, newmask=<optimized out>, oldmask=0x0) at pthread_sigmask.c:48
#1  0x00007ffa17acd71e in PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] ()
   from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#2  0x00007ffa17ace206 in JVM_handle_linux_signal () from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#3  <signal handler called>
#4  doris::vectorized::VNodeChannel::cancel (this=this@entry=0x7ff4ef107190, cancel_msg=...)
    at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/sink/writer/vtablet_writer.cpp:912
#5  0x00005646777a937b in doris::vectorized::VTabletWriter::_cancel_all_channel(doris::Status)::$_0::operator()(std::shared_ptr<doris::vectorized::VNodeChannel> const&) const (this=<optimized out>, ch=...)
    at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/sink/writer/vtablet_writer.cpp:1388
#6  std::__invoke_impl<void, doris::vectorized::VTabletWriter::_cancel_all_channel(doris::Status)::$_0&, std::shared_ptr<doris::vectorized::VNodeChannel> const&>(std::__invoke_other, doris::vectorized::VTabletWriter::_cancel_all_channel(doris::Status)::$_0&, std::shared_ptr<doris::vectorized::VNodeChannel> const&) (__f=..., __args=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61

...

(gdb) f 4
#4  doris::vectorized::VNodeChannel::cancel (this=this@entry=0x7ff4ef107190, cancel_msg=...)
    at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/sink/writer/vtablet_writer.cpp:912
912     /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/sink/writer/vtablet_writer.cpp: No such file or directory.
(gdb) p this
$1 = (doris::vectorized::VNodeChannel *) 0x7ff4ef107190
(gdb) p _stub
$2 = {<std::__shared_ptr<doris::PBackendService_Stub, (__gnu_cxx::_Lock_policy)2>> = {<std::__shared_ptr_access<doris::PBackendService_Stub, (__gnu_cxx::_Lock_policy)2, false, false>> = {<No data fields>}, _M_ptr = 0x0, _M_refcount = {_M_pi = 0x0}}, <No data fields>}
(gdb) p _inited
$3 = false
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

