### PR TITLE
[refactor](move-memtable) remove IndexStream in LoadStream

### DIFF
--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -482,8 +482,6 @@ public:
             return Status::OK();
         }
 
-        Status close() { return Status::OK(); }
-
     private:
         brpc::StreamId _stream;
         brpc::Controller _cntl;


### PR DESCRIPTION
## Proposed changes

`tablet_id` is the unique identifier of a TabletStream.
IndexStream is unnecessary in LoadStream, remove it to simplify code.
Also refactor the close logic of LoadStream, and add some timer logs. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

