### PR TITLE
[opt](memory) BE process exceed memory limit will reject new Query execution

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -131,6 +131,8 @@ DEFINE_mString(process_full_gc_size, "20%");
 // If false, cancel query when the memory used exceeds exec_mem_limit, same as before.
 DEFINE_mBool(enable_query_memory_overcommit, "true");
 
+DEFINE_mBool(enable_query_enforce_exec, "false");
+
 DEFINE_mBool(disable_memory_gc, "false");
 
 DEFINE_mInt64(large_memory_check_bytes, "2147483648");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -171,6 +171,8 @@ DECLARE_mString(process_full_gc_size);
 // used memory and the exec_mem_limit will be canceled.
 // If false, cancel query when the memory used exceeds exec_mem_limit, same as before.
 DECLARE_mBool(enable_query_memory_overcommit);
+// Default is false, BE process exceed memory limit will reject new Query execution.
+DECLARE_mBool(enable_query_enforce_exec);
 //waibibabu
 // gc will release cache, cancel task, and task will wait for gc to release memory,
 // default gc strategy is conservative, if you want to exclude the interference of gc, let it be true

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -720,10 +720,10 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
     int64_t query_reserved_memory = 0; // TODO
     if (!config::enable_query_enforce_exec &&
         doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(query_reserved_memory)) {
-        std::string errmsg =
-                fmt::format(" try exec_plan_fragment failed, fragmentInstanceId {}, but {}",
-                            print_id(fragment_instance_id),
-                            doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
+        std::string errmsg = fmt::format(
+                " exec_plan_fragment failed, please try again, fragmentInstanceId {}, {}",
+                print_id(fragment_instance_id),
+                doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
         LOG(INFO) << errmsg;
         return Status::MemoryLimitExceeded(errmsg);
     }
@@ -849,9 +849,10 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
     int64_t query_reserved_memory = 0; // TODO
     if (!config::enable_query_enforce_exec &&
         doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(query_reserved_memory)) {
-        std::string errmsg = fmt::format(
-                " try exec_plan_fragment failed, queryId {}, {}", print_id(params.query_id),
-                doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
+        std::string errmsg =
+                fmt::format(" exec_plan_fragment failed, please try again, queryId {}, {}",
+                            print_id(params.query_id),
+                            doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
         LOG(INFO) << errmsg;
         return Status::MemoryLimitExceeded(errmsg);
     }


### PR DESCRIPTION
## Proposed changes

If enable_query_enforce_exec is false, BE process exceed memory limit will reject new Query execution
```
mysql [tpch]>select count(s_name), s_name from supplier group by s_name limit 10;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[MEM_LIMIT_EXCEEDED] try exec_plan_fragment failed, queryId 261a942cbaf94e88-a14fb23aa77fb675, process memory used [ASAN]9.85 GB exceed limit 3.01 GB or sys available memory [ASAN]155.71 GB less than low water mark 1.60 GB
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

