### PR TITLE
[enhancement](Nereids): Rename `FunctionalDependencies` to `DataTraits`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Records functional dependencies (func deps), which include:
+ * Records data trait, which include:
  * 1. Unique Slot:  Represents a column where the number of distinct values (ndv)
  *                  equals the row count. This column may include null values.
  * 2. Uniform Slot: Represents a column where the number of distinct values (ndv) is 1,
@@ -43,10 +43,10 @@ import java.util.stream.Collectors;
  *                   which signifies that if values in column 'a' are identical,
  *                   then values in column 'b' must also be identical.
  */
-public class FunctionalDependencies {
+public class DataTrait {
 
-    public static final FunctionalDependencies EMPTY_FUNC_DEPS
-            = new FunctionalDependencies(new NestedSet().toImmutable(),
+    public static final DataTrait EMPTY_TRAIT
+            = new DataTrait(new NestedSet().toImmutable(),
                     new NestedSet().toImmutable(), new ImmutableSet.Builder<FdItem>().build(),
                     ImmutableEqualSet.empty(), new FuncDepsDG.Builder().build());
     private final NestedSet uniqueSet;
@@ -55,7 +55,7 @@ public class FunctionalDependencies {
     private final ImmutableEqualSet<Slot> equalSet;
     private final FuncDepsDG fdDg;
 
-    private FunctionalDependencies(NestedSet uniqueSet, NestedSet uniformSet, ImmutableSet<FdItem> fdItems,
+    private DataTrait(NestedSet uniqueSet, NestedSet uniformSet, ImmutableSet<FdItem> fdItems,
             ImmutableEqualSet<Slot> equalSet, FuncDepsDG fdDg) {
         this.uniqueSet = uniqueSet;
         this.uniformSet = uniformSet;
@@ -136,7 +136,7 @@ public class FunctionalDependencies {
     }
 
     /**
-     * Builder of Func Deps
+     * Builder of trait
      */
     public static class Builder {
         private final NestedSet uniqueSet;
@@ -153,7 +153,7 @@ public class FunctionalDependencies {
             fdDgBuilder = new FuncDepsDG.Builder();
         }
 
-        public Builder(FunctionalDependencies other) {
+        public Builder(DataTrait other) {
             this.uniformSet = new NestedSet(other.uniformSet);
             this.uniqueSet = new NestedSet(other.uniqueSet);
             this.fdItems = ImmutableSet.copyOf(other.fdItems);
@@ -165,8 +165,8 @@ public class FunctionalDependencies {
             uniformSet.add(slot);
         }
 
-        public void addUniformSlot(FunctionalDependencies functionalDependencies) {
-            uniformSet.add(functionalDependencies.uniformSet);
+        public void addUniformSlot(DataTrait dataTrait) {
+            uniformSet.add(dataTrait.uniformSet);
         }
 
         public void addUniqueSlot(Slot slot) {
@@ -177,22 +177,22 @@ public class FunctionalDependencies {
             uniqueSet.add(slotSet);
         }
 
-        public void addUniqueSlot(FunctionalDependencies functionalDependencies) {
-            uniqueSet.add(functionalDependencies.uniqueSet);
+        public void addUniqueSlot(DataTrait dataTrait) {
+            uniqueSet.add(dataTrait.uniqueSet);
         }
 
         public void addFdItems(ImmutableSet<FdItem> items) {
             fdItems = ImmutableSet.copyOf(items);
         }
 
-        public void addFunctionalDependencies(FunctionalDependencies fd) {
+        public void addDataTrait(DataTrait fd) {
             uniformSet.add(fd.uniformSet);
             uniqueSet.add(fd.uniqueSet);
             equalSetBuilder.addEqualSet(fd.equalSet);
             fdDgBuilder.addDeps(fd.fdDg);
         }
 
-        public void addFuncDepsDG(FunctionalDependencies fd) {
+        public void addFuncDepsDG(DataTrait fd) {
             fdDgBuilder.addDeps(fd.fdDg);
         }
 
@@ -301,12 +301,12 @@ public class FunctionalDependencies {
             equalSetBuilder.addEqualPair(l, r);
         }
 
-        public void addEqualSet(FunctionalDependencies functionalDependencies) {
-            equalSetBuilder.addEqualSet(functionalDependencies.equalSet);
+        public void addEqualSet(DataTrait dataTrait) {
+            equalSetBuilder.addEqualSet(dataTrait.equalSet);
         }
 
-        public FunctionalDependencies build() {
-            return new FunctionalDependencies(uniqueSet.toImmutable(), uniformSet.toImmutable(),
+        public DataTrait build() {
+            return new DataTrait(uniqueSet.toImmutable(), uniformSet.toImmutable(),
                     ImmutableSet.copyOf(fdItems), equalSetBuilder.build(), fdDgBuilder.build());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
@@ -79,7 +79,22 @@ public class FuncDeps {
     }
 
     /**
-     * Eliminate all deps in slots
+     * Reduces a given set of slot sets by eliminating dependencies using a breadth-first search (BFS) approach.
+     * <p>
+     * Let's assume we have the following sets of slots and functional dependencies:
+     * Slots: {A, B, C}, {D, E}, {F}
+     * Dependencies: {A} -> {B}, {D, E} -> {F}
+     * The BFS reduction process would look like this:
+     * 1. Initial set: [{A, B, C}, {D, E}, {F}]
+     * 2. Apply {A} -> {B}:
+     *    - New set: [{A, C}, {D, E}, {F}]
+     * 3. Apply {D, E} -> {F}:
+     *    - New set: [{A, C}, {D, E}]
+     * 4. No more dependencies can be applied, output: [{A, C}, {D, E}]
+     * </p>
+     *
+     * @param slots the initial set of slot sets to be reduced
+     * @return the minimal set of slot sets after applying all possible reductions
      */
     public Set<Set<Slot>> eliminateDeps(Set<Set<Slot>> slots) {
         Set<Set<Slot>> minSlotSet = slots;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
@@ -41,12 +41,12 @@ public class LogicalProperties {
     protected final Supplier<Set<Slot>> outputSetSupplier;
     protected final Supplier<Map<Slot, Slot>> outputMapSupplier;
     protected final Supplier<Set<ExprId>> outputExprIdSetSupplier;
-    protected final Supplier<FunctionalDependencies> fdSupplier;
+    protected final Supplier<DataTrait> dataTraitSupplier;
     private Integer hashCode = null;
 
     public LogicalProperties(Supplier<List<Slot>> outputSupplier,
-            Supplier<FunctionalDependencies> fdSupplier) {
-        this(outputSupplier, fdSupplier, ImmutableList::of);
+            Supplier<DataTrait> dataTraitSupplier) {
+        this(outputSupplier, dataTraitSupplier, ImmutableList::of);
     }
 
     /**
@@ -56,7 +56,7 @@ public class LogicalProperties {
      *                       throw exception for which children have UnboundRelation
      */
     public LogicalProperties(Supplier<List<Slot>> outputSupplier,
-            Supplier<FunctionalDependencies> fdSupplier,
+            Supplier<DataTrait> dataTraitSupplier,
             Supplier<List<Slot>> nonUserVisibleOutputSupplier) {
         this.outputSupplier = Suppliers.memoize(
                 Objects.requireNonNull(outputSupplier, "outputSupplier can not be null")
@@ -95,8 +95,8 @@ public class LogicalProperties {
             }
             return exprIdSet.build();
         });
-        this.fdSupplier = Suppliers.memoize(
-                Objects.requireNonNull(fdSupplier, "FunctionalDependencies can not be null")
+        this.dataTraitSupplier = Suppliers.memoize(
+                Objects.requireNonNull(dataTraitSupplier, "Data Trait can not be null")
         );
     }
 
@@ -116,8 +116,8 @@ public class LogicalProperties {
         return outputExprIdSetSupplier.get();
     }
 
-    public FunctionalDependencies getFunctionalDependencies() {
-        return fdSupplier.get();
+    public DataTrait getTrait() {
+        return dataTraitSupplier.get();
     }
 
     public List<Id> getOutputExprIds() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/UnboundLogicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/UnboundLogicalProperties.java
@@ -32,7 +32,7 @@ public class UnboundLogicalProperties extends LogicalProperties {
     public static final UnboundLogicalProperties INSTANCE = new UnboundLogicalProperties();
 
     private UnboundLogicalProperties() {
-        super(ImmutableList::of, () -> FunctionalDependencies.EMPTY_FUNC_DEPS);
+        super(ImmutableList::of, () -> DataTrait.EMPTY_TRAIT);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
@@ -198,7 +198,7 @@ public class HyperGraphComparator {
                 return false;
             }
             return JoinUtils.canEliminateByLeft(joinEdge.getJoin(),
-                    rigthPlan.getLogicalProperties().getFunctionalDependencies());
+                    rigthPlan.getLogicalProperties().getTrait());
         }
         // eliminate by pk fk
         if (joinEdge.getJoinType().isInnerJoin()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
@@ -60,7 +60,7 @@ public class EliminateGroupBy extends OneRewriteRuleFactory {
                     }
                     Plan child = agg.child();
                     boolean unique = child.getLogicalProperties()
-                            .getFunctionalDependencies()
+                            .getTrait()
                             .isUniqueAndNotNull(groupBySlots.build());
                     if (!unique) {
                         return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKey.java
@@ -86,7 +86,7 @@ public class EliminateGroupByKey implements RewriteRuleFactory {
         }
 
         FuncDeps funcDeps = agg.child().getLogicalProperties()
-                .getFunctionalDependencies().getAllValidFuncDeps(validSlots);
+                .getTrait().getAllValidFuncDeps(validSlots);
         if (funcDeps.isEmpty()) {
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByUnique.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByUnique.java
@@ -37,7 +37,7 @@ public class EliminateJoinByUnique extends OneRewriteRuleFactory {
                 return project;
             }
             if (!JoinUtils.canEliminateByLeft(join,
-                    join.right().getLogicalProperties().getFunctionalDependencies())) {
+                    join.right().getLogicalProperties().getTrait())) {
                 return project;
             }
             return project.withChildren(join.left());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SimplifyWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SimplifyWindowExpression.java
@@ -81,7 +81,7 @@ public class SimplifyWindowExpression extends OneRewriteRuleFactory {
             // after normalize window, partition key must be slot
             List<Slot> partitionSlots = (List<Slot>) (List) windowExpression.getPartitionKeys();
             Set<Slot> partitionSlotSet = new HashSet<>(partitionSlots);
-            if (!window.getLogicalProperties().getFunctionalDependencies().isUnique(partitionSlotSet)) {
+            if (!window.getLogicalProperties().getTrait().isUnique(partitionSlotSet)) {
                 remainWindowExpression.add(expr);
                 continue;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -19,7 +19,7 @@ package org.apache.doris.nereids.trees.plans;
 
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.UnboundLogicalProperties;
 import org.apache.doris.nereids.trees.AbstractTreeNode;
@@ -202,9 +202,9 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
             return UnboundLogicalProperties.INSTANCE;
         } else {
             Supplier<List<Slot>> outputSupplier = Suppliers.memoize(this::computeOutput);
-            Supplier<FunctionalDependencies> fdSupplier = () -> this instanceof LogicalPlan
+            Supplier<DataTrait> fdSupplier = () -> this instanceof LogicalPlan
                     ? ((LogicalPlan) this).computeFuncDeps()
-                    : FunctionalDependencies.EMPTY_FUNC_DEPS;
+                    : DataTrait.EMPTY_TRAIT;
             return new LogicalProperties(outputSupplier, fdSupplier);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/BlockFuncDepsPropagation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/BlockFuncDepsPropagation.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.nereids.trees.plans;
 
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
 import com.google.common.collect.ImmutableSet;
@@ -28,8 +28,8 @@ import com.google.common.collect.ImmutableSet;
  */
 public interface BlockFuncDepsPropagation extends LogicalPlan {
     @Override
-    default FunctionalDependencies computeFuncDeps() {
-        return FunctionalDependencies.EMPTY_FUNC_DEPS;
+    default DataTrait computeFuncDeps() {
+        return DataTrait.EMPTY_TRAIT;
     }
 
     @Override
@@ -38,22 +38,22 @@ public interface BlockFuncDepsPropagation extends LogicalPlan {
     }
 
     @Override
-    default void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    default void computeUnique(DataTrait.Builder builder) {
         // don't generate
     }
 
     @Override
-    default void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    default void computeUniform(DataTrait.Builder builder) {
         // don't generate
     }
 
     @Override
-    default void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
+    default void computeEqualSet(DataTrait.Builder builder) {
         // don't generate
     }
 
     @Override
-    default void computeFd(FunctionalDependencies.Builder fdBuilder) {
+    default void computeFd(DataTrait.Builder builder) {
         // don't generate
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/FakePlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/FakePlan.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.trees.plans;
 
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -82,7 +82,7 @@ public class FakePlan implements Plan {
 
     @Override
     public LogicalProperties getLogicalProperties() {
-        return new LogicalProperties(ArrayList::new, () -> FunctionalDependencies.EMPTY_FUNC_DEPS);
+        return new LogicalProperties(ArrayList::new, () -> DataTrait.EMPTY_TRAIT);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PropagateFuncDeps.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.nereids.trees.plans;
 
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
 import com.google.common.collect.ImmutableSet;
@@ -28,16 +28,16 @@ import com.google.common.collect.ImmutableSet;
  */
 public interface PropagateFuncDeps extends LogicalPlan {
     @Override
-    default FunctionalDependencies computeFuncDeps() {
+    default DataTrait computeFuncDeps() {
         if (children().size() == 1) {
             // Note when changing function dependencies, we always clone it.
             // So it's safe to return a reference
-            return child(0).getLogicalProperties().getFunctionalDependencies();
+            return child(0).getLogicalProperties().getTrait();
         }
-        FunctionalDependencies.Builder builder = new FunctionalDependencies.Builder();
+        DataTrait.Builder builder = new DataTrait.Builder();
         children().stream()
-                .map(p -> p.getLogicalProperties().getFunctionalDependencies())
-                .forEach(builder::addFunctionalDependencies);
+                .map(p -> p.getLogicalProperties().getTrait())
+                .forEach(builder::addDataTrait);
         ImmutableSet<FdItem> fdItems = computeFdItems();
         builder.addFdItems(fdItems);
         return builder.build();
@@ -48,32 +48,32 @@ public interface PropagateFuncDeps extends LogicalPlan {
         if (children().size() == 1) {
             // Note when changing function dependencies, we always clone it.
             // So it's safe to return a reference
-            return child(0).getLogicalProperties().getFunctionalDependencies().getFdItems();
+            return child(0).getLogicalProperties().getTrait().getFdItems();
         }
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
         children().stream()
-                .map(p -> p.getLogicalProperties().getFunctionalDependencies().getFdItems())
+                .map(p -> p.getLogicalProperties().getTrait().getFdItems())
                 .forEach(builder::addAll);
         return builder.build();
     }
 
     @Override
-    default void computeUnique(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    default void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    default void computeUniform(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    default void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    default void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    default void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    default void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child(0).getLogicalProperties().getFunctionalDependencies());
+    default void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child(0).getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -18,9 +18,9 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.TableFdItem;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -306,7 +306,7 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
         }
         Expression agg = namedExpression.child(0);
         return ExpressionUtils.isInjectiveAgg(agg)
-                && child().getLogicalProperties().getFunctionalDependencies().isUniqueAndNotNull(agg.getInputSlots());
+                && child().getLogicalProperties().getTrait().isUniqueAndNotNull(agg.getInputSlots());
     }
 
     private boolean isUniformGroupByUnique(NamedExpression namedExpression) {
@@ -318,42 +318,42 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         if (this.sourceRepeat.isPresent()) {
             // roll up may generate new data
             return;
         }
-        FunctionalDependencies childFd = child(0).getLogicalProperties().getFunctionalDependencies();
+        DataTrait childFd = child(0).getLogicalProperties().getTrait();
         ImmutableSet<Slot> groupByKeys = groupByExpressions.stream()
                 .map(s -> (Slot) s)
                 .collect(ImmutableSet.toImmutableSet());
         // when group by all tuples, the result only have one row
         if (groupByExpressions.isEmpty() || childFd.isUniformAndNotNull(groupByKeys)) {
-            getOutput().forEach(fdBuilder::addUniqueSlot);
+            getOutput().forEach(builder::addUniqueSlot);
             return;
         }
 
         // propagate all unique slots
-        fdBuilder.addUniqueSlot(childFd);
+        builder.addUniqueSlot(childFd);
 
         // group by keys is unique
-        fdBuilder.addUniqueSlot(groupByKeys);
+        builder.addUniqueSlot(groupByKeys);
 
         // group by unique may has unique aggregate result
         if (childFd.isUniqueAndNotNull(groupByKeys)) {
             for (NamedExpression namedExpression : getOutputExpressions()) {
                 if (isUniqueGroupByUnique(namedExpression)) {
-                    fdBuilder.addUniqueSlot(namedExpression.toSlot());
+                    builder.addUniqueSlot(namedExpression.toSlot());
                 }
             }
         }
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUniform(DataTrait.Builder builder) {
         // always propagate uniform
-        FunctionalDependencies childFd = child(0).getLogicalProperties().getFunctionalDependencies();
-        fdBuilder.addUniformSlot(childFd);
+        DataTrait childFd = child(0).getLogicalProperties().getTrait();
+        builder.addUniformSlot(childFd);
 
         if (this.sourceRepeat.isPresent()) {
             // roll up may generate new data
@@ -364,14 +364,14 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
                 .collect(ImmutableSet.toImmutableSet());
         // when group by all tuples, the result only have one row
         if (groupByExpressions.isEmpty() || childFd.isUniformAndNotNull(groupByKeys)) {
-            getOutput().forEach(fdBuilder::addUniformSlot);
+            getOutput().forEach(builder::addUniformSlot);
             return;
         }
 
         if (childFd.isUniqueAndNotNull(groupByKeys)) {
             for (NamedExpression namedExpression : getOutputExpressions()) {
                 if (isUniformGroupByUnique(namedExpression)) {
-                    fdBuilder.addUniformSlot(namedExpression.toSlot());
+                    builder.addUniformSlot(namedExpression.toSlot());
                 }
             }
         }
@@ -387,7 +387,7 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
                 .collect(ImmutableSet.toImmutableSet());
 
         // inherit from child
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         // todo: fill the table sets
@@ -399,12 +399,12 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
@@ -18,9 +18,9 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement.Assertion;
@@ -128,32 +128,32 @@ public class LogicalAssertNumRows<CHILD_TYPE extends Plan> extends LogicalUnary<
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
+    public void computeUnique(Builder builder) {
         if (assertNumRowsElement.getDesiredNumOfRows() == 1
                 && (assertNumRowsElement.getAssertion() == Assertion.EQ
                 || assertNumRowsElement.getAssertion() == Assertion.LT
                 || assertNumRowsElement.getAssertion() == Assertion.LE)) {
-            getOutput().forEach(fdBuilder::addUniqueSlot);
+            getOutput().forEach(builder::addUniqueSlot);
         }
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
+    public void computeUniform(Builder builder) {
         if (assertNumRowsElement.getDesiredNumOfRows() == 1
                 && (assertNumRowsElement.getAssertion() == Assertion.EQ
                 || assertNumRowsElement.getAssertion() == Assertion.LT
                 || assertNumRowsElement.getAssertion() == Assertion.LE)) {
-            getOutput().forEach(fdBuilder::addUniformSlot);
+            getOutput().forEach(builder::addUniformSlot);
         }
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -27,9 +27,9 @@ import org.apache.doris.catalog.constraint.UniqueConstraint;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.TableFdItem;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -126,7 +126,7 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         Set<Slot> outputSet = Utils.fastToImmutableSet(getOutputSet());
         if (table instanceof OlapTable && ((OlapTable) table).getKeysType().isAggregationFamily()) {
             ImmutableSet.Builder<Slot> uniqSlots = ImmutableSet.builderWithExpectedSize(outputSet.size());
@@ -139,22 +139,22 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
                     uniqSlots.add(slot);
                 }
             }
-            fdBuilder.addUniqueSlot(uniqSlots.build());
+            builder.addUniqueSlot(uniqSlots.build());
         }
 
         for (PrimaryKeyConstraint c : table.getPrimaryKeyConstraints()) {
             Set<Column> columns = c.getPrimaryKeys(table);
-            fdBuilder.addUniqueSlot((ImmutableSet) findSlotsByColumn(outputSet, columns));
+            builder.addUniqueSlot((ImmutableSet) findSlotsByColumn(outputSet, columns));
         }
 
         for (UniqueConstraint c : table.getUniqueConstraints()) {
             Set<Column> columns = c.getUniqueKeys(table);
-            fdBuilder.addUniqueSlot((ImmutableSet) findSlotsByColumn(outputSet, columns));
+            builder.addUniqueSlot((ImmutableSet) findSlotsByColumn(outputSet, columns));
         }
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUniform(DataTrait.Builder builder) {
         // No uniform slot for catalog relation
     }
 
@@ -208,12 +208,12 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
+    public void computeEqualSet(DataTrait.Builder builder) {
         // don't generate any equal pair
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+    public void computeFd(DataTrait.Builder builder) {
         // don't generate any equal pair
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
@@ -18,10 +18,10 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.ExprId;
@@ -118,26 +118,26 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniqueSlot);
+            getOutput().forEach(builder::addUniqueSlot);
         } else {
-            fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUniform(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniformSlot);
+            getOutput().forEach(builder::addUniformSlot);
         } else {
-            fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
-        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getTrait().getFdItems();
         if (getLimit() == 1) {
             ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
             List<Slot> output = getOutput();
@@ -211,12 +211,12 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
@@ -18,11 +18,11 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -124,7 +124,7 @@ public class LogicalExcept extends LogicalSetOperation {
 
             // only inherit from left side
             ImmutableSet<FdItem> leftFdItems = child(0).getLogicalProperties()
-                    .getFunctionalDependencies().getFdItems();
+                    .getTrait().getFdItems();
 
             builder.addAll(leftFdItems);
         }
@@ -133,10 +133,10 @@ public class LogicalExcept extends LogicalSetOperation {
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         if (qualifier == Qualifier.DISTINCT) {
-            fdBuilder.addUniqueSlot(ImmutableSet.copyOf(getOutput()));
+            builder.addUniqueSlot(ImmutableSet.copyOf(getOutput()));
         }
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> output = getOutput();
@@ -146,12 +146,12 @@ public class LogicalExcept extends LogicalSetOperation {
         for (int i = 0; i < output.size(); i++) {
             replaceMap.put(originalOutputs.get(i), output.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> output = getOutput();
         List<? extends Slot> originalOutputs = regularChildrenOutputs.isEmpty()
@@ -160,12 +160,12 @@ public class LogicalExcept extends LogicalSetOperation {
         for (int i = 0; i < output.size(); i++) {
             replaceMap.put(originalOutputs.get(i), output.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> output = getOutput();
         List<? extends Slot> originalOutputs = regularChildrenOutputs.isEmpty()
@@ -174,12 +174,12 @@ public class LogicalExcept extends LogicalSetOperation {
         for (int i = 0; i < output.size(); i++) {
             replaceMap.put(originalOutputs.get(i), output.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> output = getOutput();
         List<? extends Slot> originalOutputs = regularChildrenOutputs.isEmpty()
@@ -188,6 +188,6 @@ public class LogicalExcept extends LogicalSetOperation {
         for (int i = 0; i < output.size(); i++) {
             replaceMap.put(originalOutputs.get(i), output.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
@@ -19,8 +19,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -151,39 +151,39 @@ public class LogicalFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
 
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         return builder.build();
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
+    public void computeUniform(Builder builder) {
         for (Expression e : getConjuncts()) {
             Set<Slot> uniformSlots = ExpressionUtils.extractUniformSlot(e);
             for (Slot slot : uniformSlots) {
-                fdBuilder.addUniformSlot(slot);
+                builder.addUniformSlot(slot);
             }
         }
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeEqualSet(Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
         for (Expression expression : getConjuncts()) {
             Optional<Pair<Slot, Slot>> equalSlot = ExpressionUtils.extractEqualSlot(expression);
-            equalSlot.ifPresent(slotSlotPair -> fdBuilder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
+            equalSlot.ifPresent(slotSlotPair -> builder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
         }
     }
 
     @Override
-    public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
@@ -18,9 +18,9 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -162,22 +162,22 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
+    public void computeUnique(Builder builder) {
         // don't generate and propagate unique
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
@@ -19,8 +19,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -119,43 +119,43 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
+    public void computeUniform(Builder builder) {
         for (Expression e : getConjuncts()) {
             Set<Slot> uniformSlots = ExpressionUtils.extractUniformSlot(e);
             for (Slot slot : uniformSlots) {
-                fdBuilder.addUniformSlot(slot);
+                builder.addUniformSlot(slot);
             }
         }
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
 
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         return builder.build();
     }
 
     @Override
-    public void computeEqualSet(Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
         for (Expression expression : getConjuncts()) {
             Optional<Pair<Slot, Slot>> equalSlot = ExpressionUtils.extractEqualSlot(expression);
-            equalSlot.ifPresent(slotSlotPair -> fdBuilder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
+            equalSlot.ifPresent(slotSlotPair -> builder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
         }
     }
 
     @Override
-    public void computeFd(Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
@@ -18,11 +18,11 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -109,7 +109,7 @@ public class LogicalIntersect extends LogicalSetOperation {
                 Optional.empty(), Optional.empty(), children);
     }
 
-    void replaceSlotInFuncDeps(FunctionalDependencies.Builder builder,
+    void replaceSlotInFuncDeps(DataTrait.Builder builder,
             List<Slot> originalOutputs, List<Slot> newOutputs) {
         Map<Slot, Slot> replaceMap = new HashMap<>();
         for (int i = 0; i < newOutputs.size(); i++) {
@@ -119,41 +119,41 @@ public class LogicalIntersect extends LogicalSetOperation {
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
+    public void computeUnique(Builder builder) {
         for (Plan child : children) {
-            fdBuilder.addUniqueSlot(
-                    child.getLogicalProperties().getFunctionalDependencies());
-            replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
+            builder.addUniqueSlot(
+                    child.getLogicalProperties().getTrait());
+            replaceSlotInFuncDeps(builder, child.getOutput(), getOutput());
         }
         if (qualifier == Qualifier.DISTINCT) {
-            fdBuilder.addUniqueSlot(ImmutableSet.copyOf(getOutput()));
+            builder.addUniqueSlot(ImmutableSet.copyOf(getOutput()));
         }
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
+    public void computeUniform(Builder builder) {
         for (Plan child : children) {
-            fdBuilder.addUniformSlot(
-                    child.getLogicalProperties().getFunctionalDependencies());
-            replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
+            builder.addUniformSlot(
+                    child.getLogicalProperties().getTrait());
+            replaceSlotInFuncDeps(builder, child.getOutput(), getOutput());
         }
     }
 
     @Override
-    public void computeEqualSet(Builder fdBuilder) {
+    public void computeEqualSet(Builder builder) {
         for (Plan child : children) {
-            fdBuilder.addEqualSet(
-                    child.getLogicalProperties().getFunctionalDependencies());
-            replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
+            builder.addEqualSet(
+                    child.getLogicalProperties().getTrait());
+            replaceSlotInFuncDeps(builder, child.getOutput(), getOutput());
         }
     }
 
     @Override
-    public void computeFd(Builder fdBuilder) {
+    public void computeFd(Builder builder) {
         for (Plan child : children) {
-            fdBuilder.addFuncDepsDG(
-                    child.getLogicalProperties().getFunctionalDependencies());
-            replaceSlotInFuncDeps(fdBuilder, child.getOutput(), getOutput());
+            builder.addFuncDepsDG(
+                    child.getLogicalProperties().getTrait());
+            replaceSlotInFuncDeps(builder, child.getOutput(), getOutput());
         }
     }
 
@@ -172,9 +172,9 @@ public class LogicalIntersect extends LogicalSetOperation {
             builder.add(fdItem);
             // inherit from both sides
             ImmutableSet<FdItem> leftFdItems = child(0).getLogicalProperties()
-                    .getFunctionalDependencies().getFdItems();
+                    .getTrait().getFdItems();
             ImmutableSet<FdItem> rightFdItems = child(1).getLogicalProperties()
-                    .getFunctionalDependencies().getFdItems();
+                    .getTrait().getFdItems();
 
             builder.addAll(leftFdItems);
             builder.addAll(rightFdItems);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -22,9 +22,9 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.bitmap.LongBitmap;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.TableFdItem;
 import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
@@ -465,9 +465,9 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
                 || !otherJoinConjuncts.isEmpty()) {
             return ImmutableSet.of();
         } else if (joinType.isLeftAntiJoin() || joinType.isLefSemiJoin()) {
-            return left().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            return left().getLogicalProperties().getTrait().getFdItems();
         } else if (joinType.isRightSemiJoin() || joinType.isRightAntiJoin()) {
-            return right().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            return right().getLogicalProperties().getTrait().getFdItems();
         } else if (joinType.isInnerJoin()) {
             Pair<Set<Slot>, Set<Slot>> keys = extractNullRejectHashKeys();
             if (keys == null) {
@@ -477,7 +477,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             Set<Slot> rightSlotSet = keys.second;
 
             // enhance the fd from candidate to formal
-            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getTrait().getFdItems();
             leftItems.stream().filter(e -> e.isCandidate()).forEach(f -> {
                         if (leftSlotSet.containsAll(f.getParentExprs())) {
                             f.setCandidate(false);
@@ -487,7 +487,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             boolean isLeftUnique = leftItems.stream().filter(e -> e.isCandidate())
                     .anyMatch(f -> leftSlotSet.containsAll(f.getParentExprs()));
 
-            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getTrait().getFdItems();
             rightItems.stream().filter(e -> e.isCandidate()).forEach(f -> {
                         if (rightSlotSet.containsAll(f.getParentExprs())) {
                             f.setCandidate(false);
@@ -536,7 +536,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             Set<Slot> rightSlotSet = keys.second;
 
             // enhance the fd from candidate to formal
-            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getTrait().getFdItems();
             leftItems.stream().filter(e -> e.isCandidate()).forEach(f -> {
                         if (leftSlotSet.containsAll(f.getParentExprs())) {
                             f.setCandidate(false);
@@ -544,7 +544,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
                     }
             );
 
-            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getTrait().getFdItems();
             boolean isRightUnique = rightItems.stream().filter(e -> e.isCandidate())
                     .anyMatch(f -> rightSlotSet.containsAll(f.getParentExprs()));
             if (isRightUnique) {
@@ -573,11 +573,11 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             Set<Slot> rightSlotSet = keys.second;
 
             // enhance the fd from candidate to formal
-            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> leftItems = left().getLogicalProperties().getTrait().getFdItems();
             boolean isLeftUnique = leftItems.stream().filter(e -> e.isCandidate())
                     .anyMatch(f -> leftSlotSet.containsAll(f.getParentExprs()));
 
-            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getFunctionalDependencies().getFdItems();
+            ImmutableSet<FdItem> rightItems = right().getLogicalProperties().getTrait().getFdItems();
             rightItems.stream().filter(e -> e.isCandidate()).forEach(f -> {
                         if (rightSlotSet.containsAll(f.getParentExprs())) {
                             f.setCandidate(false);
@@ -641,15 +641,15 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
+    public void computeUnique(Builder builder) {
         if (isMarkJoin()) {
             // TODO disable function dependence calculation for mark join, but need re-think this in future.
             return;
         }
         if (joinType.isLeftSemiOrAntiJoin()) {
-            fdBuilder.addUniqueSlot(left().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(left().getLogicalProperties().getTrait());
         } else if (joinType.isRightSemiOrAntiJoin()) {
-            fdBuilder.addUniqueSlot(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(right().getLogicalProperties().getTrait());
         }
         // if there is non-equal join conditions, don't propagate unique
         if (hashJoinConjuncts.isEmpty()) {
@@ -664,62 +664,62 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
         // So the hash condition can't be null-safe
         // TODO: consider Null-safe hash condition when left and rigth is not nullable
         boolean isLeftUnique = left().getLogicalProperties()
-                .getFunctionalDependencies().isUnique(keys.first);
+                .getTrait().isUnique(keys.first);
         boolean isRightUnique = right().getLogicalProperties()
-                .getFunctionalDependencies().isUnique(keys.second);
+                .getTrait().isUnique(keys.second);
 
         // left/right outer join propagate left/right uniforms slots
         // And if the right/left hash keys is unique,
         // join can propagate left/right functional dependencies
         if (joinType.isLeftOuterJoin() && isRightUnique) {
-            fdBuilder.addUniqueSlot(left().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(left().getLogicalProperties().getTrait());
         } else if (joinType.isRightOuterJoin() && isLeftUnique) {
-            fdBuilder.addUniqueSlot(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(right().getLogicalProperties().getTrait());
         } else if (joinType.isInnerJoin() && isLeftUnique && isRightUnique) {
             // inner join propagate uniforms slots
             // And if the hash keys is unique, inner join can propagate all functional dependencies
-            fdBuilder.addFunctionalDependencies(left().getLogicalProperties().getFunctionalDependencies());
-            fdBuilder.addFunctionalDependencies(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addDataTrait(left().getLogicalProperties().getTrait());
+            builder.addDataTrait(right().getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
+    public void computeUniform(Builder builder) {
         if (isMarkJoin()) {
             // TODO disable function dependence calculation for mark join, but need re-think this in future.
             return;
         }
         if (!joinType.isLeftSemiOrAntiJoin()) {
-            fdBuilder.addUniformSlot(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniformSlot(right().getLogicalProperties().getTrait());
         }
         if (!joinType.isRightSemiOrAntiJoin()) {
-            fdBuilder.addUniformSlot(left().getLogicalProperties().getFunctionalDependencies());
+            builder.addUniformSlot(left().getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeEqualSet(Builder fdBuilder) {
+    public void computeEqualSet(Builder builder) {
         if (!joinType.isLeftSemiOrAntiJoin()) {
-            fdBuilder.addEqualSet(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addEqualSet(right().getLogicalProperties().getTrait());
         }
         if (!joinType.isRightSemiOrAntiJoin()) {
-            fdBuilder.addEqualSet(left().getLogicalProperties().getFunctionalDependencies());
+            builder.addEqualSet(left().getLogicalProperties().getTrait());
         }
         if (joinType.isInnerJoin()) {
             for (Expression expression : getHashJoinConjuncts()) {
                 Optional<Pair<Slot, Slot>> equalSlot = ExpressionUtils.extractEqualSlot(expression);
-                equalSlot.ifPresent(slotSlotPair -> fdBuilder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
+                equalSlot.ifPresent(slotSlotPair -> builder.addEqualPair(slotSlotPair.first, slotSlotPair.second));
             }
         }
     }
 
     @Override
-    public void computeFd(Builder fdBuilder) {
+    public void computeFd(Builder builder) {
         if (!joinType.isLeftSemiOrAntiJoin()) {
-            fdBuilder.addFuncDepsDG(right().getLogicalProperties().getFunctionalDependencies());
+            builder.addFuncDepsDG(right().getLogicalProperties().getTrait());
         }
         if (!joinType.isRightSemiOrAntiJoin()) {
-            fdBuilder.addFuncDepsDG(left().getLogicalProperties().getFunctionalDependencies());
+            builder.addFuncDepsDG(left().getLogicalProperties().getTrait());
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
@@ -18,10 +18,10 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -148,26 +148,26 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniqueSlot);
+            getOutput().forEach(builder::addUniqueSlot);
         } else {
-            fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUniform(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniformSlot);
+            getOutput().forEach(builder::addUniformSlot);
         } else {
-            fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
-        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getTrait().getFdItems();
         if (getLimit() == 1 && !phase.isLocal()) {
             ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
             List<Slot> output = getOutput();
@@ -183,12 +183,12 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -18,10 +18,10 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -143,13 +143,13 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
-        getOutput().forEach(fdBuilder::addUniqueSlot);
+    public void computeUnique(DataTrait.Builder builder) {
+        getOutput().forEach(builder::addUniqueSlot);
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
-        getOutput().forEach(fdBuilder::addUniformSlot);
+    public void computeUniform(DataTrait.Builder builder) {
+        getOutput().forEach(builder::addUniformSlot);
     }
 
     @Override
@@ -167,12 +167,12 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
+    public void computeEqualSet(DataTrait.Builder builder) {
         Map<Expression, NamedExpression> aliasMap = new HashMap<>();
         for (NamedExpression namedExpr : getOutputs()) {
             if (namedExpr instanceof Alias) {
                 if (aliasMap.containsKey(namedExpr.child(0))) {
-                    fdBuilder.addEqualPair(namedExpr.toSlot(), aliasMap.get(namedExpr.child(0)).toSlot());
+                    builder.addEqualPair(namedExpr.toSlot(), aliasMap.get(namedExpr.child(0)).toSlot());
                 }
                 aliasMap.put(namedExpr.child(0), namedExpr);
             }
@@ -180,7 +180,7 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
+    public void computeFd(DataTrait.Builder builder) {
         // don't generate
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPlan.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.nereids.trees.plans.logical;
 
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 
@@ -57,13 +57,13 @@ public interface LogicalPlan extends Plan {
     }
 
     /**
-     * Compute FunctionalDependencies for different plan
+     * Compute DataTrait for different plan
      * Note: Unless you really know what you're doing, please use the following interface.
      *   - BlockFDPropagation: clean the fd
      *   - PropagateFD: propagate the fd
      */
-    default FunctionalDependencies computeFuncDeps() {
-        FunctionalDependencies.Builder fdBuilder = new FunctionalDependencies.Builder();
+    default DataTrait computeFuncDeps() {
+        DataTrait.Builder fdBuilder = new DataTrait.Builder();
         computeUniform(fdBuilder);
         computeUnique(fdBuilder);
         computeEqualSet(fdBuilder);
@@ -93,11 +93,11 @@ public interface LogicalPlan extends Plan {
 
     ImmutableSet<FdItem> computeFdItems();
 
-    void computeUnique(FunctionalDependencies.Builder fdBuilder);
+    void computeUnique(DataTrait.Builder builder);
 
-    void computeUniform(FunctionalDependencies.Builder fdBuilder);
+    void computeUniform(DataTrait.Builder builder);
 
-    void computeEqualSet(FunctionalDependencies.Builder fdBuilder);
+    void computeEqualSet(DataTrait.Builder builder);
 
-    void computeFd(FunctionalDependencies.Builder fdBuilder);
+    void computeFd(DataTrait.Builder builder);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.analyzer.UnboundStar;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.BoundStar;
@@ -211,74 +211,74 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
 
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         return builder.build();
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         for (NamedExpression proj : getProjects()) {
             if (proj.children().isEmpty()) {
                 continue;
             }
             if (proj.child(0) instanceof Uuid) {
-                fdBuilder.addUniqueSlot(proj.toSlot());
+                builder.addUniqueSlot(proj.toSlot());
             } else if (ExpressionUtils.isInjective(proj.child(0))) {
                 ImmutableSet<Slot> inputs = ImmutableSet.copyOf(proj.getInputSlots());
-                if (child(0).getLogicalProperties().getFunctionalDependencies().isUnique(inputs)) {
-                    fdBuilder.addUniqueSlot(proj.toSlot());
+                if (child(0).getLogicalProperties().getTrait().isUnique(inputs)) {
+                    builder.addUniqueSlot(proj.toSlot());
                 }
             }
         }
-        fdBuilder.pruneSlots(getOutputSet());
+        builder.pruneSlots(getOutputSet());
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         for (NamedExpression proj : getProjects()) {
             if (proj.children().isEmpty()) {
                 continue;
             }
             if (proj.child(0).isConstant()) {
-                fdBuilder.addUniformSlot(proj.toSlot());
+                builder.addUniformSlot(proj.toSlot());
             } else if (ExpressionUtils.isInjective(proj.child(0))) {
                 ImmutableSet<Slot> inputs = ImmutableSet.copyOf(proj.getInputSlots());
-                if (child(0).getLogicalProperties().getFunctionalDependencies().isUniform(inputs)) {
-                    fdBuilder.addUniformSlot(proj.toSlot());
+                if (child(0).getLogicalProperties().getTrait().isUniform(inputs)) {
+                    builder.addUniformSlot(proj.toSlot());
                 }
             }
         }
-        fdBuilder.pruneSlots(getOutputSet());
+        builder.pruneSlots(getOutputSet());
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
+    public void computeEqualSet(DataTrait.Builder builder) {
         Map<Expression, NamedExpression> aliasMap = new HashMap<>();
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
         for (NamedExpression expr : getProjects()) {
             if (expr instanceof Alias) {
                 if (aliasMap.containsKey(expr.child(0))) {
-                    fdBuilder.addEqualPair(expr.toSlot(), aliasMap.get(expr.child(0)).toSlot());
+                    builder.addEqualPair(expr.toSlot(), aliasMap.get(expr.child(0)).toSlot());
                 }
                 aliasMap.put(expr.child(0), expr);
                 if (expr.child(0).isSlot()) {
-                    fdBuilder.addEqualPair(expr.toSlot(), (Slot) expr.child(0));
+                    builder.addEqualPair(expr.toSlot(), (Slot) expr.child(0));
                 }
             }
         }
-        fdBuilder.pruneSlots(getOutputSet());
+        builder.pruneSlots(getOutputSet());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
         for (NamedExpression expr : getProjects()) {
             if (!expr.isSlot()) {
-                fdBuilder.addDeps(expr.getInputSlots(), ImmutableSet.of(expr.toSlot()));
+                builder.addDeps(expr.getInputSlots(), ImmutableSet.of(expr.toSlot()));
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -18,8 +18,8 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -186,32 +186,32 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         // don't generate unique slot
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
 
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         return builder.build();
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -18,8 +18,8 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -164,25 +164,25 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> outputs = getOutput();
         for (int i = 0; i < outputs.size(); i++) {
             replaceMap.put(child(0).getOutput().get(i), outputs.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> outputs = getOutput();
         for (int i = 0; i < outputs.size(); i++) {
             replaceMap.put(child(0).getOutput().get(i), outputs.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
@@ -192,19 +192,19 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
         Map<Slot, Slot> replaceMap = new HashMap<>();
         List<Slot> outputs = getOutput();
         for (int i = 0; i < outputs.size(); i++) {
             replaceMap.put(child(0).getOutput().get(i), outputs.get(i));
         }
-        fdBuilder.replace(replaceMap);
+        builder.replace(replaceMap);
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 
     public void setRelationId(RelationId relationId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
@@ -18,10 +18,10 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.ExprFdItem;
 import org.apache.doris.nereids.properties.FdFactory;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -165,36 +165,36 @@ public class LogicalTopN<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
     }
 
     @Override
-    public void computeUnique(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUnique(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniqueSlot);
+            getOutput().forEach(builder::addUniqueSlot);
         } else {
-            fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeUniform(FunctionalDependencies.Builder fdBuilder) {
+    public void computeUniform(DataTrait.Builder builder) {
         if (getLimit() == 1) {
-            getOutput().forEach(fdBuilder::addUniformSlot);
+            getOutput().forEach(builder::addUniformSlot);
         } else {
-            fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+            builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         }
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
-        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> fdItems = child(0).getLogicalProperties().getTrait().getFdItems();
         if (getLimit() == 1) {
             ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
             List<Slot> output = getOutput();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -20,9 +20,9 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.View;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -139,22 +139,22 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -18,9 +18,9 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.FdItem;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -242,7 +242,7 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
                 .map(s -> (Slot) s)
                 .collect(ImmutableSet.toImmutableSet());
         // if partition by keys are uniform or empty, output is unique
-        if (child(0).getLogicalProperties().getFunctionalDependencies().isUniformAndNotNull(slotSet)
+        if (child(0).getLogicalProperties().getTrait().isUniformAndNotNull(slotSet)
                 || slotSet.isEmpty()) {
             if (windowExpr.getFunction() instanceof RowNumber) {
                 return true;
@@ -265,7 +265,7 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
                 .map(s -> (Slot) s)
                 .collect(ImmutableSet.toImmutableSet());
         // if partition by keys are unique, output is uniform
-        if (child(0).getLogicalProperties().getFunctionalDependencies().isUniqueAndNotNull(slotSet)) {
+        if (child(0).getLogicalProperties().getTrait().isUniqueAndNotNull(slotSet)) {
             if (windowExpr.getFunction() instanceof RowNumber
                     || windowExpr.getFunction() instanceof Rank
                     || windowExpr.getFunction() instanceof DenseRank) {
@@ -296,7 +296,7 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     @Override
     public ImmutableSet<FdItem> computeFdItems() {
         ImmutableSet.Builder<FdItem> builder = ImmutableSet.builder();
-        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getFunctionalDependencies().getFdItems();
+        ImmutableSet<FdItem> childItems = child().getLogicalProperties().getTrait().getFdItems();
         builder.addAll(childItems);
 
         for (NamedExpression namedExpression : windowExpressions) {
@@ -307,32 +307,32 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     @Override
-    public void computeUnique(Builder fdBuilder) {
-        fdBuilder.addUniqueSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUnique(Builder builder) {
+        builder.addUniqueSlot(child(0).getLogicalProperties().getTrait());
         for (NamedExpression namedExpression : windowExpressions) {
             if (isUnique(namedExpression)) {
-                fdBuilder.addUniqueSlot(namedExpression.toSlot());
+                builder.addUniqueSlot(namedExpression.toSlot());
             }
         }
     }
 
     @Override
-    public void computeUniform(Builder fdBuilder) {
-        fdBuilder.addUniformSlot(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeUniform(Builder builder) {
+        builder.addUniformSlot(child(0).getLogicalProperties().getTrait());
         for (NamedExpression namedExpression : windowExpressions) {
             if (isUniform(namedExpression)) {
-                fdBuilder.addUniformSlot(namedExpression.toSlot());
+                builder.addUniformSlot(namedExpression.toSlot());
             }
         }
     }
 
     @Override
-    public void computeEqualSet(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addEqualSet(child(0).getLogicalProperties().getFunctionalDependencies());
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(child(0).getLogicalProperties().getTrait());
     }
 
     @Override
-    public void computeFd(FunctionalDependencies.Builder fdBuilder) {
-        fdBuilder.addFuncDepsDG(child().getLogicalProperties().getFunctionalDependencies());
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(child().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
@@ -20,7 +20,7 @@ package org.apache.doris.nereids.trees.plans.physical;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -59,7 +59,7 @@ public class PhysicalSqlCache extends PhysicalLeaf implements SqlCache, TreeStri
             Optional<ResultSet> resultSet, List<InternalService.PCacheValue> cacheValues,
             String backendAddress, String planBody) {
         super(PlanType.PHYSICAL_SQL_CACHE, Optional.empty(),
-                new LogicalProperties(() -> ImmutableList.of(), () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(() -> ImmutableList.of(), () -> DataTrait.EMPTY_TRAIT));
         this.queryId = Objects.requireNonNull(queryId, "queryId can not be null");
         this.columnLabels = Objects.requireNonNull(columnLabels, "colNames can not be null");
         this.resultExprs = Objects.requireNonNull(resultExprs, "resultExprs can not be null");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -20,11 +20,11 @@ package org.apache.doris.nereids.util;
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.DistributionSpecHash;
 import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
 import org.apache.doris.nereids.properties.DistributionSpecReplicated;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
 import org.apache.doris.nereids.rules.rewrite.ForeignKeyContext;
 import org.apache.doris.nereids.trees.expressions.EqualPredicate;
 import org.apache.doris.nereids.trees.expressions.ExprId;
@@ -347,7 +347,7 @@ public class JoinUtils {
     /**
      * can this join be eliminated by its left child
      */
-    public static boolean canEliminateByLeft(LogicalJoin<?, ?> join, FunctionalDependencies rightFuncDeps) {
+    public static boolean canEliminateByLeft(LogicalJoin<?, ?> join, DataTrait rightFuncDeps) {
         if (join.getJoinType().isLeftOuterJoin()) {
             Pair<Set<Slot>, Set<Slot>> njHashKeys = join.extractNullRejectHashKeys();
             if (!join.getOtherJoinConjuncts().isEmpty() || njHashKeys == null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -19,7 +19,7 @@ package org.apache.doris.nereids.glue.translator;
 
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -64,7 +64,7 @@ public class PhysicalPlanTranslatorTest {
         t1Output.add(col1);
         t1Output.add(col2);
         t1Output.add(col3);
-        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> FunctionalDependencies.EMPTY_FUNC_DEPS);
+        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> DataTrait.EMPTY_TRAIT);
         PhysicalOlapScan scan = new PhysicalOlapScan(StatementScopeIdGenerator.newRelationId(), t1, qualifier, t1.getBaseIndexId(),
                 Collections.emptyList(), Collections.emptyList(), null, PreAggStatus.on(),
                 ImmutableList.of(), Optional.empty(), t1Properties, Optional.empty());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -22,7 +22,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.JobContext;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ExprId;
@@ -87,7 +87,7 @@ public class DeriveStatsJobTest {
 
         return (LogicalOlapScan) new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(), table1,
                 Collections.emptyList()).withGroupExprLogicalPropChildren(Optional.empty(),
-                Optional.of(new LogicalProperties(() -> ImmutableList.of(slot1), () -> FunctionalDependencies.EMPTY_FUNC_DEPS)), ImmutableList.of());
+                Optional.of(new LogicalProperties(() -> ImmutableList.of(slot1), () -> DataTrait.EMPTY_TRAIT)), ImmutableList.of());
     }
 
     private LogicalAggregate constructAgg(Plan child) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -22,7 +22,7 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.cost.Cost;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.properties.UnboundLogicalProperties;
@@ -90,18 +90,18 @@ class MemoTest implements MemoPatternMatchSupported {
     @Test
     void testMergeGroup() {
         Group srcGroup = new Group(new GroupId(2), new GroupExpression(new FakePlan()),
-                new LogicalProperties(ArrayList::new, () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(ArrayList::new, () -> DataTrait.EMPTY_TRAIT));
         Group dstGroup = new Group(new GroupId(3), new GroupExpression(new FakePlan()),
-                new LogicalProperties(ArrayList::new, () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(ArrayList::new, () -> DataTrait.EMPTY_TRAIT));
 
         FakePlan fakePlan = new FakePlan();
         GroupExpression srcParentExpression = new GroupExpression(fakePlan, Lists.newArrayList(srcGroup));
         Group srcParentGroup = new Group(new GroupId(0), srcParentExpression,
-                new LogicalProperties(ArrayList::new, () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(ArrayList::new, () -> DataTrait.EMPTY_TRAIT));
         srcParentGroup.setBestPlan(srcParentExpression, Cost.zeroV1(), PhysicalProperties.ANY);
         GroupExpression dstParentExpression = new GroupExpression(fakePlan, Lists.newArrayList(dstGroup));
         Group dstParentGroup = new Group(new GroupId(1), dstParentExpression,
-                new LogicalProperties(ArrayList::new, () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(ArrayList::new, () -> DataTrait.EMPTY_TRAIT));
 
         Memo memo = new Memo();
         Map<GroupId, Group> groups = Deencapsulation.getField(memo, "groups");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
@@ -21,7 +21,7 @@ import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.processor.post.MergeProjectPostProcessor;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -75,7 +75,7 @@ public class MergeProjectPostProcessTest {
         t1Output.add(a);
         t1Output.add(b);
         t1Output.add(c);
-        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> FunctionalDependencies.EMPTY_FUNC_DEPS);
+        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> DataTrait.EMPTY_TRAIT);
         PhysicalOlapScan scan = new PhysicalOlapScan(RelationId.createGenerator().getNextId(), t1, qualifier, 0L,
                 Collections.emptyList(), Collections.emptyList(), null, PreAggStatus.on(), ImmutableList.of(),
                 Optional.empty(), t1Properties, Optional.empty());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
@@ -21,7 +21,7 @@ import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.processor.post.PushDownFilterThroughProject;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
@@ -86,7 +86,7 @@ public class PushDownFilterThroughProjectTest {
         t1Output.add(a);
         t1Output.add(b);
         t1Output.add(c);
-        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> FunctionalDependencies.EMPTY_FUNC_DEPS);
+        LogicalProperties t1Properties = new LogicalProperties(() -> t1Output, () -> DataTrait.EMPTY_TRAIT);
         PhysicalOlapScan scan = new PhysicalOlapScan(RelationId.createGenerator().getNextId(), t1,
                 qualifier, 0L, Collections.emptyList(), Collections.emptyList(), null,
                 PreAggStatus.on(), ImmutableList.of(), Optional.empty(), t1Properties,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.nereids.properties;
 
-import org.apache.doris.nereids.properties.FunctionalDependencies.Builder;
+import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-class FunctionalDependenciesTest extends TestWithFeService {
+class DataTraitTest extends TestWithFeService {
     Slot slot1 = new SlotReference("1", IntegerType.INSTANCE, false);
     Slot slot2 = new SlotReference("2", IntegerType.INSTANCE, false);
     Slot slot3 = new SlotReference("1", IntegerType.INSTANCE, false);
@@ -60,7 +60,7 @@ class FunctionalDependenciesTest extends TestWithFeService {
     void testUniform() {
         Builder fdBuilder = new Builder();
         fdBuilder.addUniformSlot(slot1);
-        FunctionalDependencies fd = fdBuilder.build();
+        DataTrait fd = fdBuilder.build();
         Assertions.assertTrue(fd.isUniformAndNotNull(slot1));
         Assertions.assertFalse(fd.isUniformAndNotNull(slot2));
         fdBuilder.addUniformSlot(slot2);
@@ -80,7 +80,7 @@ class FunctionalDependenciesTest extends TestWithFeService {
     void testUnique() {
         Builder fdBuilder = new Builder();
         fdBuilder.addUniqueSlot(slot1);
-        FunctionalDependencies fd = fdBuilder.build();
+        DataTrait fd = fdBuilder.build();
         Assertions.assertTrue(fd.isUniqueAndNotNull(slot1));
         Assertions.assertFalse(fd.isUniqueAndNotNull(slot2));
         fdBuilder.addUniqueSlot(slot2);
@@ -101,8 +101,8 @@ class FunctionalDependenciesTest extends TestWithFeService {
         Builder fdBuilder2 = new Builder();
         fdBuilder2.addUniformSlot(slot2);
 
-        fdBuilder1.addFunctionalDependencies(fdBuilder2.build());
-        FunctionalDependencies fd = fdBuilder1.build();
+        fdBuilder1.addDataTrait(fdBuilder2.build());
+        DataTrait fd = fdBuilder1.build();
         Assertions.assertTrue(fd.isUniformAndNotNull(slot1));
         Assertions.assertTrue(fd.isUniformAndNotNull(slot2));
     }
@@ -113,13 +113,13 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select id from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from uni")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -129,7 +129,7 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select name from agg where name = \"1\"")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniformAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -140,61 +140,61 @@ class FunctionalDependenciesTest extends TestWithFeService {
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUniform(plan.getOutputSet()));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUniform(plan.getOutputSet()));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg full outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutputSet()));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutputSet()));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id from agg left outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id from agg left semi join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id from agg left anti join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id from agg right outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
     }
 
     @Test
@@ -203,47 +203,47 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select count(1), name from agg group by name")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select count(1), max(id), id from agg group by id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(2)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(2)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select count(1), id from agg where id = 1 group by id")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(1)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select count(name) from agg")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg where id = 1 group by cube(id, name)")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
     }
 
     @Test
@@ -252,9 +252,9 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select k1 from (select 1 k1) as t lateral view explode([1,2,3]) tmp1 as e1")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
     }
 
     @Test
@@ -263,26 +263,26 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select id, row_number() over(partition by id) from agg")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select row_number() over(partition by name) from agg where name = '1'")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select row_number() over(partition by name) from agg where name = '1' limit 1")
                 .rewrite()
                 .getPlan();
         LogicalPartitionTopN<?> ptopn = (LogicalPartitionTopN<?>) plan.child(0).child(0).child(0).child(0).child(0);
-        System.out.println(ptopn.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(ptopn.getLogicalProperties().getTrait());
         Assertions.assertTrue(ptopn.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(ImmutableSet.copyOf(ptopn.getOutputSet())));
+                .getTrait().isUniformAndNotNull(ImmutableSet.copyOf(ptopn.getOutputSet())));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select row_number() over(partition by name) from agg limit 1")
@@ -291,7 +291,7 @@ class FunctionalDependenciesTest extends TestWithFeService {
         ptopn = (LogicalPartitionTopN<?>) plan.child(0).child(0).child(0).child(0).child(0);
 
         Assertions.assertFalse(ptopn.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
     }
 
     @Test
@@ -301,9 +301,9 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutputSet()));
+                .getTrait().isUniform(plan.getOutputSet()));
     }
 
     @Test
@@ -312,17 +312,17 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select name from agg limit 1")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select name from agg order by id limit 1")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -331,9 +331,9 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select id from (select * from agg) t")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Disabled
@@ -343,9 +343,9 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("with t as (select * from agg) select id from t where id = 1")
                 .getPlan();
         System.out.println(plan.treeString());
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -354,38 +354,38 @@ class FunctionalDependenciesTest extends TestWithFeService {
                 .analyze("select * from agg union select * from uni")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
+                .getTrait().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select * from agg union all select * from uni")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
+                .getTrait().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select * from agg intersect select * from uni where name = \"1\"")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
+                .getTrait().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select * from agg except select * from uni")
                 .rewrite()
                 .getPlan();
-        System.out.println(plan.getLogicalProperties().getFunctionalDependencies());
+        System.out.println(plan.getLogicalProperties().getTrait());
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
+                .getTrait().isUniqueAndNotNull(ImmutableSet.copyOf(plan.getOutput())));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/EqualSetTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/EqualSetTest.java
@@ -59,7 +59,7 @@ class EqualSetTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id group by id, id2")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
@@ -68,12 +68,12 @@ class EqualSetTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id limit 1")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id limit 1 order by id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
@@ -82,27 +82,27 @@ class EqualSetTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id intersect select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id except select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id union all select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEmpty());
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id union all select id, id2 from agg where id2 = id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg union all select id, id2 from agg where id2 = id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEmpty());
     }
 
@@ -111,13 +111,13 @@ class EqualSetTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg  group by id, id2 having id = id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
@@ -127,7 +127,7 @@ class EqualSetTest extends TestWithFeService {
                 .analyze("select id, id2 from agg lateral view explode([1,2,3]) tmp1 as e1 where id = id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
@@ -139,7 +139,7 @@ class EqualSetTest extends TestWithFeService {
                         + "where agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
 
         // foj
@@ -148,11 +148,11 @@ class EqualSetTest extends TestWithFeService {
                         + " on t1.id = t2.id  full outer join uni as t3 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isEqualAndNotNotNull(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(2)));
 
         // loj
@@ -161,11 +161,11 @@ class EqualSetTest extends TestWithFeService {
                         + " on t1.id = t2.id  left outer join uni as t3 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEqualAndNotNotNull(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(2)));
 
         // roj
@@ -174,11 +174,11 @@ class EqualSetTest extends TestWithFeService {
                         + " on t1.id = t2.id  right outer join uni as t3 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isEqualAndNotNotNull(plan.getOutput().get(0), plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(2)));
     }
 
@@ -189,7 +189,7 @@ class EqualSetTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
     @Test
@@ -199,13 +199,13 @@ class EqualSetTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(2)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(2)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(1), plan.getOutput().get(2)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(1), plan.getOutput().get(2)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(3), plan.getOutput().get(4)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(3), plan.getOutput().get(4)));
     }
 
     @Test
@@ -214,7 +214,7 @@ class EqualSetTest extends TestWithFeService {
                 .analyze("select id, id2 from (select id, id2 from agg where id = id2) t")
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
     @Test
@@ -225,7 +225,7 @@ class EqualSetTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
+                .getTrait().isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FdTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FdTest.java
@@ -64,10 +64,10 @@ class FdTest extends TestWithFeService {
                 .getPlan();
         Set<Slot> output = ImmutableSet.copyOf(plan.getOutputSet());
         System.out.println(plan.getLogicalProperties()
-                .getFunctionalDependencies().getAllValidFuncDeps(output));
+                .getTrait().getAllValidFuncDeps(output));
         Assertions.assertTrue(
                 plan.getLogicalProperties()
-                .getFunctionalDependencies().getAllValidFuncDeps(output)
+                .getTrait().getAllValidFuncDeps(output)
                         .isFuncDeps(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
     }
 
@@ -78,10 +78,10 @@ class FdTest extends TestWithFeService {
                 .getPlan();
         Set<Slot> output = ImmutableSet.copyOf(plan.getOutputSet());
         System.out.println(plan.getLogicalProperties()
-                .getFunctionalDependencies().getAllValidFuncDeps(output));
+                .getTrait().getAllValidFuncDeps(output));
         Assertions.assertTrue(
                 plan.getLogicalProperties()
-                        .getFunctionalDependencies().getAllValidFuncDeps(output)
+                        .getTrait().getAllValidFuncDeps(output)
                         .isFuncDeps(output, ImmutableSet.of(plan.getOutput().get(0))));
     }
 
@@ -90,22 +90,22 @@ class FdTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id intersect select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id except select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id2 = id union all select id, id2 from agg")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEmpty());
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg union all select id, id2 from agg where id2 = id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEmpty());
     }
 
@@ -114,17 +114,17 @@ class FdTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg where id = 1")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from agg  group by id, id2 having id = 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
     }
 
@@ -134,7 +134,7 @@ class FdTest extends TestWithFeService {
                 .analyze("select id, id2 from  agg lateral view explode([1,2,3]) tmp1 as e1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
     }
 
@@ -146,11 +146,11 @@ class FdTest extends TestWithFeService {
                         + "where agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(2))));
 
         // foj
@@ -159,9 +159,9 @@ class FdTest extends TestWithFeService {
                         + "from uni as t1 full outer join uni as t2 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
 
         // loj
@@ -170,9 +170,9 @@ class FdTest extends TestWithFeService {
                         + "from uni as t1 left outer join uni as t2 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
 
         // roj
@@ -181,9 +181,9 @@ class FdTest extends TestWithFeService {
                         + "from uni as t1 right outer join uni as t2 on t1.id2 = t2.id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(2)), ImmutableSet.of(plan.getOutput().get(3))));
     }
 
@@ -193,7 +193,7 @@ class FdTest extends TestWithFeService {
                 .analyze("select 1, 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
     }
 
@@ -203,9 +203,9 @@ class FdTest extends TestWithFeService {
                 .analyze("select id as o1, id as o2, id2 as o4, 1 as c1, 1 as c2 from uni where id = id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
     }
 
@@ -214,9 +214,9 @@ class FdTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select id, id2 from (select id, id2 from agg where id = id2) t")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(0)), ImmutableSet.of(plan.getOutput().get(1))));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
     }
 
@@ -227,7 +227,7 @@ class FdTest extends TestWithFeService {
                 .analyze("select id, id2, row_number() over(partition by id) from agg where id = id2")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isDependent(ImmutableSet.of(plan.getOutput().get(1)), ImmutableSet.of(plan.getOutput().get(0))));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
@@ -60,26 +60,26 @@ class UniformTest extends TestWithFeService {
         Plan plan = PlanChecker.from(connectContext)
                 .analyze("select count(id) from agg group by id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
 
         // propagate uniform
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg where id = 1 group by id ")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
 
         // group by all/uniform
         plan = PlanChecker.from(connectContext)
                 .analyze("select sum(id) from agg ")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select sum(id) from agg where id = 1 group by id")
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
 
     }
@@ -90,13 +90,13 @@ class UniformTest extends TestWithFeService {
                 .analyze("select name from agg limit 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniformAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select name from agg order by name limit 1 ")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniformAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -106,13 +106,13 @@ class UniformTest extends TestWithFeService {
                 .analyze("select name from agg limit 1 except select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg intersect select name from agg limit 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
     }
 
@@ -122,13 +122,13 @@ class UniformTest extends TestWithFeService {
                 .analyze("select id from agg where id = 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniformAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select name from uni group by name having name = \"\"")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniformAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -139,7 +139,7 @@ class UniformTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutputSet()));
+                .getTrait().isUniform(plan.getOutputSet()));
     }
 
     @Test
@@ -150,7 +150,7 @@ class UniformTest extends TestWithFeService {
                         + "on agg.id = uni.id where uni.id = 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUniform(plan.getOutput().get(0)));
     }
 
     @Test
@@ -160,7 +160,7 @@ class UniformTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
     }
 
     @Test
@@ -170,9 +170,9 @@ class UniformTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(1)));
     }
 
     @Test
@@ -181,7 +181,7 @@ class UniformTest extends TestWithFeService {
                 .analyze("select id from (select id from agg where id = 1) t")
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniformAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -192,19 +192,19 @@ class UniformTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select rank() over(partition by id) from agg")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select dense_rank() over(partition by id) from agg")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniform(plan.getOutput().get(0)));
+                .getTrait().isUniform(plan.getOutput().get(0)));
     }
 
     @Test
@@ -214,6 +214,6 @@ class UniformTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutputSet()));
+                .getTrait().isUniqueAndNotNull(plan.getOutputSet()));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
@@ -60,25 +60,25 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select name from agg group by name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select sum(id) from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id, sum(id), avg(id), max(id), min(id) from agg group by id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutput().get(0)));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutput().get(1)));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutput().get(2)));
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutput().get(3)));
 
     }
@@ -90,7 +90,7 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
 
         // test unique key
@@ -98,7 +98,7 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from uni")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
 
         // test unique constraint
@@ -107,7 +107,7 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         dropConstraint("alter table agg drop constraint uq");
 
@@ -117,7 +117,7 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         dropConstraint("alter table agg drop constraint pk");
     }
@@ -128,13 +128,13 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select name from agg limit 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select name from agg order by name limit 1 ")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -144,25 +144,25 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select name from agg limit 1 except select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg intersect select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg union all select name from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isEmpty());
         plan = PlanChecker.from(connectContext)
                 .analyze("select name, id from agg union select name, id from agg")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutputSet()));
     }
 
@@ -172,13 +172,13 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from agg where id = 1")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select name from uni group by name having name = \"\"")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
@@ -189,7 +189,7 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
     }
 
     @Test
@@ -200,7 +200,7 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutputSet()));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutputSet()));
 
         // loj propagate unique when right is unique
         plan = PlanChecker.from(connectContext)
@@ -208,14 +208,14 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg left outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(1)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(1)));
 
         // roj propagate unique when left is unique
         plan = PlanChecker.from(connectContext)
@@ -223,16 +223,16 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(1)));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id, uni.id from agg right outer join uni "
                         + "on agg.id = uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(1)));
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(1)));
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
 
         // semi/anti join propagate all
         plan = PlanChecker.from(connectContext)
@@ -240,25 +240,25 @@ class UniqueTest extends TestWithFeService {
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select agg.id from agg left anti join uni "
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id from agg right semi join uni "
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id from agg right anti join uni "
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertTrue(plan.getLogicalProperties().getFunctionalDependencies().isUnique(plan.getOutput().get(0)));
+        Assertions.assertTrue(plan.getLogicalProperties().getTrait().isUnique(plan.getOutput().get(0)));
 
         // inner join propagate unique only when join key is unique
         plan = PlanChecker.from(connectContext)
@@ -267,9 +267,9 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
@@ -277,30 +277,30 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id < uni.id")
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id or agg.name > uni.name")
                 .rewrite()
                 .getPlan();
         Assertions.assertFalse(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUnique(plan.getOutputSet()));
+                .getTrait().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id and agg.name > uni.name")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
     }
 
     @Test
@@ -310,7 +310,7 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -320,7 +320,7 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -329,13 +329,13 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from agg  group by GROUPING SETS ((id, name), (id))")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select id from agg group by rollup (id, name)")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties().getFunctionalDependencies()
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
                 .isUnique(plan.getOutputSet()));
     }
 
@@ -345,7 +345,7 @@ class UniqueTest extends TestWithFeService {
                 .analyze("select id from (select id from agg) t")
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -355,7 +355,7 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
     @Test
@@ -366,9 +366,9 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
 
         // partition by None
         plan = PlanChecker.from(connectContext)
@@ -376,9 +376,9 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(0)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
     }
 
     @Test
@@ -388,7 +388,7 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutput().get(1)));
+                .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
 
         plan = PlanChecker.from(connectContext)
                 .analyze("select t1.name, t2.id from "
@@ -398,6 +398,6 @@ class UniqueTest extends TestWithFeService {
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties()
-                .getFunctionalDependencies().isUniqueAndNotNull(plan.getOutputSet()));
+                .getTrait().isUniqueAndNotNull(plan.getOutputSet()));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
@@ -20,7 +20,7 @@ package org.apache.doris.nereids.stats;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupId;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -74,14 +74,14 @@ public class JoinEstimateTest {
                     public List<Slot> get() {
                         return Lists.newArrayList(a);
                     }
-                }, () -> FunctionalDependencies.EMPTY_FUNC_DEPS)));
+                }, () -> DataTrait.EMPTY_TRAIT)));
         GroupPlan right = new GroupPlan(new Group(idGenerator.getNextId(), new LogicalProperties(
                 new Supplier<List<Slot>>() {
                     @Override
                     public List<Slot> get() {
                         return Lists.newArrayList(b);
                     }
-                }, () -> FunctionalDependencies.EMPTY_FUNC_DEPS)));
+                }, () -> DataTrait.EMPTY_TRAIT)));
         LogicalJoin join = new LogicalJoin(JoinType.INNER_JOIN, Lists.newArrayList(eq),
                 left, right, null);
         Statistics outputStats = JoinEstimation.estimate(leftStats, rightStats, join);
@@ -125,14 +125,14 @@ public class JoinEstimateTest {
                     public List<Slot> get() {
                         return Lists.newArrayList(a);
                     }
-                }, () -> FunctionalDependencies.EMPTY_FUNC_DEPS)));
+                }, () -> DataTrait.EMPTY_TRAIT)));
         GroupPlan right = new GroupPlan(new Group(idGenerator.getNextId(), new LogicalProperties(
                 new Supplier<List<Slot>>() {
                     @Override
                     public List<Slot> get() {
                         return Lists.newArrayList(b, c);
                     }
-                }, () -> FunctionalDependencies.EMPTY_FUNC_DEPS)));
+                }, () -> DataTrait.EMPTY_TRAIT)));
         LogicalJoin join = new LogicalJoin(JoinType.LEFT_OUTER_JOIN, Lists.newArrayList(eq),
                 left, right, null);
         Statistics outputStats = JoinEstimation.estimate(leftStats, rightStats, join);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -22,7 +22,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.properties.FunctionalDependencies;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
@@ -63,7 +63,7 @@ public class StatsCalculatorTest {
     private Group newFakeGroup() {
         GroupExpression groupExpression = new GroupExpression(scan);
         Group group = new Group(null, groupExpression,
-                new LogicalProperties(Collections::emptyList, () -> FunctionalDependencies.EMPTY_FUNC_DEPS));
+                new LogicalProperties(Collections::emptyList, () -> DataTrait.EMPTY_TRAIT));
         group.getLogicalExpressions().remove(0);
         return group;
     }
@@ -252,7 +252,7 @@ public class StatsCalculatorTest {
         LogicalOlapScan logicalOlapScan1 = (LogicalOlapScan) new LogicalOlapScan(
                 StatementScopeIdGenerator.newRelationId(), table1,
                 Collections.emptyList()).withGroupExprLogicalPropChildren(Optional.empty(),
-                Optional.of(new LogicalProperties(() -> ImmutableList.of(slot1), () -> FunctionalDependencies.EMPTY_FUNC_DEPS)), ImmutableList.of());
+                Optional.of(new LogicalProperties(() -> ImmutableList.of(slot1), () -> DataTrait.EMPTY_TRAIT)), ImmutableList.of());
 
         GroupExpression groupExpression = new GroupExpression(logicalOlapScan1, ImmutableList.of());
         Group ownerGroup = new Group(null, groupExpression, null);


### PR DESCRIPTION
## Proposed changes

In this PR, we are proposing a change in terminology from "Functional Dependencies" to "Data Traits" across the entire codebase.

Key Reasons for Renaming:

1. Avoiding Semantic Duplication: The term "Functional Dependencies" often overlaps semantically with the concept of functional dependencies. This overlap can lead to confusion and miscommunication.

2. Inclusive Terminology: "Data Traits" is a broader, more inclusive term that captures a variety of data characteristics. Specifically, it encompasses:
* Unique Traits: Properties that ensure data uniqueness across datasets.
* Uniform Traits: Characteristics that maintain data consistency and standardization.
* Equal Traits: Traits that enforce equality conditions across data elements.
* Functional Dependencies (funcDeps): Traditional dependencies that define relationships between different data fields based on their values.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

