### PR TITLE
[Fix](hive-writer) Fix s3 file commiter not working.

### DIFF
--- a/be/src/vec/sink/writer/vhive_partition_writer.cpp
+++ b/be/src/vec/sink/writer/vhive_partition_writer.cpp
@@ -139,9 +139,6 @@ Status VHivePartitionWriter::open(RuntimeState* state, RuntimeProfile* profile) 
 }
 
 Status VHivePartitionWriter::close(const Status& status) {
-    if (status.ok()) {
-        _state->hive_partition_updates().emplace_back(_build_partition_update());
-    }
     if (_file_format_transformer != nullptr) {
         Status st = _file_format_transformer->close();
         if (!st.ok()) {
@@ -155,6 +152,9 @@ Status VHivePartitionWriter::close(const Status& status) {
         if (!st.ok()) {
             LOG(WARNING) << fmt::format("Delete file {} failed, reason: {}", path, st.to_string());
         }
+    }
+    if (status.ok()) {
+        _state->hive_partition_updates().emplace_back(_build_partition_update());
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

### Issue
`The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed. (Service: S3, Status Code: 404, Request ID: 66557027E897233333FFC198)`

### Root cause
#35311 adjusted the order of building hive partition update information. This change caused the update id to be unable to be obtained, causing the s3 file committer to not work properly.

### Solution
Because uploading to s3 occurs after s3 file writer close(), close() must be called first, and then the build hive partiton update information is called.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

