### PR TITLE
[feature](fe) Advance the next id before transfering to master

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2371,6 +2371,14 @@ public class Config extends ConfigBase {
     })
     public static boolean enable_proxy_protocol = false;
 
+    // Advance the next id before transferring to the master.
+    @ConfField(description = {
+            "是否在成为 Master 后推进 ID 分配器，保证即使回滚元数据时，它也不会回滚",
+            "Whether to advance the ID generator after becoming Master to ensure that the id "
+                    + "generator will not be rolled back even when metadata is rolled back."
+    })
+    public static boolean enable_advance_next_id = false;
+
     @ConfField(description = {"Stream_Load 导入时，label 被限制的最大长度",
             "Stream_Load When importing, the maximum length of label is limited"})
     public static int label_regex_length = 128;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaIdGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MetaIdGenerator.java
@@ -74,8 +74,7 @@ public class MetaIdGenerator {
         }
     }
 
-    // just for checkpoint, so no need to synchronize
-    public long getBatchEndId() {
+    public synchronized long getBatchEndId() {
         return batchEndId;
     }
 


### PR DESCRIPTION
If the FE metadata needs to be rolled back (such as time travel) and the ID generator is rolled back, the corresponding relationship of the metadata in BE/MS may be abnormal. This patch attempts to use the latest timestamp to advance the next id of ID generator before becoming master each time. This can ensure that in most scenarios, the rollback of metadata will not cause the ID generator to be rolled back.

Cherry-pick #33817
