### PR TITLE
[feat](nereids)print physical plan in profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.profile;
 
 import org.apache.doris.common.util.ProfileManager;
 import org.apache.doris.common.util.RuntimeProfile;
+import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.planner.Planner;
 
 import com.google.common.collect.Lists;
@@ -95,6 +96,11 @@ public class Profile {
         try {
             if (this.isFinished) {
                 return;
+            }
+            if (planner instanceof NereidsPlanner) {
+                summaryInfo.put(SummaryProfile.PHYSICAL_PLAN,
+                        ((NereidsPlanner) planner).getPhysicalPlan()
+                                .treeString().replace("\n", "\n     "));
             }
             summaryProfile.update(summaryInfo);
             for (ExecutionProfile executionProfile : executionProfiles) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -54,7 +54,7 @@ public class SummaryProfile {
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE = "Parallel Fragment Exec Instance Num";
     public static final String TRACE_ID = "Trace ID";
     public static final String WORKLOAD_GROUP = "Workload Group";
-
+    public static final String PHYSICAL_PLAN = "Physical Plan";
     // Execution Summary
     public static final String EXECUTION_SUMMARY_PROFILE_NAME = "Execution Summary";
     public static final String ANALYSIS_TIME = "Analysis Time";
@@ -105,8 +105,12 @@ public class SummaryProfile {
     // These info will display on FE's web ui table, every one will be displayed as
     // a column, so that should not
     // add many columns here. Add to ExecutionSummary list.
-    public static final ImmutableList<String> SUMMARY_KEYS = ImmutableList.of(PROFILE_ID, TASK_TYPE,
+    public static final ImmutableList<String> SUMMARY_CAPTIONS = ImmutableList.of(PROFILE_ID, TASK_TYPE,
             START_TIME, END_TIME, TOTAL_TIME, TASK_STATE, USER, DEFAULT_DB, SQL_STATEMENT);
+    public static final ImmutableList<String> SUMMARY_KEYS = new ImmutableList.Builder<String>()
+            .addAll(SUMMARY_CAPTIONS)
+            .add(PHYSICAL_PLAN)
+            .build();
 
     // The display order of execution summary items.
     public static final ImmutableList<String> EXECUTION_SUMMARY_KEYS = ImmutableList.of(
@@ -284,7 +288,7 @@ public class SummaryProfile {
 
     public Map<String, String> getAsInfoStings() {
         Map<String, String> infoStrings = Maps.newHashMap();
-        for (String header : SummaryProfile.SUMMARY_KEYS) {
+        for (String header : SummaryProfile.SUMMARY_CAPTIONS) {
             infoStrings.put(header, summaryProfile.getInfoString(header));
         }
         return infoStrings;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -69,7 +69,7 @@ public class QueryProfileController extends BaseController {
     private void addFinishedQueryInfo(Map<String, Object> result) {
         List<List<String>> finishedQueries = ProfileManager.getInstance().getAllQueries();
         List<String> columnHeaders = Lists.newLinkedList();
-        columnHeaders.addAll(SummaryProfile.SUMMARY_KEYS);
+        columnHeaders.addAll(SummaryProfile.SUMMARY_CAPTIONS);
 
         result.put("column_names", columnHeaders);
         // The first column is profile id, which is also a href column
@@ -79,7 +79,7 @@ public class QueryProfileController extends BaseController {
 
         for (List<String> row : finishedQueries) {
             Map<String, Object> rowMap = new HashMap<>();
-            for (int i = 0; i < row.size(); ++i) {
+            for (int i = 0; i < columnHeaders.size(); ++i) {
                 rowMap.put(columnHeaders.get(i), row.get(i));
             }
 


### PR DESCRIPTION
## Proposed changes
print physical plan in profile summary
```
Summary:
   - Profile ID: f3c4842af5f64dd6-a2b4cd00e16e596f
   - Task Type: QUERY
   - Start Time: 2024-05-21 18:38:32
   - End Time: 2024-05-21 18:38:32
   - Total: 70ms
   - Task State: EOF
   - User: root
   - Default Db: tpch_sf1
   - Sql Statement: select * from region
   - Physical Plan: PhysicalResultSink[54] ( outputExprs=[r_regionkey#0, r_name#1, r_comment#2] )
     +--PhysicalDistribute[51]@0 ( stats=5, distributionSpec=DistributionSpecGather )
        +--PhysicalOlapScan[region]@0 ( stats=5 )
```
![image](https://github.com/apache/doris/assets/1747806/8eaa2b0d-c522-4153-b602-859d38d1d8bb)

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

