### PR TITLE
[fix](test) fix test_create_table_without_distribution.groovy bug

### DIFF
--- a/regression-test/data/ddl_p0/test_create_table_without_distribution.out
+++ b/regression-test/data/ddl_p0/test_create_table_without_distribution.out
@@ -5,15 +5,9 @@
 -- !test_select --
 1	2
 
--- !test_show --
-test_create_table_without_distribution	CREATE TABLE `test_create_table_without_distribution` (\n  `a` INT NULL,\n  `b` INT NULL\n) ENGINE=OLAP\nDUPLICATE KEY(`a`, `b`)\nCOMMENT 'OLAP'\nDISTRIBUTED BY RANDOM BUCKETS AUTO\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"min_load_replica_num" = "-1",\n"is_being_synced" = "false",\n"storage_medium" = "hdd",\n"storage_format" = "V2",\n"inverted_index_storage_format" = "V1",\n"light_schema_change" = "true",\n"disable_auto_compaction" = "false",\n"binlog.enable" = "false",\n"binlog.ttl_seconds" = "86400",\n"binlog.max_bytes" = "9223372036854775807",\n"binlog.max_history_nums" = "9223372036854775807",\n"enable_single_replica_compaction" = "false",\n"group_commit_interval_ms" = "10000",\n"group_commit_data_bytes" = "134217728"\n);
-
 -- !test_insert_old_planner --
 1
 
 -- !test_select_old_planner --
 1	2
-
--- !test_show_old_planner --
-test_create_table_without_distribution	CREATE TABLE `test_create_table_without_distribution` (\n  `a` INT NULL,\n  `b` INT NULL\n) ENGINE=OLAP\nDUPLICATE KEY(`a`, `b`)\nCOMMENT 'OLAP'\nDISTRIBUTED BY RANDOM BUCKETS AUTO\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"min_load_replica_num" = "-1",\n"is_being_synced" = "false",\n"storage_medium" = "hdd",\n"storage_format" = "V2",\n"inverted_index_storage_format" = "V1",\n"light_schema_change" = "true",\n"disable_auto_compaction" = "false",\n"binlog.enable" = "false",\n"binlog.ttl_seconds" = "86400",\n"binlog.max_bytes" = "9223372036854775807",\n"binlog.max_history_nums" = "9223372036854775807",\n"enable_single_replica_compaction" = "false",\n"group_commit_interval_ms" = "10000",\n"group_commit_data_bytes" = "134217728"\n);
 

--- a/regression-test/plugins/plugin_must_contains.groovy
+++ b/regression-test/plugins/plugin_must_contains.groovy
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.Suite
+
+Suite.metaClass.mustContain = {String str1, String str2 ->
+    try {
+        assert str1.contains(str2)
+        logger.info("Assertion passed: '${str1}' contains '${str2}'")
+    } catch (AssertionError e) {
+        logger.error("Assertion failed: '${str1}' does not contain '${str2}'")
+        throw e
+    }
+    return true
+}
+logger.info("Added 'assertContains' function to Suite")

--- a/regression-test/suites/ddl_p0/test_create_table_without_distribution.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_without_distribution.groovy
@@ -26,7 +26,8 @@ suite("test_create_table_without_distribution") {
     insert into test_create_table_without_distribution values(1,2);
     """
     qt_test_select "select * from test_create_table_without_distribution;"
-    qt_test_show " show create table test_create_table_without_distribution;"
+    def res1 = sql "show create table test_create_table_without_distribution;"
+    assertEquals(res1[0][1].contains("DISTRIBUTED BY RANDOM BUCKETS AUTO"), true)
 
     sql "SET enable_nereids_planner=false;"
     multi_sql """
@@ -37,7 +38,6 @@ suite("test_create_table_without_distribution") {
     insert into test_create_table_without_distribution values(1,2);
     """
     qt_test_select_old_planner "select * from test_create_table_without_distribution;"
-    qt_test_show_old_planner " show create table test_create_table_without_distribution;"
-
-
+    def res2 = sql "show create table test_create_table_without_distribution;"
+    assertEquals(res2[0][1].contains("DISTRIBUTED BY RANDOM BUCKETS AUTO"), true)
 }

--- a/regression-test/suites/ddl_p0/test_create_table_without_distribution.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_without_distribution.groovy
@@ -27,7 +27,7 @@ suite("test_create_table_without_distribution") {
     """
     qt_test_select "select * from test_create_table_without_distribution;"
     def res1 = sql "show create table test_create_table_without_distribution;"
-    assertEquals(res1[0][1].contains("DISTRIBUTED BY RANDOM BUCKETS AUTO"), true)
+    mustContain(res1[0][1], "DISTRIBUTED BY RANDOM BUCKETS AUTO")
 
     sql "SET enable_nereids_planner=false;"
     multi_sql """
@@ -39,5 +39,5 @@ suite("test_create_table_without_distribution") {
     """
     qt_test_select_old_planner "select * from test_create_table_without_distribution;"
     def res2 = sql "show create table test_create_table_without_distribution;"
-    assertEquals(res2[0][1].contains("DISTRIBUTED BY RANDOM BUCKETS AUTO"), true)
+    mustContain(res2[0][1], "DISTRIBUTED BY RANDOM BUCKETS AUTO")
 }


### PR DESCRIPTION
This pull request addresses issues in test_create_table_without_distribution.groovy by adding a mustContain function. The function checks if a string contains a specified substring, rather than verifying string equality, to prevent test failures caused by environmental variations.