### PR TITLE
[fix](compile) fix compile failed on MacOS due to ambiguous std::abs

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3021,7 +3021,7 @@ StringRef do_money_format(FunctionContext* context, UInt32 scale, T int_value, T
         auto multiplier = common::exp10_i128(std::abs(static_cast<int>(scale - 3)));
         // do devide first to avoid overflow
         // after round frac_value will be positive by design.
-        frac_value = std::abs(frac_value / multiplier) + 5;
+        frac_value = std::abs(static_cast<int>(frac_value / multiplier)) + 5;
         frac_value /= 10;
     } else if (scale < 2) {
         DCHECK(frac_value < 100);
@@ -3062,8 +3062,8 @@ StringRef do_money_format(FunctionContext* context, UInt32 scale, T int_value, T
 
     memcpy(result_data + (append_sign_manually ? 1 : 0), p, integer_str_len);
     *(result_data + whole_decimal_str_len - 3) = '.';
-    *(result_data + whole_decimal_str_len - 2) = '0' + std::abs(frac_value / 10);
-    *(result_data + whole_decimal_str_len - 1) = '0' + std::abs(frac_value % 10);
+    *(result_data + whole_decimal_str_len - 2) = '0' + std::abs(static_cast<int>(frac_value / 10));
+    *(result_data + whole_decimal_str_len - 1) = '0' + std::abs(static_cast<int>(frac_value % 10));
     return result;
 };
 


### PR DESCRIPTION
```
be/src/vec/functions/function_string.h:3066:56: error: call to 'abs' is ambiguous
    *(result_data + whole_decimal_str_len - 1) = '0' + std::abs(frac_value % 10);
                                                       ^~~~~~~~
CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/stdlib.h:132:6: note: candidate function
int      abs(int) __pure2;
         ^
llvm@16/bin/../include/c++/v1/stdlib.h:113:61: note: candidate function
_LIBCPP_NODISCARD_EXT inline _LIBCPP_INLINE_VISIBILITY long abs(long __x) _NOEXCEPT {
                                                            ^
llvm@16/bin/../include/c++/v1/stdlib.h:116:66: note: candidate function
_LIBCPP_NODISCARD_EXT inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {
                                                                 ^
llvm@16/bin/../include/c++/v1/stdlib.h:122:62: note: candidate function
_LIBCPP_NODISCARD_EXT inline _LIBCPP_INLINE_VISIBILITY float abs(float __lcpp_x) _NOEXCEPT {

llvm@16/bin/../include/c++/v1/stdlib.h:126:63: note: candidate function _LIBCPP_NODISCARD_EXT inline _LIBCPP_INLINE_VISIBILITY double abs(double __lcpp_x) _NOEXCEPT {
                                                              ^
llvm@16/bin/../include/c++/v1/stdlib.h:131:1: note: candidate function abs(long double __lcpp_x) _NOEXCEPT {
^
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

