### PR TITLE
[feature](statistics)Support drop partition statistics.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3265,9 +3265,9 @@ drop_stmt ::=
         RESULT = new DropPolicyStmt(PolicyTypeEnum.STORAGE, ifExists, policyName, null, null, null);
     :}
     /* statistics */
-    | KW_DROP KW_STATS table_name:tbl opt_col_list:cols
+    | KW_DROP KW_STATS table_name:tbl opt_col_list:cols opt_partition_names:partitionNames
     {:
-        RESULT = new DropStatsStmt(tbl, cols);
+        RESULT = new DropStatsStmt(tbl, cols, partitionNames);
     :}
     | KW_DROP KW_EXPIRED KW_STATS
     {:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
@@ -35,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Manually drop statistics for tables or partitions.
@@ -51,6 +49,7 @@ public class DropStatsStmt extends DdlStmt {
 
     private final TableName tableName;
     private Set<String> columnNames;
+    private PartitionNames partitionNames;
     // Flag to drop external table row count in table_statistics.
     private boolean dropTableRowCount;
     private boolean isAllColumns;
@@ -63,12 +62,14 @@ public class DropStatsStmt extends DdlStmt {
         this.dropExpired = dropExpired;
         this.tableName = null;
         this.columnNames = null;
+        this.partitionNames = null;
         this.dropTableRowCount = false;
     }
 
     public DropStatsStmt(TableName tableName,
-            List<String> columnNames) {
+            List<String> columnNames, PartitionNames partitionNames) {
         this.tableName = tableName;
+        this.partitionNames = partitionNames;
         if (columnNames != null) {
             this.columnNames = new HashSet<>(columnNames);
             this.dropTableRowCount = false;
@@ -122,7 +123,6 @@ public class DropStatsStmt extends DdlStmt {
             }
         } else {
             isAllColumns = true;
-            columnNames = table.getSchemaAllIndexes(false).stream().map(Column::getName).collect(Collectors.toSet());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -31,9 +31,7 @@ import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
-import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.DBObjects;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -331,10 +329,6 @@ public abstract class BaseAnalysisTask {
             return new TableSample(true, (long) info.samplePercent);
         } else if (info.sampleRows > 0) {
             return new TableSample(false, info.sampleRows);
-        } else if (info.jobType.equals(JobType.SYSTEM) && info.analysisMethod == AnalysisMethod.FULL
-                && tbl.getDataSize(true) > StatisticsUtil.getHugeTableLowerBoundSizeInBytes()) {
-            // If user doesn't specify sample percent/rows, use auto sample and update sample rows in analysis info.
-            return new TableSample(false, StatisticsUtil.getHugeTableSampleRows());
         } else {
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
@@ -35,14 +35,10 @@ public class InvalidateStatsTarget {
     @SerializedName("columns")
     public final Set<String> columns;
 
-    public InvalidateStatsTarget(long catalogId, long dbId, long tableId, Set<String> columns, boolean isAllColumns) {
+    public InvalidateStatsTarget(long catalogId, long dbId, long tableId, Set<String> columns) {
         this.catalogId = catalogId;
         this.dbId = dbId;
         this.tableId = tableId;
-        if (isAllColumns) {
-            this.columns = null;
-        } else {
-            this.columns = columns;
-        }
+        this.columns = columns;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HMSAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HMSAnalysisTaskTest.java
@@ -68,26 +68,6 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testAutoSampleHugeTable(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return 6L * 1024 * 1024 * 1024;
-            }
-        };
-        HMSAnalysisTask task = new HMSAnalysisTask();
-        task.tbl = tableIf;
-        AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
-        analysisInfoBuilder.setJobType(AnalysisInfo.JobType.SYSTEM);
-        analysisInfoBuilder.setAnalysisMethod(AnalysisInfo.AnalysisMethod.FULL);
-        task.info = analysisInfoBuilder.build();
-        TableSample tableSample = task.getTableSample();
-        Assertions.assertFalse(tableSample.isPercent());
-        Assertions.assertEquals(StatisticsUtil.getHugeTableSampleRows(), tableSample.getSampleValue());
-    }
-
-    @Test
     public void testAutoSampleSmallTable(@Mocked HMSExternalTable tableIf)
             throws Exception {
         new MockUp<HMSExternalTable>() {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -71,29 +71,6 @@ public class OlapAnalysisTaskTest {
         Assertions.assertFalse(tableSample.isPercent());
     }
 
-    // test auto big table
-    @Test
-    public void testSample2(@Mocked OlapTable tbl) {
-        new MockUp<OlapTable>() {
-
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return StatisticsUtil.getHugeTableLowerBoundSizeInBytes() + 1;
-            }
-        };
-
-        AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder()
-                .setAnalysisMethod(AnalysisMethod.FULL);
-        analysisInfoBuilder.setJobType(JobType.SYSTEM);
-        OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
-        olapAnalysisTask.info = analysisInfoBuilder.build();
-        olapAnalysisTask.tbl = tbl;
-        TableSample tableSample = olapAnalysisTask.getTableSample();
-        Assertions.assertNotNull(tableSample);
-        Assertions.assertEquals(StatisticsUtil.getHugeTableSampleRows(), tableSample.getSampleValue());
-
-    }
-
     // test auto small table
     @Test
     public void testSample3(@Mocked OlapTable tbl) {


### PR DESCRIPTION
1. Use drop stats table_name to drop column stats, and drop partition level stats.
2. Change sql_parser file to support specify a partition to drop its stats. This pr only change the gramma, will send a new pr to support this function.
3. fix a bug of auto analyze partition stats. Don't init tableSample in analyze task.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

