### PR TITLE
[Fix](executor)Fix backend_active_tasks only scan one be

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
@@ -55,10 +55,17 @@ import java.util.Set;
 public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
 
     public static final Set<String> BACKEND_TABLE = new HashSet<>();
+    // NOTE: when add a new schema table for BackendPartitionedSchemaScanNode,
+    // you need to the table's backend column id name to BACKEND_ID_COLUMN_SET
+    // it's used to backend pruner, see computePartitionInfo;
+    public static final Set<String> BEACKEND_ID_COLUMN_SET = new HashSet<>();
 
     static {
         BACKEND_TABLE.add("rowsets");
+        BEACKEND_ID_COLUMN_SET.add("backend_id");
+
         BACKEND_TABLE.add("backend_active_tasks");
+        BEACKEND_ID_COLUMN_SET.add("be_id");
     }
 
     public static boolean isBackendPartitionedSchemaTable(String tableName) {
@@ -130,7 +137,7 @@ public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
     private void computePartitionInfo() throws AnalysisException {
         List<Column> partitionColumns = new ArrayList<>();
         for (SlotDescriptor slotDesc : desc.getSlots()) {
-            if ("BACKEND_ID".equalsIgnoreCase(slotDesc.getColumn().getName())) {
+            if (BEACKEND_ID_COLUMN_SET.contains(slotDesc.getColumn().getName().toLowerCase())) {
                 partitionColumns.add(slotDesc.getColumn());
                 break;
             }


### PR DESCRIPTION
## Proposed changes
Fix select * from backend_active_tasks but only return one random be info.

Before, only return one random be.
```

    mysql [information_schema]>select * from backend_active_tasks;
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
| BE_ID | FE_HOST    | QUERY_ID                          | TASK_TIME_MS | TASK_CPU_TIME_MS | SCAN_ROWS | SCAN_BYTES | BE_PEAK_MEMORY_BYTES | CURRENT_USED_MEMORY_BYTES | SHUFFLE_SEND_BYTES | SHUFFLE_SEND_ROWS |
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
| 10025 | 127.0.0.1 | cc95f1db96c0411c-bdc9f663c0053e6a |            3 |                0 |         0 |          0 |                95520 |                         0 |                254 |                 1 |
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
3 rows in set (0.02 sec)
```

After, could return all be INFO.
```
mysql [information_schema]>select * from backend_active_tasks;
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
| BE_ID | FE_HOST    | QUERY_ID                          | TASK_TIME_MS | TASK_CPU_TIME_MS | SCAN_ROWS | SCAN_BYTES | BE_PEAK_MEMORY_BYTES | CURRENT_USED_MEMORY_BYTES | SHUFFLE_SEND_BYTES | SHUFFLE_SEND_ROWS |
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
| 10025 | 127.0.0.1 | 41eb5302f1c243e9-addee8bc1692ce2f |            2 |                0 |         0 |          0 |                 4096 |                      4096 |                  0 |                 0 |
| 10025 | 127.0.0.1 | cc95f1db96c0411c-bdc9f663c0053e6a |            3 |                0 |         0 |          0 |                95520 |                         0 |                254 |                 1 |
| 10006 | 127.0.0.1 | 41eb5302f1c243e9-addee8bc1692ce2f |            2 |                0 |         0 |          0 |                 4096 |                      4096 |                  0 |                 0 |
+-------+------------+-----------------------------------+--------------+------------------+-----------+------------+----------------------+---------------------------+--------------------+-------------------+
3 rows in set (0.02 sec)
```