### PR TITLE
[branch-2.1] remove dlf dependencies

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -652,26 +652,6 @@ under the License.
             <artifactId>HikariCP</artifactId>
         </dependency>
 
-        <!-- for aliyun dlf -->
-        <dependency>
-            <groupId>com.aliyun.datalake</groupId>
-            <artifactId>metastore-client-hive3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-openapi</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.aliyun</groupId>
-                    <artifactId>tea-util</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- for fe recognize files stored on gcs -->
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -330,7 +330,6 @@ under the License.
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
         <mariadb-java-client.version>3.0.9</mariadb-java-client.version>
-        <dlf-metastore-client-hive.version>0.2.14</dlf-metastore-client-hive.version>
         <hadoop.version>3.3.6</hadoop.version>
         <joda.version>2.8.1</joda.version>
         <project.scm.id>github</project.scm.id>
@@ -1486,11 +1485,6 @@ under the License.
                 <groupId>org.mariadb.jdbc</groupId>
                 <artifactId>mariadb-java-client</artifactId>
                 <version>${mariadb-java-client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aliyun.datalake</groupId>
-                <artifactId>metastore-client-hive3</artifactId>
-                <version>${dlf-metastore-client-hive.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
## Proposed changes

followup #35241
In #35241, we update the doris-shade version to 2.1.0, which already contains dlf dependencies.

pick part of #34749, to remove dlf dependencies in fe/pom.xml

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

