### PR TITLE
[bugfix](stdcallonce) replace std callonce with a lock because it is not exception safe

### DIFF
--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -110,7 +110,10 @@ public:
 
     // Return the stored result. The result is only meaningful when `has_called() == true`.
     ReturnType stored_result() const {
-        std::lock_guard l(_flag_lock);
+        if (!has_called()) {
+            // Could not return status if the method not called.
+            throw std::exception();
+        }
         if (_eptr) {
             std::rethrow_exception(_eptr);
         }
@@ -120,7 +123,7 @@ public:
 private:
     std::atomic<bool> _has_called;
     // std::once_flag _once_flag;
-    mutable std::mutex _flag_lock;
+    std::mutex _flag_lock;
     std::exception_ptr _eptr;
     ReturnType _status;
 };

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -120,7 +120,7 @@ public:
 private:
     std::atomic<bool> _has_called;
     // std::once_flag _once_flag;
-    std::mutex _flag_lock;
+    mutable std::mutex _flag_lock;
     std::exception_ptr _eptr;
     ReturnType _status;
 };

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -96,10 +96,14 @@ public:
             _has_called.store(true, std::memory_order_release);
             std::rethrow_exception(_eptr);
         }
+        // This memory order make sure both status and eptr is set
+        // and will be seen in another thread.
         _has_called.store(true, std::memory_order_release);
         return _status;
     }
 
+    // Has to pay attention to memory order
+    // see https://en.cppreference.com/w/cpp/atomic/memory_order
     // Return whether `call` has been invoked or not.
     bool has_called() const {
         // std::memory_order_acquire here and std::memory_order_release in

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -98,7 +98,7 @@ public:
 
 private:
     std::atomic<bool> _has_called;
-    std::once_flag _once_flag;
+    // std::once_flag _once_flag;
     std::mutex _flag_lock;
     ReturnType _status;
 };

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -87,7 +87,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
                 throw std::runtime_error("runtime error happens");
                 return Status::InternalError("");
             });
-        } catch (const std::runtime_error& error1) {
+        } catch (const std::runtime_error&) {
             // Exception has to throw to the call method
             runtime_occured = true;
         }
@@ -108,7 +108,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
                 throw std::exception("runtime error happens");
                 return Status::InternalError("");
             });
-        } catch (const std::runtime_error& error1) {
+        } catch (const std::runtime_error&) {
             // Exception has to throw to the call method, but not runtime error
             // so that this code will not hit
             runtime_occured = true;

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <time.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <mutext>
+#include <thread>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "util/once.h"
+
+namespace doris {
+class DorisCallOnceTest : public ::testing::Test {};
+
+TEST_F(DorisCallOnceTest, TestNormal) {
+    DorisCallOnce<Status> call1;
+    EXPECT_EQ(call1.has_called(), false);
+
+    call1.call([&]() -> Status { return Status::OK(); });
+    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+
+    call1.call([&]() -> Status { return Status::InternalError(""); });
+    EXPECT_EQ(call1.has_called(), true);
+    // The error code should not changed
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+}
+
+// Test that, if the string contents is shorter than the initial capacity
+// of the faststring, shrink_to_fit() leaves the string in the built-in
+// array.
+TEST_F(DorisCallOnceTest, TestErrorHappens) {
+    DorisCallOnce<Status> call1;
+    EXPECT_EQ(call1.has_called(), false);
+
+    call1.call([&]() -> Status { return Status::InternalError(""); });
+    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+
+    call1.call([&]() -> Status { return Status::OK(); });
+    EXPECT_EQ(call1.has_called(), true);
+    // The error code should not changed
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+}
+
+TEST_F(DorisCallOnceTest, TestExceptionHappens) {
+    DorisCallOnce<Status> call1;
+    EXPECT_EQ(call1.has_called(), false);
+
+    call1.call([&]() -> Status {
+        throw std::exception();
+        return Status::InternalError("");
+    });
+    EXPECT_EQ(call1.has_called(), false);
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+
+    call1.call([&]() -> Status { return Status::InternalError(""); });
+    EXPECT_EQ(call1.has_called(), true);
+    // The error code should not changed
+    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+}
+
+} // namespace doris

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include <cstring>
 #include <memory>
-#include <mutext>
+#include <mutex>
 #include <thread>
 
 #include "common/status.h"

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -66,11 +66,18 @@ TEST_F(DorisCallOnceTest, TestErrorHappens) {
 TEST_F(DorisCallOnceTest, TestExceptionHappens) {
     DorisCallOnce<Status> call1;
     EXPECT_EQ(call1.has_called(), false);
+    bool exception_occured = false;
+    try {
+        call1.call([&]() -> Status {
+            throw std::exception();
+            return Status::InternalError("");
+        });
+    } catch (...) {
+        // Exception has to throw to the call method
+        exception_occured = true;
+    }
 
-    call1.call([&]() -> Status {
-        throw std::exception();
-        return Status::InternalError("");
-    });
+    EXPECT_EQ(exception_occured, true);
     EXPECT_EQ(call1.has_called(), false);
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
 

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -38,12 +38,12 @@ TEST_F(DorisCallOnceTest, TestNormal) {
 
     Status st = call1.call([&]() -> Status { return Status::OK(); });
     EXPECT_EQ(call1.has_called(), true);
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::OK);
 
     st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::OK);
 }
 
 // Test that, if the string contents is shorter than the initial capacity
@@ -55,12 +55,12 @@ TEST_F(DorisCallOnceTest, TestErrorHappens) {
 
     Status st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::INTERNAL_ERROR);
 
     st = call1.call([&]() -> Status { return Status::OK(); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::INTERNAL_ERROR);
 }
 
 TEST_F(DorisCallOnceTest, TestExceptionHappens) {
@@ -79,12 +79,12 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
 
     EXPECT_EQ(exception_occured, true);
     EXPECT_EQ(call1.has_called(), false);
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::OK);
 
     Status st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
-    EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(call1.stored_result().code(), ErrorCode::INTERNAL_ERROR);
 }
 
 } // namespace doris

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -105,7 +105,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
     try {
         try {
             Status st = call1.call([&]() -> Status {
-                throw std::exception("runtime error happens");
+                throw std::exception();
                 return Status::InternalError("");
             });
         } catch (const std::runtime_error&) {

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -36,11 +36,11 @@ TEST_F(DorisCallOnceTest, TestNormal) {
     DorisCallOnce<Status> call1;
     EXPECT_EQ(call1.has_called(), false);
 
-    call1.call([&]() -> Status { return Status::OK(); });
+    Status st = call1.call([&]() -> Status { return Status::OK(); });
     EXPECT_EQ(call1.has_called(), true);
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
 
-    call1.call([&]() -> Status { return Status::InternalError(""); });
+    st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
@@ -53,11 +53,11 @@ TEST_F(DorisCallOnceTest, TestErrorHappens) {
     DorisCallOnce<Status> call1;
     EXPECT_EQ(call1.has_called(), false);
 
-    call1.call([&]() -> Status { return Status::InternalError(""); });
+    Status st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
 
-    call1.call([&]() -> Status { return Status::OK(); });
+    st = call1.call([&]() -> Status { return Status::OK(); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);
@@ -68,7 +68,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
     EXPECT_EQ(call1.has_called(), false);
     bool exception_occured = false;
     try {
-        call1.call([&]() -> Status {
+        Status st = call1.call([&]() -> Status {
             throw std::exception();
             return Status::InternalError("");
         });
@@ -81,7 +81,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
     EXPECT_EQ(call1.has_called(), false);
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::OK);
 
-    call1.call([&]() -> Status { return Status::InternalError(""); });
+    Status st = call1.call([&]() -> Status { return Status::InternalError(""); });
     EXPECT_EQ(call1.has_called(), true);
     // The error code should not changed
     EXPECT_EQ(call1.stored_result().error_code(), ErrorCode::INTERNAL_ERROR);


### PR DESCRIPTION
## Proposed changes

According to cppreference https://en.cppreference.com/w/cpp/thread/call_once. If an exception throws from the call method, the flag is not set and the caller method could catch the exception and handle it.

But I tried with clang16 and gcc11。 And also sometime clang17 will core. The core stack is as follows:

![img_v3_02b3_2eb61bac-8dcd-4de6-aad9-51e6d188f5bg](https://github.com/apache/doris/assets/9208457/6286bdf0-3a47-4630-8b63-4fe5b0e7a9b4)

So that doris should not depend on it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

