### PR TITLE
[fix](statistics)Cast min/max in partition stats table to double for numeric column to get correct table level min/max value.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -635,13 +635,13 @@ public class ScalarType extends Type {
                 break;
             case DECIMALV2:
                 if (Strings.isNullOrEmpty(precisionStr)) {
-                    stringBuilder.append("DECIMAL").append("(").append(precision)
+                    stringBuilder.append("DECIMALV2").append("(").append(precision)
                             .append(", ").append(scale).append(")");
                 } else if (!Strings.isNullOrEmpty(precisionStr) && !Strings.isNullOrEmpty(scaleStr)) {
-                    stringBuilder.append("DECIMAL").append("(`").append(precisionStr)
+                    stringBuilder.append("DECIMALV2").append("(`").append(precisionStr)
                             .append("`, `").append(scaleStr).append("`)");
                 } else {
-                    stringBuilder.append("DECIMAL").append("(`").append(precisionStr).append("`)");
+                    stringBuilder.append("DECIMALV2").append("(`").append(precisionStr).append("`)");
                 }
                 break;
             case DECIMAL32:


### PR DESCRIPTION
Min/max value in partition statistics table are of type String, we need to cast numeric type to double when we merge partition stats to get table stats, otherwise, the table min/max value is incorrect because they are in alphabet order.

Currently, this function is closed by default. Will open it later with more test cases.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

