### PR TITLE
[fix](profile) Fix ExecutionProfile is missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -62,11 +62,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ExecutionProfile {
     private static final Logger LOG = LogManager.getLogger(ExecutionProfile.class);
-
+    public static final long QUERY_FINISH_TIME_INIT = 0L;
     private final TUniqueId queryId;
     private boolean isFinished = false;
     private long startTime = 0L;
-    private long queryFinishTime = 0L;
+    private long queryFinishTime = QUERY_FINISH_TIME_INIT;
     // The root profile of this execution task
     private RuntimeProfile root;
     // Profiles for each fragment. And the InstanceProfile is the child of fragment profile.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -178,6 +178,11 @@ public class ProfileManager {
             if (queryIdToExecutionProfiles.size() > 2 * Config.max_query_profile_num) {
                 List<ExecutionProfile> finishOrExpireExecutionProfiles = Lists.newArrayList();
                 for (ExecutionProfile tmpProfile : queryIdToExecutionProfiles.values()) {
+                    // Query still running, skip them.
+                    if (tmpProfile.getQueryFinishTime() == ExecutionProfile.QUERY_FINISH_TIME_INIT) {
+                        continue;
+                    }
+
                     if (System.currentTimeMillis() - tmpProfile.getQueryFinishTime()
                             > Config.profile_async_collect_expire_time_secs * 1000) {
                         finishOrExpireExecutionProfiles.add(tmpProfile);


### PR DESCRIPTION
Make sure we do not eject profile of running query.