### PR TITLE
[opt](file cache) set failed_if_exists=true when create the cache directory

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -412,7 +412,6 @@ public:
         if (stacktrace && ErrorCode::error_states[abs(code)].stacktrace) {
             // Delete the first one frame pointers, which are inside the status.h
             status._err_msg->_stack = get_stack_trace(1);
-            LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif
         return status;
@@ -431,7 +430,6 @@ public:
 #ifdef ENABLE_STACKTRACE
         if (stacktrace && ErrorCode::error_states[abs(code)].stacktrace) {
             status._err_msg->_stack = get_stack_trace(1);
-            LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif
         return status;

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -118,7 +118,7 @@ Status FSFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
             writer = iter->second.get();
         } else {
             std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-            auto st = fs->create_directory(dir, true);
+            auto st = fs->create_directory(dir, false);
             if (!st.ok() && !st.is<ErrorCode::ALREADY_EXIST>()) {
                 return st;
             }

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -93,17 +93,17 @@ Status LocalFileSystem::open_file_impl(const Path& file, FileReaderSPtr* reader,
 }
 
 Status LocalFileSystem::create_directory_impl(const Path& dir, bool failed_if_exists) {
-    if (failed_if_exists) {
-        bool exists = true;
-        RETURN_IF_ERROR(exists_impl(dir, &exists));
-        if (exists) {
-            return Status::AlreadyExist("failed to create {}, already exists", dir.native());
-        }
+    bool exists = true;
+    RETURN_IF_ERROR(exists_impl(dir, &exists));
+    if (exists && failed_if_exists) {
+        return Status::AlreadyExist("failed to create {}, already exists", dir.native());
     }
-    std::error_code ec;
-    std::filesystem::create_directories(dir, ec);
-    if (ec) {
-        return localfs_error(ec, fmt::format("failed to create {}", dir.native()));
+    if (!exists) {
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        if (ec) {
+            return localfs_error(ec, fmt::format("failed to create {}", dir.native()));
+        }
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

follow up: #34935
There are many segment files for a cache remote file, so the cached directory will create many times. Therefore, we should call `fs->create_directory(dir, failed_if_exists=false)` instead of `fs->create_directory(dir, failed_if_exists=true)`.
When `failed_if_exists=true`, the next line `if (!st.ok() && !st.is<ErrorCode::ALREADY_EXIST>())` try to prevent the `ALREADY_EXIST` errors.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

