### PR TITLE
[optimize](desc) display the correct data type of aggStateType

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/AggStateType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/AggStateType.java
@@ -91,6 +91,11 @@ public class AggStateType extends Type {
     }
 
     @Override
+    public String toString() {
+        return toSql();
+    }
+
+    @Override
     protected String prettyPrint(int lpad) {
         return Strings.repeat(" ", lpad) + toSql();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescribeStmt.java
@@ -129,14 +129,13 @@ public class DescribeStmt extends ShowStmt {
             for (Column column : columns) {
                 List<String> row = Arrays.asList(
                         column.getName(),
-                        column.getOriginType().toString(),
+                        column.getOriginType().hideVersionForVersionColumn(true),
                         column.isAllowNull() ? "Yes" : "No",
                         ((Boolean) column.isKey()).toString(),
                         column.getDefaultValue() == null
                                 ? FeConstants.null_string : column.getDefaultValue(),
                         "NONE"
                 );
-                row.set(1, column.getOriginType().hideVersionForVersionColumn(false));
                 totalRows.add(row);
             }
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/IndexSchemaProcNode.java
@@ -68,14 +68,12 @@ public class IndexSchemaProcNode implements ProcNodeInterface {
             String extraStr = StringUtils.join(extras, ",");
 
             List<String> rowList = Arrays.asList(column.getDisplayName(),
-                                                 column.getOriginType().toString(),
+                                                 column.getOriginType().hideVersionForVersionColumn(true),
                                                  column.isAllowNull() ? "Yes" : "No",
                                                  ((Boolean) column.isKey()).toString(),
                                                  column.getDefaultValue() == null
                                                          ? FeConstants.null_string : column.getDefaultValue(),
                                                  extraStr);
-
-            rowList.set(1, column.getOriginType().hideVersionForVersionColumn(false));
             result.addRow(rowList);
         }
         return result;

--- a/regression-test/data/datatype_p0/agg_state/nereids/test_agg_state_nereids.out
+++ b/regression-test/data/datatype_p0/agg_state/nereids/test_agg_state_nereids.out
@@ -14,6 +14,10 @@
 -- !sum_null --
 \N
 
+-- !desc --
+k1	INT	Yes	true	\N	
+k2	AGG_STATE<max_by(INT, INT NULL)>	No	false	\N	GENERIC
+
 -- !length1 --
 1	11
 

--- a/regression-test/data/datatype_p0/agg_state/test_agg_state.out
+++ b/regression-test/data/datatype_p0/agg_state/test_agg_state.out
@@ -14,6 +14,10 @@
 -- !sum_null --
 \N
 
+-- !desc --
+k1	INT	Yes	true	\N	
+k2	AGG_STATE<max_by(INT, INT NULL)>	No	false	\N	GENERIC
+
 -- !length1 --
 1	11
 

--- a/regression-test/suites/datatype_p0/agg_state/nereids/test_agg_state_nereids.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/nereids/test_agg_state_nereids.groovy
@@ -55,6 +55,8 @@ suite("test_agg_state_nereids") {
             properties("replication_num" = "1");
         """
 
+    qt_desc "desc a_table;"
+
     sql "explain insert into a_table select 1,max_by_state(1,3);"
 
     sql "insert into a_table select 1,max_by_state(1,3);"

--- a/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
@@ -52,6 +52,8 @@ suite("test_agg_state") {
             properties("replication_num" = "1");
         """
 
+    qt_desc "desc a_table;"
+
     sql "insert into a_table select 1,max_by_state(1,3);"
     sql "insert into a_table select 1,max_by_state(2,2);"
     sql "insert into a_table values(1,max_by_state(3,1));"


### PR DESCRIPTION
If a table column is AGG_STATE type, we can't get the clear defined data type if we use `desc tbl` statement.

```sql
create table a_table(
    k1 int null,
    k2 agg_state<max_by(int not null,int)> generic,
    k3 agg_state<group_concat(string)> generic
)
aggregate key (k1)
distributed BY hash(k1) buckets 3
properties("replication_num" = "1");
```

before optimize:
```
mysql> desc a_table;
+-------+------------------------------------------------+------+-------+---------+---------+
| Field | Type                                           | Null | Key   | Default | Extra   |
+-------+------------------------------------------------+------+-------+---------+---------+
| k1    | INT                                            | Yes  | true  | NULL    |         |
| k2    | org.apache.doris.catalog.AggStateType@239f771c | No   | false | NULL    | GENERIC |
| k3    | org.apache.doris.catalog.AggStateType@2e535f50 | No   | false | NULL    | GENERIC |
+-------+------------------------------------------------+------+-------+---------+---------+
3 rows in set (0.00 sec)
```

after optimize:
```
mysql> desc a_table;
+-------+------------------------------------+------+-------+---------+---------+
| Field | Type                               | Null | Key   | Default | Extra   |
+-------+------------------------------------+------+-------+---------+---------+
| k1    | INT                                | Yes  | true  | NULL    |         |
| k2    | AGG_STATE<max_by(INT, INT NULL)>   | No   | false | NULL    | GENERIC |
| k3    | AGG_STATE<group_concat(TEXT NULL)> | No   | false | NULL    | GENERIC |
+-------+------------------------------------+------+-------+---------+---------+
```

