### PR TITLE
[fix](kerberos)enable hadoop auto renew tgt

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/Utils.java
@@ -47,6 +47,7 @@ public class Utils {
         String authentication = conf.get(Constants.HADOOP_SECURITY_AUTHENTICATION, null);
         if ("kerberos".equals(authentication)) {
             conf.set("hadoop.security.authorization", "true");
+            conf.set("hadoop.kerberos.keytab.login.autorenewal.enabled", "true");
             UserGroupInformation.setConfiguration(conf);
             String principal = conf.get(Constants.HADOOP_KERBEROS_PRINCIPAL);
             String keytab = conf.get(Constants.HADOOP_KERBEROS_KEYTAB);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -49,6 +49,8 @@ public class HdfsResource extends Resource {
     public static String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
     public static String HADOOP_KERBEROS_PRINCIPAL = "hadoop.kerberos.principal";
     public static String HADOOP_KERBEROS_AUTHORIZATION = "hadoop.security.authorization";
+    public static String HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL_ENABLED
+            = "hadoop.kerberos.keytab.login.autorenewal.enabled";
     public static String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
     public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
     public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -909,7 +909,8 @@ public class HiveMetaStoreClientHelper {
         UserGroupInformation ugi = null;
         String authentication = conf.get(HdfsResource.HADOOP_SECURITY_AUTHENTICATION, null);
         if (AuthType.KERBEROS.getDesc().equals(authentication)) {
-            conf.set("hadoop.security.authorization", "true");
+            conf.set(HdfsResource.HADOOP_KERBEROS_AUTHORIZATION, "true");
+            conf.set(HdfsResource.HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL_ENABLED, "true");
             UserGroupInformation.setConfiguration(conf);
             String principal = conf.get(HdfsResource.HADOOP_KERBEROS_PRINCIPAL);
             String keytab = conf.get(HdfsResource.HADOOP_KERBEROS_KEYTAB);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -127,6 +127,7 @@ public class DFSFileSystem extends RemoteFileSystem {
         if (AuthType.KERBEROS.getDesc().equals(
                     conf.get(HdfsResource.HADOOP_SECURITY_AUTHENTICATION, null))) {
             conf.set(HdfsResource.HADOOP_KERBEROS_AUTHORIZATION, "true");
+            conf.set(HdfsResource.HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL_ENABLED, "true");
             String principal = conf.get(HdfsResource.HADOOP_KERBEROS_PRINCIPAL);
             String keytab = conf.get(HdfsResource.HADOOP_KERBEROS_KEYTAB);
 


### PR DESCRIPTION
## Proposed changes

use hadoop properties key
enable auto renew tgt for kerberos auth, set HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL_ENABLED
change the same as https://github.com/apache/doris/pull/34439

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

