### PR TITLE
Revert "[Fix](timezone) Introduce a config to use Doris tzdata direct…

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1152,7 +1152,6 @@ DEFINE_Bool(ignore_always_true_predicate_for_segment, "true");
 
 // Dir of default timezone files
 DEFINE_String(default_tzfiles_path, "${DORIS_HOME}/zoneinfo");
-DEFINE_Bool(use_doris_tzfile, "false");
 
 // Ingest binlog work pool size, -1 is disable, 0 is hardware concurrency
 DEFINE_Int32(ingest_binlog_work_pool_size, "-1");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1234,7 +1234,6 @@ DECLARE_Bool(ignore_always_true_predicate_for_segment);
 
 // Dir of default timezone files
 DECLARE_String(default_tzfiles_path);
-DECLARE_Bool(use_doris_tzfile);
 
 // Ingest binlog work pool size
 DECLARE_Int32(ingest_binlog_work_pool_size);

--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -82,9 +82,6 @@ void TimezoneUtils::load_timezone_names() {
         path = config::default_tzfiles_path + '/';
         CHECK(std::filesystem::exists(path))
                 << "Can't find system tzfiles or default tzfiles neither.";
-    } else if (config::use_doris_tzfile) {
-        path = config::default_tzfiles_path + '/';
-        LOG(INFO) << "Directly use Doris' tzfiles in " << path;
     }
 
     auto path_prefix_len = path.size();
@@ -243,14 +240,12 @@ void TimezoneUtils::load_timezones_to_cache() {
     base_str += tzdir;
     base_str += '/';
 
-    if (!std::filesystem::exists(base_str)) {
+    auto root_path = std::filesystem::path {base_str};
+    if (!std::filesystem::exists(root_path)) {
         LOG_WARNING("Cannot find system tzfile. Use default instead.");
-        base_str = config::default_tzfiles_path + '/';
-        CHECK(std::filesystem::exists(base_str))
+        root_path = config::default_tzfiles_path + '/';
+        CHECK(std::filesystem::exists(root_path))
                 << "Can't find system tzfiles or default tzfiles neither.";
-    } else if (config::use_doris_tzfile) {
-        base_str = config::default_tzfiles_path + '/';
-        LOG(INFO) << "Directly use Doris' tzfiles in " << base_str;
     }
 
     std::set<std::string> ignore_paths = {"posix", "right"}; // duplications


### PR DESCRIPTION
…ly (#31561)"

This reverts commit 65d998f1e92873d3a2dc2fdcbcf578eba688c19c.

## Proposed changes

Issue Number: close #xxx

should also cherry-pick to 2.0, 2.1 and enterprise

doc pr: https://github.com/apache/doris-website/pull/684

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

