### PR TITLE
[fix](Nereids) remove getTableInMinidumpCache temporary

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -148,13 +148,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
         List<String> tableQualifier = RelationUtil.getQualifierName(cascadesContext.getConnectContext(),
                 unboundRelation.getNameParts());
         TableIf table = null;
-        if (!CollectionUtils.isEmpty(cascadesContext.getTables())) {
-            table = cascadesContext.getTableInMinidumpCache(tableName);
-        }
-        if (table == null) {
-            if (customTableResolver.isPresent()) {
-                table = customTableResolver.get().apply(tableQualifier);
-            }
+        if (customTableResolver.isPresent()) {
+            table = customTableResolver.get().apply(tableQualifier);
         }
         // In some cases even if we have already called the "cascadesContext.getTableByName",
         // it also gets the null. So, we just check it in the catalog again for safety.

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/minidump/MinidumpUtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/minidump/MinidumpUtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.minidump;
 
 import org.json.JSONObject;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
  */
 class MinidumpUtTest {
 
+    @Disabled
     @Test
     public void testMinidumpUt() {
         Minidump minidump = null;


### PR DESCRIPTION
bug introduced by #18747

getTableInMinidumpCache use wrong way to compare table's qualified name. we remove it temporary since it not use in productive env anymore
