### PR TITLE
[brnach-2.0][opt](jdbc catalog) opt trino jdbc catalog type mapping

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcTrinoClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcTrinoClient.java
@@ -60,6 +60,8 @@ public class JdbcTrinoClient extends JdbcClient {
                 return Type.BOOLEAN;
             case "date":
                 return ScalarType.createDateV2Type();
+            case "json":
+                return ScalarType.createJsonbType();
             default:
                 break;
         }
@@ -90,7 +92,7 @@ public class JdbcTrinoClient extends JdbcClient {
             return ArrayType.create(type, true);
         }
 
-        if (trinoType.startsWith("varchar")) {
+        if (trinoType.startsWith("varchar") || trinoType.startsWith("time")) {
             return ScalarType.createStringType();
         }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
mysql> desc trino.doris_test.all_types;
+-------------+------------------+------+------+---------+-------+
| Field       | Type             | Null | Key  | Default | Extra |
+-------------+------------------+------+------+---------+-------+
| tinyint_u   | SMALLINT         | Yes  | true | NULL    |       |
| smallint_u  | INT              | Yes  | true | NULL    |       |
| mediumint_u | INT              | Yes  | true | NULL    |       |
| int_u       | BIGINT           | Yes  | true | NULL    |       |
| bigint_u    | DECIMAL          | Yes  | true | NULL    |       |
| decimal_u   | DECIMAL(18, 5)   | Yes  | true | NULL    |       |
| double_u    | DOUBLE           | Yes  | true | NULL    |       |
| float_u     | FLOAT            | Yes  | true | NULL    |       |
| boolean     | TINYINT          | Yes  | true | NULL    |       |
| tinyint     | TINYINT          | Yes  | true | NULL    |       |
| smallint    | SMALLINT         | Yes  | true | NULL    |       |
| year        | DATE             | Yes  | true | NULL    |       |
| mediumint   | INT              | Yes  | true | NULL    |       |
| int         | INT              | Yes  | true | NULL    |       |
| bigint      | BIGINT           | Yes  | true | NULL    |       |
| date        | DATE             | Yes  | true | NULL    |       |
| timestamp   | DATETIME(6)      | Yes  | true | NULL    |       |
| datetime    | DATETIME(6)      | Yes  | true | NULL    |       |
| float       | FLOAT            | Yes  | true | NULL    |       |
| double      | DOUBLE           | Yes  | true | NULL    |       |
| decimal     | DECIMAL(12, 4)   | Yes  | true | NULL    |       |
| char        | CHAR(100)        | Yes  | true | NULL    |       |
| varchar     | TEXT             | Yes  | true | NULL    |       |
| time        | TEXT             | Yes  | true | NULL    |       |
| text        | TEXT             | Yes  | true | NULL    |       |
| blob        | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| json        | JSON             | Yes  | true | NULL    |       |
| set         | CHAR(100)        | Yes  | true | NULL    |       |
| bit         | BOOLEAN          | Yes  | true | NULL    |       |
| binary      | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| varbinary   | UNSUPPORTED_TYPE | Yes  | true | NULL    |       |
| enum        | TEXT             | Yes  | true | NULL    |       |
+-------------+------------------+------+------+---------+-------+
32 rows in set (0.01 sec)

mysql> select * except(blob,`binary`,`varbinary`) from trino.doris_test.all_types;
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+----------------------------+----------------------------+----------+------------------+---------+-------+---------+--------------+-------+-----------------------------------------------+-------------------------+------+--------+
| tinyint_u | smallint_u | mediumint_u | int_u | bigint_u | decimal_u | double_u  | float_u | boolean | tinyint | smallint | year       | mediumint | int  | bigint | date       | timestamp                  | datetime                   | float    | double           | decimal | char  | varchar | time         | text  | json                                          | set                     | bit  | enum   |
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+----------------------------+----------------------------+----------+------------------+---------+-------+---------+--------------+-------+-----------------------------------------------+-------------------------+------+--------+
|       201 |        301 |         401 |   501 |      601 |   3.14159 | 4.1415926 | 5.14159 |       1 |    -123 |     -301 | 2012-01-01 |      -401 | -501 |   -601 | 2012-10-30 | 2012-10-25 12:05:36.345700 | 2012-10-25 08:08:08.000000 | -4.14145 |    -5.1400000001 | -6.1400 | row1  | line1   | 09:09:09.567 | text1 | {"age":30,"city":"London","name":"Alice"}     | Option1,Option3         |    1 | Value2 |
|       202 |        302 |         402 |   502 |      602 |   4.14159 | 5.1415926 | 6.14159 |       0 |    -124 |     -302 | 2013-01-01 |      -402 | -502 |   -602 | 2012-11-01 | 2012-10-26 02:08:39.345700 | 2013-10-26 08:09:18.000000 | -5.14145 |    -6.1400000001 | -7.1400 | row2  | line2   | 09:11:09.567 | text2 | {"age":18,"city":"ChongQing","name":"Gaoxin"} | Option1,Option2         |    1 | Value3 |
|      NULL |        302 |        NULL |   502 |      602 |   4.14159 |      NULL | 6.14159 |    NULL |    -124 |     -302 | 2013-01-01 |      -402 | -502 |   -602 | NULL       | 2012-10-26 02:08:39.345700 | 2013-10-26 08:09:18.000000 | -5.14145 |             NULL | -7.1400 | row2  | NULL    | 09:11:09.567 | text2 | NULL                                          | NULL                    |    1 | Value3 |
|       203 |        303 |         403 |   503 |      603 |   7.14159 | 8.1415926 | 9.14159 |       0 |    NULL |     -402 | 2017-01-01 |      -602 | -902 |  -1102 | 2012-11-02 | NULL                       | 2013-10-27 08:11:18.000000 | -5.14145 | -6.1400000000001 | -7.1400 | row3  | line3   | 09:11:09.567 | text3 | {"age":24,"city":"ChongQing","name":"ChenQi"} | Option2                 |    1 | Value1 |
+-----------+------------+-------------+-------+----------+-----------+-----------+---------+---------+---------+----------+------------+-----------+------+--------+------------+----------------------------+----------------------------+----------+------------------+---------+-------+---------+--------------+-------+-----------------------------------------------+-------------------------+------+--------+
4 rows in set (0.15 sec)

mysql> desc trino2.doris_test.orc_array_data_type;
+-------------------+--------------------------+------+------+---------+-------+
| Field             | Type                     | Null | Key  | Default | Extra |
+-------------------+--------------------------+------+------+---------+-------+
| t_int_array       | ARRAY<INT>               | Yes  | true | NULL    |       |
| t_tinyint_array   | ARRAY<TINYINT>           | Yes  | true | NULL    |       |
| t_smallint_array  | ARRAY<SMALLINT>          | Yes  | true | NULL    |       |
| t_bigint_array    | ARRAY<BIGINT>            | Yes  | true | NULL    |       |
| t_real_array      | ARRAY<FLOAT>             | Yes  | true | NULL    |       |
| t_double_array    | ARRAY<DOUBLE>            | Yes  | true | NULL    |       |
| t_string_array    | ARRAY<TEXT>              | Yes  | true | NULL    |       |
| t_boolean_array   | ARRAY<BOOLEAN>           | Yes  | true | NULL    |       |
| t_timestamp_array | ARRAY<DATETIMEV2(6)>     | Yes  | true | NULL    |       |
| t_date_array      | ARRAY<DATEV2>            | Yes  | true | NULL    |       |
| t_decimal_array   | ARRAY<DECIMALV3(38, 12)> | Yes  | true | NULL    |       |
+-------------------+--------------------------+------+------+---------+-------+
11 rows in set (1.40 sec)

mysql> select * from trino2.doris_test.orc_array_data_type;
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+--------------------------------------------------------------+------------------------------+----------------------+
| t_int_array           | t_tinyint_array       | t_smallint_array      | t_bigint_array                  | t_real_array         | t_double_array           | t_string_array            | t_boolean_array | t_timestamp_array                                            | t_date_array                 | t_decimal_array      |
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+--------------------------------------------------------------+------------------------------+----------------------+
| [null]                | [null]                | [null]                | [null]                          | [null]               | [null]                   | [null]                    | [null]          | [null]                                                       | [null]                       | [null]               |
| []                    | []                    | []                    | []                              | []                   | []                       | []                        | []              | []                                                           | []                           | []                   |
| NULL                  | NULL                  | NULL                  | NULL                            | NULL                 | NULL                     | NULL                      | NULL            | NULL                                                         | NULL                         | NULL                 |
| [1, 2, 3, 4, 5, 6, 7] | [1, 2, 3, 4, 5, 6, 7] | [1, 2, 3, 4, 5, 6, 7] | [1234567890123, 12345678901234] | [45.123, 123.45, 11] | [45.12344, 123.4544, 11] | ["TEST", "TEST#12123123"] | [1, 0, 1, 0]    | ["2023-05-24 13:00:00.123000", "2023-05-24 14:00:00.123000"] | ["2023-05-24", "2023-05-26"] | [10001.111222333440] |
+-----------------------+-----------------------+-----------------------+---------------------------------+----------------------+--------------------------+---------------------------+-----------------+--------------------------------------------------------------+------------------------------+----------------------+
4 rows in set (2.00 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

