### PR TITLE
[fix](cloud) Fix group commit failed because access denied in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -120,7 +120,7 @@ public class StreamLoadHandler {
 
         ctx.setRemoteIP(request.isSetAuthCode() ? clientAddr : request.getUserIp());
         String userName = ClusterNamespace.getNameFromFullName(request.getUser());
-        if (!Strings.isNullOrEmpty(userName)) {
+        if (!request.isSetToken() && !Strings.isNullOrEmpty(userName)) {
             List<UserIdentity> currentUser = Lists.newArrayList();
             try {
                 Env.getCurrentEnv().getAuth().checkPlainPassword(userName,


### PR DESCRIPTION
## Proposed changes


The inner group commit tvf does not need check user password.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

