### PR TITLE
[opt](parquet-writer) Specify the row group size when writing data to Parquet files.

### DIFF
--- a/be/src/vec/runtime/vparquet_transformer.h
+++ b/be/src/vec/runtime/vparquet_transformer.h
@@ -130,6 +130,7 @@ private:
     const bool _parquet_disable_dictionary;
     const TParquetVersion::type _parquet_version;
     const std::string* _iceberg_schema_json;
+    uint64_t _write_size = 0;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
Previously, each Block data would write a row group every time when data was written to a Parquet file.
Which causing too many row group in a single parquet file. The the reading performance on this kind of file
is very bad.

This PR use Arrow's `WriteRecordBatch` interface, which allows caching data to be written to Parquet.
We can control the size of the row group cache."

Currently, simply accumulate the size of the blocks to determine the cache size.