### PR TITLE
[feature](table write) Avoid redundant validation of the block

### DIFF
--- a/be/src/vec/sink/vrow_distribution.h
+++ b/be/src/vec/sink/vrow_distribution.h
@@ -123,6 +123,7 @@ public:
     // mv where clause
     // v1 needs index->node->row_ids - tabletids
     // v2 needs index,tablet->rowids
+    template <bool need_validate_block = true>
     Status generate_rows_distribution(vectorized::Block& input_block,
                                       std::shared_ptr<vectorized::Block>& block,
                                       int64_t& filtered_rows, bool& has_filtered_rows,

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1367,7 +1367,8 @@ Status VTabletWriter::_send_new_partition_batch() {
         //  2. deal batched block
         //  3. now reuse the column of lval block. cuz write doesn't real adjust it. it generate a new block from that.
         _row_distribution.clear_batching_stats();
-        RETURN_IF_ERROR(this->write(tmp_block));
+        // The _batching_block has already been checked, so there is no need to validate its again.
+        RETURN_IF_ERROR(this->_write_impl<false>(tmp_block));
         _row_distribution._batching_block->set_mutable_columns(
                 tmp_block.mutate_columns()); // Recovery back
         _row_distribution._batching_block->clear_column_data();
@@ -1666,7 +1667,8 @@ void VTabletWriter::_generate_index_channels_payloads(
     }
 }
 
-Status VTabletWriter::write(doris::vectorized::Block& input_block) {
+template <bool need_validate_block>
+Status VTabletWriter::_write_impl(doris::vectorized::Block& input_block) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
     Status status = Status::OK();
 
@@ -1699,7 +1701,7 @@ Status VTabletWriter::write(doris::vectorized::Block& input_block) {
     DorisMetrics::instance()->load_bytes->increment(bytes);
 
     _row_distribution_watch.start();
-    RETURN_IF_ERROR(_row_distribution.generate_rows_distribution(
+    RETURN_IF_ERROR(_row_distribution.generate_rows_distribution<need_validate_block>(
             input_block, block, filtered_rows, has_filtered_rows, _row_part_tablet_ids,
             _number_input_rows));
 

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -545,7 +545,7 @@ class VTabletWriter final : public AsyncResultWriter {
 public:
     VTabletWriter(const TDataSink& t_sink, const VExprContextSPtrs& output_exprs);
 
-    Status write(Block& block) override;
+    Status write(Block& block) override { return _write_impl(block); }
 
     Status close(Status) override;
 
@@ -570,6 +570,9 @@ private:
     Status _init_row_distribution();
 
     Status _init(RuntimeState* state, RuntimeProfile* profile);
+
+    template <bool need_validate_block = true>
+    Status _write_impl(Block& block);
 
     void _generate_one_index_channel_payload(RowPartTabletIds& row_part_tablet_tuple,
                                              int32_t index_idx,

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -106,7 +106,7 @@ public:
 
     ~VTabletWriterV2() override;
 
-    Status write(Block& block) override;
+    Status write(Block& block) override { return _write_impl(block); }
 
     Status open(RuntimeState* state, RuntimeProfile* profile) override;
 
@@ -125,6 +125,9 @@ private:
     Status _init_row_distribution();
 
     Status _init(RuntimeState* state, RuntimeProfile* profile);
+
+    template <bool need_validate_block = true>
+    Status _write_impl(Block& block);
 
     Status _open_streams();
 


### PR DESCRIPTION
## Proposed changes

The _batching_block has already been processed by the validate_and_convert_block function, so redundant validation should be avoided.

<!--Describe your changes.-->

