### PR TITLE
[fix](routine-load) fix data source properties do not persist in edit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/AbstractDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/AbstractDataSourceProperties.java
@@ -43,6 +43,7 @@ public abstract class AbstractDataSourceProperties {
      * and this is only a temporary parameter and will be of no use after convert ends
      */
     @Getter
+    @SerializedName(value = "originalDataSourceProperties")
     protected Map<String, String> originalDataSourceProperties;
 
     @SerializedName(value = "type")


### PR DESCRIPTION
## Proposed changes

Data source properties do not persist in edit log will affect the alter command and fail to take effect in the following two scenarios:

1. FE leader change result in the loss of values changed by the alter command.
- Progress is {"0":"39"}
-  use `ALTER ROUTINE LOAD FOR lineitem FROM kafka (     "kafka_partitions" = "0",     "kafka_offsets" = "100");` to alter progress
- fe down and leader change.
- kafka offsets is the value before the alter change. which is {"0":"39"}, except is {"0":"99"}

2. Restarting FE may also result in the loss of values changed by the alter command.
