### PR TITLE
[opt](s3) auto retry when meeting 429 error

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1220,6 +1220,8 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
 DEFINE_mInt32(max_s3_client_retry, "10");
+DEFINE_mInt32(s3_read_base_wait_time_ms, "100");
+DEFINE_mInt32(s3_read_max_wait_time_ms, "800");
 
 DEFINE_mBool(enable_s3_rate_limiter, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1304,6 +1304,13 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 DECLARE_mBool(enable_s3_rate_limiter);
 // max s3 client retry times
 DECLARE_mInt32(max_s3_client_retry);
+// When meet s3 429 error, the "get" request will
+// sleep s3_read_base_wait_time_ms (*1, *2, *3, *4) ms
+// get try again.
+// The max sleep time is s3_read_max_wait_time_ms
+// and the max retry time is max_s3_client_retry
+DECLARE_mInt32(s3_read_base_wait_time_ms);
+DECLARE_mInt32(s3_read_max_wait_time_ms);
 
 // write as inverted index tmp directory
 DECLARE_String(tmp_file_dir);

--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -156,7 +156,7 @@ Result<io::FileReaderSPtr> FileFactory::create_file_reader(
         auto client_holder = std::make_shared<io::ObjClientHolder>(s3_conf.client_conf);
         RETURN_IF_ERROR_RESULT(client_holder->init());
         return io::S3FileReader::create(std::move(client_holder), s3_conf.bucket, s3_uri.get_key(),
-                                        file_description.file_size)
+                                        file_description.file_size, profile)
                 .and_then([&](auto&& reader) {
                     return io::create_cached_file_reader(std::move(reader), reader_options);
                 });

--- a/be/src/io/fs/s3_file_reader.h
+++ b/be/src/io/fs/s3_file_reader.h
@@ -28,16 +28,21 @@
 #include "io/fs/s3_file_system.h"
 #include "util/slice.h"
 
-namespace doris::io {
+namespace doris {
+class RuntimeProfile;
+
+namespace io {
 struct IOContext;
 
 class S3FileReader final : public FileReader {
 public:
+<<<<<<< HEAD
     static Result<FileReaderSPtr> create(std::shared_ptr<const ObjClientHolder> client,
-                                         std::string bucket, std::string key, int64_t file_size);
+                                         std::string bucket, std::string key, int64_t file_size,
+                                        RuntimeProfile* profile);
 
     S3FileReader(std::shared_ptr<const ObjClientHolder> client, std::string bucket, std::string key,
-                 size_t file_size);
+                 size_t file_size, RuntimeProfile* profile);
 
     ~S3FileReader() override;
 
@@ -53,7 +58,15 @@ protected:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;
 
+    void _collect_profile_before_close() override;
+
 private:
+    struct S3Statistics {
+        int64_t total_get_request_counter = 0;
+        int64_t too_many_request_err_counter = 0;
+        int64_t too_many_request_sleep_time_ms = 0;
+        int64_t total_bytes_read = 0;
+    };
     Path _path;
     size_t _file_size;
 
@@ -62,6 +75,10 @@ private:
     std::shared_ptr<const ObjClientHolder> _client;
 
     std::atomic<bool> _closed = false;
+
+    RuntimeProfile* _profile = nullptr;
+    S3Statistics _s3_stats;
 };
 
-} // namespace doris::io
+} // namespace io
+} // namespace doris

--- a/be/src/io/fs/s3_file_reader.h
+++ b/be/src/io/fs/s3_file_reader.h
@@ -36,10 +36,9 @@ struct IOContext;
 
 class S3FileReader final : public FileReader {
 public:
-<<<<<<< HEAD
     static Result<FileReaderSPtr> create(std::shared_ptr<const ObjClientHolder> client,
                                          std::string bucket, std::string key, int64_t file_size,
-                                        RuntimeProfile* profile);
+                                         RuntimeProfile* profile);
 
     S3FileReader(std::shared_ptr<const ObjClientHolder> client, std::string bucket, std::string key,
                  size_t file_size, RuntimeProfile* profile);

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -196,7 +196,7 @@ Status S3FileSystem::create_file_impl(const Path& file, FileWriterPtr* writer,
 Status S3FileSystem::open_file_internal(const Path& file, FileReaderSPtr* reader,
                                         const FileReaderOptions& opts) {
     auto key = DORIS_TRY(get_key(file));
-    *reader = DORIS_TRY(S3FileReader::create(_client, _bucket, key, opts.file_size));
+    *reader = DORIS_TRY(S3FileReader::create(_client, _bucket, key, opts.file_size, nullptr));
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Sometime the s3 sdk will return error like:
```
QpsLimitExceeded Unable to parse ExceptionName: QpsLimitExceeded Message: Please reduce your request rate. code=429 type=100, request_id=66516C288EC49
```
We should slowdown the request rate by sleeping for a while.

- Add 2 new BE config

	- `s3_read_base_wait_time_ms` and `s3_read_max_wait_time_ms`

		When meet s3 429 error, the "get" request will
		sleep `s3_read_base_wait_time_ms (*1, *2, *3, *4)` ms get try again.
		The max sleep time is s3_read_max_wait_time_ms
		and the max retry time is max_s3_client_retry
		
- Add more metrics for s3 file reader

	- `s3_file_reader_too_many_request`: counter of 429 error.
	- `s3_file_reader_s3_get_request`: the QPS of s3 get request.

	- `TotalGetRequest`: Get request counter in profile
	- `TooManyRequestErr`: 429 error counter in profile
	- `TooManyRequestSleepTime`: Sum of sleep time after 429 error in profile
	- `TotalBytesRead`: Total bytes read from s3 in profile

![image](https://github.com/apache/doris/assets/2899462/2e8f5837-270b-48c7-9397-160aeac143eb)

