### PR TITLE
[fix](agg) memory leak issue in agg operator

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -184,6 +184,12 @@ Status AggSharedState::reset_hash_table() {
                             }
                         });
 
+                        if (hash_table.has_null_key_data()) {
+                            auto st = _destroy_agg_status(hash_table.template get_null_key_data<
+                                                          vectorized::AggregateDataPtr>());
+                            RETURN_IF_ERROR(st);
+                        }
+
                         aggregate_data_container.reset(new vectorized::AggregateDataContainer(
                                 sizeof(typename HashTableType::key_type),
                                 ((total_size_of_aggregate_states + align_aggregate_states - 1) /


### PR DESCRIPTION
## Proposed changes

```
      0x60300a396150, size 32, strack trace:
0#  Allocator<true, false, false>::alloc_impl(unsigned long, unsigned long)
1#  phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigned long> >::initialize_slots(unsigned long)
2#  phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigned long> >::resize(unsigned long)
3#  phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigned long> >::raw_hash_set(phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigned long> > const&, doris::vectorized::Allocator_<unsigned long> const&)
4#  doris::HyperLogLog::merge(doris::HyperLogLog const&)
5#  doris::vectorized::IAggregateFunctionDataHelper<doris::vectorized::AggregateFunctionHLLUnionAggImpl<doris::vectorized::AggregateFunctionHLLData>, doris::vectorized::AggregateFunctionHLLUnion<doris::vectorized::AggregateFunctionHLLUnionAggImpl<doris::vectorized::AggregateFunctionHLLData> > >::deserialize_and_merge(char*, char*, doris::vectorized::BufferReadable&, doris::vectorized::Arena*) const
6#  doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionHLLUnion<doris::vectorized::AggregateFunctionHLLUnionAggImpl<doris::vectorized::AggregateFunctionHLLData> > >::deserialize_and_merge_vec(char* const*, unsigned long, char*, doris::vectorized::ColumnStr<unsigned int> const*, doris::vectorized::Arena*, unsigned long) const
7#  doris::Status doris::pipeline::AggSinkLocalState::_merge_with_serialized_key_helper<false, false>(doris::vectorized::Block*)
8#  doris::pipeline::AggSinkLocalState::Executor<false, true>::execute(doris::pipeline::AggSinkLocalState*, doris::vectorized::Block*)
9#  doris::pipeline::AggSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool)
10# doris::pipeline::PartitionedAggSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool)
11# doris::pipeline::PipelineTask::execute(bool*)
12# doris::pipeline::TaskScheduler::_do_work(unsigned long)
13# doris::ThreadPool::dispatch_thread()
14# doris::Thread::supervise_thread(void*)
15# ?
16# __clone

*** SIGABRT unknown detail explain (@0x19f60) received by PID 106336 (TID 108616 OR 0x7fc25dbbc700) from PID 106336; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
1# 0x00007FCC48CA2090 in /lib/x86_64-linux-gnu/libc.so.6
2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
4# 0x0000562FDDDBA07D in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
5# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
6# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
7# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
8# doris::MemTrackerLimiter::~MemTrackerLimiter() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
9# doris::ThreadMemTrackerMgr::detach_limiter_tracker(std::shared_ptr<doris::MemTrackerLimiter> const&) at /root/doris/be/src/runtime/memory/thread_mem_tracker_mgr.cpp:57
10# doris::ThreadContext::detach_task() at /root/doris/be/src/runtime/thread_context.h:175
11# doris::AttachTask::~AttachTask() at /root/doris/be/src/runtime/thread_context.cpp:61
12# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::Status) at /root/doris/be/src/pipeline/task_scheduler.cpp:95
13# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:186
14# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:551
15# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
16# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
17# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

