### PR TITLE
[improve](fslog) The error log should be printed by caller

### DIFF
--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -42,7 +42,6 @@ namespace doris::io {
             AsyncIO::run_task(task, _type);                 \
         }                                                   \
         if (!_s) {                                          \
-            LOG(WARNING) << _s;                             \
             _s = Status::Error<false>(_s.code(), _s.msg()); \
         }                                                   \
         return _s;                                          \


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The error log always will be printed twice. We should hanle it ourselves.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

