### PR TITLE
[chore](multi catalog) Improve network interface detection in Hive container script

### DIFF
--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -273,8 +273,15 @@ fi
 if [[ "${RUN_KAFKA}" -eq 1 ]]; then
     # kafka
     KAFKA_CONTAINER_ID="${CONTAINER_UID}kafka"
-    eth_num=$(ifconfig -a|grep flags=|grep -n ^eth|awk -F ':' '{print $1}')
-    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
+    for eth_id in {0..9}; do
+        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
+        if [ ! -z "${eth_num}" ]; then
+            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
+            if [ ! -z "${IP_HOST}" ]; then
+                break
+            fi
+        fi
+    done
     cp "${ROOT}"/docker-compose/kafka/kafka.yaml.tpl "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/doris--/${CONTAINER_UID}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/localhost/${IP_HOST}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
@@ -306,8 +313,15 @@ if [[ "${RUN_HIVE2}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    eth0_num=$(ifconfig -a|grep flags=|grep -n ^eth0|awk -F ':' '{print $1}')
-    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth0_num}|head -n 1)
+    for eth_id in {0..9}; do
+        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
+        if [ ! -z "${eth_num}" ]; then
+            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
+            if [ ! -z "${IP_HOST}" ]; then
+                break
+            fi
+        fi
+    done
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1
@@ -332,8 +346,15 @@ if [[ "${RUN_HIVE3}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    eth_num=$(ifconfig -a|grep flags=|grep -n ^eth|awk -F ':' '{print $1}')
-    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
+    for eth_id in {0..9}; do
+        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
+        if [ ! -z "${eth_num}" ]; then
+            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
+            if [ ! -z "${IP_HOST}" ]; then
+                break
+            fi
+        fi
+    done
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -273,8 +273,8 @@ fi
 if [[ "${RUN_KAFKA}" -eq 1 ]]; then
     # kafka
     KAFKA_CONTAINER_ID="${CONTAINER_UID}kafka"
-    eth0_num=$(ifconfig -a|grep flags=|grep -n ^eth0|awk -F ':' '{print $1}')
-    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth0_num}|head -n 1)
+    eth_num=$(ifconfig -a|grep flags=|grep -n ^eth|awk -F ':' '{print $1}')
+    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
     cp "${ROOT}"/docker-compose/kafka/kafka.yaml.tpl "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/doris--/${CONTAINER_UID}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/localhost/${IP_HOST}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
@@ -332,8 +332,8 @@ if [[ "${RUN_HIVE3}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    eth0_num=$(ifconfig -a|grep flags=|grep -n ^eth0|awk -F ':' '{print $1}')
-    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth0_num}|head -n 1)
+    eth_num=$(ifconfig -a|grep flags=|grep -n ^eth|awk -F ':' '{print $1}')
+    IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -273,7 +273,8 @@ fi
 if [[ "${RUN_KAFKA}" -eq 1 ]]; then
     # kafka
     KAFKA_CONTAINER_ID="${CONTAINER_UID}kafka"
-    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
+    eth_name=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|head -n 1)
+    IP_HOST=$(ifconfig "${eth_name}"|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
     cp "${ROOT}"/docker-compose/kafka/kafka.yaml.tpl "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/doris--/${CONTAINER_UID}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/localhost/${IP_HOST}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
@@ -305,7 +306,8 @@ if [[ "${RUN_HIVE2}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
+    eth_name=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|head -n 1)
+    IP_HOST=$(ifconfig "${eth_name}"|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
 
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
@@ -331,7 +333,8 @@ if [[ "${RUN_HIVE3}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
+    eth_name=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|head -n 1)
+    IP_HOST=$(ifconfig "${eth_name}"|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -273,15 +273,7 @@ fi
 if [[ "${RUN_KAFKA}" -eq 1 ]]; then
     # kafka
     KAFKA_CONTAINER_ID="${CONTAINER_UID}kafka"
-    for eth_id in {0..9}; do
-        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
-        if [ ! -z "${eth_num}" ]; then
-            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
-            if [ ! -z "${IP_HOST}" ]; then
-                break
-            fi
-        fi
-    done
+    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
     cp "${ROOT}"/docker-compose/kafka/kafka.yaml.tpl "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/doris--/${CONTAINER_UID}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
     sed -i "s/localhost/${IP_HOST}/g" "${ROOT}"/docker-compose/kafka/kafka.yaml
@@ -313,15 +305,8 @@ if [[ "${RUN_HIVE2}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    for eth_id in {0..9}; do
-        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
-        if [ ! -z "${eth_num}" ]; then
-            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
-            if [ ! -z "${IP_HOST}" ]; then
-                break
-            fi
-        fi
-    done
+    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
+
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1
@@ -346,15 +331,7 @@ if [[ "${RUN_HIVE3}" -eq 1 ]]; then
     # If the doris cluster you need to test is single-node, you can use the default values; If the doris cluster you need to test is composed of multiple nodes, then you need to set the IP_HOST according to the actual situation of your machine
     #default value
     IP_HOST="127.0.0.1"
-    for eth_id in {0..9}; do
-        eth_num=$(ifconfig -a|grep flags=|grep -n ^eth${eth_id}|awk -F ':' '{print $1}')
-        if [ ! -z "${eth_num}" ]; then
-            IP_HOST=$(ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -n +${eth_num}|head -n 1)
-            if [ ! -z "${IP_HOST}" ]; then
-                break
-            fi
-        fi
-    done
+    IP_HOST=$(ifconfig -a|grep -E "^eth[0-9]"|sort -k1.4n|awk -F ':' '{print $1}'|xargs -I {} ifconfig {}|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|head -n 1)
     if [ "_${IP_HOST}" == "_" ];then
         echo "please set IP_HOST according to your actual situation"
         exit -1

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -108,7 +108,7 @@ sk=""
 
 // jdbc connector test config
 // To enable jdbc test, you need first start mysql/pg container.
-// See `docker/thirdparties/start-thirdparties-docker.sh`
+// See `docker/thirdparties/run-thirdparties-docker.sh`
 enableJdbcTest=false
 mysql_57_port=3316
 pg_14_port=5442
@@ -121,7 +121,7 @@ db2_11_port=50000
 
 // hive catalog test config
 // To enable hive/paimon test, you need first start hive container.
-// See `docker/thirdparties/start-thirdparties-docker.sh`
+// See `docker/thirdparties/run-thirdparties-docker.sh`
 enableHiveTest=false
 enablePaimonTest=false
 
@@ -139,12 +139,12 @@ hive3PgPort=5732
 
 // kafka test config
 // to enable kafka test, you need firstly to start kafka container
-// See `docker/thirdparties/start-thirdparties-docker.sh`
+// See `docker/thirdparties/run-thirdparties-docker.sh`
 enableKafkaTest=false
 kafka_port=19193
 
 // elasticsearch catalog test config
-// See `docker/thirdparties/start-thirdparties-docker.sh`
+// See `docker/thirdparties/run-thirdparties-docker.sh`
 enableEsTest=false
 es_5_port=59200
 es_6_port=19200


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Improved the network interface detection logic in the run container script to better support systems with multiple network interfaces (such as eth0, eth1, etc.). 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

