### PR TITLE
[fix](fe) fix start fe failed when recover fe in different host

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
@@ -250,6 +250,9 @@ public class BDBHA implements HAProtocol {
 
     public void removeDroppedMember(ConcurrentLinkedQueue<String> removedFrontends) {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        if (replicationGroupAdmin == null) {
+            return;
+        }
         Set<ReplicationNode> replicationNodes = replicationGroupAdmin.getGroup().getElectableNodes();
         LOG.debug("removedFrontends:{}", removedFrontends);
         for (ReplicationNode replicationNode : replicationNodes) {


### PR DESCRIPTION
## Proposed changes

An exception introduced by #35203 cause the frontend start failed

In this cases:
1. all frontends are down and recover frontend in different host by the original metadata
2. or the only frontend's ip changed, and start with `-r` option to recover from original metadata