### PR TITLE
/api/<db>/<table>/_schema compatible datatimev2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
@@ -88,8 +88,7 @@ public class TableSchemaAction extends RestBaseController {
                             baseInfo.put("precision", scalarType.getPrecision() + "");
                             baseInfo.put("scale", scalarType.getScalarScale() + "");
                         }
-                        if (primitiveType == PrimitiveType.DATETIMEV2)
-                        {
+                        if (primitiveType == PrimitiveType.DATETIMEV2) {
                             ScalarType scalarType = (ScalarType) colType;
                             if (scalarType.getScalarScale() == 0) {
                                 primitiveType = PrimitiveType.DATETIME;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
@@ -88,6 +88,13 @@ public class TableSchemaAction extends RestBaseController {
                             baseInfo.put("precision", scalarType.getPrecision() + "");
                             baseInfo.put("scale", scalarType.getScalarScale() + "");
                         }
+                        if (primitiveType == PrimitiveType.DATETIMEV2)
+                        {
+                            ScalarType scalarType = (ScalarType) colType;
+                            if (scalarType.getScalarScale() == 0) {
+                                primitiveType = PrimitiveType.DATETIME;
+                            }
+                        }
                         baseInfo.put("type", primitiveType.toString());
                         baseInfo.put("comment", column.getComment());
                         baseInfo.put("name", column.getDisplayName());


### PR DESCRIPTION
## Proposed changes

create table type is datatime, but use api ```/api/<db>/<table>/_schema```, return datatimev2，expcted to datatime

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

