### PR TITLE
[profile](Brokerload) Support get broker load profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -252,6 +252,7 @@ public class ExecutionProfile {
     public Status updateProfile(TQueryProfile profile, TNetworkAddress backendHBAddress, boolean isDone) {
         if (isPipelineXProfile) {
             if (!profile.isSetFragmentIdToProfile()) {
+                LOG.warn("FragmentIdToProfile is not set");
                 return new Status(TStatusCode.INVALID_ARGUMENT, "FragmentIdToProfile is not set");
             }
 
@@ -266,6 +267,7 @@ public class ExecutionProfile {
                     RuntimeProfile profileNode = new RuntimeProfile(name);
                     taskProfile.add(profileNode);
                     if (!pipelineProfile.isSetProfile()) {
+                        LOG.warn("Profile is not set");
                         return new Status(TStatusCode.INVALID_ARGUMENT, "Profile is not set");
                     }
 
@@ -278,10 +280,12 @@ public class ExecutionProfile {
             }
         } else {
             if (!profile.isSetInstanceProfiles() || !profile.isSetFragmentInstanceIds()) {
+                LOG.warn("InstanceIdToProfile is not set");
                 return new Status(TStatusCode.INVALID_ARGUMENT, "InstanceIdToProfile is not set");
             }
 
             if (profile.fragment_instance_ids.size() != profile.instance_profiles.size()) {
+                LOG.warn("InstanceIdToProfile size is not equal");
                 return new Status(TStatusCode.INVALID_ARGUMENT, "InstanceIdToProfile size is not equal");
             }
 
@@ -289,6 +293,7 @@ public class ExecutionProfile {
                 TUniqueId instanceId = profile.getFragmentInstanceIds().get(idx);
                 TRuntimeProfileTree instanceProfile = profile.getInstanceProfiles().get(idx);
                 if (instanceProfile == null) {
+                    LOG.warn("Profile is not set");
                     return new Status(TStatusCode.INVALID_ARGUMENT, "Profile is not set");
                 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -250,9 +250,14 @@ public class ExecutionProfile {
     }
 
     public Status updateProfile(TQueryProfile profile, TNetworkAddress backendHBAddress, boolean isDone) {
+        if (!profile.isSetQueryId()) {
+            LOG.warn("QueryId is not set");
+            return new Status(TStatusCode.INVALID_ARGUMENT, "QueryId is not set");
+        }
+
         if (isPipelineXProfile) {
             if (!profile.isSetFragmentIdToProfile()) {
-                LOG.warn("FragmentIdToProfile is not set");
+                LOG.warn("{} FragmentIdToProfile is not set", DebugUtil.printId(profile.getQueryId()));
                 return new Status(TStatusCode.INVALID_ARGUMENT, "FragmentIdToProfile is not set");
             }
 
@@ -267,7 +272,7 @@ public class ExecutionProfile {
                     RuntimeProfile profileNode = new RuntimeProfile(name);
                     taskProfile.add(profileNode);
                     if (!pipelineProfile.isSetProfile()) {
-                        LOG.warn("Profile is not set");
+                        LOG.warn("Profile is not set, {}", DebugUtil.printId(profile.getQueryId()));
                         return new Status(TStatusCode.INVALID_ARGUMENT, "Profile is not set");
                     }
 
@@ -280,12 +285,13 @@ public class ExecutionProfile {
             }
         } else {
             if (!profile.isSetInstanceProfiles() || !profile.isSetFragmentInstanceIds()) {
-                LOG.warn("InstanceIdToProfile is not set");
+                LOG.warn("InstanceIdToProfile is not set, {}", DebugUtil.printId(profile.getQueryId()));
                 return new Status(TStatusCode.INVALID_ARGUMENT, "InstanceIdToProfile is not set");
             }
 
             if (profile.fragment_instance_ids.size() != profile.instance_profiles.size()) {
-                LOG.warn("InstanceIdToProfile size is not equal");
+                LOG.warn("InstanceIdToProfile size is not equal, {}",
+                        DebugUtil.printId(profile.getQueryId()));
                 return new Status(TStatusCode.INVALID_ARGUMENT, "InstanceIdToProfile size is not equal");
             }
 
@@ -293,7 +299,7 @@ public class ExecutionProfile {
                 TUniqueId instanceId = profile.getFragmentInstanceIds().get(idx);
                 TRuntimeProfileTree instanceProfile = profile.getInstanceProfiles().get(idx);
                 if (instanceProfile == null) {
-                    LOG.warn("Profile is not set");
+                    LOG.warn("Profile is not set {}", DebugUtil.printId(profile.getQueryId()));
                     return new Status(TStatusCode.INVALID_ARGUMENT, "Profile is not set");
                 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -134,6 +134,7 @@ public class Profile {
             }
         }
         try {
+            // For load task, they will have multiple execution_profiles.
             for (ExecutionProfile executionProfile : executionProfiles) {
                 builder.append("\n");
                 executionProfile.getRoot().prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -332,7 +332,7 @@ public class ProfileManager {
         class QueryIdAndAddress {
             public TUniqueId queryId;
             public TNetworkAddress beAddress;
-        };
+        }
 
         List<Future<TGetRealtimeExecStatusResponse>> futures = Lists.newArrayList();
         TUniqueId queryId = Util.parseTUniqueIdFromString(id);
@@ -386,7 +386,7 @@ public class ProfileManager {
 
     public String getProfile(String id) {
         List<Future<TGetRealtimeExecStatusResponse>> futures = createFetchRealTimeProfileTasks(id);
-        
+
         // beAddr of reportExecStatus of QeProcessorImpl is meaningless, so assign a dummy address
         // to avoid compile failing.
         TNetworkAddress dummyAddr = new TNetworkAddress();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -354,10 +354,10 @@ public class ProfileManager {
             Long loadJobId = (long) -1;
             try {
                 loadJobId = Long.parseLong(id);
-            } catch(Exception e) {
+            } catch (Exception e) {
                 return futures;
             }
-            
+
             LoadJob loadJob = Env.getCurrentEnv().getLoadManager().getLoadJob(loadJobId);
             if (loadJob.getLoadTaskIds() == null) {
                 return futures;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -238,6 +238,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             this.jobProfile = new Profile("BrokerLoadJob " + id + ". " + label, true,
                     Integer.valueOf(sessionVariables.getOrDefault(SessionVariable.PROFILE_LEVEL, "3")),
                     false);
+            jobProfile.updateSummary(loadStartTimestamp, getSummaryInfo(false), false, null);
         }
         ProgressManager progressManager = Env.getCurrentProgressManager();
         progressManager.registerProgressSimple(String.valueOf(id));
@@ -391,7 +392,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             builder.endTime(TimeUtils.longToTimeString(currentTimestamp));
             builder.totalTime(DebugUtil.getPrettyStringMs(currentTimestamp - createTimestamp));
         }
-        builder.taskState("FINISHED");
+        builder.taskState(isFinished ? "FINISHED" : "RUNNING");
         builder.user(getUserInfo() != null ? getUserInfo().getQualifiedUser() : "N/A");
         builder.defaultDb(getDefaultDb());
         builder.sqlStatement(getOriginStmt().originStmt);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -238,6 +238,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             this.jobProfile = new Profile("BrokerLoadJob " + id + ". " + label, true,
                     Integer.valueOf(sessionVariables.getOrDefault(SessionVariable.PROFILE_LEVEL, "3")),
                     false);
+            // profile is registered in ProfileManager, so that we can get realtime profile
             jobProfile.updateSummary(loadStartTimestamp, getSummaryInfo(false), false, null);
         }
         ProgressManager progressManager = Env.getCurrentProgressManager();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -700,6 +700,22 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         failMsg = loadJobFinalOperation.getFailMsg();
     }
 
+    public List<TUniqueId> getLoadTaskIds() {
+        readLock();
+        try {
+            List<TUniqueId> res = Lists.newArrayList();
+            for (LoadTask task : idToTasks.values()) {
+                if (task instanceof LoadLoadingTask) {
+                    LoadLoadingTask loadLoadingTask = (LoadLoadingTask) task;
+                    res.add(loadLoadingTask.getLoadId());
+                }
+            }
+            return res;
+        } finally {
+            readUnlock();
+        }
+    }
+
     public List<Comparable> getShowInfo() throws DdlException {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -389,6 +389,9 @@ public class Coordinator implements CoordInterface {
         // https://github.com/apache/doris/blob/bd6f5b6a0e5f1b12744607336123d7f97eb76af9/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java#L155
         this.enablePipelineEngine = Config.enable_pipeline_load;
         this.enablePipelineXEngine = Config.enable_pipeline_load;
+        if (this.enablePipelineXEngine) {
+            this.executionProfile.setPipelineX();
+        }
     }
 
     private void setFromUserProperty(ConnectContext connectContext) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -389,6 +389,7 @@ public class Coordinator implements CoordInterface {
         // https://github.com/apache/doris/blob/bd6f5b6a0e5f1b12744607336123d7f97eb76af9/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java#L155
         this.enablePipelineEngine = Config.enable_pipeline_load;
         this.enablePipelineXEngine = Config.enable_pipeline_load;
+        // make sure Coordinator can update profile correctlly
         if (this.enablePipelineXEngine) {
             this.executionProfile.setPipelineX();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -247,7 +247,7 @@ public final class QeProcessorImpl implements QeProcessor {
                 }
             } else {
                 LOG.warn("Invalid report profile req, this is a logical error, BE must set backendId and isDone"
-                            + " at same time, query id: {}" + DebugUtil.printId(params.query_id));
+                            + " at same time, query id: {}", DebugUtil.printId(params.query_id));
             }
         }
 


### PR DESCRIPTION
Profile of broker load can not be collected since its profile structure is different from query. The id of BrokerLoad Profile is a string representation of long type, and its real id used for profile updating should be LoadLoadingTask id.

This pr fixed the above problem.

A known bug is: when broker load is cancelled, its profile state can not  be updated correctly.