### PR TITLE
[BugFix](StoragePolicy) fix modify partition's storage policy with different resource issue succeed with execption

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -499,12 +499,11 @@ public class Alter {
                 // currently, only in memory and storage policy property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)
                         || properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY));
-                ((SchemaChangeHandler) schemaChangeHandler).updatePartitionsProperties(
-                        db, tableName, partitionNames, properties);
                 OlapTable olapTable = (OlapTable) table;
                 olapTable.writeLockOrDdlException();
                 try {
                     modifyPartitionsProperty(db, olapTable, partitionNames, properties, clause.isTempPartition());
+                    ((SchemaChangeHandler) schemaChangeHandler).updatePartitionsProperties(db, tableName, partitionNames, properties);
                 } finally {
                     olapTable.writeUnlock();
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #34229

when we try to modify a partition's storage policy which have different resource with the previous one, we get error message "currently do not support change origin storage policy to another one with different resource", but the modification same also succeed!

expect:
the modification fail with "currently do not support change origin storage policy to another one with different resource".



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

