### PR TITLE
[fix](SenderQueue) error memlimit in add/sub _blocks_memory_usage

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -49,7 +49,7 @@ VDataStreamRecvr::SenderQueue::SenderQueue(VDataStreamRecvr* parent_recvr, int n
           _num_remaining_senders(num_senders),
           _received_first_batch(false) {
     _cancel_status = Status::OK();
-    _queue_mem_tracker = std::make_unique<MemTracker>();
+    _queue_mem_tracker = std::make_unique<MemTracker>("local data queue mem tracker");
 }
 
 VDataStreamRecvr::SenderQueue::~SenderQueue() {

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -111,7 +111,7 @@ public:
     // accessing members of receiver that are allocated by Object pool
     // in this function is not safe.
     bool exceeds_limit(size_t block_byte_size);
-    bool queue_exceeds_limit(size_t byte_size);
+    bool queue_exceeds_limit(size_t byte_size) const;
     bool is_closed() const { return _is_closed; }
 
     std::shared_ptr<pipeline::Dependency> get_local_channel_dependency(int sender_id);
@@ -144,6 +144,7 @@ private:
     std::unique_ptr<MemTracker> _mem_tracker;
     // Managed by object pool
     std::vector<SenderQueue*> _sender_queues;
+    size_t _sender_queue_mem_limit;
 
     std::unique_ptr<VSortedRunMerger> _merger;
 

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -111,6 +111,7 @@ public:
     // accessing members of receiver that are allocated by Object pool
     // in this function is not safe.
     bool exceeds_limit(size_t block_byte_size);
+    bool queue_exceeds_limit(size_t byte_size);
     bool is_closed() const { return _is_closed; }
 
     std::shared_ptr<pipeline::Dependency> get_local_channel_dependency(int sender_id);
@@ -221,6 +222,8 @@ public:
 
     void sub_blocks_memory_usage(int64_t size);
 
+    bool exceeds_limit();
+
 protected:
     friend class pipeline::ExchangeLocalState;
     Status _inner_get_batch_without_lock(Block* block, bool* eos);
@@ -279,6 +282,7 @@ protected:
     int _num_remaining_senders;
     std::condition_variable _data_arrival_cv;
     std::condition_variable _data_removal_cv;
+    std::unique_ptr<MemTracker> _queue_mem_tracker;
     std::list<std::pair<BlockUPtr, size_t>> _block_queue;
 
     bool _received_first_batch;


### PR DESCRIPTION
## Proposed changes

Multiple queues will compete for the value of _recvr; here, each queue will maintain its own value instead.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

