### PR TITLE
[Chore](hash) catch error when hash method variant meet valueless_by_exception

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "common/status.h"
 #include "pipeline/exec/operator.h"
 #include "runtime/primitive_type.h"
 #include "vec/common/hash_table/hash.h"
@@ -100,7 +101,7 @@ Status AggSinkLocalState::open(RuntimeState* state) {
             _executor = std::make_unique<Executor<true, false>>();
         }
     } else {
-        _init_hash_method(Base::_shared_state->probe_expr_ctxs);
+        RETURN_IF_ERROR(_init_hash_method(Base::_shared_state->probe_expr_ctxs));
 
         std::visit(vectorized::Overload {
                            [&](std::monostate& arg) {
@@ -564,9 +565,12 @@ void AggSinkLocalState::_find_in_hash_table(vectorized::AggregateDataPtr* places
                _agg_data->method_variant);
 }
 
-void AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
-    init_agg_hash_method(_agg_data, probe_exprs,
-                         Base::_parent->template cast<AggSinkOperatorX>()._is_first_phase);
+Status AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
+    if (!init_agg_hash_method(_agg_data, probe_exprs,
+                              Base::_parent->template cast<AggSinkOperatorX>()._is_first_phase)) {
+        return Status::InternalError("init hash method failed");
+    }
+    return Status::OK();
 }
 
 AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,

--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -75,7 +75,7 @@ protected:
     Status _execute_without_key(vectorized::Block* block);
     Status _merge_without_key(vectorized::Block* block);
     void _update_memusage_without_key();
-    void _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
+    Status _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
     Status _execute_with_serialized_key(vectorized::Block* block);
     Status _merge_with_serialized_key(vectorized::Block* block);
     void _update_memusage_with_serialized_key();

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -98,7 +98,7 @@ Status DistinctStreamingAggLocalState::open(RuntimeState* state) {
         _agg_data->without_key = reinterpret_cast<vectorized::AggregateDataPtr>(
                 _agg_profile_arena->alloc(p._total_size_of_aggregate_states));
     } else {
-        _init_hash_method(_probe_expr_ctxs);
+        RETURN_IF_ERROR(_init_hash_method(_probe_expr_ctxs));
     }
     return Status::OK();
 }
@@ -168,11 +168,14 @@ bool DistinctStreamingAggLocalState::_should_expand_preagg_hash_tables() {
             _agg_data->method_variant);
 }
 
-void DistinctStreamingAggLocalState::_init_hash_method(
+Status DistinctStreamingAggLocalState::_init_hash_method(
         const vectorized::VExprContextSPtrs& probe_exprs) {
-    init_agg_hash_method(
-            _agg_data.get(), probe_exprs,
-            Base::_parent->template cast<DistinctStreamingAggOperatorX>()._is_first_phase);
+    if (!init_agg_hash_method(
+                _agg_data.get(), probe_exprs,
+                Base::_parent->template cast<DistinctStreamingAggOperatorX>()._is_first_phase)) {
+        return Status::InternalError("init agg hash method failed");
+    }
+    return Status::OK();
 }
 
 Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
@@ -52,7 +52,7 @@ private:
     friend class StatefulOperatorX;
     Status _distinct_pre_agg_with_serialized_key(vectorized::Block* in_block,
                                                  vectorized::Block* out_block);
-    void _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
+    Status _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
     void _emplace_into_hash_table_to_distinct(vectorized::IColumn::Selector& distinct_row,
                                               vectorized::ColumnRawPtrs& key_columns,
                                               const size_t num_rows);

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -46,7 +46,7 @@ Status PartitionSortSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
             &_vsort_exec_exprs, p._limit, 0, p._pool, p._is_asc_order, p._nulls_first,
             p._child_x->row_desc(), state, _profile, p._has_global_limit, p._partition_inner_limit,
             p._top_n_algorithm, p._topn_phase);
-    _init_hash_method();
+    RETURN_IF_ERROR(_init_hash_method());
     return Status::OK();
 }
 
@@ -223,8 +223,11 @@ Status PartitionSortSinkOperatorX::_emplace_into_hash_table(
             local_state._partitioned_data->method_variant);
 }
 
-void PartitionSortSinkLocalState::_init_hash_method() {
-    init_partition_hash_method(_partitioned_data.get(), _partition_expr_ctxs, true);
+Status PartitionSortSinkLocalState::_init_hash_method() {
+    if (!init_partition_hash_method(_partitioned_data.get(), _partition_expr_ctxs, true)) {
+        return Status::InternalError("init hash method failed");
+    }
+    return Status::OK();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -56,7 +56,7 @@ private:
     RuntimeProfile::Counter* _selector_block_timer = nullptr;
     RuntimeProfile::Counter* _hash_table_size_counter = nullptr;
     RuntimeProfile::Counter* _passthrough_rows_counter = nullptr;
-    void _init_hash_method();
+    Status _init_hash_method();
 };
 
 class PartitionSortSinkOperatorX final : public DataSinkOperatorX<PartitionSortSinkLocalState> {

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -152,7 +152,7 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
             }
         }
     } else {
-        _init_hash_method(_probe_expr_ctxs);
+        RETURN_IF_ERROR(_init_hash_method(_probe_expr_ctxs));
 
         std::visit(vectorized::Overload {
                            [&](std::monostate& arg) -> void {
@@ -503,9 +503,13 @@ Status StreamingAggLocalState::_merge_with_serialized_key(vectorized::Block* blo
     }
 }
 
-void StreamingAggLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
-    init_agg_hash_method(_agg_data.get(), probe_exprs,
-                         Base::_parent->template cast<StreamingAggOperatorX>()._is_first_phase);
+Status StreamingAggLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
+    if (!init_agg_hash_method(
+                _agg_data.get(), probe_exprs,
+                Base::_parent->template cast<StreamingAggOperatorX>()._is_first_phase)) {
+        return Status::InternalError("init hash method failed");
+    }
+    return Status::OK();
 }
 
 Status StreamingAggLocalState::do_pre_agg(vectorized::Block* input_block,

--- a/be/src/pipeline/exec/streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.h
@@ -63,7 +63,7 @@ private:
     Status _execute_with_serialized_key(vectorized::Block* block);
     Status _merge_with_serialized_key(vectorized::Block* block);
     void _update_memusage_with_serialized_key();
-    void _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
+    Status _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
     Status _get_without_key_result(RuntimeState* state, vectorized::Block* block, bool* eos);
     Status _serialize_without_key(RuntimeState* state, vectorized::Block* block, bool* eos);
     Status _get_with_serialized_key_result(RuntimeState* state, vectorized::Block* block,

--- a/be/src/vec/common/hash_table/hash_map_context_creator.h
+++ b/be/src/vec/common/hash_table/hash_map_context_creator.h
@@ -104,7 +104,7 @@ bool try_get_hash_map_context_fixed(Variant& variant, const std::vector<DataType
 }
 
 template <typename DataVariants, typename Data>
-void init_hash_method(DataVariants* agg_data, const vectorized::VExprContextSPtrs& probe_exprs,
+bool init_hash_method(DataVariants* agg_data, const vectorized::VExprContextSPtrs& probe_exprs,
                       bool is_first_phase) {
     using Type = DataVariants::Type;
     Type t(Type::serialized);
@@ -164,5 +164,11 @@ void init_hash_method(DataVariants* agg_data, const vectorized::VExprContextSPtr
             agg_data->init(Type::serialized);
         }
     }
+
+    if (agg_data->method_variant.valueless_by_exception()) {
+        agg_data->method_variant.template emplace<std::monostate>();
+        return false;
+    }
+    return true;
 }
 } // namespace doris

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -533,7 +533,7 @@ private:
     Status _merge_with_serialized_key(Block* block);
     void _update_memusage_with_serialized_key();
     void _close_with_serialized_key();
-    void _init_hash_method(const VExprContextSPtrs& probe_exprs);
+    Status _init_hash_method(const VExprContextSPtrs& probe_exprs);
 
     template <bool limit>
     Status _execute_with_serialized_key_helper(Block* block) {

--- a/be/src/vec/exec/vpartition_sort_node.cpp
+++ b/be/src/vec/exec/vpartition_sort_node.cpp
@@ -158,7 +158,7 @@ Status VPartitionSortNode::prepare(RuntimeState* state) {
     SCOPED_TIMER(_exec_timer);
     RETURN_IF_ERROR(_vsort_exec_exprs.prepare(state, child(0)->row_desc(), _row_descriptor));
     RETURN_IF_ERROR(VExpr::prepare(_partition_expr_ctxs, state, child(0)->row_desc()));
-    _init_hash_method();
+    RETURN_IF_ERROR(_init_hash_method());
 
     _partition_sort_info = std::make_shared<PartitionSortInfo>(
             &_vsort_exec_exprs, _limit, 0, _pool, _is_asc_order, _nulls_first, child(0)->row_desc(),
@@ -182,45 +182,50 @@ Status VPartitionSortNode::_emplace_into_hash_table(const ColumnRawPtrs& key_col
                                                     const vectorized::Block* input_block,
                                                     bool eos) {
     return std::visit(
-            [&](auto&& agg_method) -> Status {
-                SCOPED_TIMER(_build_timer);
-                using HashMethodType = std::decay_t<decltype(agg_method)>;
-                using AggState = typename HashMethodType::State;
+            vectorized::Overload {
+                    [&](std::monostate& arg) -> Status {
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                        return Status::InternalError("Unit hash table");
+                    },
+                    [&](auto&& agg_method) -> Status {
+                        SCOPED_TIMER(_build_timer);
+                        using HashMethodType = std::decay_t<decltype(agg_method)>;
+                        using AggState = typename HashMethodType::State;
 
-                AggState state(key_columns);
-                size_t num_rows = input_block->rows();
-                agg_method.init_serialized_keys(key_columns, num_rows);
+                        AggState state(key_columns);
+                        size_t num_rows = input_block->rows();
+                        agg_method.init_serialized_keys(key_columns, num_rows);
 
-                auto creator = [&](const auto& ctor, auto& key, auto& origin) {
-                    HashMethodType::try_presis_key(key, origin, *_agg_arena_pool);
-                    auto* aggregate_data = _pool->add(
-                            new PartitionBlocks(_partition_sort_info, _value_places.empty()));
-                    _value_places.push_back(aggregate_data);
-                    ctor(key, aggregate_data);
-                    _num_partition++;
-                };
-                auto creator_for_null_key = [&](auto& mapped) {
-                    mapped = _pool->add(
-                            new PartitionBlocks(_partition_sort_info, _value_places.empty()));
-                    _value_places.push_back(mapped);
-                    _num_partition++;
-                };
-                {
-                    SCOPED_TIMER(_emplace_key_timer);
-                    for (size_t row = 0; row < num_rows; ++row) {
-                        auto& mapped =
-                                agg_method.lazy_emplace(state, row, creator, creator_for_null_key);
-                        mapped->add_row_idx(row);
-                    }
-                }
-                {
-                    SCOPED_TIMER(_selector_block_timer);
-                    for (auto* place : _value_places) {
-                        RETURN_IF_ERROR(place->append_block_by_selector(input_block, eos));
-                    }
-                }
-                return Status::OK();
-            },
+                        auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                            HashMethodType::try_presis_key(key, origin, *_agg_arena_pool);
+                            auto* aggregate_data = _pool->add(new PartitionBlocks(
+                                    _partition_sort_info, _value_places.empty()));
+                            _value_places.push_back(aggregate_data);
+                            ctor(key, aggregate_data);
+                            _num_partition++;
+                        };
+                        auto creator_for_null_key = [&](auto& mapped) {
+                            mapped = _pool->add(new PartitionBlocks(_partition_sort_info,
+                                                                    _value_places.empty()));
+                            _value_places.push_back(mapped);
+                            _num_partition++;
+                        };
+                        {
+                            SCOPED_TIMER(_emplace_key_timer);
+                            for (size_t row = 0; row < num_rows; ++row) {
+                                auto& mapped = agg_method.lazy_emplace(state, row, creator,
+                                                                       creator_for_null_key);
+                                mapped->add_row_idx(row);
+                            }
+                        }
+                        {
+                            SCOPED_TIMER(_selector_block_timer);
+                            for (auto* place : _value_places) {
+                                RETURN_IF_ERROR(place->append_block_by_selector(input_block, eos));
+                            }
+                        }
+                        return Status::OK();
+                    }},
             _partitioned_data->method_variant);
 }
 
@@ -397,8 +402,11 @@ void VPartitionSortNode::release_resource(RuntimeState* state) {
     ExecNode::release_resource(state);
 }
 
-void VPartitionSortNode::_init_hash_method() {
-    init_partition_hash_method(_partitioned_data.get(), _partition_expr_ctxs, true);
+Status VPartitionSortNode::_init_hash_method() {
+    if (!init_partition_hash_method(_partitioned_data.get(), _partition_expr_ctxs, true)) {
+        return Status::InternalError("init hash method failed");
+    }
+    return Status::OK();
 }
 
 void VPartitionSortNode::debug_profile() {

--- a/be/src/vec/exec/vpartition_sort_node.h
+++ b/be/src/vec/exec/vpartition_sort_node.h
@@ -133,7 +133,7 @@ using PartitionDataWithUInt256Key = PHHashMap<UInt256, PartitionDataPtr, HashCRC
 using PartitionDataWithUInt136Key = PHHashMap<UInt136, PartitionDataPtr, HashCRC32<UInt136>>;
 
 using PartitionedMethodVariants = std::variant<
-        MethodSerialized<PartitionDataWithStringKey>,
+        std::monostate, MethodSerialized<PartitionDataWithStringKey>,
         MethodOneNumber<UInt8, PartitionDataWithUInt8Key>,
         MethodOneNumber<UInt16, PartitionDataWithUInt16Key>,
         MethodOneNumber<UInt32, PartitionDataWithUInt32Key>,
@@ -236,7 +236,7 @@ public:
     bool can_read();
 
 private:
-    void _init_hash_method();
+    Status _init_hash_method();
     Status _split_block_by_partition(vectorized::Block* input_block, bool eos);
     Status _emplace_into_hash_table(const ColumnRawPtrs& key_columns,
                                     const vectorized::Block* input_block, bool eos);


### PR DESCRIPTION
## Proposed changes
hash method variant may valueless when memory not enough
```cpp
terminate called after throwing an instance of 'std::bad_variant_access'
  what():  std::visit: variant is valueless
*** Query id: 6a23d37a72684550-b556b16377e1ebe6 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1715768949 (unix time) try "date -d @1715768949" if you are using GNU date ***
*** Current BE git commitID: 533c3ed656 ***
*** SIGABRT unknown detail explain (@0x3eb16a) received by PID 4108650 (TID 4112014 OR 0x7f84c459d700) from PID 4108650; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F8942E3D090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x000055B16F22B8B1 in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
 7# 0x000055B16F22BA04 in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
 8# doris::pipeline::DistinctStreamingAggLocalState::close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp:509
 9# doris::pipeline::OperatorXBase::close(doris::RuntimeState*) in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
10# doris::pipeline::PipelineTask::close(doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:418
11# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:88
12# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:172
13# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
14# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:499
15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

