### PR TITLE
[feature](be jvm monitor)append enable_jvm_monitor in be.conf to control jvm monitor.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1283,7 +1283,12 @@ DEFINE_Int64(max_nonblock_close_thread_num, "64");
 DEFINE_mDouble(mem_alloc_fault_probability, "0.0");
 // The time out milliseconds for remote fetch schema RPC, default 60s
 DEFINE_mInt64(fetch_remote_schema_rpc_timeout_ms, "60000");
+
 DEFINE_Int64(s3_file_system_local_upload_buffer_size, "5242880");
+
+//JVM monitoring enable. To prevent be from crashing due to jvm compatibility issues. The default setting is off.
+DEFINE_Bool(enable_jvm_monitor, "false");
+
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1289,7 +1289,6 @@ DEFINE_Int64(s3_file_system_local_upload_buffer_size, "5242880");
 //JVM monitoring enable. To prevent be from crashing due to jvm compatibility issues. The default setting is off.
 DEFINE_Bool(enable_jvm_monitor, "false");
 
-
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1361,7 +1361,11 @@ DECLARE_mDouble(mem_alloc_fault_probability);
 // The time out milliseconds for remote fetch schema RPC
 DECLARE_mInt64(fetch_remote_schema_rpc_timeout_ms);
 // The size of the local buffer for S3FileSytem's upload function
+
 DECLARE_Int64(s3_file_system_local_upload_buffer_size);
+
+//JVM monitoring enable. To prevent be from crashing due to jvm compatibility issues.
+DECLARE_Bool(enable_jvm_monitor);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/util/jvm_metrics.h
+++ b/be/src/util/jvm_metrics.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <jni.h>
-
 #include "jni.h"
 #include "util/jni-util.h"
 #include "util/metrics.h"
@@ -27,7 +25,7 @@ namespace doris {
 
 class JvmMetrics;
 
-class jvmStats {
+class JvmStats {
 private:
     JNIEnv* env = nullptr;
     jclass _managementFactoryClass = nullptr;
@@ -98,16 +96,16 @@ private:
     bool _init_complete = false;
 
 public:
-    jvmStats(JNIEnv* ENV);
-    bool init_complete() { return _init_complete; }
+    JvmStats(JNIEnv* ENV);
+    bool init_complete() const { return _init_complete; }
     void refresh(JvmMetrics* jvm_metrics);
-    ~jvmStats();
+    ~JvmStats();
 };
 
 class JvmMetrics {
 public:
     JvmMetrics(MetricRegistry* registry, JNIEnv* env);
-    ~JvmMetrics() {}
+    ~JvmMetrics() = default;
     void update();
 
     IntGauge* jvm_heap_size_bytes_max = nullptr;
@@ -140,7 +138,7 @@ public:
     IntGauge* jvm_gc_g1_old_generation_time_ms = nullptr;
 
 private:
-    jvmStats _jvm_stats;
+    JvmStats _jvm_stats;
     std::shared_ptr<MetricEntity> _server_entity;
     static const char* _s_hook_name;
     MetricRegistry* _registry = nullptr;

--- a/be/src/util/jvm_metrics.h
+++ b/be/src/util/jvm_metrics.h
@@ -96,8 +96,10 @@ private:
     bool _init_complete = false;
 
 public:
-    JvmStats(JNIEnv* ENV);
+    //    JvmStats(JNIEnv* ENV);
+    void init(JNIEnv* ENV);
     bool init_complete() const { return _init_complete; }
+    void set_complete(bool val) { _init_complete = val; }
     void refresh(JvmMetrics* jvm_metrics);
     ~JvmStats();
 };

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -74,3 +74,4 @@ enable_feature_binlog=true
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
 
 enable_jvm_monitor = true
+

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -72,3 +72,5 @@ enable_set_in_bitmap_value=true
 enable_feature_binlog=true
 
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
+
+enable_jvm_monitor = true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -60,3 +60,5 @@ enable_debug_points=true
 enable_debug_log_timeout_secs=0
 
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
+
+enable_jvm_monitor = true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -62,3 +62,4 @@ enable_debug_log_timeout_secs=0
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
 
 enable_jvm_monitor = true
+

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -60,3 +60,4 @@ enable_debug_points=true
 enable_debug_log_timeout_secs=0
 
 enable_jvm_monitor = true
+

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -58,3 +58,5 @@ user_files_secure_path=/
 enable_debug_points=true
 # debug scanner context dead loop
 enable_debug_log_timeout_secs=0
+
+enable_jvm_monitor = true


### PR DESCRIPTION
## Proposed changes

before pr : #35023
In order to prevent doris_be from crashing when collecting jvm information due to jvm incompatibility issues, you can set `enable_jvm_monitor = true / false` in `be.conf` to enable the jvm metrics.

The default value of `enable_jvm_monitor` is false.

When JVM monitoring has 30 consecutive exceptions, turn off JVM information collection and set all values ​​to 0.

Issue Number: close #xxx

<!--Describe your changes.-->

