### PR TITLE
[bugfix](iceberg)support null values as partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class IcebergTransaction implements Transaction {
 
@@ -154,9 +155,20 @@ public class IcebergTransaction implements Transaction {
             this.path = path;
             this.fileSizeInBytes = fileSizeInBytes;
             this.metrics = metrics;
-            this.partitionValues = partitionValues;
+            this.partitionValues = convertPartitionValuesForNull(partitionValues);
             this.content = content;
             this.referencedDataFiles = referencedDataFiles;
+        }
+
+        private Optional<List<String>> convertPartitionValuesForNull(Optional<List<String>> partitionValues) {
+            if (!partitionValues.isPresent()) {
+                return partitionValues;
+            }
+            List<String> values = partitionValues.get();
+            if (!values.contains("null")) {
+                return partitionValues;
+            }
+            return Optional.of(values.stream().map(s -> s.equals("null") ? null : s).collect(Collectors.toList()));
         }
 
         public String getPath() {


### PR DESCRIPTION
## Proposed changes

#31442
test in #34929


When null value is used as the partition value, BE will return the "null" string, so this string needs to be processed specially.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

