### PR TITLE
[fix](cancel load) s3 load can not be cancelled because JobManager throws exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -136,6 +136,7 @@ import org.apache.doris.cloud.load.CopyJob;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.ProfileManager;
+import org.apache.doris.job.exception.JobException;
 import org.apache.doris.load.EtlStatus;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.loadv2.JobState;
@@ -199,6 +200,11 @@ public class DdlExecutor {
             CancelLoadStmt cs = (CancelLoadStmt) ddlStmt;
             // cancel all
             env.getJobManager().cancelLoadJob(cs);
+            try {
+                env.getJobManager().cancelLoadJob(cs);
+            } catch (JobException e) {
+                LOG.warn("cancel load job failed", e);
+            }
             env.getLoadManager().cancelLoadJob(cs);
         } else if (ddlStmt instanceof CreateRoutineLoadStmt) {
             env.getRoutineLoadManager().createRoutineLoadJob((CreateRoutineLoadStmt) ddlStmt);


### PR DESCRIPTION
## Proposed changes

S3 load can not be cancelled because the JobManager throws exception:
```
2024-05-24 11:33:50,211 WARN (mysql-nio-pool-2|739) [StmtExecutor.handleDdlStmt():2951] DDL statement(cancel load where label = 'txn_insert_concurrent_insert_2_647679386') process failed.
org.apache.doris.job.exception.JobException: Load job does not exist
        at org.apache.doris.nereids.jobs.load.LabelProcessor.getJobs(LabelProcessor.java:73) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.manager.JobManager.cancelLoadJob(JobManager.java:432) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:201) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2930) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:1011) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:622) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:533) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:375) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:236) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:177) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:205) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:258) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

