### PR TITLE
[feature](statistics)Support partition stats cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -36,6 +36,8 @@ import org.apache.doris.qe.ShowResultSetMetaData;
 import org.apache.doris.statistics.AnalysisManager;
 import org.apache.doris.statistics.ColStatsMeta;
 import org.apache.doris.statistics.ColumnStatistic;
+import org.apache.doris.statistics.PartitionColumnStatistic;
+import org.apache.doris.statistics.PartitionColumnStatisticCacheKey;
 import org.apache.doris.statistics.ResultRow;
 import org.apache.doris.statistics.TableStatsMeta;
 
@@ -44,6 +46,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -220,6 +223,32 @@ public class ShowColumnStatsStmt extends ShowStmt {
             }
             row.add(updateRows); // update_rows
             row.add("Manual"); // trigger. Manual or System
+            result.add(row);
+        }
+        return new ShowResultSet(getMetaData(), result);
+    }
+
+    public ShowResultSet constructPartitionCachedColumnStats(
+            Map<PartitionColumnStatisticCacheKey, PartitionColumnStatistic> resultMap, TableIf tableIf) {
+        List<List<String>> result = Lists.newArrayList();
+        for (Map.Entry<PartitionColumnStatisticCacheKey, PartitionColumnStatistic> entry : resultMap.entrySet()) {
+            PartitionColumnStatisticCacheKey key = entry.getKey();
+            PartitionColumnStatistic value = entry.getValue();
+            List<String> row = Lists.newArrayList();
+            row.add(key.colName); // column_name
+            row.add(key.partId); // partition_name
+            long indexId = key.idxId;
+            String indexName = indexId == -1 ? tableIf.getName() : ((OlapTable) tableIf).getIndexNameById(indexId);
+            row.add(indexName); // index_name.
+            row.add(String.valueOf(value.count)); // count
+            row.add(String.valueOf(value.ndv.estimateCardinality())); // ndv
+            row.add(String.valueOf(value.numNulls)); // num_null
+            row.add(String.valueOf(value.minValue)); // min
+            row.add(String.valueOf(value.maxValue)); // max
+            row.add(String.valueOf(value.dataSize)); // data_size
+            row.add(value.updatedTime); // updated_time
+            row.add("N/A"); // update_rows
+            row.add("N/A"); // trigger
             result.add(row);
         }
         return new ShowResultSet(getMetaData(), result);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3178,7 +3178,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         ColStatsData data = GsonUtils.GSON.fromJson(request.colStatsData, ColStatsData.class);
         ColumnStatistic c = data.toColumnStatistic();
         if (c == ColumnStatistic.UNKNOWN) {
-            Env.getCurrentEnv().getStatisticsCache().invalidate(k.catalogId, k.dbId, k.tableId, k.idxId, k.colName);
+            Env.getCurrentEnv().getStatisticsCache().invalidate(k.catalogId, k.dbId, k.tableId,
+                    k.idxId, null, k.colName);
         } else {
             Env.getCurrentEnv().getStatisticsCache().updateColStatsCache(
                     k.catalogId, k.dbId, k.tableId, k.idxId, k.colName, c);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -703,7 +703,7 @@ public class AnalysisManager implements Writable {
                     }
                 }
                 tableStats.removeColumn(indexName, column);
-                statisticsCache.invalidate(catalogId, dbId, tableId, indexId, column);
+                statisticsCache.invalidate(catalogId, dbId, tableId, indexId, null, column);
             }
         }
         tableStats.updatedTime = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -30,9 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class ColumnStatistic {
@@ -110,7 +108,6 @@ public class ColumnStatistic {
     }
 
     public static ColumnStatistic fromResultRow(List<ResultRow> resultRows) {
-        Map<String, ColumnStatistic> partitionIdToColStats = new HashMap<>();
         ColumnStatistic columnStatistic = null;
         try {
             for (ResultRow resultRow : resultRows) {
@@ -118,7 +115,7 @@ public class ColumnStatistic {
                 if (partId == null) {
                     columnStatistic = fromResultRow(resultRow);
                 } else {
-                    partitionIdToColStats.put(partId, fromResultRow(resultRow));
+                    LOG.warn("Column statistics table shouldn't contain partition stats. [{}]", resultRow);
                 }
             }
         } catch (Throwable t) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticsCacheLoader.java
@@ -44,9 +44,8 @@ public class ColumnStatisticsCacheLoader extends BasicAsyncCacheLoader<Statistic
                     columnStatistic = table.getColumnStatistic(key.colName);
                 } catch (Exception e) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug(String.format("Exception to get column statistics by metadata."
-                                + "[Catalog:{}, DB:{}, Table:{}]",
-                                key.catalogId, key.dbId, key.tableId), e);
+                        LOG.debug("Exception to get column statistics by metadata. [Catalog:{}, DB:{}, Table:{}]",
+                                key.catalogId, key.dbId, key.tableId, e);
                     }
                 }
             }
@@ -69,7 +68,7 @@ public class ColumnStatisticsCacheLoader extends BasicAsyncCacheLoader<Statistic
     }
 
     private Optional<ColumnStatistic> loadFromStatsTable(StatisticsCacheKey key) {
-        List<ResultRow> columnResults = null;
+        List<ResultRow> columnResults;
         try {
             columnResults = StatisticsRepository.loadColStats(
                     key.catalogId, key.dbId, key.tableId, key.idxId, key.colName);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatistic.java
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.io.Hll;
+import org.apache.doris.statistics.util.Hll128;
+import org.apache.doris.statistics.util.StatisticsUtil;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class PartitionColumnStatistic {
+
+    private static final Logger LOG = LogManager.getLogger(PartitionColumnStatistic.class);
+
+    public static PartitionColumnStatistic UNKNOWN = new PartitionColumnStatisticBuilder().setAvgSizeByte(1)
+            .setNdv(new Hll128()).setNumNulls(1).setCount(1).setMaxValue(Double.POSITIVE_INFINITY)
+            .setMinValue(Double.NEGATIVE_INFINITY)
+            .setIsUnknown(true).setUpdatedTime("")
+            .build();
+
+    public static PartitionColumnStatistic ZERO = new PartitionColumnStatisticBuilder().setAvgSizeByte(0)
+            .setNdv(new Hll128()).setNumNulls(0).setCount(0).setMaxValue(Double.NaN).setMinValue(Double.NaN)
+            .build();
+
+    public final double count;
+    public final Hll128 ndv;
+    public final double numNulls;
+    public final double dataSize;
+    public final double avgSizeByte;
+    public final double minValue;
+    public final double maxValue;
+    public final boolean isUnKnown;
+    public final LiteralExpr minExpr;
+    public final LiteralExpr maxExpr;
+    public final String updatedTime;
+
+    public PartitionColumnStatistic(double count, Hll128 ndv, double avgSizeByte,
+                           double numNulls, double dataSize, double minValue, double maxValue,
+                           LiteralExpr minExpr, LiteralExpr maxExpr, boolean isUnKnown,
+                           String updatedTime) {
+        this.count = count;
+        this.ndv = ndv;
+        this.avgSizeByte = avgSizeByte;
+        this.numNulls = numNulls;
+        this.dataSize = dataSize;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.minExpr = minExpr;
+        this.maxExpr = maxExpr;
+        this.isUnKnown = isUnKnown;
+        this.updatedTime = updatedTime;
+    }
+
+    public static PartitionColumnStatistic fromResultRow(List<ResultRow> resultRows) {
+        if (resultRows == null || resultRows.isEmpty()) {
+            return PartitionColumnStatistic.UNKNOWN;
+        }
+        // This should never happen. resultRows should be empty or contain only 1 result row.
+        if (resultRows.size() > 1) {
+            StringJoiner stringJoiner = new StringJoiner("][", "[", "]");
+            for (ResultRow row : resultRows) {
+                stringJoiner.add(row.toString());
+            }
+            LOG.warn("Partition stats has more than one row, please drop stats and analyze again. {}",
+                    stringJoiner.toString());
+            return PartitionColumnStatistic.UNKNOWN;
+        }
+        try {
+            return fromResultRow(resultRows.get(0));
+        } catch (Throwable t) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Failed to deserialize column stats", t);
+            }
+            return PartitionColumnStatistic.UNKNOWN;
+        }
+    }
+
+    public static PartitionColumnStatistic fromResultRow(ResultRow row) {
+        // row : [catalog_id, db_id, tbl_id, idx_id, col_id, count, ndv, null_count, min, max, data_size, update_time]
+        try {
+            long catalogId = Long.parseLong(row.get(0));
+            long dbID = Long.parseLong(row.get(1));
+            long tblId = Long.parseLong(row.get(2));
+            long idxId = Long.parseLong(row.get(3));
+            String colName = row.get(4);
+            Column col = StatisticsUtil.findColumn(catalogId, dbID, tblId, idxId, colName);
+            if (col == null) {
+                LOG.info("Failed to deserialize column statistics, ctlId: {} dbId: {}, "
+                        + "tblId: {} column: {} not exists", catalogId, dbID, tblId, colName);
+                return PartitionColumnStatistic.UNKNOWN;
+            }
+
+            PartitionColumnStatisticBuilder partitionStatisticBuilder = new PartitionColumnStatisticBuilder();
+            double count = Double.parseDouble(row.get(5));
+            partitionStatisticBuilder.setCount(count);
+            String ndv = row.get(6);
+            Base64.Decoder decoder = Base64.getDecoder();
+            DataInputStream dis = new DataInputStream(new ByteArrayInputStream(decoder.decode(ndv)));
+            Hll hll = new Hll();
+            if (!hll.deserialize(dis)) {
+                LOG.warn("Failed to deserialize ndv. [{}]", row);
+                return PartitionColumnStatistic.UNKNOWN;
+            }
+            partitionStatisticBuilder.setNdv(Hll128.fromHll(hll));
+            String nullCount = row.getWithDefault(7, "0");
+            partitionStatisticBuilder.setNumNulls(Double.parseDouble(nullCount));
+            partitionStatisticBuilder.setDataSize(Double
+                    .parseDouble(row.getWithDefault(10, "0")));
+            partitionStatisticBuilder.setAvgSizeByte(partitionStatisticBuilder.getCount() == 0
+                    ? 0 : partitionStatisticBuilder.getDataSize()
+                    / partitionStatisticBuilder.getCount());
+            String min = row.get(8);
+            String max = row.get(9);
+            if (!"NULL".equalsIgnoreCase(min)) {
+                try {
+                    partitionStatisticBuilder.setMinValue(StatisticsUtil.convertToDouble(col.getType(), min));
+                    partitionStatisticBuilder.setMinExpr(StatisticsUtil.readableValue(col.getType(), min));
+                } catch (AnalysisException e) {
+                    LOG.warn("Failed to deserialize column {} min value {}.", col, min, e);
+                    partitionStatisticBuilder.setMinValue(Double.NEGATIVE_INFINITY);
+                }
+            } else {
+                partitionStatisticBuilder.setMinValue(Double.NEGATIVE_INFINITY);
+            }
+            if (!"NULL".equalsIgnoreCase(max)) {
+                try {
+                    partitionStatisticBuilder.setMaxValue(StatisticsUtil.convertToDouble(col.getType(), max));
+                    partitionStatisticBuilder.setMaxExpr(StatisticsUtil.readableValue(col.getType(), max));
+                } catch (AnalysisException e) {
+                    LOG.warn("Failed to deserialize column {} max value {}.", col, max, e);
+                    partitionStatisticBuilder.setMaxValue(Double.POSITIVE_INFINITY);
+                }
+            } else {
+                partitionStatisticBuilder.setMaxValue(Double.POSITIVE_INFINITY);
+            }
+            partitionStatisticBuilder.setUpdatedTime(row.get(11));
+            return partitionStatisticBuilder.build();
+        } catch (Exception e) {
+            LOG.warn("Failed to deserialize column statistics. Row [{}]", row, e);
+            return PartitionColumnStatistic.UNKNOWN;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticBuilder.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.statistics.util.Hll128;
+
+public class PartitionColumnStatisticBuilder {
+    private double count;
+    private Hll128 ndv;
+    private double avgSizeByte;
+    private double numNulls;
+    private double dataSize;
+    private double minValue = Double.NEGATIVE_INFINITY;
+    private double maxValue = Double.POSITIVE_INFINITY;
+    private LiteralExpr minExpr;
+    private LiteralExpr maxExpr;
+    private boolean isUnknown;
+    private String updatedTime;
+
+    public PartitionColumnStatisticBuilder() {
+    }
+
+    public PartitionColumnStatisticBuilder(PartitionColumnStatistic statistic) {
+        this.count = statistic.count;
+        this.ndv = statistic.ndv;
+        this.avgSizeByte = statistic.avgSizeByte;
+        this.numNulls = statistic.numNulls;
+        this.dataSize = statistic.dataSize;
+        this.minValue = statistic.minValue;
+        this.maxValue = statistic.maxValue;
+        this.minExpr = statistic.minExpr;
+        this.maxExpr = statistic.maxExpr;
+        this.isUnknown = statistic.isUnKnown;
+        this.updatedTime = statistic.updatedTime;
+    }
+
+    public PartitionColumnStatisticBuilder setCount(double count) {
+        this.count = count;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setNdv(Hll128 ndv) {
+        this.ndv = ndv;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setAvgSizeByte(double avgSizeByte) {
+        this.avgSizeByte = avgSizeByte;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setNumNulls(double numNulls) {
+        this.numNulls = numNulls;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setDataSize(double dataSize) {
+        this.dataSize = dataSize;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setMinValue(double minValue) {
+        this.minValue = minValue;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setMaxValue(double maxValue) {
+        this.maxValue = maxValue;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setMinExpr(LiteralExpr minExpr) {
+        this.minExpr = minExpr;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setMaxExpr(LiteralExpr maxExpr) {
+        this.maxExpr = maxExpr;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setIsUnknown(boolean isUnknown) {
+        this.isUnknown = isUnknown;
+        return this;
+    }
+
+    public PartitionColumnStatisticBuilder setUpdatedTime(String updatedTime) {
+        this.updatedTime = updatedTime;
+        return this;
+    }
+
+    public double getCount() {
+        return count;
+    }
+
+    public Hll128 getNdv() {
+        return ndv;
+    }
+
+    public double getAvgSizeByte() {
+        return avgSizeByte;
+    }
+
+    public double getNumNulls() {
+        return numNulls;
+    }
+
+    public double getDataSize() {
+        return dataSize;
+    }
+
+    public double getMinValue() {
+        return minValue;
+    }
+
+    public double getMaxValue() {
+        return maxValue;
+    }
+
+    public LiteralExpr getMinExpr() {
+        return minExpr;
+    }
+
+    public LiteralExpr getMaxExpr() {
+        return maxExpr;
+    }
+
+    public boolean isUnknown() {
+        return isUnknown;
+    }
+
+    public String getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public PartitionColumnStatistic build() {
+        dataSize = dataSize > 0 ? dataSize : Math.max((count - numNulls + 1) * avgSizeByte, 0);
+        return new PartitionColumnStatistic(count, ndv, avgSizeByte, numNulls,
+                dataSize, minValue, maxValue, minExpr, maxExpr,
+                isUnknown, updatedTime);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticCacheKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticCacheKey.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class PartitionColumnStatisticCacheKey {
+
+    @SerializedName("catalogId")
+    public final long catalogId;
+    @SerializedName("dbId")
+    public final long dbId;
+    @SerializedName("tableId")
+    public final long tableId;
+    @SerializedName("idxId")
+    public final long idxId;
+    @SerializedName("partId")
+    public final String partId;
+    @SerializedName("colName")
+    public final String colName;
+
+    private static final String DELIMITER = "-";
+
+    public PartitionColumnStatisticCacheKey(long catalogId, long dbId, long tableId, long idxId,
+                                       String partId, String colName) {
+        this.catalogId = catalogId;
+        this.dbId = dbId;
+        this.tableId = tableId;
+        this.idxId = idxId;
+        this.partId = partId;
+        this.colName = colName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(catalogId, dbId, tableId, idxId, colName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PartitionColumnStatisticCacheKey k = (PartitionColumnStatisticCacheKey) obj;
+        return this.catalogId == k.catalogId && this.dbId == k.dbId && this.tableId == k.tableId
+            && this.idxId == k.idxId && this.partId.equals(k.partId) && this.colName.equals(k.colName);
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner sj = new StringJoiner(DELIMITER);
+        sj.add("PartitionColumnStats");
+        sj.add(String.valueOf(catalogId));
+        sj.add(String.valueOf(dbId));
+        sj.add(String.valueOf(tableId));
+        sj.add(String.valueOf(idxId));
+        sj.add(partId);
+        sj.add(colName);
+        return sj.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatisticCacheLoader.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.qe.InternalQueryExecutionException;
+import org.apache.doris.statistics.util.StatisticsUtil;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+
+public class PartitionColumnStatisticCacheLoader extends
+        BasicAsyncCacheLoader<PartitionColumnStatisticCacheKey, Optional<PartitionColumnStatistic>> {
+
+    private static final Logger LOG = LogManager.getLogger(PartitionColumnStatisticCacheLoader.class);
+
+    @Override
+    protected Optional<PartitionColumnStatistic> doLoad(PartitionColumnStatisticCacheKey key) {
+        Optional<PartitionColumnStatistic> partitionStatistic = Optional.empty();
+        try {
+            partitionStatistic = loadFromPartitionStatsTable(key);
+        } catch (Throwable t) {
+            LOG.warn("Failed to load stats for column [Catalog:{}, DB:{}, Table:{}, Part:{}, Column:{}],"
+                    + "Reason: {}", key.catalogId, key.dbId, key.tableId, key.partId, key.colName, t.getMessage());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(t);
+            }
+        }
+        if (partitionStatistic.isPresent()) {
+            // For non-empty table, return UNKNOWN if we can't collect ndv value.
+            // Because inaccurate ndv is very misleading.
+            PartitionColumnStatistic stats = partitionStatistic.get();
+            if (stats.count > 0 && stats.ndv.estimateCardinality() == 0 && stats.count != stats.numNulls) {
+                partitionStatistic = Optional.of(PartitionColumnStatistic.UNKNOWN);
+            }
+        }
+        return partitionStatistic;
+    }
+
+    private Optional<PartitionColumnStatistic> loadFromPartitionStatsTable(PartitionColumnStatisticCacheKey key) {
+        List<ResultRow> partitionResults;
+        try {
+            partitionResults = StatisticsRepository.loadPartitionColumnStats(
+                key.catalogId, key.dbId, key.tableId, key.idxId, key.partId, key.colName);
+        } catch (InternalQueryExecutionException e) {
+            LOG.info("Failed to load stats for table {} column {}. Reason:{}",
+                    key.tableId, key.colName, e.getMessage());
+            return Optional.empty();
+        }
+        PartitionColumnStatistic partitionStatistic;
+        try {
+            partitionStatistic = StatisticsUtil.deserializeToPartitionStatistics(partitionResults);
+        } catch (Exception e) {
+            LOG.warn("Exception to deserialize partition statistics", e);
+            return Optional.empty();
+        }
+        return Optional.ofNullable(partitionStatistic);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -58,15 +58,17 @@ public class StatisticsCache {
             = ThreadPoolManager.newDaemonFixedThreadPool(
             10, Integer.MAX_VALUE, "STATS_FETCH", true);
 
-    private final ColumnStatisticsCacheLoader columnStatisticsCacheLoader = new ColumnStatisticsCacheLoader();
+    private final ColumnStatisticsCacheLoader columnStatisticCacheLoader = new ColumnStatisticsCacheLoader();
     private final HistogramCacheLoader histogramCacheLoader = new HistogramCacheLoader();
+    private final PartitionColumnStatisticCacheLoader partitionColumnStatisticCacheLoader
+            = new PartitionColumnStatisticCacheLoader();
 
     private final AsyncLoadingCache<StatisticsCacheKey, Optional<ColumnStatistic>> columnStatisticsCache =
             Caffeine.newBuilder()
                     .maximumSize(Config.stats_cache_size)
                     .refreshAfterWrite(Duration.ofHours(StatisticConstants.STATISTICS_CACHE_REFRESH_INTERVAL))
                     .executor(threadPool)
-                    .buildAsync(columnStatisticsCacheLoader);
+                    .buildAsync(columnStatisticCacheLoader);
 
     private final AsyncLoadingCache<StatisticsCacheKey, Optional<Histogram>> histogramCache =
             Caffeine.newBuilder()
@@ -74,6 +76,14 @@ public class StatisticsCache {
                     .refreshAfterWrite(Duration.ofHours(StatisticConstants.STATISTICS_CACHE_REFRESH_INTERVAL))
                     .executor(threadPool)
                     .buildAsync(histogramCacheLoader);
+
+    private final AsyncLoadingCache<PartitionColumnStatisticCacheKey, Optional<PartitionColumnStatistic>>
+            partitionColumnStatisticCache =
+            Caffeine.newBuilder()
+                .maximumSize(Config.stats_cache_size)
+                .refreshAfterWrite(Duration.ofHours(StatisticConstants.STATISTICS_CACHE_REFRESH_INTERVAL))
+                .executor(threadPool)
+                .buildAsync(partitionColumnStatisticCacheLoader);
 
     public ColumnStatistic getColumnStatistics(long catalogId, long dbId, long tblId, long idxId, String colName) {
         ConnectContext ctx = ConnectContext.get();
@@ -90,6 +100,25 @@ public class StatisticsCache {
             LOG.warn("Unexpected exception while returning ColumnStatistic", e);
         }
         return ColumnStatistic.UNKNOWN;
+    }
+
+    public PartitionColumnStatistic getPartitionColumnStatistics(long catalogId, long dbId, long tblId, long idxId,
+                                                  String partName, String colName) {
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null && ctx.getSessionVariable().internalSession) {
+            return PartitionColumnStatistic.UNKNOWN;
+        }
+        PartitionColumnStatisticCacheKey k = new PartitionColumnStatisticCacheKey(
+                catalogId, dbId, tblId, idxId, partName, colName);
+        try {
+            CompletableFuture<Optional<PartitionColumnStatistic>> f = partitionColumnStatisticCache.get(k);
+            if (f.isDone()) {
+                return f.get().orElse(PartitionColumnStatistic.UNKNOWN);
+            }
+        } catch (Exception e) {
+            LOG.warn("Unexpected exception while returning ColumnStatistic", e);
+        }
+        return PartitionColumnStatistic.UNKNOWN;
     }
 
     public Histogram getHistogram(long ctlId, long dbId, long tblId, String colName) {
@@ -113,8 +142,13 @@ public class StatisticsCache {
         return Optional.empty();
     }
 
-    public void invalidate(long ctlId, long dbId, long tblId, long idxId, String colName) {
-        columnStatisticsCache.synchronous().invalidate(new StatisticsCacheKey(ctlId, dbId, tblId, idxId, colName));
+    public void invalidate(long ctlId, long dbId, long tblId, long idxId, String partId, String colName) {
+        if (partId == null) {
+            columnStatisticsCache.synchronous().invalidate(new StatisticsCacheKey(ctlId, dbId, tblId, idxId, colName));
+        } else {
+            partitionColumnStatisticCache.synchronous().invalidate(
+                new PartitionColumnStatisticCacheKey(ctlId, dbId, tblId, idxId, partId, colName));
+        }
     }
 
     public void updateColStatsCache(long ctlId, long dbId, long tblId, long idxId, String colName,
@@ -192,7 +226,7 @@ public class StatisticsCache {
                 statsId.idxId, statsId.colId);
         ColumnStatistic columnStatistic = data.toColumnStatistic();
         if (columnStatistic == ColumnStatistic.UNKNOWN) {
-            invalidate(k.catalogId, k.dbId, k.tableId, k.idxId, k.colName);
+            invalidate(k.catalogId, k.dbId, k.tableId, k.idxId, null, k.colName);
         } else {
             putCache(k, columnStatistic);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -72,6 +72,7 @@ import org.apache.doris.statistics.ColStatsMeta;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.Histogram;
+import org.apache.doris.statistics.PartitionColumnStatistic;
 import org.apache.doris.statistics.ResultRow;
 import org.apache.doris.statistics.StatisticConstants;
 import org.apache.doris.statistics.TableStatsMeta;
@@ -185,9 +186,15 @@ public class StatisticsUtil {
         return ColumnStatistic.fromResultRow(resultBatches);
     }
 
-    public static List<Histogram> deserializeToHistogramStatistics(List<ResultRow> resultBatches)
-            throws Exception {
+    public static List<Histogram> deserializeToHistogramStatistics(List<ResultRow> resultBatches) {
         return resultBatches.stream().map(Histogram::fromResultRow).collect(Collectors.toList());
+    }
+
+    public static PartitionColumnStatistic deserializeToPartitionStatistics(List<ResultRow> resultBatches) {
+        if (CollectionUtils.isEmpty(resultBatches)) {
+            return null;
+        }
+        return PartitionColumnStatistic.fromResultRow(resultBatches);
     }
 
     public static AutoCloseConnectContext buildConnectContext() {

--- a/regression-test/suites/statistics/test_show_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_show_partition_stats.groovy
@@ -87,6 +87,36 @@ suite("test_show_partition_stats") {
 
     def result = sql """show table stats part"""
     assertEquals(1, result.size())
+    assertEquals("18", result[0][0])
+
+    sql """analyze table part with sync;"""
+    result = sql """show column cached stats part(id) partition(p1)"""
+    assertEquals(1, result.size())
+    Thread.sleep(1000)
+    for (int i = 0; i < 10; i++) {
+        result = sql """show column cached stats part(id) partition(p1)"""
+        if (result[0][3] == "6.0") {
+            logger.info("cache is ready.")
+            assertEquals("id", result[0][0])
+            assertEquals("p1", result[0][1])
+            assertEquals("part", result[0][2])
+            assertEquals("6.0", result[0][3])
+            assertEquals("6", result[0][4])
+            assertEquals("0.0", result[0][5])
+            assertEquals("1.0", result[0][6])
+            assertEquals("6.0", result[0][7])
+            assertEquals("24.0", result[0][8])
+            assertEquals("N/A", result[0][10])
+            assertEquals("N/A", result[0][11])
+            break;
+        }
+        logger.info("cache is not ready yet.")
+        Thread.sleep(1000)
+    }
+    result = sql """show column cached stats part partition(p1)"""
+    assertEquals(9, result.size())
+    result = sql """show column cached stats part partition(*)"""
+    assertEquals(27, result.size())
     sql """drop database if exists test_show_partition_stats"""
 }
 


### PR DESCRIPTION
Support cache partition level stats and show partition level cached stats.
Nereids could call StatisticsCache.getPartitionStatistics to fetch cached partition stats.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

