### PR TITLE
[Chore](topn) rename TTopnFilterContext to TTopnFilterDesc

### DIFF
--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -698,7 +698,7 @@ struct TExportStatusResult {
     3: optional list<string> files
 }
 
-struct TTopnFilterContext {
+struct TTopnFilterDesc {
   1: required i32 source_node_id
   2: required bool is_asc
   3: required bool null_first
@@ -713,8 +713,8 @@ struct TPipelineInstanceParams {
   5: optional TRuntimeFilterParams runtime_filter_params
   6: optional i32 backend_num
   7: optional map<Types.TPlanNodeId, bool> per_node_shared_scans
-  8: optional list<i32> topn_filter_source_node_ids // deprecated after we set topn_filter_contexts
-  9: optional list<TTopnFilterContext> topn_filter_contexts
+  8: optional list<i32> topn_filter_source_node_ids // deprecated after we set topn_filter_descs
+  9: optional list<TTopnFilterDesc> topn_filter_descs
 }
 
 // ExecPlanFragment


### PR DESCRIPTION
## Proposed changes
rename TTopnFilterContext to TTopnFilterDesc
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

