### PR TITLE
[bugfix](external)fix concurrency issues

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -372,7 +372,7 @@ public abstract class ExternalCatalog
         return allDatabases;
     }
 
-    public void onRefresh(boolean invalidCache) {
+    public synchronized void onRefresh(boolean invalidCache) {
         this.objectCreated = false;
         this.initialized = false;
         synchronized (this.propLock) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -115,7 +115,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         }
     }
 
-    public void setUnInitialized(boolean invalidCache) {
+    public synchronized void setUnInitialized(boolean invalidCache) {
         this.initialized = false;
         this.invalidCacheInInit = invalidCache;
         if (extCatalog.getUseMetaCache().isPresent()) {


### PR DESCRIPTION
## Proposed changes

issue:
```
create table tb1 (id int);
select * from tb1;
drop table tb1;
```
When executing these SQLs in a loop, there will be a probability of select failure and an error that the table cannot be found.
```
Statistics thread                       |      create/drop/select table thread
---------------------------------------------------------------------------------------------
                                        |      drop table -->  initialized = false
if (!initialized) {                     |
    get_tables();                       |
    // There is no new table here yet   |
                                        |       create table ---> initialized = false
    initialized = true;                 |
}                                       |
                                        |       select table ---> Because initialized is true at this time, the db will not be updated,
                                        |                       but there are no new tables in the db at this time, so an error will be reported here.
```



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

