### PR TITLE
[Bug](backend-options) fix use after free on BackendOptions::get_local_backend()

### DIFF
--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -33,9 +33,9 @@ static const std::string PRIORITY_CIDR_SEPARATOR = ";";
 
 std::string BackendOptions::_s_localhost;
 std::vector<CIDR> BackendOptions::_s_priority_cidrs;
-TBackend BackendOptions::_backend;
 bool BackendOptions::_bind_ipv6 = false;
 const char* _service_bind_address = "0.0.0.0";
+int64_t BackendOptions::_s_backend_id = 0;
 
 bool BackendOptions::init() {
     if (!analyze_priority_cidrs(config::priority_networks, &_s_priority_cidrs)) {
@@ -72,15 +72,17 @@ std::string BackendOptions::get_be_endpoint() {
 }
 
 TBackend BackendOptions::get_local_backend() {
-    _backend.__set_host(_s_localhost);
-    _backend.__set_be_port(config::be_port);
-    _backend.__set_http_port(config::webserver_port);
-    _backend.__set_brpc_port(config::brpc_port);
-    return _backend;
+    TBackend backend;
+    backend.__set_host(_s_localhost);
+    backend.__set_be_port(config::be_port);
+    backend.__set_http_port(config::webserver_port);
+    backend.__set_brpc_port(config::brpc_port);
+    backend.__set_id(_s_backend_id);
+    return backend;
 }
 
 void BackendOptions::set_backend_id(int64_t backend_id) {
-    _backend.__set_id(backend_id);
+    _s_backend_id = backend_id;
 }
 
 void BackendOptions::set_localhost(const std::string& host) {

--- a/be/src/service/backend_options.h
+++ b/be/src/service/backend_options.h
@@ -31,6 +31,7 @@ class CIDR;
 
 class BackendOptions {
 public:
+    BackendOptions() = delete;
     static bool init();
     static const std::string& get_localhost();
     static std::string get_be_endpoint();
@@ -49,11 +50,9 @@ private:
     static bool is_in_prior_network(const std::string& ip);
 
     static std::string _s_localhost;
-    static TBackend _backend;
+    static int64_t _s_backend_id;
     static std::vector<CIDR> _s_priority_cidrs;
     static bool _bind_ipv6;
-
-    DISALLOW_COPY_AND_ASSIGN(BackendOptions);
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

```cpp
==1825462==ERROR: AddressSanitizer: heap-use-after-free on address 0x5030012ea880 at pc 0x555cc645e1aa bp 0x7fe4a9407e20 sp 0x7fe4a94075e0
READ of size 22 at 0x5030012ea880 thread T2250 (REPORT_DISK_STA)
    #0 0x555cc645e1a9 in __asan_memcpy (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x22cb01a9) (BuildId: 76fba423c52f4da5)
    #1 0x555cc64b6990 in std::char_traits<char>::copy(char*, char const*, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/char_traits.h:445:33
    #2 0x555cc64b68a1 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_copy(char*, char const*, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:420:4
    #3 0x555cc64c526e in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:291:6
    #4 0x555cc64c5070 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:1596:8
    #5 0x555cc64b1d9c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:802:15
    #6 0x555ccb05a722 in doris::TBackend::TBackend(doris::TBackend const&) /mnt/disk1/xiaolei/incubator-doris/gensrc/build/gen_cpp/Types_types.cpp:5755:8
    #7 0x555cc9c9234e in doris::BackendOptions::get_local_backend() /mnt/disk1/xiaolei/incubator-doris/be/src/service/backend_options.cpp:79:12
    #8 0x555cc6586e5a in doris::report_disk_callback(doris::StorageEngine&, doris::TMasterInfo const&) /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:1021:27
    #9 0x555cc64f2a0a in doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/agent_server.cpp:190:133
    #10 0x555cc64f2994 in void std::__invoke_impl<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>(std::__invoke_other, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #11 0x555cc64f2944 in std::enable_if<is_invocable_r_v<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>, void>::type std::__invoke_r<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>(doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #12 0x555cc64f280c in std::_Function_handler<void (), doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #13 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #14 0x555cc65b01f9 in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:689:13
    #15 0x555cc65afcd4 in void std::__invoke_impl<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(std::__invoke_other, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #16 0x555cc65afc74 in std::enable_if<is_invocable_r_v<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>, void>::type std::__invoke_r<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #17 0x555cc65afa6c in std::_Function_handler<void (), doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #18 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #19 0x555cca138dab in doris::Thread::supervise_thread(void*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:498:5
    #20 0x555cc645de0a in asan_thread_start(void*) crtstuff.c
    #21 0x7fef061601c9 in start_thread (/lib64/libpthread.so.0+0x81c9) (BuildId: 823fccea3475e5870a4167dfe47df20e53222db0)
    #22 0x7fef06b4fe72 in clone (/lib64/libc.so.6+0x39e72) (BuildId: ec3d7025354f1f1985831ff08ef0eb3b50aefbce)

0x5030012ea880 is located 0 bytes inside of 31-byte region [0x5030012ea880,0x5030012ea89f)
freed by thread T2249 (REPORT_TASK-182) here:
    #0 0x555cc649d43d in operator delete(void*) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x22cef43d) (BuildId: 76fba423c52f4da5)
    #1 0x555cc64b6bbc in std::__new_allocator<char>::deallocate(char*, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:168:2
    #2 0x555cc64b6b5d in std::allocator<char>::deallocate(char*, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h:210:25
    #3 0x555cc64b6b5d in std::allocator_traits<std::allocator<char>>::deallocate(std::allocator<char>&, char*, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:516:13
    #4 0x555cc64b6b5d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_destroy(unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:289:9
    #5 0x555cc64b6a56 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_dispose() /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:283:4
    #6 0x555cc64c51ee in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:285:8
    #7 0x555cc64c5070 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:1596:8
    #8 0x555cc64b1d9c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:802:15
    #9 0x555ccb058510 in doris::TBackend::__set_host(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/incubator-doris/gensrc/build/gen_cpp/Types_types.cpp:5584:14
    #10 0x555cc9c92239 in doris::BackendOptions::get_local_backend() /mnt/disk1/xiaolei/incubator-doris/be/src/service/backend_options.cpp:75:14
    #11 0x555cc6585b9d in doris::report_task_callback(doris::TMasterInfo const&) /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:1004:27
    #12 0x555cc64f24b9 in doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/agent_server.cpp:187:112
    #13 0x555cc64f2474 in void std::__invoke_impl<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20&>(std::__invoke_other, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #14 0x555cc64f2424 in std::enable_if<is_invocable_r_v<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20&>, void>::type std::__invoke_r<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20&>(doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #15 0x555cc64f22ec in std::_Function_handler<void (), doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_20>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #16 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #17 0x555cc65b01f9 in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:689:13
    #18 0x555cc65afcd4 in void std::__invoke_impl<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(std::__invoke_other, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #19 0x555cc65afc74 in std::enable_if<is_invocable_r_v<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>, void>::type std::__invoke_r<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #20 0x555cc65afa6c in std::_Function_handler<void (), doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #21 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #22 0x555cca138dab in doris::Thread::supervise_thread(void*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:498:5
    #23 0x555cc645de0a in asan_thread_start(void*) crtstuff.c

previously allocated by thread T2250 (REPORT_DISK_STA) here:
    #0 0x555cc649cbdd in operator new(unsigned long) (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x22ceebdd) (BuildId: 76fba423c52f4da5)
    #1 0x555cc64b684e in std::__new_allocator<char>::allocate(unsigned long, void const*) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:147:27
    #2 0x555cc64b67b0 in std::allocator<char>::allocate(unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h:198:32
    #3 0x555cc64b67b0 in std::allocator_traits<std::allocator<char>>::allocate(std::allocator<char>&, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482:20
    #4 0x555cc64b67b0 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_allocate(std::allocator<char>&, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:126:16
    #5 0x555cc64b63b1 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_create(unsigned long&, unsigned long) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:155:14
    #6 0x555cc64c51de in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:284:24
    #7 0x555cc64c5070 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:1596:8
    #8 0x555cc64b1d9c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::operator=(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:802:15
    #9 0x555ccb058510 in doris::TBackend::__set_host(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /mnt/disk1/xiaolei/incubator-doris/gensrc/build/gen_cpp/Types_types.cpp:5584:14
    #10 0x555cc9c92239 in doris::BackendOptions::get_local_backend() /mnt/disk1/xiaolei/incubator-doris/be/src/service/backend_options.cpp:75:14
    #11 0x555cc6586e5a in doris::report_disk_callback(doris::StorageEngine&, doris::TMasterInfo const&) /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:1021:27
    #12 0x555cc64f2a0a in doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/agent_server.cpp:190:133
    #13 0x555cc64f2994 in void std::__invoke_impl<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>(std::__invoke_other, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #14 0x555cc64f2944 in std::enable_if<is_invocable_r_v<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>, void>::type std::__invoke_r<void, doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&>(doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #15 0x555cc64f280c in std::_Function_handler<void (), doris::AgentServer::start_workers(doris::StorageEngine&, doris::ExecEnv*)::$_21>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #16 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #17 0x555cc65b01f9 in doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:689:13
    #18 0x555cc65afcd4 in void std::__invoke_impl<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(std::__invoke_other, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #19 0x555cc65afc74 in std::enable_if<is_invocable_r_v<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>, void>::type std::__invoke_r<void, doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&>(doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111:2
    #20 0x555cc65afa6c in std::_Function_handler<void (), doris::ReportWorker::ReportWorker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, doris::TMasterInfo const&, int, std::function<void ()>)::$_0>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #21 0x555cc6612ef2 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #22 0x555cca138dab in doris::Thread::supervise_thread(void*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:498:5
    #23 0x555cc645de0a in asan_thread_start(void*) crtstuff.c

```

