### PR TITLE
[fix](move-memtable) clear load streams before shutdown SegmentFileWriterThreadPool

### DIFF
--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -169,6 +169,6 @@ private:
     QueryThreadContext _query_thread_context;
 };
 
-using LoadStreamSharedPtr = std::shared_ptr<LoadStream>;
+using LoadStreamPtr = std::unique_ptr<LoadStream>;
 
 } // namespace doris

--- a/be/src/runtime/load_stream_mgr.h
+++ b/be/src/runtime/load_stream_mgr.h
@@ -38,8 +38,7 @@ public:
                   FifoThreadPool* light_work_pool);
     ~LoadStreamMgr();
 
-    Status open_load_stream(const POpenLoadStreamRequest* request,
-                            LoadStreamSharedPtr& load_stream);
+    Status open_load_stream(const POpenLoadStreamRequest* request, LoadStream*& load_stream);
     void clear_load(UniqueId loadid);
     void create_tokens(std::vector<std::unique_ptr<ThreadPoolToken>>& tokens) {
         for (int i = 0; i < _num_threads * 2; i++) {
@@ -56,7 +55,7 @@ public:
 
 private:
     std::mutex _lock;
-    std::unordered_map<UniqueId, LoadStreamSharedPtr> _load_streams_map;
+    std::unordered_map<UniqueId, LoadStreamPtr> _load_streams_map;
     std::unique_ptr<ThreadPool> _file_writer_thread_pool;
 
     uint32_t _num_threads = 0;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -376,14 +376,14 @@ void PInternalService::open_load_stream(google::protobuf::RpcController* control
             tablet->tablet_schema()->to_schema_pb(resp->mutable_tablet_schema());
         }
 
-        LoadStreamSharedPtr load_stream;
+        LoadStream* load_stream = nullptr;
         auto st = _load_stream_mgr->open_load_stream(request, load_stream);
         if (!st.ok()) {
             st.to_protobuf(response->mutable_status());
             return;
         }
 
-        stream_options.handler = load_stream.get();
+        stream_options.handler = load_stream;
         stream_options.idle_timeout_ms = request->idle_timeout_ms();
         DBUG_EXECUTE_IF("PInternalServiceImpl.open_load_stream.set_idle_timeout",
                         { stream_options.idle_timeout_ms = 1; });

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -376,12 +376,12 @@ public:
                 tablet->tablet_schema()->to_schema_pb(resp->mutable_tablet_schema());
             }
 
-            LoadStreamSharedPtr load_stream;
+            LoadStream* load_stream;
             LOG(INFO) << "total streams: " << request->total_streams();
             EXPECT_GT(request->total_streams(), 0);
             auto st = _load_stream_mgr->open_load_stream(request, load_stream);
 
-            stream_options.handler = load_stream.get();
+            stream_options.handler = load_stream;
 
             StreamId streamid;
             if (brpc::StreamAccept(&streamid, *cntl, &stream_options) != 0) {


### PR DESCRIPTION
## Proposed changes

In `~LoadStreamMgr()`, clear load streams before shutdown SegmentFileWriterThreadPool.
To fix the following check failure.

```
F20240428 03:36:59.966398 10071 threadpool.cpp:253] Check failed: 1 == _tokens.size() (1 vs. 97) Threadpool SegmentFileWriterThreadPool destroyed with 97 allocated tokens
*** Check failure stack trace: ***
    @     0x55a0d476b7a6  google::LogMessage::SendToLog()
    @     0x55a0d47681f0  google::LogMessage::Flush()
    @     0x55a0d476bfe9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55a0cad50d19  doris::ThreadPool::~ThreadPool()
    @     0x55a0cac64f8b  doris::LoadStreamMgr::~LoadStreamMgr()
    @     0x55a0cac36d02  doris::PInternalServiceImpl::~PInternalServiceImpl()
    @     0x55a0cac372ee  doris::PInternalServiceImpl::~PInternalServiceImpl()
    @     0x55a0d63604f5  brpc::Server::ClearServices()
    @     0x55a0cac2bab1  doris::BRpcService::join()
    @     0x55a0cac2b9cf  doris::BRpcService::~BRpcService()
    @     0x55a0c9e3ef7b  main
    @     0x7f24519bd083  __libc_start_main
    @     0x55a0c9e3d02a  _start
    @              (nil)  (unknown)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

