### PR TITLE
[improve](routine-load) optimize routine load job auto resume policy

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1240,7 +1240,7 @@ public class Config extends ConfigBase {
      * a period for auto resume routine load
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static int period_of_auto_resume_min = 5;
+    public static int period_of_auto_resume_min = 10;
 
     /**
      * If set to true, the backend will be automatically dropped after finishing decommission.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -225,9 +225,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     protected int currentTaskConcurrentNum;
     protected RoutineLoadProgress progress;
 
-    protected long firstResumeTimestamp; // the first resume time
+    protected long latestResumeTimestamp; // the latest resume time
     protected long autoResumeCount;
-    protected boolean autoResumeLock = false; //it can't auto resume iff true
     // some other msg which need to show to user;
     protected String otherMsg = "";
     protected ErrorReason pauseReason;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
@@ -368,8 +368,7 @@ public class RoutineLoadManager implements Writable {
             try {
                 routineLoadJob.jobStatistic.errorRowsAfterResumed = 0;
                 routineLoadJob.autoResumeCount = 0;
-                routineLoadJob.firstResumeTimestamp = 0;
-                routineLoadJob.autoResumeLock = false;
+                routineLoadJob.latestResumeTimestamp = 0;
                 routineLoadJob.updateState(RoutineLoadJob.JobState.NEED_SCHEDULE, null, false /* not replay */);
                 LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, routineLoadJob.getId())
                         .add("current_state", routineLoadJob.getState())

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -638,21 +638,20 @@ public class RoutineLoadManagerTest {
 
         Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
 
-        // 第一次自动恢复
         for (int i = 0; i < 3; i++) {
             Deencapsulation.setField(routineLoadJob, "pauseReason",
                     new ErrorReason(InternalErrorCode.REPLICA_FEW_ERR, ""));
+            try {
+                Thread.sleep(((long) Math.pow(2, i) * 10 * 1000L));
+            } catch (InterruptedException e) {
+                throw new UserException("thread sleep failed");
+            }
             routineLoadManager.updateRoutineLoadJob();
             Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
             Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
-            boolean autoResumeLock = Deencapsulation.getField(routineLoadJob, "autoResumeLock");
-            Assert.assertEquals(autoResumeLock, false);
         }
-        // 第四次自动恢复 就会锁定
         routineLoadManager.updateRoutineLoadJob();
         Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
-        boolean autoResumeLock = Deencapsulation.getField(routineLoadJob, "autoResumeLock");
-        Assert.assertEquals(autoResumeLock, true);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

When some exception occur, such as `get offset failed ` for network isolation or be node down when upgrade, job will pause unexpectedly. Therefore, Doris introduce auto resume to keep job stable in https://github.com/apache/doris/pull/2958.

**But currently there are some issues with this policy:**

- If the fault recovery time is relatively long, such as the downtime of BE, then after auto resume three times, it will be completely unable to automatically resume. But in reality, it can be restored by automatically resume.

**Improvement measures:**

- Unrestricted retry attempts to solve the problem of automatic resume caused by long recovery time.

- Add the backoff algorithm to solve the problem of some resume being invalid, such as Kafka having problems, but Doris still having a high resume frequency. The maximum backoff time is five minutes to avoid the difficulty of recovery caused by too much backoff time.
