### PR TITLE
[feat](nereids) count prefix index in CBO

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -164,6 +164,18 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         initColumnNameMap();
     }
 
+    public List<Column> getPrefixKeyColumns() {
+        List<Column> keys = Lists.newArrayList();
+        for (Column col : schema) {
+            if (col.isKey()) {
+                keys.add(col);
+            } else {
+                break;
+            }
+        }
+        return keys;
+    }
+
     public void setSchemaHash(int newSchemaHash) {
         this.schemaHash = newSchemaHash;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.cost;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.PlanContext;
@@ -24,14 +25,19 @@ import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.DistributionSpecGather;
 import org.apache.doris.nereids.properties.DistributionSpecHash;
 import org.apache.doris.nereids.properties.DistributionSpecReplicated;
+import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAssertNumRows;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDeferMaterializeOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDeferMaterializeTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalEsScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFileScan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalGenerate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
@@ -52,8 +58,11 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
 
@@ -111,6 +120,61 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             }
         }
         return CostV1.ofCpu(context.getSessionVariable(), rows - aggMvBonus);
+    }
+
+    private Set<Column> getColumnForRangePredicate(Set<Expression> expressions) {
+        Set<Column> columns = Sets.newHashSet();
+        for (Expression expr : expressions) {
+            if (expr instanceof ComparisonPredicate) {
+                ComparisonPredicate compare = (ComparisonPredicate) expr;
+                boolean hasLiteral = compare.left() instanceof Literal || compare.right() instanceof Literal;
+                boolean hasSlot = compare.left() instanceof SlotReference || compare.right() instanceof SlotReference;
+                if (hasSlot && hasLiteral) {
+                    if (compare.left() instanceof SlotReference) {
+                        if (((SlotReference) compare.left()).getColumn().isPresent()) {
+                            columns.add(((SlotReference) compare.left()).getColumn().get());
+                        }
+                    } else {
+                        if (((SlotReference) compare.right()).getColumn().isPresent()) {
+                            columns.add(((SlotReference) compare.right()).getColumn().get());
+                        }
+                    }
+                }
+            }
+        }
+        return columns;
+    }
+
+    @Override
+    public Cost visitPhysicalFilter(PhysicalFilter<? extends Plan> filter, PlanContext context) {
+        double prefixIndexFilterCostFactor = 0.01;
+        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null) {
+            prefixIndexFilterCostFactor = ConnectContext.get().getSessionVariable().prefixIndexFilterCostFactor;
+        }
+
+        if (filter.getGroupExpression().isPresent()) {
+            OlapScan olapScan = (OlapScan) filter.getGroupExpression().get().getFirstChildPlan(OlapScan.class);
+            if (olapScan != null) {
+                // check prefix index
+                long idxId = olapScan.getSelectedIndexId();
+                List<Column> keyColumns = olapScan.getTable().getIndexMetaByIndexId(idxId).getPrefixKeyColumns();
+                Set<Column> predicateColumns = getColumnForRangePredicate(filter.getConjuncts());
+                int prefixIndexMatched = 0;
+                for (Column col : keyColumns) {
+                    if (predicateColumns.contains(col)) {
+                        prefixIndexMatched++;
+                    } else {
+                        break;
+                    }
+                }
+                if (prefixIndexMatched > 0) {
+                    prefixIndexFilterCostFactor = prefixIndexFilterCostFactor / (1 + prefixIndexMatched);
+                }
+            }
+        }
+
+        return CostV1.ofCpu(context.getSessionVariable(),
+                context.getStatisticsWithCheck().getRowCount() * prefixIndexFilterCostFactor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -147,7 +147,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
 
     @Override
     public Cost visitPhysicalFilter(PhysicalFilter<? extends Plan> filter, PlanContext context) {
-        if (context.getStatementContext().isDpHyp()) {
+        if (context.getStatementContext() == null || context.getStatementContext().isDpHyp()) {
             return CostV1.zero();
         }
         double filterCostFactor = 0.0001;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -349,4 +349,28 @@ public class GroupExpression {
     public ObjectId getId() {
         return id;
     }
+
+    /**
+     * the first child plan of clazz
+     * @param clazz the operator type, like join/aggregate
+     * @return child operator of type clazz, if not found, return null
+     */
+    public Plan getFirstChildPlan(Class clazz) {
+        for (Group childGroup : children) {
+            for (GroupExpression logical : childGroup.getLogicalExpressions()) {
+                if (clazz.isInstance(logical.getPlan())) {
+                    return logical.getPlan();
+                }
+            }
+        }
+        // for dphyp
+        for (Group childGroup : children) {
+            for (GroupExpression physical : childGroup.getPhysicalExpressions()) {
+                if (clazz.isInstance(physical.getPlan())) {
+                    return physical.getPlan();
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -857,9 +857,6 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_ODBC_TRANSCATION)
     public boolean enableOdbcTransaction = false;
 
-    @VariableMgr.VarAttr(name = "prefix_index_filter_cost_factor")
-    public double prefixIndexFilterCostFactor = 0.001;
-
     @VariableMgr.VarAttr(name = ENABLE_SCAN_RUN_SERIAL,  description = {
             "是否开启ScanNode串行读，以避免limit较小的情况下的读放大，可以提高查询的并发能力",
             "Whether to enable ScanNode serial reading to avoid read amplification in cases of small limits"

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -857,6 +857,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_ODBC_TRANSCATION)
     public boolean enableOdbcTransaction = false;
 
+    @VariableMgr.VarAttr(name = "prefix_index_filter_cost_factor")
+    public double prefixIndexFilterCostFactor = 0.001;
+
     @VariableMgr.VarAttr(name = ENABLE_SCAN_RUN_SERIAL,  description = {
             "是否开启ScanNode串行读，以避免limit较小的情况下的读放大，可以提高查询的并发能力",
             "Whether to enable ScanNode serial reading to avoid read amplification in cases of small limits"

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1189,6 +1189,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_NEW_COST_MODEL, needForward = true)
     private boolean enableNewCostModel = false;
 
+    @VariableMgr.VarAttr(name = "filter_cost_factor", needForward = true)
+    public double filterCostFactor = 0.0001;
+
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query2.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query2.out
@@ -27,9 +27,6 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------hashJoin[INNER_JOIN] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))) otherCondition=()
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject
-----------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------------PhysicalProject
@@ -38,6 +35,9 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------------PhysicalProject
 ----------------------------filter((date_dim.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
 --------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------PhysicalProject
 ------------------filter((date_dim.d_year = 1998))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query59.out
@@ -22,28 +22,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------hashJoin[INNER_JOIN] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))) otherCondition=()
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
-------------------------PhysicalDistribute[DistributionSpecExecutionAny]
---------------------------PhysicalProject
-----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
-------------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------------PhysicalProject
-----------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
-------------------------------PhysicalOlapScan[date_dim]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=()
 ----------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ------------------------------PhysicalProject
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
 ----------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[store]
 ------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------PhysicalProject
 ----------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
+------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
+------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------------PhysicalProject
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1
+------------------------PhysicalDistribute[DistributionSpecReplicated]
+--------------------------PhysicalProject
+----------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
 ------------------------------PhysicalOlapScan[date_dim]
 --------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query2.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query2.out
@@ -27,9 +27,6 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------hashJoin[INNER_JOIN] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))) otherCondition=()
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject
-----------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------------PhysicalProject
@@ -38,6 +35,9 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------------PhysicalProject
 ----------------------------filter((date_dim.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
 --------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------PhysicalProject
 ------------------filter((date_dim.d_year = 1998))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query59.out
@@ -22,28 +22,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------hashJoin[INNER_JOIN] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))) otherCondition=()
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
-------------------------PhysicalDistribute[DistributionSpecExecutionAny]
---------------------------PhysicalProject
-----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF5
-------------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------------PhysicalProject
-----------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
-------------------------------PhysicalOlapScan[date_dim]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
+--------------------------hashJoin[INNER_JOIN] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 ----------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ------------------------------PhysicalProject
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF2
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF3
 ----------------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[store] apply RFs: RF4
 ------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------PhysicalProject
 ----------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
+------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
+------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------------PhysicalProject
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF5
+------------------------PhysicalDistribute[DistributionSpecReplicated]
+--------------------------PhysicalProject
+----------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
 ------------------------------PhysicalOlapScan[date_dim]
 --------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------PhysicalProject


### PR DESCRIPTION
## Proposed changes
1. if prefix index is choosen, lower the filter cost in CBO
2. for join cost: if left.rowcount==right.rowcount, we will choose the wider (stats.getWidthInJoinCluster()) child as left child, since we prefer left deep tree.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

