### PR TITLE
[Bug](runtime-filter) fix brpc ctrl use after free and remove apply filter v1

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -980,7 +980,7 @@ Status IRuntimeFilter::publish(bool publish_local) {
         TNetworkAddress addr;
         DCHECK(_state != nullptr);
         RETURN_IF_ERROR(_state->runtime_filter_mgr->get_merge_addr(&addr));
-        return filter->push_to_remote(&addr, _opt_remote_rf);
+        return filter->push_to_remote(&addr);
     };
     auto send_to_local = [&](RuntimePredicateWrapper* wrapper) {
         std::vector<IRuntimeFilter*> filters;
@@ -1091,7 +1091,7 @@ Status IRuntimeFilter::send_filter_size(uint64_t local_filter_size) {
     return Status::OK();
 }
 
-Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr, bool opt_remote_rf) {
+Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr) {
     DCHECK(is_producer());
     std::shared_ptr<PBackendService_Stub> stub(
             _state->exec_env->brpc_internal_client_cache()->get_client(*addr));
@@ -1117,7 +1117,6 @@ Status IRuntimeFilter::push_to_remote(const TNetworkAddress* addr, bool opt_remo
     pfragment_instance_id->set_lo((int64_t)this);
 
     merge_filter_request->set_filter_id(_filter_id);
-    merge_filter_request->set_opt_remote_rf(opt_remote_rf);
     merge_filter_request->set_is_pipeline(_state->enable_pipeline_exec);
     auto column_type = _wrapper->column_type();
     merge_filter_request->set_column_type(to_proto(column_type));
@@ -1308,7 +1307,6 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     _has_local_target = desc->has_local_targets;
     _has_remote_target = desc->has_remote_targets;
     _expr_order = desc->expr_order;
-    _opt_remote_rf = desc->__isset.opt_remote_rf && desc->opt_remote_rf;
     vectorized::VExprContextSPtr build_ctx;
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(desc->src_expr, build_ctx));
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -306,7 +306,7 @@ public:
     bool need_sync_filter_size();
 
     // async push runtimefilter to remote node
-    Status push_to_remote(const TNetworkAddress* addr, bool opt_remote_rf);
+    Status push_to_remote(const TNetworkAddress* addr);
 
     void init_profile(RuntimeProfile* parent_profile);
 
@@ -444,7 +444,6 @@ protected:
     // parent profile
     // only effect on consumer
     std::unique_ptr<RuntimeProfile> _profile;
-    bool _opt_remote_rf;
     // `_need_local_merge` indicates whether this runtime filter is global on this BE.
     // All runtime filters should be merged on each BE before push_to_remote or publish.
     bool _need_local_merge = false;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1393,7 +1393,6 @@ Status FragmentMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
 Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
                                  butil::IOBufAsZeroCopyInputStream* attach_data) {
     UniqueId queryid = request->query_id();
-    bool opt_remote_rf = request->has_opt_remote_rf() && request->opt_remote_rf();
     std::shared_ptr<RuntimeFilterMergeControllerEntity> filter_controller;
     RETURN_IF_ERROR(_runtimefilter_controller.acquire(queryid, &filter_controller));
 
@@ -1413,7 +1412,7 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
         query_ctx = iter->second;
     }
     SCOPED_ATTACH_TASK_WITH_ID(query_ctx->query_mem_tracker, query_ctx->query_id());
-    auto merge_status = filter_controller->merge(request, attach_data, opt_remote_rf);
+    auto merge_status = filter_controller->merge(request, attach_data);
     return merge_status;
 }
 

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -158,8 +158,8 @@ public:
                 const TQueryOptions& query_options);
 
     // handle merge rpc
-    Status merge(const PMergeFilterRequest* request, butil::IOBufAsZeroCopyInputStream* attach_data,
-                 bool opt_remote_rf);
+    Status merge(const PMergeFilterRequest* request,
+                 butil::IOBufAsZeroCopyInputStream* attach_data);
 
     Status send_filter_size(const PSendFilterSizeRequest* request);
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -560,7 +560,7 @@ message PMergeFilterRequest {
     optional PBloomFilter bloom_filter = 6;
     optional PInFilter in_filter = 7;
     optional bool is_pipeline = 8;
-    optional bool opt_remote_rf = 9;
+    optional bool opt_remote_rf = 9; // Deprecated
     optional PColumnType column_type = 10;
     optional bool contain_null = 11;
     optional bool ignored = 12;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1228,7 +1228,7 @@ struct TRuntimeFilterDesc {
   // for bitmap filter
   11: optional bool bitmap_filter_not_in
 
-  12: optional bool opt_remote_rf;
+  12: optional bool opt_remote_rf; // Deprecated
   
   // for min/max rf
   13: optional TMinMaxRuntimeFilterType min_max_type;


### PR DESCRIPTION
## Proposed changes
do not pick this pr to 2.1 coz will broken rolling upgrade 2.0 to 2.1 compatibility

```cpp
==3466609==ERROR: AddressSanitizer: heap-use-after-free on address 0x618002362928 at pc 0x55862351a934 bp 0x7fc25fc84290 sp 0x7fc25fc84288
READ of size 8 at 0x618002362928 thread T1997
pure virtual method called
terminate called without an active exception
*** Query id: 99cf19b643a34f40-836df91f53120e33 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1716277295 (unix time) try "date -d @1716277295" if you are using GNU date ***
*** Current BE git commitID: 6fe533eede ***
*** SIGABRT unknown detail explain (@0x34e571) received by PID 3466609 (TID 3470467 OR 0x7fc17f0c3700) from PID 3466609; stack trace: ***
pure virtual method called
terminate called recursively
pure virtual method called
terminate called recursively
    #0 0x55862351a933 in std::__cxx11::basic_string, std::allocator>::size() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:907:16
    #1 0x558623683fe3 in std::__cxx11::basic_string, std::allocator>::resize(unsigned long, char) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:375:38
    #2 0x5586591e228d  (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c54828d) (BuildId: 96775b8c13e02111)
    #3 0x5586591e254c in butil::string_appendf(std::__cxx11::basic_string, std::allocator>*, char const*, ...) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c54854c) (BuildId: 96775b8c13e02111)
    #4 0x558659213f85 in brpc::Controller::SetFailed(int, char const*, ...) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c579f85) (BuildId: 96775b8c13e02111)
    #5 0x558659218b35 in brpc::Controller::HandleSocketFailed(bthread_id_t, void*, int, std::__cxx11::basic_string, std::allocator> const&) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c57eb35) (BuildId: 96775b8c13e02111)
    #6 0x5586592109c9 in bthread_id_error_verbose (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c5769c9) (BuildId: 96775b8c13e02111)
    #7 0x5586591d0a51 in bthread::TimerThread::Task::run_and_delete() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c536a51) (BuildId: 96775b8c13e02111)
    #8 0x5586591d141a in bthread::TimerThread::run() (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c53741a) (BuildId: 96775b8c13e02111)
    #9 0x5586591d1e78 in bthread::TimerThread::run_this(void*) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x5c537e78) (BuildId: 96775b8c13e02111)
    #10 0x7fca8abd7608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #11 0x7fca8ae84132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x618002362928 is located 168 bytes inside of 792-byte region [0x618002362880,0x618002362b98)
freed by thread T1917 (brpc_light) here:
    #0 0x558623500d9d in operator delete(void*) (/mnt/hdd01/ci/branch21-deploy/be/lib/doris_be+0x26866d9d) (BuildId: 96775b8c13e02111)
    #1 0x558627179365 in std::default_delete>::operator()(doris::AsyncRPCContext*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #2 0x55862717924b in std::unique_ptr, std::default_delete>>::~unique_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #3 0x558627179186 in void std::destroy_at, std::default_delete>>>(std::unique_ptr, std::default_delete>>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #4 0x558627179156 in void std::_Destroy, std::default_delete>>>(std::unique_ptr, std::default_delete>>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
    #5 0x55862717910a in void std::_Destroy_aux::__destroy, std::default_delete>>*>(std::unique_ptr, std::default_delete>>*, std::unique_ptr, std::default_delete>>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
    #6 0x5586271790ae in void std::_Destroy, std::default_delete>>*>(std::unique_ptr, std::default_delete>>*, std::unique_ptr, std::default_delete>>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
    #7 0x558627178f72 in void std::_Destroy, std::default_delete>>*, std::unique_ptr, std::default_delete>>>(std::unique_ptr, std::default_delete>>*, std::unique_ptr, std::default_delete>>*, std::allocator, std::default_delete>>>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
    #8 0x5586271534d0 in std::vector, std::default_delete>>, std::allocator, std::default_delete>>>>::~vector() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
    #9 0x55862713e124 in doris::RuntimeFilterMergeControllerEntity::merge(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*, bool) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/runtime_filter_mgr.cpp:507:9
    #10 0x558626cdacea in doris::FragmentMgr::merge_filter(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:1480:44
    #11 0x558627564e40 in doris::PInternalServiceImpl::merge_filter(google::protobuf::RpcController*, doris::PMergeFilterRequest const*, doris::PMergeFilterResponse*, google::protobuf::Closure*)::$_0::operator()() const /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/internal_service.cpp:1299:48
    #12 0x558627564b96 in void std::__invoke_impl(std::__invoke_other, doris::PInternalServiceImpl::merge_filter(google::protobuf::RpcController*, doris::PMergeFilterRequest const*, doris::PMergeFilterResponse*, google::protobuf::Closure*)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #13 0x558627564b08 in std::enable_if, void>::type std::__invoke_r(doris::PInternalServiceImpl::merge_filter(google::protobuf::RpcController*, doris::PMergeFilterRequest const*, doris::PMergeFilterResponse*, google::protobuf::Closure*)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #14 0x5586275648de in std::_Function_handler::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #15 0x55862375c4e6 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #16 0x5586275a5fae in doris::WorkThreadPool::work_thread(int) /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:158:17
    #17 0x5586275a75c4 in void std::__invoke_impl::* const&)(int), doris::WorkThreadPool*&, int&>(std::__invoke_memfun_deref, void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #18 0x5586275a7486 in std::__invoke_result::* const&)(int), doris::WorkThreadPool*&, int&>::type std::__invoke::* const&)(int), doris::WorkThreadPool*&, int&>(void (doris::WorkThreadPool::* const&)(int), doris::WorkThreadPool*&, int&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #19 0x5586275a7446 in decltype(std::__invoke((*this)._M_pmf, std::forward*&>(fp), std::forward(fp))) std::_Mem_fn_base::*)(int), true>::operator()*&, int&>(doris::WorkThreadPool*&, int&) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:131:11
    #20 0x5586275a7406 in void std::__invoke_impl::*)(int)>&, doris::WorkThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #21 0x5586275a7338 in std::enable_if::*)(int)>&, doris::WorkThreadPool*&, int&>, void>::type std::__invoke_r::*)(int)>&, doris::WorkThreadPool*&, int&>(std::_Mem_fn::*)(int)>&, doris::WorkThreadPool*&, int&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #22 0x5586275a7285 in void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570:11
    #23 0x5586275a70df in void std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>::operator()<>() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629:17
    #24 0x5586275a6fe6 in void std::__invoke_impl::*)(int)> (doris::WorkThreadPool*, int)>>(std::__invoke_other, std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #25 0x5586275a6f86 in std::__invoke_result::*)(int)> (doris::WorkThreadPool*, int)>>::type std::__invoke::*)(int)> (doris::WorkThreadPool*, int)>>(std::_Bind_result::*)(int)> (doris::WorkThreadPool*, int)>&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #26 0x5586275a6f4e in void std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)>>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:253:13
    #27 0x5586275a6f16 in std::thread::_Invoker::*)(int)> (doris::WorkThreadPool*, int)>>>::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:260:11
    #28 0x5586275a6e5a in std::thread::_State_impl::*)(int)> (doris::WorkThreadPool*, int)>>>>::_M_run() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211:13
    #29 0x55865a9237ef in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

