### PR TITLE
[branch-2.1](memory) Avoid frequently refresh cgroup memory info

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -59,6 +59,8 @@ bvar::PassiveStatus<int64_t> g_sys_mem_avail(
 
 bool MemInfo::_s_initialized = false;
 std::atomic<int64_t> MemInfo::_s_physical_mem = std::numeric_limits<int64_t>::max();
+int64_t MemInfo::_s_cgroup_mem_limit = std::numeric_limits<int64_t>::max();
+int64_t MemInfo::_s_cgroup_mem_limit_refresh_wait_times = 0;
 std::atomic<int64_t> MemInfo::_s_mem_limit = std::numeric_limits<int64_t>::max();
 std::atomic<int64_t> MemInfo::_s_soft_mem_limit = std::numeric_limits<int64_t>::max();
 
@@ -395,10 +397,23 @@ void MemInfo::refresh_proc_meminfo() {
     int64_t physical_mem = -1;
     int64_t cgroup_mem_limit = -1;
     physical_mem = _mem_info_bytes["MemTotal"];
-    Status status = CGroupUtil::find_cgroup_mem_limit(&cgroup_mem_limit);
-    if (status.ok() && cgroup_mem_limit > 0) {
+    if (_s_cgroup_mem_limit_refresh_wait_times >= 0) {
+        Status status = CGroupUtil::find_cgroup_mem_limit(&cgroup_mem_limit);
+        if (status.ok() && cgroup_mem_limit > 0) {
+            _s_cgroup_mem_limit = cgroup_mem_limit;
+            _s_cgroup_mem_limit_refresh_wait_times =
+                    -1000; // wait 10s, 1000 * 100ms, avoid too frequently.
+        } else {
+            _s_cgroup_mem_limit = std::numeric_limits<int64_t>::max();
+            _s_cgroup_mem_limit_refresh_wait_times =
+                    -6000; // find cgroup failed, wait 60s, 6000 * 100ms.
+        }
+    } else {
+        _s_cgroup_mem_limit_refresh_wait_times++;
+    }
+    if (_s_cgroup_mem_limit > 0) {
         // In theory, always cgroup_mem_limit < physical_mem
-        physical_mem = std::min(physical_mem, cgroup_mem_limit);
+        physical_mem = std::min(physical_mem, _s_cgroup_mem_limit);
     }
 
     if (physical_mem <= 0) {
@@ -438,7 +453,7 @@ void MemInfo::refresh_proc_meminfo() {
     if (_mem_info_bytes.find("MemAvailable") != _mem_info_bytes.end()) {
         mem_available = _mem_info_bytes["MemAvailable"];
     }
-    status = CGroupUtil::find_cgroup_mem_usage(&cgroup_mem_usage);
+    auto status = CGroupUtil::find_cgroup_mem_usage(&cgroup_mem_usage);
     if (status.ok() && cgroup_mem_usage > 0 && cgroup_mem_limit > 0) {
         if (mem_available < 0) {
             mem_available = cgroup_mem_limit - cgroup_mem_usage;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -197,6 +197,8 @@ public:
 private:
     static bool _s_initialized;
     static std::atomic<int64_t> _s_physical_mem;
+    static int64_t _s_cgroup_mem_limit;
+    static int64_t _s_cgroup_mem_limit_refresh_wait_times;
     static std::atomic<int64_t> _s_mem_limit;
     static std::atomic<int64_t> _s_soft_mem_limit;
 


### PR DESCRIPTION
## Proposed changes

pick #35083

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

