### PR TITLE
[fix](statistics) NPE when drop partition during publish

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -262,7 +263,9 @@ public class PublishVersionDaemon extends MasterDaemon {
                 .getIdToPartitionCommitInfo()
                 .values().stream()
                 .map(PartitionCommitInfo::getPartitionId)
-                .map(table::getPartition)
+                .map(partitionId -> Optional.ofNullable(table.getPartition(partitionId)))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .map(Partition::getBaseIndex)
                 .map(MaterializedIndex::getTablets)
                 .flatMap(Collection::stream)


### PR DESCRIPTION
skip null partition when get base tablets for each be (for further usage in dedup updated row count in MV)
This may cause publish fail

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

