### PR TITLE
[fix](load) fix error due to jsonpaths resolution results

### DIFF
--- a/regression-test/data/load_p0/stream_load/test_json_load.out
+++ b/regression-test/data/load_p0/stream_load/test_json_load.out
@@ -245,3 +245,5 @@ John	30	New York	{"email":"john@example.com","phone":"+1-123-456-7890"}
 android	\N	\N	\N	\N	\N
 android	\N	\N	\N	\N	\N
 
+-- !select28 --
+test  k2_value

--- a/regression-test/data/load_p0/stream_load/test_special_key_json.json
+++ b/regression-test/data/load_p0/stream_load/test_special_key_json.json
@@ -1,0 +1,1 @@
+{"tags": {"a.b": "test","k2": "k2_value"}}

--- a/regression-test/suites/load_p0/stream_load/test_json_load.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_json_load.groovy
@@ -827,4 +827,27 @@ suite("test_json_load", "p0") {
     } finally {
         try_sql("DROP TABLE IF EXISTS ${testTable}")
     }
+        // test a.b key columns
+    try {
+        sql "DROP TABLE IF EXISTS ${testTable}"
+        sql """CREATE TABLE IF NOT EXISTS ${testTable} 
+            (
+                `k1` varchar(1024) NULL,
+                `k2` varchar(1024) NULL
+            )
+            DUPLICATE KEY(`k1`)
+            COMMENT ''
+            DISTRIBUTED BY RANDOM BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            );"""
+        load_json_data.call("${testTable}", "${testTable}_case28_1", 'false', '', 'json', '', '[\"$.tags.(a.b)\",\"$.tags.k2\"]',
+                             '', '', '', 'test_special_key_json.json')
+
+        sql "sync"
+        sleep(1000)
+        qt_select28 "select * from ${testTable}"
+    } finally {
+        try_sql("DROP TABLE IF EXISTS ${testTable}")
+    }
 }


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->
1. problem
`When the key name in json is a.b, the value will be parsed incorrectly`
2. resolve
`Add a key like a.b and put it in parentheses for normal parsing`
3. sql
```
CREATE TABLE `test`.`q1` (
  `k1` varchar(1024) NULL,
  `k2` varchar(1024) NULL
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1"
);
```
4. json
```
{
        "tags": {
                "a.b": "test",
                "k2": "k2_value"
        }
}
```
5. stream load
```
curl -v --location-trusted -u root:"" -H "format: json" -H "jsonpaths: [\"$.tags.(a.b)\",\"$.tags.k2\"]" -T test.json http://127.0.0.1:8030/api/test/q1/_stream_load
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

