### PR TITLE
[Configurations](multi-catalog) Add `enable_parquet_filter_by_min_max` and `enable_orc_filter_by_min_max` Session variables.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -573,6 +573,7 @@ private:
 
     io::IOContext* _io_ctx = nullptr;
     bool _enable_lazy_mat = true;
+    bool _enable_filter_by_min_max = true;
 
     std::vector<DecimalScaleParams> _decimal_scale_params;
     size_t _decimal_scale_params_index;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -272,6 +272,7 @@ private:
     // Maybe null if not used
     FileMetaCache* _meta_cache = nullptr;
     bool _enable_lazy_mat = true;
+    bool _enable_filter_by_min_max = true;
     const TupleDescriptor* _tuple_descriptor = nullptr;
     const RowDescriptor* _row_descriptor = nullptr;
     const std::unordered_map<std::string, int>* _colname_to_slot_id = nullptr;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -433,6 +433,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_ORC_LAZY_MAT = "enable_orc_lazy_materialization";
 
+    public static final String ENABLE_PARQUET_FILTER_BY_MIN_MAX = "enable_parquet_filter_by_min_max";
+
+    public static final String ENABLE_ORC_FILTER_BY_MIN_MAX = "enable_orc_filter_by_min_max";
+
     public static final String INLINE_CTE_REFERENCED_THRESHOLD = "inline_cte_referenced_threshold";
 
     public static final String ENABLE_CTE_MATERIALIZE = "enable_cte_materialize";
@@ -1484,6 +1488,24 @@ public class SessionVariable implements Serializable, Writable {
                             + "The default value is true."},
             needForward = true)
     public boolean enableOrcLazyMat = true;
+
+
+    @VariableMgr.VarAttr(
+            name = ENABLE_PARQUET_FILTER_BY_MIN_MAX,
+            description = {"控制 parquet reader 是否启用 min-max 值过滤。默认为 true。",
+                    "Controls whether to filter by min-max values in parquet reader. "
+                            + "The default value is true."},
+            needForward = true)
+    public boolean enableParquetFilterByMinMax = true;
+
+
+    @VariableMgr.VarAttr(
+            name = ENABLE_ORC_FILTER_BY_MIN_MAX,
+            description = {"控制 orc reader 是否启用 min-max 值过滤。默认为 true。",
+                    "Controls whether to filter by min-max values in orc reader. "
+                            + "The default value is true."},
+            needForward = true)
+    public boolean enableOrcFilterByMinMax = true;
 
     @VariableMgr.VarAttr(
             name = EXTERNAL_TABLE_ANALYZE_PART_NUM,
@@ -2734,6 +2756,22 @@ public class SessionVariable implements Serializable, Writable {
         this.enableOrcLazyMat = enableOrcLazyMat;
     }
 
+    public boolean isEnableParquetFilterByMinMax() {
+        return enableParquetFilterByMinMax;
+    }
+
+    public void setEnableParquetFilterByMinMax(boolean enableParquetFilterByMinMax) {
+        this.enableParquetFilterByMinMax = enableParquetFilterByMinMax;
+    }
+
+    public boolean isEnableOrcFilterByMinMax() {
+        return enableOrcFilterByMinMax;
+    }
+
+    public void setEnableOrcFilterByMinMax(boolean enableOrcFilterByMinMax) {
+        this.enableOrcFilterByMinMax = enableOrcFilterByMinMax;
+    }
+
     public String getSqlDialect() {
         return sqlDialect;
     }
@@ -3272,6 +3310,8 @@ public class SessionVariable implements Serializable, Writable {
 
         tResult.setEnableParquetLazyMat(enableParquetLazyMat);
         tResult.setEnableOrcLazyMat(enableOrcLazyMat);
+        tResult.setEnableParquetFilterByMinMax(enableParquetFilterByMinMax);
+        tResult.setEnableOrcFilterByMinMax(enableOrcFilterByMinMax);
 
         tResult.setEnableDeleteSubPredicateV2(enableDeleteSubPredicateV2);
         tResult.setTruncateCharOrVarcharColumns(truncateCharOrVarcharColumns);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -294,6 +294,9 @@ struct TQueryOptions {
   108: optional i64 local_exchange_free_blocks_limit;
 
   109: optional bool enable_force_spill = false;
+
+  110: optional bool enable_parquet_filter_by_min_max = true
+  111: optional bool enable_orc_filter_by_min_max = true
   
   // For cloud, to control if the content would be written into file cache
   1000: optional bool disable_file_cache = false

--- a/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
@@ -21,135 +21,142 @@ suite("test_hive_basic_type", "external_docker,hive,external_docker_hive,p0,exte
         logger.info("diable Hive test.")
         return;
     }
-    
-	for (String hivePrefix : ["hive2", "hive3"]) {
-        String catalog_name = "test_${hivePrefix}_basic_type"
-        String ex_db_name = "`default`"
-        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-        String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
 
-        sql """drop catalog if exists ${catalog_name} """
+    for (String hivePrefix : ["hive2", "hive3"]) {
+        for (boolean enable_filter_by_min_max : [true, false]) {
+            String catalog_name = "test_${hivePrefix}_basic_type"
+            String ex_db_name = "`default`"
+            String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+            String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+            String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
 
-        sql """CREATE CATALOG ${catalog_name} PROPERTIES (
+            sql """set enable_parquet_filter_by_min_max = ${enable_filter_by_min_max};"""
+
+            sql """set enable_orc_filter_by_min_max = ${enable_filter_by_min_max};"""
+
+            sql """drop catalog if exists ${catalog_name} """
+
+            sql """CREATE CATALOG ${catalog_name} PROPERTIES (
                 'type'='hms',
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 'hadoop.username' = 'hive'
             );"""
 
-        sql """switch ${catalog_name}"""
+            sql """switch ${catalog_name}"""
 
-        def res_dbs_log = sql "show databases;"
-		for(int i = 0;i < res_dbs_log.size();i++) {
-			def tbs = sql "show tables from  `${res_dbs_log[i][0]}`"
-			log.info( "database = ${res_dbs_log[i][0]} => tables = "+tbs.toString())
-		}
-		try {
-			order_qt_2 """select * from ${catalog_name}.${ex_db_name}.parquet_partition_table order by l_orderkey limit 1;"""
-			order_qt_3 """select * from ${catalog_name}.${ex_db_name}.parquet_delta_binary_packed order by int_value limit 1;"""
-			order_qt_4 """select * from ${catalog_name}.${ex_db_name}.parquet_alltypes_tiny_pages  order by id desc  limit 5;"""
-			order_qt_5 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_partition order by bigint_col desc limit 3;"""
-			order_qt_6 """select * from ${catalog_name}.${ex_db_name}.csv_partition_table order by k1 limit 1;"""
-			order_qt_9 """select * from ${catalog_name}.${ex_db_name}.csv_all_types limit 1;"""
-			order_qt_10 """select * from ${catalog_name}.${ex_db_name}.text_all_types limit 1;"""
+            def res_dbs_log = sql "show databases;"
+            for (int i = 0; i < res_dbs_log.size(); i++) {
+                def tbs = sql "show tables from  `${res_dbs_log[i][0]}`"
+                log.info("database = ${res_dbs_log[i][0]} => tables = " + tbs.toString())
+            }
+            try {
+                order_qt_2 """select * from ${catalog_name}.${ex_db_name}.parquet_partition_table order by l_orderkey limit 1;"""
+                order_qt_3 """select * from ${catalog_name}.${ex_db_name}.parquet_delta_binary_packed order by int_value limit 1;"""
+                order_qt_4 """select * from ${catalog_name}.${ex_db_name}.parquet_alltypes_tiny_pages  order by id desc  limit 5;"""
+                order_qt_5 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_partition order by bigint_col desc limit 3;"""
+                order_qt_6 """select * from ${catalog_name}.${ex_db_name}.csv_partition_table order by k1 limit 1;"""
+                order_qt_9 """select * from ${catalog_name}.${ex_db_name}.csv_all_types limit 1;"""
+                order_qt_10 """select * from ${catalog_name}.${ex_db_name}.text_all_types limit 1;"""
 
-			// parquet bloom
-			order_qt_11 """select * from ${catalog_name}.${ex_db_name}.bloom_parquet_table limit 1;"""
+                // parquet bloom
+                order_qt_11 """select * from ${catalog_name}.${ex_db_name}.bloom_parquet_table limit 1;"""
 
-			// orc bloom
-			order_qt_12 """select * from ${catalog_name}.${ex_db_name}.bloom_orc_table limit 1;"""
+                // orc bloom
+                order_qt_12 """select * from ${catalog_name}.${ex_db_name}.bloom_orc_table limit 1;"""
 
-			// orc predicate
-			order_qt_13 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 6 limit 10;"""
-			order_qt_14 """select count(1) from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 6;"""
-			order_qt_15 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 1 limit 10;"""
-			order_qt_16 """select count(1) from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 1;"""
-			order_qt_17 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_integer = 3 and column_primitive_bigint = 6 limit 10;"""
+                // orc predicate
+                order_qt_13 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 6 limit 10;"""
+                order_qt_14 """select count(1) from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 6;"""
+                order_qt_15 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 1 limit 10;"""
+                order_qt_16 """select count(1) from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_bigint = 1;"""
+                order_qt_17 """select * from ${catalog_name}.${ex_db_name}.orc_predicate_table where column_primitive_integer = 3 and column_primitive_bigint = 6 limit 10;"""
 
-			// parquet predicate
-			order_qt_18 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 1 limit 10;"""
-			order_qt_19 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 1;"""
-			order_qt_20 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3 limit 10;"""
-			order_qt_21 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3;"""
-			order_qt_22 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 1 limit 10;"""
-			order_qt_23 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 1;"""
+                // parquet predicate
+                order_qt_18 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 1 limit 10;"""
+                order_qt_19 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 1;"""
+                order_qt_20 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3 limit 10;"""
+                order_qt_21 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3;"""
+                order_qt_22 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 1 limit 10;"""
+                order_qt_23 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 1;"""
 
-			// only null parquet file test
-			order_qt_24 """select * from ${catalog_name}.${ex_db_name}.only_null;"""
-			order_qt_25 """select * from ${catalog_name}.${ex_db_name}.only_null where x is null;"""
-			order_qt_26 """select * from ${catalog_name}.${ex_db_name}.only_null where x is not null;"""
+                // only null parquet file test
+                order_qt_24 """select * from ${catalog_name}.${ex_db_name}.only_null;"""
+                order_qt_25 """select * from ${catalog_name}.${ex_db_name}.only_null where x is null;"""
+                order_qt_26 """select * from ${catalog_name}.${ex_db_name}.only_null where x is not null;"""
 
-			// parquet timestamp millis test
-			order_qt_27 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_millis;"""
-			order_qt_28 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_millis order by test;"""
+                // parquet timestamp millis test
+                order_qt_27 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_millis;"""
+                order_qt_28 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_millis order by test;"""
 
-			// parquet timestamp micros test
-			order_qt_29 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_micros;"""
-			order_qt_30 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_micros order by test;"""
+                // parquet timestamp micros test
+                order_qt_29 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_micros;"""
+                order_qt_30 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_micros order by test;"""
 
-			// parquet timestamp nanos test
-			order_qt_31 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_nanos;"""
-			order_qt_32 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_nanos order by test;"""
+                // parquet timestamp nanos test
+                order_qt_31 """desc ${catalog_name}.${ex_db_name}.parquet_timestamp_nanos;"""
+                order_qt_32 """select * from ${catalog_name}.${ex_db_name}.parquet_timestamp_nanos order by test;"""
 
-			order_qt_7 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_t limit 1;"""
+                order_qt_7 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_t limit 1;"""
 
-			// parquet predicate
-			order_qt_38 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 6 limit 10;"""
-			order_qt_39 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 6;"""
-			order_qt_40 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3 and column_primitive_bigint = 6 limit 10;"""
+                // parquet predicate
+                order_qt_38 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 6 limit 10;"""
+                order_qt_39 """select count(1) from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_bigint = 6;"""
+                order_qt_40 """select * from ${catalog_name}.${ex_db_name}.parquet_predicate_table where column_primitive_integer = 3 and column_primitive_bigint = 6 limit 10;"""
 
-			order_qt_33 """select * from ${catalog_name}.${ex_db_name}.parquet_all_types limit 1;"""
+                order_qt_33 """select * from ${catalog_name}.${ex_db_name}.parquet_all_types limit 1;"""
 
-			order_qt_36 """select * from ${catalog_name}.${ex_db_name}.parquet_gzip_all_types limit 1;"""
-			order_qt_42 """select * from ${catalog_name}.${ex_db_name}.parquet_zstd_all_types limit 1;"""
+                order_qt_36 """select * from ${catalog_name}.${ex_db_name}.parquet_gzip_all_types limit 1;"""
+                order_qt_42 """select * from ${catalog_name}.${ex_db_name}.parquet_zstd_all_types limit 1;"""
 
-			// hive tables of json classes do not necessarily support column separation to identify errors
-			//order_qt_8 """select * from ${catalog_name}.${ex_db_name}.json_all_types limit 1;"""
+                // hive tables of json classes do not necessarily support column separation to identify errors
+                //order_qt_8 """select * from ${catalog_name}.${ex_db_name}.json_all_types limit 1;"""
 
-			// At present, doris only supports three formats of orc parquet textfile, while others are not supported
+                // At present, doris only supports three formats of orc parquet textfile, while others are not supported
 
-			// hive tables in avro format are not supported
-			//order_qt_34 """select * from ${catalog_name}.${ex_db_name}.avro_all_types limit 1;"""
+                // hive tables in avro format are not supported
+                //order_qt_34 """select * from ${catalog_name}.${ex_db_name}.avro_all_types limit 1;"""
 
-			// hive tables in SEQUENCEFILE format are not supported
-			//order_qt_35 """select * from ${catalog_name}.${ex_db_name}.sequence_all_types limit 1;"""
+                // hive tables in SEQUENCEFILE format are not supported
+                //order_qt_35 """select * from ${catalog_name}.${ex_db_name}.sequence_all_types limit 1;"""
 
-			// hive tables in rcbinary format are not supported
-			//order_qt_37 """select * from ${catalog_name}.${ex_db_name}.rcbinary_all_types limit 1;"""
+                // hive tables in rcbinary format are not supported
+                //order_qt_37 """select * from ${catalog_name}.${ex_db_name}.rcbinary_all_types limit 1;"""
 
-			// orc_all_types_t predicate test
-			order_qt_41 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_t where t_int = 3;"""
+                // orc_all_types_t predicate test
+                order_qt_41 """select * from ${catalog_name}.${ex_db_name}.orc_all_types_t where t_int = 3;"""
 
-			//test parquet  byte_array_decimal and rle_bool 
-			order_qt_parquet """ select count(*) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool """
-			order_qt_parquet1 """ select * from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals is not null and  bool_rle is not null  order by decimals,bool_rle limit 7 """ 
-			order_qt_parquet2 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals is not null and decimals > 1  order by decimals limit 7 """ 
-			order_qt_parquet3 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals = 123.456  order by decimals limit 7 """ 
-			order_qt_parquet4 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals != -7871.416 and decimals is not null order by decimals limit 7 """ 
-		
-			order_qt_parquet5 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals is not null and decimals < 0  order by decimals limit 7 """ 
-			
-			order_qt_parquet7 """ select bool_rle from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where bool_rle is not null and bool_rle = 1 limit 7 """ 
-			order_qt_parquet8 """ select bool_rle from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where bool_rle is not null and bool_rle = 1 limit 7 """ 
-			order_qt_parquet9 """ select count(bool_rle) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool; """ 
-			order_qt_parquet10 """ select count(decimals) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool; """ 
-			order_qt_parquet11 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
-					where decimals is not null and decimals > 1  order by decimals limit 7 """ 
-		}finally {
-			res_dbs_log = sql "show databases;"
-			for(int i = 0;i < res_dbs_log.size();i++) {
-				def tbs = sql "show tables from  `${res_dbs_log[i][0]}`"
-				log.info( "database = ${res_dbs_log[i][0]} => tables = "+tbs.toString())
-			}
-		}
-        //sql """drop catalog if exists ${catalog_name} """
+                //test parquet  byte_array_decimal and rle_bool
+                order_qt_parquet """ select count(*) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool """
+                order_qt_parquet1 """ select * from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals is not null and  bool_rle is not null  order by decimals,bool_rle limit 7 """
+                order_qt_parquet2 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals is not null and decimals > 1  order by decimals limit 7 """
+                order_qt_parquet3 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals = 123.456  order by decimals limit 7 """
+                order_qt_parquet4 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals != -7871.416 and decimals is not null order by decimals limit 7 """
+
+                order_qt_parquet5 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals is not null and decimals < 0  order by decimals limit 7 """
+
+                order_qt_parquet7 """ select bool_rle from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where bool_rle is not null and bool_rle = 1 limit 7 """
+                order_qt_parquet8 """ select bool_rle from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where bool_rle is not null and bool_rle = 1 limit 7 """
+                order_qt_parquet9 """ select count(bool_rle) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool; """
+                order_qt_parquet10 """ select count(decimals) from ${catalog_name}.${ex_db_name}.parquet_decimal_bool; """
+                order_qt_parquet11 """ select decimals from ${catalog_name}.${ex_db_name}.parquet_decimal_bool 
+					where decimals is not null and decimals > 1  order by decimals limit 7 """
+            } finally {
+                res_dbs_log = sql "show databases;"
+                for (int i = 0; i < res_dbs_log.size(); i++) {
+                    def tbs = sql "show tables from  `${res_dbs_log[i][0]}`"
+                    log
+                            .info("database = ${res_dbs_log[i][0]} => tables  =  " + tbs.toString())
+                }
+            }
+            //sql """drop catalog if exists ${catalog_name} """
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

[Configurations] (multi-catalog) Add `enable_parquet_filter_by_min_max` and `enable_orc_filter_by_min_max` Session variables for workaround.
In case that when the column min max statistics in file are incorrect, we can set these variables to skip them

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

