### PR TITLE
[improvement](mtmv) Add id to statistics map in statement context for cost estimation later

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -155,8 +155,7 @@ public class StatementContext implements Closeable {
     // Record the materialization statistics by id which is used for cost estimation.
     // Maybe return null, which means the id according statistics should calc normally rather than getting
     // form this map
-    // id maybe relation id or cteId or other type of id
-    private final Map<Pair<Id, Class<? extends Id>>, Statistics> idToStatisticsMap = new LinkedHashMap<>();
+    private final Map<RelationId, Statistics> relationIdToStatisticsMap = new LinkedHashMap<>();
 
     public StatementContext() {
         this(ConnectContext.get(), null, 0);
@@ -424,16 +423,21 @@ public class StatementContext implements Closeable {
     }
 
     public void addStatistics(Id id, Statistics statistics) {
-        this.idToStatisticsMap.put(Pair.of(id, id.getClass()), statistics);
+        if (id instanceof RelationId) {
+            this.relationIdToStatisticsMap.put((RelationId) id, statistics);
+        }
     }
 
     public Optional<Statistics> getStatistics(Id id) {
-        return Optional.ofNullable(this.idToStatisticsMap.get(Pair.of(id, id.getClass())));
+        if (id instanceof RelationId) {
+            return Optional.ofNullable(this.relationIdToStatisticsMap.get((RelationId) id));
+        }
+        return Optional.empty();
     }
 
     @VisibleForTesting
-    public Map<Pair<Id, Class<? extends Id>>, Statistics> getIdToStatisticsMap() {
-        return idToStatisticsMap;
+    public Map<RelationId, Statistics> getRelationIdToStatisticsMap() {
+        return relationIdToStatisticsMap;
     }
 
     /** addTableReadLock */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewAggregateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewAggregateRule.java
@@ -97,7 +97,7 @@ public abstract class AbstractMaterializedViewAggregateRule extends AbstractMate
                 viewStructInfo)) {
             List<Expression> rewrittenQueryExpressions = rewriteExpression(queryTopPlan.getOutput(),
                     queryTopPlan,
-                    materializationContext.getMvExprToMvScanExprMapping(),
+                    materializationContext.getExprToScanExprMapping(),
                     viewToQuerySlotMapping,
                     true,
                     queryStructInfo.getTableBitSet());
@@ -121,7 +121,7 @@ public abstract class AbstractMaterializedViewAggregateRule extends AbstractMate
                     () -> String.format("expressionToWrite = %s,\n mvExprToMvScanExprMapping = %s,\n"
                                     + "viewToQuerySlotMapping = %s",
                             queryTopPlan.getOutput(),
-                            materializationContext.getMvExprToMvScanExprMapping(),
+                            materializationContext.getExprToScanExprMapping(),
                             viewToQuerySlotMapping));
         }
         // if view is scalar aggregate but query is not. Or if query is scalar aggregate but view is not
@@ -150,7 +150,7 @@ public abstract class AbstractMaterializedViewAggregateRule extends AbstractMate
         List<? extends Expression> queryExpressions = queryTopPlan.getOutput();
         // permute the mv expr mapping to query based
         Map<Expression, Expression> mvExprToMvScanExprQueryBased =
-                materializationContext.getMvExprToMvScanExprMapping().keyPermute(viewToQuerySlotMapping)
+                materializationContext.getExprToScanExprMapping().keyPermute(viewToQuerySlotMapping)
                         .flattenMap().get(0);
         for (Expression topExpression : queryExpressions) {
             // if agg function, try to roll up and rewrite

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
@@ -46,7 +46,7 @@ public abstract class AbstractMaterializedViewJoinRule extends AbstractMateriali
         List<Expression> expressionsRewritten = rewriteExpression(
                 queryStructInfo.getExpressions(),
                 queryStructInfo.getTopPlan(),
-                materializationContext.getMvExprToMvScanExprMapping(),
+                materializationContext.getExprToScanExprMapping(),
                 targetToSourceMapping,
                 true,
                 queryStructInfo.getTableBitSet()
@@ -57,7 +57,7 @@ public abstract class AbstractMaterializedViewJoinRule extends AbstractMateriali
                     "Rewrite expressions by view in join fail",
                     () -> String.format("expressionToRewritten is %s,\n mvExprToMvScanExprMapping is %s,\n"
                                     + "targetToSourceMapping = %s", queryStructInfo.getExpressions(),
-                            materializationContext.getMvExprToMvScanExprMapping(),
+                            materializationContext.getExprToScanExprMapping(),
                             targetToSourceMapping));
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.rules.exploration.mv;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.common.Id;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.memo.GroupId;
@@ -34,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -47,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -56,69 +59,75 @@ import java.util.stream.Collectors;
  */
 public abstract class MaterializationContext {
     private static final Logger LOG = LogManager.getLogger(MaterializationContext.class);
-    public final Map<RelationMapping, SlotMapping> queryToMvSlotMappingCache = new HashMap<>();
+    public final Map<RelationMapping, SlotMapping> queryToMaterializationSlotMappingCache = new HashMap<>();
     protected List<Table> baseTables;
     protected List<Table> baseViews;
-    // The plan of mv def sql
-    protected Plan mvPlan;
-    // The original plan of mv def sql
-    protected Plan originalMvPlan;
+    // The plan of materialization def sql
+    protected Plan plan;
+    // The original plan of materialization sql
+    protected Plan originalPlan;
     // Should regenerate when materialization is already rewritten successfully because one query may hit repeatedly
     // make sure output is different in multi using
-    protected Plan mvScanPlan;
-    // The mvPlan output shuttled expression, this is used by generate field mvExprToMvScanExprMapping
-    protected List<? extends Expression> mvPlanOutputShuttledExpressions;
-    // Generated mapping from mv plan out shuttled expr to mv scan plan out slot mapping, this is used for later used
-    protected ExpressionMapping mvExprToMvScanExprMapping;
+    protected Plan scanPlan;
+    // The materialization plan output shuttled expression, this is used by generate field
+    // exprToScanExprMapping
+    protected List<? extends Expression> planOutputShuttledExpressions;
+    // Generated mapping from materialization plan out shuttled expr to materialization scan plan out slot mapping,
+    // this is used for later used
+    protected ExpressionMapping exprToScanExprMapping;
     // This mark the materialization context is available or not,
     // will not be used in query transparent rewritten if false
     protected boolean available = true;
-    // Mark the mv plan in the context is already rewritten successfully or not
+    // Mark the materialization plan in the context is already rewritten successfully or not
     protected boolean success = false;
     // Mark enable record failure detail info or not, because record failure detail info is performance-depleting
     protected final boolean enableRecordFailureDetail;
-    // The mv plan struct info
+    // The materialization plan struct info
     protected final StructInfo structInfo;
-    // Group id set that are rewritten unsuccessfully by this mv for reducing rewrite times
+    // Group id set that are rewritten unsuccessfully by this materialization for reducing rewrite times
     protected final Set<GroupId> matchedFailGroups = new HashSet<>();
-    // Group id set that are rewritten successfully by this mv for reducing rewrite times
+    // Group id set that are rewritten successfully by this materialization for reducing rewrite times
     protected final Set<GroupId> matchedSuccessGroups = new HashSet<>();
-    // Record the reason, if rewrite by mv fail. The failReason should be empty if success.
+    // Record the reason, if rewrite by materialization fail. The failReason should be empty if success.
     // The key is the query belonged group expression objectId, the value is the fail reasons because
     // for one materialization query may be multi when nested materialized view.
     protected final Multimap<ObjectId, Pair<String, String>> failReason = HashMultimap.create();
 
     /**
-     * MaterializationContext, this contains necessary info for query rewriting by mv
+     * MaterializationContext, this contains necessary info for query rewriting by materialization
      */
-    public MaterializationContext(Plan mvPlan, Plan originalMvPlan, Plan mvScanPlan, CascadesContext cascadesContext) {
-        this.mvPlan = mvPlan;
-        this.originalMvPlan = originalMvPlan;
-        this.mvScanPlan = mvScanPlan;
+    public MaterializationContext(Plan plan, Plan originalPlan,
+            Plan scanPlan, CascadesContext cascadesContext) {
+        this.plan = plan;
+        this.originalPlan = originalPlan;
+        this.scanPlan = scanPlan;
 
         StatementBase parsedStatement = cascadesContext.getStatementContext().getParsedStatement();
         this.enableRecordFailureDetail = parsedStatement != null && parsedStatement.isExplain()
                 && ExplainLevel.MEMO_PLAN == parsedStatement.getExplainOptions().getExplainLevel();
 
-        this.mvPlanOutputShuttledExpressions = ExpressionUtils.shuttleExpressionWithLineage(
-                originalMvPlan.getOutput(),
-                originalMvPlan,
+        this.planOutputShuttledExpressions = ExpressionUtils.shuttleExpressionWithLineage(
+                originalPlan.getOutput(),
+                originalPlan,
                 new BitSet());
-        // mv output expression shuttle, this will be used to expression rewrite
-        this.mvExprToMvScanExprMapping = ExpressionMapping.generate(this.mvPlanOutputShuttledExpressions,
-                this.mvScanPlan.getOutput());
-        // Construct mv struct info, catch exception which may cause planner roll back
+        // materialization output expression shuttle, this will be used to expression rewrite
+        this.exprToScanExprMapping = ExpressionMapping.generate(
+                this.planOutputShuttledExpressions,
+                this.scanPlan.getOutput());
+        // Construct materialization struct info, catch exception which may cause planner roll back
         List<StructInfo> viewStructInfos;
         try {
-            viewStructInfos = MaterializedViewUtils.extractStructInfo(mvPlan, cascadesContext, new BitSet());
+            viewStructInfos = MaterializedViewUtils.extractStructInfo(plan, cascadesContext, new BitSet());
             if (viewStructInfos.size() > 1) {
                 // view struct info should only have one, log error and use the first struct info
-                LOG.warn(String.format("view strut info is more than one, mv scan plan is %s, mv plan is %s",
-                        mvScanPlan.treeString(), mvPlan.treeString()));
+                LOG.warn(String.format("view strut info is more than one, materialization scan plan is %s, "
+                                + "materialization plan is %s",
+                        scanPlan.treeString(), plan.treeString()));
             }
         } catch (Exception exception) {
-            LOG.warn(String.format("construct mv struct info fail, mv scan plan is %s, mv plan is %s",
-                    mvScanPlan.treeString(), mvPlan.treeString()), exception);
+            LOG.warn(String.format("construct materialization struct info fail, materialization scan plan is %s, "
+                            + "materialization plan is %s",
+                    scanPlan.treeString(), plan.treeString()), exception);
             this.available = false;
             this.structInfo = null;
             return;
@@ -141,32 +150,33 @@ public abstract class MaterializationContext {
     /**
      * Try to generate scan plan for materialization
      * if MaterializationContext is already rewritten successfully, then should generate new scan plan in later
-     * query rewrite, because one plan may hit the materialized view repeatedly and the mv scan output
+     * query rewrite, because one plan may hit the materialized view repeatedly and the materialization scan output
      * should be different.
      * This method should be called when query rewrite successfully
      */
-    public void tryReGenerateMvScanPlan(CascadesContext cascadesContext) {
-        this.mvScanPlan = doGenerateMvPlan(cascadesContext);
-        // mv output expression shuttle, this will be used to expression rewrite
-        this.mvExprToMvScanExprMapping = ExpressionMapping.generate(this.mvPlanOutputShuttledExpressions,
-                this.mvScanPlan.getOutput());
+    public void tryReGenerateScanPlan(CascadesContext cascadesContext) {
+        this.scanPlan = doGenerateScanPlan(cascadesContext);
+        // materialization output expression shuttle, this will be used to expression rewrite
+        this.exprToScanExprMapping = ExpressionMapping.generate(
+                this.planOutputShuttledExpressions,
+                this.scanPlan.getOutput());
     }
 
     public void addSlotMappingToCache(RelationMapping relationMapping, SlotMapping slotMapping) {
-        queryToMvSlotMappingCache.put(relationMapping, slotMapping);
+        queryToMaterializationSlotMappingCache.put(relationMapping, slotMapping);
     }
 
     public SlotMapping getSlotMappingFromCache(RelationMapping relationMapping) {
-        return queryToMvSlotMappingCache.get(relationMapping);
+        return queryToMaterializationSlotMappingCache.get(relationMapping);
     }
 
     /**
      * Try to generate scan plan for materialization
      * if MaterializationContext is already rewritten successfully, then should generate new scan plan in later
-     * query rewrite, because one plan may hit the materialized view repeatedly and the mv scan output
+     * query rewrite, because one plan may hit the materialized view repeatedly and the materialization scan output
      * should be different
      */
-    abstract Plan doGenerateMvPlan(CascadesContext cascadesContext);
+    abstract Plan doGenerateScanPlan(CascadesContext cascadesContext);
 
     /**
      * Get materialization unique qualifier which identify it
@@ -179,20 +189,27 @@ public abstract class MaterializationContext {
     abstract String getStringInfo();
 
     /**
+     * Get materialization plan statistics, the key is the identifier of statistics
+     * the value is Statistics.
+     * the statistics is used by cost estimation when the materialization is used
+     */
+    abstract Optional<Pair<Id, Statistics>> getPlanStatistics(CascadesContext cascadesContext);
+
+    /**
      * Calc the relation is chosen finally or not
      */
     abstract boolean isFinalChosen(Relation relation);
 
-    public Plan getMvPlan() {
-        return mvPlan;
+    public Plan getPlan() {
+        return plan;
     }
 
-    public Plan getOriginalMvPlan() {
-        return originalMvPlan;
+    public Plan getOriginalPlan() {
+        return originalPlan;
     }
 
-    public Plan getMvScanPlan() {
-        return mvScanPlan;
+    public Plan getScanPlan() {
+        return scanPlan;
     }
 
     public List<Table> getBaseTables() {
@@ -203,8 +220,8 @@ public abstract class MaterializationContext {
         return baseViews;
     }
 
-    public ExpressionMapping getMvExprToMvScanExprMapping() {
-        return mvExprToMvScanExprMapping;
+    public ExpressionMapping getExprToScanExprMapping() {
+        return exprToScanExprMapping;
     }
 
     public boolean isAvailable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewScanRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewScanRule.java
@@ -47,7 +47,7 @@ public abstract class MaterializedViewScanRule extends AbstractMaterializedViewR
         List<Expression> expressionsRewritten = rewriteExpression(
                 queryStructInfo.getExpressions(),
                 queryStructInfo.getTopPlan(),
-                materializationContext.getMvExprToMvScanExprMapping(),
+                materializationContext.getExprToScanExprMapping(),
                 targetToSourceMapping,
                 true,
                 queryStructInfo.getTableBitSet()
@@ -58,7 +58,7 @@ public abstract class MaterializedViewScanRule extends AbstractMaterializedViewR
                     "Rewrite expressions by view in scan fail",
                     () -> String.format("expressionToRewritten is %s,\n mvExprToMvScanExprMapping is %s,\n"
                                     + "targetToSourceMapping = %s", queryStructInfo.getExpressions(),
-                            materializationContext.getMvExprToMvScanExprMapping(),
+                            materializationContext.getExprToScanExprMapping(),
                             targetToSourceMapping));
             return null;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
@@ -15,15 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.memo;
+package org.apache.doris.nereids.mv;
 
 import org.apache.doris.catalog.MTMV;
+import org.apache.doris.common.Id;
+import org.apache.doris.common.Pair;
 import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.statistics.Statistics;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -31,14 +34,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
+import java.util.Map;
+import java.util.Optional;
 
 /**
- * Test mv rewrite when base table id is lager then integer
+ * Test idStatisticsMap in StatementContext is valid
  */
-public class MvTableIdIsLongTest extends SqlTestBase {
+public class IdStatisticsMapTest extends SqlTestBase {
 
     @Test
-    void testMvRewriteWhenBaseTableIdIsLong() throws Exception {
+    void testIdStatisticsIsExistWhenRewriteByMv() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
         BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
         new MockUp<SessionVariable>() {
@@ -55,7 +60,7 @@ public class MvTableIdIsLongTest extends SqlTestBase {
         };
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
-        createMvByNereids("create materialized view mv1 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
+        createMvByNereids("create materialized view mv100 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
                 + "        DISTRIBUTED BY RANDOM BUCKETS 1\n"
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
@@ -71,7 +76,11 @@ public class MvTableIdIsLongTest extends SqlTestBase {
                 .rewrite()
                 .optimize()
                 .printlnBestPlanTree();
-        Assertions.assertTrue(c1.getMemo().toString().contains("mv1"));
-        dropMvByNereids("drop materialized view mv1");
+        Map<Pair<Id, Class<? extends Id>>, Statistics> idStatisticsMap = c1.getStatementContext().getIdToStatisticsMap();
+        Assertions.assertFalse(idStatisticsMap.isEmpty());
+        Pair<Id, Class<? extends Id>> mvIdStatistics = idStatisticsMap.keySet().iterator().next();
+        Optional<Statistics> statistics = c1.getStatementContext().getStatistics(mvIdStatistics.key());
+        Assertions.assertTrue(statistics.isPresent());
+        dropMvByNereids("drop materialized view mv100");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
@@ -18,11 +18,10 @@
 package org.apache.doris.nereids.mv;
 
 import org.apache.doris.catalog.MTMV;
-import org.apache.doris.common.Id;
-import org.apache.doris.common.Pair;
 import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
+import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
@@ -76,10 +75,10 @@ public class IdStatisticsMapTest extends SqlTestBase {
                 .rewrite()
                 .optimize()
                 .printlnBestPlanTree();
-        Map<Pair<Id, Class<? extends Id>>, Statistics> idStatisticsMap = c1.getStatementContext().getIdToStatisticsMap();
+        Map<RelationId, Statistics> idStatisticsMap = c1.getStatementContext().getRelationIdToStatisticsMap();
         Assertions.assertFalse(idStatisticsMap.isEmpty());
-        Pair<Id, Class<? extends Id>> mvIdStatistics = idStatisticsMap.keySet().iterator().next();
-        Optional<Statistics> statistics = c1.getStatementContext().getStatistics(mvIdStatistics.key());
+        RelationId relationId = idStatisticsMap.keySet().iterator().next();
+        Optional<Statistics> statistics = c1.getStatementContext().getStatistics(relationId);
         Assertions.assertTrue(statistics.isPresent());
         dropMvByNereids("drop materialized view mv100");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.mv;
+
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.mtmv.MTMVRelationManager;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.sqltest.SqlTestBase;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+
+/**
+ * Test mv rewrite when base table id is lager then integer
+ */
+public class MvTableIdIsLongTest extends SqlTestBase {
+
+    @Test
+    void testMvRewriteWhenBaseTableIdIsLong() throws Exception {
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
+        new MockUp<SessionVariable>() {
+            @Mock
+            public BitSet getDisableNereidsRules() {
+                return disableNereidsRules;
+            }
+        };
+        new MockUp<MTMVRelationManager>() {
+            @Mock
+            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx) {
+                return true;
+            }
+        };
+        connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
+        connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
+        createMvByNereids("create materialized view mv1 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
+                + "        DISTRIBUTED BY RANDOM BUCKETS 1\n"
+                + "        PROPERTIES ('replication_num' = '1') \n"
+                + "        as select T1.id from T1 inner join T2 "
+                + "on T1.id = T2.id;");
+        CascadesContext c1 = createCascadesContext(
+                "select T1.id from T1 inner join T2 "
+                        + "on T1.id = T2.id "
+                        + "inner join T3 on T1.id = T3.id",
+                connectContext
+        );
+        PlanChecker.from(c1)
+                .analyze()
+                .rewrite()
+                .optimize()
+                .printlnBestPlanTree();
+        Assertions.assertTrue(c1.getMemo().toString().contains("mv1"));
+        dropMvByNereids("drop materialized view mv1");
+    }
+}


### PR DESCRIPTION
## Proposed changes

Add id to statistics map in statement context for cost estimation later
this helps to improve the probability to use materialized view when query a single table with aggregate and many filter


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

