### PR TITLE
[bug](Cloud) Use value capture for done closure when alter vault sync

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -37,7 +37,7 @@ void CloudInternalServiceImpl::alter_vault_sync(google::protobuf::RpcController*
     // If the vaults containing hdfs vault then it would try to create hdfs connection using jni
     // which would acuiqre one thread local jniEnv. But bthread context can't guarantee that the brpc
     // worker thread wouldn't do bthread switch between worker threads.
-    bool ret = _heavy_work_pool.try_offer([&]() {
+    bool ret = _heavy_work_pool.try_offer([this, done]() {
         brpc::ClosureGuard closure_guard(done);
         _engine.sync_storage_vault();
     });


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

