### PR TITLE
[BugFix](Replica) fix bug that replica remote data size set to data size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -1137,7 +1137,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             }
 
             replica.updateVersionInfo(reportedTablet.getVersion(), reportedTablet.getDataSize(),
-                    reportedTablet.getDataSize(), reportedTablet.getRowCount());
+                    reportedTablet.getRemoteDataSize(), reportedTablet.getRowCount());
             if (replica.getLastFailedVersion() > partition.getCommittedVersion()
                     && reportedTablet.getVersion() >= partition.getCommittedVersion()
                     //&& !(reportedTablet.isSetVersionMiss() && reportedTablet.isVersionMiss()


### PR DESCRIPTION
## Proposed changes

when finish clone task, the replica's remote data  size will set to data size, it's a bug.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

