### PR TITLE
[opt](memory) avoid allocate memory in agg operator constructor

### DIFF
--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -224,16 +224,15 @@ using ArenaUPtr = std::unique_ptr<Arena>;
 struct AggregateDataContainer {
 public:
     AggregateDataContainer(size_t size_of_key, size_t size_of_aggregate_states)
-            : _size_of_key(size_of_key), _size_of_aggregate_states(size_of_aggregate_states) {
-        _expand();
-    }
+            : _size_of_key(size_of_key), _size_of_aggregate_states(size_of_aggregate_states) {}
 
     int64_t memory_usage() const { return _arena_pool.size(); }
 
     template <typename KeyType>
     AggregateDataPtr append_data(const KeyType& key) {
         DCHECK_EQ(sizeof(KeyType), _size_of_key);
-        if (UNLIKELY(_index_in_sub_container == SUB_CONTAINER_CAPACITY)) {
+        // SUB_CONTAINER_CAPACITY should add a new sub container, and also expand when it is zero
+        if (UNLIKELY(_index_in_sub_container % SUB_CONTAINER_CAPACITY == 0)) {
             _expand();
         }
 
@@ -351,7 +350,7 @@ private:
     Arena _arena_pool;
     std::vector<char*> _key_containers;
     std::vector<AggregateDataPtr> _value_containers;
-    AggregateDataPtr _current_agg_data;
+    AggregateDataPtr _current_agg_data = nullptr;
     char* _current_keys = nullptr;
     size_t _size_of_key {};
     size_t _size_of_aggregate_states {};


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

