### PR TITLE
[fix](fe) Fix drop frontend cause `bdbje` and `fe memory` inconsistent state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1494,6 +1494,8 @@ public class Env {
             long replayEndTime = System.currentTimeMillis();
             LOG.info("finish replay in " + (replayEndTime - replayStartTime) + " msec");
 
+            removeDroppedFrontends(removedFrontends);
+
             if (Config.enable_check_compatibility_mode) {
                 String msg = "check metadata compatibility successfully";
                 LOG.info(msg);
@@ -2998,6 +3000,9 @@ public class Env {
                 ensureSafeToDropAliveFollower();
             }
 
+            editLog.logRemoveFrontend(fe);
+            LOG.info("remove frontend: {}", fe);
+
             int targetFollowerCount = getFollowerCount() - 1;
             if (fe.getRole() == FrontendNodeType.FOLLOWER || fe.getRole() == FrontendNodeType.REPLICA) {
                 haProtocol.removeElectableNode(fe.getNodeName());
@@ -3006,16 +3011,20 @@ public class Env {
                 ha.removeUnReadyElectableNode(fe.getNodeName(), targetFollowerCount);
             }
 
-            LOG.info("remove frontend: {}", fe);
-
             // Only remove frontend after removing the electable node success, to ensure the
             // exception safety.
             frontends.remove(fe.getNodeName());
             removedFrontends.add(fe.getNodeName());
 
-            editLog.logRemoveFrontend(fe);
         } finally {
             unlock();
+        }
+    }
+
+    private void removeDroppedFrontends(ConcurrentLinkedQueue<String> removedFrontends) {
+        if (haProtocol != null && haProtocol instanceof BDBHA) {
+            BDBHA bdbha = (BDBHA) haProtocol;
+            bdbha.removeDroppedMember(removedFrontends);
         }
     }
 
@@ -3924,6 +3933,7 @@ public class Env {
             }
 
             removedFrontends.add(removedFe.getNodeName());
+
         } finally {
             unlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class BDBHA implements HAProtocol {
     private static final Logger LOG = LogManager.getLogger(BDBHA.class);
@@ -168,11 +169,11 @@ public class BDBHA implements HAProtocol {
             LOG.info("remove electable node: {}", nodeName);
             replicationGroupAdmin.removeMember(nodeName);
         } catch (MemberNotFoundException e) {
-            LOG.error("the deleting electable node is not found {}", nodeName, e);
+            LOG.warn("the electable node is not found {}", nodeName, e);
             return false;
-        } catch (MasterStateException e) {
-            LOG.error("the deleting electable node is master {}", nodeName, e);
-            return false;
+        } catch (Exception e) {
+            LOG.error("remove electable node {} meeting unkown exception:", nodeName, e);
+            System.exit(-1);
         }
         return true;
     }
@@ -243,6 +244,25 @@ public class BDBHA implements HAProtocol {
                         override, totalFollowerCount, nodeName);
                 replicatedEnvironment.setRepMutableConfig(new ReplicationMutableConfig()
                         .setElectableGroupSizeOverride(override));
+            }
+        }
+    }
+
+    public void removeDroppedMember(ConcurrentLinkedQueue<String> removedFrontends) {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        Set<ReplicationNode> replicationNodes = replicationGroupAdmin.getGroup().getElectableNodes();
+        LOG.debug("removedFrontends:{}", removedFrontends);
+        for (ReplicationNode replicationNode : replicationNodes) {
+            LOG.debug("node:{}", replicationNode.toString());
+            if (removedFrontends.contains(replicationNode.getName())) {
+                try {
+                    replicationGroupAdmin.removeMember(nodeName);
+                } catch (MemberNotFoundException e) {
+                    LOG.warn("the electable node is not found {}", nodeName);
+                } catch (Exception e) {
+                    LOG.error("remove electable node {} meeting unknown exception:", nodeName, e);
+                    System.exit(-1);
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Frontend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Frontend.java
@@ -226,4 +226,8 @@ public class Frontend implements Writable {
     public HostInfo toHostInfo() {
         return new HostInfo(host, editLogPort);
     }
+
+    public boolean isOldStyleNodeName() {
+        return nodeName.equals(host + "_" + editLogPort);
+    }
 }


### PR DESCRIPTION
* dropFrontend use `ReplicationGroupAdmin` to remove bdbje node, in some corner case
  `ReplicationGroupAdmin.removeMember` success but `editLog.logRemoveFrontend` fail
   will cause inconsistent node info between `fe memory` and `bdbje`