### PR TITLE
[BugFix](Replica)fix bug that replica's remote data size set to data size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -1019,7 +1019,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             }
 
             replica.updateVersionInfo(reportedTablet.getVersion(), reportedTablet.getDataSize(),
-                    reportedTablet.getDataSize(), reportedTablet.getRowCount());
+                    reportedTablet.getRemoteDataSize(), reportedTablet.getRowCount());
             if (reportedTablet.isSetPathHash()) {
                 replica.setPathHash(reportedTablet.getPathHash());
             }


### PR DESCRIPTION
## Proposed changes

when finish clone task, the replica's remote data size will set to data size, it's a BUG.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

