### PR TITLE
[Enhancement](group commit)Optimize be select for group commit

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -442,6 +442,13 @@ Status GroupCommitTable::_finish_group_commit_load(int64_t db_id, int64_t table_
         request.__set_db_id(db_id);
         request.__set_table_id(table_id);
         request.__set_txnId(txn_id);
+        request.__set_groupCommit(true);
+        request.__set_receiveBytes(state->num_bytes_load_total());
+        if (_exec_env->master_info()->__isset.backend_id) {
+            request.__set_backendId(_exec_env->master_info()->backend_id);
+        } else {
+            LOG(WARNING) << "_exec_env->master_info not set backend_id";
+        }
         if (state) {
             request.__set_commitInfos(state->tablet_commit_infos());
         }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2660,6 +2660,12 @@ public class Config extends ConfigBase {
     })
     public static boolean enable_advance_next_id = false;
 
+    @ConfField(description = {
+            "是否采用反馈group commit BE选择算法",
+            "Whether to use feedback group commit BE select strategy."
+    })
+    public static boolean enable_feedback_group_commit_be_select_strategy = false;
+
     // The count threshold to do manual GC when doing checkpoint but not enough memory.
     // Set zero to disable it.
     @ConfField(description = {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2660,12 +2660,6 @@ public class Config extends ConfigBase {
     })
     public static boolean enable_advance_next_id = false;
 
-    @ConfField(description = {
-            "是否采用反馈group commit BE选择算法",
-            "Whether to use feedback group commit BE select strategy."
-    })
-    public static boolean enable_feedback_group_commit_be_select_strategy = false;
-
     // The count threshold to do manual GC when doing checkpoint but not enough memory.
     // Set zero to disable it.
     @ConfField(description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/planner/CloudGroupCommitPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/planner/CloudGroupCommitPlanner.java
@@ -47,12 +47,6 @@ public class CloudGroupCommitPlanner extends GroupCommitPlanner {
         try {
             backend = Env.getCurrentEnv().getGroupCommitManager()
                     .selectBackendForGroupCommit(this.table.getId(), ctx, true);
-            if (backend != null && backend.isAlive() && !backend.isDecommissioned()
-                    && backend.getCloudClusterName().equals(ctx.getCloudCluster())) {
-                LOG.info("Group commit cloud select be {}, label is {}", backend.getId(), loadId.toString());
-            } else {
-                throw new DdlException("No suitable backend");
-            }
         } catch (LoadException e) {
             throw new DdlException("No suitable backend");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SlidingWindowCounter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SlidingWindowCounter.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+public class SlidingWindowCounter {
+    private final int windowSizeInSeconds;
+    private final int numberOfBuckets;
+    private final AtomicLongArray buckets;
+    private final AtomicLongArray bucketTimestamps;
+
+    public SlidingWindowCounter(int windowSizeInSeconds) {
+        this.windowSizeInSeconds = windowSizeInSeconds;
+        this.numberOfBuckets = windowSizeInSeconds; // Each bucket represents 1 second
+        this.buckets = new AtomicLongArray(numberOfBuckets);
+        this.bucketTimestamps = new AtomicLongArray(numberOfBuckets);
+    }
+
+    private int getCurrentBucketIndex() {
+        long currentTime = System.currentTimeMillis() / 1000; // Current time in seconds
+        return (int) (currentTime % numberOfBuckets);
+    }
+
+    private void updateCurrentBucket() {
+        long currentTime = System.currentTimeMillis() / 1000; // Current time in seconds
+        int currentBucketIndex = getCurrentBucketIndex();
+        long bucketTimestamp = bucketTimestamps.get(currentBucketIndex);
+
+        if (currentTime - bucketTimestamp >= 1) {
+            buckets.set(currentBucketIndex, 0);
+            bucketTimestamps.set(currentBucketIndex, currentTime);
+        }
+    }
+
+    public void add(long value) {
+        updateCurrentBucket();
+        int bucketIndex = getCurrentBucketIndex();
+        buckets.addAndGet(bucketIndex, value);
+    }
+
+    public long get() {
+        updateCurrentBucket();
+        long currentTime = System.currentTimeMillis() / 1000; // Current time in seconds
+        long count = 0;
+
+        for (int i = 0; i < numberOfBuckets; i++) {
+            if (currentTime - bucketTimestamps.get(i) < windowSizeInSeconds) {
+                count += buckets.get(i);
+            }
+        }
+        return count;
+    }
+
+    public String toString() {
+        return String.valueOf(get());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -408,7 +408,12 @@ public class LoadAction extends RestBaseController {
                 ctx.setQualifiedUser(Auth.ADMIN_USER);
                 ctx.setThreadLocalInfo();
 
-                backend = Env.getCurrentEnv().getGroupCommitManager().selectBackendForGroupCommit(tableId, ctx);
+                try {
+                    backend = Env.getCurrentEnv().getGroupCommitManager()
+                            .selectBackendForGroupCommit(tableId, ctx, false);
+                } catch (DdlException e) {
+                    throw new RuntimeException(e);
+                }
             } else {
                 for (Long backendId : backendIds) {
                     Backend candidateBe = Env.getCurrentSystemInfo().getBackend(backendId);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -403,8 +403,6 @@ public class LoadAction extends RestBaseController {
             ctx.setEnv(Env.getCurrentEnv());
             ctx.setThreadLocalInfo();
             ctx.setRemoteIP(request.getRemoteAddr());
-            // set user to ADMIN_USER, so that we can get the proper resource tag
-            ctx.setQualifiedUser(Auth.ADMIN_USER);
             ctx.setThreadLocalInfo();
 
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -399,29 +399,19 @@ public class LoadAction extends RestBaseController {
             throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
         }
         if (groupCommit) {
-            if (Config.enable_feedback_group_commit_be_select_strategy) {
-                ConnectContext ctx = new ConnectContext();
-                ctx.setEnv(Env.getCurrentEnv());
-                ctx.setThreadLocalInfo();
-                ctx.setRemoteIP(request.getRemoteAddr());
-                // set user to ADMIN_USER, so that we can get the proper resource tag
-                ctx.setQualifiedUser(Auth.ADMIN_USER);
-                ctx.setThreadLocalInfo();
+            ConnectContext ctx = new ConnectContext();
+            ctx.setEnv(Env.getCurrentEnv());
+            ctx.setThreadLocalInfo();
+            ctx.setRemoteIP(request.getRemoteAddr());
+            // set user to ADMIN_USER, so that we can get the proper resource tag
+            ctx.setQualifiedUser(Auth.ADMIN_USER);
+            ctx.setThreadLocalInfo();
 
-                try {
-                    backend = Env.getCurrentEnv().getGroupCommitManager()
-                            .selectBackendForGroupCommit(tableId, ctx, false);
-                } catch (DdlException e) {
-                    throw new RuntimeException(e);
-                }
-            } else {
-                for (Long backendId : backendIds) {
-                    Backend candidateBe = Env.getCurrentSystemInfo().getBackend(backendId);
-                    if (!candidateBe.isDecommissioned()) {
-                        backend = candidateBe;
-                        break;
-                    }
-                }
+            try {
+                backend = Env.getCurrentEnv().getGroupCommitManager()
+                        .selectBackendForGroupCommit(tableId, ctx, false);
+            } catch (DdlException e) {
+                throw new RuntimeException(e);
             }
         } else {
             backend = Env.getCurrentSystemInfo().getBackend(backendIds.get(0));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.rest;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -143,11 +144,16 @@ public class LoadAction extends RestBaseController {
         String sql = request.getHeader("sql");
         LOG.info("streaming load sql={}", sql);
         boolean groupCommit = false;
+        long tableId = -1;
         String groupCommitStr = request.getHeader("group_commit");
         if (groupCommitStr != null && groupCommitStr.equalsIgnoreCase("async_mode")) {
             groupCommit = true;
             try {
                 String[] pair = parseDbAndTb(sql);
+                Database db = Env.getCurrentInternalCatalog()
+                        .getDbOrException(pair[0], s -> new TException("database is invalid for dbName: " + s));
+                Table tbl = db.getTableOrException(pair[1], s -> new TException("table is invalid: " + s));
+                tableId = tbl.getId();
                 if (isGroupCommitBlock(pair[0], pair[1])) {
                     String msg = "insert table " + pair[1] + GroupCommitPlanner.SCHEMA_CHANGE;
                     return new RestBaseResult(msg);
@@ -165,7 +171,7 @@ public class LoadAction extends RestBaseController {
             }
 
             String label = request.getHeader(LABEL_KEY);
-            TNetworkAddress redirectAddr = selectRedirectBackend(request, groupCommit);
+            TNetworkAddress redirectAddr = selectRedirectBackend(request, groupCommit, tableId);
 
             LOG.info("redirect load action to destination={}, label: {}",
                     redirectAddr.toString(), label);
@@ -287,7 +293,9 @@ public class LoadAction extends RestBaseController {
                     return new RestBaseResult(e.getMessage());
                 }
             } else {
-                redirectAddr = selectRedirectBackend(request, groupCommit);
+                long tableId = ((OlapTable) ((Database) Env.getCurrentEnv().getCurrentCatalog().getDb(dbName)
+                        .get()).getTable(tableName).get()).getId();
+                redirectAddr = selectRedirectBackend(request, groupCommit, tableId);
             }
 
             LOG.info("redirect load action to destination={}, stream: {}, db: {}, tbl: {}, label: {}",
@@ -320,7 +328,7 @@ public class LoadAction extends RestBaseController {
                 return new RestBaseResult("No transaction operation(\'commit\' or \'abort\') selected.");
             }
 
-            TNetworkAddress redirectAddr = selectRedirectBackend(request, false);
+            TNetworkAddress redirectAddr = selectRedirectBackend(request, false, -1);
             LOG.info("redirect stream load 2PC action to destination={}, db: {}, txn: {}, operation: {}",
                     redirectAddr.toString(), dbName, request.getHeader(TXN_ID_KEY), txnOperation);
 
@@ -352,7 +360,7 @@ public class LoadAction extends RestBaseController {
         return "";
     }
 
-    private TNetworkAddress selectRedirectBackend(HttpServletRequest request, boolean groupCommit)
+    private TNetworkAddress selectRedirectBackend(HttpServletRequest request, boolean groupCommit, long tableId)
             throws LoadException {
         long debugBackendId = DebugPointUtil.getDebugParamOrDefault("LoadAction.selectRedirectBackend.backendId", -1L);
         if (debugBackendId != -1L) {
@@ -366,11 +374,12 @@ public class LoadAction extends RestBaseController {
             }
             return selectCloudRedirectBackend(cloudClusterName, request, groupCommit);
         } else {
-            return selectLocalRedirectBackend(groupCommit);
+            return selectLocalRedirectBackend(groupCommit, request, tableId);
         }
     }
 
-    private TNetworkAddress selectLocalRedirectBackend(boolean groupCommit) throws LoadException {
+    private TNetworkAddress selectLocalRedirectBackend(boolean groupCommit, HttpServletRequest request, long tableId)
+            throws LoadException {
         Backend backend = null;
         BeSelectionPolicy policy = null;
         String qualifiedUser = ConnectContext.get().getQualifiedUser();
@@ -390,11 +399,23 @@ public class LoadAction extends RestBaseController {
             throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
         }
         if (groupCommit) {
-            for (Long backendId : backendIds) {
-                Backend candidateBe = Env.getCurrentSystemInfo().getBackend(backendId);
-                if (!candidateBe.isDecommissioned()) {
-                    backend = candidateBe;
-                    break;
+            if (Config.enable_feedback_group_commit_be_select_strategy) {
+                ConnectContext ctx = new ConnectContext();
+                ctx.setEnv(Env.getCurrentEnv());
+                ctx.setThreadLocalInfo();
+                ctx.setRemoteIP(request.getRemoteAddr());
+                // set user to ADMIN_USER, so that we can get the proper resource tag
+                ctx.setQualifiedUser(Auth.ADMIN_USER);
+                ctx.setThreadLocalInfo();
+
+                backend = Env.getCurrentEnv().getGroupCommitManager().selectBackendForGroupCommit(tableId, ctx);
+            } else {
+                for (Long backendId : backendIds) {
+                    Backend candidateBe = Env.getCurrentSystemInfo().getBackend(backendId);
+                    if (!candidateBe.isDecommissioned()) {
+                        backend = candidateBe;
+                        break;
+                    }
                 }
             }
         } else {
@@ -573,10 +594,10 @@ public class LoadAction extends RestBaseController {
                 return new RestBaseResult("No label selected.");
             }
 
-            TNetworkAddress redirectAddr = selectRedirectBackend(request, false);
+            TNetworkAddress redirectAddr = selectRedirectBackend(request, false, -1);
 
             LOG.info("Redirect load action with auth token to destination={},"
-                        + "stream: {}, db: {}, tbl: {}, label: {}",
+                            + "stream: {}, db: {}, tbl: {}, label: {}",
                     redirectAddr.toString(), isStreamLoad, dbName, tableName, label);
 
             URI urlObj = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
@@ -208,7 +208,7 @@ public class GroupCommitManager {
                     tablePressureMap.toString());
             OlapTable table = (OlapTable) Env.getCurrentEnv().getInternalCatalog().getTableByTableId(tableId);
             if (tableToBeMap.containsKey(tableId)) {
-                if (tablePressureMap.get(tableToBeMap.get(tableId)).get() < table.getGroupCommitDataBytes()) {
+                if (tablePressureMap.get(tableId).get() < table.getGroupCommitDataBytes()) {
                     return tableToBeMap.get(tableId);
                 } else {
                     tableToBeMap.remove(tableId);
@@ -233,7 +233,7 @@ public class GroupCommitManager {
                     tablePressureMap.toString());
             OlapTable table = (OlapTable) Env.getCurrentEnv().getInternalCatalog().getTableByTableId(tableId);
             if (tableToBeMap.containsKey(tableId)) {
-                if (tablePressureMap.get(tableToBeMap.get(tableId)).get() < table.getGroupCommitDataBytes()) {
+                if (tablePressureMap.get(tableId).get() < table.getGroupCommitDataBytes()) {
                     return tableToBeMap.get(tableId);
                 } else {
                     tableToBeMap.remove(tableId);
@@ -265,9 +265,9 @@ public class GroupCommitManager {
         }
     }
 
-    public void updateLoadData(long backendId, long receiveData) {
-        if (backendId == -1) {
-            LOG.warn("invalid backend id: " + backendId);
+    public void updateLoadData(long tableId, long receiveData) {
+        if (tableId == -1) {
+            LOG.warn("invalid table id: " + tableId);
         }
         if (!Env.getCurrentEnv().isMaster()) {
             ConnectContext ctx = new ConnectContext();
@@ -277,22 +277,22 @@ public class GroupCommitManager {
             ctx.setQualifiedUser(Auth.ADMIN_USER);
             ctx.setThreadLocalInfo();
             try {
-                new MasterOpExecutor(ctx).updateLoadData(backendId, receiveData);
+                new MasterOpExecutor(ctx).updateLoadData(tableId, receiveData);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         } else {
-            updateLoadDataInternal(backendId, receiveData);
+            updateLoadDataInternal(tableId, receiveData);
         }
     }
 
-    public void updateLoadDataInternal(long backendId, long receiveData) {
-        if (tablePressureMap.containsKey(backendId)) {
-            tablePressureMap.get(backendId).add(receiveData);
-            LOG.info("Update load data for backend {}, receiveData {}, bePressureMap {}", backendId, receiveData,
+    public void updateLoadDataInternal(long tableId, long receiveData) {
+        if (tablePressureMap.containsKey(tableId)) {
+            tablePressureMap.get(tableId).add(receiveData);
+            LOG.info("Update load data for table{}, receiveData {}, tablePressureMap {}", tableId, receiveData,
                     tablePressureMap.toString());
         } else {
-            LOG.warn("can not find backend id: {}", backendId);
+            LOG.warn("can not find backend id: {}", tableId);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
@@ -223,7 +223,8 @@ public class GroupCommitManager {
             for (Backend backend : backends) {
                 if (backend.isActive() && !backend.isDecommissioned()) {
                     tableToBeMap.put(tableId, backend.getId());
-                    tablePressureMap.put(tableId, new SlidingWindowCounter(table.getGroupCommitIntervalMs()));
+                    tablePressureMap.put(tableId,
+                            new SlidingWindowCounter(table.getGroupCommitIntervalMs() / 1000 + 1));
                     return backend.getId();
                 }
             }
@@ -252,11 +253,11 @@ public class GroupCommitManager {
             for (Backend backend : backends) {
                 if (backend.isActive() && !backend.isDecommissioned()) {
                     tableToBeMap.put(tableId, backend.getId());
-                    tablePressureMap.put(tableId, new SlidingWindowCounter(table.getGroupCommitIntervalMs()));
+                    tablePressureMap.put(tableId,
+                            new SlidingWindowCounter(table.getGroupCommitIntervalMs() / 1000 + 1));
                     return backend.getId();
                 }
             }
-
             List<String> backendsInfo = backends.stream()
                     .map(be -> "{ beId=" + be.getId() + ", alive=" + be.isAlive() + ", active=" + be.isActive()
                             + ", decommission=" + be.isDecommissioned() + " }")

--- a/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
@@ -206,7 +206,6 @@ public class GroupCommitManager {
 
     public long selectBackendForGroupCommitInternal(long tableId, String cluster, boolean isCloud)
             throws LoadException, DdlException {
-        // 
         return isCloud ? selectBackendForCloudGroupCommitInternal(tableId, cluster)
                 : selectBackendForLocalGroupCommitInternal(tableId);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
-import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.LoadException;
@@ -72,8 +73,8 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
     protected void beforeExec() {
         try {
             this.coordinator.setGroupCommitBe(Env.getCurrentEnv().getGroupCommitManager()
-                    .selectBackendForGroupCommit(table.getId(), ctx));
-        } catch (LoadException e) {
+                    .selectBackendForGroupCommit(table.getId(), ctx, false));
+        } catch (LoadException | DdlException e) {
             throw new RuntimeException(e);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -18,11 +18,13 @@
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.LoadException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mtmv.MTMVUtil;
 import org.apache.doris.nereids.NereidsPlanner;
@@ -64,6 +66,16 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
                 && tableSink.getPartitions().isEmpty()
                 && (!(table instanceof MTMV) || MTMVUtil.allowModifyMTMVData(ctx))
                 && (tableSink.child() instanceof OneRowRelation || tableSink.child() instanceof LogicalUnion));
+    }
+
+    @Override
+    protected void beforeExec() {
+        try {
+            this.coordinator.setGroupCommitBe(Env.getCurrentEnv().getGroupCommitManager()
+                    .selectBackendForGroupCommit(table.getId(), ctx));
+        } catch (LoadException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
@@ -149,11 +149,6 @@ public class GroupCommitPlanner {
         try {
             backend = Env.getCurrentEnv().getGroupCommitManager()
                     .selectBackendForGroupCommit(this.table.getId(), ctx, false);
-            if (backend != null && backend.isAlive() && !backend.isDecommissioned()) {
-                LOG.info("Group commit new strategy select be {}, label is {}", backend.getId(), loadId.toString());
-            } else {
-                throw new DdlException("No suitable backend");
-            }
         } catch (LoadException e) {
             throw new DdlException("No suitable backend");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
@@ -25,8 +25,10 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FormatOptions;
+import org.apache.doris.common.LoadException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.InternalService.PGroupCommitInsertRequest;
@@ -147,28 +149,38 @@ public class GroupCommitPlanner {
 
     // cloud override
     protected void selectBackends(ConnectContext ctx) throws DdlException {
-        backend = ctx.getInsertGroupCommit(this.table.getId());
-        if (backend != null && backend.isAlive() && !backend.isDecommissioned()) {
-            return;
-        }
-
-        List<Long> allBackendIds = Env.getCurrentSystemInfo().getAllBackendIds(true);
-        if (allBackendIds.isEmpty()) {
-            throw new DdlException("No alive backend");
-        }
-        Collections.shuffle(allBackendIds);
-        for (Long beId : allBackendIds) {
-            backend = Env.getCurrentSystemInfo().getBackend(beId);
-            if (!backend.isDecommissioned()) {
-                ctx.setInsertGroupCommit(this.table.getId(), backend);
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("choose new be {}", backend.getId());
-                }
+        if (Config.enable_feedback_group_commit_be_select_strategy) {
+            try {
+                backend = Env.getCurrentEnv().getGroupCommitManager()
+                        .selectBackendForGroupCommit(this.table.getId(), ctx);
+                LOG.info("Group commit new strategy select be {}, label is {}", backend.getId(), loadId.toString());
+            } catch (LoadException e) {
+                throw new DdlException("No suitable backend");
+            }
+        } else {
+            backend = ctx.getInsertGroupCommit(this.table.getId());
+            if (backend != null && backend.isAlive() && !backend.isDecommissioned()) {
                 return;
             }
-        }
 
-        throw new DdlException("No suitable backend");
+            List<Long> allBackendIds = Env.getCurrentSystemInfo().getAllBackendIds(true);
+            if (allBackendIds.isEmpty()) {
+                throw new DdlException("No alive backend");
+            }
+            Collections.shuffle(allBackendIds);
+            for (Long beId : allBackendIds) {
+                backend = Env.getCurrentSystemInfo().getBackend(beId);
+                if (!backend.isDecommissioned()) {
+                    ctx.setInsertGroupCommit(this.table.getId(), backend);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("choose new be {}", backend.getId());
+                    }
+                    return;
+                }
+            }
+
+            throw new DdlException("No suitable backend");
+        }
     }
 
     public Backend getBackend() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -268,6 +268,8 @@ public class Coordinator implements CoordInterface {
 
     private boolean useNereids = false;
 
+    private Backend groupCommitBackend;
+
     // Runtime filter merge instance address and ID
     public TNetworkAddress runtimeFilterMergeAddr;
     public TUniqueId runtimeFilterMergeInstanceId;
@@ -293,6 +295,10 @@ public class Coordinator implements CoordInterface {
     // A countdown latch to mark the completion of each fragment. use for pipelineX
     // fragmentid -> backendid
     private MarkedCountDownLatch<Integer, Long> fragmentsDoneLatch = null;
+
+    public void setGroupCommitBe(Backend backend) {
+        this.groupCommitBackend = backend;
+    }
 
     public void setTWorkloadGroups(List<TPipelineWorkloadGroup> tWorkloadGroups) {
         this.tWorkloadGroups = tWorkloadGroups;
@@ -1716,8 +1722,11 @@ public class Coordinator implements CoordInterface {
             if (fragment.getDataPartition() == DataPartition.UNPARTITIONED) {
                 Reference<Long> backendIdRef = new Reference<Long>();
                 TNetworkAddress execHostport;
-                if (((ConnectContext.get() != null && ConnectContext.get().isResourceTagsSet()) || (isAllExternalScan
-                        && Config.prefer_compute_node_for_external_table)) && !addressToBackendID.isEmpty()) {
+                if (groupCommitBackend != null) {
+                    execHostport = getGroupCommitBackend(addressToBackendID);
+                } else if (((ConnectContext.get() != null && ConnectContext.get().isResourceTagsSet()) || (
+                        isAllExternalScan
+                                && Config.prefer_compute_node_for_external_table)) && !addressToBackendID.isEmpty()) {
                     // 2 cases:
                     // case 1: user set resource tag, we need to use the BE with the specified resource tags.
                     // case 2: All scan nodes are external scan node,
@@ -1908,7 +1917,9 @@ public class Coordinator implements CoordInterface {
             if (params.instanceExecParams.isEmpty()) {
                 Reference<Long> backendIdRef = new Reference<Long>();
                 TNetworkAddress execHostport;
-                if (ConnectContext.get() != null && ConnectContext.get().isResourceTagsSet()
+                if (groupCommitBackend != null) {
+                    execHostport = getGroupCommitBackend(addressToBackendID);
+                } else if (ConnectContext.get() != null && ConnectContext.get().isResourceTagsSet()
                         && !addressToBackendID.isEmpty()) {
                     // In this case, we only use the BE where the replica selected by the tag is located to
                     // execute this query. Otherwise, except for the scan node, the rest of the execution nodes
@@ -1930,6 +1941,14 @@ public class Coordinator implements CoordInterface {
                 params.instanceExecParams.add(instanceParam);
             }
         }
+    }
+
+    private TNetworkAddress getGroupCommitBackend(Map<TNetworkAddress, Long> addressToBackendID) {
+        // Used for Nereids planner Group commit insert BE select.
+        TNetworkAddress execHostport = new TNetworkAddress(groupCommitBackend.getHost(),
+                groupCommitBackend.getBePort());
+        addressToBackendID.put(execHostport, groupCommitBackend.getId());
+        return execHostport;
     }
 
     // Traverse the expected runtimeFilterID in each fragment, and establish the corresponding relationship

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -101,6 +101,17 @@ public class MasterOpExecutor {
         waitOnReplaying();
     }
 
+    public long getGroupCommitLoadBeId(long tableId) throws Exception {
+        result = forward(buildGetGroupCommitLoadBeIdParmas(tableId));
+        waitOnReplaying();
+        return result.groupCommitLoadBeId;
+    }
+
+    public void updateLoadData(long backendId, long receiveData) throws Exception {
+        result = forward(buildUpdateLoadDataParams(backendId, receiveData));
+        waitOnReplaying();
+    }
+
     public void cancel() throws Exception {
         TUniqueId queryId = ctx.queryId();
         if (queryId == null) {
@@ -225,6 +236,35 @@ public class MasterOpExecutor {
         params.setClientNodeHost(Env.getCurrentEnv().getSelfNode().getHost());
         params.setClientNodePort(Env.getCurrentEnv().getSelfNode().getPort());
         params.setSyncJournalOnly(true);
+        params.setDb(ctx.getDatabase());
+        params.setUser(ctx.getQualifiedUser());
+        // just make the protocol happy
+        params.setSql("");
+        return params;
+    }
+
+    private TMasterOpRequest buildGetGroupCommitLoadBeIdParmas(long tableId) {
+        final TMasterOpRequest params = new TMasterOpRequest();
+        // node ident
+        params.setClientNodeHost(Env.getCurrentEnv().getSelfNode().getHost());
+        params.setClientNodePort(Env.getCurrentEnv().getSelfNode().getPort());
+        params.setGetGroupCommitLoadBeId(true);
+        params.setGroupCommitLoadTableId(tableId);
+        params.setDb(ctx.getDatabase());
+        params.setUser(ctx.getQualifiedUser());
+        // just make the protocol happy
+        params.setSql("");
+        return params;
+    }
+
+    private TMasterOpRequest buildUpdateLoadDataParams(long backendId, long receiveData) {
+        final TMasterOpRequest params = new TMasterOpRequest();
+        // node ident
+        params.setClientNodeHost(Env.getCurrentEnv().getSelfNode().getHost());
+        params.setClientNodePort(Env.getCurrentEnv().getSelfNode().getPort());
+        params.setUpdateLoadData(true);
+        params.setBackendId(backendId);
+        params.setReceiveData(receiveData);
         params.setDb(ctx.getDatabase());
         params.setUser(ctx.getQualifiedUser());
         // just make the protocol happy

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -108,8 +108,8 @@ public class MasterOpExecutor {
         return result.groupCommitLoadBeId;
     }
 
-    public void updateLoadData(long backendId, long receiveData) throws Exception {
-        result = forward(buildUpdateLoadDataParams(backendId, receiveData));
+    public void updateLoadData(long tableId, long receiveData) throws Exception {
+        result = forward(buildUpdateLoadDataParams(tableId, receiveData));
         waitOnReplaying();
     }
 
@@ -263,10 +263,10 @@ public class MasterOpExecutor {
         return params;
     }
 
-    private TMasterOpRequest buildUpdateLoadDataParams(long backendId, long receiveData) {
+    private TMasterOpRequest buildUpdateLoadDataParams(long tableId, long receiveData) {
         final TGroupCommitInfo groupCommitParams = new TGroupCommitInfo();
         groupCommitParams.setUpdateLoadData(true);
-        groupCommitParams.setBackendId(backendId);
+        groupCommitParams.setTableId(tableId);
         groupCommitParams.setReceiveData(receiveData);
 
         final TMasterOpRequest params = new TMasterOpRequest();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1050,7 +1050,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             final TGroupCommitInfo info = params.getGroupCommitInfo();
             final TMasterOpResult result = new TMasterOpResult();
             Env.getCurrentEnv().getGroupCommitManager()
-                    .updateLoadData(info.backendId, info.receiveData);
+                    .updateLoadData(info.tableId, info.receiveData);
             // just make the protocol happy
             result.setPacket("".getBytes());
             return result;
@@ -1655,8 +1655,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         if (request.groupCommit) {
             try {
-                long backendId = request.getBackendId();
-                Env.getCurrentEnv().getGroupCommitManager().updateLoadData(backendId, request.receiveBytes);
+                Env.getCurrentEnv().getGroupCommitManager().updateLoadData(request.table_id, request.receiveBytes);
             } catch (Exception e) {
                 LOG.warn("Failed to update group commit load data, {}", e.getMessage());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -173,6 +173,7 @@ import org.apache.doris.thrift.TGetTablesParams;
 import org.apache.doris.thrift.TGetTablesResult;
 import org.apache.doris.thrift.TGetTabletReplicaInfosRequest;
 import org.apache.doris.thrift.TGetTabletReplicaInfosResult;
+import org.apache.doris.thrift.TGroupCommitInfo;
 import org.apache.doris.thrift.TInitExternalCtlMetaRequest;
 import org.apache.doris.thrift.TInitExternalCtlMetaResult;
 import org.apache.doris.thrift.TInvalidateFollowerStatsCacheRequest;
@@ -1032,22 +1033,24 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setPacket("".getBytes());
             return result;
         }
-        if (params.isGetGroupCommitLoadBeId()) {
+        if (params.getGroupCommitInfo().isGetGroupCommitLoadBeId()) {
+            final TGroupCommitInfo info = params.getGroupCommitInfo();
             final TMasterOpResult result = new TMasterOpResult();
             try {
                 result.setGroupCommitLoadBeId(Env.getCurrentEnv().getGroupCommitManager()
-                        .selectBackendForGroupCommitInternal(params.groupCommitLoadTableId));
-            } catch (LoadException e) {
+                        .selectBackendForGroupCommitInternal(info.groupCommitLoadTableId, info.cluster, info.isCloud));
+            } catch (LoadException | DdlException e) {
                 throw new TException(e.getMessage());
             }
             // just make the protocol happy
             result.setPacket("".getBytes());
             return result;
         }
-        if (params.isUpdateLoadData()) {
+        if (params.getGroupCommitInfo().isUpdateLoadData()) {
+            final TGroupCommitInfo info = params.getGroupCommitInfo();
             final TMasterOpResult result = new TMasterOpResult();
             Env.getCurrentEnv().getGroupCommitManager()
-                    .updateLoadData(params.backendId, params.receiveData);
+                    .updateLoadData(info.backendId, info.receiveData);
             // just make the protocol happy
             result.setPacket("".getBytes());
             return result;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -573,6 +573,11 @@ struct TMasterOpRequest {
     28: optional map<string, Exprs.TExprNode> user_variables
     // transaction load
     29: optional TTxnLoadInfo txnLoadInfo
+    30: optional bool getGroupCommitLoadBeId
+    31: optional i64 groupCommitLoadTableId
+    32: optional bool updateLoadData
+    33: optional i64 backendId
+    34: optional i64 receiveData
 
     // selectdb cloud
     1000: optional string cloud_cluster
@@ -606,6 +611,7 @@ struct TMasterOpResult {
     8: optional list<binary> queryResultBufList;
     // transaction load
     9: optional TTxnLoadInfo txnLoadInfo;
+    10: optional i64 groupCommitLoadBeId;
 }
 
 struct TUpdateExportTaskStatusRequest {
@@ -817,6 +823,9 @@ struct TLoadTxnCommitRequest {
     15: optional list<string> tbls
     16: optional i64 table_id
     17: optional string auth_code_uuid
+    18: optional bool groupCommit
+    19: optional i64 receiveBytes
+    20: optional i64 backendId 
 }
 
 struct TLoadTxnCommitResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -546,7 +546,7 @@ struct TGroupCommitInfo{
     3: optional string cluster
     4: optional bool isCloud
     5: optional bool updateLoadData
-    6: optional i64 backendId
+    6: optional i64 tableId 
     7: optional i64 receiveData
 }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -540,6 +540,16 @@ struct TTxnLoadInfo {
     6: optional list<TSubTxnInfo> subTxnInfos
 }
 
+struct TGroupCommitInfo{
+    1: optional bool getGroupCommitLoadBeId
+    2: optional i64 groupCommitLoadTableId
+    3: optional string cluster
+    4: optional bool isCloud
+    5: optional bool updateLoadData
+    6: optional i64 backendId
+    7: optional i64 receiveData
+}
+
 struct TMasterOpRequest {
     1: required string user
     2: required string db
@@ -573,11 +583,7 @@ struct TMasterOpRequest {
     28: optional map<string, Exprs.TExprNode> user_variables
     // transaction load
     29: optional TTxnLoadInfo txnLoadInfo
-    30: optional bool getGroupCommitLoadBeId
-    31: optional i64 groupCommitLoadTableId
-    32: optional bool updateLoadData
-    33: optional i64 backendId
-    34: optional i64 receiveData
+    30: optional TGroupCommitInfo groupCommitInfo
 
     // selectdb cloud
     1000: optional string cloud_cluster


### PR DESCRIPTION
1. Streamload and insert into, if batched and sent to the master FE, should use a consistent BE strategy (previously, insert into reused the first selected BE, while streamload used round robin). First, a map <table id, be id> records a fixed be id for a certain table. The first time a table is imported, a BE is randomly selected, and this table id and be id are recorded in the map permanently. Subsequently, all data imported into this table will select the BE corresponding to the table id recorded in the map. This ensures that batching is maximized to a single BE.
To address the issue of excessive load on a single BE, a variable similar to a bvar window is used to monitor the total data volume sent to a specific BE for a specific table during the batch interval (default 10 seconds). A second map <be id, window variable> is used to track this. If a new import finds that its corresponding BE's window variable is less than a certain value (e.g., 1G), the new import continues to be sent to the corresponding BE according to map1. If it exceeds this value, the new import is sent to another BE with the smallest window variable value, and map1 is updated. If every BE exceeds this value, the one with the smallest value is still chosen. This helps to alleviate excessive pressure on a single BE.

2. For streamload, if batched and sent to a BE, it will batch directly on this BE and will commit the transaction at the end of the import. At this point, a request is sent to the FE, which records the size of this import and adds it to the window variable.

3. Streamload sent to observer FE, as well as insert into sent to observer FE, follow the logic in 1 by RPC, passing the table id to the master FE to obtain the selected be id.

