### PR TITLE
[fix](shuffle) Do not return error if local recvr is null

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -155,12 +155,17 @@ Status ExchangeSinkLocalState::open(RuntimeState* state) {
         size_t dep_id = 0;
         for (auto* channel : channels) {
             if (channel->is_local()) {
-                _local_channels_dependency.push_back(channel->get_local_channel_dependency());
-                DCHECK(_local_channels_dependency[dep_id] != nullptr);
-                _wait_channel_timer.push_back(_profile->add_nonzero_counter(
-                        fmt::format("WaitForLocalExchangeBuffer{}", dep_id), TUnit ::TIME_NS,
-                        timer_name, 1));
-                dep_id++;
+                if (auto dep = channel->get_local_channel_dependency()) {
+                    _local_channels_dependency.push_back(dep);
+                    DCHECK(_local_channels_dependency[dep_id] != nullptr);
+                    _wait_channel_timer.push_back(_profile->add_nonzero_counter(
+                            fmt::format("WaitForLocalExchangeBuffer{}", dep_id), TUnit ::TIME_NS,
+                            timer_name, 1));
+                    dep_id++;
+                } else {
+                    LOG(WARNING) << "local recvr is null: query id = "
+                                 << print_id(state->query_id()) << " node id = " << p.node_id();
+                }
             }
         }
     }

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -178,11 +178,7 @@ Status Channel<Parent>::open(RuntimeState* state) {
 
 std::shared_ptr<pipeline::Dependency> PipChannel::get_local_channel_dependency() {
     if (!Channel<pipeline::ExchangeSinkLocalState>::_local_recvr) {
-        throw Exception(
-                ErrorCode::INTERNAL_ERROR,
-                "_local_recvr is null: " +
-                        std::to_string(Channel<pipeline::ExchangeSinkLocalState>::_parent->parent()
-                                               ->node_id()));
+        return nullptr;
     }
     return Channel<pipeline::ExchangeSinkLocalState>::_local_recvr->get_local_channel_dependency(
             Channel<pipeline::ExchangeSinkLocalState>::_parent->sender_id());


### PR DESCRIPTION
## Proposed changes

errCode = 2, detailMessage = (172.30.0.248)[INTERNAL_ERROR]_local_recvr is null: 27

If downstream exchange operator finish earlier (e.g. if limited rows has reached), _local_recvr will be released. And then exchange sink operator try to get _local_recvr will be failed.
In fact, if downstream exchange operator finished, exchange sink operator can ignore it.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

