### PR TITLE
[fix](multi-catalog)remove http scheme in oss endpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
@@ -493,7 +493,7 @@ public class PropertyConverter {
     }
 
     private static String getOssEndpoint(String region, boolean publicAccess) {
-        String prefix = "http://oss-";
+        String prefix = "oss-";
         String suffix = ".aliyuncs.com";
         if (!publicAccess) {
             suffix = "-internal" + suffix;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
@@ -336,7 +336,7 @@ public class PropertyConverterTest extends TestWithFeService {
         Map<String, String> hdProps = catalog.getCatalogProperty().getHadoopProperties();
         Assertions.assertEquals("akk", hdProps.get(OssProperties.ACCESS_KEY));
         Assertions.assertEquals("skk", hdProps.get(OssProperties.SECRET_KEY));
-        Assertions.assertEquals("http://oss-cn-beijing-internal.aliyuncs.com",
+        Assertions.assertEquals("oss-cn-beijing-internal.aliyuncs.com",
                 hdProps.get(OssProperties.ENDPOINT));
 
         String queryDlf2 = "create catalog hms_dlf2 properties (\n"
@@ -392,7 +392,7 @@ public class PropertyConverterTest extends TestWithFeService {
         Map<String, String> hdProps3 = catalog3.getCatalogProperty().getHadoopProperties();
         Assertions.assertEquals("akk", hdProps3.get(OssProperties.ACCESS_KEY));
         Assertions.assertEquals("skk", hdProps3.get(OssProperties.SECRET_KEY));
-        Assertions.assertEquals("http://oss-cn-beijing-internal.aliyuncs.com", hdProps3.get(OssProperties.ENDPOINT));
+        Assertions.assertEquals("oss-cn-beijing-internal.aliyuncs.com", hdProps3.get(OssProperties.ENDPOINT));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

remove http scheme in oss endpoint, scheme maybe appear in url (http://bucket.http//.region.aliyuncs.com) if use http client 

p2 case (test_cloud_accessible_oss.groovy) :

```
CREATE CATALOG  dlf
PROPERTIES (
    "type"="hms",
    "hive.metastore.type" = "dlf",
    "dlf.endpoint" = "dlf.cn-beijing.aliyuncs.com",
    "dlf.region" = "cn-beijing",
    "dlf.proxy.mode" = "DLF_ONLY",
    "dlf.uid" = "xx",
    "dlf.access_key" = "",
    "dlf.secret_key" = "",
    "dlf.access.public" = "true"
);

use jz_datalake;

select * from web_site where web_site_id='AAAAAAAAKBAAAAAA' order by web_site_sk,web_site_id limit 1;

```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

