### PR TITLE
[fix](memory) Fix nested scoped tracker and nested reserve memory

### DIFF
--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -48,6 +48,8 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(
     flush_untracked_mem();
     _reserved_mem_stack.push_back(_reserved_mem);
     if (_reserved_mem != 0) {
+        // _untracked_mem temporary store bytes that not synchronized to process reserved memory,
+        // but bytes have been subtracted from thread _reserved_mem.
         doris::GlobalMemoryArbitrator::release_process_reserved_memory(_untracked_mem);
         _reserved_mem = 0;
         _untracked_mem = 0;

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -45,27 +45,27 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
     DCHECK(mem_tracker);
     CHECK(init());
-    if (_reserved_mem == 0) {
-        flush_untracked_mem();
+    flush_untracked_mem();
+    _reserved_mem_stack.push_back(_reserved_mem);
+    if (_reserved_mem != 0) {
+        doris::GlobalMemoryArbitrator::release_process_reserved_memory(_untracked_mem);
+        _reserved_mem = 0;
+        _untracked_mem = 0;
     }
     _limiter_tracker = mem_tracker;
     _limiter_tracker_raw = mem_tracker.get();
-    _attach_level++;
 }
 
 void ThreadMemTrackerMgr::detach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& old_mem_tracker) {
     CHECK(init());
-    // If reserve memory is called in nested attach, release reserved in outermost detach.
-    if (_attach_level == 1) {
-        release_reserved();
-    }
-    if (_reserved_mem == 0) {
-        flush_untracked_mem();
-    }
+    flush_untracked_mem();
+    release_reserved();
+    DCHECK(!_reserved_mem_stack.empty());
+    _reserved_mem = _reserved_mem_stack.back();
+    _reserved_mem_stack.pop_back();
     _limiter_tracker = old_mem_tracker;
     _limiter_tracker_raw = old_mem_tracker.get();
-    _attach_level--;
 }
 
 void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -75,8 +75,8 @@ int64_t MemInfo::_s_cgroup_mem_refresh_wait_times = 0;
 
 static std::unordered_map<std::string, int64_t> _mem_info_bytes;
 std::atomic<int64_t> MemInfo::_s_sys_mem_available = -1;
-int64_t MemInfo::_s_sys_mem_available_low_water_mark = -1;
-int64_t MemInfo::_s_sys_mem_available_warning_water_mark = -1;
+int64_t MemInfo::_s_sys_mem_available_low_water_mark = std::numeric_limits<int64_t>::min();
+int64_t MemInfo::_s_sys_mem_available_warning_water_mark = std::numeric_limits<int64_t>::min();
 std::atomic<int64_t> MemInfo::_s_process_minor_gc_size = -1;
 std::atomic<int64_t> MemInfo::_s_process_full_gc_size = -1;
 std::mutex MemInfo::je_purge_dirty_pages_lock;


### PR DESCRIPTION
## Proposed changes

SCOPED_ATTACH_TASK cannot be nested, but SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER can continue to be called, so `attach_limiter_tracker` may be nested.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

