### PR TITLE
[improve](cache) optimize the cache log

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1425,10 +1425,11 @@ void BlockFileCache::check_disk_resource_limit(const std::string& path) {
     }
     if (_disk_resource_limit_mode) {
         // log per mins
-        LOG_EVERY_N(WARNING, 3) << "file cache background thread space percent=" << capacity_percentage
-            << " inode percent=" << inode_percentage
-            << " is inode insufficient=" << inode_is_insufficient(inode_percentage)
-            << " mode run in resource limit";
+        LOG_EVERY_N(WARNING, 3) << "file cache background thread space percent="
+                                << capacity_percentage << " inode percent=" << inode_percentage
+                                << " is inode insufficient="
+                                << inode_is_insufficient(inode_percentage)
+                                << " mode run in resource limit";
     }
 }
 

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1417,8 +1417,6 @@ void BlockFileCache::check_disk_resource_limit(const std::string& path) {
     }
     if (capacity_percentage >= config::file_cache_enter_disk_resource_limit_mode_percent ||
         inode_is_insufficient(inode_percentage)) {
-        LOG(WARNING) << capacity_percentage << " "
-                     << config::file_cache_enter_disk_resource_limit_mode_percent;
         _disk_resource_limit_mode = true;
     } else if (_disk_resource_limit_mode &&
                (capacity_percentage < config::file_cache_exit_disk_resource_limit_mode_percent) &&
@@ -1426,11 +1424,11 @@ void BlockFileCache::check_disk_resource_limit(const std::string& path) {
         _disk_resource_limit_mode = false;
     }
     if (_disk_resource_limit_mode) {
-        LOG_WARNING("file cache background thread")
-                .tag("space percent", capacity_percentage)
-                .tag("inode percent", inode_percentage)
-                .tag("is inode insufficient", inode_is_insufficient(inode_percentage))
-                .tag("mode", "run in resource limit");
+        // log per mins
+        LOG_EVERY_N(WARNING, 3) << "file cache background thread space percent=" << capacity_percentage
+            << " inode percent=" << inode_percentage
+            << " is inode insufficient=" << inode_is_insufficient(inode_percentage)
+            << " mode run in resource limit";
     }
 }
 


### PR DESCRIPTION
The file cache prints too many logs in _disk_resource_limit_mode. Need to reduce printing frequency.
