### PR TITLE
[chore](FE) Fix issues with the activation of profile protoc_rosetta

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -63,7 +63,7 @@ under the License.
             <id>protoc_rosetta</id>
             <activation>
                 <os>
-                    <name>Mac OS X</name>
+                    <family>mac</family>
                     <arch>aarch64</arch>
                 </os>
             </activation>


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

The profile `protoc_rosetta` can not be activated and causes build failures on macOS (arm64) when using maven (>= 3.9.7) to build FE.
Change the conditions for activation to fix this issue.

```shell
[ERROR] Failed to execute goal com.github.os72:protoc-jar-maven-plugin:3.11.4:run (default) on project fe-core: Error resolving artifact: io.grpc:protoc-gen-grpc-java:1.34.0: The following artifacts could not be resolved: io.grpc:protoc-gen-grpc-java:exe:osx-aarch_64:1.34.0 (absent): io.grpc:protoc-gen-grpc-java:exe:osx-aarch_64:1.34.0 was not found in https://repo.huaweicloud.com/repository/maven/huaweicloudsdk/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of huawei-obs-sdk has elapsed or updates are forced
```