### PR TITLE
[opt](routine-load) do not schedule invalid task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -123,6 +123,9 @@ public class RoutineLoadTaskScheduler extends MasterDaemon {
         }
 
         try {
+            if (routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).isFinal()) {
+                return;
+            }
             // check if topic has more data to consume
             if (!routineLoadTaskInfo.hasMoreDataToConsume()) {
                 needScheduleTasksQueue.addLast(routineLoadTaskInfo);


### PR DESCRIPTION
## Proposed changes

When the job state of routine load job is stop or cancel, it is not need schedule or execute any task, but
1. task in needScheduleTasksQueue will still be scheduled
2. task executing do not cancel until commit transaction.

It will occupy lots of CPU/memory/disk resource, even if they are invalid. 
