### PR TITLE
[opt](s3) auto retry when meeting 429 error

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1262,7 +1262,7 @@ void push_storage_policy_callback(StorageEngine& engine, const TAgentTaskRequest
             s3_conf.use_virtual_addressing = !resource.s3_storage_param.use_path_style;
             std::shared_ptr<io::S3FileSystem> fs;
             if (existed_resource.fs == nullptr) {
-                st = io::S3FileSystem::create(s3_conf, std::to_string(resource.id), &fs);
+                st = io::S3FileSystem::create(s3_conf, std::to_string(resource.id), nullptr, &fs);
             } else {
                 fs = std::static_pointer_cast<io::S3FileSystem>(existed_resource.fs);
                 st = fs->set_conf(s3_conf);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1190,6 +1190,9 @@ DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
 DEFINE_mInt32(max_s3_client_retry, "10");
 
+DEFINE_mInt32(s3_read_base_wait_time_ms, "100");
+DEFINE_mInt32(s3_read_max_wait_time_ms, "800");
+
 // ca_cert_file is in this path by default, Normally no modification is required
 // ca cert default path is different from different OS
 DEFINE_mString(ca_cert_file_paths,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1267,6 +1267,8 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 // max s3 client retry times
 DECLARE_mInt32(max_s3_client_retry);
+DECLARE_mInt32(s3_read_base_wait_time_ms);
+DECLARE_mInt32(s3_read_max_wait_time_ms);
 
 // write as inverted index tmp directory
 DECLARE_String(tmp_file_dir);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1267,6 +1267,11 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 // max s3 client retry times
 DECLARE_mInt32(max_s3_client_retry);
+// When meet s3 429 error, the "get" request will
+// sleep s3_read_base_wait_time_ms (*1, *2, *3, *4) ms
+// get try again.
+// The max sleep time is s3_read_max_wait_time_ms
+// and the max retry time is max_s3_client_retry
 DECLARE_mInt32(s3_read_base_wait_time_ms);
 DECLARE_mInt32(s3_read_max_wait_time_ms);
 

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -98,7 +98,7 @@ public:
                                    const io::FileDescription& fd,
                                    const io::FileReaderOptions& reader_options,
                                    std::shared_ptr<io::FileSystem>* s3_file_system,
-                                   io::FileReaderSPtr* reader);
+                                   io::FileReaderSPtr* reader, RuntimeProfile* profile);
 
     static Status create_broker_reader(const TNetworkAddress& broker_addr,
                                        const std::map<std::string, std::string>& prop,

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -52,7 +52,7 @@ bvar::PerSecond<bvar::Adder<uint64_t>> s3_read_througthput("s3_file_reader", "s3
 // Although we can get QPS from s3_bytes_per_read, but s3_bytes_per_read only
 // record successfull request, and s3_get_request_qps will record all request.
 bvar::PerSecond<bvar::Adder<uint64_t>> s3_get_request_qps("s3_file_reader", "s3_get_request",
-                                                           &s3_file_reader_read_counter);
+                                                          &s3_file_reader_read_counter);
 
 S3FileReader::S3FileReader(size_t file_size, std::string key, std::shared_ptr<S3FileSystem> fs,
                            RuntimeProfile* profile)
@@ -111,9 +111,9 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
     SCOPED_BVAR_LATENCY(s3_bvar::s3_get_latency);
 
     int retry_count = 0;
-    const int base_wait_time = config::s3_read_base_wait_time_ms ; // Base wait time in milliseconds
-    const int max_wait_time = config::s3_read_max_wait_time_ms;  // Maximum wait time in milliseconds
-    const int max_retries = config::max_s3_client_retry;     // wait 1s, 2s, 4s, 8s for each backoff
+    const int base_wait_time = config::s3_read_base_wait_time_ms; // Base wait time in milliseconds
+    const int max_wait_time = config::s3_read_max_wait_time_ms; // Maximum wait time in milliseconds
+    const int max_retries = config::max_s3_client_retry; // wait 1s, 2s, 4s, 8s for each backoff
 
     int total_sleep_time = 0;
     while (retry_count <= max_retries) {

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -35,6 +35,7 @@
 #include "io/fs/s3_common.h"
 #include "util/bvar_helper.h"
 #include "util/doris_metrics.h"
+#include "util/runtime_profile.h"
 #include "util/s3_util.h"
 
 namespace doris {
@@ -44,13 +45,16 @@ bvar::Adder<uint64_t> s3_file_reader_read_counter("s3_file_reader", "read_at");
 bvar::Adder<uint64_t> s3_file_reader_total("s3_file_reader", "total_num");
 bvar::Adder<uint64_t> s3_bytes_read_total("s3_file_reader", "bytes_read");
 bvar::Adder<uint64_t> s3_file_being_read("s3_file_reader", "file_being_read");
+bvar::Adder<uint64_t> s3_file_reader_too_many_request_counter("s3_file_reader", "too_many_request");
 
-S3FileReader::S3FileReader(size_t file_size, std::string key, std::shared_ptr<S3FileSystem> fs)
+S3FileReader::S3FileReader(size_t file_size, std::string key, std::shared_ptr<S3FileSystem> fs,
+                           RuntimeProfile* profile)
         : _path(fmt::format("s3://{}/{}", fs->s3_conf().bucket, key)),
           _file_size(file_size),
           _bucket(fs->s3_conf().bucket),
           _key(std::move(key)),
-          _fs(std::move(fs)) {
+          _fs(std::move(fs)),
+          _profile(profile) {
     DorisMetrics::instance()->s3_file_open_reading->increment(1);
     DorisMetrics::instance()->s3_file_reader_total->increment(1);
     s3_file_reader_total << 1;
@@ -98,20 +102,63 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         return Status::InternalError("init s3 client error");
     }
     SCOPED_BVAR_LATENCY(s3_bvar::s3_get_latency);
-    auto outcome = client->GetObject(request);
-    if (!outcome.IsSuccess()) {
-        return s3fs_error(outcome.GetError(),
-                          fmt::format("failed to read from {}", _path.native()));
+
+    int retry_count = 0;
+    const int base_wait_time = 1000; // Base wait time in milliseconds
+    const int max_wait_time = 8000;  // Maximum wait time in milliseconds
+    const int max_retries = 4;       // wait 1s, 2s, 4s, 8s for each backoff
+
+    while (retry_count <= max_retries) {
+        auto outcome = client->GetObject(request);
+        _s3_stats.total_get_request_counter++;
+        if (!outcome.IsSuccess()) {
+            auto error = outcome.GetError();
+            if (error.GetResponseCode() == Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) {
+                s3_file_reader_too_many_request_counter << 1;
+                retry_count++;
+                int wait_time = std::min(base_wait_time * (1 << retry_count),
+                                         max_wait_time); // Exponential backoff
+                std::this_thread::sleep_for(std::chrono::milliseconds(wait_time));
+                _s3_stats.too_many_request_err_counter++;
+                _s3_stats.too_many_request_sleep_time_ms += wait_time;
+                continue;
+            } else {
+                // Handle other errors
+                return s3fs_error(outcome.GetError(), "failed to read");
+            }
+        }
+        *bytes_read = outcome.GetResult().GetContentLength();
+        if (*bytes_read != bytes_req) {
+            return Status::InternalError("failed to read (bytes read: {}, bytes req: {})",
+                                         *bytes_read, bytes_req);
+        }
+        _s3_stats.total_bytes_read += bytes_req;
+        s3_bytes_read_total << bytes_req;
+        s3_file_reader_read_counter << 1;
+        DorisMetrics::instance()->s3_bytes_read_total->increment(bytes_req);
+        return Status::OK();
     }
-    *bytes_read = outcome.GetResult().GetContentLength();
-    if (*bytes_read != bytes_req) {
-        return Status::InternalError("failed to read from {}(bytes read: {}, bytes req: {})",
-                                     _path.native(), *bytes_read, bytes_req);
+    return Status::InternalError("failed to read from s3, exceeded maximum retries");
+}
+
+void S3FileReader::_collect_profile_before_close() {
+    if (_profile != nullptr) {
+        const char* s3_profile_name = "S3Profile";
+        ADD_TIMER(_profile, s3_profile_name);
+        RuntimeProfile::Counter* total_get_request_counter =
+                ADD_CHILD_COUNTER(_profile, "TotalGetRequest", TUnit::UNIT, s3_profile_name);
+        RuntimeProfile::Counter* too_many_request_err_counter =
+                ADD_CHILD_COUNTER(_profile, "TooManyRequestErr", TUnit::UNIT, s3_profile_name);
+        RuntimeProfile::Counter* too_many_request_sleep_time = ADD_CHILD_COUNTER(
+                _profile, "TooManyRequestSleepTime", TUnit::TIME_MS, s3_profile_name);
+        RuntimeProfile::Counter* total_bytes_read =
+                ADD_CHILD_COUNTER(_profile, "TotalBytesRead", TUnit::BYTES, s3_profile_name);
+
+        COUNTER_UPDATE(total_get_request_counter, _s3_stats.total_get_request_counter);
+        COUNTER_UPDATE(too_many_request_err_counter, _s3_stats.too_many_request_err_counter);
+        COUNTER_UPDATE(too_many_request_sleep_time, _s3_stats.too_many_request_sleep_time_ms);
+        COUNTER_UPDATE(total_bytes_read, _s3_stats.total_bytes_read);
     }
-    s3_bytes_read_total << *bytes_read;
-    s3_file_reader_read_counter << 1;
-    DorisMetrics::instance()->s3_bytes_read_total->increment(*bytes_read);
-    return Status::OK();
 }
 
 } // namespace io

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -104,10 +104,11 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
     SCOPED_BVAR_LATENCY(s3_bvar::s3_get_latency);
 
     int retry_count = 0;
-    const int base_wait_time = 1000; // Base wait time in milliseconds
-    const int max_wait_time = 8000;  // Maximum wait time in milliseconds
-    const int max_retries = 4;       // wait 1s, 2s, 4s, 8s for each backoff
+    const int base_wait_time = config::s3_read_base_wait_time_ms ; // Base wait time in milliseconds
+    const int max_wait_time = config::s3_read_max_wait_time_ms;  // Maximum wait time in milliseconds
+    const int max_retries = config::max_s3_client_retry;     // wait 1s, 2s, 4s, 8s for each backoff
 
+    int total_sleep_time = 0;
     while (retry_count <= max_retries) {
         auto outcome = client->GetObject(request);
         _s3_stats.total_get_request_counter++;
@@ -121,6 +122,7 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
                 std::this_thread::sleep_for(std::chrono::milliseconds(wait_time));
                 _s3_stats.too_many_request_err_counter++;
                 _s3_stats.too_many_request_sleep_time_ms += wait_time;
+                total_sleep_time += wait_time;
                 continue;
             } else {
                 // Handle other errors
@@ -136,6 +138,10 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         s3_bytes_read_total << bytes_req;
         s3_file_reader_read_counter << 1;
         DorisMetrics::instance()->s3_bytes_read_total->increment(bytes_req);
+        if (retry_count > 0) {
+            LOG(INFO) << fmt::format("read s3 file {} succeed after {} times with {} ms sleeping",
+                                     _path.native(), retry_count, total_sleep_time);
+        }
         return Status::OK();
     }
     return Status::InternalError("failed to read from s3, exceeded maximum retries");

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -40,6 +40,8 @@ class PooledThreadExecutor;
 } // namespace Aws::Utils::Threading
 
 namespace doris {
+class RuntimeProfile;
+
 namespace io {
 struct FileInfo;
 
@@ -56,7 +58,8 @@ struct FileInfo;
 // This class is thread-safe.(Except `set_xxx` method)
 class S3FileSystem final : public RemoteFileSystem {
 public:
-    static Status create(S3Conf s3_conf, std::string id, std::shared_ptr<S3FileSystem>* fs);
+    static Status create(S3Conf s3_conf, std::string id, RuntimeProfile* profile,
+                         std::shared_ptr<S3FileSystem>* fs);
     ~S3FileSystem() override;
     // Guarded by external lock.
     Status set_conf(S3Conf s3_conf);
@@ -101,7 +104,7 @@ protected:
     }
 
 private:
-    S3FileSystem(S3Conf&& s3_conf, std::string&& id);
+    S3FileSystem(S3Conf&& s3_conf, std::string&& id, RuntimeProfile* profile);
 
     // Full path for error message, format: endpoint/bucket/key
     std::string full_path(std::string_view key) const;
@@ -114,6 +117,7 @@ private:
     mutable std::mutex _client_mu;
     std::shared_ptr<Aws::S3::S3Client> _client;
     std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> _executor;
+    RuntimeProfile* _profile = nullptr;
 };
 
 } // namespace io

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -104,7 +104,7 @@ Status SnapshotLoader::init(TStorageBackendType::type type, const std::string& l
         RETURN_IF_ERROR(s3_uri.parse());
         RETURN_IF_ERROR(S3ClientFactory::convert_properties_to_s3_conf(_prop, s3_uri, &s3_conf));
         std::shared_ptr<io::S3FileSystem> fs;
-        RETURN_IF_ERROR(io::S3FileSystem::create(std::move(s3_conf), "", &fs));
+        RETURN_IF_ERROR(io::S3FileSystem::create(std::move(s3_conf), "", nullptr, &fs));
         _remote_fs = std::move(fs);
     } else if (TStorageBackendType::type::HDFS == type) {
         THdfsParams hdfs_params = parse_properties(_prop);

--- a/be/src/vec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/vec/sink/writer/vfile_result_writer.cpp
@@ -373,7 +373,7 @@ Status VFileResultWriter::_delete_dir() {
         std::shared_ptr<io::S3FileSystem> s3_fs = nullptr;
         RETURN_IF_ERROR(S3ClientFactory::convert_properties_to_s3_conf(
                 _file_opts->broker_properties, s3_uri, &s3_conf));
-        RETURN_IF_ERROR(io::S3FileSystem::create(s3_conf, "", &s3_fs));
+        RETURN_IF_ERROR(io::S3FileSystem::create(s3_conf, "", nullptr, &s3_fs));
         file_system = s3_fs;
         break;
     }


### PR DESCRIPTION
master #35396

- Add 2 new BE config

	- `s3_read_base_wait_time_ms` and `s3_read_max_wait_time_ms`

		When meet s3 429 error, the "get" request will
		sleep `s3_read_base_wait_time_ms (*1, *2, *3, *4)` ms get try again.
		The max sleep time is s3_read_max_wait_time_ms
		and the max retry time is max_s3_client_retry
		
- Add more metrics for s3 file reader

	- `s3_file_reader_too_many_request`: counter of 429 error.
	- `s3_file_reader_s3_get_request`: the QPS of s3 get request.

	- `TotalGetRequest`: Get request counter in profile
	- `TooManyRequestErr`: 429 error counter in profile
	- `TooManyRequestSleepTime`: Sum of sleep time after 429 error in profile
	- `TotalBytesRead`: Total bytes read from s3 in profile

![image](https://github.com/apache/doris/assets/2899462/2e8f5837-270b-48c7-9397-160aeac143eb)

