### PR TITLE
[feature](rowset) To support rowset on remote FS using paths of different format

### DIFF
--- a/be/src/cloud/cloud_delete_task.cpp
+++ b/be/src/cloud/cloud_delete_task.cpp
@@ -62,11 +62,12 @@ Status CloudDeleteTask::execute(CloudStorageEngine& engine, const TPushReq& requ
     load_id.set_hi(0);
     load_id.set_lo(0);
     RowsetWriterContext context;
-    context.fs = engine.get_fs_by_vault_id(request.storage_vault_id);
-    if (context.fs == nullptr) {
+    context.storage_resource = engine.get_storage_resource(request.storage_vault_id);
+    if (!context.storage_resource) {
         return Status::InternalError("vault id not found, maybe not sync, vault id {}",
                                      request.storage_vault_id);
     }
+
     context.txn_id = request.transaction_id;
     context.load_id = load_id;
     context.rowset_state = PREPARED;

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -518,8 +518,7 @@ Status CloudMetaMgr::sync_tablet_rowsets(CloudTablet* tablet, bool warmup_delta_
                 rs_meta->init_from_pb(meta_pb);
                 RowsetSharedPtr rowset;
                 // schema is nullptr implies using RowsetMeta.tablet_schema
-                Status s = RowsetFactory::create_rowset(nullptr, tablet->tablet_path(), rs_meta,
-                                                        &rowset);
+                Status s = RowsetFactory::create_rowset(nullptr, "", rs_meta, &rowset);
                 if (!s.ok()) {
                     LOG_WARNING("create rowset").tag("status", s);
                     return s;

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -70,12 +70,12 @@ Status CloudRowsetBuilder::init() {
     context.write_file_cache = _req.write_file_cache;
     context.partial_update_info = _partial_update_info;
     context.file_cache_ttl_sec = _tablet->ttl_seconds();
-    context.fs = _engine.get_fs_by_vault_id(_req.storage_vault_id);
-    if (context.fs == nullptr) {
+    context.storage_resource = _engine.get_storage_resource(_req.storage_vault_id);
+    if (!context.storage_resource) {
         return Status::InternalError("vault id not found, maybe not sync, vault id {}",
                                      _req.storage_vault_id);
     }
-    context.rowset_dir = _tablet->tablet_path();
+
     _rowset_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
 
     _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();

--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -18,6 +18,7 @@
 #include "cloud/cloud_rowset_writer.h"
 
 #include "io/cache/block_file_cache_factory.h"
+#include "io/fs/file_system.h"
 #include "olap/rowset/rowset_factory.h"
 
 namespace doris {
@@ -29,13 +30,15 @@ CloudRowsetWriter::~CloudRowsetWriter() = default;
 Status CloudRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
     _context = rowset_writer_context;
     _rowset_meta = std::make_shared<RowsetMeta>();
-    if (_context.fs) {
-        _rowset_meta->set_fs(_context.fs);
-    } else {
+
+    if (_context.is_local_rowset()) {
         // In cloud mode, this branch implies it is an intermediate rowset for external merge sort,
-        // we use `global_local_filesystem` to write data to `tmp_file_dir`(see `BetaRowset::segment_file_path`).
-        _context.rowset_dir = io::FileCacheFactory::instance()->get_cache_path();
+        // we use `global_local_filesystem` to write data to `tmp_file_dir`(see `local_segment_path`).
+        _context.tablet_path = io::FileCacheFactory::instance()->get_cache_path();
+    } else {
+        _rowset_meta->set_remote_storage_resource(*_context.storage_resource);
     }
+
     _rowset_meta->set_rowset_id(_context.rowset_id);
     _rowset_meta->set_partition_id(_context.partition_id);
     _rowset_meta->set_tablet_id(_context.tablet_id);
@@ -113,7 +116,7 @@ Status CloudRowsetWriter::build(RowsetSharedPtr& rowset) {
     }
 
     RETURN_NOT_OK_STATUS_WITH_WARN(
-            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_dir, _rowset_meta,
+            RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path, _rowset_meta,
                                          &rowset),
             "rowset init failed when build new rowset");
     _already_built = true;

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -106,7 +106,7 @@ struct VaultCreateFSVisitor {
         LOG(INFO) << "get new s3 info: " << s3_conf.to_string() << " resource_id=" << id;
 
         auto fs = DORIS_TRY(io::S3FileSystem::create(s3_conf, id));
-        put_storage_resource(id, {std::move(fs), 0});
+        put_storage_resource(id, {std::move(fs), 0}, 0);
         LOG_INFO("successfully create s3 vault, vault id {}", id);
         return Status::OK();
     }
@@ -114,10 +114,9 @@ struct VaultCreateFSVisitor {
     // TODO(ByteYue): Make sure enable_java_support is on
     Status operator()(const cloud::HdfsVaultInfo& vault) const {
         auto hdfs_params = io::to_hdfs_params(vault);
-        auto fs =
-                DORIS_TRY(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, id, nullptr,
-                                                     vault.has_prefix() ? vault.prefix() : ""));
-        put_storage_resource(id, {std::move(fs), 0});
+        auto fs = DORIS_TRY(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, id,
+                                                       nullptr, vault.prefix()));
+        put_storage_resource(id, {std::move(fs), 0}, 0);
         LOG_INFO("successfully create hdfs vault, vault id {}", id);
         return Status::OK();
     }
@@ -146,7 +145,7 @@ struct RefreshFSVaultVisitor {
                 DORIS_TRY(io::HdfsFileSystem::create(hdfs_params, hdfs_params.fs_name, id, nullptr,
                                                      vault.has_prefix() ? vault.prefix() : ""));
         auto hdfs = std::static_pointer_cast<io::HdfsFileSystem>(hdfs_fs);
-        put_storage_resource(id, {std::move(hdfs), 0});
+        put_storage_resource(id, {std::move(hdfs), 0}, 0);
         return Status::OK();
     }
 
@@ -301,8 +300,7 @@ void CloudStorageEngine::_check_file_cache_ttl_block_valid() {
             int64_t ttl_seconds = tablet->tablet_meta()->ttl_seconds();
             if (rowset->newest_write_timestamp() + ttl_seconds <= UnixSeconds()) continue;
             for (int64_t seg_id = 0; seg_id < rowset->num_segments(); seg_id++) {
-                auto seg_path = rowset->segment_file_path(seg_id);
-                auto hash = io::BlockFileCache::hash(io::Path(seg_path).filename().native());
+                auto hash = Segment::file_cache_key(rowset->rowset_id().to_string(), seg_id);
                 auto* file_cache = io::FileCacheFactory::instance()->get_by_path(hash);
                 file_cache->update_ttl_atime(hash);
             }

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -74,19 +74,24 @@ public:
     }
     void _check_file_cache_ttl_block_valid();
 
-    io::FileSystemSPtr get_fs_by_vault_id(const std::string& vault_id) const {
+    std::optional<StorageResource> get_storage_resource(const std::string& vault_id) const {
         if (vault_id.empty()) {
-            return latest_fs();
+            return StorageResource {latest_fs(), 0};
         }
-        return get_filesystem(vault_id);
+
+        if (auto storage_resource = doris::get_storage_resource(vault_id); storage_resource) {
+            return storage_resource->first;
+        }
+
+        return std::nullopt;
     }
 
-    io::FileSystemSPtr latest_fs() const {
+    io::RemoteFileSystemSPtr latest_fs() const {
         std::lock_guard lock(_latest_fs_mtx);
         return _latest_fs;
     }
 
-    void set_latest_fs(const io::FileSystemSPtr& fs) {
+    void set_latest_fs(const io::RemoteFileSystemSPtr& fs) {
         std::lock_guard lock(_latest_fs_mtx);
         _latest_fs = fs;
     }
@@ -159,7 +164,7 @@ private:
 
     // FileSystem with latest shared storage info, new data will be written to this fs.
     mutable std::mutex _latest_fs_mtx;
-    io::FileSystemSPtr _latest_fs;
+    io::RemoteFileSystemSPtr _latest_fs;
 
     std::vector<scoped_refptr<Thread>> _bg_threads;
 

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -81,11 +81,9 @@ void CloudWarmUpManager::handle_jobs() {
             auto rs_metas = tablet_meta->snapshot_rs_metas();
             for (auto& [_, rs] : rs_metas) {
                 for (int64_t seg_id = 0; seg_id < rs->num_segments(); seg_id++) {
-                    auto fs = rs->fs();
-                    if (!fs) {
-                        LOG(WARNING) << "failed to get fs. tablet_id=" << tablet_id
-                                     << " rowset_id=" << rs->rowset_id()
-                                     << " resource_id=" << rs->resource_id();
+                    auto storage_resource = rs->remote_storage_resource();
+                    if (!storage_resource) {
+                        LOG(WARNING) << storage_resource.error();
                         continue;
                     }
 
@@ -100,10 +98,10 @@ void CloudWarmUpManager::handle_jobs() {
                     wait->add_count();
                     _engine.file_cache_block_downloader().submit_download_task(
                             io::DownloadFileMeta {
-                                    .path = BetaRowset::remote_segment_path(
-                                            rs->tablet_id(), rs->rowset_id(), seg_id),
+                                    .path = storage_resource.value()->remote_segment_path(*rs,
+                                                                                          seg_id),
                                     .file_size = rs->segment_file_size(seg_id),
-                                    .file_system = std::move(fs),
+                                    .file_system = storage_resource.value()->fs,
                                     .ctx =
                                             {
                                                     .expiration_time = expiration_time,

--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -494,18 +494,17 @@ int main(int argc, char** argv) {
             std::cout << "no data file flag for check " << std::endl;
             return -1;
         }
+
+        const std::string rowset_id = "test_rowset";
+        constexpr int seg_id = 0;
         std::string name = "test";
-        std::string file_dir = FLAGS_idx_file_path;
-        std::string file_name = "test_index_0.dat";
-        int64_t index_id = 1;
-        std::string index_suffix = "";
+        const std::string& file_dir = FLAGS_idx_file_path;
+        constexpr int64_t index_id = 1;
         doris::TabletIndexPB index_pb;
         index_pb.set_index_id(index_id);
-        index_pb.set_index_suffix_name(index_suffix);
         TabletIndex index_meta;
         index_meta.init_from_pb(index_pb);
-        auto index_path = InvertedIndexDescriptor::get_temporary_index_path(
-                file_dir + "/" + file_name, index_id, index_suffix);
+
         std::vector<std::string> datas;
         {
             if (std::filesystem::exists(FLAGS_data_file_path) &&
@@ -533,7 +532,10 @@ int main(int argc, char** argv) {
 
         auto fs = doris::io::global_local_filesystem();
         auto index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                fs, file_dir, file_name, doris::InvertedIndexStorageFormatPB::V2);
+                fs,
+                std::string {InvertedIndexDescriptor::get_index_path_prefix(
+                        doris::local_segment_path(file_dir, rowset_id, seg_id))},
+                rowset_id, seg_id, doris::InvertedIndexStorageFormatPB::V2);
         auto st = index_file_writer->open(&index_meta);
         if (!st.has_value()) {
             std::cerr << "InvertedIndexFileWriter init error:" << st.error() << std::endl;
@@ -588,19 +590,17 @@ int main(int argc, char** argv) {
             std::cout << "no file flag for show " << std::endl;
             return -1;
         }
-        std::filesystem::path p(FLAGS_idx_file_path);
-        auto dir_path = p.parent_path();
-        std::string file_str = StripSuffixString(p.filename().string(), ".idx");
+        std::string index_path_prefix = StripSuffixString(FLAGS_idx_file_path, ".idx");
         auto fs = doris::io::global_local_filesystem();
         try {
             auto index_file_reader = std::make_unique<InvertedIndexFileReader>(
-                    fs, dir_path, file_str, doris::InvertedIndexStorageFormatPB::V2);
+                    fs, index_path_prefix, doris::InvertedIndexStorageFormatPB::V2);
             auto st = index_file_reader->init(4096);
             if (!st.ok()) {
                 std::cerr << "InvertedIndexFileReader init error:" << st.msg() << std::endl;
                 return -1;
             }
-            std::cout << "Nested files for " << file_str << std::endl;
+            std::cout << "Nested files for " << index_path_prefix << std::endl;
             std::cout << "==================================" << std::endl;
             auto dirs = index_file_reader->get_all_directories();
             for (auto& dir : *dirs) {
@@ -636,13 +636,11 @@ int main(int argc, char** argv) {
             std::cout << "no file flag for check " << std::endl;
             return -1;
         }
-        std::filesystem::path p(FLAGS_idx_file_path);
-        std::string dir_path = p.parent_path();
-        std::string file_str = StripSuffixString(p.filename().string(), ".idx");
+        std::string index_path_prefix = StripSuffixString(FLAGS_idx_file_path, ".idx");
         auto fs = doris::io::global_local_filesystem();
         try {
             auto index_file_reader = std::make_unique<InvertedIndexFileReader>(
-                    fs, dir_path, file_str, doris::InvertedIndexStorageFormatPB::V2);
+                    fs, index_path_prefix, doris::InvertedIndexStorageFormatPB::V2);
             auto st = index_file_reader->init(4096);
             if (!st.ok()) {
                 std::cerr << "InvertedIndexFileReader init error:" << st.msg() << std::endl;
@@ -664,7 +662,7 @@ int main(int argc, char** argv) {
             using T = std::decay_t<decltype(ret)>;
             auto reader = std::forward<T>(ret).value();
             index_file_reader->debug_file_entries();
-            std::cout << "Term statistics for " << file_str << std::endl;
+            std::cout << "Term statistics for " << index_path_prefix << std::endl;
             std::cout << "==================================" << std::endl;
             check_terms_stats(reader.get());
             reader->close();

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -50,7 +50,6 @@ public:
     BaseTablet(const BaseTablet&) = delete;
     BaseTablet& operator=(const BaseTablet&) = delete;
 
-    const std::string& tablet_path() const { return _tablet_path; }
     TabletState tablet_state() const { return _tablet_meta->tablet_state(); }
     Status set_tablet_state(TabletState state);
     int64_t table_id() const { return _tablet_meta->table_id(); }
@@ -283,8 +282,6 @@ protected:
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _stale_rs_version_map;
     const TabletMetaSharedPtr _tablet_meta;
     TabletSchemaSPtr _max_version_schema;
-
-    std::string _tablet_path;
 
     // metrics of this tablet
     std::shared_ptr<MetricEntity> _metric_entity;

--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -75,9 +75,9 @@ Status ColdDataCompaction::execute_compact() {
 
 Status ColdDataCompaction::construct_output_rowset_writer(RowsetWriterContext& ctx) {
     // write output rowset to storage policy resource
-    io::RemoteFileSystemSPtr fs;
-    RETURN_IF_ERROR(get_remote_file_system(tablet()->storage_policy_id(), &fs));
-    ctx.fs = std::move(fs);
+    auto storage_resource =
+            DORIS_TRY(get_resource_by_storage_policy_id(tablet()->storage_policy_id()));
+    ctx.storage_resource = std::move(storage_resource);
     return CompactionMixin::construct_output_rowset_writer(ctx);
 }
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -56,6 +56,7 @@
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/rowset/segment_v2/inverted_index_compaction.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/rowset/segment_v2/inverted_index_file_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_file_writer.h"
 #include "olap/rowset/segment_v2/inverted_index_fs_directory.h"
@@ -272,7 +273,7 @@ Status CompactionMixin::do_compact_ordered_rowsets() {
     auto seg_id = 0;
     std::vector<KeyBoundsPB> segment_key_bounds;
     for (auto rowset : _input_rowsets) {
-        RETURN_IF_ERROR(rowset->link_files_to(_tablet->tablet_path(),
+        RETURN_IF_ERROR(rowset->link_files_to(tablet()->tablet_path(),
                                               _output_rs_writer->rowset_id(), seg_id));
         seg_id += rowset->num_segments();
 
@@ -528,25 +529,25 @@ Status Compaction::do_inverted_index_compaction() {
         return Status::OK();
     }
 
-    // src index files
-    // format: rowsetId_segmentId
-    std::vector<std::string> src_index_files(src_segment_num);
-    for (const auto& m : src_seg_to_id_map) {
-        std::pair<RowsetId, uint32_t> p = m.first;
-        src_index_files[m.second] = p.first.to_string() + "_" + std::to_string(p.second);
-    }
-
-    // dest index files
-    // format: rowsetId_segmentId
-    std::vector<std::string> dest_index_files(dest_segment_num);
-    for (int i = 0; i < dest_segment_num; ++i) {
-        auto prefix = dest_rowset_id.to_string() + "_" + std::to_string(i);
-        dest_index_files[i] = prefix;
-    }
-
     // Only write info files when debug index compaction is enabled.
     // The files are used to debug index compaction and works with index_tool.
     if (config::debug_inverted_index_compaction) {
+        // src index files
+        // format: rowsetId_segmentId
+        std::vector<std::string> src_index_files(src_segment_num);
+        for (const auto& m : src_seg_to_id_map) {
+            std::pair<RowsetId, uint32_t> p = m.first;
+            src_index_files[m.second] = p.first.to_string() + "_" + std::to_string(p.second);
+        }
+
+        // dest index files
+        // format: rowsetId_segmentId
+        std::vector<std::string> dest_index_files(dest_segment_num);
+        for (int i = 0; i < dest_segment_num; ++i) {
+            auto prefix = dest_rowset_id.to_string() + "_" + std::to_string(i);
+            dest_index_files[i] = prefix;
+        }
+
         auto write_json_to_file = [&](const nlohmann::json& json_obj,
                                       const std::string& file_name) {
             io::FileWriterPtr file_writer;
@@ -583,25 +584,42 @@ Status Compaction::do_inverted_index_compaction() {
     }
 
     // create index_writer to compaction indexes
-    const auto& fs = _output_rowset->rowset_meta()->fs();
-    const auto& tablet_path = _tablet->tablet_path();
+    std::unordered_map<RowsetId, Rowset*> rs_id_to_rowset_map;
+    for (auto&& rs : _input_rowsets) {
+        rs_id_to_rowset_map.emplace(rs->rowset_id(), rs.get());
+    }
 
     // src index dirs
-    // format: rowsetId_segmentId
     std::vector<std::unique_ptr<InvertedIndexFileReader>> inverted_index_file_readers(
             src_segment_num);
     for (const auto& m : src_seg_to_id_map) {
-        std::pair<RowsetId, uint32_t> p = m.first;
-        auto segment_file_name = p.first.to_string() + "_" + std::to_string(p.second) + ".dat";
+        const auto& [rowset_id, seg_id] = m.first;
+
+        auto find_it = rs_id_to_rowset_map.find(rowset_id);
+        if (find_it == rs_id_to_rowset_map.end()) [[unlikely]] {
+            DCHECK(false) << _tablet->tablet_id() << ' ' << rowset_id;
+            return Status::InternalError("cannot find rowset. tablet_id={} rowset_id={}",
+                                         _tablet->tablet_id(), rowset_id.to_string());
+        }
+
+        auto* rowset = find_it->second;
+        const auto& fs = rowset->rowset_meta()->fs();
+        if (!fs) {
+            return Status::InternalError("get fs failed, resource_id={}",
+                                         rowset->rowset_meta()->resource_id());
+        }
+
+        auto seg_path = DORIS_TRY(rowset->segment_path(seg_id));
         auto inverted_index_file_reader = std::make_unique<InvertedIndexFileReader>(
-                fs, tablet_path, segment_file_name,
+                fs, std::string {InvertedIndexDescriptor::get_index_path_prefix(seg_path)},
                 _cur_tablet_schema->get_inverted_index_storage_format());
         bool open_idx_file_cache = false;
         auto st = inverted_index_file_reader->init(config::inverted_index_read_buffer_size,
                                                    open_idx_file_cache);
         if (!st.ok()) {
             LOG(ERROR) << "init inverted index "
-                       << InvertedIndexDescriptor::get_index_file_name(segment_file_name)
+                       << InvertedIndexDescriptor::get_index_path_v2(
+                                  InvertedIndexDescriptor::get_index_path_prefix(seg_path))
                        << " failed in compaction when init inverted index file reader";
             return st;
         }
@@ -613,9 +631,11 @@ Status Compaction::do_inverted_index_compaction() {
     std::vector<std::unique_ptr<InvertedIndexFileWriter>> inverted_index_file_writers(
             dest_segment_num);
     for (int i = 0; i < dest_segment_num; ++i) {
-        auto prefix = dest_rowset_id.to_string() + "_" + std::to_string(i) + ".dat";
+        std::string index_path_prefix {
+                InvertedIndexDescriptor::get_index_path_prefix(ctx.segment_path(i))};
         auto inverted_index_file_reader = std::make_unique<InvertedIndexFileReader>(
-                fs, tablet_path, prefix, _cur_tablet_schema->get_inverted_index_storage_format());
+                ctx.fs(), index_path_prefix,
+                _cur_tablet_schema->get_inverted_index_storage_format());
         bool open_idx_file_cache = false;
         auto st = inverted_index_file_reader->init(config::inverted_index_read_buffer_size,
                                                    open_idx_file_cache);
@@ -623,21 +643,21 @@ Status Compaction::do_inverted_index_compaction() {
             auto index_not_need_to_compact =
                     DORIS_TRY(inverted_index_file_reader->get_all_directories());
             auto inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                    fs, tablet_path, prefix,
+                    ctx.fs(), index_path_prefix, ctx.rowset_id.to_string(), i,
                     _cur_tablet_schema->get_inverted_index_storage_format());
             RETURN_NOT_OK_STATUS_WITH_WARN(
                     inverted_index_file_writer->initialize(index_not_need_to_compact),
                     "failed to initialize inverted_index_file_writer for " +
-                            inverted_index_file_writer->get_index_file_name());
+                            inverted_index_file_writer->get_index_file_path());
             inverted_index_file_writers[i] = std::move(inverted_index_file_writer);
         } else if (st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>()) {
             auto inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                    fs, tablet_path, prefix,
+                    ctx.fs(), index_path_prefix, ctx.rowset_id.to_string(), i,
                     _cur_tablet_schema->get_inverted_index_storage_format());
             inverted_index_file_writers[i] = std::move(inverted_index_file_writer);
         } else {
             LOG(ERROR) << "init inverted index "
-                       << InvertedIndexDescriptor::get_index_file_name(prefix)
+                       << InvertedIndexDescriptor::get_index_path_v2(index_path_prefix)
                        << " failed in compaction when create inverted index file writer";
             return st;
         }
@@ -704,8 +724,8 @@ Status Compaction::do_inverted_index_compaction() {
                         DORIS_TRY(inverted_index_file_writers[dest_segment_id]->open(index_meta));
                 dest_index_dirs[dest_segment_id] = dest_dir;
             }
-            auto st = compact_column(index_meta->index_id(), src_index_dirs, dest_index_dirs, fs,
-                                     index_tmp_path, trans_vec, dest_segment_num_rows);
+            auto st = compact_column(index_meta->index_id(), src_index_dirs, dest_index_dirs,
+                                     index_tmp_path.native(), trans_vec, dest_segment_num_rows);
             if (!st.ok()) {
                 error_handler(index_meta->index_id(), column_uniq_id);
                 status = Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(st.msg());
@@ -752,6 +772,11 @@ void Compaction::construct_skip_inverted_index(RowsetWriterContext& ctx) {
             }
 
             const auto& fs = rowset->rowset_meta()->fs();
+            if (!fs) {
+                LOG(WARNING) << "get fs failed, resource_id="
+                             << rowset->rowset_meta()->resource_id();
+                return false;
+            }
 
             const auto* index_meta = rowset->tablet_schema()->get_inverted_index(col_unique_id, "");
             if (index_meta == nullptr) {
@@ -761,10 +786,15 @@ void Compaction::construct_skip_inverted_index(RowsetWriterContext& ctx) {
             }
 
             for (auto i = 0; i < rowset->num_segments(); i++) {
-                auto segment_file = rowset->segment_file_path(i);
-                io::Path segment_path(segment_file);
+                // TODO: inverted_index_path
+                auto seg_path = rowset->segment_path(i);
+                if (!seg_path) {
+                    LOG(WARNING) << seg_path.error();
+                    return false;
+                }
+
                 auto inverted_index_file_reader = std::make_unique<InvertedIndexFileReader>(
-                        fs, segment_path.parent_path(), segment_path.filename(),
+                        fs, std::string {InvertedIndexDescriptor::get_index_path_prefix(*seg_path)},
                         _cur_tablet_schema->get_inverted_index_storage_format());
                 bool open_idx_file_cache = false;
                 auto st = inverted_index_file_reader->init(config::inverted_index_read_buffer_size,
@@ -1096,16 +1126,11 @@ Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext&
           _tablet->keys_type() == KeysType::DUP_KEYS))) {
         construct_skip_inverted_index(ctx);
     }
-    // Use the vault id of the previous rowset
-    for (const auto& rs : _input_rowsets) {
-        if (nullptr != rs->rowset_meta()->fs()) {
-            ctx.fs = rs->rowset_meta()->fs();
-            break;
-        }
-    }
-    if (nullptr == ctx.fs) [[unlikely]] {
-        return Status::InternalError("Failed to find fs");
-    }
+
+    // Use the storage resource of the previous rowset
+    ctx.storage_resource =
+            *DORIS_TRY(_input_rowsets.back()->rowset_meta()->remote_storage_resource());
+
     ctx.txn_id = boost::uuids::hash_value(UUIDGenerator::instance()->next_uuid()) &
                  std::numeric_limits<int64_t>::max(); // MUST be positive
     ctx.txn_expiration = _expiration;

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -37,6 +37,7 @@
 #include "gutil/strings/numbers.h"
 #include "io/fs/file_writer.h" // IWYU pragma: keep
 #include "olap/memtable_flush_executor.h"
+#include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/beta_rowset_writer.h"
 #include "olap/rowset/rowset_meta.h"
@@ -267,22 +268,22 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(const PNodeInfo& node_info) 
     }
     request->set_host(BackendOptions::get_localhost());
     request->set_http_port(config::webserver_port);
-    string tablet_path = _rowset_builder->tablet()->tablet_path();
+    const auto& tablet_path = cur_rowset->tablet_path();
     request->set_rowset_path(tablet_path);
     request->set_token(ExecEnv::GetInstance()->token());
     request->set_brpc_port(config::brpc_port);
     request->set_node_id(node_info.id());
     for (int segment_id = 0; segment_id < cur_rowset->rowset_meta()->num_segments(); segment_id++) {
-        std::stringstream segment_name;
-        segment_name << cur_rowset->rowset_id() << "_" << segment_id << ".dat";
-        int64_t segment_size = std::filesystem::file_size(tablet_path + "/" + segment_name.str());
+        auto seg_path =
+                local_segment_path(tablet_path, cur_rowset->rowset_id().to_string(), segment_id);
+        int64_t segment_size = std::filesystem::file_size(seg_path);
         request->mutable_segments_size()->insert({segment_id, segment_size});
-
+        auto index_path_prefix = InvertedIndexDescriptor::get_index_path_prefix(seg_path);
         if (!indices_ids.empty()) {
             if (tablet_schema->get_inverted_index_storage_format() !=
                 InvertedIndexStorageFormatPB::V1) {
-                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
-                        tablet_path + "/" + segment_name.str());
+                std::string inverted_index_file =
+                        InvertedIndexDescriptor::get_index_path_v2(index_path_prefix);
                 int64_t size = std::filesystem::file_size(inverted_index_file);
                 PTabletWriteSlaveRequest::IndexSize index_size;
                 // special id for non-V1 format
@@ -297,9 +298,8 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(const PNodeInfo& node_info) 
                 *index_size_map_value.mutable_index_sizes()->Add() = std::move(index_size);
             } else {
                 for (auto index_id : indices_ids) {
-                    std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
-                            tablet_path + "/" + segment_name.str(), index_id.first,
-                            index_id.second);
+                    std::string inverted_index_file = InvertedIndexDescriptor::get_index_path_v1(
+                            seg_path, index_id.first, index_id.second);
                     int64_t size = std::filesystem::file_size(inverted_index_file);
                     PTabletWriteSlaveRequest::IndexSize index_size;
                     index_size.set_indexid(index_id.first);

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -403,8 +403,8 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
     _generate_key_group_cluster_key_idxes(tablet_schema, column_groups,
                                           key_group_cluster_key_idxes);
 
-    vectorized::RowSourcesBuffer row_sources_buf(tablet->tablet_id(), tablet->tablet_path(),
-                                                 reader_type);
+    vectorized::RowSourcesBuffer row_sources_buf(
+            tablet->tablet_id(), dst_rowset_writer->context().tablet_path, reader_type);
     // compact group one by one
     for (auto i = 0; i < column_groups.size(); ++i) {
         VLOG_NOTICE << "row source size: " << row_sources_buf.total_size();

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <stdint.h>
 
 #include <cstdlib>
 #include <sstream>
 #include <string>
-
-#include "common/status.h"
 
 namespace doris {
 // Here are some unified definitions
@@ -100,15 +99,14 @@ static const std::string CLONE_PREFIX = "clone";
 static const std::string SPILL_DIR_PREFIX = "spill";
 static const std::string SPILL_GC_DIR_PREFIX = "spill_gc";
 
-// define paths
-static inline std::string remote_tablet_path(int64_t tablet_id) {
-    // data/{tablet_id}
-    return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
+static inline std::string local_segment_path(std::string_view tablet_path,
+                                             std::string_view rowset_id, int64_t seg_id) {
+    return fmt::format("{}/{}_{}.dat", tablet_path, rowset_id, seg_id);
 }
-static inline std::string remote_tablet_meta_path(int64_t tablet_id, int64_t replica_id,
-                                                  int64_t cooldown_term) {
-    // data/{tablet_id}/{replica_id}.{cooldown_term}.meta
-    return fmt::format("{}/{}.{}.meta", remote_tablet_path(tablet_id), replica_id, cooldown_term);
+
+static inline std::string cooldown_tablet_meta_filename(int64_t cooldown_replica_id,
+                                                        int64_t cooldown_term) {
+    return fmt::format("{}.{}.meta", cooldown_replica_id, cooldown_term);
 }
 
 static const std::string TABLET_UID = "tablet_uid";

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -49,28 +49,6 @@
 namespace doris {
 using namespace ErrorCode;
 
-std::string BetaRowset::segment_file_path(int segment_id) const {
-    return segment_file_path(_rowset_dir, rowset_id(), segment_id);
-}
-
-std::string BetaRowset::segment_file_path(const std::string& rowset_dir, const RowsetId& rowset_id,
-                                          int segment_id) {
-    // {rowset_dir}/{rowset_id}_{seg_num}.dat
-    return fmt::format("{}/{}_{}.dat", rowset_dir, rowset_id.to_string(), segment_id);
-}
-
-std::string BetaRowset::remote_segment_path(int64_t tablet_id, const RowsetId& rowset_id,
-                                            int segment_id) {
-    // data/{tablet_id}/{rowset_id}_{seg_num}.dat
-    return remote_segment_path(tablet_id, rowset_id.to_string(), segment_id);
-}
-
-std::string BetaRowset::remote_segment_path(int64_t tablet_id, const std::string& rowset_id,
-                                            int segment_id) {
-    // data/{tablet_id}/{rowset_id}_{seg_num}.dat
-    return fmt::format("{}/{}_{}.dat", remote_tablet_path(tablet_id), rowset_id, segment_id);
-}
-
 std::string BetaRowset::local_segment_path_segcompacted(const std::string& tablet_path,
                                                         const RowsetId& rowset_id, int64_t begin,
                                                         int64_t end) {
@@ -78,9 +56,9 @@ std::string BetaRowset::local_segment_path_segcompacted(const std::string& table
     return fmt::format("{}/{}_{}-{}.dat", tablet_path, rowset_id.to_string(), begin, end);
 }
 
-BetaRowset::BetaRowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,
-                       const RowsetMetaSharedPtr& rowset_meta)
-        : Rowset(schema, rowset_meta), _rowset_dir(tablet_path) {}
+BetaRowset::BetaRowset(const TabletSchemaSPtr& schema, const RowsetMetaSharedPtr& rowset_meta,
+                       std::string tablet_path)
+        : Rowset(schema, rowset_meta, std::move(tablet_path)) {}
 
 BetaRowset::~BetaRowset() = default;
 
@@ -95,30 +73,33 @@ Status BetaRowset::do_load(bool /*use_cache*/) {
 }
 
 Status BetaRowset::get_inverted_index_size(size_t* index_size) {
-    auto fs = _rowset_meta->fs();
-    if (!fs || _schema == nullptr) {
-        return Status::Error<INIT_FAILED>("get fs failed");
+    const auto& fs = _rowset_meta->fs();
+    if (!fs) {
+        return Status::Error<INIT_FAILED>("get fs failed, resource_id={}",
+                                          _rowset_meta->resource_id());
     }
+
     if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
         auto indices = _schema->indexes();
         for (auto& index : indices) {
             for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-                auto seg_path = segment_file_path(seg_id);
+                auto seg_path = DORIS_TRY(segment_path(seg_id));
                 int64_t file_size = 0;
 
-                std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_name(
-                        seg_path, index.index_id(), index.get_index_suffix());
+                std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_path_v1(
+                        InvertedIndexDescriptor::get_index_path_prefix(seg_path), index.index_id(),
+                        index.get_index_suffix());
                 RETURN_IF_ERROR(fs->file_size(inverted_index_file_path, &file_size));
                 *index_size += file_size;
             }
         }
     } else {
         for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-            auto seg_path = segment_file_path(seg_id);
+            auto seg_path = DORIS_TRY(segment_path(seg_id));
             int64_t file_size = 0;
 
-            std::string inverted_index_file_path =
-                    InvertedIndexDescriptor::get_index_file_name(seg_path);
+            std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_path_v2(
+                    InvertedIndexDescriptor::get_index_path_prefix(seg_path));
             RETURN_IF_ERROR(fs->file_size(inverted_index_file_path, &file_size));
             *index_size += file_size;
         }
@@ -128,12 +109,17 @@ Status BetaRowset::get_inverted_index_size(size_t* index_size) {
 
 void BetaRowset::clear_inverted_index_cache() {
     for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_file_path(i);
-        for (auto& column : tablet_schema()->columns()) {
+        auto seg_path = segment_path(i);
+        if (!seg_path) {
+            continue;
+        }
+
+        auto index_path_prefix = InvertedIndexDescriptor::get_index_path_prefix(*seg_path);
+        for (const auto& column : tablet_schema()->columns()) {
             const TabletIndex* index_meta = tablet_schema()->get_inverted_index(*column);
             if (index_meta) {
-                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
-                        seg_path, index_meta->index_id(), index_meta->get_index_suffix());
+                std::string inverted_index_file = InvertedIndexDescriptor::get_index_path_v1(
+                        index_path_prefix, index_meta->index_id(), index_meta->get_index_suffix());
                 (void)segment_v2::InvertedIndexSearcherCache::instance()->erase(
                         inverted_index_file);
             }
@@ -143,17 +129,20 @@ void BetaRowset::clear_inverted_index_cache() {
 
 Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
     auto fs = _rowset_meta->fs();
-    if (!fs || _schema == nullptr) {
-        return Status::Error<INIT_FAILED>("get fs failed");
+    if (!fs) {
+        return Status::Error<INIT_FAILED>("get fs failed, resource_id={}",
+                                          _rowset_meta->resource_id());
     }
+
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = segment_file_path(seg_id);
+        auto seg_path = DORIS_TRY(segment_path(seg_id));
         int64_t file_size;
         RETURN_IF_ERROR(fs->file_size(seg_path, &file_size));
         segments_size->push_back(file_size);
     }
     return Status::OK();
 }
+
 Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
     return load_segments(0, num_segments(), segments);
 }
@@ -172,11 +161,12 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
 
 Status BetaRowset::load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment) {
     auto fs = _rowset_meta->fs();
-    if (!fs || _schema == nullptr) {
+    if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");
     }
+
     DCHECK(seg_id >= 0);
-    auto seg_path = segment_file_path(seg_id);
+    auto seg_path = DORIS_TRY(segment_path(seg_id));
     io::FileReaderOptions reader_options {
             .cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
                                                     : io::FileCachePolicy::NO_CACHE,
@@ -200,6 +190,11 @@ Status BetaRowset::create_reader(RowsetReaderSharedPtr* result) {
 }
 
 Status BetaRowset::remove() {
+    if (!is_local()) {
+        DCHECK(false) << _rowset_meta->tablet_id() << ' ' << rowset_id();
+        return Status::OK();
+    }
+
     // TODO should we close and remove all segment reader first?
     VLOG_NOTICE << "begin to remove files in rowset " << rowset_id()
                 << ", version:" << start_version() << "-" << end_version()
@@ -207,35 +202,35 @@ Status BetaRowset::remove() {
     // If the rowset was removed, it need to remove the fds in segment cache directly
     clear_cache();
 
-    auto fs = _rowset_meta->fs();
-    if (!fs) {
-        return Status::Error<INIT_FAILED>("get fs failed");
-    }
     bool success = true;
     Status st;
+    const auto& fs = io::global_local_filesystem();
     for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_file_path(i);
+        auto seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
         LOG(INFO) << "deleting " << seg_path;
         st = fs->delete_file(seg_path);
         if (!st.ok()) {
             LOG(WARNING) << st.to_string();
             success = false;
         }
+
         if (_schema->get_inverted_index_storage_format() != InvertedIndexStorageFormatPB::V1 &&
             _schema->has_inverted_index()) {
-            std::string inverted_index_file =
-                    InvertedIndexDescriptor::get_index_file_name(seg_path);
+            std::string inverted_index_file = InvertedIndexDescriptor::get_index_path_v2(
+                    InvertedIndexDescriptor::get_index_path_prefix(seg_path));
             st = fs->delete_file(inverted_index_file);
             if (!st.ok()) {
                 LOG(WARNING) << st.to_string();
                 success = false;
             }
         }
+
         for (auto& column : _schema->columns()) {
             const TabletIndex* index_meta = _schema->get_inverted_index(*column);
             if (index_meta) {
-                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
-                        seg_path, index_meta->index_id(), index_meta->get_index_suffix());
+                std::string inverted_index_file = InvertedIndexDescriptor::get_index_path_v1(
+                        InvertedIndexDescriptor::get_index_path_prefix(seg_path),
+                        index_meta->index_id(), index_meta->get_index_suffix());
                 if (_schema->get_inverted_index_storage_format() ==
                     InvertedIndexStorageFormatPB::V1) {
                     st = fs->delete_file(inverted_index_file);
@@ -261,15 +256,13 @@ void BetaRowset::do_close() {
 Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
                                  size_t new_rowset_start_seg_id,
                                  std::set<int64_t>* without_index_uids) {
-    DCHECK(is_local());
-    auto fs = _rowset_meta->fs();
-    if (!fs) {
-        return Status::Error<INIT_FAILED>("get fs failed");
-    }
-    if (fs->type() != io::FileSystemType::LOCAL) {
-        return Status::InternalError("should be local file system");
+    if (!is_local()) {
+        DCHECK(false) << _rowset_meta->tablet_id() << ' ' << rowset_id();
+        return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                     _rowset_meta->tablet_id(), rowset_id().to_string());
     }
 
+    const auto& local_fs = io::global_local_filesystem();
     Status status;
     std::vector<string> linked_success_files;
     Defer remove_linked_files {[&]() { // clear linked files if errors happen
@@ -280,21 +273,21 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
                 paths.emplace_back(file);
                 LOG(WARNING) << "will delete linked success file " << file << " due to error";
             }
-            static_cast<void>(fs->batch_delete(paths));
+            static_cast<void>(local_fs->batch_delete(paths));
             LOG(WARNING) << "done delete linked success files due to error " << status;
         }
     }};
 
-    io::LocalFileSystem* local_fs = (io::LocalFileSystem*)fs.get();
     for (int i = 0; i < num_segments(); ++i) {
-        auto dst_path = segment_file_path(dir, new_rowset_id, i + new_rowset_start_seg_id);
+        auto dst_path =
+                local_segment_path(dir, new_rowset_id.to_string(), i + new_rowset_start_seg_id);
         bool dst_path_exist = false;
-        if (!fs->exists(dst_path, &dst_path_exist).ok() || dst_path_exist) {
+        if (!local_fs->exists(dst_path, &dst_path_exist).ok() || dst_path_exist) {
             status = Status::Error<FILE_ALREADY_EXIST>(
                     "failed to create hard link, file already exist: {}", dst_path);
             return status;
         }
-        auto src_path = segment_file_path(i);
+        auto src_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
         // TODO(lingbin): how external storage support link?
         //     use copy? or keep refcount to avoid being delete?
         if (!local_fs->link_file(src_path, dst_path).ok()) {
@@ -310,13 +303,13 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
         if (_schema->get_inverted_index_storage_format() != InvertedIndexStorageFormatPB::V1) {
             if (_schema->has_inverted_index() &&
                 (without_index_uids == nullptr || without_index_uids->empty())) {
-                std::string inverted_index_file_src =
-                        InvertedIndexDescriptor::get_index_file_name(src_path);
-                std::string inverted_index_file_dst =
-                        InvertedIndexDescriptor::get_index_file_name(dst_path);
+                std::string inverted_index_file_src = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(src_path));
+                std::string inverted_index_file_dst = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(dst_path));
                 bool index_dst_path_exist = false;
 
-                if (!fs->exists(inverted_index_file_dst, &index_dst_path_exist).ok() ||
+                if (!local_fs->exists(inverted_index_file_dst, &index_dst_path_exist).ok() ||
                     index_dst_path_exist) {
                     status = Status::Error<FILE_ALREADY_EXIST>(
                             "failed to create hard link, file already exist: {}",
@@ -342,11 +335,13 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
                     continue;
                 }
                 std::string inverted_index_src_file_path =
-                        InvertedIndexDescriptor::get_index_file_name(src_path, index_id,
-                                                                     index.get_index_suffix());
+                        InvertedIndexDescriptor::get_index_path_v1(
+                                InvertedIndexDescriptor::get_index_path_prefix(src_path), index_id,
+                                index.get_index_suffix());
                 std::string inverted_index_dst_file_path =
-                        InvertedIndexDescriptor::get_index_file_name(dst_path, index_id,
-                                                                     index.get_index_suffix());
+                        InvertedIndexDescriptor::get_index_path_v1(
+                                InvertedIndexDescriptor::get_index_path_prefix(dst_path), index_id,
+                                index.get_index_suffix());
                 bool index_file_exists = true;
                 RETURN_IF_ERROR(local_fs->exists(inverted_index_src_file_path, &index_file_exists));
                 if (index_file_exists) {
@@ -381,22 +376,27 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
 }
 
 Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_rowset_id) {
-    DCHECK(is_local());
+    if (!is_local()) {
+        DCHECK(false) << _rowset_meta->tablet_id() << ' ' << rowset_id();
+        return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                     _rowset_meta->tablet_id(), rowset_id().to_string());
+    }
+
     bool exists = false;
     for (int i = 0; i < num_segments(); ++i) {
-        auto dst_path = segment_file_path(dir, new_rowset_id, i);
+        auto dst_path = local_segment_path(dir, new_rowset_id.to_string(), i);
         RETURN_IF_ERROR(io::global_local_filesystem()->exists(dst_path, &exists));
         if (exists) {
             return Status::Error<FILE_ALREADY_EXIST>("file already exist: {}", dst_path);
         }
-        auto src_path = segment_file_path(i);
+        auto src_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
         RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(src_path, dst_path));
         if (_schema->get_inverted_index_storage_format() != InvertedIndexStorageFormatPB::V1) {
             if (_schema->has_inverted_index()) {
-                std::string inverted_index_dst_file =
-                        InvertedIndexDescriptor::get_index_file_name(dst_path);
-                std::string inverted_index_src_file =
-                        InvertedIndexDescriptor::get_index_file_name(src_path);
+                std::string inverted_index_src_file = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(src_path));
+                std::string inverted_index_dst_file = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(dst_path));
                 RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(inverted_index_src_file,
                                                                          inverted_index_dst_file));
                 LOG(INFO) << "success to copy file. from=" << inverted_index_src_file << ", "
@@ -408,13 +408,13 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
                 const TabletIndex* index_meta = _schema->get_inverted_index(*column);
                 if (index_meta) {
                     std::string inverted_index_src_file_path =
-                            InvertedIndexDescriptor::get_index_file_name(
-                                    src_path, index_meta->index_id(),
-                                    index_meta->get_index_suffix());
+                            InvertedIndexDescriptor::get_index_path_v1(
+                                    InvertedIndexDescriptor::get_index_path_prefix(src_path),
+                                    index_meta->index_id(), index_meta->get_index_suffix());
                     std::string inverted_index_dst_file_path =
-                            InvertedIndexDescriptor::get_index_file_name(
-                                    dst_path, index_meta->index_id(),
-                                    index_meta->get_index_suffix());
+                            InvertedIndexDescriptor::get_index_path_v1(
+                                    InvertedIndexDescriptor::get_index_path_prefix(dst_path),
+                                    index_meta->index_id(), index_meta->get_index_suffix());
                     RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(
                             inverted_index_src_file_path, inverted_index_dst_file_path));
                     LOG(INFO) << "success to copy file. from=" << inverted_index_src_file_path
@@ -427,8 +427,13 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
     return Status::OK();
 }
 
-Status BetaRowset::upload_to(io::RemoteFileSystem* dest_fs, const RowsetId& new_rowset_id) {
-    DCHECK(is_local());
+Status BetaRowset::upload_to(const StorageResource& dest_fs, const RowsetId& new_rowset_id) {
+    if (!is_local()) {
+        DCHECK(false) << _rowset_meta->tablet_id() << ' ' << rowset_id();
+        return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                     _rowset_meta->tablet_id(), rowset_id().to_string());
+    }
+
     if (num_segments() < 1) {
         return Status::OK();
     }
@@ -438,16 +443,17 @@ Status BetaRowset::upload_to(io::RemoteFileSystem* dest_fs, const RowsetId& new_
     dest_paths.reserve(num_segments());
     for (int i = 0; i < num_segments(); ++i) {
         // Note: Here we use relative path for remote.
-        auto remote_seg_path = remote_segment_path(_rowset_meta->tablet_id(), new_rowset_id, i);
-        auto local_seg_path = segment_file_path(i);
+        auto remote_seg_path = dest_fs.remote_segment_path(_rowset_meta->tablet_id(),
+                                                           new_rowset_id.to_string(), i);
+        auto local_seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
         dest_paths.emplace_back(remote_seg_path);
         local_paths.emplace_back(local_seg_path);
         if (_schema->get_inverted_index_storage_format() != InvertedIndexStorageFormatPB::V1) {
             if (_schema->has_inverted_index()) {
-                std::string remote_inverted_index_file =
-                        InvertedIndexDescriptor::get_index_file_name(remote_seg_path);
-                std::string local_inverted_index_file =
-                        InvertedIndexDescriptor::get_index_file_name(local_seg_path);
+                std::string remote_inverted_index_file = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(remote_seg_path));
+                std::string local_inverted_index_file = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(local_seg_path));
                 dest_paths.emplace_back(remote_inverted_index_file);
                 local_paths.emplace_back(local_inverted_index_file);
             }
@@ -457,20 +463,20 @@ Status BetaRowset::upload_to(io::RemoteFileSystem* dest_fs, const RowsetId& new_
                 const TabletIndex* index_meta = _schema->get_inverted_index(*column);
                 if (index_meta) {
                     std::string remote_inverted_index_file =
-                            InvertedIndexDescriptor::get_index_file_name(
-                                    remote_seg_path, index_meta->index_id(),
-                                    index_meta->get_index_suffix());
+                            InvertedIndexDescriptor::get_index_path_v1(
+                                    InvertedIndexDescriptor::get_index_path_prefix(remote_seg_path),
+                                    index_meta->index_id(), index_meta->get_index_suffix());
                     std::string local_inverted_index_file =
-                            InvertedIndexDescriptor::get_index_file_name(
-                                    local_seg_path, index_meta->index_id(),
-                                    index_meta->get_index_suffix());
+                            InvertedIndexDescriptor::get_index_path_v1(
+                                    InvertedIndexDescriptor::get_index_path_prefix(local_seg_path),
+                                    index_meta->index_id(), index_meta->get_index_suffix());
                     dest_paths.emplace_back(remote_inverted_index_file);
                     local_paths.emplace_back(local_inverted_index_file);
                 }
             }
         }
     }
-    auto st = dest_fs->batch_upload(local_paths, dest_paths);
+    auto st = dest_fs.fs->batch_upload(local_paths, dest_paths);
     if (st.ok()) {
         DorisMetrics::instance()->upload_rowset_count->increment(1);
         DorisMetrics::instance()->upload_total_byte->increment(data_disk_size());
@@ -480,40 +486,36 @@ Status BetaRowset::upload_to(io::RemoteFileSystem* dest_fs, const RowsetId& new_
     return st;
 }
 
-bool BetaRowset::check_path(const std::string& path) {
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_file_path(i);
-        if (seg_path == path) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool BetaRowset::check_file_exist() {
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_file_path(i);
-        auto fs = _rowset_meta->fs();
-        if (!fs) {
-            return false;
-        }
-        bool seg_file_exist = false;
-        if (!fs->exists(seg_path, &seg_file_exist).ok() || !seg_file_exist) {
-            LOG(WARNING) << "data file not existed: " << seg_path
-                         << " for rowset_id: " << rowset_id();
-            return false;
-        }
-    }
-    return true;
-}
-
-bool BetaRowset::check_current_rowset_segment() {
-    auto fs = _rowset_meta->fs();
+Status BetaRowset::check_file_exist() {
+    const auto& fs = _rowset_meta->fs();
     if (!fs) {
-        return false;
+        return Status::InternalError("fs is not initialized, resource_id={}",
+                                     _rowset_meta->resource_id());
     }
+
+    for (int i = 0; i < num_segments(); ++i) {
+        auto seg_path = DORIS_TRY(segment_path(i));
+        bool seg_file_exist = false;
+        RETURN_IF_ERROR(fs->exists(seg_path, &seg_file_exist));
+        if (!seg_file_exist) {
+            return Status::InternalError("data file not existed: {}, rowset_id={}", seg_path,
+                                         rowset_id().to_string());
+        }
+    }
+
+    return Status::OK();
+}
+
+Status BetaRowset::check_current_rowset_segment() {
+    const auto& fs = _rowset_meta->fs();
+    if (!fs) {
+        return Status::InternalError("fs is not initialized, resource_id={}",
+                                     _rowset_meta->resource_id());
+    }
+
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = segment_file_path(seg_id);
+        auto seg_path = DORIS_TRY(segment_path(seg_id));
+
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options {
                 .cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
@@ -525,23 +527,22 @@ bool BetaRowset::check_current_rowset_segment() {
                                            reader_options, &segment);
         if (!s.ok()) {
             LOG(WARNING) << "segment can not be opened. file=" << seg_path;
-            return false;
+            return s;
         }
     }
-    return true;
+
+    return Status::OK();
 }
 
 Status BetaRowset::add_to_binlog() {
     // FIXME(Drogon): not only local file system
-    DCHECK(is_local());
-    auto fs = _rowset_meta->fs();
-    if (!fs) {
-        return Status::Error<INIT_FAILED>("get fs failed");
+    if (!is_local()) {
+        DCHECK(false) << _rowset_meta->tablet_id() << ' ' << rowset_id();
+        return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                     _rowset_meta->tablet_id(), rowset_id().to_string());
     }
-    if (fs->type() != io::FileSystemType::LOCAL) {
-        return Status::InternalError("should be local file system");
-    }
-    auto* local_fs = static_cast<io::LocalFileSystem*>(fs.get());
+
+    const auto& fs = io::global_local_filesystem();
 
     // all segments are in the same directory, so cache binlog_dir without multi times check
     std::string binlog_dir;
@@ -560,21 +561,21 @@ Status BetaRowset::add_to_binlog() {
                 paths.emplace_back(file);
                 LOG(WARNING) << "will delete linked success file " << file << " due to error";
             }
-            static_cast<void>(local_fs->batch_delete(paths));
+            static_cast<void>(fs->batch_delete(paths));
             LOG(WARNING) << "done delete linked success files due to error " << status;
         }
     }};
 
     for (int i = 0; i < segments_num; ++i) {
-        auto seg_file = segment_file_path(i);
+        auto seg_file = local_segment_path(_tablet_path, rowset_id().to_string(), i);
 
         if (binlog_dir.empty()) {
             binlog_dir = std::filesystem::path(seg_file).parent_path().append("_binlog").string();
 
             bool exists = true;
-            RETURN_IF_ERROR(local_fs->exists(binlog_dir, &exists));
+            RETURN_IF_ERROR(fs->exists(binlog_dir, &exists));
             if (!exists) {
-                RETURN_IF_ERROR(local_fs->create_directory(binlog_dir));
+                RETURN_IF_ERROR(fs->create_directory(binlog_dir));
             }
         }
 
@@ -582,7 +583,7 @@ Status BetaRowset::add_to_binlog() {
                 (std::filesystem::path(binlog_dir) / std::filesystem::path(seg_file).filename())
                         .string();
         VLOG_DEBUG << "link " << seg_file << " to " << binlog_file;
-        if (!local_fs->link_file(seg_file, binlog_file).ok()) {
+        if (!fs->link_file(seg_file, binlog_file).ok()) {
             status = Status::Error<OS_ERROR>("fail to create hard link. from={}, to={}, errno={}",
                                              seg_file, binlog_file, Errno::no());
             return status;
@@ -595,33 +596,25 @@ Status BetaRowset::add_to_binlog() {
                     continue;
                 }
                 auto index_id = index.index_id();
-                auto index_file = InvertedIndexDescriptor::get_index_file_name(
-                        seg_file, index_id, index.get_index_suffix());
+                auto index_file = InvertedIndexDescriptor::get_index_path_v1(
+                        InvertedIndexDescriptor::get_index_path_prefix(seg_file), index_id,
+                        index.get_index_suffix());
                 auto binlog_index_file = (std::filesystem::path(binlog_dir) /
                                           std::filesystem::path(index_file).filename())
                                                  .string();
                 VLOG_DEBUG << "link " << index_file << " to " << binlog_index_file;
-                if (!local_fs->link_file(index_file, binlog_index_file).ok()) {
-                    status = Status::Error<OS_ERROR>(
-                            "fail to create hard link. from={}, to={}, errno={}", index_file,
-                            binlog_index_file, Errno::no());
-                    return status;
-                }
+                RETURN_IF_ERROR(fs->link_file(index_file, binlog_index_file));
                 linked_success_files.push_back(binlog_index_file);
             }
         } else {
             if (_schema->has_inverted_index()) {
-                auto index_file = InvertedIndexDescriptor::get_index_file_name(seg_file);
+                auto index_file = InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(seg_file));
                 auto binlog_index_file = (std::filesystem::path(binlog_dir) /
                                           std::filesystem::path(index_file).filename())
                                                  .string();
                 VLOG_DEBUG << "link " << index_file << " to " << binlog_index_file;
-                if (!local_fs->link_file(index_file, binlog_index_file).ok()) {
-                    status = Status::Error<OS_ERROR>(
-                            "fail to create hard link. from={}, to={}, errno={}", index_file,
-                            binlog_index_file, Errno::no());
-                    return status;
-                }
+                RETURN_IF_ERROR(fs->link_file(index_file, binlog_index_file));
                 linked_success_files.push_back(binlog_index_file);
             }
         }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -201,15 +201,12 @@ BetaRowsetWriter::BetaRowsetWriter(StorageEngine& engine)
         : _engine(engine), _segcompaction_worker(std::make_shared<SegcompactionWorker>(this)) {}
 
 BaseBetaRowsetWriter::~BaseBetaRowsetWriter() {
-    // TODO(lingbin): Should wrapper exception logic, no need to know file ops directly.
-    if (!_already_built) { // abnormal exit, remove all files generated
-        const auto& fs = _rowset_meta->fs();
-        if (!fs || !_rowset_meta->is_local()) { // Remote fs will delete them asynchronously
-            return;
-        }
+    if (!_already_built && _rowset_meta->is_local()) {
+        // abnormal exit, remove all files generated
+        auto& fs = io::global_local_filesystem();
         for (int i = _segment_start_id; i < _segment_creator.next_segment_id(); ++i) {
             std::string seg_path =
-                    BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, i);
+                    local_segment_path(_context.tablet_path, _context.rowset_id.to_string(), i);
             // Even if an error is encountered, these files that have not been cleaned up
             // will be cleaned up by the GC background. So here we only print the error
             // message when we encounter an error.
@@ -230,7 +227,9 @@ BetaRowsetWriter::~BetaRowsetWriter() {
 Status BaseBetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
     _context = rowset_writer_context;
     _rowset_meta.reset(new RowsetMeta);
-    _rowset_meta->set_fs(_context.fs);
+    if (_context.storage_resource) {
+        _rowset_meta->set_remote_storage_resource(*_context.storage_resource);
+    }
     _rowset_meta->set_rowset_id(_context.rowset_id);
     _rowset_meta->set_partition_id(_context.partition_id);
     _rowset_meta->set_tablet_id(_context.tablet_id);
@@ -296,7 +295,8 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
         return Status::Error<INIT_FAILED>(
                 "BetaRowsetWriter::_load_noncompacted_segment _rowset_meta->fs get failed");
     }
-    auto path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, segment_id);
+    auto path =
+            local_segment_path(_context.tablet_path, _context.rowset_id.to_string(), segment_id);
     io::FileReaderOptions reader_options {
             .cache_type =
                     _context.write_file_cache
@@ -304,8 +304,8 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
                                                          : io::FileCachePolicy::NO_CACHE)
                             : io::FileCachePolicy::NO_CACHE,
             .is_doris_table = true};
-    auto s = segment_v2::Segment::open(fs, path, segment_id, rowset_id(), _context.tablet_schema,
-                                       reader_options, &segment);
+    auto s = segment_v2::Segment::open(io::global_local_filesystem(), path, segment_id, rowset_id(),
+                                       _context.tablet_schema, reader_options, &segment);
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << path << ":" << s;
         return s;
@@ -381,10 +381,10 @@ Status BetaRowsetWriter::_find_longest_consecutive_small_segment(
 
 Status BetaRowsetWriter::_rename_compacted_segments(int64_t begin, int64_t end) {
     int ret;
-    auto src_seg_path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir,
+    auto src_seg_path = BetaRowset::local_segment_path_segcompacted(_context.tablet_path,
                                                                     _context.rowset_id, begin, end);
-    auto dst_seg_path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id,
-                                                      _num_segcompacted);
+    auto dst_seg_path = local_segment_path(_context.tablet_path, _context.rowset_id.to_string(),
+                                           _num_segcompacted);
     ret = rename(src_seg_path.c_str(), dst_seg_path.c_str());
     if (ret) {
         return Status::Error<ROWSET_RENAME_FILE_FAILED>(
@@ -414,9 +414,9 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint64_t seg_id) {
     }
 
     auto src_seg_path =
-            BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, seg_id);
-    auto dst_seg_path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id,
-                                                      _num_segcompacted);
+            local_segment_path(_context.tablet_path, _context.rowset_id.to_string(), seg_id);
+    auto dst_seg_path = local_segment_path(_context.tablet_path, _context.rowset_id.to_string(),
+                                           _num_segcompacted);
     VLOG_DEBUG << "segcompaction skip this segment. rename " << src_seg_path << " to "
                << dst_seg_path;
     {
@@ -443,18 +443,22 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint64_t seg_id) {
 
 Status BetaRowsetWriter::_rename_compacted_indices(int64_t begin, int64_t end, uint64_t seg_id) {
     int ret;
+
+    auto src_seg_path = begin < 0 ? local_segment_path(_context.tablet_path,
+                                                       _context.rowset_id.to_string(), seg_id)
+                                  : BetaRowset::local_segment_path_segcompacted(
+                                            _context.tablet_path, _context.rowset_id, begin, end);
+    auto src_index_path_prefix = InvertedIndexDescriptor::get_index_path_prefix(src_seg_path);
+    auto dst_seg_path = local_segment_path(_context.tablet_path, _context.rowset_id.to_string(),
+                                           _num_segcompacted);
+    auto dst_index_path_prefix = InvertedIndexDescriptor::get_index_path_prefix(dst_seg_path);
+
     if (_context.tablet_schema->get_inverted_index_storage_format() !=
         InvertedIndexStorageFormatPB::V1) {
         if (_context.tablet_schema->has_inverted_index()) {
-            auto src_seg_path =
-                    begin < 0 ? BetaRowset::segment_file_path(_context.rowset_dir,
-                                                              _context.rowset_id, seg_id)
-                              : BetaRowset::local_segment_path_segcompacted(
-                                        _context.rowset_dir, _context.rowset_id, begin, end);
-            auto dst_seg_path = BetaRowset::segment_file_path(
-                    _context.rowset_dir, _context.rowset_id, _num_segcompacted);
-            auto src_idx_path = InvertedIndexDescriptor::get_index_file_name(src_seg_path);
-            auto dst_idx_path = InvertedIndexDescriptor::get_index_file_name(dst_seg_path);
+            auto src_idx_path = InvertedIndexDescriptor::get_index_path_v2(src_index_path_prefix);
+            auto dst_idx_path = InvertedIndexDescriptor::get_index_path_v2(dst_index_path_prefix);
+
             ret = rename(src_idx_path.c_str(), dst_idx_path.c_str());
             if (ret) {
                 return Status::Error<ROWSET_RENAME_FILE_FAILED>(
@@ -466,18 +470,12 @@ Status BetaRowsetWriter::_rename_compacted_indices(int64_t begin, int64_t end, u
     // rename remaining inverted index files
     for (auto column : _context.tablet_schema->columns()) {
         if (_context.tablet_schema->has_inverted_index(*column)) {
-            auto index_info = _context.tablet_schema->get_inverted_index(*column);
+            const auto* index_info = _context.tablet_schema->get_inverted_index(*column);
             auto index_id = index_info->index_id();
-            auto src_idx_path =
-                    begin < 0 ? InvertedIndexDescriptor::inverted_index_file_path(
-                                        _context.rowset_dir, _context.rowset_id, seg_id, index_id,
-                                        index_info->get_index_suffix())
-                              : InvertedIndexDescriptor::local_inverted_index_path_segcompacted(
-                                        _context.rowset_dir, _context.rowset_id, begin, end,
-                                        index_id, index_info->get_index_suffix());
-            auto dst_idx_path = InvertedIndexDescriptor::inverted_index_file_path(
-                    _context.rowset_dir, _context.rowset_id, _num_segcompacted, index_id,
-                    index_info->get_index_suffix());
+            auto src_idx_path = InvertedIndexDescriptor::get_index_path_v1(
+                    src_index_path_prefix, index_id, index_info->get_index_suffix());
+            auto dst_idx_path = InvertedIndexDescriptor::get_index_path_v1(
+                    dst_index_path_prefix, index_id, index_info->get_index_suffix());
             if (_context.tablet_schema->get_inverted_index_storage_format() ==
                 InvertedIndexStorageFormatPB::V1) {
                 VLOG_DEBUG << "segcompaction skip this index. rename " << src_idx_path << " to "
@@ -563,7 +561,7 @@ Status BetaRowsetWriter::_segcompaction_rename_last_segments() {
 
 Status BaseBetaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
     assert(rowset->rowset_meta()->rowset_type() == BETA_ROWSET);
-    RETURN_IF_ERROR(rowset->link_files_to(_context.rowset_dir, _context.rowset_id));
+    RETURN_IF_ERROR(rowset->link_files_to(_context.tablet_path, _context.rowset_id));
     _num_rows_written += rowset->num_rows();
     _total_data_size += rowset->rowset_meta()->data_disk_size();
     _total_index_size += rowset->rowset_meta()->index_disk_size();
@@ -637,7 +635,7 @@ RowsetSharedPtr BaseBetaRowsetWriter::manual_build(const RowsetMetaSharedPtr& sp
 
     build_rowset_meta_with_spec_field(*_rowset_meta, *spec_rowset_meta);
     RowsetSharedPtr rowset;
-    auto status = RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_dir,
+    auto status = RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path,
                                                _rowset_meta, &rowset);
     if (!status.ok()) {
         LOG(WARNING) << "rowset init failed when build new rowset, res=" << status;
@@ -702,7 +700,7 @@ Status BetaRowsetWriter::build(RowsetSharedPtr& rowset) {
     }
 
     RETURN_NOT_OK_STATUS_WITH_WARN(
-            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_dir, _rowset_meta,
+            RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path, _rowset_meta,
                                          &rowset),
             "rowset init failed when build new rowset");
     _already_built = true;
@@ -795,7 +793,7 @@ Status BaseBetaRowsetWriter::_build_tmp(RowsetSharedPtr& rowset_ptr) {
         return status;
     }
 
-    status = RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_dir, tmp_rs_meta,
+    status = RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path, tmp_rs_meta,
                                           &rowset_ptr);
     DBUG_EXECUTE_IF("BaseBetaRowsetWriter::_build_tmp.create_rowset_failed",
                     { status = Status::InternalError("create rowset failed"); });
@@ -806,11 +804,8 @@ Status BaseBetaRowsetWriter::_build_tmp(RowsetSharedPtr& rowset_ptr) {
     return Status::OK();
 }
 
-Status BaseBetaRowsetWriter::_create_file_writer(std::string path, io::FileWriterPtr& file_writer) {
-    auto fs = _rowset_meta->fs();
-    if (!fs) {
-        return Status::Error<INIT_FAILED>("get fs failed");
-    }
+Status BaseBetaRowsetWriter::_create_file_writer(const std::string& path,
+                                                 io::FileWriterPtr& file_writer) {
     io::FileWriterOptions opts {
             .write_file_cache = _context.write_file_cache,
             .is_cold_data = _context.is_hot_data,
@@ -818,7 +813,7 @@ Status BaseBetaRowsetWriter::_create_file_writer(std::string path, io::FileWrite
                     _context.file_cache_ttl_sec > 0 && _context.newest_write_timestamp > 0
                             ? _context.newest_write_timestamp + _context.file_cache_ttl_sec
                             : 0};
-    Status st = fs->create_file(path, &file_writer, &opts);
+    Status st = _context.fs()->create_file(path, &file_writer, &opts);
     if (!st.ok()) {
         LOG(WARNING) << "failed to create writable file. path=" << path << ", err: " << st;
         return st;
@@ -830,15 +825,14 @@ Status BaseBetaRowsetWriter::_create_file_writer(std::string path, io::FileWrite
 
 Status BaseBetaRowsetWriter::create_file_writer(uint32_t segment_id,
                                                 io::FileWriterPtr& file_writer) {
-    std::string path;
-    path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, segment_id);
+    auto path = _context.segment_path(segment_id);
     return _create_file_writer(path, file_writer);
 }
 
 Status BetaRowsetWriter::_create_segment_writer_for_segcompaction(
         std::unique_ptr<segment_v2::SegmentWriter>* writer, int64_t begin, int64_t end) {
     DCHECK(begin >= 0 && end >= 0);
-    std::string path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir,
+    std::string path = BetaRowset::local_segment_path_segcompacted(_context.tablet_path,
                                                                    _context.rowset_id, begin, end);
     io::FileWriterPtr file_writer;
     RETURN_IF_ERROR(_create_file_writer(path, file_writer));
@@ -851,8 +845,7 @@ Status BetaRowsetWriter::_create_segment_writer_for_segcompaction(
 
     *writer = std::make_unique<segment_v2::SegmentWriter>(
             file_writer.get(), _num_segcompacted, _context.tablet_schema, _context.tablet,
-            _context.data_dir, _context.max_rows_per_segment, writer_options, _context.mow_context,
-            _context.fs);
+            _context.data_dir, _context.max_rows_per_segment, writer_options, _context.mow_context);
     if (auto& seg_writer = _segcompaction_worker->get_file_writer();
         seg_writer != nullptr && seg_writer->state() != io::FileWriter::State::CLOSED) {
         RETURN_IF_ERROR(_segcompaction_worker->get_file_writer()->close());

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -162,7 +162,7 @@ private:
 protected:
     Status _generate_delete_bitmap(int32_t segment_id);
     Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false);
-    Status _create_file_writer(std::string path, io::FileWriterPtr& file_writer);
+    Status _create_file_writer(const std::string& path, io::FileWriterPtr& file_writer);
     virtual Status _close_file_writers();
     virtual Status _check_segment_number_limit();
     virtual int64_t _num_seg() const;

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -28,8 +28,13 @@ namespace doris {
 
 static bvar::Adder<size_t> g_total_rowset_num("doris_total_rowset_num");
 
-Rowset::Rowset(const TabletSchemaSPtr& schema, const RowsetMetaSharedPtr& rowset_meta)
-        : _rowset_meta(rowset_meta), _refs_by_reader(0) {
+Rowset::Rowset(const TabletSchemaSPtr& schema, RowsetMetaSharedPtr rowset_meta,
+               std::string tablet_path)
+        : _rowset_meta(std::move(rowset_meta)),
+          _tablet_path(std::move(tablet_path)),
+          _refs_by_reader(0) {
+    DCHECK(!is_local() || !_tablet_path.empty()); // local rowset MUST has tablet path
+
     _is_pending = !_rowset_meta->has_version();
     if (_is_pending) {
         _is_cumulative = false;
@@ -104,6 +109,17 @@ std::string Rowset::get_rowset_info_str() {
 void Rowset::clear_cache() {
     SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
     clear_inverted_index_cache();
+}
+
+Result<std::string> Rowset::segment_path(int64_t seg_id) {
+    if (is_local()) {
+        return local_segment_path(_tablet_path, _rowset_meta->rowset_id().to_string(), seg_id);
+    }
+
+    return _rowset_meta->remote_storage_resource().transform([=](auto&& storage_resource) {
+        return storage_resource->remote_segment_path(_rowset_meta->tablet_id(),
+                                                     _rowset_meta->rowset_id().to_string(), seg_id);
+    });
 }
 
 Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -33,7 +33,9 @@ Rowset::Rowset(const TabletSchemaSPtr& schema, RowsetMetaSharedPtr rowset_meta,
         : _rowset_meta(std::move(rowset_meta)),
           _tablet_path(std::move(tablet_path)),
           _refs_by_reader(0) {
+#ifndef BE_TEST
     DCHECK(!is_local() || !_tablet_path.empty()); // local rowset MUST has tablet path
+#endif
 
     _is_pending = !_rowset_meta->has_version();
     if (_is_pending) {

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -118,7 +118,7 @@ Result<std::string> Rowset::segment_path(int64_t seg_id) {
         return local_segment_path(_tablet_path, _rowset_meta->rowset_id().to_string(), seg_id);
     }
 
-    return _rowset_meta->remote_storage_resource().transform([=](auto&& storage_resource) {
+    return _rowset_meta->remote_storage_resource().transform([=, this](auto&& storage_resource) {
         return storage_resource->remote_segment_path(_rowset_meta->tablet_id(),
                                                      _rowset_meta->rowset_id().to_string(), seg_id);
     });

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -136,6 +136,8 @@ public:
 
     bool is_local() const { return _rowset_meta->is_local(); }
 
+    const std::string& tablet_path() const { return _tablet_path; }
+
     // publish rowset to make it visible to read
     void make_visible(Version version);
     void set_version(Version version);
@@ -168,8 +170,6 @@ public:
     // remove all files in this rowset
     // TODO should we rename the method to remove_files() to be more specific?
     virtual Status remove() = 0;
-
-    virtual std::string segment_file_path(int segment_id) const = 0;
 
     // close to clear the resource owned by rowset
     // including: open files, indexes and so on
@@ -209,16 +209,11 @@ public:
     // copy all files to `dir`
     virtual Status copy_files_to(const std::string& dir, const RowsetId& new_rowset_id) = 0;
 
-    virtual Status upload_to(io::RemoteFileSystem* dest_fs, const RowsetId& new_rowset_id) {
-        return Status::OK();
-    }
+    virtual Status upload_to(const StorageResource& dest_fs, const RowsetId& new_rowset_id) = 0;
 
     virtual Status remove_old_files(std::vector<std::string>* files_to_remove) = 0;
 
-    // return whether `path` is one of the files in this rowset
-    virtual bool check_path(const std::string& path) = 0;
-
-    virtual bool check_file_exist() = 0;
+    virtual Status check_file_exist() = 0;
 
     bool need_delete_file() const { return _need_delete_file; }
 
@@ -305,12 +300,15 @@ public:
 
     void clear_cache();
 
+    Result<std::string> segment_path(int64_t seg_id);
+
 protected:
     friend class RowsetFactory;
 
     DISALLOW_COPY_AND_ASSIGN(Rowset);
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
-    Rowset(const TabletSchemaSPtr& schema, const RowsetMetaSharedPtr& rowset_meta);
+    Rowset(const TabletSchemaSPtr& schema, RowsetMetaSharedPtr rowset_meta,
+           std::string tablet_path);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual Status init() = 0;
@@ -321,13 +319,17 @@ protected:
     // release resources in this api
     virtual void do_close() = 0;
 
-    virtual bool check_current_rowset_segment() = 0;
+    virtual Status check_current_rowset_segment() = 0;
 
-    virtual void clear_inverted_index_cache() { LOG(INFO) << "should not reach here"; }
+    virtual void clear_inverted_index_cache() = 0;
 
     TabletSchemaSPtr _schema;
 
     RowsetMetaSharedPtr _rowset_meta;
+
+    // Local rowset requires a tablet path to obtain the absolute path on the local fs
+    std::string _tablet_path;
+
     // init in constructor
     bool _is_pending;    // rowset is pending iff it's not in visible state
     bool _is_cumulative; // rowset is cumulative iff it's visible and start version < end version

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -42,7 +42,7 @@ Status RowsetFactory::create_rowset(const TabletSchemaSPtr& schema, const std::s
         return Status::Error<ROWSET_INVALID>("invalid rowset_type");
     }
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
-        rowset->reset(new BetaRowset(schema, tablet_path, rowset_meta));
+        rowset->reset(new BetaRowset(schema, rowset_meta, tablet_path));
         return (*rowset)->init();
     }
     return Status::Error<ROWSET_TYPE_NOT_FOUND>("invalid rowset_type"); // should never happen

--- a/be/src/olap/rowset/rowset_meta.cpp
+++ b/be/src/olap/rowset/rowset_meta.cpp
@@ -86,23 +86,43 @@ bool RowsetMeta::json_rowset_meta(std::string* json_rowset_meta) {
     return ret;
 }
 
-const io::FileSystemSPtr& RowsetMeta::fs() {
-    if (!_fs) {
-        if (is_local()) {
-            _fs = io::global_local_filesystem();
-        } else {
-            _fs = get_filesystem(resource_id());
-            LOG_IF(WARNING, !_fs) << "Cannot get file system: " << resource_id();
-        }
+io::FileSystemSPtr RowsetMeta::fs() {
+    if (is_local()) {
+        return io::global_local_filesystem();
     }
-    return _fs;
+
+    auto storage_resource = remote_storage_resource();
+    if (storage_resource) {
+        return storage_resource.value()->fs;
+    } else {
+        LOG(WARNING) << storage_resource.error();
+        return nullptr;
+    }
 }
 
-void RowsetMeta::set_fs(io::FileSystemSPtr fs) {
-    if (fs && fs->type() != io::FileSystemType::LOCAL) {
-        _rowset_meta_pb.set_resource_id(fs->id());
+Result<const StorageResource*> RowsetMeta::remote_storage_resource() {
+    if (is_local()) {
+        return ResultError(Status::InternalError(
+                "local rowset has no storage resource. tablet_id={} rowset_id={}", tablet_id(),
+                _rowset_id.to_string()));
     }
-    _fs = std::move(fs);
+
+    if (!_storage_resource.fs) {
+        // not initialized yet
+        auto storage_resource = get_storage_resource(resource_id());
+        if (storage_resource) {
+            _storage_resource = std::move(storage_resource->first);
+        } else {
+            return ResultError(Status::InternalError("cannot find storage resource. resource_id={}",
+                                                     resource_id()));
+        }
+    }
+
+    return &_storage_resource;
+}
+
+void RowsetMeta::set_remote_storage_resource(StorageResource resource) {
+    _storage_resource = std::move(resource);
 }
 
 bool RowsetMeta::has_variant_type_in_schema() const {

--- a/be/src/olap/rowset/rowset_meta.cpp
+++ b/be/src/olap/rowset/rowset_meta.cpp
@@ -123,6 +123,7 @@ Result<const StorageResource*> RowsetMeta::remote_storage_resource() {
 
 void RowsetMeta::set_remote_storage_resource(StorageResource resource) {
     _storage_resource = std::move(resource);
+    _rowset_meta_pb.set_resource_id(_storage_resource.fs->id());
 }
 
 bool RowsetMeta::has_variant_type_in_schema() const {

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -27,6 +27,7 @@
 #include "io/fs/file_system.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/rowset_fwd.h"
+#include "olap/storage_policy.h"
 #include "olap/tablet_fwd.h"
 #include "runtime/memory/lru_cache_policy.h"
 
@@ -49,10 +50,14 @@ public:
 
     bool json_rowset_meta(std::string* json_rowset_meta);
 
-    // This method may return nullptr.
-    const io::FileSystemSPtr& fs();
+    // If the rowset is a local rowset, return the global local file system.
+    // Otherwise, return the remote file system corresponding to rowset's resource id.
+    // Note that if the resource id cannot be found for the corresponding remote file system, nullptr will be returned.
+    io::FileSystemSPtr fs();
 
-    void set_fs(io::FileSystemSPtr fs);
+    Result<const StorageResource*> remote_storage_resource();
+
+    void set_remote_storage_resource(StorageResource resource);
 
     const std::string& resource_id() const { return _rowset_meta_pb.resource_id(); }
 
@@ -351,7 +356,7 @@ private:
     TabletSchemaSPtr _schema;
     Cache::Handle* _handle = nullptr;
     RowsetId _rowset_id;
-    io::FileSystemSPtr _fs;
+    StorageResource _storage_resource;
     bool _is_removed_from_rowset_meta = false;
 };
 

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -19,9 +19,9 @@
 
 #include <gen_cpp/olap_file.pb.h>
 
-#include "io/fs/file_system.h"
 #include "olap/olap_define.h"
 #include "olap/partial_update_info.h"
+#include "olap/storage_policy.h"
 #include "olap/tablet.h"
 #include "olap/tablet_schema.h"
 
@@ -49,8 +49,7 @@ struct RowsetWriterContext {
     int64_t index_id {0};
     int64_t partition_id {0};
     RowsetTypePB rowset_type {BETA_ROWSET};
-    io::FileSystemSPtr fs;
-    std::string rowset_dir;
+
     TabletSchemaSPtr tablet_schema;
     TabletSchemaSPtr original_tablet_schema;
     // PREPARED/COMMITTED for pending rowset
@@ -105,6 +104,38 @@ struct RowsetWriterContext {
     std::shared_ptr<std::mutex> schema_lock;
 
     int64_t compaction_level = 0;
+
+    // For local rowset
+    std::string tablet_path;
+
+    // For remote rowset
+    std::optional<StorageResource> storage_resource;
+
+    bool is_local_rowset() const { return !storage_resource; }
+
+    std::string segment_path(int seg_id) const {
+        if (is_local_rowset()) {
+            return local_segment_path(tablet_path, rowset_id.to_string(), seg_id);
+        } else {
+            return storage_resource->remote_segment_path(tablet_id, rowset_id.to_string(), seg_id);
+        }
+    }
+
+    io::FileSystemSPtr fs() const {
+        if (is_local_rowset()) {
+            return io::global_local_filesystem();
+        } else {
+            return storage_resource->fs;
+        }
+    }
+
+    io::FileSystem& fs_ref() const {
+        if (is_local_rowset()) {
+            return *io::global_local_filesystem();
+        } else {
+            return *storage_resource->fs;
+        }
+    }
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -119,15 +119,14 @@ std::unique_ptr<segment_v2::SegmentWriter> SegcompactionWorker::_create_segcompa
 }
 
 Status SegcompactionWorker::_delete_original_segments(uint32_t begin, uint32_t end) {
-    auto fs = _writer->_rowset_meta->fs();
+    DCHECK(_writer->rowset_meta()->is_local());
+
+    const auto& fs = io::global_local_filesystem();
     auto ctx = _writer->_context;
     auto schema = ctx.tablet_schema;
-    if (!fs) {
-        return Status::Error<INIT_FAILED>(
-                "SegcompactionWorker::_delete_original_segments get fs failed");
-    }
+
     for (uint32_t i = begin; i <= end; ++i) {
-        auto seg_path = BetaRowset::segment_file_path(ctx.rowset_dir, ctx.rowset_id, i);
+        auto seg_path = local_segment_path(ctx.tablet_path, ctx.rowset_id.to_string(), i);
         // Even if an error is encountered, these files that have not been cleaned up
         // will be cleaned up by the GC background. So here we only print the error
         // message when we encounter an error.
@@ -135,19 +134,21 @@ Status SegcompactionWorker::_delete_original_segments(uint32_t begin, uint32_t e
                                        strings::Substitute("Failed to delete file=$0", seg_path));
         if (schema->has_inverted_index() &&
             schema->get_inverted_index_storage_format() != InvertedIndexStorageFormatPB::V1) {
-            auto idx_path = InvertedIndexDescriptor::get_index_file_name(seg_path);
+            auto idx_path = InvertedIndexDescriptor::get_index_path_v2(
+                    InvertedIndexDescriptor::get_index_path_prefix(seg_path));
             VLOG_DEBUG << "segcompaction index. delete file " << idx_path;
             RETURN_NOT_OK_STATUS_WITH_WARN(
                     fs->delete_file(idx_path),
                     strings::Substitute("Failed to delete file=$0", idx_path));
         }
         // Delete inverted index files
-        for (auto column : schema->columns()) {
+        for (auto&& column : schema->columns()) {
             if (schema->has_inverted_index(*column)) {
-                auto index_info = schema->get_inverted_index(*column);
+                const auto* index_info = schema->get_inverted_index(*column);
                 auto index_id = index_info->index_id();
-                auto idx_path = InvertedIndexDescriptor::inverted_index_file_path(
-                        ctx.rowset_dir, ctx.rowset_id, i, index_id, index_info->get_index_suffix());
+                auto idx_path = InvertedIndexDescriptor::get_index_path_v1(
+                        InvertedIndexDescriptor::get_index_path_prefix(seg_path), index_id,
+                        index_info->get_index_suffix());
                 VLOG_DEBUG << "segcompaction index. delete file " << idx_path;
                 if (schema->get_inverted_index_storage_format() ==
                     InvertedIndexStorageFormatPB::V1) {
@@ -291,7 +292,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
 
     if (VLOG_DEBUG_IS_ON) {
         _writer->vlog_buffer.clear();
-        for (const auto& entry : std::filesystem::directory_iterator(ctx.rowset_dir)) {
+        for (const auto& entry : std::filesystem::directory_iterator(ctx.tablet_path)) {
             fmt::format_to(_writer->vlog_buffer, "[{}]", string(entry.path()));
         }
         VLOG_DEBUG << "tablet_id:" << ctx.tablet_id << " rowset_id:" << ctx.rowset_id

--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -198,7 +198,7 @@ Status SegmentFlusher::_create_segment_writer(std::unique_ptr<segment_v2::Segmen
     const auto& tablet_schema = flush_schema ? flush_schema : _context.tablet_schema;
     writer = std::make_unique<segment_v2::SegmentWriter>(
             file_writer.get(), segment_id, tablet_schema, _context.tablet, _context.data_dir,
-            _context.max_rows_per_segment, writer_options, _context.mow_context, _context.fs);
+            _context.max_rows_per_segment, writer_options, _context.mow_context);
     RETURN_IF_ERROR(_seg_files.add(segment_id, std::move(file_writer)));
     auto s = writer->init();
     if (!s.ok()) {
@@ -226,7 +226,7 @@ Status SegmentFlusher::_create_segment_writer(
     const auto& tablet_schema = flush_schema ? flush_schema : _context.tablet_schema;
     writer = std::make_unique<segment_v2::VerticalSegmentWriter>(
             file_writer.get(), segment_id, tablet_schema, _context.tablet, _context.data_dir,
-            _context.max_rows_per_segment, writer_options, _context.mow_context, _context.fs);
+            _context.max_rows_per_segment, writer_options, _context.mow_context);
     RETURN_IF_ERROR(_seg_files.add(segment_id, std::move(file_writer)));
     auto s = writer->init();
     if (!s.ok()) {
@@ -299,7 +299,7 @@ Status SegmentFlusher::_flush_segment_writer(std::unique_ptr<segment_v2::Segment
         return Status::Error(s.code(), "failed to finalize segment: {}", s.to_string());
     }
     VLOG_DEBUG << "tablet_id:" << _context.tablet_id
-               << " flushing rowset_dir: " << _context.rowset_dir
+               << " flushing rowset_dir: " << _context.tablet_path
                << " rowset_id:" << _context.rowset_id;
 
     KeyBoundsPB key_bounds;

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
@@ -19,15 +19,16 @@
 
 #include "inverted_index_file_writer.h"
 #include "inverted_index_fs_directory.h"
+#include "io/fs/local_file_system.h"
 #include "olap/tablet_schema.h"
 #include "util/debug_points.h"
 
 namespace doris::segment_v2 {
 Status compact_column(int64_t index_id, std::vector<lucene::store::Directory*>& src_index_dirs,
                       std::vector<lucene::store::Directory*>& dest_index_dirs,
-                      const io::FileSystemSPtr& fs, std::string tmp_path,
-                      std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
-                      std::vector<uint32_t> dest_segment_num_rows) {
+                      std::string_view tmp_path,
+                      const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>& trans_vec,
+                      const std::vector<uint32_t>& dest_segment_num_rows) {
     DBUG_EXECUTE_IF("index_compaction_compact_column_throw_error", {
         if (index_id % 2 == 0) {
             _CLTHROWA(CL_ERR_IO, "debug point: test throw error in index compaction");
@@ -40,7 +41,8 @@ Status compact_column(int64_t index_id, std::vector<lucene::store::Directory*>& 
         }
     })
 
-    lucene::store::Directory* dir = DorisFSDirectoryFactory::getDirectory(fs, tmp_path.c_str());
+    lucene::store::Directory* dir =
+            DorisFSDirectoryFactory::getDirectory(io::global_local_filesystem(), tmp_path.data());
     lucene::analysis::SimpleAnalyzer<char> analyzer;
     auto* index_writer = _CLNEW lucene::index::IndexWriter(dir, &analyzer, true /* create */,
                                                            true /* closeDirOnShutdown */);
@@ -70,7 +72,7 @@ Status compact_column(int64_t index_id, std::vector<lucene::store::Directory*>& 
     }
 
     // delete temporary segment_path
-    static_cast<void>(fs->delete_directory(tmp_path.c_str()));
+    std::ignore = io::global_local_filesystem()->delete_directory(tmp_path.data());
     return Status::OK();
 }
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
@@ -19,10 +19,10 @@
 #include <CLucene.h>
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 #include <vector>
 
-#include "io/fs/file_system.h"
+#include "common/status.h"
 
 namespace doris {
 class TabletIndex;
@@ -32,8 +32,8 @@ class InvertedIndexFileReader;
 
 Status compact_column(int64_t index_id, std::vector<lucene::store::Directory*>& src_index_dirs,
                       std::vector<lucene::store::Directory*>& dest_index_dirs,
-                      const io::FileSystemSPtr& fs, std::string tmp_path,
-                      std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
-                      std::vector<uint32_t> dest_segment_num_rows);
+                      std::string_view tmp_path,
+                      const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>& trans_vec,
+                      const std::vector<uint32_t>& dest_segment_num_rows);
 } // namespace segment_v2
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.cpp
@@ -23,44 +23,41 @@
 #include "olap/olap_common.h"
 
 namespace doris::segment_v2 {
-const std::string InvertedIndexDescriptor::segment_suffix = ".dat";
-const std::string InvertedIndexDescriptor::index_suffix = ".idx";
-const std::string InvertedIndexDescriptor::index_name_separator = "_";
 
-std::string InvertedIndexDescriptor::get_temporary_index_path(
-        const std::string& segment_path, uint64_t uuid, const std::string& index_suffix_path) {
-    std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
-    return StripSuffixString(segment_path, segment_suffix) + index_name_separator +
-           std::to_string(uuid) + suffix;
+// {tmp_dir}/{rowset_id}_{seg_id}_{index_id}@{suffix}
+std::string InvertedIndexDescriptor::get_temporary_index_path(std::string_view tmp_dir_path,
+                                                              std::string_view rowset_id,
+                                                              int64_t seg_id, uint64_t uuid,
+                                                              std::string_view index_path_suffix) {
+    std::string suffix =
+            index_path_suffix.empty() ? "" : std::string {"@"} + index_path_suffix.data();
+    return fmt::format("{}/{}_{}_{}{}", tmp_dir_path, rowset_id, seg_id, uuid, suffix);
 }
 
-std::string InvertedIndexDescriptor::get_index_file_name(const std::string& segment_path,
-                                                         uint64_t uuid,
-                                                         const std::string& index_suffix_path) {
-    std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
-    return StripSuffixString(segment_path, segment_suffix) + index_name_separator +
-           std::to_string(uuid) + suffix + index_suffix;
+// InvertedIndexStorageFormat V1
+// {prefix}_{index_id}@{suffix}.idx
+std::string InvertedIndexDescriptor::get_index_path_v1(std::string_view index_path_prefix,
+                                                       uint64_t uuid,
+                                                       std::string_view index_path_suffix) {
+    std::string suffix =
+            index_path_suffix.empty() ? "" : std::string {"@"} + index_path_suffix.data();
+    return fmt::format("{}_{}{}{}", index_path_prefix, uuid, suffix, index_suffix);
 }
 
-std::string InvertedIndexDescriptor::inverted_index_file_path(
-        const string& rowset_dir, const RowsetId& rowset_id, int segment_id, int64_t index_id,
-        const std::string& index_suffix_path) {
-    // {rowset_dir}/{schema_hash}/{rowset_id}_{seg_num}_{index_id}.idx
-    std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
-    return fmt::format("{}/{}_{}_{}{}.idx", rowset_dir, rowset_id.to_string(), segment_id, index_id,
-                       suffix);
+// InvertedIndexStorageFormat V2
+// {prefix}.idx
+std::string InvertedIndexDescriptor::get_index_path_v2(std::string_view index_path_prefix) {
+    return fmt::format("{}{}", index_path_prefix, index_suffix);
 }
 
-std::string InvertedIndexDescriptor::get_index_file_name(const std::string& segment_file_name) {
-    return StripSuffixString(segment_file_name, segment_suffix) + index_suffix;
+// local path prefix:
+//   {storage_dir}/data/{shard_id}/{tablet_id}/{schema_hash}/{rowset_id}_{seg_id}
+// remote path v0 prefix:
+//   data/{tablet_id}/{rowset_id}_{seg_id}
+std::string_view InvertedIndexDescriptor::get_index_path_prefix(std::string_view segment_path) {
+    CHECK(segment_path.ends_with(segment_suffix));
+    segment_path.remove_suffix(segment_suffix.size());
+    return segment_path;
 }
 
-std::string InvertedIndexDescriptor::local_inverted_index_path_segcompacted(
-        const string& tablet_path, const RowsetId& rowset_id, int64_t begin, int64_t end,
-        int64_t index_id, const std::string& index_suffix_path) {
-    // {root_path}/data/{shard_id}/{tablet_id}/{schema_hash}/{rowset_id}_{begin_seg}-{end_seg}_{index_id}.idx
-    std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
-    return fmt::format("{}/{}_{}-{}_{}{}.idx", tablet_path, rowset_id.to_string(), begin, end,
-                       index_id, suffix);
-}
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.h
@@ -41,14 +41,10 @@ public:
 
     static std::string_view get_index_path_prefix(std::string_view segment_path);
 
-    static constexpr std::string_view get_temporary_null_bitmap_file_name() {
-        return "null_bitmap";
-    }
-    static constexpr std::string_view get_temporary_bkd_index_data_file_name() { return "bkd"; }
-    static constexpr std::string_view get_temporary_bkd_index_meta_file_name() {
-        return "bkd_meta";
-    }
-    static constexpr std::string_view get_temporary_bkd_index_file_name() { return "bkd_index"; }
+    static const char* get_temporary_null_bitmap_file_name() { return "null_bitmap"; }
+    static const char* get_temporary_bkd_index_data_file_name() { return "bkd"; }
+    static const char* get_temporary_bkd_index_meta_file_name() { return "bkd_meta"; }
+    static const char* get_temporary_bkd_index_file_name() { return "bkd_index"; }
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.h
@@ -28,28 +28,27 @@ namespace segment_v2 {
 
 class InvertedIndexDescriptor {
 public:
-    static const std::string segment_suffix;
-    static const std::string index_suffix;
-    static const std::string index_name_separator;
-    static std::string get_temporary_index_path(const std::string& segment_path, uint64_t uuid,
-                                                const std::string& index_suffix_path);
-    static std::string get_index_file_name(const std::string& path, uint64_t uuid,
-                                           const std::string& index_suffix_path);
-    static std::string get_index_file_name(const std::string& path);
-    static const std::string get_temporary_null_bitmap_file_name() { return "null_bitmap"; }
-    static const std::string get_temporary_bkd_index_data_file_name() { return "bkd"; }
-    static const std::string get_temporary_bkd_index_meta_file_name() { return "bkd_meta"; }
-    static const std::string get_temporary_bkd_index_file_name() { return "bkd_index"; }
-    static std::string inverted_index_file_path(const std::string& rowset_dir,
-                                                const RowsetId& rowset_id, int segment_id,
-                                                int64_t index_id,
-                                                const std::string& index_suffix_path);
+    static constexpr std::string_view segment_suffix = ".dat";
+    static constexpr std::string_view index_suffix = ".idx";
+    static std::string get_temporary_index_path(std::string_view tmp_dir_path,
+                                                std::string_view rowset_id, int64_t seg_id,
+                                                uint64_t uuid, std::string_view index_path_suffix);
+    // InvertedIndexStorageFormat V1
+    static std::string get_index_path_v1(std::string_view index_path_prefix, uint64_t uuid,
+                                         std::string_view index_path_suffix);
+    // InvertedIndexStorageFormat V2
+    static std::string get_index_path_v2(std::string_view index_path_prefix);
 
-    static std::string local_inverted_index_path_segcompacted(const std::string& tablet_path,
-                                                              const RowsetId& rowset_id,
-                                                              int64_t begin, int64_t end,
-                                                              int64_t index_id,
-                                                              const std::string& index_suffix_path);
+    static std::string_view get_index_path_prefix(std::string_view segment_path);
+
+    static constexpr std::string_view get_temporary_null_bitmap_file_name() {
+        return "null_bitmap";
+    }
+    static constexpr std::string_view get_temporary_bkd_index_data_file_name() { return "bkd"; }
+    static constexpr std::string_view get_temporary_bkd_index_meta_file_name() {
+        return "bkd_meta";
+    }
+    static constexpr std::string_view get_temporary_bkd_index_file_name() { return "bkd_index"; }
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
@@ -37,21 +37,22 @@ Status InvertedIndexFileReader::init(int32_t read_buffer_size, bool open_idx_fil
 }
 
 Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
+    auto index_file_full_path = InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix);
+
     std::unique_lock<std::shared_mutex> lock(_mutex); // Lock for writing
-    auto index_file_full_path = _index_file_dir / _index_file_name;
     try {
         bool exists = false;
         RETURN_IF_ERROR(_fs->exists(index_file_full_path, &exists));
         if (!exists) {
             return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                    "inverted index file {} is not found", index_file_full_path.native());
+                    "inverted index file {} is not found", index_file_full_path);
         }
         int64_t file_size = 0;
         RETURN_IF_ERROR(_fs->file_size(index_file_full_path, &file_size));
         if (file_size == 0) {
             LOG(WARNING) << "inverted index file " << index_file_full_path << " is empty.";
             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                    "inverted index file {} is empty", index_file_full_path.native());
+                    "inverted index file {} is empty", index_file_full_path);
         }
 
         CLuceneError err;
@@ -60,8 +61,8 @@ Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
                                                        index_input, err, read_buffer_size);
         if (!ok) {
             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                    "CLuceneError occur when open idx file {}, error msg: {}",
-                    index_file_full_path.native(), err.what());
+                    "CLuceneError occur when open idx file {}, error msg: {}", index_file_full_path,
+                    err.what());
         }
         index_input->setIdxFileCache(_open_idx_file_cache);
         _stream = std::unique_ptr<CL_NS(store)::IndexInput>(index_input);
@@ -113,12 +114,12 @@ Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
             } catch (CLuceneError& err) {
                 return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                         "CLuceneError occur when close idx file {}, error msg: {}",
-                        index_file_full_path.native(), err.what());
+                        index_file_full_path, err.what());
             }
         }
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                "CLuceneError occur when init idx file {}, error msg: {}",
-                index_file_full_path.native(), err.what());
+                "CLuceneError occur when init idx file {}, error msg: {}", index_file_full_path,
+                err.what());
     }
     return Status::OK();
 }
@@ -126,9 +127,8 @@ Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
 Result<InvertedIndexDirectoryMap> InvertedIndexFileReader::get_all_directories() {
     InvertedIndexDirectoryMap res;
     std::shared_lock<std::shared_mutex> lock(_mutex); // Lock for reading
-    for (auto& index : _indices_entries) {
-        auto index_id = index.first.first;
-        auto index_suffix = index.first.second;
+    for (auto& [index, _] : _indices_entries) {
+        auto&& [index_id, index_suffix] = index;
         LOG(INFO) << "index_id:" << index_id << " index_suffix:" << index_suffix;
         auto ret = _open(index_id, index_suffix);
         if (!ret.has_value()) {
@@ -140,33 +140,33 @@ Result<InvertedIndexDirectoryMap> InvertedIndexFileReader::get_all_directories()
 }
 
 Result<std::unique_ptr<DorisCompoundReader>> InvertedIndexFileReader::_open(
-        int64_t index_id, std::string& index_suffix) const {
+        int64_t index_id, const std::string& index_suffix) const {
     std::unique_ptr<DorisCompoundReader> compound_reader;
 
     if (_storage_format == InvertedIndexStorageFormatPB::V1) {
         DorisFSDirectory* dir = nullptr;
-        auto file_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name, index_id,
-                                                                      index_suffix);
+        auto index_path = InvertedIndexDescriptor::get_index_path_v1(_index_path_prefix, index_id,
+                                                                     index_suffix);
         try {
-            dir = DorisFSDirectoryFactory::getDirectory(_fs, _index_file_dir.c_str());
-
+            std::filesystem::path path(index_path);
+            dir = DorisFSDirectoryFactory::getDirectory(_fs, path.parent_path().c_str());
             compound_reader = std::make_unique<DorisCompoundReader>(
-                    dir, file_name.c_str(), _read_buffer_size, _open_idx_file_cache);
+                    dir, path.filename().c_str(), _read_buffer_size, _open_idx_file_cache);
         } catch (CLuceneError& err) {
             if (dir != nullptr) {
                 dir->close();
                 _CLDELETE(dir)
             }
             return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                    "CLuceneError occur when open idx file {}, error msg: {}",
-                    (_index_file_dir / file_name).native(), err.what()));
+                    "CLuceneError occur when open idx file {}, error msg: {}", index_path,
+                    err.what()));
         }
     } else {
         std::shared_lock<std::shared_mutex> lock(_mutex); // Lock for reading
         if (_stream == nullptr) {
             return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
                     "CLuceneError occur when open idx file {}, stream is nullptr",
-                    (_index_file_dir / _index_file_name).native()));
+                    InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix)));
         }
 
         // Check if the specified index exists
@@ -176,7 +176,7 @@ Result<std::unique_ptr<DorisCompoundReader>> InvertedIndexFileReader::_open(
             errMsg << "No index with id " << index_id << " found";
             return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                     "CLuceneError occur when open idx file {}, error msg: {}",
-                    (_index_file_dir / _index_file_name).native(), errMsg.str()));
+                    InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix), errMsg.str()));
         }
         // Need to clone resource here, because index searcher cache need it.
         bool own_index_input = true;
@@ -193,32 +193,28 @@ Result<std::unique_ptr<DorisCompoundReader>> InvertedIndexFileReader::open(
 }
 
 std::string InvertedIndexFileReader::get_index_file_key(const TabletIndex* index_meta) const {
-    return InvertedIndexDescriptor::get_index_file_name(_index_file_dir / _segment_file_name,
-                                                        index_meta->index_id(),
-                                                        index_meta->get_index_suffix());
+    return InvertedIndexDescriptor::get_index_path_v1(_index_path_prefix, index_meta->index_id(),
+                                                      index_meta->get_index_suffix());
 }
 
 std::string InvertedIndexFileReader::get_index_file_path(const TabletIndex* index_meta) const {
     if (_storage_format == InvertedIndexStorageFormatPB::V1) {
-        return InvertedIndexDescriptor::get_index_file_name(_index_file_dir / _segment_file_name,
-                                                            index_meta->index_id(),
-                                                            index_meta->get_index_suffix());
+        return InvertedIndexDescriptor::get_index_path_v1(
+                _index_path_prefix, index_meta->index_id(), index_meta->get_index_suffix());
     }
-    return _index_file_dir / _index_file_name;
+    return InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix);
 }
 
 Status InvertedIndexFileReader::index_file_exist(const TabletIndex* index_meta, bool* res) const {
     if (_storage_format == InvertedIndexStorageFormatPB::V1) {
-        auto index_file_path = _index_file_dir / InvertedIndexDescriptor::get_index_file_name(
-                                                         _segment_file_name, index_meta->index_id(),
-                                                         index_meta->get_index_suffix());
+        auto index_file_path = get_index_file_path(index_meta);
         return _fs->exists(index_file_path, res);
     } else {
         std::shared_lock<std::shared_mutex> lock(_mutex); // Lock for reading
         if (_stream == nullptr) {
             *res = false;
             return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                    "idx file {} is not opened", (_index_file_dir / _index_file_name).native());
+                    "idx file {} is not opened", get_index_file_path(index_meta));
         }
         // Check if the specified index exists
         auto index_it = _indices_entries.find(
@@ -240,7 +236,7 @@ Status InvertedIndexFileReader::has_null(const TabletIndex* index_meta, bool* re
     std::shared_lock<std::shared_mutex> lock(_mutex); // Lock for reading
     if (_stream == nullptr) {
         return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                "idx file {} is not opened", (_index_file_dir / _index_file_name).native());
+                "idx file {} is not opened", get_index_file_path(index_meta));
     }
     // Check if the specified index exists
     auto index_it = _indices_entries.find(
@@ -250,7 +246,7 @@ Status InvertedIndexFileReader::has_null(const TabletIndex* index_meta, bool* re
     } else {
         auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
         auto* entries = index_it->second.get();
-        ReaderFileEntry* e = entries->get((char*)(null_bitmap_file_name.c_str()));
+        ReaderFileEntry* e = entries->get((char*)(null_bitmap_file_name.data()));
         if (e == nullptr) {
             *res = false;
             return Status::OK();

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
@@ -244,9 +244,9 @@ Status InvertedIndexFileReader::has_null(const TabletIndex* index_meta, bool* re
     if (index_it == _indices_entries.end()) {
         *res = false;
     } else {
-        auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
         auto* entries = index_it->second.get();
-        ReaderFileEntry* e = entries->get((char*)(null_bitmap_file_name.data()));
+        ReaderFileEntry* e =
+                entries->get((char*)InvertedIndexDescriptor::get_temporary_null_bitmap_file_name());
         if (e == nullptr) {
             *res = false;
             return Status::OK();

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_reader.h
@@ -50,17 +50,11 @@ public:
     using IndicesEntriesMap =
             std::map<std::pair<int64_t, std::string>, std::unique_ptr<EntriesType>>;
 
-    InvertedIndexFileReader(io::FileSystemSPtr fs, io::Path segment_file_dir,
-                            std::string segment_file_name,
+    InvertedIndexFileReader(io::FileSystemSPtr fs, std::string index_path_prefix,
                             InvertedIndexStorageFormatPB storage_format)
             : _fs(std::move(fs)),
-              _index_file_dir(std::move(segment_file_dir)),
-              _segment_file_name(std::move(segment_file_name)),
-              _storage_format(storage_format) {
-        if (_storage_format != InvertedIndexStorageFormatPB::V1) {
-            _index_file_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name);
-        }
-    }
+              _index_path_prefix(std::move(index_path_prefix)),
+              _storage_format(storage_format) {}
 
     Status init(int32_t read_buffer_size = config::inverted_index_read_buffer_size,
                 bool open_idx_file_cache = false);
@@ -75,15 +69,12 @@ public:
 private:
     Status _init_from_v2(int32_t read_buffer_size);
     Result<std::unique_ptr<DorisCompoundReader>> _open(int64_t index_id,
-                                                       std::string& index_suffix) const;
+                                                       const std::string& index_suffix) const;
 
     IndicesEntriesMap _indices_entries;
     std::unique_ptr<CL_NS(store)::IndexInput> _stream;
     const io::FileSystemSPtr _fs;
-    io::Path _index_file_dir;
-    // index file name by storage format V2
-    std::string _index_file_name;
-    std::string _segment_file_name;
+    std::string _index_path_prefix;
     int32_t _read_buffer_size = -1;
     bool _open_idx_file_cache = false;
     InvertedIndexStorageFormatPB _storage_format;

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
@@ -48,6 +48,9 @@ Result<DorisFSDirectory*> InvertedIndexFileWriter::open(const TabletIndex* index
             index_meta->get_index_suffix());
     auto index_path = InvertedIndexDescriptor::get_index_path_v1(
             _index_path_prefix, index_meta->index_id(), index_meta->get_index_suffix());
+    // FIXME(plat1ko): hardcode
+    index_path =
+            index_path.substr(0, index_path.size() - InvertedIndexDescriptor::index_suffix.size());
 
     bool exists = false;
     auto st = local_fs->exists(local_fs_index_path, &exists);

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
@@ -17,6 +17,8 @@
 
 #include "olap/rowset/segment_v2/inverted_index_file_writer.h"
 
+#include <filesystem>
+
 #include "common/status.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
@@ -29,10 +31,8 @@
 
 namespace doris::segment_v2 {
 
-std::string InvertedIndexFileWriter::get_index_file_path(const TabletIndex* index_meta) const {
-    return InvertedIndexDescriptor::get_index_file_name(_index_file_dir / _segment_file_name,
-                                                        index_meta->index_id(),
-                                                        index_meta->get_index_suffix());
+std::string InvertedIndexFileWriter::get_index_file_path() const {
+    return InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix);
 }
 
 Status InvertedIndexFileWriter::initialize(InvertedIndexDirectoryMap& indices_dirs) {
@@ -41,33 +41,32 @@ Status InvertedIndexFileWriter::initialize(InvertedIndexDirectoryMap& indices_di
 }
 
 Result<DorisFSDirectory*> InvertedIndexFileWriter::open(const TabletIndex* index_meta) {
-    auto index_id = index_meta->index_id();
-    auto index_suffix = index_meta->get_index_suffix();
     auto tmp_file_dir = ExecEnv::GetInstance()->get_tmp_file_dirs()->get_tmp_file_dir();
-    _lfs = io::global_local_filesystem();
-    auto lfs_index_path = InvertedIndexDescriptor::get_temporary_index_path(
-            tmp_file_dir / _segment_file_name, index_meta->index_id(),
+    const auto& local_fs = io::global_local_filesystem();
+    auto local_fs_index_path = InvertedIndexDescriptor::get_temporary_index_path(
+            tmp_file_dir.native(), _rowset_id, _seg_id, index_meta->index_id(),
             index_meta->get_index_suffix());
-    auto index_path = InvertedIndexDescriptor::get_temporary_index_path(
-            (_index_file_dir / _segment_file_name).native(), index_id, index_suffix);
+    auto index_path = InvertedIndexDescriptor::get_index_path_v1(
+            _index_path_prefix, index_meta->index_id(), index_meta->get_index_suffix());
 
     bool exists = false;
-    auto st = _lfs->exists(lfs_index_path.c_str(), &exists);
+    auto st = local_fs->exists(local_fs_index_path, &exists);
     if (!st.ok()) {
-        LOG(ERROR) << "index_path:" << lfs_index_path << " exists error:" << st;
+        LOG(ERROR) << "index_path:" << local_fs_index_path << " exists error:" << st;
         return ResultError(st);
     }
+
     if (exists) {
-        LOG(ERROR) << "try to init a directory:" << lfs_index_path << " already exists";
+        LOG(ERROR) << "try to init a directory:" << local_fs_index_path << " already exists";
         return ResultError(Status::InternalError("init_fulltext_index directory already exists"));
     }
 
     bool can_use_ram_dir = true;
     bool use_compound_file_writer = false;
-    auto* dir = DorisFSDirectoryFactory::getDirectory(_lfs, lfs_index_path.c_str(),
+    auto* dir = DorisFSDirectoryFactory::getDirectory(local_fs, local_fs_index_path.c_str(),
                                                       use_compound_file_writer, can_use_ram_dir,
                                                       nullptr, _fs, index_path.c_str());
-    _indices_dirs.emplace(std::make_pair(index_id, index_suffix),
+    _indices_dirs.emplace(std::make_pair(index_meta->index_id(), index_meta->get_index_suffix()),
                           std::unique_ptr<DorisFSDirectory>(dir));
     return dir;
 }
@@ -78,7 +77,7 @@ Status InvertedIndexFileWriter::delete_index(const TabletIndex* index_meta) {
     }
 
     auto index_id = index_meta->index_id();
-    auto index_suffix = index_meta->get_index_suffix();
+    const auto& index_suffix = index_meta->get_index_suffix();
 
     // Check if the specified index exists
     auto index_it = _indices_dirs.find(std::make_pair(index_id, index_suffix));
@@ -150,19 +149,21 @@ Status InvertedIndexFileWriter::close() {
     } catch (CLuceneError& err) {
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                 "CLuceneError occur when close idx file {}, error msg: {}",
-                InvertedIndexDescriptor::get_index_file_name(_index_file_dir / _segment_file_name),
-                err.what());
+                InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix), err.what());
     }
     return Status::OK();
 }
+
 size_t InvertedIndexFileWriter::write() {
     // Create the output stream to write the compound file
     int64_t current_offset = headerLength();
-    std::string idx_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name);
-    auto* out_dir = DorisFSDirectoryFactory::getDirectory(_fs, _index_file_dir.c_str());
 
-    auto compound_file_output =
-            std::unique_ptr<lucene::store::IndexOutput>(out_dir->createOutput(idx_name.c_str()));
+    io::Path index_path {InvertedIndexDescriptor::get_index_path_v2(_index_path_prefix)};
+
+    auto* out_dir = DorisFSDirectoryFactory::getDirectory(_fs, index_path.parent_path().c_str());
+
+    auto compound_file_output = std::unique_ptr<lucene::store::IndexOutput>(
+            out_dir->createOutput(index_path.filename().c_str()));
 
     // Write the version number
     compound_file_output->writeInt(InvertedIndexStorageFormatPB::V2);

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
@@ -61,12 +61,13 @@ private:
 
 class InvertedIndexFileWriter {
 public:
-    InvertedIndexFileWriter(io::FileSystemSPtr fs, io::Path segment_file_dir,
-                            std::string segment_file_name,
+    InvertedIndexFileWriter(io::FileSystemSPtr fs, std::string index_path_prefix,
+                            std::string rowset_id, int64_t seg_id,
                             InvertedIndexStorageFormatPB storage_format)
             : _fs(std::move(fs)),
-              _index_file_dir(std::move(segment_file_dir)),
-              _segment_file_name(std::move(segment_file_name)),
+              _index_path_prefix(std::move(index_path_prefix)),
+              _rowset_id(std::move(rowset_id)),
+              _seg_id(seg_id),
               _storage_format(storage_format) {}
 
     Result<DorisFSDirectory*> open(const TabletIndex* index_meta);
@@ -76,20 +77,16 @@ public:
     size_t write();
     Status close();
     size_t headerLength();
-    const io::Path& get_index_file_dir() const { return _index_file_dir; };
-    std::string get_index_file_name() const {
-        return InvertedIndexDescriptor::get_index_file_name(_segment_file_name);
-    };
-    std::string get_index_file_path(const TabletIndex* index_meta) const;
+    std::string get_index_file_path() const;
     size_t get_index_file_size() const { return _file_size; }
     const io::FileSystemSPtr& get_fs() const { return _fs; }
 
 private:
     InvertedIndexDirectoryMap _indices_dirs;
     const io::FileSystemSPtr _fs;
-    io::FileSystemSPtr _lfs;
-    io::Path _index_file_dir;
-    std::string _segment_file_name;
+    std::string _index_path_prefix;
+    std::string _rowset_id;
+    int64_t _seg_id;
     InvertedIndexStorageFormatPB _storage_format;
     size_t _file_size = 0;
 };

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -213,8 +213,8 @@ Status InvertedIndexReader::read_null_bitmap(InvertedIndexQueryCacheHandle* cach
         // ownership of null_bitmap and its deletion will be transfered to cache
         std::shared_ptr<roaring::Roaring> null_bitmap = std::make_shared<roaring::Roaring>();
         auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
-        if (dir->fileExists(null_bitmap_file_name.c_str())) {
-            null_bitmap_in = dir->openInput(null_bitmap_file_name.c_str());
+        if (dir->fileExists(null_bitmap_file_name.data())) {
+            null_bitmap_in = dir->openInput(null_bitmap_file_name.data());
             size_t null_bitmap_size = null_bitmap_in->length();
             faststring buf;
             buf.resize(null_bitmap_size);

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -212,9 +212,10 @@ Status InvertedIndexReader::read_null_bitmap(InvertedIndexQueryCacheHandle* cach
 
         // ownership of null_bitmap and its deletion will be transfered to cache
         std::shared_ptr<roaring::Roaring> null_bitmap = std::make_shared<roaring::Roaring>();
-        auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
-        if (dir->fileExists(null_bitmap_file_name.data())) {
-            null_bitmap_in = dir->openInput(null_bitmap_file_name.data());
+        const char* null_bitmap_file_name =
+                InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
+        if (dir->fileExists(null_bitmap_file_name)) {
+            null_bitmap_in = dir->openInput(null_bitmap_file_name);
             size_t null_bitmap_size = null_bitmap_in->length();
             faststring buf;
             buf.resize(null_bitmap_size);

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -563,18 +563,15 @@ public:
                 if constexpr (field_is_numeric_type(field_type)) {
                     _bkd_writer->max_doc_ = _rid;
                     _bkd_writer->docs_seen_ = _row_ids_seen_for_bkd;
-                    null_bitmap_out =
-                            std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                                    InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()
-                                            .data()));
+                    null_bitmap_out = std::unique_ptr<
+                            lucene::store::IndexOutput>(_dir->createOutput(
+                            InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()));
                     data_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                            InvertedIndexDescriptor::get_temporary_bkd_index_data_file_name()
-                                    .data()));
+                            InvertedIndexDescriptor::get_temporary_bkd_index_data_file_name()));
                     meta_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                            InvertedIndexDescriptor::get_temporary_bkd_index_meta_file_name()
-                                    .data()));
+                            InvertedIndexDescriptor::get_temporary_bkd_index_meta_file_name()));
                     index_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                            InvertedIndexDescriptor::get_temporary_bkd_index_file_name().data()));
+                            InvertedIndexDescriptor::get_temporary_bkd_index_file_name()));
                     write_null_bitmap(null_bitmap_out.get());
 
                     DBUG_EXECUTE_IF("InvertedIndexWriter._set_bkd_data_out_nullptr",
@@ -594,10 +591,9 @@ public:
                     index_out->close();
                     _dir->close();
                 } else if constexpr (field_is_slice_type(field_type)) {
-                    null_bitmap_out =
-                            std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                                    InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()
-                                            .data()));
+                    null_bitmap_out = std::unique_ptr<
+                            lucene::store::IndexOutput>(_dir->createOutput(
+                            InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()));
                     write_null_bitmap(null_bitmap_out.get());
                     close();
                     DBUG_EXECUTE_IF(

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -566,15 +566,15 @@ public:
                     null_bitmap_out =
                             std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
                                     InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()
-                                            .c_str()));
+                                            .data()));
                     data_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
                             InvertedIndexDescriptor::get_temporary_bkd_index_data_file_name()
-                                    .c_str()));
+                                    .data()));
                     meta_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
                             InvertedIndexDescriptor::get_temporary_bkd_index_meta_file_name()
-                                    .c_str()));
+                                    .data()));
                     index_out = std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
-                            InvertedIndexDescriptor::get_temporary_bkd_index_file_name().c_str()));
+                            InvertedIndexDescriptor::get_temporary_bkd_index_file_name().data()));
                     write_null_bitmap(null_bitmap_out.get());
 
                     DBUG_EXECUTE_IF("InvertedIndexWriter._set_bkd_data_out_nullptr",
@@ -597,7 +597,7 @@ public:
                     null_bitmap_out =
                             std::unique_ptr<lucene::store::IndexOutput>(_dir->createOutput(
                                     InvertedIndexDescriptor::get_temporary_null_bitmap_file_name()
-                                            .c_str()));
+                                            .data()));
                     write_null_bitmap(null_bitmap_out.get());
                     close();
                     DBUG_EXECUTE_IF(

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -83,6 +83,12 @@ public:
                        RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
                        const io::FileReaderOptions& reader_options,
                        std::shared_ptr<Segment>* output);
+
+    static io::UInt128Wrapper file_cache_key(std::string_view rowset_id, uint32_t seg_id);
+    io::UInt128Wrapper file_cache_key() const {
+        return file_cache_key(_rowset_id.to_string(), _segment_id);
+    }
+
     ~Segment();
 
     Status new_iterator(SchemaSPtr schema, const StorageReadOptions& read_options,

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -85,7 +85,7 @@ SegmentWriter::SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
                              TabletSchemaSPtr tablet_schema, BaseTabletSPtr tablet,
                              DataDir* data_dir, uint32_t max_row_per_segment,
                              const SegmentWriterOptions& opts,
-                             std::shared_ptr<MowContext> mow_context, const io::FileSystemSPtr& fs)
+                             std::shared_ptr<MowContext> mow_context)
         : _segment_id(segment_id),
           _tablet_schema(std::move(tablet_schema)),
           _tablet(std::move(tablet)),
@@ -136,8 +136,10 @@ SegmentWriter::SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
     }
     if (_tablet_schema->has_inverted_index()) {
         _inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                fs ? fs : io::global_local_filesystem(), _file_writer->path().parent_path(),
-                _file_writer->path().filename(),
+                _opts.rowset_ctx->fs(),
+                std::string {InvertedIndexDescriptor::get_index_path_prefix(
+                        _opts.rowset_ctx->segment_path(segment_id))},
+                _opts.rowset_ctx->rowset_id.to_string(), segment_id,
                 _tablet_schema->get_inverted_index_storage_format());
     }
 }

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -82,11 +82,10 @@ using TabletSharedPtr = std::shared_ptr<Tablet>;
 
 class SegmentWriter {
 public:
-    // If `fs` is nullptr, use global local fs
     explicit SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
                            TabletSchemaSPtr tablet_schema, BaseTabletSPtr tablet, DataDir* data_dir,
                            uint32_t max_row_per_segment, const SegmentWriterOptions& opts,
-                           std::shared_ptr<MowContext> mow_context, const io::FileSystemSPtr& fs);
+                           std::shared_ptr<MowContext> mow_context);
     ~SegmentWriter();
 
     Status init();

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
@@ -82,8 +82,7 @@ public:
                                    TabletSchemaSPtr tablet_schema, BaseTabletSPtr tablet,
                                    DataDir* data_dir, uint32_t max_row_per_segment,
                                    const VerticalSegmentWriterOptions& opts,
-                                   std::shared_ptr<MowContext> mow_context,
-                                   const std::shared_ptr<io::FileSystem>& fs);
+                                   std::shared_ptr<MowContext> mow_context);
     ~VerticalSegmentWriter();
 
     VerticalSegmentWriter(const VerticalSegmentWriter&) = delete;

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -168,11 +168,7 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
     auto& context = this->_context;
 
     int seg_id = this->_num_segment.fetch_add(1, std::memory_order_relaxed);
-    auto path = BetaRowset::segment_file_path(context.rowset_dir, context.rowset_id, seg_id);
-    auto fs = this->_rowset_meta->fs();
-    if (!fs) {
-        return Status::Error<INIT_FAILED>("get fs failed");
-    }
+
     io::FileWriterPtr file_writer;
     io::FileWriterOptions opts {
             .write_file_cache = this->_context.write_file_cache,
@@ -182,7 +178,10 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
                                              ? this->_context.newest_write_timestamp +
                                                        this->_context.file_cache_ttl_sec
                                              : 0};
-    Status st = fs->create_file(path, &file_writer, &opts);
+
+    auto path = context.segment_path(seg_id);
+    auto& fs = context.fs_ref();
+    Status st = fs.create_file(path, &file_writer, &opts);
     if (!st.ok()) {
         LOG(WARNING) << "failed to create writable file. path=" << path << ", err: " << st;
         return st;
@@ -194,7 +193,7 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
     writer_options.rowset_ctx = &context;
     *writer = std::make_unique<segment_v2::SegmentWriter>(
             file_writer.get(), seg_id, context.tablet_schema, context.tablet, context.data_dir,
-            context.max_rows_per_segment, writer_options, nullptr, fs);
+            context.max_rows_per_segment, writer_options, nullptr);
     RETURN_IF_ERROR(this->_seg_files.add(seg_id, std::move(file_writer)));
 
     auto s = (*writer)->init(column_ids, is_key);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1115,7 +1115,12 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         context.segments_overlap = rs_reader->rowset()->rowset_meta()->segments_overlap();
         context.tablet_schema = _new_tablet_schema;
         context.newest_write_timestamp = rs_reader->newest_write_timestamp();
-        context.fs = rs_reader->rowset()->rowset_meta()->fs();
+
+        if (!rs_reader->rowset()->is_local()) {
+            context.storage_resource =
+                    *DORIS_TRY(rs_reader->rowset()->rowset_meta()->remote_storage_resource());
+        }
+
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         auto result = _new_tablet->create_rowset_writer(context, false);
         if (!result.has_value()) {

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -283,7 +283,7 @@ Status SingleReplicaCompaction::_fetch_rowset(const TReplicaInfo& addr, const st
                                                      _tablet->tablet_id());
     }
 
-    std::string local_data_path = _tablet->tablet_path() + CLONE_PREFIX;
+    std::string local_data_path = tablet()->tablet_path() + CLONE_PREFIX;
     std::string local_path = local_data_path + "/";
     std::string snapshot_path;
     int timeout_s = 0;
@@ -523,7 +523,7 @@ Status SingleReplicaCompaction::_finish_clone(const string& clone_dir,
             }
 
             std::vector<io::FileInfo> local_files;
-            const auto& tablet_dir = _tablet->tablet_path();
+            const auto& tablet_dir = tablet()->tablet_path();
             RETURN_IF_ERROR(
                     io::global_local_filesystem()->list(tablet_dir, true, &local_files, &exists));
             std::unordered_set<std::string> local_file_names;

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -264,7 +264,7 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb,
     context.partition_id = org_rowset_meta->partition_id();
     context.tablet_schema_hash = org_rowset_meta->tablet_schema_hash();
     context.rowset_type = org_rowset_meta->rowset_type();
-    context.rowset_dir = new_tablet_path;
+    context.tablet_path = new_tablet_path;
     context.tablet_schema =
             org_rowset_meta->tablet_schema() ? org_rowset_meta->tablet_schema() : tablet_schema;
     context.rowset_state = org_rowset_meta->rowset_state();
@@ -688,8 +688,8 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                     }
                 } else {
                     if (tablet_schema.has_inverted_index()) {
-                        auto index_file =
-                                InvertedIndexDescriptor::get_index_file_name(segment_file_path);
+                        auto index_file = InvertedIndexDescriptor::get_index_path_v2(
+                                InvertedIndexDescriptor::get_index_path_prefix(segment_file_path));
                         auto snapshot_segment_index_file_path =
                                 fmt::format("{}/{}_{}.binlog-index", schema_full_path, rowset_id,
                                             segment_index);

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1304,7 +1304,7 @@ bool StorageEngine::check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id)
 }
 
 PendingRowsetGuard StorageEngine::add_pending_rowset(const RowsetWriterContext& ctx) {
-    if (!ctx.fs || ctx.fs->type() == io::FileSystemType::LOCAL) {
+    if (ctx.is_local_rowset()) {
         return _pending_local_rowsets.add(ctx.rowset_id);
     }
     return _pending_remote_rowsets.add(ctx.rowset_id);

--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -24,6 +24,9 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "olap/olap_define.h"
+#include "olap/rowset/rowset_meta.h"
+
 namespace doris {
 
 struct StoragePolicyMgr {
@@ -33,20 +36,19 @@ struct StoragePolicyMgr {
 
 static StoragePolicyMgr s_storage_policy_mgr;
 
-Status get_remote_file_system(int64_t storage_policy_id,
-                              std::shared_ptr<io::RemoteFileSystem>* fs) {
+Result<StorageResource> get_resource_by_storage_policy_id(int64_t storage_policy_id) {
     auto storage_policy = get_storage_policy(storage_policy_id);
     if (storage_policy == nullptr) {
-        return Status::NotFound<false>("could not find storage_policy, storage_policy_id={}",
-                                       storage_policy_id);
+        return ResultError(Status::NotFound<false>(
+                "could not find storage_policy, storage_policy_id={}", storage_policy_id));
     }
-    auto resource = get_storage_resource(storage_policy->resource_id);
-    *fs = resource.fs;
-    if (*fs == nullptr) {
-        return Status::NotFound<false>("could not find resource, resource_id={}",
-                                       storage_policy->resource_id);
+
+    if (auto resource = get_storage_resource(storage_policy->resource_id); resource) {
+        return resource->first;
+    } else {
+        return ResultError(Status::NotFound<false>("could not find resource, resource_id={}",
+                                                   storage_policy->resource_id));
     }
-    return Status::OK();
 }
 
 StoragePolicyPtr get_storage_policy(int64_t id) {
@@ -79,7 +81,8 @@ std::vector<std::pair<int64_t, int64_t>> get_storage_policy_ids() {
 
 struct StorageResourceMgr {
     std::mutex mtx;
-    std::unordered_map<std::string, StorageResource> map;
+    // resource_id -> storage_resource, resource_version
+    std::unordered_map<std::string, std::pair<StorageResource, int64_t>> map;
 };
 
 static StorageResourceMgr s_storage_resource_mgr;
@@ -88,28 +91,33 @@ io::RemoteFileSystemSPtr get_filesystem(const std::string& resource_id) {
     std::lock_guard lock(s_storage_resource_mgr.mtx);
     if (auto it = s_storage_resource_mgr.map.find(resource_id);
         it != s_storage_resource_mgr.map.end()) {
-        return it->second.fs;
+        return it->second.first.fs;
     }
     return nullptr;
 }
 
-StorageResource get_storage_resource(int64_t resource_id) {
-    auto id_str = std::to_string(resource_id);
+std::optional<std::pair<StorageResource, int64_t>> get_storage_resource(int64_t resource_id) {
+    return get_storage_resource(std::to_string(resource_id));
+}
+
+std::optional<std::pair<StorageResource, int64_t>> get_storage_resource(
+        const std::string& resource_id) {
     std::lock_guard lock(s_storage_resource_mgr.mtx);
-    if (auto it = s_storage_resource_mgr.map.find(id_str); it != s_storage_resource_mgr.map.end()) {
+    if (auto it = s_storage_resource_mgr.map.find(resource_id);
+        it != s_storage_resource_mgr.map.end()) {
         return it->second;
     }
-    return StorageResource {nullptr, -1};
+    return std::nullopt;
 }
 
-void put_storage_resource(std::string resource_id, StorageResource resource) {
+void put_storage_resource(std::string resource_id, StorageResource resource, int64_t version) {
     std::lock_guard lock(s_storage_resource_mgr.mtx);
-    s_storage_resource_mgr.map[resource_id] = std::move(resource);
+    s_storage_resource_mgr.map[resource_id] = std::make_pair(std::move(resource), version);
 }
 
-void put_storage_resource(int64_t resource_id, StorageResource resource) {
+void put_storage_resource(int64_t resource_id, StorageResource resource, int64_t version) {
     auto id_str = std::to_string(resource_id);
-    put_storage_resource(id_str, std::move(resource));
+    put_storage_resource(id_str, std::move(resource), version);
 }
 
 void delete_storage_resource(int64_t resource_id) {
@@ -123,9 +131,54 @@ std::vector<std::pair<std::string, int64_t>> get_storage_resource_ids() {
     res.reserve(s_storage_resource_mgr.map.size());
     std::lock_guard lock(s_storage_resource_mgr.mtx);
     for (auto& [id, resource] : s_storage_resource_mgr.map) {
-        res.emplace_back(id, resource.version);
+        res.emplace_back(id, resource.second);
     }
     return res;
+}
+
+namespace {
+
+[[noreturn]] void exit_at_unknown_path_version(std::string_view resource_id, int64_t path_version) {
+    CHECK(false)
+            << "unknown path version, please upgrade BE or drop this storage vault. resource_id="
+            << resource_id << " path_version=" << path_version;
+}
+
+} // namespace
+
+std::string StorageResource::remote_segment_path(int64_t tablet_id, std::string_view rowset_id,
+                                                 int64_t seg_id) const {
+    switch (path_version) {
+    case 0:
+        return fmt::format("{}/{}/{}_{}.dat", DATA_PREFIX, tablet_id, rowset_id, seg_id);
+    default:
+        exit_at_unknown_path_version(fs->id(), path_version);
+    }
+}
+
+std::string StorageResource::remote_segment_path(const RowsetMeta& rowset, int64_t seg_id) const {
+    switch (path_version) {
+    case 0:
+        return fmt::format("{}/{}/{}_{}.dat", DATA_PREFIX, rowset.tablet_id(),
+                           rowset.rowset_id().to_string(), seg_id);
+    default:
+        exit_at_unknown_path_version(fs->id(), path_version);
+    }
+}
+
+std::string StorageResource::remote_tablet_path(int64_t tablet_id) const {
+    switch (path_version) {
+    case 0:
+        return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
+    default:
+        exit_at_unknown_path_version(fs->id(), path_version);
+    }
+}
+
+std::string StorageResource::cooldown_tablet_meta_path(int64_t tablet_id, int64_t replica_id,
+                                                       int64_t cooldown_term) const {
+    return remote_tablet_path(tablet_id) + '/' +
+           cooldown_tablet_meta_filename(replica_id, cooldown_term);
 }
 
 } // namespace doris

--- a/be/src/olap/storage_policy.h
+++ b/be/src/olap/storage_policy.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -30,6 +31,7 @@
 #include "io/fs/remote_file_system.h"
 
 namespace doris {
+class RowsetMeta;
 
 struct StoragePolicy {
     std::string name;
@@ -47,8 +49,6 @@ struct StoragePolicy {
 
 using StoragePolicyPtr = std::shared_ptr<StoragePolicy>;
 
-Status get_remote_file_system(int64_t storage_policy_id, std::shared_ptr<io::RemoteFileSystem>* fs);
-
 // return nullptr if not found
 StoragePolicyPtr get_storage_policy(int64_t id);
 
@@ -62,20 +62,35 @@ std::vector<std::pair<int64_t, int64_t>> get_storage_policy_ids();
 
 struct StorageResource {
     io::RemoteFileSystemSPtr fs;
-    int64_t version = -1;
+    int64_t path_version = 0;
+
+    StorageResource() = default;
+    StorageResource(io::RemoteFileSystemSPtr fs_, int64_t path_version_)
+            : fs(std::move(fs_)), path_version(path_version_) {}
+
+    std::string remote_segment_path(int64_t tablet_id, std::string_view rowset_id,
+                                    int64_t seg_id) const;
+    std::string remote_segment_path(const RowsetMeta& rowset, int64_t seg_id) const;
+    std::string remote_tablet_path(int64_t tablet_id) const;
+    std::string cooldown_tablet_meta_path(int64_t tablet_id, int64_t replica_id,
+                                          int64_t cooldown_term) const;
 };
 
 // return nullptr if not found
 io::RemoteFileSystemSPtr get_filesystem(const std::string& resource_id);
 
-// return [nullptr, -1] if not found
-StorageResource get_storage_resource(int64_t resource_id);
+// Get `StorageResource` and its version
+std::optional<std::pair<StorageResource, int64_t>> get_storage_resource(int64_t resource_id);
+std::optional<std::pair<StorageResource, int64_t>> get_storage_resource(
+        const std::string& resource_id);
+
+Result<StorageResource> get_resource_by_storage_policy_id(int64_t storage_policy_id);
 
 // always success
-void put_storage_resource(std::string resource_id, StorageResource resource);
+void put_storage_resource(std::string resource_id, StorageResource resource, int64_t version);
 
 // always success
-void put_storage_resource(int64_t resource_id, StorageResource resource);
+void put_storage_resource(int64_t resource_id, StorageResource resource, int64_t version);
 
 void delete_storage_resource(int64_t resource_id);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1117,30 +1117,6 @@ void Tablet::check_tablet_path_exists() {
     }
 }
 
-bool Tablet::check_path(const std::string& path_to_check) const {
-    std::shared_lock rdlock(_meta_lock);
-    if (path_to_check == _tablet_path) {
-        return true;
-    }
-    auto tablet_id_dir = io::Path(_tablet_path).parent_path();
-    if (path_to_check == tablet_id_dir) {
-        return true;
-    }
-    for (auto& version_rowset : _rs_version_map) {
-        bool ret = version_rowset.second->check_path(path_to_check);
-        if (ret) {
-            return true;
-        }
-    }
-    for (auto& stale_version_rowset : _stale_rs_version_map) {
-        bool ret = stale_version_rowset.second->check_path(path_to_check);
-        if (ret) {
-            return true;
-        }
-    }
-    return false;
-}
-
 Status Tablet::_contains_version(const Version& version) {
     // check if there exist a rowset contains the added rowset
     for (auto& it : _rs_version_map) {
@@ -1890,20 +1866,19 @@ void Tablet::_init_context_common_fields(RowsetWriterContext& context) {
     if (context.rowset_type == ALPHA_ROWSET) {
         context.rowset_type = _engine.default_rowset_type();
     }
-    if (context.fs != nullptr && context.fs->type() != io::FileSystemType::LOCAL) {
-        context.rowset_dir = remote_tablet_path(tablet_id());
-    } else {
-        context.rowset_dir = tablet_path();
+
+    if (context.is_local_rowset()) {
+        context.tablet_path = _tablet_path;
     }
+
     context.data_dir = data_dir();
     context.enable_unique_key_merge_on_write = enable_unique_key_merge_on_write();
 }
 
 Status Tablet::create_rowset(const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
-    return RowsetFactory::create_rowset(
-            _tablet_meta->tablet_schema(),
-            rowset_meta->is_local() ? _tablet_path : remote_tablet_path(tablet_id()), rowset_meta,
-            rowset);
+    return RowsetFactory::create_rowset(_tablet_meta->tablet_schema(),
+                                        rowset_meta->is_local() ? _tablet_path : "", rowset_meta,
+                                        rowset);
 }
 
 Status Tablet::cooldown(RowsetSharedPtr rowset) {
@@ -1943,8 +1918,7 @@ Status Tablet::cooldown(RowsetSharedPtr rowset) {
 Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     DCHECK(_cooldown_conf.cooldown_replica_id == replica_id());
 
-    std::shared_ptr<io::RemoteFileSystem> dest_fs;
-    RETURN_IF_ERROR(get_remote_file_system(storage_policy_id(), &dest_fs));
+    auto storage_resource = DORIS_TRY(get_resource_by_storage_policy_id(storage_policy_id()));
     RowsetSharedPtr old_rowset = nullptr;
 
     if (rowset) {
@@ -1972,18 +1946,20 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     Defer defer {[&] {
         if (!st.ok()) {
             // reclaim the incomplete rowset data in remote storage
-            record_unused_remote_rowset(new_rowset_id, dest_fs->id(), old_rowset->num_segments());
+            record_unused_remote_rowset(new_rowset_id, storage_resource.fs->id(),
+                                        old_rowset->num_segments());
         }
     }};
     auto start = std::chrono::steady_clock::now();
-    if (st = old_rowset->upload_to(dest_fs.get(), new_rowset_id); !st.ok()) {
+    if (st = old_rowset->upload_to(storage_resource, new_rowset_id); !st.ok()) {
         return st;
     }
 
     auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now() - start);
     LOG(INFO) << "Upload rowset " << old_rowset->version() << " " << new_rowset_id.to_string()
-              << " to " << dest_fs->root_path().native() << ", tablet_id=" << tablet_id()
-              << ", duration=" << duration.count() << ", capacity=" << old_rowset->data_disk_size()
+              << " to " << storage_resource.fs->root_path().native()
+              << ", tablet_id=" << tablet_id() << ", duration=" << duration.count()
+              << ", capacity=" << old_rowset->data_disk_size()
               << ", tp=" << old_rowset->data_disk_size() / duration.count()
               << ", old rowset_id=" << old_rowset->rowset_id().to_string();
 
@@ -1991,12 +1967,11 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     auto new_rowset_meta = std::make_shared<RowsetMeta>();
     new_rowset_meta->init(old_rowset->rowset_meta().get());
     new_rowset_meta->set_rowset_id(new_rowset_id);
-    new_rowset_meta->set_fs(dest_fs);
+    new_rowset_meta->set_remote_storage_resource(std::move(storage_resource));
     new_rowset_meta->set_creation_time(time(nullptr));
     UniqueId cooldown_meta_id = UniqueId::gen_uid();
     RowsetSharedPtr new_rowset;
-    RETURN_IF_ERROR(RowsetFactory::create_rowset(_tablet_meta->tablet_schema(),
-                                                 remote_tablet_path(tablet_id()), new_rowset_meta,
+    RETURN_IF_ERROR(RowsetFactory::create_rowset(_tablet_meta->tablet_schema(), "", new_rowset_meta,
                                                  &new_rowset));
 
     {
@@ -2025,20 +2000,20 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
 }
 
 // hold SHARED `cooldown_conf_lock`
-Status Tablet::_read_cooldown_meta(const std::shared_ptr<io::RemoteFileSystem>& fs,
+Status Tablet::_read_cooldown_meta(const StorageResource& storage_resource,
                                    TabletMetaPB* tablet_meta_pb) {
-    std::string remote_meta_path = remote_tablet_meta_path(
+    std::string remote_meta_path = storage_resource.cooldown_tablet_meta_path(
             tablet_id(), _cooldown_conf.cooldown_replica_id, _cooldown_conf.term);
     io::FileReaderSPtr tablet_meta_reader;
-    RETURN_IF_ERROR(fs->open_file(remote_meta_path, &tablet_meta_reader));
+    RETURN_IF_ERROR(storage_resource.fs->open_file(remote_meta_path, &tablet_meta_reader));
     auto file_size = tablet_meta_reader->size();
     size_t bytes_read;
     auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[file_size]);
     RETURN_IF_ERROR(tablet_meta_reader->read_at(0, {buf.get(), file_size}, &bytes_read));
     RETURN_IF_ERROR(tablet_meta_reader->close());
     if (!tablet_meta_pb->ParseFromArray(buf.get(), file_size)) {
-        return Status::InternalError("malformed tablet meta, path={}/{}", fs->root_path().native(),
-                                     remote_meta_path);
+        return Status::InternalError("malformed tablet meta, path={}/{}",
+                                     storage_resource.fs->root_path().native(), remote_meta_path);
     }
     return Status::OK();
 }
@@ -2092,8 +2067,7 @@ Status Tablet::write_cooldown_meta() {
                                       _cooldown_conf.cooldown_replica_id, tablet_id());
     }
 
-    std::shared_ptr<io::RemoteFileSystem> fs;
-    RETURN_IF_ERROR(get_remote_file_system(storage_policy_id(), &fs));
+    auto storage_resource = DORIS_TRY(get_resource_by_storage_policy_id(storage_policy_id()));
 
     std::vector<RowsetMetaSharedPtr> cooldowned_rs_metas;
     UniqueId cooldown_meta_id;
@@ -2120,7 +2094,7 @@ Status Tablet::write_cooldown_meta() {
     }
 
     TabletMetaPB tablet_meta_pb;
-    auto rs_metas = tablet_meta_pb.mutable_rs_metas();
+    auto* rs_metas = tablet_meta_pb.mutable_rs_metas();
     rs_metas->Reserve(cooldowned_rs_metas.size());
     for (auto& rs_meta : cooldowned_rs_metas) {
         rs_metas->Add(rs_meta->get_rowset_pb());
@@ -2128,11 +2102,11 @@ Status Tablet::write_cooldown_meta() {
     tablet_meta_pb.mutable_cooldown_meta_id()->set_hi(cooldown_meta_id.hi);
     tablet_meta_pb.mutable_cooldown_meta_id()->set_lo(cooldown_meta_id.lo);
 
-    std::string remote_meta_path = remote_tablet_meta_path(
+    std::string remote_meta_path = storage_resource.cooldown_tablet_meta_path(
             tablet_id(), _cooldown_conf.cooldown_replica_id, _cooldown_conf.term);
     io::FileWriterPtr tablet_meta_writer;
     // FIXME(plat1ko): What if object store permanently unavailable?
-    RETURN_IF_ERROR(fs->create_file(remote_meta_path, &tablet_meta_writer));
+    RETURN_IF_ERROR(storage_resource.fs->create_file(remote_meta_path, &tablet_meta_writer));
     auto val = tablet_meta_pb.SerializeAsString();
     RETURN_IF_ERROR(tablet_meta_writer->append({val.data(), val.size()}));
     return tablet_meta_writer->close();
@@ -2145,8 +2119,7 @@ Status Tablet::_follow_cooldowned_data() {
               << " cooldown_replica_id=" << _cooldown_conf.cooldown_replica_id
               << " local replica=" << replica_id();
 
-    std::shared_ptr<io::RemoteFileSystem> fs;
-    RETURN_IF_ERROR(get_remote_file_system(storage_policy_id(), &fs));
+    auto storage_resource = DORIS_TRY(get_resource_by_storage_policy_id(storage_policy_id()));
     // MUST executing serially with cold data compaction, because compaction input rowsets may be deleted by this function
     std::unique_lock cold_compaction_lock(_cold_compaction_lock, std::try_to_lock);
     if (!cold_compaction_lock.owns_lock()) {
@@ -2154,7 +2127,7 @@ Status Tablet::_follow_cooldowned_data() {
     }
 
     TabletMetaPB cooldown_meta_pb;
-    auto st = _read_cooldown_meta(fs, &cooldown_meta_pb);
+    auto st = _read_cooldown_meta(storage_resource, &cooldown_meta_pb);
     if (!st.ok()) {
         LOG(INFO) << "cannot read cooldown meta: " << st;
         return Status::InternalError<false>("cannot read cooldown meta");
@@ -2219,8 +2192,8 @@ Status Tablet::_follow_cooldowned_data() {
             auto rs_meta = std::make_shared<RowsetMeta>();
             rs_meta->init_from_pb(*rs_pb_it);
             RowsetSharedPtr rs;
-            RETURN_IF_ERROR(RowsetFactory::create_rowset(
-                    _tablet_meta->tablet_schema(), remote_tablet_path(tablet_id()), rs_meta, &rs));
+            RETURN_IF_ERROR(
+                    RowsetFactory::create_rowset(_tablet_meta->tablet_schema(), "", rs_meta, &rs));
             to_add.push_back(std::move(rs));
         }
         // Note: We CANNOT call `modify_rowsets` here because `modify_rowsets` cannot process version graph correctly.

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -110,6 +110,8 @@ public:
     int64_t replica_id() const { return _tablet_meta->replica_id(); }
     TabletUid tablet_uid() const { return _tablet_meta->tablet_uid(); }
 
+    const std::string& tablet_path() const { return _tablet_path; }
+
     bool set_tablet_schema_into_rowset_meta();
     Status init();
     bool init_succeeded();
@@ -265,8 +267,6 @@ public:
     void delete_all_files();
 
     void check_tablet_path_exists();
-
-    bool check_path(const std::string& check_path) const;
 
     TabletInfo get_tablet_info() const;
 
@@ -515,7 +515,7 @@ private:
     ////////////////////////////////////////////////////////////////////////////
     Status _cooldown_data(RowsetSharedPtr rowset);
     Status _follow_cooldowned_data();
-    Status _read_cooldown_meta(const std::shared_ptr<io::RemoteFileSystem>& fs,
+    Status _read_cooldown_meta(const StorageResource& storage_resource,
                                TabletMetaPB* tablet_meta_pb);
     bool _has_data_to_cooldown();
     int64_t _get_newest_cooldown_time(const RowsetSharedPtr& rowset);
@@ -531,6 +531,8 @@ public:
 private:
     StorageEngine& _engine;
     DataDir* _data_dir = nullptr;
+
+    std::string _tablet_path;
 
     DorisCallOnce<Status> _init_once;
     // meta store lock is used for prevent 2 threads do checkpoint concurrently

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -18,8 +18,10 @@
 #include "olap/task/index_builder.h"
 
 #include "common/status.h"
+#include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset_writer_context.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/rowset/segment_v2/inverted_index_file_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_file_writer.h"
 #include "olap/rowset/segment_v2/inverted_index_fs_directory.h"
@@ -65,6 +67,13 @@ Status IndexBuilder::update_inverted_index_info() {
     _output_rowsets.reserve(_input_rowsets.size());
     _pending_rs_guards.reserve(_input_rowsets.size());
     for (auto&& input_rowset : _input_rowsets) {
+        if (!input_rowset->is_local()) [[unlikely]] {
+            DCHECK(false) << _tablet->tablet_id() << ' ' << input_rowset->rowset_id();
+            return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                         _tablet->tablet_id(),
+                                         input_rowset->rowset_id().to_string());
+        }
+
         TabletSchemaSPtr output_rs_tablet_schema = std::make_shared<TabletSchema>();
         const auto& input_rs_tablet_schema = input_rowset->tablet_schema();
         output_rs_tablet_schema->copy_from(*input_rs_tablet_schema);
@@ -98,17 +107,18 @@ Status IndexBuilder::update_inverted_index_info() {
                 }
                 if (output_rs_tablet_schema->get_inverted_index_storage_format() ==
                     InvertedIndexStorageFormatPB::V1) {
+                    const auto& fs = io::global_local_filesystem();
+
                     for (int seg_id = 0; seg_id < num_segments; seg_id++) {
-                        auto segment_full_path =
-                                io::Path(static_cast<BetaRowset*>(input_rowset.get())
-                                                 ->segment_file_path(seg_id));
-                        auto index_file_full_path = InvertedIndexDescriptor::get_index_file_name(
-                                segment_full_path, index_meta->index_id(),
-                                index_meta->get_index_suffix());
+                        auto seg_path =
+                                local_segment_path(_tablet->tablet_path(),
+                                                   input_rowset->rowset_id().to_string(), seg_id);
+                        auto index_path = InvertedIndexDescriptor::get_index_path_v1(
+                                InvertedIndexDescriptor::get_index_path_prefix(seg_path),
+                                index_meta->index_id(), index_meta->get_index_suffix());
                         int64_t index_size = 0;
-                        RETURN_IF_ERROR(input_rowset->rowset_meta()->fs()->file_size(
-                                index_file_full_path, &index_size));
-                        VLOG_DEBUG << "inverted index file:" << index_file_full_path
+                        RETURN_IF_ERROR(fs->file_size(index_path, &index_size));
+                        VLOG_DEBUG << "inverted index file:" << index_path
                                    << " size:" << index_size;
                         drop_index_size += index_size;
                     }
@@ -151,10 +161,9 @@ Status IndexBuilder::update_inverted_index_info() {
         RowsetWriterContext context;
         context.version = input_rs_reader->version();
         context.rowset_state = VISIBLE;
-        context.segments_overlap = input_rs_reader->rowset()->rowset_meta()->segments_overlap();
+        context.segments_overlap = input_rowset->rowset_meta()->segments_overlap();
         context.tablet_schema = output_rs_tablet_schema;
         context.newest_write_timestamp = input_rs_reader->newest_write_timestamp();
-        context.fs = input_rs_reader->rowset()->rowset_meta()->fs();
         auto output_rs_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
         _pending_rs_guards.push_back(_engine.add_pending_rowset(context));
 
@@ -192,12 +201,10 @@ Status IndexBuilder::update_inverted_index_info() {
             }
         } else {
             for (int seg_id = 0; seg_id < num_segments; seg_id++) {
-                auto segment_full_path = io::Path(
-                        static_cast<BetaRowset*>(input_rowset.get())->segment_file_path(seg_id));
-                std::string segment_filename = segment_full_path.filename().native();
-                auto segment_dir = segment_full_path.parent_path();
+                auto seg_path = DORIS_TRY(input_rowset->segment_path(seg_id));
                 auto idx_file_reader = std::make_unique<InvertedIndexFileReader>(
-                        context.fs, segment_dir, segment_filename,
+                        context.fs(),
+                        std::string {InvertedIndexDescriptor::get_index_path_prefix(seg_path)},
                         output_rs_tablet_schema->get_inverted_index_storage_format());
                 auto st = idx_file_reader->init();
                 if (!st.ok() && !st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>()) {
@@ -233,18 +240,22 @@ Status IndexBuilder::update_inverted_index_info() {
 
 Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta,
                                           std::vector<segment_v2::SegmentSharedPtr>& segments) {
+    if (!output_rowset_meta->is_local()) [[unlikely]] {
+        DCHECK(false) << _tablet->tablet_id() << ' ' << output_rowset_meta->rowset_id();
+        return Status::InternalError("should be local rowset. tablet_id={} rowset_id={}",
+                                     _tablet->tablet_id(),
+                                     output_rowset_meta->rowset_id().to_string());
+    }
+
     if (_is_drop_op) {
-        auto output_rs_tablet_schema = output_rowset_meta->tablet_schema();
+        const auto& output_rs_tablet_schema = output_rowset_meta->tablet_schema();
         if (output_rs_tablet_schema->get_inverted_index_storage_format() !=
             InvertedIndexStorageFormatPB::V1) {
-            std::string segment_dir = _tablet->tablet_path();
-            auto fs = output_rowset_meta->fs();
-            auto output_rowset_schema = output_rowset_meta->tablet_schema();
+            const auto& fs = io::global_local_filesystem();
+
+            const auto& output_rowset_schema = output_rowset_meta->tablet_schema();
             size_t inverted_index_size = 0;
             for (auto& seg_ptr : segments) {
-                std::string segment_filename = fmt::format(
-                        "{}_{}.dat", output_rowset_meta->rowset_id().to_string(), seg_ptr->id());
-
                 auto idx_file_reader_iter = _inverted_index_file_readers.find(
                         std::make_pair(output_rowset_meta->rowset_id().to_string(), seg_ptr->id()));
                 if (idx_file_reader_iter == _inverted_index_file_readers.end()) {
@@ -253,8 +264,15 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                     continue;
                 }
                 auto dirs = DORIS_TRY(idx_file_reader_iter->second->get_all_directories());
+
+                std::string index_path_prefix {
+                        InvertedIndexDescriptor::get_index_path_prefix(local_segment_path(
+                                _tablet->tablet_path(), output_rowset_meta->rowset_id().to_string(),
+                                seg_ptr->id()))};
+
                 auto inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                        fs, segment_dir, segment_filename,
+                        fs, std::move(index_path_prefix),
+                        output_rowset_meta->rowset_id().to_string(), seg_ptr->id(),
                         output_rowset_schema->get_inverted_index_storage_format());
                 RETURN_IF_ERROR(inverted_index_file_writer->initialize(dirs));
                 // create inverted index writer
@@ -264,14 +282,13 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 _inverted_index_file_writers.emplace(seg_ptr->id(),
                                                      std::move(inverted_index_file_writer));
             }
-            for (auto& kv : _inverted_index_file_writers) {
-                auto* inverted_index_writer = kv.second.get();
+            for (auto&& [seg_id, inverted_index_writer] : _inverted_index_file_writers) {
                 LOG(INFO) << "close inverted index file "
-                          << inverted_index_writer->get_index_file_name();
+                          << inverted_index_writer->get_index_file_path();
                 auto st = inverted_index_writer->close();
                 if (!st.ok()) {
                     LOG(ERROR) << "close inverted index file "
-                               << inverted_index_writer->get_index_file_name() << " error:" << st;
+                               << inverted_index_writer->get_index_file_path() << " error:" << st;
                 }
                 inverted_index_size += inverted_index_writer->get_index_file_size();
             }
@@ -287,13 +304,14 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
         return Status::OK();
     } else {
         // create inverted index writer
-        std::string segment_dir = _tablet->tablet_path();
-        auto fs = output_rowset_meta->fs();
+        const auto& fs = io::global_local_filesystem();
         auto output_rowset_schema = output_rowset_meta->tablet_schema();
         size_t inverted_index_size = 0;
         for (auto& seg_ptr : segments) {
-            std::string segment_filename = fmt::format(
-                    "{}_{}.dat", output_rowset_meta->rowset_id().to_string(), seg_ptr->id());
+            std::string index_path_prefix {
+                    InvertedIndexDescriptor::get_index_path_prefix(local_segment_path(
+                            _tablet->tablet_path(), output_rowset_meta->rowset_id().to_string(),
+                            seg_ptr->id()))};
             std::vector<ColumnId> return_columns;
             std::vector<std::pair<int64_t, int64_t>> inverted_index_writer_signs;
             _olap_data_convertor->reserve(_alter_inverted_indexes.size());
@@ -310,13 +328,13 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 }
                 auto dirs = DORIS_TRY(idx_file_reader_iter->second->get_all_directories());
                 inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                        fs, segment_dir, segment_filename,
-                        output_rowset_schema->get_inverted_index_storage_format());
+                        fs, index_path_prefix, output_rowset_meta->rowset_id().to_string(),
+                        seg_ptr->id(), output_rowset_schema->get_inverted_index_storage_format());
                 RETURN_IF_ERROR(inverted_index_file_writer->initialize(dirs));
             } else {
                 inverted_index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                        fs, segment_dir, segment_filename,
-                        output_rowset_schema->get_inverted_index_storage_format());
+                        fs, index_path_prefix, output_rowset_meta->rowset_id().to_string(),
+                        seg_ptr->id(), output_rowset_schema->get_inverted_index_storage_format());
             }
             // create inverted index writer
             for (auto inverted_index : _alter_inverted_indexes) {
@@ -421,14 +439,13 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
 
             _olap_data_convertor->reset();
         }
-        for (auto& kv : _inverted_index_file_writers) {
-            auto* inverted_index_file_writer = kv.second.get();
+        for (auto&& [seg_id, inverted_index_file_writer] : _inverted_index_file_writers) {
             LOG(INFO) << "close inverted index file "
-                      << inverted_index_file_writer->get_index_file_name();
+                      << inverted_index_file_writer->get_index_file_path();
             auto st = inverted_index_file_writer->close();
             if (!st.ok()) {
                 LOG(ERROR) << "close inverted index file "
-                           << inverted_index_file_writer->get_index_file_name() << " error:" << st;
+                           << inverted_index_file_writer->get_index_file_path() << " error:" << st;
             }
             inverted_index_size += inverted_index_file_writer->get_index_file_size();
         }

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -266,24 +266,24 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
             estimate_timeout = config::download_low_speed_time;
         }
 
-        auto local_segment_path = BetaRowset::segment_file_path(
-                local_tablet->tablet_path(), rowset_meta->rowset_id(), segment_index);
+        auto segment_path = local_segment_path(local_tablet->tablet_path(),
+                                               rowset_meta->rowset_id().to_string(), segment_index);
         LOG(INFO) << fmt::format("download segment file from {} to {}", get_segment_file_url,
-                                 local_segment_path);
-        auto get_segment_file_cb = [&get_segment_file_url, &local_segment_path, segment_file_size,
+                                 segment_path);
+        auto get_segment_file_cb = [&get_segment_file_url, &segment_path, segment_file_size,
                                     estimate_timeout, &download_success_files](HttpClient* client) {
             RETURN_IF_ERROR(client->init(get_segment_file_url));
             client->set_timeout_ms(estimate_timeout * 1000);
-            RETURN_IF_ERROR(client->download(local_segment_path));
-            download_success_files.push_back(local_segment_path);
+            RETURN_IF_ERROR(client->download(segment_path));
+            download_success_files.push_back(segment_path);
 
             std::error_code ec;
             // Check file length
-            uint64_t local_file_size = std::filesystem::file_size(local_segment_path, ec);
+            uint64_t local_file_size = std::filesystem::file_size(segment_path, ec);
             if (ec) {
                 LOG(WARNING) << "download file error" << ec.message();
-                return Status::IOError("can't retrive file_size of {}, due to {}",
-                                       local_segment_path, ec.message());
+                return Status::IOError("can't retrive file_size of {}, due to {}", segment_path,
+                                       ec.message());
             }
             if (local_file_size != segment_file_size) {
                 LOG(WARNING) << "download file length error"
@@ -292,7 +292,7 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
                              << ", local_file_size=" << local_file_size;
                 return Status::InternalError("downloaded file size is not equal");
             }
-            return io::global_local_filesystem()->permission(local_segment_path,
+            return io::global_local_filesystem()->permission(segment_path,
                                                              io::LocalFileSystem::PERMS_OWNER_RW);
         };
 
@@ -332,10 +332,13 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
                             RETURN_IF_ERROR(client->head());
                             return client->get_content_length(&segment_index_file_size);
                         };
-                auto index_file = InvertedIndexDescriptor::inverted_index_file_path(
-                        local_tablet->tablet_path(), rowset_meta->rowset_id(), segment_index,
-                        index_id, index.get_index_suffix());
-                segment_index_file_names.push_back(index_file);
+
+                auto segment_path =
+                        local_segment_path(local_tablet->tablet_path(),
+                                           rowset_meta->rowset_id().to_string(), segment_index);
+                segment_index_file_names.push_back(InvertedIndexDescriptor::get_index_path_v1(
+                        InvertedIndexDescriptor::get_index_path_prefix(segment_path), index_id,
+                        index.get_index_suffix()));
 
                 status = HttpClient::execute_with_retry(max_retry, 1,
                                                         get_segment_index_file_size_cb);
@@ -368,10 +371,11 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
                             RETURN_IF_ERROR(client->head());
                             return client->get_content_length(&segment_index_file_size);
                         };
-                auto local_segment_path = BetaRowset::segment_file_path(
-                        local_tablet->tablet_path(), rowset_meta->rowset_id(), segment_index);
-                auto index_file = InvertedIndexDescriptor::get_index_file_name(local_segment_path);
-                segment_index_file_names.push_back(index_file);
+                auto segment_path =
+                        local_segment_path(local_tablet->tablet_path(),
+                                           rowset_meta->rowset_id().to_string(), segment_index);
+                segment_index_file_names.push_back(InvertedIndexDescriptor::get_index_path_v2(
+                        InvertedIndexDescriptor::get_index_path_prefix(segment_path)));
 
                 status = HttpClient::execute_with_retry(max_retry, 1,
                                                         get_segment_index_file_size_cb);

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -104,7 +104,7 @@ public:
         Status st = fs->create_file(path, &file_writer);
         EXPECT_TRUE(st.ok());
         SegmentWriter writer(file_writer.get(), segment_id, build_schema, nullptr, nullptr,
-                             INT32_MAX, opts, nullptr, fs);
+                             INT32_MAX, opts, nullptr);
         st = writer.init();
         EXPECT_TRUE(st.ok());
 

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -934,7 +934,7 @@ protected:
         rsm->set_rowset_id(id);
         rsm->set_delete_predicate(del_pred);
         rsm->set_tablet_schema(tablet->tablet_schema());
-        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), "", rsm);
+        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), rsm, "");
         static_cast<void>(tablet->add_rowset(rowset));
     }
 

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -200,7 +200,7 @@ protected:
         rowset_writer_context->data_dir = _data_dir.get();
         rowset_writer_context->rowset_state = VISIBLE;
         rowset_writer_context->tablet_schema = tablet_schema;
-        rowset_writer_context->rowset_dir = rowset_dir;
+        rowset_writer_context->tablet_path = rowset_dir;
         rowset_writer_context->version = Version(inc_id, inc_id);
         rowset_writer_context->segments_overlap = overlap;
         rowset_writer_context->max_rows_per_segment = max_rows_per_segment;
@@ -308,7 +308,7 @@ protected:
         rsm->set_rowset_id(id);
         rsm->set_delete_predicate(del_pred);
         rsm->set_tablet_schema(tablet->tablet_schema());
-        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), "", rsm);
+        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), rsm, "");
         static_cast<void>(tablet->add_rowset(rowset));
     }
 

--- a/be/test/olap/path_gc_test.cpp
+++ b/be/test/olap/path_gc_test.cpp
@@ -92,8 +92,8 @@ TEST(PathGcTest, GcTabletAndRowset) {
         rowset_meta->set_tablet_id(tablet->tablet_id());
         rowset_meta->set_tablet_uid(tablet->tablet_uid());
         rowset_meta->set_rowset_id(engine.next_rowset_id());
-        return std::make_shared<BetaRowset>(tablet->tablet_schema(), tablet->tablet_path(),
-                                            std::move(rowset_meta));
+        return std::make_shared<BetaRowset>(tablet->tablet_schema(), std::move(rowset_meta),
+                                            tablet->tablet_path());
     };
     // tablet_id -> filenames
     std::unordered_map<int64_t, std::vector<std::string>> expected_rowset_files;
@@ -101,25 +101,25 @@ TEST(PathGcTest, GcTabletAndRowset) {
         auto& filenames = expected_rowset_files[rs.rowset_meta()->tablet_id()];
         std::unique_ptr<io::FileWriter> writer;
         auto filename = fmt::format("{}_{}.dat", rs.rowset_id().to_string(), 0);
-        RETURN_IF_ERROR(fs->create_file(rs._rowset_dir + '/' + filename, &writer));
+        RETURN_IF_ERROR(fs->create_file(rs.tablet_path() + '/' + filename, &writer));
         if (!is_garbage) {
             filenames.push_back(std::move(filename));
         }
         RETURN_IF_ERROR(writer->close());
         filename = fmt::format("{}_{}_{}.idx", rs.rowset_id().to_string(), 0, 987);
-        RETURN_IF_ERROR(fs->create_file(rs._rowset_dir + '/' + filename, &writer));
+        RETURN_IF_ERROR(fs->create_file(rs.tablet_path() + '/' + filename, &writer));
         if (!is_garbage) {
             filenames.push_back(std::move(filename));
         }
         RETURN_IF_ERROR(writer->close());
         filename = fmt::format("{}_{}.dat", rs.rowset_id().to_string(), 1);
-        RETURN_IF_ERROR(fs->create_file(rs._rowset_dir + '/' + filename, &writer));
+        RETURN_IF_ERROR(fs->create_file(rs.tablet_path() + '/' + filename, &writer));
         if (!is_garbage) {
             filenames.push_back(std::move(filename));
         }
         RETURN_IF_ERROR(writer->close());
         filename = fmt::format("{}_{}_{}.idx", rs.rowset_id().to_string(), 1, 987);
-        RETURN_IF_ERROR(fs->create_file(rs._rowset_dir + '/' + filename, &writer));
+        RETURN_IF_ERROR(fs->create_file(rs.tablet_path() + '/' + filename, &writer));
         if (!is_garbage) {
             filenames.push_back(std::move(filename));
         }

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -154,7 +154,7 @@ protected:
         rowset_writer_context.rowset_type = BETA_ROWSET;
         rowset_writer_context.rowset_state = VISIBLE;
         rowset_writer_context.tablet_schema = tablet_schema;
-        rowset_writer_context.rowset_dir = absolute_dir + "/tablet_path";
+        rowset_writer_context.tablet_path = absolute_dir + "/tablet_path";
         rowset_writer_context.version = version;
         rowset_writer_context.segments_overlap = overlap;
         rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
@@ -245,7 +245,7 @@ protected:
         rsm->set_rowset_id(id);
         rsm->set_delete_predicate(std::move(del_pred));
         rsm->set_tablet_schema(schema);
-        return std::make_shared<BetaRowset>(schema, "", rsm);
+        return std::make_shared<BetaRowset>(schema, rsm, "");
     }
 
     TabletSharedPtr create_tablet(const TabletSchema& tablet_schema,

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -53,6 +53,7 @@
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/rowset/segment_v2/segment.h"
 #include "olap/storage_engine.h"
+#include "olap/storage_policy.h"
 #include "olap/tablet_schema.h"
 #include "runtime/exec_env.h"
 #include "util/s3_util.h"
@@ -152,7 +153,7 @@ protected:
         rowset_writer_context->tablet_schema_hash = 1111;
         rowset_writer_context->partition_id = 10;
         rowset_writer_context->rowset_type = BETA_ROWSET;
-        rowset_writer_context->rowset_dir = kTestDir;
+        rowset_writer_context->tablet_path = kTestDir;
         rowset_writer_context->rowset_state = VISIBLE;
         rowset_writer_context->tablet_schema = tablet_schema;
         rowset_writer_context->version.first = 10;
@@ -227,7 +228,7 @@ class S3ClientMockGetErrorData : public S3ClientMock {
 
 TEST_F(BetaRowsetTest, ReadTest) {
     RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-    BetaRowset rowset(nullptr, "", rowset_meta);
+    BetaRowset rowset(nullptr, rowset_meta, "");
     S3Conf s3_conf {.bucket = "bucket",
                     .prefix = "prefix",
                     .client_conf = {
@@ -240,6 +241,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
     auto res = io::S3FileSystem::create(std::move(s3_conf), io::FileSystem::TMP_FS_ID);
     ASSERT_TRUE(res.has_value()) << res.error();
     auto fs = res.value();
+    StorageResource storage_resource(fs, 0);
     auto& client = fs->client_holder()->_client;
     // failed to head object
     {
@@ -252,7 +254,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
         client.reset(new io::S3ObjStorageClient(std::move(s3_client)));
 
         rowset.rowset_meta()->set_num_segments(1);
-        rowset.rowset_meta()->set_fs(fs);
+        rowset.rowset_meta()->set_remote_storage_resource(storage_resource);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
         Status st = rowset.load_segments(&segments);
@@ -267,7 +269,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
                 std::make_shared<Aws::S3::S3Client>(S3ClientMockGetError())));
 
         rowset.rowset_meta()->set_num_segments(1);
-        rowset.rowset_meta()->set_fs(fs);
+        rowset.rowset_meta()->set_remote_storage_resource(storage_resource);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
         Status st = rowset.load_segments(&segments);
@@ -282,7 +284,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
                 std::make_shared<Aws::S3::S3Client>(S3ClientMockGetErrorData())));
 
         rowset.rowset_meta()->set_num_segments(1);
-        rowset.rowset_meta()->set_fs(fs);
+        rowset.rowset_meta()->set_remote_storage_resource(storage_resource);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
         Status st = rowset.load_segments(&segments);

--- a/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
@@ -29,6 +29,7 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/rowset/segment_v2/inverted_index_file_writer.h"
 #include "olap/rowset/segment_v2/inverted_index_fs_directory.h"
 #include "olap/rowset/segment_v2/inverted_index_writer.h"
@@ -109,16 +110,20 @@ public:
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());
     }
 
-    void test_string(std::string testname, Field* field) {
+    void test_string(std::string_view rowset_id, int seg_id, Field* field) {
         EXPECT_TRUE(field->type() == FieldType::OLAP_FIELD_TYPE_ARRAY);
-        std::string filename = kTestDir + "/" + testname;
+        std::string index_path_prefix {InvertedIndexDescriptor::get_index_path_prefix(
+                local_segment_path(kTestDir, rowset_id, seg_id))};
+        int index_id = 26033;
+        std::string index_path =
+                InvertedIndexDescriptor::get_index_path_v1(index_path_prefix, index_id, "");
         auto fs = io::global_local_filesystem();
 
         io::FileWriterPtr file_writer;
-        EXPECT_TRUE(fs->create_file(filename, &file_writer).ok());
+        EXPECT_TRUE(fs->create_file(index_path, &file_writer).ok());
         auto index_meta_pb = std::make_unique<TabletIndexPB>();
         index_meta_pb->set_index_type(IndexType::INVERTED);
-        index_meta_pb->set_index_id(26033);
+        index_meta_pb->set_index_id(index_id);
         index_meta_pb->set_index_name("index_inverted_arr1");
         index_meta_pb->clear_col_unique_id();
         index_meta_pb->add_col_unique_id(0);
@@ -127,7 +132,7 @@ public:
         idx_meta.index_type();
         idx_meta.init_from_pb(*index_meta_pb.get());
         auto index_file_writer = std::make_unique<InvertedIndexFileWriter>(
-                fs, file_writer->path().parent_path(), file_writer->path().filename(),
+                fs, index_path_prefix, std::string {rowset_id}, seg_id,
                 InvertedIndexStorageFormatPB::V1);
         std::unique_ptr<segment_v2::InvertedIndexColumnWriter> _inverted_index_builder = nullptr;
         EXPECT_EQ(InvertedIndexColumnWriter::create(field, &_inverted_index_builder,
@@ -197,12 +202,7 @@ public:
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
         EXPECT_EQ(index_file_writer->close(), Status::OK());
 
-        {
-            std::cout << "dir: " << file_writer->path().parent_path().string() << std::endl;
-            string idx_file_name = file_writer->path().filename().string() + "_26033.idx";
-            std::cout << "file: " << file_writer->path().filename().string() << std::endl;
-            check_terms_stats(file_writer->path().parent_path().string(), idx_file_name);
-        }
+        check_terms_stats(file_writer->path().parent_path(), file_writer->path().filename());
     }
 };
 
@@ -217,7 +217,7 @@ TEST_F(InvertedIndexArrayTest, ArrayString) {
     arraySubColumn.set_type(FieldType::OLAP_FIELD_TYPE_STRING);
     arrayTabletColumn.add_sub_column(arraySubColumn);
     Field* field = FieldFactory::create(arrayTabletColumn);
-    test_string("InvertedIndexArray", field);
+    test_string("rowset_id", 0, field);
     delete field;
 }
 

--- a/be/test/olap/single_compaction_test.cpp
+++ b/be/test/olap/single_compaction_test.cpp
@@ -64,8 +64,8 @@ protected:
         rowset_meta->set_tablet_id(tablet->tablet_id());
         rowset_meta->set_tablet_uid(tablet->tablet_uid());
         rowset_meta->set_rowset_id(_engine->next_rowset_id());
-        return std::make_shared<BetaRowset>(tablet->tablet_schema(), tablet->tablet_path(),
-                                            std::move(rowset_meta));
+        return std::make_shared<BetaRowset>(tablet->tablet_schema(), std::move(rowset_meta),
+                                            tablet->tablet_path());
     }
     void TearDown() override {
         delete _engine;

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -203,8 +203,8 @@ public:
     static void SetUpTestSuite() {
         s_fs.reset(
                 new RemoteFileSystemMock("", std::to_string(kResourceId), io::FileSystemType::S3));
-        StorageResource resource = {s_fs, 1};
-        put_storage_resource(kResourceId, resource);
+        StorageResource resource = {s_fs, 0};
+        put_storage_resource(kResourceId, resource, 1);
         auto storage_policy = std::make_shared<StoragePolicy>();
         storage_policy->name = "TabletCooldownTest";
         storage_policy->version = 1;
@@ -387,12 +387,9 @@ static void write_rowset(TabletSharedPtr* tablet, PUniqueId load_id, int64_t rep
 
 void createTablet(TabletSharedPtr* tablet, int64_t replica_id, int32_t schema_hash,
                   int64_t tablet_id, int64_t txn_id, int64_t partition_id, bool with_data = true) {
-    EXPECT_TRUE(io::global_local_filesystem()
-                        ->delete_directory(get_remote_path(remote_tablet_path(tablet_id)))
-                        .ok());
-    EXPECT_TRUE(io::global_local_filesystem()
-                        ->create_directory(get_remote_path(remote_tablet_path(tablet_id)))
-                        .ok());
+    auto tablet_path = fmt::format("data/{}", tablet_id);
+    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(get_remote_path(tablet_path)).ok());
+    EXPECT_TRUE(io::global_local_filesystem()->create_directory(get_remote_path(tablet_path)).ok());
     // create tablet
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("CreateTablet");

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -402,8 +402,8 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
             rowset_meta->set_tablet_id(tablet->tablet_id());
             rowset_meta->set_tablet_uid(tablet->tablet_uid());
             rowset_meta->set_rowset_id(k_engine->next_rowset_id());
-            return std::make_shared<BetaRowset>(tablet->tablet_schema(), tablet->tablet_path(),
-                                                std::move(rowset_meta));
+            return std::make_shared<BetaRowset>(tablet->tablet_schema(), std::move(rowset_meta),
+                                                tablet->tablet_path());
         };
         auto st = tablet->init();
         ASSERT_TRUE(st.ok()) << st;

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -275,17 +275,17 @@ TEST_F(TestTablet, pad_rowset) {
     auto ptr1 = std::make_shared<RowsetMeta>();
     init_rs_meta(ptr1, 1, 2);
     rs_metas.push_back(ptr1);
-    RowsetSharedPtr rowset1 = make_shared<BetaRowset>(nullptr, "", ptr1);
+    RowsetSharedPtr rowset1 = make_shared<BetaRowset>(nullptr, ptr1, "");
 
     auto ptr2 = std::make_shared<RowsetMeta>();
     init_rs_meta(ptr2, 3, 4);
     rs_metas.push_back(ptr2);
-    RowsetSharedPtr rowset2 = make_shared<BetaRowset>(nullptr, "", ptr2);
+    RowsetSharedPtr rowset2 = make_shared<BetaRowset>(nullptr, ptr2, "");
 
     auto ptr3 = std::make_shared<RowsetMeta>();
     init_rs_meta(ptr3, 6, 7);
     rs_metas.push_back(ptr3);
-    RowsetSharedPtr rowset3 = make_shared<BetaRowset>(nullptr, "", ptr3);
+    RowsetSharedPtr rowset3 = make_shared<BetaRowset>(nullptr, ptr3, "");
 
     for (auto& rowset : rs_metas) {
         static_cast<void>(_tablet_meta->add_rs_meta(rowset));
@@ -309,27 +309,27 @@ TEST_F(TestTablet, cooldown_policy) {
     RowsetMetaSharedPtr ptr1(new RowsetMeta());
     init_rs_meta(ptr1, 0, 2, 200);
     rs_metas.push_back(ptr1);
-    RowsetSharedPtr rowset1 = make_shared<BetaRowset>(nullptr, "", ptr1);
+    RowsetSharedPtr rowset1 = make_shared<BetaRowset>(nullptr, ptr1, "");
 
     RowsetMetaSharedPtr ptr2(new RowsetMeta());
     init_rs_meta(ptr2, 3, 4, 600);
     rs_metas.push_back(ptr2);
-    RowsetSharedPtr rowset2 = make_shared<BetaRowset>(nullptr, "", ptr2);
+    RowsetSharedPtr rowset2 = make_shared<BetaRowset>(nullptr, ptr2, "");
 
     RowsetMetaSharedPtr ptr3(new RowsetMeta());
     init_rs_meta(ptr3, 5, 5, 800);
     rs_metas.push_back(ptr3);
-    RowsetSharedPtr rowset3 = make_shared<BetaRowset>(nullptr, "", ptr3);
+    RowsetSharedPtr rowset3 = make_shared<BetaRowset>(nullptr, ptr3, "");
 
     RowsetMetaSharedPtr ptr4(new RowsetMeta());
     init_rs_meta(ptr4, 6, 7, 1400);
     rs_metas.push_back(ptr4);
-    RowsetSharedPtr rowset4 = make_shared<BetaRowset>(nullptr, "", ptr4);
+    RowsetSharedPtr rowset4 = make_shared<BetaRowset>(nullptr, ptr4, "");
 
     RowsetMetaSharedPtr ptr5(new RowsetMeta());
     init_rs_meta(ptr5, 8, 9, 2000);
     rs_metas.push_back(ptr5);
-    RowsetSharedPtr rowset5 = make_shared<BetaRowset>(nullptr, "", ptr5);
+    RowsetSharedPtr rowset5 = make_shared<BetaRowset>(nullptr, ptr5, "");
 
     for (auto& rowset : rs_metas) {
         static_cast<void>(_tablet_meta->add_rs_meta(rowset));

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -641,7 +641,9 @@ public:
             if (tablet.tablet_id != tablet_id || rowset == nullptr) {
                 continue;
             }
-            auto path = static_cast<BetaRowset*>(rowset.get())->segment_file_path(segid);
+
+            auto path = local_segment_path(rowset->tablet_path(), rowset->rowset_id().to_string(),
+                                           segid);
             LOG(INFO) << "read data from " << path;
             std::ifstream inputFile(path, std::ios::binary);
             inputFile.seekg(0, std::ios::end);

--- a/be/test/testutil/mock_rowset.h
+++ b/be/test/testutil/mock_rowset.h
@@ -42,15 +42,15 @@ class MockRowset : public Rowset {
         return Status::NotSupported("MockRowset not support this method.");
     }
 
-    bool check_path(const std::string& path) override {
+    Status check_file_exist() override {
         return Status::NotSupported("MockRowset not support this method.");
     }
 
-    bool check_file_exist() override {
+    Status upload_to(const StorageResource& dest_fs, const RowsetId& new_rowset_id) override {
         return Status::NotSupported("MockRowset not support this method.");
     }
 
-    std::string segment_file_path(int segment_id) const override { return ""; }
+    void clear_inverted_index_cache() override {}
 
     Status get_segments_key_bounds(std::vector<KeyBoundsPB>* segments_key_bounds) override {
         // TODO(zhangchen): remove this after we implemented memrowset.
@@ -69,7 +69,7 @@ class MockRowset : public Rowset {
 
 protected:
     MockRowset(TabletSchemaSPtr schema, RowsetMetaSharedPtr rowset_meta)
-            : Rowset(schema, rowset_meta) {}
+            : Rowset(schema, rowset_meta, "") {}
 
     Status init() override { return Status::NotSupported("MockRowset not support this method."); }
 
@@ -81,7 +81,7 @@ protected:
         // Do nothing.
     }
 
-    bool check_current_rowset_segment() override { return true; }
+    Status check_current_rowset_segment() override { return Status::OK(); }
 
 private:
     bool is_mem_rowset_;

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -203,7 +203,7 @@ protected:
         rowset_writer_context.rowset_type = BETA_ROWSET;
         rowset_writer_context.rowset_state = VISIBLE;
         rowset_writer_context.tablet_schema = tablet_schema;
-        rowset_writer_context.rowset_dir = absolute_dir + "/tablet_path";
+        rowset_writer_context.tablet_path = absolute_dir + "/tablet_path";
         rowset_writer_context.version = version;
         rowset_writer_context.segments_overlap = overlap;
         rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
@@ -296,7 +296,7 @@ protected:
         rsm->set_rowset_id(id);
         rsm->set_delete_predicate(std::move(del_pred));
         rsm->set_tablet_schema(schema);
-        return std::make_shared<BetaRowset>(schema, "", rsm);
+        return std::make_shared<BetaRowset>(schema, rsm, "");
     }
 
     TabletSharedPtr create_tablet(const TabletSchema& tablet_schema,


### PR DESCRIPTION
## Proposed changes

The current storage path format for remote segment files in Doris is:
`${prefix}/data/${tablet_id}/${rowset_id}_${seg_id}.dat`
There are the following issues with this storage path on HDFS:

- HDFS has a limitation on the number of directory entries in a directory, typically not exceeding 1 million (dfs.namenode.fs-limits.max-directory-items).
- The HDFS list interface does not have pagination functionality, resulting in high overhead when listing a large number of files.
- The Recycler needs to support recycling rowsets with an unknown number of segments, but efficiently deleting all files with the `rowset_id` prefix is challenging in HDFS.

A more HDFS-friendly path format would be:
`${prefix}/data/${shard_id}/${tablet_id}/${rowset_id}/${seg_id}.dat`

To support the aforementioned path format while maintaining compatibility with existing data, all existing `StorageResource` / `StorageVault`s are assumed to use path v0 for reading and writing segment files. When reading or writing remote segment files, the corresponding file paths need to be obtained from the `StorageResource`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

