### PR TITLE
[enhance](mtmv)allow add index for MTMV (#34225)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOpType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOpType.java
@@ -70,10 +70,4 @@ public enum AlterOpType {
     public boolean needCheckCapacity() {
         return this == ADD_ROLLUP || this == SCHEMA_CHANGE || this == ADD_PARTITION || this == ENABLE_FEATURE;
     }
-
-    public boolean mtmvAllowOp() {
-        return this == MODIFY_TABLE_PROPERTY || this == MODIFY_DISTRIBUTION || this == MODIFY_TABLE_COMMENT
-                || this == ADD_PARTITION || this == DROP_PARTITION || this == REPLACE_PARTITION
-                || this == MODIFY_PARTITION;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
@@ -50,8 +50,8 @@ public class AlterOperations {
 
     public void checkMTMVAllow(List<AlterClause> alterClauses) throws DdlException {
         for (AlterClause alterClause : alterClauses) {
-            if (!alterClause.getOpType().mtmvAllowOp()) {
-                throw new DdlException("Alter operation " + alterClause.getOpType() + " Not allowed to MTMV");
+            if (!(alterClause.allowOpMTMV())) {
+                throw new DdlException("Not allowed to perform current operation on MTMV");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -111,6 +111,11 @@ public class AddColumnClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ADD COLUMN ").append(columnDef.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
@@ -79,6 +79,11 @@ public class AddColumnsClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ADD COLUMN (");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddPartitionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddPartitionClause.java
@@ -61,6 +61,11 @@ public class AddPartitionClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ADD ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddPartitionLikeClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddPartitionLikeClause.java
@@ -47,6 +47,11 @@ public class AddPartitionLikeClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ADD PARTITION ").append(partitionName).append(" LIKE ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddRollupClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddRollupClause.java
@@ -90,6 +90,11 @@ public class AddRollupClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("ADD ROLLUP `").append(rollupName).append("` (");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterClause.java
@@ -39,4 +39,8 @@ public abstract class AlterClause implements ParseNode {
     public AlterOpType getOpType() {
         return opType;
     }
+
+    public boolean allowOpMTMV() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
@@ -38,4 +38,6 @@ public abstract class AlterTableClause extends AlterClause {
     public void setTableName(TableName tableName) {
         this.tableName = tableName;
     }
+
+    public abstract boolean allowOpMTMV();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BuildIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BuildIndexClause.java
@@ -77,6 +77,11 @@ public class BuildIndexClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         if (alter) {
             return indexDef.toSql();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnRenameClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnRenameClause.java
@@ -64,6 +64,11 @@ public class ColumnRenameClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         return "RENAME COLUMN " + colName + " " + newColName;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateIndexClause.java
@@ -77,6 +77,11 @@ public class CreateIndexClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         if (alter) {
             return indexDef.toSql();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropColumnClause.java
@@ -66,6 +66,11 @@ public class DropColumnClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("DROP COLUMN `").append(colName).append("`");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropIndexClause.java
@@ -69,6 +69,11 @@ public class DropIndexClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("DROP INDEX ").append(indexName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropPartitionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropPartitionClause.java
@@ -72,6 +72,11 @@ public class DropPartitionClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("DROP PARTITION " + partitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropPartitionFromIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropPartitionFromIndexClause.java
@@ -78,6 +78,11 @@ public class DropPartitionFromIndexClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("DROP PARTITION " + partitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRollupClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRollupClause.java
@@ -49,6 +49,11 @@ public class DropRollupClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("DROP ROLLUP ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/EnableFeatureClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/EnableFeatureClause.java
@@ -85,6 +85,11 @@ public class EnableFeatureClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ENABLE FEATURE \"").append(featureName).append("\"");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -97,6 +97,11 @@ public class ModifyColumnClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY COLUMN ").append(columnDef.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnCommentClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnCommentClause.java
@@ -60,6 +60,11 @@ public class ModifyColumnCommentClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY COLUMN COMMENT ").append(colName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyDistributionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyDistributionClause.java
@@ -41,6 +41,11 @@ public class ModifyDistributionClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY DISTRIBUTION ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyEngineClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyEngineClause.java
@@ -65,6 +65,11 @@ public class ModifyEngineClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY ENGINE TO ").append(engine);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyPartitionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyPartitionClause.java
@@ -132,6 +132,11 @@ public class ModifyPartitionClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY PARTITION ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTableCommentClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTableCommentClause.java
@@ -51,6 +51,11 @@ public class ModifyTableCommentClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("MODIFY COMMENT ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -315,6 +315,11 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return true;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("PROPERTIES (");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionRenameClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionRenameClause.java
@@ -64,6 +64,11 @@ public class PartitionRenameClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         return "RENAME PARTITION " + partitionName + " " + newPartitionName;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ReorderColumnsClause.java
@@ -68,6 +68,11 @@ public class ReorderColumnsClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ORDER BY ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplacePartitionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplacePartitionClause.java
@@ -108,6 +108,11 @@ public class ReplacePartitionClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("REPLACE PARTITION(");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplaceTableClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplaceTableClause.java
@@ -71,6 +71,11 @@ public class ReplaceTableClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("REPLACE WITH TABLE ").append(tblName);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RollupRenameClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RollupRenameClause.java
@@ -64,6 +64,11 @@ public class RollupRenameClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         return "RENAME ROLLUP " + rollupName + " " + newRollupName;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRenameClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRenameClause.java
@@ -54,6 +54,11 @@ public class TableRenameClause extends AlterTableClause {
     }
 
     @Override
+    public boolean allowOpMTMV() {
+        return false;
+    }
+
+    @Override
     public String toSql() {
         return "RENAME " + newTableName;
     }

--- a/regression-test/suites/mtmv_p0/test_build_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_build_mtmv.groovy
@@ -439,58 +439,6 @@ suite("test_build_mtmv") {
     """
     order_qt_select "select MvProperties from mv_infos('database'='regression_test_mtmv_p0') where Name = '${mvName}'"
 
-    // use alter table
-    // not allow rename
-    try {
-        sql """
-            alter table ${mvName} rename ${mvNameRenamed}
-            """
-        Assert.fail();
-    } catch (Exception e) {
-        log.info(e.getMessage())
-    }
-
-
-    // not allow modify `grace_period`
-    try {
-        sql """
-            alter table ${mvName} set("grace_period"="3333");
-            """
-        Assert.fail();
-    } catch (Exception e) {
-        log.info(e.getMessage())
-    }
-
-    // allow modify comment
-    try {
-        sql """
-            alter table ${mvName} MODIFY COMMENT "new table comment";
-            """
-    } catch (Exception e) {
-        log.info(e.getMessage())
-        Assert.fail();
-    }
-
-    // not allow modify column
-    try {
-        sql """
-            alter table ${mvName} DROP COLUMN pv;
-            """
-        Assert.fail();
-    } catch (Exception e) {
-        log.info(e.getMessage())
-    }
-
-    // not allow replace
-    try {
-        sql """
-            alter table ${mvName} REPLACE WITH TABLE ${tableName};
-            """
-        Assert.fail();
-    } catch (Exception e) {
-        log.info(e.getMessage())
-    }
-
     // not allow use mv modify property of table
     try {
         sql """

--- a/regression-test/suites/mtmv_p0/test_limit_op_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_limit_op_mtmv.groovy
@@ -1,0 +1,247 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Assert;
+
+suite("test_limit_op_mtmv") {
+    def tableName = "t_test_limit_op_mtmv_user"
+    def mvName = "test_limit_op_mtmv"
+    def dbName = "regression_test_mtmv_p0"
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE TABLE `${tableName}` (
+          `user_id` LARGEINT NOT NULL COMMENT '\"用户id\"',
+          `num` SMALLINT NOT NULL COMMENT '\"数量\"',
+          `k3` DATE
+        ) ENGINE=OLAP
+        COMMENT 'OLAP'
+        PARTITION BY RANGE(`k3`)
+        (
+            FROM ("2020-01-01") TO ("2020-01-03") INTERVAL 1 DAY
+        )
+        DISTRIBUTED BY HASH(`user_id`) BUCKETS 2
+        PROPERTIES ('replication_num' = '1') ;
+        """
+    
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by(`k3`)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS
+        SELECT * FROM ${tableName};
+    """
+
+    // not allow add partition
+    try {
+        sql """
+            alter table ${mvName} add partition p_20200103_20200104 values less than ("2020-01-04");
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow drop partition
+    try {
+        sql """
+            alter table ${mvName} drop partition p_20200102_20200103;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow modify partition
+    try {
+        sql """
+            alter table ${mvName} MODIFY PARTITION (*) SET("storage_medium"="HDD");
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow replace partition
+    try {
+        sql """
+            ALTER TABLE ${mvName} REPLACE PARTITION (p_20200102_20200103) WITH TEMPORARY PARTITION (tp_20200102_20200103);
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow rename
+    try {
+        sql """
+            alter table ${mvName} rename ${mvName}1
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow replace table
+    try {
+        sql """
+            alter table ${mvName} REPLACE WITH TABLE tbl2
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+
+    // not allow modify property of mv
+    try {
+        sql """
+            alter table ${mvName} set("grace_period"="3333");
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow add column
+    try {
+        sql """
+            alter table ${mvName} ADD COLUMN new_col INT DEFAULT "0" AFTER num;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow add columns
+    try {
+        sql """
+            alter table ${mvName} ADD COLUMN (new_col1 INT DEFAULT "0" ,new_col2 INT DEFAULT "0");
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow drop column
+    try {
+        sql """
+            alter table ${mvName} DROP COLUMN num;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow modify column
+    try {
+        sql """
+            alter table ${mvName} modify COLUMN num BIGINT;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+
+    // not allow reorder column
+    try {
+        sql """
+            alter table ${mvName} ORDER BY(num,k3,user_id);
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow modify column
+    try {
+        sql """
+            alter table ${mvName} modify COLUMN num BIGINT;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow replace
+    try {
+        sql """
+            alter table ${mvName} REPLACE WITH TABLE ${tableName};
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+
+    // not allow add rollup
+    try {
+        sql """
+            alter table ${mvName} ADD ROLLUP example_rollup_index(num, k3);;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // not allow drop rollup
+    try {
+        sql """
+            alter table ${mvName} drop ROLLUP example_rollup_index;
+            """
+        Assert.fail();
+    } catch (Exception e) {
+        log.info(e.getMessage())
+    }
+
+    // allow modify comment
+    try {
+        sql """
+            alter table ${mvName} MODIFY COMMENT "new table comment";
+            """
+    } catch (Exception e) {
+        log.info(e.getMessage())
+        Assert.fail();
+    }
+
+    // allow add index
+    try {
+        sql """
+            CREATE INDEX index1 ON ${mvName} (num) USING INVERTED;
+            """
+    } catch (Exception e) {
+        log.info(e.getMessage())
+        Assert.fail();
+    }
+
+    // allow drop index
+    try {
+        sql """
+            DROP INDEX index1 ON ${mvName};
+            """
+    } catch (Exception e) {
+        log.info(e.getMessage())
+        Assert.fail();
+    }
+
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+}


### PR DESCRIPTION
pick from master #34225

Previously, the limitation on whether operations can be performed on materialized views was to determine `opType`.

Now, a `allowOpMTMV()` method is implemented through various `clauses`.

Because some operations have the same `opType`, but some operations allow and some do not.

For example, the `opType` for both `add column` and `create index` is `SCHEMA-CHANGE`, but `add column` is not allowed and `create index` is allowed.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

