### PR TITLE
[bugfix](hdfs)support default fsname in processing hash

### DIFF
--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -47,7 +47,11 @@ uint64 hdfs_hash_code(const THdfsParams& hdfs_params, const std::string& fs_name
     // If there is no specified fsname, the default fsname is used
     if (!fs_name.empty()) {
         hash_code ^= Fingerprint(fs_name);
-    } else if (hdfs_params.__isset.user) {
+    } else if (hdfs_params.__isset.fs_name) {
+        hash_code ^= Fingerprint(hdfs_params.fs_name);
+    }
+
+    if (hdfs_params.__isset.user) {
         hash_code ^= Fingerprint(hdfs_params.user);
     }
     if (hdfs_params.__isset.hdfs_kerberos_principal) {


### PR DESCRIPTION
## Proposed changes

When the hash is calculated, if there is no `fsname` specified, use the `fsname` in `hdfs_params`.

follow: #34790

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

