### PR TITLE
[regression] Add test checkpoint  for the Show Procedure status and Show create procedure command

### DIFF
--- a/regression-test/suites/plsql_p0/test_plsql_show_procedure.groovy
+++ b/regression-test/suites/plsql_p0/test_plsql_show_procedure.groovy
@@ -109,6 +109,22 @@ suite("test_plsql_show_procedure") {
     sql """SHOW PROCEDURE STATUS where Db="${dbName}" and name = "test_plsql_show_proc1";"""
     sql """SHOW PROCEDURE STATUS where Db="${dbName}" and Name LIKE "test_plsql_show_proc1";"""
     sql """SHOW PROCEDURE STATUS where procedureName="test_plsql_show_proc1";"""
+  
+    test {
+        sql """SHOW PROCEDURE STATUS where procedureName="not_exist_procedure";"""
+        check { result, ex, startTime, endTime -> 
+             assertTrue(result.isEmpty());
+        }
+    }
+
+    test {
+        sql """SHOW CREATE PROCEDURE not_exist_procedure;"""
+        check { result, ex, startTime, endTime ->
+             assertTrue(result.isEmpty());
+        }
+    }
+
+
 
     sql """DROP PROC test_plsql_show_proc1"""
     sql """DROP PROC test_plsql_show_proc2"""


### PR DESCRIPTION

Issue Number: close #xxx
improve regression check point for bug #35350

Added EmptySet checkpoint for SHOW PROCEDURE STATUS and SHOW CREATE PROCEDURE commands.

If empty set return the result in groovy check point will be empty. 
if return OK query, the result will contains [0]
added empty check for result for cases where both command return 0 rows.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

