### PR TITLE
[fix](Nereids) remove getTableInMinidumpCache temporary

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -143,13 +143,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
         List<String> tableQualifier = RelationUtil.getQualifierName(cascadesContext.getConnectContext(),
                 unboundRelation.getNameParts());
         TableIf table = null;
-        if (!CollectionUtils.isEmpty(cascadesContext.getTables())) {
-            table = cascadesContext.getTableByName(tableName);
-        }
-        if (table == null) {
-            if (customTableResolver.isPresent()) {
-                table = customTableResolver.get().apply(tableQualifier);
-            }
+        if (customTableResolver.isPresent()) {
+            table = customTableResolver.get().apply(tableQualifier);
         }
         // In some cases even if we have already called the "cascadesContext.getTableByName",
         // it also gets the null. So, we just check it in the catalog again for safety.


### PR DESCRIPTION
pick from master #35571

bug introduced by #18747

getTableInMinidumpCache use wrong way to compare table's qualified name. we remove it temporary since it not use in productive env anymore

