### PR TITLE
[fix](catalog) close connection on refresh

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
@@ -110,4 +110,9 @@ public interface HMSCachedClient {
     void addPartitions(String dbName, String tableName, List<HivePartitionWithStatistics> partitions);
 
     void dropPartition(String dbName, String tableName, List<String> partitionValues, boolean deleteData);
+
+    /**
+     * close the connection, eg, to hms
+     */
+    void close();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -163,6 +163,14 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     @Override
+    public void onRefresh(boolean invalidCache) {
+        super.onRefresh(invalidCache);
+        if (metadataOps != null) {
+            metadataOps.close();
+        }
+    }
+
+    @Override
     public List<String> listTableNames(SessionContext ctx, String dbName) {
         makeSureInitialized();
         return metadataOps.listTableNames(ClusterNamespace.getNameFromFullName(dbName));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -81,8 +81,8 @@ public class HiveMetadataOps implements ExternalMetadataOps {
         return catalog;
     }
 
-    public static HMSCachedClient createCachedClient(HiveConf hiveConf, int thriftClientPoolSize,
-                                                     JdbcClientConfig jdbcClientConfig) {
+    private static HMSCachedClient createCachedClient(HiveConf hiveConf, int thriftClientPoolSize,
+            JdbcClientConfig jdbcClientConfig) {
         if (hiveConf != null) {
             return new ThriftHMSCachedClient(hiveConf, thriftClientPoolSize);
         }
@@ -264,6 +264,11 @@ public class HiveMetadataOps implements ExternalMetadataOps {
     @Override
     public boolean databaseExist(String dbName) {
         return listDatabaseNames().contains(dbName);
+    }
+
+    @Override
+    public void close() {
+        client.close();
     }
 
     public List<String> listDatabaseNames() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PostgreSQLJdbcHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PostgreSQLJdbcHMSCachedClient.java
@@ -64,6 +64,11 @@ public class PostgreSQLJdbcHMSCachedClient extends JdbcHMSCachedClient {
     }
 
     @Override
+    public void close() {
+        // the jdbc connection is used on demand, so we do not need to close it.
+    }
+
+    @Override
     public Database getDatabase(String dbName) {
         throw new HMSClientException("Do not support in PostgreSQLJdbcHMSCachedClient.");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -65,6 +65,10 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
     }
 
     @Override
+    public void close() {
+    }
+
+    @Override
     public boolean tableExist(String dbName, String tblName) {
         return catalog.tableExists(TableIdentifier.of(dbName, tblName));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
@@ -82,4 +82,9 @@ public interface ExternalMetadataOps {
     boolean tableExist(String dbName, String tblName);
 
     boolean databaseExist(String dbName);
+
+    /**
+     * close the connection, eg, to hms
+     */
+    void close();
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/TestHMSCachedClient.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/TestHMSCachedClient.java
@@ -53,6 +53,10 @@ public class TestHMSCachedClient implements HMSCachedClient {
     public List<Database> dbs = new ArrayList<>();
 
     @Override
+    public void close() {
+    }
+
+    @Override
     public Database getDatabase(String dbName) {
         for (Database db : this.dbs) {
             if (db.getName().equals(dbName)) {


### PR DESCRIPTION
## Proposed changes

1. When refresh the catalog, the related client(such as HMSClient) should be closed,
or the connection may be leaked.

2. Remove some unused code related to deprecated hive external table

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

