### PR TITLE
[Chore](pipeline) remove duplicate method Operator::id()

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -157,7 +157,7 @@ public:
 
     Status reset_hash_table(RuntimeState* state);
 
-    using DataSinkOperatorX<AggSinkLocalState>::id;
+    using DataSinkOperatorX<AggSinkLocalState>::node_id;
     using DataSinkOperatorX<AggSinkLocalState>::operator_id;
     using DataSinkOperatorX<AggSinkLocalState>::get_local_state;
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -109,8 +109,6 @@ public:
 
     [[nodiscard]] bool is_closed() const { return _is_closed; }
 
-    [[nodiscard]] virtual int id() const = 0;
-
     virtual size_t revocable_mem_size(RuntimeState* state) const { return 0; }
 
     virtual Status revoke_memory(RuntimeState* state) { return Status::OK(); };
@@ -493,8 +491,6 @@ public:
         return result.value()->close(state, exec_status);
     }
 
-    [[nodiscard]] int id() const override { return node_id(); }
-
     [[nodiscard]] int operator_id() const { return _operator_id; }
 
     [[nodiscard]] const std::vector<int>& dests_id() const { return _dests_id; }
@@ -707,7 +703,6 @@ public:
     [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
     [[nodiscard]] virtual RowDescriptor& row_descriptor() { return _row_descriptor; }
 
-    [[nodiscard]] int id() const override { return node_id(); }
     [[nodiscard]] int operator_id() const { return _operator_id; }
     [[nodiscard]] int node_id() const { return _node_id; }
 

--- a/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
@@ -226,8 +226,8 @@ Status PartitionedAggSinkLocalState::setup_in_memory_agg_op(RuntimeState* state)
 }
 
 Status PartitionedAggSinkLocalState::revoke_memory(RuntimeState* state) {
-    VLOG_DEBUG << "query " << print_id(state->query_id()) << " agg node " << Base::_parent->id()
-               << " revoke_memory"
+    VLOG_DEBUG << "query " << print_id(state->query_id()) << " agg node "
+               << Base::_parent->node_id() << " revoke_memory"
                << ", eos: " << _eos;
     RETURN_IF_ERROR(Base::_shared_state->sink_status);
     if (!_shared_state->is_spilled) {
@@ -281,13 +281,13 @@ Status PartitionedAggSinkLocalState::revoke_memory(RuntimeState* state) {
                         if (!_shared_state->sink_status.ok()) {
                             LOG(WARNING)
                                     << "query " << print_id(query_id) << " agg node "
-                                    << Base::_parent->id()
+                                    << Base::_parent->node_id()
                                     << " revoke_memory error: " << Base::_shared_state->sink_status;
                         }
                         _shared_state->close();
                     } else {
                         VLOG_DEBUG << "query " << print_id(query_id) << " agg node "
-                                   << Base::_parent->id() << " revoke_memory finish"
+                                   << Base::_parent->node_id() << " revoke_memory finish"
                                    << ", eos: " << _eos;
                     }
 

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
@@ -615,7 +615,7 @@ Status PartitionedHashJoinProbeOperatorX::_setup_internal_operators(
     }
     RETURN_IF_ERROR(_inner_sink_operator->sink(local_state._runtime_state.get(), &block, true));
     VLOG_DEBUG << "query: " << print_id(state->query_id())
-               << ", internal build operator finished, node id: " << id()
+               << ", internal build operator finished, node id: " << node_id()
                << ", task id: " << state->task_id()
                << ", partition: " << local_state._partition_cursor;
     return Status::OK();
@@ -726,7 +726,7 @@ size_t PartitionedHashJoinProbeOperatorX::revocable_mem_size(RuntimeState* state
 
 Status PartitionedHashJoinProbeOperatorX::_revoke_memory(RuntimeState* state) {
     auto& local_state = get_local_state(state);
-    VLOG_DEBUG << "query: " << print_id(state->query_id()) << ", hash probe node: " << id()
+    VLOG_DEBUG << "query: " << print_id(state->query_id()) << ", hash probe node: " << node_id()
                << ", task: " << state->task_id();
 
     RETURN_IF_ERROR(local_state.spill_probe_blocks(state));

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
@@ -186,7 +186,7 @@ Status PartitionedHashJoinProbeLocalState::spill_probe_blocks(RuntimeState* stat
             if (!spilling_stream) {
                 RETURN_IF_ERROR(ExecEnv::GetInstance()->spill_stream_mgr()->register_spill_stream(
                         state, spilling_stream, print_id(state->query_id()), "hash_probe",
-                        _parent->id(), std::numeric_limits<int32_t>::max(),
+                        _parent->node_id(), std::numeric_limits<int32_t>::max(),
                         std::numeric_limits<size_t>::max(), _runtime_profile.get()));
                 RETURN_IF_ERROR(spilling_stream->prepare_spill());
                 spilling_stream->set_write_counters(

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -406,7 +406,7 @@ public:
     }
 
     int64_t get_push_down_count() const { return _push_down_count; }
-    using OperatorX<LocalStateType>::id;
+    using OperatorX<LocalStateType>::node_id;
     using OperatorX<LocalStateType>::operator_id;
     using OperatorX<LocalStateType>::get_local_state;
 

--- a/be/src/pipeline/exec/spill_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.cpp
@@ -199,13 +199,13 @@ Status SpillSortSinkLocalState::revoke_memory(RuntimeState* state) {
         profile()->add_info_string("Spilled", "true");
     }
 
-    VLOG_DEBUG << "query " << print_id(state->query_id()) << " sort node " << Base::_parent->id()
-               << " revoke_memory"
+    VLOG_DEBUG << "query " << print_id(state->query_id()) << " sort node "
+               << Base::_parent->node_id() << " revoke_memory"
                << ", eos: " << _eos;
     RETURN_IF_ERROR(Base::_shared_state->sink_status);
 
     auto status = ExecEnv::GetInstance()->spill_stream_mgr()->register_spill_stream(
-            state, _spilling_stream, print_id(state->query_id()), "sort", _parent->id(),
+            state, _spilling_stream, print_id(state->query_id()), "sort", _parent->node_id(),
             _shared_state->spill_block_batch_row_count,
             SpillSortSharedState::SORT_BLOCK_SPILL_BATCH_BYTES, profile());
     RETURN_IF_ERROR(status);

--- a/be/src/pipeline/exec/spill_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.cpp
@@ -243,12 +243,13 @@ Status SpillSortSinkLocalState::revoke_memory(RuntimeState* state) {
         Defer defer {[&]() {
             if (!_shared_state->sink_status.ok() || state->is_cancelled()) {
                 if (!_shared_state->sink_status.ok()) {
-                    LOG(WARNING) << "query " << print_id(query_id) << " sort node " << _parent->id()
+                    LOG(WARNING) << "query " << print_id(query_id) << " sort node "
+                                 << _parent->node_id()
                                  << " revoke memory error: " << _shared_state->sink_status;
                 }
                 _shared_state->close();
             } else {
-                VLOG_DEBUG << "query " << print_id(query_id) << " sort node " << _parent->id()
+                VLOG_DEBUG << "query " << print_id(query_id) << " sort node " << _parent->node_id()
                            << " revoke memory finish";
             }
 

--- a/be/src/pipeline/exec/spill_sort_sink_operator.h
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.h
@@ -86,7 +86,7 @@ public:
 
     Status revoke_memory(RuntimeState* state) override;
 
-    using DataSinkOperatorX<LocalStateType>::id;
+    using DataSinkOperatorX<LocalStateType>::node_id;
     using DataSinkOperatorX<LocalStateType>::operator_id;
     using DataSinkOperatorX<LocalStateType>::get_local_state;
 

--- a/be/src/pipeline/exec/spill_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_source_operator.cpp
@@ -122,7 +122,7 @@ Status SpillSortLocalState::initiate_merge_sort_spill_streams(RuntimeState* stat
         vectorized::SpillStreamSPtr tmp_stream;
         while (!state->is_cancelled()) {
             int max_stream_count = _calc_spill_blocks_to_merge();
-            VLOG_DEBUG << "query " << print_id(query_id) << " sort node " << _parent->id()
+            VLOG_DEBUG << "query " << print_id(query_id) << " sort node " << _parent->node_id()
                        << " merge spill streams, streams count: "
                        << _shared_state->sorted_streams.size()
                        << ", curren merge max stream count: " << max_stream_count;
@@ -141,7 +141,7 @@ Status SpillSortLocalState::initiate_merge_sort_spill_streams(RuntimeState* stat
 
             {
                 _status = ExecEnv::GetInstance()->spill_stream_mgr()->register_spill_stream(
-                        state, tmp_stream, print_id(state->query_id()), "sort", _parent->id(),
+                        state, tmp_stream, print_id(state->query_id()), "sort", _parent->node_id(),
                         _shared_state->spill_block_batch_row_count,
                         SpillSortSharedState::SORT_BLOCK_SPILL_BATCH_BYTES, profile());
                 RETURN_IF_ERROR(_status);

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -625,7 +625,7 @@ Status PipelineFragmentContext::_create_tree_helper(ObjectPool* pool,
     }
 
     cur_pipe->_name.push_back('-');
-    cur_pipe->_name.append(std::to_string(op->id()));
+    cur_pipe->_name.append(std::to_string(op->node_id()));
     cur_pipe->_name.append(op->get_name());
 
     // rely on that tnodes is preorder of the plan


### PR DESCRIPTION
## Proposed changes
remove duplicate method Operator::id()

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

