### PR TITLE
[Fix](parquet-reader) Fix Timestamp Int96 min-max statistics is incorrect when was written by some old parquet writers by disable it.

### DIFF
--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -256,6 +256,17 @@ private:
                 ParquetInt96 datetime96_max =
                         *reinterpret_cast<const ParquetInt96*>(encoded_max.data());
                 int64_t micros_max = datetime96_max.to_timestamp_micros();
+
+                // From Trino: Parquet INT96 timestamp values were compared incorrectly
+                // for the purposes of producing statistics by older parquet writers,
+                // so PARQUET-1065 deprecated them. The result is that any writer that produced stats
+                // was producing unusable incorrect values, except the special case where min == max
+                // and an incorrect ordering would not be material to the result.
+                // PARQUET-1026 made binary stats available and valid in that special case.
+                if (micros_min != micros_max) {
+                    return false;
+                }
+
                 if constexpr (std::is_same_v<CppType, VecDateTimeValue> ||
                               std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
                     min_value.from_unixtime(micros_min / 1000000, ctz);


### PR DESCRIPTION
## Proposed changes

backport #35041

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

