### PR TITLE
[Fix](bug) agg limit contains null values may cause error result

### DIFF
--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -136,6 +136,14 @@ struct HashMethodSingleLowNullableColumn : public SingleColumnMethod {
         data.lazy_emplace(std::forward<KeyHolder>(key), it, hash_value, std::forward<Func>(f));
         return *lookup_result_get_mapped(it);
     }
+
+    template <typename Data, typename Key>
+    ALWAYS_INLINE FindResult find_key_with_hash(Data& data, size_t i, Key key, size_t hash_value) {
+        if (key_column->is_null_at(i) && data.has_null_key_data()) {
+            return FindResult {&data.template get_null_key_data<Mapped>(), true};
+        }
+        return Base::find_key_impl(key, hash_value, data);
+    }
 };
 
 } // namespace ColumnsHashing

--- a/be/src/vec/common/columns_hashing_impl.h
+++ b/be/src/vec/common/columns_hashing_impl.h
@@ -89,7 +89,7 @@ public:
     }
 
     template <typename Data, typename Key>
-    ALWAYS_INLINE FindResult find_key_with_hash(Data& data, size_t hash_value, Key key) {
+    ALWAYS_INLINE FindResult find_key_with_hash(Data& data, size_t i, Key key, size_t hash_value) {
         return find_key_impl(key, hash_value, data);
     }
 

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -125,7 +125,7 @@ struct MethodBaseInner {
         if constexpr (!is_string_hash_map()) {
             prefetch<true>(i);
         }
-        return state.find_key_with_hash(*hash_table, hash_values[i], keys[i]);
+        return state.find_key_with_hash(*hash_table, i, keys[i], hash_values[i]);
     }
 
     template <typename State, typename F, typename FF>

--- a/regression-test/data/query_p0/aggregate/aggregate.out
+++ b/regression-test/data/query_p0/aggregate/aggregate.out
@@ -695,3 +695,5 @@ TESTING	AGAIN
 -- !subquery_without_inner_predicate --
 7
 
+-- !aggregate_limit_contain_null --
+16	\N

--- a/regression-test/suites/query_p0/aggregate/aggregate.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate.groovy
@@ -304,4 +304,8 @@ suite("aggregate") {
     qt_subquery_without_inner_predicate """
         select count(*) from (select t2.c_bigint, t2.c_double, t2.c_string from (select c_bigint, c_double, c_string, c_date,c_timestamp, c_short_decimal from regression_test_query_p0_aggregate.${tableName} where c_bigint > 5000) t2)t1
     """
+
+    qt_aggregate_limit_contain_null """
+    select count(), cast(k12 as int) as t from baseall group by t limit 1;
+	"""
 }


### PR DESCRIPTION
## Proposed changes

before：
```
mysql [test_query_db]>set parallel_pipeline_task_num = 1;                                                                                                                                     Query OK, 0 rows affected (0.00 sec)

mysql [test_query_db]>select count(), cast(k12 as int) as t from baseall group by t limit 1;
+----------+------+
| count(*) | t    |
+----------+------+
|       16 | NULL |
+----------+------+
1 row in set (0.01 sec)

mysql [test_query_db]>set parallel_pipeline_task_num = 2;
Query OK, 0 rows affected (0.01 sec)

mysql [test_query_db]>select count(), cast(k12 as int) as t from baseall group by t limit 1;
+----------+------+
| count(*) | t    |
+----------+------+
|        7 | NULL |
+----------+------+
1 row in set (0.01 sec)

```

after:
```
mysql [test_query_db]>set parallel_pipeline_task_num = 2;
Query OK, 0 rows affected (0.01 sec)

mysql [test_query_db]>select count(), cast(k12 as int) as t from baseall group by t limit 1;
+----------+------+
| count(*) | t    |
+----------+------+
|        16 | NULL |
+----------+------+
1 row in set (0.01 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

