### PR TITLE
[enhance](auth)hive ranger support datamask

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/hive/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/hive/RangerHiveAccessController.java
@@ -25,7 +25,6 @@ import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AuthorizationException;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.datasource.InternalCatalog;
-import org.apache.doris.mysql.privilege.DataMaskPolicy;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 
 import com.google.common.collect.Maps;
@@ -43,7 +42,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -176,12 +174,6 @@ public class RangerHiveAccessController extends RangerAccessController {
     public boolean checkCloudPriv(UserIdentity currentUser, String resourceName,
             PrivPredicate wanted, ResourceTypeEnum type) {
         return false;
-    }
-
-    @Override
-    public Optional<DataMaskPolicy> evalDataMaskPolicy(UserIdentity currentUser, String ctl, String db, String tbl,
-            String col) {
-        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Functions supported by Doris need to be configured through `Custom`, 
otherwise it will throw exception `Can not found function 'xxx'`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

