### PR TITLE
[Fix](executor)Fix cloud p0 workload policy test failed

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/fe_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/fe_custom.conf
@@ -39,4 +39,5 @@ enable_light_index_change=false
 # For debug
 sys_log_verbose_modules = org.apache.doris.service.FrontendServiceImpl
 
+workload_sched_policy_interval_ms = 1000
 enable_advance_next_id = true


### PR DESCRIPTION
## Proposed changes
```
/ 3 disable test_set_var_policy2
sql "alter workload policy test_set_var_policy2 properties('enabled'='false');"
def result3 = connect(user = 'test_workload_sched_user', password = '12345', url = context.config.jdbcUrl)
{ Thread.sleep(3000) sql "show variables like '%parallel_pipeline_task_num%';" }
assertEquals("parallel_pipeline_task_num", result3[0][0])
assertEquals("33", result3[0][1])
^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^
```
This is because using daemon thread to publish policy, we can only reset the interval in fe.conf