### PR TITLE
[opt](external) ignore not find files

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -334,6 +334,8 @@ Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool*
                 _cur_reader_eof = true;
                 COUNTER_UPDATE(_empty_file_counter, 1);
                 continue;
+            } else if (!st) {
+                return st;
             }
         }
 

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -326,7 +326,15 @@ Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool*
     do {
         RETURN_IF_CANCELLED(state);
         if (_cur_reader == nullptr || _cur_reader_eof) {
-            RETURN_IF_ERROR(_get_next_reader());
+            // The file may not exist because the file list is got from meta cache,
+            // And the file may already be removed from storage.
+            // Just ignore not found files.
+            Status st = _get_next_reader();
+            if (st.is<ErrorCode::NOT_FOUND>()) {
+                _cur_reader_eof = true;
+                COUNTER_UPDATE(_empty_file_counter, 1);
+                continue;
+            }
         }
 
         if (_scanner_eof) {


### PR DESCRIPTION
## Proposed changes

The file list is got from external meta cache, and the file may already be removed from storage.
We should ignore not found files and that query continue.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

