### PR TITLE
[fix](transaction) Fix publish failed because this.subTxnIds is null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1155,9 +1155,12 @@ public class DatabaseTransactionMgr {
     }
 
     private void setTableVersion(TransactionState transactionState, Database db) {
-        List<TableCommitInfo> tableCommitInfos = transactionState.getIdToTableCommitInfos().isEmpty()
-                ? transactionState.getSubTxnTableCommitInfos()
-                : Lists.newArrayList(transactionState.getIdToTableCommitInfos().values());
+        List<TableCommitInfo> tableCommitInfos;
+        if (!transactionState.getSubTxnIdToTableCommitInfo().isEmpty()) {
+            tableCommitInfos = transactionState.getSubTxnTableCommitInfos();
+        } else {
+            tableCommitInfos = Lists.newArrayList(transactionState.getIdToTableCommitInfos().values());
+        }
         for (TableCommitInfo tableCommitInfo : tableCommitInfos) {
             long tableId = tableCommitInfo.getTableId();
             OlapTable table = (OlapTable) db.getTableNullable(tableId);


### PR DESCRIPTION
## Proposed changes

```
2024-05-22 22:53:30,470 WARN (PUBLISH_VERSION|33) [PublishVersionDaemon.tryFinishTxn():204] error happens when finish transaction 2413
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "this.subTxnIds" is null
        at org.apache.doris.transaction.TransactionState.getSubTxnTableCommitInfos(TransactionState.java:873) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.DatabaseTransactionMgr.setTableVersion(DatabaseTransactionMgr.java:1159) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1126) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:455) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.tryFinishTxn(PublishVersionDaemon.java:201) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.publishVersion(PublishVersionDaemon.java:95) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:69) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

