### PR TITLE
[Fix](auto inc) Fix auto inc db id overflow

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -115,7 +115,7 @@ public:
     RuntimeState* runtime_state = nullptr;
     RowsetId rowset_id;
     Version version;
-    int32_t tablet_id = 0;
+    int64_t tablet_id = 0;
     // slots that cast may be eliminated in storage layer
     std::map<std::string, PrimitiveType> target_cast_type_for_variants;
     RowRanges row_ranges;

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -600,7 +600,7 @@ public:
 
 private:
     rowid_t _current_rowid = 0;
-    int32_t _tablet_id = 0;
+    int64_t _tablet_id = 0;
     RowsetId _rowset_id;
     int32_t _segment_id = 0;
 };

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -124,7 +124,7 @@ public:
     bool is_lazy_materialization_read() const override { return _lazy_materialization_read; }
     uint64_t data_id() const override { return _segment->id(); }
     RowsetId rowset_id() const { return _segment->rowset_id(); }
-    int32_t tablet_id() const { return _tablet_id; }
+    int64_t tablet_id() const { return _tablet_id; }
 
     bool update_profile(RuntimeProfile* profile) override {
         bool updated = false;
@@ -490,7 +490,7 @@ private:
     // used to collect filter information.
     std::vector<ColumnPredicate*> _filter_info_id;
     bool _record_rowids = false;
-    int32_t _tablet_id = 0;
+    int64_t _tablet_id = 0;
     std::set<int32_t> _output_columns;
 
     std::unique_ptr<HierarchicalDataReader> _path_reader;

--- a/be/src/olap/schema_cache.cpp
+++ b/be/src/olap/schema_cache.cpp
@@ -40,7 +40,7 @@ SchemaCache* SchemaCache::instance() {
 }
 
 // format: tabletId-unique_id1-uniqueid2...-version-type
-std::string SchemaCache::get_schema_key(int32_t tablet_id, const TabletSchemaSPtr& schema,
+std::string SchemaCache::get_schema_key(int64_t tablet_id, const TabletSchemaSPtr& schema,
                                         const std::vector<uint32_t>& column_ids, int32_t version,
                                         Type type) {
     if (column_ids.empty() || schema->column(column_ids[0]).unique_id() < 0) {
@@ -57,7 +57,7 @@ std::string SchemaCache::get_schema_key(int32_t tablet_id, const TabletSchemaSPt
 }
 
 // format: tabletId-unique_id1-uniqueid2...-version-type
-std::string SchemaCache::get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
+std::string SchemaCache::get_schema_key(int64_t tablet_id, const std::vector<TColumn>& columns,
                                         int32_t version, Type type) {
     if (columns.empty() || columns[0].col_unique_id < 0) {
         return "";

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -53,10 +53,10 @@ public:
     static void create_global_instance(size_t capacity);
 
     // get cache schema key, delimiter with SCHEMA_DELIMITER
-    static std::string get_schema_key(int32_t tablet_id, const TabletSchemaSPtr& schema,
+    static std::string get_schema_key(int64_t tablet_id, const TabletSchemaSPtr& schema,
                                       const std::vector<uint32_t>& column_ids, int32_t version,
                                       Type type);
-    static std::string get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
+    static std::string get_schema_key(int64_t tablet_id, const std::vector<TColumn>& columns,
                                       int32_t version, Type type);
 
     // Get a shared cached schema from cache, schema_key is a subset of column unique ids

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -368,10 +368,10 @@ public:
     }
     std::string auto_increment_column() const { return _auto_increment_column; }
 
-    void set_table_id(int32_t table_id) { _table_id = table_id; }
-    int32_t table_id() const { return _table_id; }
-    void set_db_id(int32_t db_id) { _db_id = db_id; }
-    int32_t db_id() const { return _db_id; }
+    void set_table_id(int64_t table_id) { _table_id = table_id; }
+    int64_t table_id() const { return _table_id; }
+    void set_db_id(int64_t db_id) { _db_id = db_id; }
+    int64_t db_id() const { return _db_id; }
     void build_current_tablet_schema(int64_t index_id, int32_t version,
                                      const OlapTableIndexSchema* index,
                                      const TabletSchema& out_tablet_schema);
@@ -488,8 +488,8 @@ private:
     int32_t _sequence_col_idx = -1;
     int32_t _version_col_idx = -1;
     int32_t _schema_version = -1;
-    int32_t _table_id = -1;
-    int32_t _db_id = -1;
+    int64_t _table_id = -1;
+    int64_t _db_id = -1;
     bool _disable_auto_compaction = false;
     bool _enable_single_replica_compaction = false;
     int64_t _mem_size = 0;

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -296,9 +296,9 @@ struct RowLocation {
 };
 
 struct GlobalRowLoacation {
-    GlobalRowLoacation(uint32_t tid, RowsetId rsid, uint32_t sid, uint32_t rid)
+    GlobalRowLoacation(int64_t tid, RowsetId rsid, uint32_t sid, uint32_t rid)
             : tablet_id(tid), row_location(rsid, sid, rid) {}
-    uint32_t tablet_id;
+    int64_t tablet_id;
     RowLocation row_location;
 
     bool operator==(const GlobalRowLoacation& rhs) const {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -147,13 +147,13 @@ public:
     ::doris::TTableType::type table_type() const { return _table_type; }
     const std::string& name() const { return _name; }
     const std::string& database() const { return _database; }
-    int32_t table_id() const { return _table_id; }
+    int64_t table_id() const { return _table_id; }
 
 private:
     ::doris::TTableType::type _table_type;
     std::string _name;
     std::string _database;
-    int32_t _table_id;
+    int64_t _table_id;
     int _num_cols;
     int _num_clustering_cols;
 };

--- a/be/src/vec/sink/autoinc_buffer.cpp
+++ b/be/src/vec/sink/autoinc_buffer.cpp
@@ -19,6 +19,8 @@
 
 #include <gen_cpp/HeartbeatService_types.h>
 
+#include <string>
+
 #include "common/status.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
@@ -69,6 +71,11 @@ Status AutoIncIDBuffer::sync_request_ids(size_t length,
         }
 
         DCHECK_LE(length, _front_buffer.second);
+        if (length > _front_buffer.second) {
+            return Status::RpcError("auto inc sync result length > front buffer. " +
+                                    std::to_string(length) + " vs " +
+                                    std::to_string(_front_buffer.second));
+        }
         result->emplace_back(_front_buffer.first, length);
         _front_buffer.first += length;
         _front_buffer.second -= length;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

db_id, table_id and tablet_id should be int64_t instead of int32_t

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

