### PR TITLE
[fix](Nereids) could not push down filter through cte producer sometimes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
@@ -42,6 +42,7 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import java.util.HashSet;
 import java.util.List;
@@ -86,14 +87,17 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
             outer = (LogicalPlan) cteAnchor.child(1).accept(this, outerCascadesCtx);
             cascadesContext.getStatementContext().getRewrittenCteConsumer().put(cteAnchor.getCteId(), outer);
         }
-        boolean reserveAnchor = outer.anyMatch(p -> {
+        Set<LogicalCTEConsumer> cteConsumers = Sets.newHashSet();
+        outer.foreach(p -> {
             if (p instanceof LogicalCTEConsumer) {
                 LogicalCTEConsumer logicalCTEConsumer = (LogicalCTEConsumer) p;
-                return logicalCTEConsumer.getCteId().equals(cteAnchor.getCteId());
+                if (logicalCTEConsumer.getCteId().equals(cteAnchor.getCteId())) {
+                    cteConsumers.add(logicalCTEConsumer);
+                }
             }
-            return false;
         });
-        if (!reserveAnchor) {
+        cascadesContext.getCteIdToConsumers().put(cteAnchor.getCteId(), cteConsumers);
+        if (cteConsumers.isEmpty()) {
             return outer;
         }
         Plan producer = cteAnchor.child(0).accept(this, cascadesContext);


### PR DESCRIPTION
pick from master #35463
commit id 0632309209cc3f9b6523ef7054eb1abdb9d0e7d8

when consumer side eliminate some consumers from plan, the size of consumers is wrong. so we cannot push down some filter in producer side. this PR fix this problem by update consumer set after rewrite outer side