### PR TITLE
[Fix](executor)log profile and exit when find invalid fe addr

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -660,7 +660,8 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
         LOG(INFO) << "query_id: " << UniqueId(query_ctx->query_id().hi, query_ctx->query_id().lo)
                   << " coord_addr " << query_ctx->coord_addr
                   << " total fragment num on current host: " << params.fragment_num_on_host
-                  << " fe process uuid: " << params.query_options.fe_process_uuid;
+                  << " fe process uuid: " << params.query_options.fe_process_uuid
+                  << " params coord addr:" << params.coord;
         query_ctx->query_globals = params.query_globals;
 
         if (params.__isset.resource_info) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -610,7 +610,7 @@ void PlanFragmentExecutor::close() {
             }
         }
 
-        if (_runtime_state->enable_profile()) {
+        if (_runtime_state->enable_profile() || _query_ctx->is_coord_addr_invalid()) {
             std::stringstream ss;
             // Compute the _local_time_percent before pretty_print the runtime_profile
             // Before add this operation, the print out like that:
@@ -630,6 +630,7 @@ void PlanFragmentExecutor::close() {
                                              collect_realtime_query_profile(),
                                              collect_realtime_load_channel_profile());
         }
+        DCHECK_EQ(_query_ctx->is_coord_addr_invalid(), false);
     }
 
     _closed = true;

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -291,6 +291,9 @@ public:
     // only for file scan node
     std::map<int, TFileScanRangeParams> file_scan_range_params_map;
 
+    // NOTE(wb) log profile when find invalid fe host to debug problem
+    bool is_coord_addr_invalid() { return coord_addr.hostname.empty() || coord_addr.port == 0; }
+
 private:
     int _timeout_second;
     TUniqueId _query_id;


### PR DESCRIPTION
Find some query without valid FE coord addr.
```
I20240514 16:13:40.403275 36382 fragment_mgr.cpp:660] query_id: 65a3b7c24d6840e5-a255ce57dc178922 coord_addr TNetworkAddress(hostname=, port=0) total fragment num on current host: 0 fe process uuid: 0
I20240514 16:13:56.078752 36575 fragment_mgr.cpp:660] query_id: c8d342bc79f54bb3-9163dc61dd3cc91f coord_addr TNetworkAddress(hostname=, port=0) total fragment num on current host: 0 fe process uuid: 0
I20240514 16:13:57.491098 36590 fragment_mgr.cpp:660] query_id: 5566395318f947f0-85c82e9d0915d4fd coord_addr TNetworkAddress(hostname=, port=0) total fragment num on current host: 0 fe process uuid: 0
I20240514 16:14:01.316201 36695 fragment_mgr.cpp:660] query_id: 99a5087b6c714059-b5f76352901cbf1a coord_addr TNetworkAddress(hostname=, port=0) total fragment num on current host: 0 fe process uuid: 0
```

The queries are all non-pipeline select.
```
I20240514 16:13:40.403275 36382 fragment_mgr.cpp:660] query_id: 65a3b7c24d6840e5-a255ce57dc178922 coord_addr TNetworkAddress(hostname=, port=0) total fragment num on current host: 0 fe process uuid: 0
I20240514 16:13:40.403342 36382 fragment_mgr.cpp:699] Register query/load memory tracker, query/load id: 65a3b7c24d6840e5-a255ce57dc178922 limit: 0
I20240514 16:13:41.010730 36382 plan_fragment_executor.cpp:123] PlanFragmentExecutor::prepare|query_id=65a3b7c24d6840e5-a255ce57dc178922|instance_id=144f452d10cc44da-9d2611b0ce919c80|backend_num=0|pthread_id=140485081507584
I20240514 16:13:41.015050 13191 plan_fragment_executor.cpp:257] PlanFragmentExecutor::open 65a3b7c24d6840e5-a255ce57dc178922|144f452d10cc44da-9d2611b0ce919c80, mem_limit 2.00 GB
I20240514 16:13:41.039989 13191 exec_node.cpp:246] query= 65a3b7c24d6840e5-a255ce57dc178922, fragment_instance_id=144f452d10cc44da-9d2611b0ce919c80, id=0 type=OLAP_SCAN_NODE closed
I20240514 16:13:41.040112 13191 fragment_mgr.cpp:498] Query 65a3b7c24d6840e5-a255ce57dc178922 finished
I20240514 16:13:41.040323 13191 query_context.cpp:171] Query 65a3b7c24d6840e5-a255ce57dc178922 deconstructed, , deregister query/load memory tracker, queryId=65a3b7c24d6840e5-a255ce57dc178922, Limit=2.00 GB, CurrUsed=4.00 KB, PeakUsed=379.05 KB
```

Add log and dcheck when find this query, find what the query is.

