### PR TITLE
[fix](jdbc_catalog) fix error datetime literal caused be core

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -266,13 +266,10 @@ public class StringLiteral extends LiteralExpr {
                     break;
             }
         } else if (targetType.isDateType()) {
-            // FE only support 'yyyy-MM-dd hh:mm:ss' && 'yyyy-MM-dd' format
-            // so if FE unchecked cast fail, we also build CastExpr for BE
-            // BE support other format suck as 'yyyyMMdd'...
             try {
                 return convertToDate(targetType);
             } catch (AnalysisException e) {
-                // pass;
+                throw new AnalysisException(e.getMessage());
             }
         } else if (targetType.equals(type)) {
             return this;


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Steps to reproduce:
1. create a table test_table contains a timestamp type column which named create_time, and insert some rows.
2. create a doris jdbc catalog pointer the above mysql server.
3. run doris sql: set enable_nereids_planner=false; select case when create_time = '0000-00-00 00:00:00' then '' else create_time end from jdbc.db.test_table;

then you will got be core error:
ERROR 1105 (HY000): RpcException, msg: org.apache.doris.rpc.RpcException: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason

error in be.out
```sql
 1# 0x00007F3A6DD33400 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x00005588299AADC1 in /data/d12/output/be/lib/doris_be
 7# 0x00005588299AAF14 in /data/d12/output/be/lib/doris_be
 8# 0x0000558824A99D2E in /data/d12/output/be/lib/doris_be
 9# 0x0000558824A99E86 in /data/d12/output/be/lib/doris_be
10# doris::Status doris::vectorized::FunctionCase<false, true>::execute_get_when_null<doris::vectorized::ColumnString>(std:
:shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::Block&, std::vector<unsigned long, std::allocato
r<unsigned long> > const&, unsigned long, unsigned long) [clone .isra.0] at /data/d12/be/src/vec/functions/function_case.h:
354
11# doris::vectorized::FunctionCase<false, true>::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std:
:vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) at /data/d12/be/src/vec/functi
ons/function_case.h:377
12# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::ve
ctorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at
 /data/d12/be/src/vec/functions/function.cpp:244
13# doris::vectorized::PreparedFunctionImpl::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<un
signed long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /data/d12/be/src/vec/functions/
function.cpp:267
14# doris::vectorized::VCaseExpr::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /data/d12/be/src/vec/exprs/vcase_expr.cpp:90
15# doris::vectorized::VExprContext::get_output_block_after_execute_exprs(std::vector<doris::vectorized::VExprContext*, std::allocator<doris::vectorized::VExprContext*> > const&, doris::vectorized::Block const&, doris::Status&) at /data/d12/be/src/vec/exprs/vexpr_context.cpp:148
16# doris::vectorized::VMysqlResultWriter::append_block(doris::vectorized::Block&) at /data/d12/be/src/vec/sink/vmysql_result_writer.cpp:459
17# doris::vectorized::VResultSink::send(doris::RuntimeState*, doris::vectorized::Block*) at /data/d12/be/src/vec/sink/vresult_sink.cpp:96
```

while when using nereids planer,
fe throw analysis error: ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: Table name [jdbc2.db1.mc_work_contact_employee_1] is invalid.

so make legacy planner act like nereids.
 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

