### PR TITLE
[fix](group commit) should set wal id in runtime_state when building pipeline task

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -376,6 +376,9 @@ Status PipelineFragmentContext::_build_pipeline_tasks(
             if (request.__isset.load_job_id) {
                 runtime_state->set_load_job_id(request.load_job_id);
             }
+            if (request.__isset.wal_id) {
+                runtime_state->set_wal_id(request.wal_id);
+            }
 
             runtime_state->set_desc_tbl(_desc_tbl);
             runtime_state->set_per_fragment_instance_idx(local_params.sender_id);


### PR DESCRIPTION
after commit https://github.com/apache/doris/commit/85026759d6ed8d89240beb1b546b08c67db098d7, stream load using pipeline engine to load data, wal id should be setted in runtime_state when building pipeline task, like plan_fragment_executor does. Wal id in runtime_state is used to find wal file.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

