### PR TITLE
[fix](group commit) Fix test_group_commit_async_wal_msg_fault_injection case

### DIFF
--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -36,6 +36,7 @@ Status GroupCommitBlockSinkLocalState::open(RuntimeState* state) {
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_open_timer);
     auto& p = _parent->cast<GroupCommitBlockSinkOperatorX>();
+    _table_id = p._table_id;
     _group_commit_mode = p._group_commit_mode;
     _vpartition = std::make_unique<doris::VOlapTablePartitionParam>(p._schema, p._partition);
     RETURN_IF_ERROR(_vpartition->init());
@@ -211,18 +212,20 @@ Status GroupCommitBlockSinkLocalState::_add_blocks(RuntimeState* state,
     _is_block_appended = true;
     _blocks.clear();
     DBUG_EXECUTE_IF("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg", {
-        if (_load_block_queue) {
-            _remove_estimated_wal_bytes();
-            _load_block_queue->remove_load_id(p._load_id);
-        }
-        if (ExecEnv::GetInstance()->group_commit_mgr()->debug_future.wait_for(
-                    std ::chrono ::seconds(60)) == std ::future_status ::ready) {
-            auto st = ExecEnv::GetInstance()->group_commit_mgr()->debug_future.get();
-            ExecEnv::GetInstance()->group_commit_mgr()->debug_promise = std::promise<Status>();
-            ExecEnv::GetInstance()->group_commit_mgr()->debug_future =
-                    ExecEnv::GetInstance()->group_commit_mgr()->debug_promise.get_future();
-            LOG(INFO) << "debug future output: " << st.to_string();
-            RETURN_IF_ERROR(st);
+        if (dp->param<int64_t>("table_id", -1) == _table_id) {
+            if (_load_block_queue) {
+                _remove_estimated_wal_bytes();
+                _load_block_queue->remove_load_id(p._load_id);
+            }
+            if (ExecEnv::GetInstance()->group_commit_mgr()->debug_future.wait_for(
+                        std ::chrono ::seconds(60)) == std ::future_status ::ready) {
+                auto st = ExecEnv::GetInstance()->group_commit_mgr()->debug_future.get();
+                ExecEnv::GetInstance()->group_commit_mgr()->debug_promise = std::promise<Status>();
+                ExecEnv::GetInstance()->group_commit_mgr()->debug_future =
+                        ExecEnv::GetInstance()->group_commit_mgr()->debug_promise.get_future();
+                LOG(INFO) << "debug future output: " << st.to_string();
+                RETURN_IF_ERROR(st);
+            }
         }
     });
     return Status::OK();

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.h
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.h
@@ -60,6 +60,7 @@ private:
     size_t _estimated_wal_bytes = 0;
     TGroupCommitMode::type _group_commit_mode;
     Bitmap _filter_bitmap;
+    int64_t _table_id;
 };
 
 class GroupCommitBlockSinkOperatorX final

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -441,10 +441,12 @@ Status GroupCommitTable::_finish_group_commit_load(int64_t db_id, int64_t table_
     }
     LOG(INFO) << ss.str();
     DBUG_EXECUTE_IF("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg", {
-        std ::string msg = _exec_env->wal_mgr()->get_wal_dirs_info_string();
-        LOG(INFO) << "debug promise set: " << msg;
-        ExecEnv::GetInstance()->group_commit_mgr()->debug_promise.set_value(
-                Status ::InternalError(msg));
+        if (dp->param<int64_t>("table_id", -1) == table_id) {
+            std ::string msg = _exec_env->wal_mgr()->get_wal_dirs_info_string();
+            LOG(INFO) << "table_id" << std::to_string(table_id) << " set debug promise: " << msg;
+            ExecEnv::GetInstance()->group_commit_mgr()->debug_promise.set_value(
+                    Status ::InternalError(msg));
+        }
     };);
     return st;
 }

--- a/regression-test/suites/fault_injection_p0/test_group_commit_async_wal_msg_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_group_commit_async_wal_msg_fault_injection.groovy
@@ -16,8 +16,7 @@
 // under the License.
 
 suite("test_group_commit_async_wal_msg_fault_injection","nonConcurrent") {
-
-
+    def dbName = "regression_test_fault_injection_p0"
     def tableName = "wal_test"
  
     // test successful group commit async load
@@ -34,10 +33,11 @@ suite("test_group_commit_async_wal_msg_fault_injection","nonConcurrent") {
         """
 
     GetDebugPoint().clearDebugPointsForAllBEs()
+    def tableId = getTableId(dbName, tableName)
 
     def exception = false;
         try {
-            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg")
+            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg", [table_id:"${tableId}"])
             streamLoad {
                 table "${tableName}"
                 set 'column_separator', ','
@@ -70,10 +70,11 @@ suite("test_group_commit_async_wal_msg_fault_injection","nonConcurrent") {
         """
 
     GetDebugPoint().clearDebugPointsForAllBEs()
+    tableId = getTableId(dbName, tableName)
 
     exception = false;
         try {
-            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg")
+            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg", [table_id:"${tableId}"])
             GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.err_st")
             streamLoad {
                 table "${tableName}"
@@ -108,10 +109,11 @@ suite("test_group_commit_async_wal_msg_fault_injection","nonConcurrent") {
         """
 
     GetDebugPoint().clearDebugPointsForAllBEs()
+    tableId = getTableId(dbName, tableName)
 
     exception = false;
         try {
-            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg")
+            GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.get_wal_back_pressure_msg", [table_id:"${tableId}"])
             GetDebugPoint().enableDebugPointForAllBEs("LoadBlockQueue._finish_group_commit_load.err_status")
             streamLoad {
                 table "${tableName}"


### PR DESCRIPTION
## Proposed changes

The test_group_commit_async_wal_msg_fault_injection case may get:

```
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: Promise already satisfied
*** Query id: 68dda9ae3c7e4815-aeac2090983b45e2 ***
*** tablet id: 0 ***
*** Aborted at 1716427902 (unix time) try "date -d @1716427902" if you are using GNU date ***
*** Current BE git commitID: 3175a62a849 ***
*** SIGABRT unknown detail explain (@0x1e5a) received by PID 7770 (TID 8350 OR 0x7f0d3e7a5700) from PID 7770; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-cloud-dev/selectdb-core/be/src/common/signal_handler.h:435
 1# 0x00007F0E6DBF7090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x0000565170AE5721 in /mnt/disk1/selectdb-cloud-dev-asan/cluster0/be/lib/doris_be
 7# 0x0000565170AE5874 in /mnt/disk1/selectdb-cloud-dev-asan/cluster0/be/lib/doris_be
 8# std::__throw_future_error(int) at ../../../../../libstdc++-v3/src/c++11/future.cc:76
 9# std::__future_base::_State_baseV2::_M_set_result(std::function ()>, bool) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/future:411
10# std::promise::set_value(doris::Status&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/future:1137
11# doris::GroupCommitTable::_finish_group_commit_load(long, long, std::__cxx11::basic_string, std::allocator > const&, long, doris::TUniqueId const&, doris::Status&, doris::RuntimeState*) in /mnt/disk1/selectdb-cloud-dev-asan/cluster0/be/lib/doris_be
12# std::_Function_handler, std::allocator > const&, long, bool, doris::TExecPlanFragmentParams const&, doris::TPipelineFragmentParams const&)::$_0>::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::Status*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

