### PR TITLE
[enhance](mtmv)generate bidirectional mapping between base table and materialized view partitions

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
@@ -17,18 +17,33 @@
 
 package org.apache.doris.mtmv;
 
+import org.apache.doris.analysis.PartitionKeyDesc;
+import org.apache.doris.analysis.PartitionValue;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.PartitionItem;
+import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.RangePartitionItem;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.job.common.IntervalUnit;
 import org.apache.doris.job.extensions.mtmv.MTMVTask;
 import org.apache.doris.mtmv.MTMVRefreshEnum.BuildMode;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshMethod;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshTrigger;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 public class MTMVTest {
     @Test
@@ -82,5 +97,51 @@ public class MTMVTest {
         MTMVTask task = new MTMVTask(mtmv, null, null);
         task.setTaskId(1L);
         return task;
+    }
+
+    @Test
+    public void testCalculateDoublyPartitionMappings() throws AnalysisException {
+        Map<String, Set<String>> mvToBase = Maps.newHashMap();
+        Map<String, String> baseToMv = Maps.newHashMap();
+        Map<PartitionKeyDesc, Set<String>> relatedPartitionDescs = mockRelatedPartitionDescs();
+        Map<String, PartitionItem> mvPartitionItems = mockMvPartitionItems();
+        for (Entry<String, PartitionItem> entry : mvPartitionItems.entrySet()) {
+            Set<String> basePartitionNames = relatedPartitionDescs.getOrDefault(entry.getValue().toPartitionKeyDesc(),
+                    Sets.newHashSet());
+            String mvPartitionName = entry.getKey();
+            mvToBase.put(mvPartitionName, basePartitionNames);
+            for (String basePartitionName : basePartitionNames) {
+                baseToMv.put(basePartitionName, mvPartitionName);
+            }
+        }
+        Assert.assertEquals(mvToBase.get("mvp1"), Sets.newHashSet("baseP1_1", "baseP1_2"));
+        Assert.assertEquals(baseToMv.get("baseP1_1"), "mvp1");
+        Assert.assertEquals(baseToMv.get("baseP1_2"), "mvp1");
+    }
+
+    private Map<PartitionKeyDesc, Set<String>> mockRelatedPartitionDescs() throws AnalysisException {
+        Map<PartitionKeyDesc, Set<String>> res = Maps.newHashMap();
+        Column k1 = new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", "key1");
+        PartitionKey rangeP1Lower = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")),
+                Lists.newArrayList(k1));
+        PartitionKey rangeP1Upper = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("10")),
+                Lists.newArrayList(k1));
+        Range<PartitionKey> rangeP1 = Range.closedOpen(rangeP1Lower, rangeP1Upper);
+        PartitionItem item1 = new RangePartitionItem(rangeP1);
+        res.put(item1.toPartitionKeyDesc(), Sets.newHashSet("baseP1_1", "baseP1_2"));
+        return res;
+    }
+
+    private Map<String, PartitionItem> mockMvPartitionItems() throws AnalysisException {
+        Map<String, PartitionItem> res = Maps.newHashMap();
+        Column k1 = new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", "key1");
+        PartitionKey rangeP1Lower = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")),
+                Lists.newArrayList(k1));
+        PartitionKey rangeP1Upper = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("10")),
+                Lists.newArrayList(k1));
+        Range<PartitionKey> rangeP1 = Range.closedOpen(rangeP1Lower, rangeP1Upper);
+        PartitionItem item1 = new RangePartitionItem(rangeP1);
+        res.put("mvp1", item1);
+        return res;
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

MTMV.calculateDoublyPartitionMappings();

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

