### PR TITLE
[fix](pipeline) Fix query hang if limited rows is reached

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -184,6 +184,13 @@ void LocalExchangeSharedState::sub_running_sink_operators() {
     }
 }
 
+void LocalExchangeSharedState::sub_running_source_operators() {
+    std::unique_lock<std::mutex> lc(le_lock);
+    if (exchanger->_running_source_operators.fetch_sub(1) == 1) {
+        _set_always_ready();
+    }
+}
+
 LocalExchangeSharedState::LocalExchangeSharedState(int num_instances) {
     source_deps.resize(num_instances, nullptr);
     mem_trackers.resize(num_instances, nullptr);

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -759,8 +759,13 @@ public:
         }
     };
     void sub_running_sink_operators();
+    void sub_running_source_operators();
     void _set_always_ready() {
         for (auto& dep : source_deps) {
+            DCHECK(dep);
+            dep->set_always_ready();
+        }
+        for (auto& dep : sink_deps) {
             DCHECK(dep);
             dep->set_always_ready();
         }

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.cpp
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.cpp
@@ -47,13 +47,26 @@ Status LocalExchangeSourceLocalState::open(RuntimeState* state) {
     return Status::OK();
 }
 
+Status LocalExchangeSourceLocalState::close(RuntimeState* state) {
+    if (_closed) {
+        return Status::OK();
+    }
+
+    if (_shared_state) {
+        _shared_state->sub_running_source_operators();
+    }
+
+    return Base::close(state);
+}
+
 std::string LocalExchangeSourceLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer,
-                   "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}",
+                   "{}, _channel_id: {}, _num_partitions: {}, _num_senders: {}, _num_sources: {}, "
+                   "_running_sink_operators: {}, _running_source_operators: {}",
                    Base::debug_string(indentation_level), _channel_id, _exchanger->_num_partitions,
                    _exchanger->_num_senders, _exchanger->_num_sources,
-                   _exchanger->_running_sink_operators);
+                   _exchanger->_running_sink_operators, _exchanger->_running_source_operators);
     return fmt::to_string(debug_string_buffer);
 }
 

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.h
@@ -36,6 +36,7 @@ public:
 
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
     std::string debug_string(int indentation_level) const override;
 
 private:

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -30,12 +30,14 @@ class Exchanger {
 public:
     Exchanger(int running_sink_operators, int num_partitions, int free_block_limit)
             : _running_sink_operators(running_sink_operators),
+              _running_source_operators(num_partitions),
               _num_partitions(num_partitions),
               _num_senders(running_sink_operators),
               _num_sources(num_partitions),
               _free_block_limit(free_block_limit) {}
     Exchanger(int running_sink_operators, int num_sources, int num_partitions, int free_block_limit)
             : _running_sink_operators(running_sink_operators),
+              _running_source_operators(num_partitions),
               _num_partitions(num_partitions),
               _num_senders(running_sink_operators),
               _num_sources(num_sources),
@@ -51,8 +53,10 @@ protected:
     friend struct LocalExchangeSharedState;
     friend struct ShuffleBlockWrapper;
     friend class LocalExchangeSourceLocalState;
+    friend class LocalExchangeSinkOperatorX;
     friend class LocalExchangeSinkLocalState;
     std::atomic<int> _running_sink_operators = 0;
+    std::atomic<int> _running_source_operators = 0;
     const int _num_partitions;
     const int _num_senders;
     const int _num_sources;


### PR DESCRIPTION
## Proposed changes

Some operators has limit condition, the source operator should notify the sink operator that limit reached.
Although FE has limit logic but it not always send .

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

