### PR TITLE
[fix](Nereids) fix ShowProcedureStatusCommand sendResultSet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 // Show database statement.
@@ -95,7 +96,7 @@ public class ShowDbStmt extends ShowStmt {
         if (pattern != null) {
             sb.append(" LIKE '").append(pattern).append("'");
         }
-        if (!InternalCatalog.INTERNAL_CATALOG_NAME.equals(catalogName)) {
+        if (!Strings.isNullOrEmpty(catalogName) && !InternalCatalog.INTERNAL_CATALOG_NAME.equals(catalogName)) {
             sb.append(" FROM ").append(catalogName);
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateProcedureCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateProcedureCommand.java
@@ -65,10 +65,8 @@ public class ShowCreateProcedureCommand extends Command implements NoForward {
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         List<List<String>> results = new ArrayList<>();
         ctx.getPlSqlOperation().getExec().functions.showCreateProcedure(this.procedureName, results);
-        if (!results.isEmpty()) {
-            ShowResultSet commonResultSet = new ShowResultSet(getMetaData(), results);
-            executor.sendResultSet(commonResultSet);
-        }
+        ShowResultSet commonResultSet = new ShowResultSet(getMetaData(), results);
+        executor.sendResultSet(commonResultSet);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowProcedureStatusCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowProcedureStatusCommand.java
@@ -127,10 +127,8 @@ public class ShowProcedureStatusCommand extends Command implements NoForward {
 
         List<List<String>> results = new ArrayList<>();
         ctx.getPlSqlOperation().getExec().functions.showProcedure(results, dbFilter.toString(), procFilter.toString());
-        if (!results.isEmpty()) {
-            ShowResultSet commonResultSet = new ShowResultSet(getMetaData(), results);
-            executor.sendResultSet(commonResultSet);
-        }
+        ShowResultSet commonResultSet = new ShowResultSet(getMetaData(), results);
+        executor.sendResultSet(commonResultSet);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Show Command should return an empty Set even if the result is empty

Fix compatible problem with mysql workbench

before repair
```
Doris > SHOW PROCEDURE STATUS WHERE Db='test';
Query OK, 0 rows affected (0.00 sec)
```

After repair:
```
Doris > SHOW PROCEDURE STATUS WHERE Db='test';
Empty set (0.11 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

