### PR TITLE
[fix](memory) Avoid frequently refresh cgroup memory info

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -457,7 +457,7 @@ void MemInfo::refresh_proc_meminfo() {
     if (_mem_info_bytes.find("MemAvailable") != _mem_info_bytes.end()) {
         mem_available = _mem_info_bytes["MemAvailable"];
     }
-    status = CGroupUtil::find_cgroup_mem_usage(&cgroup_mem_usage);
+    auto status = CGroupUtil::find_cgroup_mem_usage(&cgroup_mem_usage);
     if (status.ok() && cgroup_mem_usage > 0 && cgroup_mem_limit > 0) {
         if (mem_available < 0) {
             mem_available = cgroup_mem_limit - cgroup_mem_usage;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -211,6 +211,8 @@ public:
 private:
     static bool _s_initialized;
     static std::atomic<int64_t> _s_physical_mem;
+    static int64_t _s_cgroup_mem_limit;
+    static int64_t _s_cgroup_mem_limit_refresh_wait_times;
     static std::atomic<int64_t> _s_mem_limit;
     static std::atomic<int64_t> _s_soft_mem_limit;
 


### PR DESCRIPTION
## Proposed changes

If not enable cgroup, log will frequently print `Could not find subsystem memory in /proc/self/cgroup`.
frequently refresh cgroup information is not necessary.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

