### PR TITLE
[bug](Fe) fix potential deadlock in show proc statement

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,6 +45,8 @@ public class StatisticProcNode implements ProcNodeInterface {
             .build();
     private Env env;
 
+    private ForkJoinPool taskPool = new ForkJoinPool();
+
     public StatisticProcNode(Env env) {
         Preconditions.checkNotNull(env);
         this.env = env;
@@ -51,12 +54,14 @@ public class StatisticProcNode implements ProcNodeInterface {
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
-        List<DBStatistic> statistics = env.getInternalCatalog().getDbIds().parallelStream()
-                // skip information_schema database
-                .flatMap(id -> Stream.of(id == 0 ? null : env.getCatalogMgr().getDbNullable(id)))
-                .filter(Objects::nonNull).map(DBStatistic::new)
-                // sort by dbName
-                .sorted(Comparator.comparing(db -> db.db.getFullName())).collect(Collectors.toList());
+        List<DBStatistic> statistics = taskPool.submit(() ->
+                env.getInternalCatalog().getDbIds().parallelStream()
+                    // skip information_schema database
+                    .flatMap(id -> Stream.of(id == 0 ? null : env.getCatalogMgr().getDbNullable(id)))
+                    .filter(Objects::nonNull).map(DBStatistic::new)
+                    // sort by dbName
+                    .sorted(Comparator.comparing(db -> db.db.getFullName())).collect(Collectors.toList())
+        ).join();
 
         List<List<String>> rows = new ArrayList<>(statistics.size() + 1);
         for (DBStatistic statistic : statistics) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

version: 1.2|2.0|2.1

We have encountered Fe hang and the number connections reach limits.
Unfortunately, I restarted FE without Jstack the Fe process.

But I found a lot of logs like:

```
2024-05-11 14:09:32,533 WARN (thrift-server-pool-424042|4684871) [ReportHandler.putToQueue():190] the report queue size exceeds the limit: 100.
 current: 101
2024-05-11 14:09:32,545 WARN (thrift-server-pool-392529|4367180) [ReportHandler.putToQueue():190] the report queue size exceeds the limit: 100.
 current: 101
2024-05-11 14:09:32,663 WARN (thrift-server-pool-421895|4663462) [ReportHandler.putToQueue():190] the report queue size exceeds the limit: 100.
 current: 101
2024-05-11 14:09:32,816 WARN (thrift-server-pool-379243|4167917) [ReportHandler.putToQueue():190] the report queue size exceeds the limit: 100.
 current: 101
2024-05-11 14:09:33,531 WARN (thrift-server-pool-420797|4652941) [ReportHandler.putToQueue():190] the report queue size exceeds the limit: 100.
 current: 101
```

The tablet report task is hang:

```
2024-05-11 14:07:57,671 INFO (Thread-57|105) [ReportHandler.tabletReport():250] backend[10009] reports 28982 tablet(s). repor
t version: 17094493386232
2024-05-11 14:24:15,323 INFO (Thread-57|105) [TabletInvertedIndex.tabletReport():308] finished to do tablet diff with backend[10009].
sync: 0. metaDel: 7. foundInMeta: 28953. migration: 0. found invalid transactions 0. found republish transactions 0. tabletInMemorySync:
0. need recovery: 0. cost: 66 ms
```

And the dynamic partition scheduler seems also hang:

<img width="1499" alt="image" src="https://github.com/apache/doris/assets/22125576/c6bfd9a5-2168-4ba0-8794-034f4d2cd458">

I found a similar issue, as issue #11319 saying, we should avoid using common global `ForkJoinPool` to execute parallelStream tasks and prevent Fe deadlocks from occurring.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

