### PR TITLE
[bug](metrics) fix be metric doris_be_process_thread_num is zero

### DIFF
--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -338,7 +338,7 @@ void DorisMetrics::_update_process_thread_num() {
     int64_t count =
             std::count_if(dict_iter, std::filesystem::end(dict_iter), [](const auto& entry) {
                 std::error_code error_code;
-                return entry.is_regular_file(error_code) && !error_code;
+                return entry.is_directory(error_code) && !error_code;
             });
 
     process_thread_num->set_value(count);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

introdued by #26013

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

