### PR TITLE
[Fix](trino-connector) When an exception occurs, the query may not be cleared

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/source/TrinoConnectorScanNode.java
@@ -135,25 +135,25 @@ public class TrinoConnectorScanNode extends FileQueryScanNode {
         connectorMetadata = source.getConnectorMetadata();
         ConnectorSession connectorSession = source.getTrinoSession().toConnectorSession(source.getCatalogHandle());
 
-        // 2. Begin query
-        connectorMetadata.beginQuery(connectorSession);
-        applyPushDown(connectorSession);
-
-        // 3. get splitSource
         List<Split> splits = Lists.newArrayList();
-        try (SplitSource splitSource = getTrinoSplitSource(connector, source.getTrinoSession(),
-                source.getTrinoConnectorTableHandle(), DynamicFilter.EMPTY)) {
-            // 4. get trino.Splits and convert it to doris.Splits
-            while (!splitSource.isFinished()) {
-                for (io.trino.metadata.Split split : getNextSplitBatch(splitSource)) {
-                    splits.add(new TrinoConnectorSplit(split.getConnectorSplit(), source.getConnectorName()));
+        try {
+            connectorMetadata.beginQuery(connectorSession);
+            applyPushDown(connectorSession);
+
+            // 3. get splitSource
+            try (SplitSource splitSource = getTrinoSplitSource(connector, source.getTrinoSession(),
+                    source.getTrinoConnectorTableHandle(), DynamicFilter.EMPTY)) {
+                // 4. get trino.Splits and convert it to doris.Splits
+                while (!splitSource.isFinished()) {
+                    for (io.trino.metadata.Split split : getNextSplitBatch(splitSource)) {
+                        splits.add(new TrinoConnectorSplit(split.getConnectorSplit(), source.getConnectorName()));
+                    }
                 }
             }
+        } finally {
+            // 4. Clear query
+            connectorMetadata.cleanupQuery(connectorSession);
         }
-
-        // 4. Clear query
-        // It is necessary for hive connector
-        connectorMetadata.cleanupQuery(connectorSession);
         return splits;
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Bug description:

If an exception occurs in `applyPushDown` or `getTrinoSplitSource`,  the query id in connectorMetadata may not be cleared

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

