### PR TITLE
[Fix](Nereids) fix leading with multi level of brace pairs (#34169)

### DIFF
--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query64.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query64.out
@@ -43,25 +43,25 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF6 cd_demo_sk->[ss_cdemo_sk]
 ----------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
+--------------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF8 RF9 RF10 RF11 RF12 RF16 RF17 RF18 RF19
-----------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
+--------------------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
+----------------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+------------------------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF4 RF6 RF8 RF9 RF10 RF11 RF12 RF16 RF17 RF18 RF19
 ----------------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[c_first_sales_date_sk]
 ----------------------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF7 RF13 RF14
+--------------------------------------------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF5 RF7 RF13 RF14
 ----------------------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+------------------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------------------PhysicalOlapScan[customer_demographics]

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -236,48 +236,45 @@ SyntaxError:
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------PhysicalProject
---------NestedLoopJoin[RIGHT_OUTER_JOIN](c3 > 500)
-----------PhysicalDistribute[DistributionSpecGather]
-------------PhysicalProject
---------------NestedLoopJoin[LEFT_OUTER_JOIN](c1 < 200)(c1 > 500)
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------filter((t2.c2 > 500))
-----------------------PhysicalOlapScan[t2]
-----------PhysicalDistribute[DistributionSpecGather]
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
+------NestedLoopJoin[RIGHT_OUTER_JOIN](c3 > 500)
+--------PhysicalDistribute[DistributionSpecGather]
+----------NestedLoopJoin[LEFT_OUTER_JOIN](c1 < 200)(c1 > 500)
+------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------filter((t2.c2 > 500))
+----------------PhysicalOlapScan[t2]
+--------PhysicalDistribute[DistributionSpecGather]
+----------PhysicalOlapScan[t3]
 
 Hint log:
 Used: leading(t1 t2 t3 )
 UnUsed:
 SyntaxError:
 
--- !select5_1 --
+-- !select6_1 --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------NestedLoopJoin[LEFT_OUTER_JOIN](t3.c3 > 500)
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------NestedLoopJoin[LEFT_OUTER_JOIN](t1.c1 > 500)
-------------------PhysicalProject
---------------------filter((t1.c1 < 200))
-----------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------filter((t2.c2 > 500))
-------------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t6.c6)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t1.c1 = t3.c3) and (t1.c1 = t4.c4) and (t1.c1 = t5.c5)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4) and (t2.c2 = t5.c5) and (t3.c3 = t4.c4) and (t3.c3 = t5.c5)) otherCondition=()
+----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+------------------PhysicalOlapScan[t2]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalOlapScan[t3]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------hashJoin[INNER_JOIN] hashCondition=((t4.c4 = t5.c5)) otherCondition=()
+--------------------PhysicalOlapScan[t4]
+--------------------PhysicalDistribute[DistributionSpecHash]
+----------------------PhysicalOlapScan[t5]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t6]
 
 Hint log:
-Used:
+Used: leading(t1 { { t2 t3 } { t4 t5 } } t6 )
 UnUsed:
-SyntaxError: leading(t1 t2) Msg:leading should have all tables in query block, missing tables: t3 
+SyntaxError:
 

--- a/regression-test/data/nereids_p0/hint/multi_leading.out
+++ b/regression-test/data/nereids_p0/hint/multi_leading.out
@@ -4,42 +4,32 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------filter((t2.c2 > 300))
---------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------filter((cte.c1 > 300))
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+------------filter((t2.c2 > 300))
+--------------PhysicalOlapScan[t2]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------filter((t1.c1 > 300))
-------------------PhysicalOlapScan[t1]
+--------------filter((cte.c1 > 300))
+----------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------filter((t1.c1 > 300))
+--------------PhysicalOlapScan[t1]
 
 -- !sql1_2 --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
-------------PhysicalProject
---------------filter((t1.c1 > 300))
-----------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------filter((t2.c2 > 300))
-----------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------filter((cte.c1 > 300))
-------------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
+----------filter((t1.c1 > 300))
+------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+--------------filter((t2.c2 > 300))
+----------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------filter((cte.c1 > 300))
+------------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(t2 t1 ) leading(t1 cte )
@@ -51,20 +41,15 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
-------------PhysicalProject
---------------filter((t1.c1 > 300))
-----------------PhysicalOlapScan[t1]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------filter((cte.c1 > 300))
---------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------filter((t2.c2 > 300))
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
+----------filter((t1.c1 > 300))
+------------PhysicalOlapScan[t1]
+----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+------------filter((cte.c1 > 300))
+--------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------filter((t2.c2 > 300))
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used: leading(t1 t2 ) leading(t1 cte )
@@ -76,20 +61,15 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
-------------PhysicalProject
---------------filter((t1.c1 > 300))
-----------------PhysicalOlapScan[t1]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------filter((cte.c1 > 300))
---------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------filter((t2.c2 > 300))
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t1.c1)) otherCondition=()
+----------filter((t1.c1 > 300))
+------------PhysicalOlapScan[t1]
+----------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+------------filter((cte.c1 > 300))
+--------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------filter((t2.c2 > 300))
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used: leading(t1 t2 ) leading(t1 cte )
@@ -113,36 +93,26 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 -- !sql2_2 --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used: leading(t3 alias1 )
@@ -154,18 +124,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used: leading(t2 t1 )
@@ -177,18 +142,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(t2 t1 ) leading(t3 alias1 )
@@ -212,56 +172,38 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 -- !sql3_2 --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t3]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t1]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+------------PhysicalOlapScan[t3]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(t2 t1 ) leading(t3 alias1 cte )
@@ -273,28 +215,19 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used: leading(t2 t1 )
@@ -306,28 +239,19 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t3]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = cte.c11)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+------------PhysicalOlapScan[t3]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t2.c2)) otherCondition=()
+----------------PhysicalOlapScan[t2]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((cte.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(t2 t1 ) leading(t2 t1 ) leading(t2 t1 ) leading(t3 alias1 cte )
@@ -351,46 +275,32 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t4]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
+----------------PhysicalOlapScan[t2]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalOlapScan[t4]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 -- !sql4_1 --
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
+------------------PhysicalOlapScan[t2]
 ------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t2]
-------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[t4]
+--------------------PhysicalOlapScan[t4]
 
 Hint log:
 Used: leading(t3 alias1 )
@@ -402,23 +312,16 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t4]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t4]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used: leading(alias2 t1 )
@@ -430,23 +333,16 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t4]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
+----------------PhysicalOlapScan[t4]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used: leading(t4 t2 )
@@ -458,112 +354,21 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t4]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
+--------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
+----------------PhysicalOlapScan[t2]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalOlapScan[t4]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(alias2 t1 ) leading(t3 alias1 )
 UnUsed:
 SyntaxError:
-
--- !sql4_5 --
-PhysicalResultSink
---hashAgg[GLOBAL]
-----PhysicalDistribute[DistributionSpecGather]
-------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = alias2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t4]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
-
-Hint log:
-Used:
-UnUsed: leading(t3 alias1)
-SyntaxError: leading(t4 t2) Msg:one query block can only have one leading clause
-
--- !sql4_6 --
-PhysicalResultSink
---hashAgg[GLOBAL]
-----PhysicalDistribute[DistributionSpecGather]
-------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[t2]
-----------------------PhysicalDistribute[DistributionSpecHash]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t4]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
-
-Hint log:
-Used:
-UnUsed: leading(alias2 t1)
-SyntaxError: leading(t4 t2) Msg:one query block can only have one leading clause
-
--- !sql4_7 --
-PhysicalResultSink
---hashAgg[GLOBAL]
-----PhysicalDistribute[DistributionSpecGather]
-------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((alias1.c1 = alias2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t4.c4)) otherCondition=()
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[t2]
-------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[t4]
-
-Hint log:
-Used: leading(t3 alias1 )
-UnUsed: leading(alias2 t1)
-SyntaxError: leading(t4 t2) Msg:one query block can only have one leading clause
 
 -- !sql4_res_0 --
 6224
@@ -592,55 +397,45 @@ SyntaxError: leading(t4 t2) Msg:one query block can only have one leading clause
 -- !sql5_1 --
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalProject
-------PhysicalOlapScan[t1]
+----PhysicalOlapScan[t1]
 --PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
-------PhysicalProject
---------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > (cast(0.05 as DOUBLE) * avg(c11)))
-----------PhysicalProject
-------------hashAgg[GLOBAL]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------hashAgg[LOCAL]
-------------------PhysicalDistribute[DistributionSpecExecutionAny]
+------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > (cast(0.05 as DOUBLE) * avg(c11)))
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashAgg[LOCAL]
+--------------PhysicalDistribute[DistributionSpecExecutionAny]
+----------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------PhysicalDistribute[DistributionSpecReplicated]
+----------hashAgg[GLOBAL]
+------------PhysicalDistribute[DistributionSpecGather]
+--------------hashAgg[LOCAL]
+----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = cte.c11)) otherCondition=()
+------------------PhysicalOlapScan[t1]
+------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------PhysicalDistribute[DistributionSpecReplicated]
-------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecGather]
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = cte.c11)) otherCondition=()
-------------------------PhysicalOlapScan[t1]
-------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 
 -- !sql5_2 --
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalProject
-------PhysicalOlapScan[t1]
+----PhysicalOlapScan[t1]
 --PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
-------PhysicalProject
---------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > (cast(0.05 as DOUBLE) * avg(c11)))
-----------PhysicalProject
-------------hashAgg[GLOBAL]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------hashAgg[LOCAL]
+------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > (cast(0.05 as DOUBLE) * avg(c11)))
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashAgg[LOCAL]
+--------------PhysicalDistribute[DistributionSpecExecutionAny]
+----------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------PhysicalDistribute[DistributionSpecReplicated]
+----------hashAgg[GLOBAL]
+------------PhysicalDistribute[DistributionSpecGather]
+--------------hashAgg[LOCAL]
+----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = cte.c11)) otherCondition=()
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------PhysicalDistribute[DistributionSpecReplicated]
-------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecGather]
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = cte.c11)) otherCondition=()
-------------------------PhysicalDistribute[DistributionSpecExecutionAny]
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-------------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------------PhysicalOlapScan[t1]
+------------------PhysicalDistribute[DistributionSpecReplicated]
+--------------------PhysicalOlapScan[t1]
 
 Hint log:
 Used: leading(cte t1 )

--- a/regression-test/data/nereids_p0/hint/test_leading.out
+++ b/regression-test/data/nereids_p0/hint/test_leading.out
@@ -2152,13 +2152,10 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t2]
 
 Hint log:
 Used: [broadcast]_2
@@ -2170,19 +2167,14 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used: [broadcast]_2 [shuffle]_3
@@ -2194,19 +2186,14 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used: [broadcast]_2 [shuffle]_3
@@ -2218,18 +2205,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t1 shuffle t2 broadcast t3 )
@@ -2241,18 +2223,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t1 shuffle { t2 broadcast t3 } )
@@ -2264,18 +2241,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:   leading(t1 shuffle { t3 broadcast t2 } )
@@ -2287,18 +2259,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t2 shuffle t1 broadcast t3 )
@@ -2310,17 +2277,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t2 shuffle { t1 broadcast t3 } )
@@ -2332,17 +2295,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t3]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:   leading(t2 shuffle { t3 broadcast t1 } )
@@ -2354,18 +2313,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t1 t2 broadcast t3 )
@@ -2377,18 +2331,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t1 { t2 broadcast t3 } )
@@ -2400,18 +2349,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:  leading(t1 { t3 broadcast t2 } )
@@ -2423,18 +2367,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t2 t1 broadcast t3 )
@@ -2446,17 +2385,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t2 { t1 broadcast t3 } )
@@ -2468,17 +2403,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t3]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:  leading(t2 { t3 broadcast t1 } )
@@ -2490,18 +2421,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t1 shuffle t2 t3 )
@@ -2513,18 +2439,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t1 shuffle { t2 t3 } )
@@ -2536,18 +2457,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+----------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:  leading(t1 shuffle { t3 t2 } )
@@ -2559,18 +2475,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t2 shuffle t1 t3 )
@@ -2582,17 +2493,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t2 shuffle { t1 t3 } )
@@ -2604,17 +2511,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t3]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2) and (t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t3.c3)) otherCondition=()
+--------------PhysicalOlapScan[t3]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:  leading(t2 shuffle { t3 t1 } )
@@ -2626,18 +2529,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
 ------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t1 broadcast t2 t3 )
@@ -2649,18 +2547,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:  leading(t2 broadcast t1 t3 )
@@ -2672,18 +2565,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:  leading(t3 broadcast { t1 t2 } )
@@ -2695,18 +2583,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:  leading(t3 broadcast { t2 t1 } )
@@ -2718,18 +2601,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t1]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t1 shuffle t2 broadcast t3 )
@@ -2741,18 +2619,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t2 shuffle t1 broadcast t3 )
@@ -2764,18 +2637,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:   leading(t3 shuffle { t1 broadcast t2 } )
@@ -2787,18 +2655,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:   leading(t3 shuffle { t2 broadcast t1 } )
@@ -2810,19 +2673,14 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalDistribute[DistributionSpecHash]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecReplicated]
+----------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t1 broadcast t2 shuffle t3 )
@@ -2834,18 +2692,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalOlapScan[t2]
-----------------PhysicalDistribute[DistributionSpecReplicated]
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------PhysicalDistribute[DistributionSpecHash]
---------------PhysicalProject
-----------------PhysicalOlapScan[t3]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+------------PhysicalOlapScan[t2]
+------------PhysicalDistribute[DistributionSpecReplicated]
+--------------PhysicalOlapScan[t1]
+----------PhysicalDistribute[DistributionSpecHash]
+------------PhysicalOlapScan[t3]
 
 Hint log:
 Used:   leading(t2 broadcast t1 shuffle t3 )
@@ -2857,18 +2710,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t1]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t2]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t1]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t2]
 
 Hint log:
 Used:   leading(t3 broadcast { t1 shuffle t2 } )
@@ -2880,18 +2728,13 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----PhysicalDistribute[DistributionSpecGather]
 ------hashAgg[LOCAL]
---------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[t3]
-------------PhysicalDistribute[DistributionSpecReplicated]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
-------------------PhysicalProject
---------------------PhysicalOlapScan[t2]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[t1]
+--------hashJoin[INNER_JOIN] hashCondition=((t2.c2 = t3.c3)) otherCondition=()
+----------PhysicalOlapScan[t3]
+----------PhysicalDistribute[DistributionSpecReplicated]
+------------hashJoin[INNER_JOIN] hashCondition=((t1.c1 = t2.c2)) otherCondition=()
+--------------PhysicalOlapScan[t2]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------PhysicalOlapScan[t1]
 
 Hint log:
 Used:   leading(t3 broadcast { t2 shuffle t1 } )

--- a/regression-test/suites/nereids_p0/hint/fix_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/fix_leading.groovy
@@ -27,6 +27,8 @@ suite("fix_leading") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'
+    sql "set ignore_shape_nodes='PhysicalProject'"
+
 
     // create tables
     sql """drop table if exists t1;"""
@@ -38,6 +40,8 @@ suite("fix_leading") {
     sql """create table t2 (c2 int, c22 int) distributed by hash(c2) buckets 3 properties('replication_num' = '1');"""
     sql """create table t3 (c3 int, c33 int) distributed by hash(c3) buckets 3 properties('replication_num' = '1');"""
     sql """create table t4 (c4 int, c44 int) distributed by hash(c4) buckets 3 properties('replication_num' = '1');"""
+    sql """create table t5 (c5 int, c55 int) distributed by hash(c5) buckets 3 properties('replication_num' = '1');"""
+    sql """create table t6 (c6 int, c66 int) distributed by hash(c6) buckets 3 properties('replication_num' = '1');"""
 
     streamLoad {
         table "t1"
@@ -176,4 +180,8 @@ suite("fix_leading") {
         sql """shape plan select /*+ leading(t1 t2)*/ count(*) from t1 left join t2 on c1 > 500 and c2 >500 right join t3 on c3 > 500 and c1 < 200;"""
         contains("SyntaxError: leading(t1 t2) Msg:leading should have all tables in query block, missing tables: t3")
     }
+
+    // check brace problem
+    qt_select6_1 """explain shape plan select /*+ leading(t1 {{t2 t3}{t4 t5}} t6) */ count(*) from t1 join t2 on c1 = c2 join t3 on c1 = c3 join t4 on c1 = c4 join t5 on c1 = c5 join t6 on c1 = c6;"""
+
 }

--- a/regression-test/suites/nereids_p0/hint/multi_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/multi_leading.groovy
@@ -24,6 +24,7 @@ suite("multi_leading") {
 
     // setting planner to nereids
     sql 'set enable_nereids_planner=true'
+    sql "set ignore_shape_nodes='PhysicalProject'"
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'
 

--- a/regression-test/suites/nereids_p0/hint/test_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_leading.groovy
@@ -25,6 +25,7 @@ suite("test_leading") {
 
     // setting planner to nereids
     sql 'set enable_nereids_planner=true'
+    sql "set ignore_shape_nodes='PhysicalProject'"
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'
 


### PR DESCRIPTION
pick: #34169
fix leading with multi level of brace pairs
example:
leading(t1 {{t2 t3} {t4 t5}} t6) can be reduced to leading(t1 {t2 t3 {t4 t5}} t6) also update cases which remove project node from explain shape plan

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

