### PR TITLE
[Fix](compile) fix master compile failure using gcc

### DIFF
--- a/be/src/util/deletion_vector.h
+++ b/be/src/util/deletion_vector.h
@@ -68,7 +68,7 @@ public:
         roaring::Roaring roaring_bitmap;
         try {
             roaring_bitmap = roaring::Roaring::readSafe(buf, length);
-        } catch (std::runtime_error) {
+        } catch (std::runtime_error&) {
             return ResultError(Status::RuntimeError(
                     "DeletionVector deserialize error: failed to deserialize roaring bitmap"));
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```shell
/root/doris/be/src/util/deletion_vector.h: In static member function 'static doris::Result<doris::DeletionVector> doris::DeletionVector::deserialize(const char*, size_t)':
/root/doris/be/src/util/deletion_vector.h:71:23: error: catching polymorphic type 'class std::runtime_error' by value [-Werror=catch-value=]
71 |         } catch (std::runtime_error) {
   |                       ^~~~~~~~~~~~~
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

