### PR TITLE
[feature](datatype) add BE config to allow zero date

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1075,6 +1075,7 @@ DEFINE_mBool(enable_delete_when_cumu_compaction, "false");
 // max_write_buffer_number for rocksdb
 DEFINE_Int32(rocksdb_max_write_buffer_number, "5");
 
+DEFINE_mBool(allow_zero_date, "false");
 DEFINE_Bool(allow_invalid_decimalv2_literal, "false");
 DEFINE_mString(kerberos_ccache_path, "");
 DEFINE_mString(kerberos_krb5_conf_path, "/etc/krb5.conf");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1121,6 +1121,8 @@ DECLARE_mBool(enable_delete_when_cumu_compaction);
 // max_write_buffer_number for rocksdb
 DECLARE_Int32(rocksdb_max_write_buffer_number);
 
+// Convert date 0000-00-00 to 0000-01-01. It's recommended to set to false.
+DECLARE_mBool(allow_zero_date);
 // Allow invalid decimalv2 literal for compatible with old version. Recommend set it false strongly.
 DECLARE_mBool(allow_invalid_decimalv2_literal);
 // Allow to specify kerberos credentials cache path.

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -343,6 +343,7 @@ template <typename T>
 bool read_date_v2_text_impl(T& x, ReadBuffer& buf) {
     static_assert(std::is_same_v<UInt32, T>);
     auto dv = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(x);
+    // TODO: convert zero to 1
     auto ans = dv.from_date_str(buf.position(), buf.count());
 
     // only to match the is_all_read() check to prevent return null
@@ -355,6 +356,7 @@ template <typename T>
 bool read_date_v2_text_impl(T& x, ReadBuffer& buf, const cctz::time_zone& local_time_zone) {
     static_assert(std::is_same_v<UInt32, T>);
     auto dv = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(x);
+    // TODO: convert zero to 1
     auto ans = dv.from_date_str(buf.position(), buf.count(), local_time_zone);
 
     // only to match the is_all_read() check to prevent return null
@@ -367,6 +369,7 @@ template <typename T>
 bool read_datetime_v2_text_impl(T& x, ReadBuffer& buf, UInt32 scale = -1) {
     static_assert(std::is_same_v<UInt64, T>);
     auto dv = binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(x);
+    // TODO: convert zero to 1
     auto ans = dv.from_date_str(buf.position(), buf.count(), scale);
 
     // only to match the is_all_read() check to prevent return null
@@ -380,6 +383,7 @@ bool read_datetime_v2_text_impl(T& x, ReadBuffer& buf, const cctz::time_zone& lo
                                 UInt32 scale = -1) {
     static_assert(std::is_same_v<UInt64, T>);
     auto dv = binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(x);
+    // TODO: convert zero to 1
     auto ans = dv.from_date_str(buf.position(), buf.count(), local_time_zone, scale);
 
     // only to match the is_all_read() check to prevent return null

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -343,8 +343,7 @@ template <typename T>
 bool read_date_v2_text_impl(T& x, ReadBuffer& buf) {
     static_assert(std::is_same_v<UInt32, T>);
     auto dv = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(x);
-    // TODO: convert zero to 1
-    auto ans = dv.from_date_str(buf.position(), buf.count());
+    auto ans = dv.from_date_str(buf.position(), buf.count(), config::allow_zero_date);
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
@@ -356,8 +355,8 @@ template <typename T>
 bool read_date_v2_text_impl(T& x, ReadBuffer& buf, const cctz::time_zone& local_time_zone) {
     static_assert(std::is_same_v<UInt32, T>);
     auto dv = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(x);
-    // TODO: convert zero to 1
-    auto ans = dv.from_date_str(buf.position(), buf.count(), local_time_zone);
+    auto ans =
+            dv.from_date_str(buf.position(), buf.count(), local_time_zone, config::allow_zero_date);
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
@@ -369,8 +368,7 @@ template <typename T>
 bool read_datetime_v2_text_impl(T& x, ReadBuffer& buf, UInt32 scale = -1) {
     static_assert(std::is_same_v<UInt64, T>);
     auto dv = binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(x);
-    // TODO: convert zero to 1
-    auto ans = dv.from_date_str(buf.position(), buf.count(), scale);
+    auto ans = dv.from_date_str(buf.position(), buf.count(), scale, config::allow_zero_date);
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
@@ -383,8 +381,8 @@ bool read_datetime_v2_text_impl(T& x, ReadBuffer& buf, const cctz::time_zone& lo
                                 UInt32 scale = -1) {
     static_assert(std::is_same_v<UInt64, T>);
     auto dv = binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(x);
-    // TODO: convert zero to 1
-    auto ans = dv.from_date_str(buf.position(), buf.count(), local_time_zone, scale);
+    auto ans = dv.from_date_str(buf.position(), buf.count(), local_time_zone, scale,
+                                config::allow_zero_date);
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -842,9 +842,9 @@ public:
     // 'YYMMDD', 'YYYYMMDD', 'YYMMDDHHMMSS', 'YYYYMMDDHHMMSS'
     // 'YY-MM-DD', 'YYYY-MM-DD', 'YY-MM-DD HH.MM.SS'
     // 'YYYYMMDDTHHMMSS'
-    bool from_date_str(const char* str, int len, int scale = -1);
+    bool from_date_str(const char* str, int len, int scale = -1, bool convert_zero = false);
     bool from_date_str(const char* str, int len, const cctz::time_zone& local_time_zone,
-                       int scale = -1);
+                       int scale = -1, bool convert_zero = false);
 
     // Convert this value to string
     // this will check type to decide which format to convert
@@ -1213,7 +1213,7 @@ private:
                              bool disable_lut = false);
 
     bool from_date_str_base(const char* date_str, int len, int scale,
-                            const cctz::time_zone* local_time_zone);
+                            const cctz::time_zone* local_time_zone, bool convert_zero);
 
     // Used to construct from int value
     int64_t standardize_timevalue(int64_t value);

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -522,11 +522,11 @@ TEST(TEST_VEXPR, LITERALTEST) {
     {
         DateV2Value<DateV2ValueType> data_time_value;
         const char* date = "00000000";
-        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1 , true), true);
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1, true), true);
 
         DateV2Value<DateV2ValueType> data_time_value1;
         const char* date1 = "00000101";
-        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1 , true), true);
+        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1, true), true);
         EXPECT_EQ(data_time_value.to_int64(), data_time_value1.to_int64());
 
         EXPECT_EQ(data_time_value.from_date_str(date, strlen(date)), false);
@@ -534,11 +534,11 @@ TEST(TEST_VEXPR, LITERALTEST) {
     {
         DateV2Value<DateTimeV2ValueType> data_time_value;
         const char* date = "00000000111111";
-        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1 , true), true);
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1, true), true);
 
         DateV2Value<DateTimeV2ValueType> data_time_value1;
         const char* date1 = "00000101111111";
-        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1 , true), true);
+        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1, true), true);
         EXPECT_EQ(data_time_value.to_int64(), data_time_value1.to_int64());
 
         EXPECT_EQ(data_time_value.from_date_str(date, strlen(date)), false);

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -519,6 +519,30 @@ TEST(TEST_VEXPR, LITERALTEST) {
         EXPECT_EQ(v, dt);
         EXPECT_EQ("2021-04-07", literal.value());
     }
+    {
+        DateV2Value<DateV2ValueType> data_time_value;
+        const char* date = "00000000";
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1 , true), true);
+
+        DateV2Value<DateV2ValueType> data_time_value1;
+        const char* date1 = "00000101";
+        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1 , true), true);
+        EXPECT_EQ(data_time_value.to_int64(), data_time_value1.to_int64());
+
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date)), false);
+    }
+    {
+        DateV2Value<DateTimeV2ValueType> data_time_value;
+        const char* date = "00000000111111";
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date), -1 , true), true);
+
+        DateV2Value<DateTimeV2ValueType> data_time_value1;
+        const char* date1 = "00000101111111";
+        EXPECT_EQ(data_time_value1.from_date_str(date1, strlen(date1), -1 , true), true);
+        EXPECT_EQ(data_time_value.to_int64(), data_time_value1.to_int64());
+
+        EXPECT_EQ(data_time_value.from_date_str(date, strlen(date)), false);
+    }
     // jsonb
     {
         std::string j = R"([null,true,false,100,6.18,"abc"])";


### PR DESCRIPTION
## Proposed changes

Add a BE config `allow_zero_date`, which defaults to `false`.

If set to `false`, `0000-00-00` will be converted to `NULL` (old behavior).
If set to `true`, `0000-00-00` will be converted to `0000-01-01`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

Co-authored-by: Gabriel <gabrielleebuaa@gmail.com>
