### PR TITLE
[Fix](Nereids) fix leading hint with update of alias name (#34434)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
@@ -216,6 +216,10 @@ public class LeadingHint extends Hint {
                 pair.second = relationIdTableNamePair.second;
                 isUpdate = true;
             }
+            if (pair.second.equals(relationIdTableNamePair.second)) {
+                pair.first = relationIdTableNamePair.first;
+                isUpdate = true;
+            }
         }
         if (!isUpdate) {
             relationIdAndTableName.add(relationIdTableNamePair);

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q15.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q15.out
@@ -5,23 +5,24 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalQuickSort[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=()
-------------PhysicalProject
---------------PhysicalOlapScan[supplier]
+----------hashJoin[INNER_JOIN] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute[DistributionSpecGather]
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------hashAgg[GLOBAL]
-----------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------hashAgg[LOCAL]
---------------------------------PhysicalProject
-----------------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
-------------------------------------PhysicalOlapScan[lineitem]
-------------------PhysicalDistribute[DistributionSpecReplicated]
+----------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=()
+------------------PhysicalProject
+--------------------PhysicalOlapScan[supplier]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------hashAgg[GLOBAL]
+------------------------PhysicalDistribute[DistributionSpecHash]
+--------------------------hashAgg[LOCAL]
+----------------------------PhysicalProject
+------------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
+--------------------------------PhysicalOlapScan[lineitem]
+------------PhysicalDistribute[DistributionSpecHash]
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute[DistributionSpecGather]
+------------------hashAgg[LOCAL]
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalDistribute[DistributionSpecHash]
@@ -31,7 +32,7 @@ PhysicalResultSink
 --------------------------------PhysicalOlapScan[lineitem]
 
 Hint log:
-Used: leading(revenue0 supplier )
+Used: leading(supplier revenue0 )
 UnUsed:
 SyntaxError:
 

--- a/regression-test/suites/nereids_hint_tpch_p0/shape/q15.groovy
+++ b/regression-test/suites/nereids_hint_tpch_p0/shape/q15.groovy
@@ -37,7 +37,7 @@ suite("q15") {
     qt_select """
     explain shape plan
     select 
-    /*+ leading(revenue0 supplier) */
+    /*+ leading(supplier revenue0) */
         s_suppkey,
         s_name,
         s_address,

--- a/regression-test/suites/nereids_p0/hint/fix_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/fix_leading.groovy
@@ -184,4 +184,42 @@ suite("fix_leading") {
     // check brace problem
     qt_select6_1 """explain shape plan select /*+ leading(t1 {{t2 t3}{t4 t5}} t6) */ count(*) from t1 join t2 on c1 = c2 join t3 on c1 = c3 join t4 on c1 = c4 join t5 on c1 = c5 join t6 on c1 = c6;"""
 
+    // check filter in duplicated aliasName
+    explain {
+        sql """shape plan SELECT
+                t1.c2 AS c4
+            FROM
+                (
+                    SELECT
+                        /*+   leading( { tbl2 tbl3 }  tbl1      ) */
+                        tbl3.c3 AS c4,
+                        4 AS c2
+                    FROM
+                        t1 AS tbl1
+                        INNER JOIN t2 AS tbl2 ON tbl2.c2 >= tbl1.c1
+                        OR tbl2.c2 < (5 * 1)
+                        INNER JOIN t3 AS tbl3 ON tbl2.c2 >= tbl2.c2
+                    WHERE
+                        (
+                            tbl1.c1 <> tbl3.c3
+                        )
+                    ORDER BY
+                        2,
+                        4,
+                        1,
+                        3 ASC
+                    LIMIT
+                        5 OFFSET 10
+                ) AS t1
+                INNER JOIN t4 AS tbl2 ON tbl2.c4 != (7 * 1)
+            WHERE
+                NOT (
+                    t1.c2 > tbl2.c4
+                )
+            ORDER BY
+                1 DESC
+            LIMIT
+                5;"""
+        contains("Used: leading({ tbl2 tbl3 } tbl1 )")
+    }
 }


### PR DESCRIPTION
pick: #34434
Problem:
when using leading like leading(tbl1 tbl2) in
"select * from (select tbl1.c1 from t1 as tbl1 join t2 as tbl2) join t3 as tbl2 on tbl2.c3 != 101;", in which tbl2.c3 means t3.c3 but not t2.c3
Causes and solved:
when finding columns in condition, leading hint would find tbl2.c3's RelationId, and when we collect RelationId and aliasName we should update it if aliasName is repeat

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

