### PR TITLE
[Bug](runtime-filter) try to fix DCHECK fail on _acquire_runtime_filter

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -290,7 +290,7 @@ Status PipelineTask::execute(bool* eos) {
         return Status::OK();
     }
     // The status must be runnable
-    if (!_opened) {
+    if (!_opened && !_fragment_context->is_canceled()) {
         RETURN_IF_ERROR(_open());
     }
 


### PR DESCRIPTION
## Proposed changes
try to fix DCHECK fail on _acquire_runtime_filter

```cpp
F20240527 10:25:53.101488 13812 runtime_filter.cpp:1218] Check failed: MonotonicMillis() - registration_time_ >= wait_times_ms 

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F9D49218090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x0000560234F24DCD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 5# 0x0000560234F1746A in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# doris::IRuntimeFilter::update_state() at /home/zcp/repo_center/doris_master/doris/be/src/exprs/runtime_filter.cpp:1215
10# doris::vectorized::RuntimeFilterConsumer::_acquire_runtime_filter(bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/runtime_filter_consumer.cpp:108
11# doris::pipeline::ScanLocalState<doris::pipeline::OlapScanLocalState>::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/scan_operator.cpp:113
12# doris::pipeline::PipelineTask::_open() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:193
13# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:294
14# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:150
15# doris::pipeline::TaskScheduler::start()::$_0::operator()() const at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:64
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

