### PR TITLE
Update load-ssb-data.sh

### DIFF
--- a/tools/ssb-tools/bin/load-ssb-data.sh
+++ b/tools/ssb-tools/bin/load-ssb-data.sh
@@ -299,12 +299,12 @@ fi
 echo 'Loading data for table: date'
 if [[ -z ${TXN_ID} ]]; then
     curl --location-trusted -u "${USER}":"${PASSWORD}" \
-        -H "label:${TXN_ID}_date" -H "column_separator:|" \
+        -H "column_separator:|" \
         -H "columns:d_datekey,d_date,d_dayofweek,d_month,d_year,d_yearmonthnum,d_yearmonth,d_daynuminweek,d_daynuminmonth,d_daynuminyear,d_monthnuminyear,d_weeknuminyear,d_sellingseason,d_lastdayinweekfl,d_lastdayinmonthfl,d_holidayfl,d_weekdayfl,d_dummy" \
         -T "${SSB_DATA_DIR}"/date.tbl http://"${FE_HOST}":"${FE_HTTP_PORT}"/api/"${DB}"/dates/_stream_load
 else
     curl --location-trusted -u "${USER}":"${PASSWORD}" \
-        -H "column_separator:|" \
+        -H "label:${TXN_ID}_date" -H "column_separator:|" \
         -H "columns:d_datekey,d_date,d_dayofweek,d_month,d_year,d_yearmonthnum,d_yearmonth,d_daynuminweek,d_daynuminmonth,d_daynuminyear,d_monthnuminyear,d_weeknuminyear,d_sellingseason,d_lastdayinweekfl,d_lastdayinmonthfl,d_holidayfl,d_weekdayfl,d_dummy" \
         -T "${SSB_DATA_DIR}"/date.tbl http://"${FE_HOST}":"${FE_HTTP_PORT}"/api/"${DB}"/dates/_stream_load
 fi


### PR DESCRIPTION
小BUG修复：因Label默认为空字符串，这个bug导致该脚本重复执行时date表的数据无法导入，报错Label已存在
