### PR TITLE
[fix](Nereids) DatetimeV2 round floor was incorrectly implemented as round ceil

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -180,7 +180,7 @@ public class DateTimeV2Literal extends DateTimeLiteral {
         long newYear = year;
         if (remain != 0) {
             newMicroSecond = Double
-                    .valueOf((microSecond + (Math.pow(10, 6 - newScale)))
+                    .valueOf((microSecond + (int) (Math.pow(10, 6 - newScale)))
                             / (int) (Math.pow(10, 6 - newScale)) * (Math.pow(10, 6 - newScale)))
                     .longValue();
         }
@@ -199,8 +199,8 @@ public class DateTimeV2Literal extends DateTimeLiteral {
     }
 
     public DateTimeV2Literal roundFloor(int newScale) {
-        // use roundMicroSecond in constructor
-        return new DateTimeV2Literal(DateTimeV2Type.of(newScale), year, month, day, hour, minute, second, microSecond);
+        return new DateTimeV2Literal(DateTimeV2Type.of(newScale), year, month, day, hour, minute, second,
+                microSecond / (int) Math.pow(10, 6 - newScale) * (int) Math.pow(10, 6 - newScale));
     }
 
     public static Expression fromJavaDateType(LocalDateTime dateTime) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateSqlTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateSqlTest.java
@@ -66,7 +66,7 @@ class SimplifyComparisonPredicateSqlTest extends TestWithFeService implements Me
                 .rewrite()
                 .matches(
                         logicalFilter()
-                                .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(a <= '2023-06-16 00:00:00')")))
+                                .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(a <= '2023-06-15 23:59:59')")))
                                 .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(b <= 111.11)")))
                 );
 
@@ -82,7 +82,7 @@ class SimplifyComparisonPredicateSqlTest extends TestWithFeService implements Me
                 .rewrite()
                 .matches(
                         logicalFilter()
-                                .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(a > '2023-06-16 00:00:00')")))
+                                .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(a > '2023-06-15 23:59:59')")))
                                 .when(f -> f.getConjuncts().stream().anyMatch(e -> e.toSql().equals("(b > 111.11)")))
                 );
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -120,7 +120,7 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
         Expression rewrittenExpression = executor.rewrite(typeCoercion(expression), context);
 
         // right should round to be 2021-01-02 00:00:00.00
-        Assertions.assertEquals(new DateTimeV2Literal("2021-01-02 00:00:00"), rewrittenExpression.child(1));
+        Assertions.assertEquals(new DateTimeV2Literal("2021-01-01 23:59:59.9"), rewrittenExpression.child(1));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -453,5 +453,36 @@ class DateTimeLiteralTest {
                 new DateTimeV2Literal(DateTimeV2Type.of(5), "2016-12-31 23:59:59.999999"),
                 new DateTimeV2Literal("2017-01-01 00:00:00.0"));
     }
-}
 
+    @Test
+    void testRoundFloor() {
+        DateTimeV2Literal literal;
+        literal = new DateTimeV2Literal(DateTimeV2Type.of(6), 2000, 2, 2, 2, 2, 2, 222222);
+        Assertions.assertEquals(222222, literal.roundFloor(6).microSecond);
+        Assertions.assertEquals(222220, literal.roundFloor(5).microSecond);
+        Assertions.assertEquals(222200, literal.roundFloor(4).microSecond);
+        Assertions.assertEquals(222000, literal.roundFloor(3).microSecond);
+        Assertions.assertEquals(220000, literal.roundFloor(2).microSecond);
+        Assertions.assertEquals(200000, literal.roundFloor(1).microSecond);
+        Assertions.assertEquals(0, literal.roundFloor(0).microSecond);
+    }
+
+    @Test
+    void testRoundCeiling() {
+        DateTimeV2Literal literal;
+        literal = new DateTimeV2Literal(DateTimeV2Type.of(6), 2000, 12, 31, 23, 59, 59, 888888);
+        Assertions.assertEquals(888888, literal.roundCeiling(6).microSecond);
+        Assertions.assertEquals(888890, literal.roundCeiling(5).microSecond);
+        Assertions.assertEquals(888900, literal.roundCeiling(4).microSecond);
+        Assertions.assertEquals(889000, literal.roundCeiling(3).microSecond);
+        Assertions.assertEquals(890000, literal.roundCeiling(2).microSecond);
+        Assertions.assertEquals(900000, literal.roundCeiling(1).microSecond);
+        Assertions.assertEquals(0, literal.roundCeiling(0).microSecond);
+        Assertions.assertEquals(0, literal.roundCeiling(0).second);
+        Assertions.assertEquals(0, literal.roundCeiling(0).minute);
+        Assertions.assertEquals(0, literal.roundCeiling(0).hour);
+        Assertions.assertEquals(1, literal.roundCeiling(0).day);
+        Assertions.assertEquals(1, literal.roundCeiling(0).month);
+        Assertions.assertEquals(2001, literal.roundCeiling(0).year);
+    }
+}


### PR DESCRIPTION
pick from master #35153