### PR TITLE
[fix](catalog) fix the that failed to check if input format is splitable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
@@ -185,11 +185,11 @@ public final class HiveUtil {
         }
     }
 
-    public static boolean isSplittable(RemoteFileSystem remoteFileSystem, InputFormat<?, ?> inputFormat,
-            String location, JobConf jobConf) throws UserException {
+    public static boolean isSplittable(RemoteFileSystem remoteFileSystem, String inputFormat,
+            String location) throws UserException {
         if (remoteFileSystem instanceof BrokerFileSystem) {
             return ((BrokerFileSystem) remoteFileSystem)
-                    .isSplittable(location, inputFormat.getClass().getCanonicalName());
+                    .isSplittable(location, inputFormat);
         }
 
         return HMSExternalTable.SUPPORTED_HIVE_FILE_FORMATS.contains(inputFormat);


### PR DESCRIPTION
## Proposed changes

Introduced from #33242
When we check supported inputformat in a `Set<String>`, we should use string, not object

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

