### PR TITLE
[fix](resource-tag) missing resource tag after forwarding to master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -709,6 +709,9 @@ public abstract class ConnectProcessor {
             ctx.setUserVars(userVariableFromThrift(request.getUserVariables()));
         }
 
+        // set resource tag
+        ctx.setResourceTags(Env.getCurrentEnv().getAuth().getResourceTags(ctx.qualifiedUser));
+
         ctx.setThreadLocalInfo();
         StmtExecutor executor = null;
         try {


### PR DESCRIPTION
## Proposed changes

All DDL and DML will be forwarded to Master FE.
And we forgot to set resource tag in ConnectionContext
after forwarding