### PR TITLE
[improve](jdbc catalog) Remove all property checks during create

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.JdbcTable;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
@@ -88,10 +87,6 @@ public class JdbcExternalCatalog extends ExternalCatalog {
                 throw new DdlException("Required property '" + requiredProperty + "' is missing");
             }
         }
-        Map<String, String> propertiesIncludeRequired = Maps.newHashMap(catalogProperty.getProperties());
-        propertiesIncludeRequired.remove(JdbcResource.CHECK_SUM);
-        propertiesIncludeRequired.remove(CatalogMgr.METADATA_REFRESH_INTERVAL_SEC);
-        JdbcResource.validateProperties(propertiesIncludeRequired);
 
         JdbcResource.checkBooleanProperty(JdbcResource.ONLY_SPECIFIED_DATABASE, getOnlySpecifiedDatabase());
         JdbcResource.checkBooleanProperty(JdbcResource.LOWER_CASE_META_NAMES, getLowerCaseMetaNames());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Previously, in order to prevent users from writing wrong parameters when creating a jdbc catalog, we checked all properties. However, we found that when the parent class adds a new property, the subclass cannot sense the parent class's newly added property and can only manually add a check list. In order to avoid this trouble, I will delete this check for now and will check it in a better way later.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

