### PR TITLE
[Fix](nereids) fix bug when insert into select empty table with agg

### DIFF
--- a/regression-test/data/load_p0/insert/insert_select_empty_table.out
+++ b/regression-test/data/load_p0/insert/insert_select_empty_table.out
@@ -15,3 +15,9 @@ PhysicalOlapTableSink
 PhysicalOlapTableSink
 --PhysicalEmptyRelation
 
+-- !test_insert_empty_agg --
+1
+
+-- !test_insert_empty_agg_select --
+\N	0	\N
+

--- a/regression-test/suites/load_p0/insert/insert_select_empty_table.groovy
+++ b/regression-test/suites/load_p0/insert/insert_select_empty_table.groovy
@@ -50,4 +50,8 @@ suite("insert_select_empty_table") {
     qt_test_shape_agg_filter_limit """ explain shape plan
     insert into insert_select_empty_table1 select pk,a,b from insert_select_empty_table2 where a > 10 group by pk,a,b  limit 10;
     """
+
+    qt_test_insert_empty_agg "insert into insert_select_empty_table1(a) select count(*) from insert_select_empty_table1"
+    qt_test_insert_empty_agg_select "select * from insert_select_empty_table1"
+
 }


### PR DESCRIPTION
This bug introduced by #34418.
Some operators can produce data even if the input is an empty table, such as AGGREGATE.  Therefore, it is necessary to check whether sink's child is in an empty relation. Only when the child is in an empty relation can it return directly without performing actual data insertion.