### PR TITLE
[fix](Nereids): avoid memory usage due to multiple iterations when eliminate func deps

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/FuncDeps.java
@@ -100,7 +100,11 @@ public class FuncDeps {
         Set<Set<Slot>> minSlotSet = slots;
         List<Set<Set<Slot>>> reduceSlotSets = new ArrayList<>();
         reduceSlotSets.add(slots);
-        while (!reduceSlotSets.isEmpty()) {
+        // To avoid memory usage due to multiple iterations,
+        // we set a maximum number of loop iterations.
+        int count = 0;
+        while (!reduceSlotSets.isEmpty() && count < 100) {
+            count += 1;
             List<Set<Set<Slot>>> newReduceSlotSets = new ArrayList<>();
             for (Set<Set<Slot>> slotSet : reduceSlotSets) {
                 for (FuncDepsItem funcDepsItem : items) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

