### PR TITLE
[FE](session-variable) Add a debug variable of constant fold

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -119,6 +119,8 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
     public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {
         return ImmutableList.of(
                 root(Expression.class)
+                        .whenCtx(ctx -> !ctx.cascadesContext.getConnectContext().getSessionVariable()
+                                .isDebugSkipFoldConstant())
                         .whenCtx(FoldConstantRuleOnBE::isEnableFoldByBe)
                         .thenApply(FoldConstantRuleOnBE::foldByBE)
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -690,6 +690,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
     private <E extends Expression> ExpressionPatternMatcher<? extends Expression> matches(
             Class<E> clazz, BiFunction<E, ExpressionRewriteContext, Expression> visitMethod) {
         return matchesType(clazz)
+                .whenCtx(ctx -> !ctx.cascadesContext.getConnectContext().getSessionVariable()
+                        .isDebugSkipFoldConstant())
                 .whenCtx(NOT_UNDER_AGG_DISTINCT.as())
                 .thenApply(ctx -> visitMethod.apply(ctx.expr, ctx.rewriteContext));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -135,6 +135,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String PREFER_JOIN_METHOD = "prefer_join_method";
 
     public static final String ENABLE_FOLD_CONSTANT_BY_BE = "enable_fold_constant_by_be";
+    public static final String DEBUG_SKIP_FOLD_CONSTANT = "debug_skip_fold_constant";
 
     public static final String ENABLE_REWRITE_ELEMENT_AT_TO_SLOT = "enable_rewrite_element_at_to_slot";
     public static final String ENABLE_ODBC_TRANSCATION = "enable_odbc_transcation";
@@ -999,6 +1000,8 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_FOLD_CONSTANT_BY_BE, fuzzy = true)
     public boolean enableFoldConstantByBe = true;
+    @VariableMgr.VarAttr(name = DEBUG_SKIP_FOLD_CONSTANT)
+    public boolean debugSkipFoldConstant = false;
 
     @VariableMgr.VarAttr(name = ENABLE_REWRITE_ELEMENT_AT_TO_SLOT, fuzzy = true)
     private boolean enableRewriteElementAtToSlot = true;
@@ -2491,6 +2494,10 @@ public class SessionVariable implements Serializable, Writable {
         return enableFoldConstantByBe;
     }
 
+    public boolean isDebugSkipFoldConstant() {
+        return debugSkipFoldConstant;
+    }
+
     public boolean isEnableRewriteElementAtToSlot() {
         return enableRewriteElementAtToSlot;
     }
@@ -2505,6 +2512,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnableFoldConstantByBe(boolean foldConstantByBe) {
         this.enableFoldConstantByBe = foldConstantByBe;
+    }
+
+    public void setDebugSkipFoldConstant(boolean debugSkipFoldConstant) {
+        this.debugSkipFoldConstant = debugSkipFoldConstant;
     }
 
     public int getParallelExecInstanceNum() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1424,7 +1424,8 @@ public class StmtExecutor {
             }
             ExprRewriter rewriter = analyzer.getExprRewriter();
             rewriter.reset();
-            if (context.getSessionVariable().isEnableFoldConstantByBe()) {
+            if (context.getSessionVariable().isEnableFoldConstantByBe()
+                    && !context.getSessionVariable().isDebugSkipFoldConstant()) {
                 // fold constant expr
                 parsedStmt.foldConstant(rewriter, tQueryOptions);
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

which force skip constant fold in nereids. make it easier for test, especially for SqlLogic platform

```sql
mysql> desc select date_add('2020-12-12', interval 1 day);
+---------------------------------+
| Explain String(Nereids Planner) |
+---------------------------------+
| PLAN FRAGMENT 0                 |
|   OUTPUT EXPRS:                 |
|     '2020-12-13 00:00:00'[#0]   |
|   PARTITION: UNPARTITIONED      |
|                                 |
|   HAS_COLO_PLAN_NODE: false     |
|                                 |
|   VRESULT SINK                  |
|      MYSQL_PROTOCAL             |
|                                 |
|   0:VUNION(32)                  |
|      constant exprs:            |
|          '2020-12-13 00:00:00'  |
+---------------------------------+
13 rows in set (0.18 sec)

mysql> set debug_skip_fold_constant=true;
Query OK, 0 rows affected (0.10 sec)

mysql> desc select date_add('2020-12-12', interval 1 day);
+-----------------------------------------------------------+
| Explain String(Nereids Planner)                           |
+-----------------------------------------------------------+
| PLAN FRAGMENT 0                                           |
|   OUTPUT EXPRS:                                           |
|     days_add(cast('2020-12-12' as DATETIMEV2(0)), 1)[#0]  |
|   PARTITION: UNPARTITIONED                                |
|                                                           |
|   HAS_COLO_PLAN_NODE: false                               |
|                                                           |
|   VRESULT SINK                                            |
|      MYSQL_PROTOCAL                                       |
|                                                           |
|   0:VUNION(30)                                            |
|      constant exprs:                                      |
|          days_add(CAST('2020-12-12' AS DATETIMEV2(0)), 1) |
+-----------------------------------------------------------+
13 rows in set (0.11 sec)
```
