### PR TITLE
[fix](inverted index) Remove float/double support in index writer

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -695,8 +695,6 @@ Status InvertedIndexColumnWriter::create(const Field* field,
         M(FieldType::OLAP_FIELD_TYPE_DECIMAL128I)
         M(FieldType::OLAP_FIELD_TYPE_DECIMAL256)
         M(FieldType::OLAP_FIELD_TYPE_BOOL)
-        M(FieldType::OLAP_FIELD_TYPE_DOUBLE)
-        M(FieldType::OLAP_FIELD_TYPE_FLOAT)
 #undef M
     default:
         return Status::NotSupported("unsupported type for inverted index: " +


### PR DESCRIPTION
## Proposed changes

`float` and `double` is not allowed to build inverted index.
We remove them in `inverted_index_writer` to keep consistent with FE. And to avoid unnecessary exception.
<!--Describe your changes.-->

