### PR TITLE
[test](regression) add cases for data quality error url

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -563,7 +563,7 @@ inline std::string Status::to_string() const {
 }
 
 inline std::string Status::to_string_no_stack() const {
-    return fmt::format("[{}] {}", code_as_string(), msg());
+    return fmt::format("[{}]{}", code_as_string(), msg());
 }
 
 // some generally useful macros

--- a/be/src/vec/sink/vtablet_finder.cpp
+++ b/be/src/vec/sink/vtablet_finder.cpp
@@ -62,7 +62,7 @@ Status OlapTabletFinder::find_tablets(RuntimeState* state, Block* block, int row
             _num_filtered_rows++;
             _filter_bitmap.Set(row_index, true);
             if (stop_processing) {
-                return Status::EndOfFile("Encountered unqualified data, stop processing");
+                return Status::DataQualityError("Encountered unqualified data, stop processing");
             }
             skip[row_index] = true;
             continue;

--- a/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
@@ -17,10 +17,10 @@
 
 import com.mysql.cj.jdbc.StatementImpl
 
-suite("test_insert_partition_url") {
+suite("test_insert_partition_fail_url") {
     def dbName = "regression_test_insert_p0"
-    def srcTableName = "test_insert_partition_url_src"
-    def dstTableName = "test_insert_partition_url_dst"
+    def srcTableName = "test_insert_partition_fail_url_src"
+    def dstTableName = "test_insert_partition_fail_url_dst"
     def srcName = dbName + "." + srcTableName
     def dstName = dbName + "." + dstTableName
 

--- a/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
@@ -87,5 +87,5 @@ suite("test_insert_partition_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "[DATA_QUALITY_ERROR] Encountered unqualified data, stop processing. url: ")
+    }, "[DATA_QUALITY_ERROR]Encountered unqualified data, stop processing. url: ")
 }

--- a/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import com.mysql.cj.jdbc.StatementImpl
+
+suite("test_insert_partition_url") {
+    def dbName = "regression_test_insert_p0"
+    def srcTableName = "test_insert_partition_url_src"
+    def dstTableName = "test_insert_partition_url_dst"
+    def srcName = dbName + "." + srcTableName
+    def dstName = dbName + "." + dstTableName
+
+    // create table
+    sql """ drop table if exists ${srcName}; """
+    sql """
+        CREATE TABLE ${srcName} (
+            `id` int NOT NULL,
+            `score` int NULL default "-1"
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """ drop table if exists ${dstName}; """
+    sql """
+        CREATE TABLE ${dstName} (
+            `id` int NOT NULL,
+            `score` int NULL default "-1"
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION `p0` VALUES LESS THAN ("0"),
+            PARTITION `p1` VALUES LESS THAN ("2")
+        )
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """ SET enable_insert_strict = true; """
+
+    // prepare data
+    sql """
+        INSERT INTO ${srcName} (`id`, `score`)
+        VALUES (0, 9), (1, 7), (2, 10), (3, 6), (4, 5), (5, 8);
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+
+    expectExceptionLike({
+        sql """
+            INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
+        """
+    }, "Insert has filtered data in strict mode. url: ")
+
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+
+    expectExceptionLike({
+        sql """
+            INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
+        """
+    }, "[DATA_QUALITY_ERROR] Encountered unqualified data, stop processing. url: ")
+}

--- a/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
@@ -83,5 +83,5 @@ suite("test_insert_strict_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "[DATA_QUALITY_ERROR] Encountered unqualified data, stop processing. url: ")
+    }, "[DATA_QUALITY_ERROR]Encountered unqualified data, stop processing. url: ")
 }

--- a/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import com.mysql.cj.jdbc.StatementImpl
+
+suite("test_insert_strict_fail_url") {
+    def dbName = "regression_test_insert_p0"
+    def srcTableName = "test_insert_strict_fail_url_src"
+    def dstTableName = "test_insert_strict_fail_url_dst"
+    def srcName = dbName + "." + srcTableName
+    def dstName = dbName + "." + dstTableName
+
+    // create table
+    sql """ drop table if exists ${srcName}; """
+    sql """
+        CREATE TABLE ${srcName} (
+            `key` int NOT NULL,
+            `id` int NULL,
+            `score` int NULL default "-1"
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`key`)
+        DISTRIBUTED BY HASH(`key`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """ drop table if exists ${dstName}; """
+    sql """
+        CREATE TABLE ${dstName} (
+            `id` int NOT NULL,
+            `score` int NULL default "-1"
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """ SET enable_insert_strict = true; """
+
+    // prepare data
+    sql """
+        INSERT INTO ${srcName} (`key`, `id`, `score`)
+        VALUES (0, 1, 9), (1, 2, 7), (2, NULL, 10), (3, NULL, 6), (4, NULL, 5), (5, NULL, 8);
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+
+    expectExceptionLike({
+        sql """
+            INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
+        """
+    }, "Insert has filtered data in strict mode. url: ")
+
+    sql """
+        INSERT INTO ${srcName} SELECT * FROM ${srcName};
+    """
+
+    expectExceptionLike({
+        sql """
+            INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
+        """
+    }, "[DATA_QUALITY_ERROR] Encountered unqualified data, stop processing. url: ")
+}


### PR DESCRIPTION
## Proposed changes

Add regression tests to check url is returned when filtered rows in strict mode (data quality error).
Also fix some small bugs:
1. Error type returned when partition is not found (`END_OF_FILE` -> `DATA_QUALITY_ERROR`).
2. Unify status string format (`"[ERROR] message"` -> `"[ERROR]message"`)  

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

