### PR TITLE
[Configurations](multi-catalog)Fix enable_orc_filter_by_min_max functionality, the mistake for #35012.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -690,7 +690,7 @@ bool static build_search_argument(std::vector<OrcPredicate>& predicates, int ind
 
 bool OrcReader::_init_search_argument(
         std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range) {
-    if (_enable_filter_by_min_max || colname_to_value_range->empty()) {
+    if ((!_enable_filter_by_min_max) || colname_to_value_range->empty()) {
         return false;
     }
     std::vector<OrcPredicate> predicates;


### PR DESCRIPTION
## Proposed changes

fix bug introduced from  #35012

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

