### PR TITLE
[fix](auth) revoke column privs the second time failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -790,19 +790,22 @@ public class Role implements Writable, GsonPostProcessable {
     public void revokePrivs(TablePattern tblPattern, PrivBitSet privs, Map<ColPrivilegeKey, Set<String>> colPrivileges,
             boolean errOnNonExist)
             throws DdlException {
-        PrivBitSet existingPriv = tblPatternToPrivs.get(tblPattern);
-        if (existingPriv == null) {
-            if (errOnNonExist) {
-                throw new DdlException(tblPattern + " does not exist in role " + roleName);
+        if (!colPrivileges.isEmpty()) {
+            revokeCols(colPrivileges);
+        } else {
+            PrivBitSet existingPriv = tblPatternToPrivs.get(tblPattern);
+            if (existingPriv == null) {
+                if (errOnNonExist) {
+                    throw new DdlException(tblPattern + " does not exist in role " + roleName);
+                }
+                return;
             }
-            return;
+            existingPriv.remove(privs);
+            if (existingPriv.isEmpty()) {
+                tblPatternToPrivs.remove(tblPattern);
+            }
+            revokePrivs(tblPattern, privs);
         }
-        existingPriv.remove(privs);
-        if (existingPriv.isEmpty()) {
-            tblPatternToPrivs.remove(tblPattern);
-        }
-        revokePrivs(tblPattern, privs);
-        revokeCols(colPrivileges);
     }
 
     private void revokeCols(Map<ColPrivilegeKey, Set<String>> colPrivileges) {
@@ -814,6 +817,12 @@ public class Role implements Writable, GsonPostProcessable {
                 colPrivMap.get(entry.getKey()).removeAll(entry.getValue());
                 if (CollectionUtils.isEmpty(colPrivMap.get(entry.getKey()))) {
                     colPrivMap.remove(entry.getKey());
+                    TablePattern tblPattern = new TablePattern(entry.getKey().getCtl(), entry.getKey().getDb(),
+                            entry.getKey().getTbl());
+                    PrivBitSet existingPriv = tblPatternToPrivs.get(tblPattern);
+                    if (existingPriv != null && existingPriv.isEmpty()) {
+                        tblPatternToPrivs.remove(tblPattern);
+                    }
                 }
             }
         }

--- a/regression-test/suites/nereids_p0/authorization/column_authorization.groovy
+++ b/regression-test/suites/nereids_p0/authorization/column_authorization.groovy
@@ -36,6 +36,12 @@ suite("column_authorization") {
 
     sql "drop user if exists ${user1}"
     sql "create user ${user1}"
+
+    sql "grant SELECT_PRIV(id) on ${db}.${baseTable} to '${user1}'@'%';"
+    sql "grant SELECT_PRIV(name) on ${db}.${baseTable} to '${user1}'@'%';"
+    sql "revoke SELECT_PRIV(name) on ${db}.${baseTable} from '${user1}'@'%';"
+    sql "revoke SELECT_PRIV(id) on ${db}.${baseTable} from '${user1}'@'%';"
+
     sql "grant SELECT_PRIV(id) on ${db}.${baseTable} to '${user1}'@'%';"
 
     //cloud-mode


### PR DESCRIPTION
## Proposed changes

Reproduce steps:
1. grant SELECT_PRIV(col1) on table1 to test_user
2. grant SELECT_PRIV(col2) on table1 to test_user
3. revoke SELECT_PRIV(col2) on table1 from test_user
4. revoke SELECT_PRIV(col1) on table1 from test_user

Then we will got following error message:
`ERROR 1105 (HY000): errCode = 2, detailMessage = internal.example_db.test does not exist in role default_role_rbac_test@%`


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

