### PR TITLE
[fix](mow) the recycling timing of compaction input rowsets should rely on config compacted_rowset_retention_seconds

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1450,7 +1450,10 @@ int InstanceRecycler::recycle_rowsets() {
         // RecycleRowsetPB created by compacted or dropped rowset has no expiration time, and will be recycled when exceed retention time
         int64_t expiration = rs.expiration() > 0 ? rs.expiration() : rs.creation_time();
         int64_t retention_seconds = config::retention_seconds;
-        if (rs.type() == RecycleRowsetPB::COMPACT || rs.type() == RecycleRowsetPB::DROP) {
+        if (rs.type() == RecycleRowsetPB::COMPACT) {
+            retention_seconds = config::compacted_rowset_retention_seconds;
+        }
+        if (rs.type() == RecycleRowsetPB::DROP) {
             retention_seconds =
                     std::min(config::compacted_rowset_retention_seconds, retention_seconds);
         }


### PR DESCRIPTION
## Proposed changes
now in cloud mode, compaction input rowsets's recycling timing  is rely on retention_seconds, and this retention_seconds should only rely on config compacted_rowset_retention_seconds to avoid deleting these rowsets too early, becasue these rowset is reading by last loading task to calculate delete bitmap. 
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

