### PR TITLE
[refactor](cancel) disable cancel instance for pipeline

### DIFF
--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -103,8 +103,8 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
     }
     if (context != nullptr) {
         // first cancel the fragment instance, just ignore return status
-        _exec_env->fragment_mgr()->cancel_instance(
-                context->fragment_instance_id, Status::InternalError("cancelled by clear thread"));
+        _exec_env->fragment_mgr()->cancel_query(context->query_id,
+                                                Status::InternalError("cancelled by clear thread"));
         // clear the fragment instance's related result queue
         static_cast<void>(_exec_env->result_queue_mgr()->cancel(context->fragment_instance_id));
         LOG(INFO) << "close scan context: context id [ " << context_id << " ]";
@@ -144,9 +144,8 @@ void ExternalScanContextMgr::gc_expired_context() {
         }
         for (auto expired_context : expired_contexts) {
             // must cancel the fragment instance, otherwise return thrift transport TTransportException
-            _exec_env->fragment_mgr()->cancel_instance(
-                    expired_context->fragment_instance_id,
-                    Status::InternalError("scan context is expired"));
+            _exec_env->fragment_mgr()->cancel_query(
+                    expired_context->query_id, Status::InternalError("scan context is expired"));
             static_cast<void>(
                     _exec_env->result_queue_mgr()->cancel(expired_context->fragment_instance_id));
         }

--- a/be/src/runtime/external_scan_context_mgr.h
+++ b/be/src/runtime/external_scan_context_mgr.h
@@ -38,6 +38,7 @@ class Thread;
 struct ScanContext {
 public:
     TUniqueId fragment_instance_id;
+    TUniqueId query_id;
     int64_t offset;
     // use this access_time to clean zombie context
     time_t last_access_time;
@@ -45,8 +46,6 @@ public:
     std::string context_id;
     short keep_alive_min;
     ScanContext(std::string id) : context_id(std::move(id)) {}
-    ScanContext(const TUniqueId& fragment_id, int64_t offset)
-            : fragment_instance_id(fragment_id), offset(offset) {}
 };
 
 class ExternalScanContextMgr {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gen_cpp/FrontendService_types.h>
+#include <gen_cpp/QueryPlanExtra_types.h>
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/types.pb.h>
 #include <stdint.h>
@@ -101,9 +102,6 @@ public:
 
     // Cancel instance (pipeline or nonpipeline).
     void cancel_instance(const TUniqueId instance_id, const Status reason);
-    // Cancel fragment (only pipelineX).
-    // {query id fragment} -> PipelineFragmentContext
-    void cancel_fragment(const TUniqueId query_id, int32_t fragment_id, const Status reason);
 
     // Can be used in both version.
     void cancel_query(const TUniqueId query_id, const Status reason);
@@ -112,10 +110,11 @@ public:
 
     void debug(std::stringstream& ss) override;
 
-    // input: TScanOpenParams fragment_instance_id
+    // input: TQueryPlanInfo fragment_instance_id
     // output: selected_columns
     // execute external query, all query info are packed in TScanOpenParams
     Status exec_external_plan_fragment(const TScanOpenParams& params,
+                                       const TQueryPlanInfo& t_query_plan_info,
                                        const TUniqueId& fragment_instance_id,
                                        std::vector<TScanColumnDesc>* selected_columns);
 
@@ -154,9 +153,6 @@ public:
                                     TReportExecStatusParams* exec_status);
 
 private:
-    void cancel_unlocked_impl(const TUniqueId& id, const Status& reason,
-                              const std::unique_lock<std::mutex>& state_lock, bool is_pipeline);
-
     void _exec_actual(std::shared_ptr<PlanFragmentExecutor> fragment_executor,
                       const FinishCallback& cb);
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -74,6 +74,7 @@
 #include "util/threadpool.h"
 #include "util/thrift_server.h"
 #include "util/uid_util.h"
+#include "util/url_coding.h"
 
 namespace apache {
 namespace thrift {
@@ -750,10 +751,40 @@ void BaseBackendService::open_scanner(TScanOpenResult& result_, const TScanOpenP
     } else {
         p_context->keep_alive_min = 5;
     }
+
+    Status exec_st;
+    TQueryPlanInfo t_query_plan_info;
+    {
+        const std::string& opaqued_query_plan = params.opaqued_query_plan;
+        std::string query_plan_info;
+        // base64 decode query plan
+        if (!base64_decode(opaqued_query_plan, &query_plan_info)) {
+            LOG(WARNING) << "open context error: base64_decode decode opaqued_query_plan failure";
+            std::stringstream msg;
+            msg << "query_plan_info: " << query_plan_info
+                << " validate error, should not be modified after returned Doris FE processed";
+            exec_st = Status::InvalidArgument(msg.str());
+        }
+
+        const uint8_t* buf = (const uint8_t*)query_plan_info.data();
+        uint32_t len = query_plan_info.size();
+        // deserialize TQueryPlanInfo
+        auto st = deserialize_thrift_msg(buf, &len, false, &t_query_plan_info);
+        if (!st.ok()) {
+            LOG(WARNING) << "open context error: deserialize TQueryPlanInfo failure";
+            std::stringstream msg;
+            msg << "query_plan_info: " << query_plan_info
+                << " deserialize error, should not be modified after returned Doris FE processed";
+            exec_st = Status::InvalidArgument(msg.str());
+        }
+        p_context->query_id = t_query_plan_info.query_id;
+    }
     std::vector<TScanColumnDesc> selected_columns;
-    // start the scan procedure
-    Status exec_st = _exec_env->fragment_mgr()->exec_external_plan_fragment(
-            params, fragment_instance_id, &selected_columns);
+    if (exec_st.ok()) {
+        // start the scan procedure
+        exec_st = _exec_env->fragment_mgr()->exec_external_plan_fragment(
+                params, t_query_plan_info, fragment_instance_id, &selected_columns);
+    }
     exec_st.to_thrift(&t_status);
     //return status
     // t_status.status_code = TStatusCode::OK;


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

For pipeline engine, query will be cancelled only if all pipeline tasks should be stopped. So we should disable `cancel_instance` which is to stop fragment instances in non-pipeline engine.