### PR TITLE
[fix](publish) fix publish failed when balance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -335,6 +335,9 @@ public class TabletInvertedIndex {
                 // make transaction VISIBLE when last publish failed.
                 Map<Long, List<PublishVersionTask>> publishVersionTask = transactionState.getPublishVersionTasks();
                 List<PublishVersionTask> tasks = publishVersionTask.get(backendId);
+                if (tasks == null) {
+                    continue;
+                }
                 for (PublishVersionTask task : tasks) {
                     if (task != null && task.isFinished()) {
                         List<Long> errorTablets = task.getErrorTablets();

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1340,6 +1340,10 @@ public class DatabaseTransactionMgr {
                     tabletWriteFailedReplicas.clear();
                     tabletVersionFailedReplicas.clear();
                     for (Replica replica : tablet.getReplicas()) {
+                        if (publishTasks.get(replica.getBackendId()) == null) {
+                            errorReplicaIds.add(replica.getId());
+                            continue;
+                        }
                         for (PublishVersionTask publishVersionTask : publishTasks.get(replica.getBackendId())) {
                             checkReplicaContinuousVersionSucc(tablet.getId(), replica, alterReplicaLoadedTxn,
                                     newVersion, publishVersionTask,
@@ -2627,6 +2631,10 @@ public class DatabaseTransactionMgr {
                         // TODO always use the visible version because the replica version is not changed
                         long newVersion = partition.getVisibleVersion() + 1;
                         for (Replica replica : tablet.getReplicas()) {
+                            if (publishTasks.get(replica.getBackendId()) == null) {
+                                errorReplicaIds.add(replica.getId());
+                                continue;
+                            }
                             for (PublishVersionTask publishVersionTask : publishTasks.get(replica.getBackendId())) {
                                 boolean needCheck = publishVersionTask.getTransactionId()
                                         == subTransactionState.getSubTransactionId()


### PR DESCRIPTION
## Proposed changes

When load and do balance, the publish is failed:
```
2024-05-27 11:40:16,082 WARN (PUBLISH_VERSION|32) [PublishVersionDaemon.tryFinishTxn():204] error happens when finish transaction 4358
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because the return value of "java.util.Map.get(Object)" is null
        at org.apache.doris.transaction.DatabaseTransactionMgr.finishCheckQuorumReplicas(DatabaseTransactionMgr.java:1343) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1106) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:455) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.tryFinishTxn(PublishVersionDaemon.java:201) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.publishVersion(PublishVersionDaemon.java:95) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:69) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

