### PR TITLE
[feature](statistics)Record partition update rows for each column.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -35,7 +35,9 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -188,6 +190,8 @@ public class AnalysisInfo implements Writable {
 
     @SerializedName("updateRows")
     public final long updateRows;
+
+    public final Map<Long, Long> partitionUpdateRows = new HashMap();
     /**
      *
      * Used to store the newest partition version of tbl when creating this job.
@@ -209,7 +213,7 @@ public class AnalysisInfo implements Writable {
             boolean partitionOnly, boolean samplingPartition,
             boolean isAllPartition, long partitionCount, CronExpression cronExpression, boolean forceFull,
             boolean usingSqlForExternalTable, long tblUpdateTime, long rowCount, boolean userInject,
-            long updateRows, JobPriority priority) {
+            long updateRows, JobPriority priority, Map<Long, Long> partitionUpdateRows) {
         this.jobId = jobId;
         this.taskId = taskId;
         this.taskIds = taskIds;
@@ -248,6 +252,9 @@ public class AnalysisInfo implements Writable {
         this.userInject = userInject;
         this.updateRows = updateRows;
         this.priority = priority;
+        if (partitionUpdateRows != null) {
+            this.partitionUpdateRows.putAll(partitionUpdateRows);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -27,6 +27,7 @@ import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 import org.apache.logging.log4j.core.util.CronExpression;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class AnalysisInfoBuilder {
@@ -65,6 +66,7 @@ public class AnalysisInfoBuilder {
     private boolean userInject;
     private long updateRows;
     private JobPriority priority;
+    private Map<Long, Long> partitionUpdateRows;
 
     public AnalysisInfoBuilder() {
     }
@@ -105,6 +107,7 @@ public class AnalysisInfoBuilder {
         userInject = info.userInject;
         updateRows = info.updateRows;
         priority = info.priority;
+        partitionUpdateRows = info.partitionUpdateRows;
     }
 
     public AnalysisInfoBuilder setJobId(long jobId) {
@@ -282,13 +285,18 @@ public class AnalysisInfoBuilder {
         return this;
     }
 
+    public AnalysisInfoBuilder setPartitionUpdateRows(Map<Long, Long> partitionUpdateRows) {
+        this.partitionUpdateRows = partitionUpdateRows;
+        return this;
+    }
+
     public AnalysisInfo build() {
         return new AnalysisInfo(jobId, taskId, taskIds, catalogId, dbId, tblId, jobColumns, partitionNames,
                 colName, indexId, jobType, analysisMode, analysisMethod, analysisType, samplePercent,
                 sampleRows, maxBucketNum, periodTimeInMs, message, lastExecTimeInMs, timeCostInMs, state, scheduleType,
                 partitionOnly, samplingPartition, isAllPartition, partitionCount,
                 cronExpression, forceFull, usingSqlForExternalTable, tblUpdateTime, rowCount, userInject, updateRows,
-                priority);
+                priority, partitionUpdateRows);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -381,6 +381,7 @@ public class AnalysisManager implements Writable {
         TableStatsMeta tableStatsStatus = findTableStatsStatus(table.getId());
         infoBuilder.setUpdateRows(tableStatsStatus == null ? 0 : tableStatsStatus.updatedRows.get());
         infoBuilder.setPriority(JobPriority.MANUAL);
+        infoBuilder.setPartitionUpdateRows(tableStatsStatus == null ? null : tableStatsStatus.partitionUpdateRows);
         return infoBuilder.build();
     }
 
@@ -513,6 +514,9 @@ public class AnalysisManager implements Writable {
         }
         if (jobInfo.partitionNames != null) {
             jobInfo.partitionNames.clear();
+        }
+        if (jobInfo.partitionUpdateRows != null) {
+            jobInfo.partitionUpdateRows.clear();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsMeta.java
@@ -23,6 +23,9 @@ import org.apache.doris.statistics.AnalysisInfo.JobType;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ColStatsMeta {
@@ -49,8 +52,11 @@ public class ColStatsMeta {
     @SerializedName("rowCount")
     public long rowCount;
 
+    @SerializedName("pur")
+    public ConcurrentMap<Long, Long> partitionUpdateRows = new ConcurrentHashMap<>();
+
     public ColStatsMeta(long updatedTime, AnalysisMethod analysisMethod, AnalysisType analysisType, JobType jobType,
-            long queriedTimes, long rowCount, long updatedRows) {
+            long queriedTimes, long rowCount, long updatedRows, Map<Long, Long> partitionUpdateRows) {
         this.updatedTime = updatedTime;
         this.analysisMethod = analysisMethod;
         this.analysisType = analysisType;
@@ -58,5 +64,8 @@ public class ColStatsMeta {
         this.queriedTimes.addAndGet(queriedTimes);
         this.updatedRows = updatedRows;
         this.rowCount = rowCount;
+        if (partitionUpdateRows != null) {
+            this.partitionUpdateRows.putAll(partitionUpdateRows);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -210,6 +210,7 @@ public class StatisticsAutoCollector extends MasterDaemon {
                 .setRowCount(rowCount)
                 .setUpdateRows(tableStatsStatus == null ? 0 : tableStatsStatus.updatedRows.get())
                 .setPriority(priority)
+                .setPartitionUpdateRows(tableStatsStatus == null ? null : tableStatsStatus.partitionUpdateRows)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -34,6 +34,7 @@ import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,6 +123,9 @@ public class StatisticsRepository {
 
     public static List<ResultRow> queryColumnStatisticsByPartitions(TableIf table, Set<String> columnNames,
             List<String> partitionNames) {
+        if (!table.isPartitionedTable()) {
+            return new ArrayList<>();
+        }
         long ctlId = table.getDatabase().getCatalog().getId();
         long dbId = table.getDatabase().getId();
         Map<String, String> params = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -134,16 +134,22 @@ public class TableStatsMeta implements Writable {
         for (Pair<String, String> colPair : analyzedJob.jobColumns) {
             ColStatsMeta colStatsMeta = colToColStatsMeta.get(colPair);
             if (colStatsMeta == null) {
-                colToColStatsMeta.put(colPair, new ColStatsMeta(updatedTime, analyzedJob.analysisMethod,
+                colToColStatsMeta.put(colPair, new ColStatsMeta(analyzedJob.createTime, analyzedJob.analysisMethod,
                         analyzedJob.analysisType, analyzedJob.jobType, 0, analyzedJob.rowCount,
-                        analyzedJob.updateRows));
+                        analyzedJob.updateRows, analyzedJob.partitionUpdateRows));
             } else {
-                colStatsMeta.updatedTime = updatedTime;
+                colStatsMeta.updatedTime = analyzedJob.startTime;
                 colStatsMeta.analysisType = analyzedJob.analysisType;
                 colStatsMeta.analysisMethod = analyzedJob.analysisMethod;
                 colStatsMeta.jobType = analyzedJob.jobType;
                 colStatsMeta.updatedRows = analyzedJob.updateRows;
                 colStatsMeta.rowCount = analyzedJob.rowCount;
+                if (colStatsMeta.partitionUpdateRows == null) {
+                    colStatsMeta.partitionUpdateRows = new ConcurrentHashMap<>();
+                } else {
+                    colStatsMeta.partitionUpdateRows.clear();
+                }
+                colStatsMeta.partitionUpdateRows.putAll(analyzedJob.partitionUpdateRows);
             }
         }
         jobType = analyzedJob.jobType;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -196,7 +196,7 @@ class StatisticsUtilTest {
         new MockUp<TableStatsMeta>() {
             @Mock
             public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(0, null, null, null, 0, 0, 0);
+                return new ColStatsMeta(0, null, null, null, 0, 0, 0, null);
             }
         };
 
@@ -244,7 +244,7 @@ class StatisticsUtilTest {
         new MockUp<TableStatsMeta>() {
             @Mock
             public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(0, null, null, null, 0, 100, 0);
+                return new ColStatsMeta(0, null, null, null, 0, 100, 0, null);
             }
         };
         tableMeta.newPartitionLoaded.set(false);
@@ -254,7 +254,7 @@ class StatisticsUtilTest {
         new MockUp<TableStatsMeta>() {
             @Mock
             public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(0, null, null, null, 0, 0, 0);
+                return new ColStatsMeta(0, null, null, null, 0, 0, 0, null);
             }
         };
         tableMeta.newPartitionLoaded.set(false);
@@ -270,7 +270,7 @@ class StatisticsUtilTest {
         new MockUp<TableStatsMeta>() {
             @Mock
             public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(0, null, null, null, 0, 500, 0);
+                return new ColStatsMeta(0, null, null, null, 0, 500, 0, null);
             }
         };
         tableMeta.newPartitionLoaded.set(false);
@@ -286,7 +286,7 @@ class StatisticsUtilTest {
         new MockUp<TableStatsMeta>() {
             @Mock
             public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(0, null, null, null, 0, 100, 80);
+                return new ColStatsMeta(0, null, null, null, 0, 100, 80, null);
             }
         };
         tableMeta.newPartitionLoaded.set(false);


### PR DESCRIPTION
While doing analyze, record the current partitionId -> updateRows map to each column, so that we can use the recorded update rows to calculate column partition level health rate during auto analyzing.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

