### PR TITLE
[chore](cloud) Print storage vault info when refresh

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -835,6 +835,17 @@ Status CloudMetaMgr::get_storage_vault_info(StorageVaultInfos* vault_infos) {
             add_obj_store(vault.obj_info());
         }
     });
+
+    for (int i = 0; i < resp.obj_info_size(); ++i) {
+        resp.mutable_obj_info(i)->set_sk(resp.obj_info(i).sk().substr(0, 2) + "xxx");
+    }
+    for (int i = 0; i < resp.storage_vault_size(); ++i) {
+        auto j = resp.mutable_storage_vault(i);
+        if (!j->has_obj_info()) continue;
+        j->mutable_obj_info()->set_sk(j->obj_info().sk().substr(0, 2) + "xxx");
+    }
+
+    LOG(INFO) << "get storage vault response: " << resp.ShortDebugString();
     return Status::OK();
 }
 

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -323,7 +323,7 @@ void CloudStorageEngine::sync_storage_vault() {
     }
 
     if (vault_infos.empty()) {
-        LOG(WARNING) << "no storage vault info";
+        LOG(WARNING) << "empty storage vault info";
         return;
     }
 


### PR DESCRIPTION
This is useful when the storage vault complains about authorization issues.