### PR TITLE
[hotfix](jdbc table) Restoring a table type that should not be deleted

### DIFF
--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -404,7 +404,7 @@ enum TOdbcTableType {
     PRESTO,
     OCEANBASE,
     OCEANBASE_ORACLE,
-    NEBULA,
+    NEBULA, // Deprecated
     DB2
 }
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -404,6 +404,7 @@ enum TOdbcTableType {
     PRESTO,
     OCEANBASE,
     OCEANBASE_ORACLE,
+    NEBULA,
     DB2
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

prefix #34986 

We cannot directly delete fields in thrift, which will affect enumeration errors caused by version inconsistencies between FE and BE during upgrades.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

