### PR TITLE
[enhancement](atomicstatus) use lock to make the status object more stable

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -573,7 +573,6 @@ public:
     // This stauts could only be called when ok==false
     Status status() const {
         std::lock_guard l(mutex_);
-        DCHECK(error_code_.load(std::memory_order_acquire) != 0);
         return error_st_;
     }
 


### PR DESCRIPTION
## Proposed changes

1. In the past, if error code is not ok and then get status, the status maybe ok. some dcheck maybe failed.

In this PR use std mutex to make this behavior stable.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

