### PR TITLE
[Bug](udtf) fix udtf core dump use as normal function

### DIFF
--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -74,7 +74,9 @@ Status VectorizedFnCall::prepare(RuntimeState* state, const RowDescriptor& desc,
         if (config::enable_java_support) {
             if (_fn.is_udtf_function) {
                 // fake function. it's no use and can't execute.
-                _function = FunctionFake<UDTFImpl>::create();
+                auto builder =
+                        std::make_shared<DefaultFunctionBuilder>(FunctionFake<UDTFImpl>::create());
+                _function = builder->build(argument_template, std::make_shared<DataTypeUInt8>());
             } else {
                 _function = JavaFunctionCall::create(_fn, argument_template, _data_type);
             }

--- a/be/src/vec/functions/function_fake.cpp
+++ b/be/src/vec/functions/function_fake.cpp
@@ -51,11 +51,9 @@ struct FunctionFakeBaseImpl {
 
 struct FunctionExplode {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        auto remove_nullable_arg = remove_nullable(arguments[0]);
-        DCHECK(is_array(remove_nullable_arg))
-                << remove_nullable_arg->get_name() << " not supported";
-        return make_nullable(check_and_get_data_type<DataTypeArray>(remove_nullable_arg.get())
-                                     ->get_nested_type());
+        DCHECK(is_array(arguments[0])) << arguments[0]->get_name() << " not supported";
+        return make_nullable(
+                check_and_get_data_type<DataTypeArray>(arguments[0].get())->get_nested_type());
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
@@ -63,13 +61,10 @@ struct FunctionExplode {
 // explode map: make map k,v as struct field
 struct FunctionExplodeMap {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        auto remove_nullable_arg = remove_nullable(arguments[0]);
-        DCHECK(is_map(remove_nullable_arg)) << remove_nullable_arg->get_name() << " not supported";
+        DCHECK(is_map(arguments[0])) << arguments[0]->get_name() << " not supported";
         DataTypes fieldTypes(2);
-        fieldTypes[0] =
-                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_key_type();
-        fieldTypes[1] =
-                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_value_type();
+        fieldTypes[0] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_key_type();
+        fieldTypes[1] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_value_type();
         return make_nullable(std::make_shared<vectorized::DataTypeStruct>(fieldTypes));
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }

--- a/be/src/vec/functions/function_fake.cpp
+++ b/be/src/vec/functions/function_fake.cpp
@@ -51,9 +51,11 @@ struct FunctionFakeBaseImpl {
 
 struct FunctionExplode {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        DCHECK(is_array(arguments[0])) << arguments[0]->get_name() << " not supported";
-        return make_nullable(
-                check_and_get_data_type<DataTypeArray>(arguments[0].get())->get_nested_type());
+        auto remove_nullable_arg = remove_nullable(arguments[0]);
+        DCHECK(is_array(remove_nullable_arg))
+                << remove_nullable_arg->get_name() << " not supported";
+        return make_nullable(check_and_get_data_type<DataTypeArray>(remove_nullable_arg.get())
+                                     ->get_nested_type());
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
@@ -61,10 +63,13 @@ struct FunctionExplode {
 // explode map: make map k,v as struct field
 struct FunctionExplodeMap {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        DCHECK(is_map(arguments[0])) << arguments[0]->get_name() << " not supported";
+        auto remove_nullable_arg = remove_nullable(arguments[0]);
+        DCHECK(is_map(remove_nullable_arg)) << remove_nullable_arg->get_name() << " not supported";
         DataTypes fieldTypes(2);
-        fieldTypes[0] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_key_type();
-        fieldTypes[1] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_value_type();
+        fieldTypes[0] =
+                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_key_type();
+        fieldTypes[1] =
+                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_value_type();
         return make_nullable(std::make_shared<vectorized::DataTypeStruct>(fieldTypes));
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }

--- a/be/src/vec/functions/function_fake.h
+++ b/be/src/vec/functions/function_fake.h
@@ -25,6 +25,7 @@
 #include "vec/core/column_numbers.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
 
 namespace doris {
@@ -53,7 +54,7 @@ public:
         return Impl::get_return_type_impl(arguments);
     }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
+    bool use_default_implementation_for_nulls() const override { return false; }
 
     bool use_default_implementation_for_constants() const override { return false; }
 
@@ -65,10 +66,11 @@ public:
 
 struct UDTFImpl {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        DCHECK(false) << "get_return_type_impl not supported, shouldn't into here.";
-        return nullptr;
+        return std::make_shared<DataTypeUInt8>(); //just fake return uint8
     }
-    static std::string get_error_msg() { return "Fake function do not support execute"; }
+    static std::string get_error_msg() {
+        return "UDTF function do not support this, it's should execute with lateral view.";
+    }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_fake.h
+++ b/be/src/vec/functions/function_fake.h
@@ -36,6 +36,16 @@ class Block;
 } // namespace doris
 
 namespace doris::vectorized {
+
+struct UDTFImpl {
+    static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
+        return std::make_shared<DataTypeUInt8>(); //just fake return uint8
+    }
+    static std::string get_error_msg() {
+        return "UDTF function do not support this, it's should execute with lateral view.";
+    }
+};
+
 // FunctionFake is use for some function call expr only work at prepare/open phase, do not support execute().
 template <typename Impl>
 class FunctionFake : public IFunction {
@@ -54,22 +64,18 @@ public:
         return Impl::get_return_type_impl(arguments);
     }
 
-    bool use_default_implementation_for_nulls() const override { return false; }
+    bool use_default_implementation_for_nulls() const override {
+        if constexpr (std::is_same_v<Impl, UDTFImpl>) {
+            return false;
+        }
+        return true;
+    }
 
     bool use_default_implementation_for_constants() const override { return false; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         return Status::NotSupported(Impl::get_error_msg());
-    }
-};
-
-struct UDTFImpl {
-    static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        return std::make_shared<DataTypeUInt8>(); //just fake return uint8
-    }
-    static std::string get_error_msg() {
-        return "UDTF function do not support this, it's should execute with lateral view.";
     }
 };
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.analysis.FunctionName;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
@@ -746,6 +747,29 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
     }
 
     public synchronized void dropFunction(FunctionSearchDesc function, boolean ifExists) throws UserException {
+        Function udfFunction = null;
+        if (ifExists) {
+            try {
+                // here we must first getFunction, as dropFunctionImpl will remove it
+                udfFunction = getFunction(function);
+            } catch (AnalysisException e) {
+                // ignore it, as drop it if exist, so can't sure it must exist
+            }
+        }
+        dropFunctionImpl(function, ifExists);
+        if (udfFunction != null && udfFunction.isUDTFunction()) {
+            // all of the table function in doris will have two function
+            // one is the normal, and another is outer, the different of them is deal with
+            // empty: whether need to insert NULL result value
+            FunctionName name = new FunctionName(function.getName().getDb(),
+                    function.getName().getFunction() + "_outer");
+            FunctionSearchDesc functionOuter = new FunctionSearchDesc(name, function.getArgTypes(),
+                    function.isVariadic());
+            dropFunctionImpl(functionOuter, ifExists);
+        }
+    }
+
+    public synchronized void dropFunctionImpl(FunctionSearchDesc function, boolean ifExists) throws UserException {
         if (FunctionUtil.dropFunctionImpl(function, ifExists, name2Function)) {
             Env.getCurrentEnv().getEditLog().logDropFunction(function);
             FunctionUtil.dropFromNereids(this.getFullName(), function);

--- a/regression-test/suites/javaudf_p0/test_javaudtf_all_types.groovy
+++ b/regression-test/suites/javaudf_p0/test_javaudtf_all_types.groovy
@@ -196,23 +196,6 @@ suite("test_javaudtf_all_types") {
         qt_select_string_col_outer   """select int_col, string_col,e1 from ${tableName} lateral view udtf_string_outer(string_col, "") tmp1 as e1 order by int_col,2,3;"""  
         qt_select_array_col_outer    """select int_col, array_col,e1 from ${tableName} lateral view udtf_list_outer(array_col, int_col) tmp1 as e1 order by int_col,3;"""
         qt_select_map_col_outer      """select int_col, map_col,e1 from ${tableName} lateral view udtf_map_outer(map_col, int_col) tmp1 as e1 order by int_col,3;"""
-        // qt_java_udf_all_types """select
-        //     int_col,
-        //     udtf_boolean(boolean_col),
-        //     udtf_tinyint(tinyint_col),
-        //     udtf_short(smallint_col),
-        //     udtf_int(int_col),
-        //     udtf_long(bigint_col),
-        //     udtf_largeint(largeint_col),
-        //     udtf_decimal(decimal_col),
-        //     udtf_float(float_col),
-        //     udtf_double(double_col),
-        //     udtf_date(date_col),
-        //     udtf_datetime(datetime_col),
-        //     udtf_string(string_col),
-        //     udtf_list(array_col),
-        //     udtf_map(map_col)
-        //     from ${tableName} order by int_col;"""
     } finally {
         try_sql """DROP FUNCTION IF EXISTS udtf_boolean_outer(boolean, int);"""
         try_sql """DROP FUNCTION IF EXISTS udtf_tinyint_outer(tinyint, int);"""
@@ -228,6 +211,6 @@ suite("test_javaudtf_all_types") {
         try_sql """DROP FUNCTION IF EXISTS udtf_string_outer(string, string);"""
         try_sql """DROP FUNCTION IF EXISTS udtf_list_outer(array<string>, int);"""
         try_sql """DROP FUNCTION IF EXISTS udtf_map_outer(map<string,string>, int);"""
-        // try_sql("""DROP TABLE IF EXISTS ${tableName};""")
+        try_sql """DROP TABLE IF EXISTS ${tableName};"""
     }
 }

--- a/regression-test/suites/javaudf_p0/test_javaudtf_int.groovy
+++ b/regression-test/suites/javaudf_p0/test_javaudtf_int.groovy
@@ -57,7 +57,6 @@ suite("test_javaudtf_int") {
             throw new IllegalStateException("""${jarPath} doesn't exist! """)
         }
 
-        sql """DROP FUNCTION IF EXISTS udtf_int_outer(int);"""
         sql """ CREATE TABLES FUNCTION udtf_int(int) RETURNS array<int> PROPERTIES (
             "file"="file://${jarPath}",
             "symbol"="org.apache.doris.udf.UDTFIntTest",
@@ -67,6 +66,10 @@ suite("test_javaudtf_int") {
 
         qt_select1 """ SELECT user_id, varchar_col, e1 FROM ${tableName} lateral view  udtf_int(user_id) temp as e1 order by user_id; """
 
+        test {
+            sql """ select /*+SET_VAR(enable_fallback_to_original_planner=true)*/ udtf_int(1); """
+            exception "UDTF function do not support this"
+        }
     } finally {
         try_sql("DROP FUNCTION IF EXISTS udtf_int(int);")
         try_sql("DROP TABLE IF EXISTS ${tableName}")


### PR DESCRIPTION
## Proposed changes

```
1. select my_udtf(1) will be coredump as it's can't execute like a normal function, must use with lateral view2. 
2. when drop a UDTF function, it's should remove two function, another is utdf_outer function.
```

udtf not in 2.1， not  need pick
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

