### PR TITLE
[fix](compile) use brew's m4 on MacOS

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -62,6 +62,7 @@ CELLARS=(
     pcre
     maven
     llvm@16
+    m4
 )
 for cellar in "\${CELLARS[@]}"; do
     EXPORT_CELLARS="\${HOMEBREW_REPO_PREFIX}/opt/\${cellar}/bin:\${EXPORT_CELLARS}"


### PR DESCRIPTION
after MacOS 14.4, MacOS remove m4 in CommandLineTools. So use brew's m4 instead of system one

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

