### PR TITLE
[fix](mem_tracker) attach mem tracker in FragmentMgr::apply_filter

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1249,6 +1249,7 @@ Status FragmentMgr::apply_filter(const PPublishFilterRequest* request,
 
     std::shared_ptr<PlanFragmentExecutor> fragment_executor;
     std::shared_ptr<pipeline::PipelineFragmentContext> pip_context;
+    QueryThreadContext query_thread_context;
 
     RuntimeFilterMgr* runtime_filter_mgr = nullptr;
     if (is_pipeline) {
@@ -1262,6 +1263,8 @@ Status FragmentMgr::apply_filter(const PPublishFilterRequest* request,
 
         DCHECK(pip_context != nullptr);
         runtime_filter_mgr = pip_context->get_query_ctx()->runtime_filter_mgr();
+        query_thread_context = {pip_context->get_query_ctx()->query_id(),
+                                pip_context->get_query_ctx()->query_mem_tracker};
     } else {
         std::unique_lock<std::mutex> lock(_lock);
         auto iter = _fragment_instance_map.find(tfragment_instance_id);
@@ -1274,8 +1277,11 @@ Status FragmentMgr::apply_filter(const PPublishFilterRequest* request,
         DCHECK(fragment_executor != nullptr);
         runtime_filter_mgr =
                 fragment_executor->runtime_state()->get_query_ctx()->runtime_filter_mgr();
+        query_thread_context = {fragment_executor->get_query_ctx()->query_id(),
+                                fragment_executor->get_query_ctx()->query_mem_tracker};
     }
 
+    SCOPED_ATTACH_TASK(query_thread_context);
     return runtime_filter_mgr->update_filter(request, attach_data);
 }
 


### PR DESCRIPTION
## Proposed changes

```
10:12:38.051641 840137 thread_context.h:200] Check failed: doris::k_doris_exit || !doris::config::enable_memory_orphan_check || thread_mem_tracker()->label() != "Orphan" If you crash here, it means that SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the thread will crash. If you want to switch MemTrackerLimiter during thread execution, please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach. Of course, you can modify enable_memory_orphan_check=false in be.conf to avoid this crash.
*** Check failure stack trace: ***
    @     0x55db1851f67b  Allocator<>::alloc_impl()
    @     0x55db1851f3c7  Allocator<>::alloc()
    @     0x55db1851f3c7  Allocator<>::alloc()
    @     0x55db1851f3c7  Allocator<>::alloc()
    @     0x55db1851f3c7  Allocator<>::alloc()
    @     0x55db02997cd7  doris::vectorized::Allocator_<>::allocate()
    @     0x55db02997cd7  doris::vectorized::Allocator_<>::allocate()
    @     0x55db350bcef6  google::LogMessage::SendToLog()
    @     0x55db02997cd7  doris::vectorized::Allocator_<>::allocate()
.......
    _ZN5phmap4priv17FlatHashSetPolicyIN5doris11DateV2ValueINS2_19DateTimeV2ValueTypeEEEE5applyINS0_12raw_hash_setIS6_NS_4HashIS5_EENS_7EqualToIS5_EENS2_10vectorized10Allocator_IS5_EEE19EmplaceDecomposableEJRKS5_EEEDTclsr5phmap4privE14DecomposeValueclsr3stdE7declvalIT_EEspclsr3stdE7declvalIT0_EEEEOSK_DpOSL_
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007FB340283090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x000055DB350C76AD in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 5# 0x000055DB350B9E0A in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 9# doris::ThreadContext::consume_memory(long) const in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
10# Allocator<true, false, false>::consume_memory(unsigned long) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.cpp:172
11# Allocator<true, false, false>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.h:100
12# Allocator<true, false, false>::alloc(unsigned long, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/allocator.cpp:197
13# doris::vectorized::Allocator_<phmap::priv::Allocate<4ul, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >(doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> >*, unsigned long)::M>::allocate(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/hash_table/phmap_fwd_decl.h:39
14# phmap::allocator_traits<doris::vectorized::Allocator_<phmap::priv::Allocate<4ul, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >(doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> >*, unsigned long)::M> >::allocate(doris::vectorized::Allocator_<phmap::priv::Allocate<4ul, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >(doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> >*, unsigned long)::M>&, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap_base.h:1468
15# void* phmap::priv::Allocate<4ul, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >(doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> >*, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap_base.h:4356
16# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::initialize_slots(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1983
17# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::resize(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2014
18# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::rehash_and_grow_if_necessary() at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2102
19# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::prepare_insert(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2198
20# std::pair<unsigned long, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::find_or_prepare_insert<doris::DateV2Value<doris::DateV2ValueType> >(doris::DateV2Value<doris::DateV2ValueType> const&, unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2186
21# std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::emplace_decomposable<doris::DateV2Value<doris::DateV2ValueType>, doris::DateV2Value<doris::DateV2ValueType> const&>(doris::DateV2Value<doris::DateV2ValueType> const&, unsigned long, doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1887
22# std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable::operator()<doris::DateV2Value<doris::DateV2ValueType>, doris::DateV2Value<doris::DateV2ValueType> const&>(doris::DateV2Value<doris::DateV2ValueType> const&, doris::DateV2Value<doris::DateV2ValueType> const&) const at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1898
23# decltype ((std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable>())(std::declval<doris::DateV2Value<doris::DateV2ValueType> const& const&>(), std::declval<doris::DateV2Value<doris::DateV2ValueType> const&>())) phmap::priv::DecomposeValue<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable, doris::DateV2Value<doris::DateV2ValueType> const&>(phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable&&, doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:4129
24# decltype (phmap::priv::DecomposeValue(std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable>(), std::declval<doris::DateV2Value<doris::DateV2ValueType> const&>())) phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable, doris::DateV2Value<doris::DateV2ValueType> const&>(phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable&&, doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:4184
25# decltype (phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >::apply(std::forward<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable>({parm#1}), std::forward<doris::DateV2Value<doris::DateV2ValueType> const&>({parm#2}))) phmap::priv::hash_policy_traits<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, void>::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable, doris::DateV2Value<doris::DateV2ValueType> const&, phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> > >(phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::EmplaceDecomposable&&, doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap_base.h:548
26# std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::emplace<doris::DateV2Value<doris::DateV2ValueType> const&, 0>(doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1438
27# std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<doris::DateV2Value<doris::DateV2ValueType> >, phmap::Hash<doris::DateV2Value<doris::DateV2ValueType> >, phmap::EqualTo<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::Allocator_<doris::DateV2Value<doris::DateV2ValueType> > >::insert<doris::DateV2Value<doris::DateV2ValueType>, 0, 0>(doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1319
28# doris::DynamicContainer<doris::DateV2Value<doris::DateV2ValueType> >::insert(doris::DateV2Value<doris::DateV2ValueType> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/hybrid_set.h:161
29# doris::HybridSet<(doris::PrimitiveType)25, doris::DynamicContainer<doris::DateV2Value<doris::DateV2ValueType> >, doris::vectorized::ColumnVector<unsigned int> >::insert(void const*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/hybrid_set.h:283
30# doris::RuntimePredicateWrapper::assign(doris::PInFilter const*, bool)::{lambda(std::shared_ptr<doris::HybridSetBase>&, doris::PColumnValue&, doris::ObjectPool*)#9}::operator()(std::shared_ptr<doris::HybridSetBase>&, doris::PColumnValue&, doris::ObjectPool*) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:636
31# doris::RuntimePredicateWrapper::assign(doris::PInFilter const*, bool)::{lambda(std::shared_ptr<doris::HybridSetBase>&, doris::PColumnValue&, doris::ObjectPool*)#9}::__invoke(std::shared_ptr<doris::HybridSetBase>&, doris::PColumnValue&, doris::ObjectPool*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:633
32# doris::RuntimePredicateWrapper::batch_assign(doris::PInFilter const*, void (*)(std::shared_ptr<doris::HybridSetBase>&, doris::PColumnValue&, doris::ObjectPool*)) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:917
33# doris::RuntimePredicateWrapper::assign(doris::PInFilter const*, bool) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:633
34# doris::Status doris::IRuntimeFilter::_create_wrapper<doris::UpdateRuntimeFilterParams>(doris::UpdateRuntimeFilterParams const*, doris::ObjectPool*, std::unique_ptr<doris::RuntimePredicateWrapper, std::default_delete<doris::RuntimePredicateWrapper> >*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:1492
35# doris::IRuntimeFilter::create_wrapper(doris::UpdateRuntimeFilterParams const*, doris::ObjectPool*, std::unique_ptr<doris::RuntimePredicateWrapper, std::default_delete<doris::RuntimePredicateWrapper> >*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:1425
36# doris::IRuntimeFilter::update_filter(doris::UpdateRuntimeFilterParams const*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/exprs/runtime_filter.cpp:1834
37# doris::RuntimeFilterMgr::update_filter(doris::PPublishFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/runtime_filter_mgr.cpp:214
38# doris::FragmentMgr::apply_filter(doris::PPublishFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:1343
39# doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0::operator()() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/internal_service.cpp:1348
40# void std::__invoke_impl<void, doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0&>(std::__invoke_other, doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
41# std::enable_if<is_invocable_r_v<void, doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0&>, void>::type std::__invoke_r<void, doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0&>(doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
42# std::_Function_handler<void (), doris::PInternalServiceImpl::apply_filter(google::protobuf::RpcController*, doris::PPublishFilterRequest const*, doris::PPublishFilterResponse*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
43# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
44# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:158
45# void std::__invoke_impl<void, void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&>(std::__invoke_memfun_deref, void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
46# std::__invoke_result<void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&>::type std::__invoke<void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&>(void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
47# decltype (std::__invoke((*this)._M_pmf, std::forward<doris::WorkThreadPool<false>*&>({parm#1}), std::forward<int&>({parm#1}))) std::_Mem_fn_base<void (doris::WorkThreadPool<false>::*)(int), true>::operator()<doris::WorkThreadPool<false>*&, int&>(doris::WorkThreadPool<false>*&, int&) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:131
48# void std::__invoke_impl<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)>&, doris::WorkThreadPool<false>*&, int&>(std::__invoke_other, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)>&, doris::WorkThreadPool<false>*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
49# std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)>&, doris::WorkThreadPool<false>*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)>&, doris::WorkThreadPool<false>*&, int&>(std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)>&, doris::WorkThreadPool<false>*&, int&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
50# void std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
51# void std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>::operator()<>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
52# void std::__invoke_impl<void, std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>>(std::__invoke_other, std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
53# std::__invoke_result<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>>::type std::__invoke<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>>(std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
54# void std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253
55# std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)> > >::operator()() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260
56# std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::WorkThreadPool<false>::*)(int)> (doris::WorkThreadPool<false>*, int)> > > >::_M_run() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211
57# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
58# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
59# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

