### PR TITLE
[fix](Nereids) adjust nullable for set operation may cause IndexOutOfBound

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AdjustNullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AdjustNullable.java
@@ -168,7 +168,7 @@ public class AdjustNullable extends DefaultPlanRewriter<Map<ExprId, Slot>> imple
         ImmutableList.Builder<List<SlotReference>> newChildrenOutputs = ImmutableList.builder();
         List<Boolean> inputNullable = null;
         if (!setOperation.children().isEmpty()) {
-            inputNullable = setOperation.child(0).getOutput().stream()
+            inputNullable = setOperation.getRegularChildOutput(0).stream()
                     .map(ExpressionTrait::nullable).collect(Collectors.toList());
             for (int i = 0; i < setOperation.arity(); i++) {
                 List<Slot> childOutput = setOperation.child(i).getOutput();

--- a/regression-test/suites/nereids_rules_p0/adjust_nullable/set_operation.groovy
+++ b/regression-test/suites/nereids_rules_p0/adjust_nullable/set_operation.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_set_operation_adjust_nullable") {
+
+    sql """
+        DROP TABLE IF EXISTS t1
+    """
+    sql """
+        DROP TABLE IF EXISTS t2
+    """
+
+    sql """
+        CREATE TABLE t1(c1 varchar) DISTRIBUTED BY hash(c1) PROPERTIES ("replication_num" = "1");
+    """
+
+    sql """
+        CREATE TABLE t2(c2 date) DISTRIBUTED BY hash(c2) PROPERTIES ("replication_num" = "1");
+    """
+
+    sql """
+        insert into t1 values('+06-00');
+    """
+
+    sql """
+        insert into t2 values('1990-11-11');
+    """
+
+    sql """
+        SELECT c1, c1 FROM t1 MINUS SELECT c2, c2 FROM t2;
+    """
+}


### PR DESCRIPTION
after we refactor set oepration, let it has projection ability, its output size may diff with its child's output size. so we should use it output size as nullable flag list size to ensure it has same size with set operation's output.