### PR TITLE
[refine](pipeline) refine some VDataStreamRecvr code 

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -98,16 +98,13 @@ Status VDataStreamRecvr::SenderQueue::_inner_get_batch_without_lock(Block* block
 
     DCHECK(!_block_queue.empty());
     auto [next_block, block_byte_size] = std::move(_block_queue.front());
-    update_blocks_memory_usage(-block_byte_size);
     _block_queue.pop_front();
+    sub_blocks_memory_usage(block_byte_size);
     _record_debug_info();
     if (_block_queue.empty() && _source_dependency) {
         if (!_is_cancelled && _num_remaining_senders > 0) {
             _source_dependency->block();
         }
-    }
-    if (_local_channel_dependency) {
-        _local_channel_dependency->set_ready();
     }
 
     if (!_pending_closures.empty()) {
@@ -136,9 +133,6 @@ void VDataStreamRecvr::SenderQueue::try_set_dep_ready_without_lock() {
 Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_number,
                                                 int64_t packet_seq,
                                                 ::google::protobuf::Closure** done) {
-    const auto pblock_byte_size = pblock.ByteSizeLong();
-    COUNTER_UPDATE(_recvr->_bytes_received_counter, pblock_byte_size);
-
     {
         std::lock_guard<std::mutex> l(_lock);
         if (_is_cancelled) {
@@ -191,6 +185,7 @@ Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_num
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
     _block_queue.emplace_back(std::move(block), block_byte_size);
+    COUNTER_UPDATE(_recvr->_remote_bytes_received_counter, block_byte_size);
     _record_debug_info();
     try_set_dep_ready_without_lock();
 
@@ -202,7 +197,7 @@ Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_num
         _pending_closures.emplace_back(*done, monotonicStopWatch);
         *done = nullptr;
     }
-    update_blocks_memory_usage(block_byte_size);
+    add_blocks_memory_usage(block_byte_size);
     _data_arrival_cv.notify_one();
     return Status::OK();
 }
@@ -216,7 +211,6 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
         }
     }
 
-    auto block_bytes_received = block->bytes();
     // Has to use unique ptr here, because clone column may failed if allocate memory failed.
     BlockUPtr nblock = Block::create_unique(block->get_columns_with_type_and_name());
 
@@ -236,11 +230,11 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     if (_is_cancelled) {
         return;
     }
-    COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_bytes_received);
     COUNTER_UPDATE(_recvr->_rows_produced_counter, rows);
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
     _block_queue.emplace_back(std::move(nblock), block_mem_size);
+    COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_mem_size);
     _record_debug_info();
     try_set_dep_ready_without_lock();
     _data_arrival_cv.notify_one();
@@ -249,7 +243,7 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     // should be done before the following logic, because the _lock will be released
     // by `iter->second->wait(l)`, after `iter->second->wait(l)` returns, _recvr may
     // have been closed and resouces in _recvr are released;
-    update_blocks_memory_usage(block_mem_size);
+    add_blocks_memory_usage(block_mem_size);
     if (_recvr->exceeds_limit(0)) {
         // yiguolei
         // It is too tricky here, if the running thread is bthread then the tid may be wrong.
@@ -348,7 +342,6 @@ VDataStreamRecvr::VDataStreamRecvr(VDataStreamMgr* stream_mgr, RuntimeState* sta
           _is_merging(is_merging),
           _is_closed(false),
           _profile(profile),
-          _peak_memory_usage_counter(nullptr),
           _enable_pipeline(state->enable_pipeline_x_exec()) {
     // DataStreamRecvr may be destructed after the instance execution thread ends.
     _mem_tracker =
@@ -381,10 +374,9 @@ VDataStreamRecvr::VDataStreamRecvr(VDataStreamMgr* stream_mgr, RuntimeState* sta
 
     // Initialize the counters
     _memory_usage_counter = ADD_LABEL_COUNTER(_profile, "MemoryUsage");
-    _blocks_memory_usage = _profile->AddHighWaterMarkCounter("Blocks", TUnit::BYTES, "MemoryUsage");
     _peak_memory_usage_counter =
-            _profile->AddHighWaterMarkCounter("PeakMemoryUsage", TUnit::BYTES, "MemoryUsage");
-    _bytes_received_counter = ADD_COUNTER(_profile, "BytesReceived", TUnit::BYTES);
+            _profile->add_counter("PeakMemoryUsage", TUnit::BYTES, "MemoryUsage");
+    _remote_bytes_received_counter = ADD_COUNTER(_profile, "RemoteBytesReceived", TUnit::BYTES);
     _local_bytes_received_counter = ADD_COUNTER(_profile, "LocalBytesReceived", TUnit::BYTES);
 
     _deserialize_row_batch_timer = ADD_TIMER(_profile, "DeserializeRowBatchTimer");
@@ -430,7 +422,6 @@ Status VDataStreamRecvr::add_block(const PBlock& pblock, int sender_id, int be_n
 }
 
 void VDataStreamRecvr::add_block(Block* block, int sender_id, bool use_move) {
-    _mem_tracker->consume(block->allocated_bytes());
     int use_sender_id = _is_merging ? sender_id : 0;
     _sender_queues[use_sender_id]->add_block(block, use_move);
 }
@@ -457,7 +448,6 @@ bool VDataStreamRecvr::ready_to_read() {
 
 Status VDataStreamRecvr::get_next(Block* block, bool* eos) {
     _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
-    Defer release_mem([&]() { _mem_tracker->release(block->allocated_bytes()); });
     if (!_is_merging) {
         block->clear();
         return _sender_queues[0]->get_batch(block, eos);
@@ -484,16 +474,24 @@ void VDataStreamRecvr::cancel_stream(Status exec_status) {
     }
 }
 
-void VDataStreamRecvr::SenderQueue::update_blocks_memory_usage(int64_t size) {
-    _recvr->update_blocks_memory_usage(size);
+void VDataStreamRecvr::SenderQueue::add_blocks_memory_usage(int64_t size) {
+    DCHECK(size >= 0);
+    _recvr->_mem_tracker->consume(size);
     if (_local_channel_dependency && _recvr->exceeds_limit(0)) {
         _local_channel_dependency->block();
     }
 }
 
-void VDataStreamRecvr::update_blocks_memory_usage(int64_t size) {
-    _blocks_memory_usage->add(size);
-    _blocks_memory_usage_current_value.fetch_add(size);
+void VDataStreamRecvr::SenderQueue::sub_blocks_memory_usage(int64_t size) {
+    DCHECK(size >= 0);
+    _recvr->_mem_tracker->release(size);
+    if (_local_channel_dependency) {
+        _local_channel_dependency->set_ready();
+    }
+}
+
+bool VDataStreamRecvr::exceeds_limit(int batch_size) {
+    return _mem_tracker->consumption() + batch_size > config::exchg_node_buffer_size_bytes;
 }
 
 void VDataStreamRecvr::close() {
@@ -552,7 +550,7 @@ void VDataStreamRecvr::PipSenderQueue::add_block(Block* block, bool use_move) {
         _record_debug_info();
         try_set_dep_ready_without_lock();
         COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_mem_size);
-        update_blocks_memory_usage(block_mem_size);
+        add_blocks_memory_usage(block_mem_size);
         _data_arrival_cv.notify_one();
     }
 }

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -485,13 +485,13 @@ void VDataStreamRecvr::SenderQueue::add_blocks_memory_usage(int64_t size) {
 void VDataStreamRecvr::SenderQueue::sub_blocks_memory_usage(int64_t size) {
     DCHECK(size >= 0);
     _recvr->_mem_tracker->release(size);
-    if (_local_channel_dependency) {
+    if (_local_channel_dependency && (!_recvr->exceeds_limit(0))) {
         _local_channel_dependency->set_ready();
     }
 }
 
-bool VDataStreamRecvr::exceeds_limit(int batch_size) {
-    return _mem_tracker->consumption() + batch_size > config::exchg_node_buffer_size_bytes;
+bool VDataStreamRecvr::exceeds_limit(size_t block_byte_size) {
+    return _mem_tracker->consumption() + block_byte_size > config::exchg_node_buffer_size_bytes;
 }
 
 void VDataStreamRecvr::close() {

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -110,7 +110,7 @@ public:
     // Careful: stream sender will call this function for a local receiver,
     // accessing members of receiver that are allocated by Object pool
     // in this function is not safe.
-    bool exceeds_limit(int batch_size);
+    bool exceeds_limit(size_t block_byte_size);
     bool is_closed() const { return _is_closed; }
 
     std::shared_ptr<pipeline::Dependency> get_local_channel_dependency(int sender_id);

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -110,17 +110,12 @@ public:
     // Careful: stream sender will call this function for a local receiver,
     // accessing members of receiver that are allocated by Object pool
     // in this function is not safe.
-    bool exceeds_limit(int batch_size) {
-        return _blocks_memory_usage_current_value + batch_size >
-               config::exchg_node_buffer_size_bytes;
-    }
-
+    bool exceeds_limit(int batch_size);
     bool is_closed() const { return _is_closed; }
 
     std::shared_ptr<pipeline::Dependency> get_local_channel_dependency(int sender_id);
 
 private:
-    void update_blocks_memory_usage(int64_t size);
     class PipSenderQueue;
 
     friend struct BlockSupplierSortCursorImpl;
@@ -154,7 +149,7 @@ private:
     ObjectPool _sender_queue_pool;
     RuntimeProfile* _profile = nullptr;
 
-    RuntimeProfile::Counter* _bytes_received_counter = nullptr;
+    RuntimeProfile::Counter* _remote_bytes_received_counter = nullptr;
     RuntimeProfile::Counter* _local_bytes_received_counter = nullptr;
     RuntimeProfile::Counter* _deserialize_row_batch_timer = nullptr;
     RuntimeProfile::Counter* _first_batch_wait_total_timer = nullptr;
@@ -163,8 +158,6 @@ private:
     RuntimeProfile::Counter* _decompress_timer = nullptr;
     RuntimeProfile::Counter* _decompress_bytes = nullptr;
     RuntimeProfile::Counter* _memory_usage_counter = nullptr;
-    RuntimeProfile::HighWaterMarkCounter* _blocks_memory_usage = nullptr;
-    std::atomic<int64_t> _blocks_memory_usage_current_value = 0;
     RuntimeProfile::Counter* _peak_memory_usage_counter = nullptr;
 
     // Number of rows received
@@ -224,7 +217,9 @@ public:
         _source_dependency = dependency;
     }
 
-    void update_blocks_memory_usage(int64_t size);
+    void add_blocks_memory_usage(int64_t size);
+
+    void sub_blocks_memory_usage(int64_t size);
 
 protected:
     friend class pipeline::ExchangeLocalState;


### PR DESCRIPTION
## Proposed changes
The memory statistics in VDataStreamRecvr are disorganized.
We will use _mem_tracker to record peak memory usage and manage the logic.
Rename some counter.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

