### PR TITLE
[chore](multi catalog) Print serde properties when show create hive-external-table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -828,10 +828,10 @@ public class HiveMetaStoreClientHelper {
             }
             if (descriptor.getSerdeInfo().isSetParameters()) {
                 output.append("WITH SERDEPROPERTIES (\n")
-                    .append(descriptor.getSerdeInfo().getParameters().entrySet().stream()
+                        .append(descriptor.getSerdeInfo().getParameters().entrySet().stream()
                         .map(entry -> String.format("  '%s' = '%s'", entry.getKey(), entry.getValue()))
                         .collect(Collectors.joining(",\n")))
-                    .append(")\n");
+                        .append(")\n");
             }
             if (descriptor.isSetInputFormat()) {
                 output.append("STORED AS INPUTFORMAT\n")

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -826,6 +826,13 @@ public class HiveMetaStoreClientHelper {
                 output.append("ROW FORMAT SERDE\n")
                         .append(String.format("  '%s'\n", descriptor.getSerdeInfo().getSerializationLib()));
             }
+            if (descriptor.getSerdeInfo().isSetParameters()) {
+                output.append("WITH SERDEPROPERTIES (\n")
+                    .append(descriptor.getSerdeInfo().getParameters().entrySet().stream()
+                        .map(entry -> String.format("  '%s' = '%s'", entry.getKey(), entry.getValue()))
+                        .collect(Collectors.joining(",\n")))
+                    .append(")\n");
+            }
             if (descriptor.isSetInputFormat()) {
                 output.append("STORED AS INPUTFORMAT\n")
                         .append(String.format("  '%s'\n", descriptor.getInputFormat()));

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_show_create_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_show_create_table.groovy
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_hive_show_create_table", "p0,external,hive,external_docker,external_docker_hive") {
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String hms_port = context.config.otherConfigs.get("hive2HmsPort")
+        String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
+        String catalog_name = "test_hive_show_create_table"
+        String table_name = "table_with_pars";
+
+        sql """drop catalog if exists ${catalog_name};"""
+
+        sql """
+            create catalog if not exists ${catalog_name} properties (
+                'type'='hms',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
+            );
+        """
+        logger.info("catalog " + catalog_name + " created")
+        sql """switch ${catalog_name};"""
+        logger.info("switched to catalog " + catalog_name)
+        sql """use `default`;"""
+
+        def serde = "'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'"
+        def serdeFormat = "'serialization.format' = '|'"
+        def filedDelim = "'field.delim' = '|'"
+        def inputFormat = "'org.apache.hadoop.mapred.TextInputFormat'"
+        def outputFormat = "'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'"
+        def create_tbl_res = sql """ show create table table_with_pars """
+        logger.info("${create_tbl_res}")
+        assertTrue(create_tbl_res.toString().containsIgnoreCase("${serde}"))
+        assertTrue(create_tbl_res.toString().containsIgnoreCase("${serdeFormat}"))
+        assertTrue(create_tbl_res.toString().containsIgnoreCase("${filedDelim}"))
+        assertTrue(create_tbl_res.toString().containsIgnoreCase("${inputFormat}"))
+        assertTrue(create_tbl_res.toString().containsIgnoreCase("${outputFormat}"))
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:

```
CREATE TABLE `test`(
  `id` int,
  `name` string)
ROW FORMAT SERDE
  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
STORED AS INPUTFORMAT
  'org.apache.hadoop.mapred.TextInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
LOCATION
  'hdfs://HDFS1012837/usr/hive/warehouse/test.db/test'
TBLPROPERTIES (
  ...
)
```

after:

```
CREATE TABLE `test`(
  `id` int,
  `name` string)
ROW FORMAT SERDE
  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES (
  'serialization.format' = ',',
  'field.delim' = ',')
STORED AS INPUTFORMAT
  'org.apache.hadoop.mapred.TextInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
LOCATION
  'hdfs://HDFS1012837/usr/hive/warehouse/test.db/test'
TBLPROPERTIES (
  ...
)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

