### PR TITLE
[fix](Nereids): use project input slots as require slots when eliminating group by key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKey.java
@@ -67,7 +67,7 @@ public class EliminateGroupByKey implements RewriteRuleFactory {
                                     LogicalAggregate<? extends Plan> agg = proj.child().child();
                                     Set<Slot> requireSlots = new HashSet<>(proj.getInputSlots());
                                     requireSlots.addAll(proj.child(0).getInputSlots());
-                                    LogicalAggregate<Plan> newAgg = eliminateGroupByKey(agg, proj.getOutputSet());
+                                    LogicalAggregate<Plan> newAgg = eliminateGroupByKey(agg, requireSlots);
                                     if (newAgg == null) {
                                         return null;
                                     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

