### PR TITLE
[refactor](jdbc catalog) split trino jdbc executor

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -513,7 +513,8 @@ Status JdbcConnector::_check_type(SlotDescriptor* slot_desc, const std::string& 
     case TYPE_DATETIMEV2: {
         if (type_str != "java.sql.Timestamp" && type_str != "java.time.LocalDateTime" &&
             type_str != "java.sql.Date" && type_str != "java.time.LocalDate" &&
-            type_str != "oracle.sql.TIMESTAMP" && type_str != "java.time.OffsetDateTime") {
+            type_str != "oracle.sql.TIMESTAMP" && type_str != "java.time.OffsetDateTime" &&
+            type_str != "java.lang.String") {
             return Status::InternalError(error_msg);
         }
         break;

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorFactory.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorFactory.java
@@ -34,6 +34,9 @@ public class JdbcExecutorFactory {
                 return "org/apache/doris/jdbc/DB2JdbcExecutor";
             case SAP_HANA:
                 return "org/apache/doris/jdbc/SapHanaJdbcExecutor";
+            case TRINO:
+            case PRESTO:
+                return "org/apache/doris/jdbc/TrinoJdbcExecutor";
             default:
                 return "org/apache/doris/jdbc/DefaultJdbcExecutor";
         }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/TrinoJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/TrinoJdbcExecutor.java
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jdbc;
+
+import org.apache.doris.common.jni.vec.ColumnType;
+import org.apache.doris.common.jni.vec.ColumnType.Type;
+import org.apache.doris.common.jni.vec.ColumnValueConverter;
+import org.apache.doris.common.jni.vec.VectorTable;
+
+import com.google.common.collect.Lists;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class TrinoJdbcExecutor extends BaseJdbcExecutor {
+    public TrinoJdbcExecutor(byte[] thriftParams) throws Exception {
+        super(thriftParams);
+    }
+
+    @Override
+    protected void initializeBlock(int columnCount, String[] replaceStringList, int batchSizeNum,
+            VectorTable outputTable) {
+        for (int i = 0; i < columnCount; ++i) {
+            if (outputTable.getColumnType(i).getType() == Type.DATETIME
+                    || outputTable.getColumnType(i).getType() == Type.DATETIMEV2) {
+                block.add(new Timestamp[batchSizeNum]);
+            } else if (outputTable.getColumnType(i).getType() == Type.ARRAY) {
+                block.add(new Object[batchSizeNum]);
+            } else {
+                block.add(outputTable.getColumn(i).newObjectContainerArray(batchSizeNum));
+            }
+        }
+    }
+
+    @Override
+    protected Object getColumnValue(int columnIndex, ColumnType type, String[] replaceStringList) throws SQLException {
+        switch (type.getType()) {
+            case BOOLEAN:
+                return resultSet.getObject(columnIndex + 1, Boolean.class);
+            case TINYINT:
+                return resultSet.getObject(columnIndex + 1, Byte.class);
+            case SMALLINT:
+                return resultSet.getObject(columnIndex + 1, Short.class);
+            case INT:
+                return resultSet.getObject(columnIndex + 1, Integer.class);
+            case BIGINT:
+                return resultSet.getObject(columnIndex + 1, Long.class);
+            case FLOAT:
+                return resultSet.getObject(columnIndex + 1, Float.class);
+            case DOUBLE:
+                return resultSet.getObject(columnIndex + 1, Double.class);
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                return resultSet.getObject(columnIndex + 1, BigDecimal.class);
+            case DATE:
+            case DATEV2:
+                return resultSet.getObject(columnIndex + 1, LocalDate.class);
+            case DATETIME:
+            case DATETIMEV2:
+                return resultSet.getObject(columnIndex + 1, Timestamp.class);
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+                return resultSet.getObject(columnIndex + 1, String.class);
+            case ARRAY: {
+                Array array = resultSet.getArray(columnIndex + 1);
+                if (array == null) {
+                    return null;
+                }
+                Object[] dataArray = (Object[]) array.getArray();
+                if (dataArray.length == 0) {
+                    return Collections.emptyList();
+                }
+                return Arrays.asList(dataArray);
+            }
+            default:
+                throw new IllegalArgumentException("Unsupported column type: " + type.getType());
+        }
+    }
+
+    @Override
+    protected ColumnValueConverter getOutputConverter(ColumnType columnType, String replaceString) {
+        switch (columnType.getType()) {
+            case DATETIME:
+            case DATETIMEV2:
+                return createConverter(
+                        input -> ((Timestamp) input).toLocalDateTime(), java.time.LocalDateTime.class);
+            case ARRAY:
+                return createConverter(
+                        input -> convertArray((List<?>) input, columnType.getChildTypes().get(0)), List.class);
+            default:
+                return null;
+        }
+    }
+
+    private List<?> convertArray(List<?> array, ColumnType type) {
+        if (array == null) {
+            return null;
+        }
+        if (array.isEmpty()) {
+            return Collections.emptyList();
+        }
+        switch (type.getType()) {
+            case DATE:
+            case DATEV2: {
+                List<LocalDate> result = Lists.newArrayList();
+                for (Object element : array) {
+                    result.add(element != null ? ((Date) element).toLocalDate() : null);
+                }
+                return result;
+            }
+            case DATETIME:
+            case DATETIMEV2: {
+                List<LocalDateTime> result = Lists.newArrayList();
+                for (Object element : array) {
+                    result.add(element != null ? ((Timestamp) element).toLocalDateTime() : null);
+                }
+                return result;
+            }
+            case ARRAY: {
+                List<List<?>> resultArray = Lists.newArrayList();
+                for (Object element : array) {
+                    if (element == null) {
+                        resultArray.add(null);
+                    } else {
+                        resultArray.add(
+                                Lists.newArrayList(convertArray((List<?>) element, type.getChildTypes().get(0))));
+                    }
+                }
+                return resultArray;
+            }
+            default:
+                return array;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcTrinoClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcTrinoClient.java
@@ -50,6 +50,8 @@ public class JdbcTrinoClient extends JdbcClient {
                 return Type.BOOLEAN;
             case "date":
                 return ScalarType.createDateV2Type();
+            case "json":
+                return ScalarType.createStringType();
             default:
                 break;
         }
@@ -83,7 +85,7 @@ public class JdbcTrinoClient extends JdbcClient {
             return ArrayType.create(type, true);
         }
 
-        if (trinoType.startsWith("varchar")) {
+        if (trinoType.startsWith("varchar") || trinoType.startsWith("time")) {
             return ScalarType.createStringType();
         }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
Doris > desc trino.doris_test.all_types;
+-------------+------------------+------+------+---------+-------+
| Field       | Type             | Null | Key  | Default | Extra |
+-------------+------------------+------+------+---------+-------+
| tinyint_u   | SMALLINT         | Yes  | true | NULL    |       |
| smallint_u  | INT              | Yes  | true | NULL    |       |
| mediumint_u | INT              | Yes  | true | NULL    |       |
| int_u       | BIGINT           | Yes  | true | NULL    |       |
| bigint_u    | DECIMAL(20, 0)   | Yes  | true | NULL    |       |
| decimal_u   | DECIMAL(18, 5)   | Yes  | true | NULL    |       |
| double_u    | DOUBLE           | Yes  | true | NULL    |       |
| float_u     | FLOAT            | Yes  | true | NULL    |       |
| boolean     | TINYINT          | Yes  | true | NULL    |       |
| tinyint     | TINYINT          | Yes  | true | NULL    |       |
| smallint    | SMALLINT         | Yes  | true | NULL    |       |
| year        | DATE             | Yes  | true | NULL    |       |
| mediumint   | INT              | Yes  | true | NULL    |       |
| int         | INT              | Yes  | true | NULL    |       |
| bigint      | BIGINT           | Yes  | true | NULL    |       |
| date        | DATE             | Yes  | true | NULL    |       |
| timestamp   | DATETIME(4)      | Yes  | true | NULL    |       |
| datetime    | DATETIME         | Yes  | true | NULL    |       |
| float       | FLOAT            | Yes  | true | NULL    |       |
| double      | DOUBLE           | Yes  | true | NULL    |       |
| decimal     | DECIMAL(12, 4)   | Yes  | true | NULL    |       |
| char        | CHAR(23)         | Yes  | true | NULL    |       |
| varchar     | TEXT             | Yes  | true | NULL    |       |
| time        | TEXT             | Yes  | true | NULL    |       |
| text        | TEXT             | Yes  | true | NULL    |       |
| blob        | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| json        | TEXT             | Yes  | true | NULL    |       |
| set         | CHAR(23)         | Yes  | true | NULL    |       |
| bit         | BOOLEAN          | Yes  | true | NULL    |       |
| binary      | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| varbinary   | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| enum        | TEXT             | Yes  | true | NULL    |       |
+-------------+------------------+------+------+---------+-------+
32 rows in set (0.02 sec)

Doris > select * except(blob,`binary`,`varbinary`) from trino.doris_test.all_types;
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+-------+---------+---------------+-------+-----------------------------------------------+-------------------------+------+--------+
| tinyint_u | smallint_u | mediumint_u | int_u | bigint_u | decimal_u | double_u  | float_u | boolean | tinyint | smallint | year       | mediumint | int  | bigint | date       | timestamp                | datetime            | float    | double           | decimal | char  | varchar | time          | text  | json                                          | set                     | bit  | enum   |
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+-------+---------+---------------+-------+-----------------------------------------------+-------------------------+------+--------+
|       201 |        301 |         401 |   501 |      601 |   3.14159 | 4.1415926 | 5.14159 |       1 |    -123 |     -301 | 2012-01-01 |      -401 | -501 |   -601 | 2012-10-30 | 2012-10-25 12:05:36.3457 | 2012-10-25 08:08:08 | -4.14145 |    -5.1400000001 | -6.1400 | row1  | line1   | 09:09:09.5678 | text1 | {"age":30,"city":"London","name":"Alice"}     | Option1,Option3         |    1 | Value2 |
|       202 |        302 |         402 |   502 |      602 |   4.14159 | 5.1415926 | 6.14159 |       0 |    -124 |     -302 | 2013-01-01 |      -402 | -502 |   -602 | 2012-11-01 | 2012-10-26 02:08:39.3457 | 2013-10-26 08:09:18 | -5.14145 |    -6.1400000001 | -7.1400 | row2  | line2   | 09:11:09.5678 | text2 | {"age":18,"city":"ChongQing","name":"Gaoxin"} | Option1,Option2         |    1 | Value3 |
|      NULL |        302 |        NULL |   502 |      602 |   4.14159 |      NULL | 6.14159 |    NULL |    -124 |     -302 | 2013-01-01 |      -402 | -502 |   -602 | NULL       | 2012-10-26 02:08:39.3457 | 2013-10-26 08:09:18 | -5.14145 |             NULL | -7.1400 | row2  | NULL    | 09:11:09.5678 | text2 | NULL                                          | NULL                    |    1 | Value3 |
|       203 |        303 |         403 |   503 |      603 |   7.14159 | 8.1415926 | 9.14159 |       0 |    NULL |     -402 | 2017-01-01 |      -602 | -902 |  -1102 | 2012-11-02 | NULL                     | 2013-10-27 08:11:18 | -5.14145 | -6.1400000000001 | -7.1400 | row3  | line3   | 09:11:09.5678 | text3 | {"age":24,"city":"ChongQing","name":"ChenQi"} | Option2                 |    1 | Value1 |
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+--------------------------+---------------------+----------+------------------+---------+-------+---------+---------------+-------+-----------------------------------------------+-------------------------+------+--------+
4 rows in set (0.39 sec)

Doris > desc trino2.doris_test.orc_array_data_type;
+-------------------+------------------------+------+------+---------+-------+
| Field             | Type                   | Null | Key  | Default | Extra |
+-------------------+------------------------+------+------+---------+-------+
| t_int_array       | ARRAY<INT>             | Yes  | true | NULL    |       |
| t_tinyint_array   | ARRAY<TINYINT>         | Yes  | true | NULL    |       |
| t_smallint_array  | ARRAY<SMALLINT>        | Yes  | true | NULL    |       |
| t_bigint_array    | ARRAY<BIGINT>          | Yes  | true | NULL    |       |
| t_real_array      | ARRAY<FLOAT>           | Yes  | true | NULL    |       |
| t_double_array    | ARRAY<DOUBLE>          | Yes  | true | NULL    |       |
| t_string_array    | ARRAY<TEXT>            | Yes  | true | NULL    |       |
| t_boolean_array   | ARRAY<BOOLEAN>         | Yes  | true | NULL    |       |
| t_timestamp_array | ARRAY<DATETIME>        | Yes  | true | NULL    |       |
| t_date_array      | ARRAY<DATE>            | Yes  | true | NULL    |       |
| t_decimal_array   | ARRAY<DECIMAL(38, 12)> | Yes  | true | NULL    |       |
+-------------------+------------------------+------+------+---------+-------+
11 rows in set (0.00 sec)

Doris > select * from trino2.doris_test.orc_array_data_type;
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+------------------------------------------------+------------------------------+----------------------+
| t_int_array           | t_tinyint_array       | t_smallint_array      | t_bigint_array                  | t_real_array         | t_double_array           | t_string_array            | t_boolean_array | t_timestamp_array                              | t_date_array                 | t_decimal_array      |
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+------------------------------------------------+------------------------------+----------------------+
| [null]                | [null]                | [null]                | [null]                          | [null]               | [null]                   | [null]                    | [null]          | [null]                                         | [null]                       | [null]               |
| [1, 2, 3, 4, 5, 6, 7] | [1, 2, 3, 4, 5, 6, 7] | [1, 2, 3, 4, 5, 6, 7] | [1234567890123, 12345678901234] | [45.123, 123.45, 11] | [45.12344, 123.4544, 11] | ["TEST", "TEST#12123123"] | [1, 0, 1, 0]    | ["2023-05-24 13:00:00", "2023-05-24 14:00:00"] | ["2023-05-24", "2023-05-26"] | [10001.111222333440] |
| NULL                  | NULL                  | NULL                  | NULL                            | NULL                 | NULL                     | NULL                      | NULL            | NULL                                           | NULL                         | NULL                 |
| []                    | []                    | []                    | []                              | []                   | []                       | []                        | []              | []                                             | []                           | []                   |
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+------------------------------------------------+------------------------------+----------------------+
4 rows in set (5.10 sec)

Doris > desc trino2.doris_test.orc_array_data_type2;
+-------------+-------------------+------+------+---------+-------+
| Field       | Type              | Null | Key  | Default | Extra |
+-------------+-------------------+------+------+---------+-------+
| t_int_array | ARRAY<ARRAY<INT>> | Yes  | true | NULL    |       |
+-------------+-------------------+------+------+---------+-------+
1 row in set (0.00 sec)

Doris > select * from trino2.doris_test.orc_array_data_type2;
+------------------------+
| t_int_array            |
+------------------------+
| [[null]]               |
| []                     |
| NULL                   |
| [[1, 2, 3], [4, 5, 6]] |
| [[]]                   |
| [null]                 |
+------------------------+
6 rows in set (5.23 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

