### PR TITLE
[fix](binlog) Add is temp for UpsertRecord

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/UpsertRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/UpsertRecord.java
@@ -42,6 +42,9 @@ public class UpsertRecord {
 
             @SerializedName(value = "version")
             public long version;
+
+            @SerializedName(value = "isTempPartition")
+            public boolean isTemp;
         }
 
         @SerializedName(value = "partitionRecords")
@@ -60,6 +63,7 @@ public class UpsertRecord {
             partitionRecord.partitionId = partitionCommitInfo.getPartitionId();
             partitionRecord.range = partitionCommitInfo.getPartitionRange();
             partitionRecord.version = partitionCommitInfo.getVersion();
+            partitionRecord.isTemp = partitionCommitInfo.isTempPartition();
             partitionRecords.add(partitionRecord);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -276,6 +276,10 @@ public class OlapTable extends Table implements MTMVRelatedTableIf {
         return getOrCreatTableProperty().isBeingSynced();
     }
 
+    public boolean isTemporaryPartition(long partitionId) {
+        return tempPartitions.hasPartition(partitionId);
+    }
+
     public void setTableProperty(TableProperty tableProperty) {
         this.tableProperty = tableProperty;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TempPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TempPartitions.java
@@ -98,6 +98,10 @@ public class TempPartitions implements Writable, GsonPostProcessable {
         return nameToPartition.containsKey(partName);
     }
 
+    public boolean hasPartition(long partitionId) {
+        return idToPartition.containsKey(partitionId);
+    }
+
     public boolean isEmpty() {
         return idToPartition.isEmpty();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1491,7 +1491,8 @@ public class DatabaseTransactionMgr {
                         || tblPartitionInfo.getType() == PartitionType.LIST) {
                     partitionRange = tblPartitionInfo.getItem(partitionId).getItems().toString();
                 }
-                PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(partitionId, partitionRange, -1, -1);
+                PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(partitionId, partitionRange, -1, -1,
+                        table.isTemporaryPartition(partitionId));
                 tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             }
             transactionState.putIdToTableCommitInfo(tableId, tableCommitInfo);
@@ -1514,7 +1515,8 @@ public class DatabaseTransactionMgr {
             partitionRange = tblPartitionInfo.getItem(partitionId).getItems().toString();
         }
         return new PartitionCommitInfo(partitionId, partitionRange,
-                partitionVersion, System.currentTimeMillis() /* use as partition visible time */);
+                partitionVersion, System.currentTimeMillis() /* use as partition visible time */,
+                table.isTemporaryPartition(partitionId));
     }
 
     protected void unprotectedCommitTransaction(TransactionState transactionState, Set<Long> errorReplicaIds,

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PartitionCommitInfo.java
@@ -37,17 +37,21 @@ public class PartitionCommitInfo implements Writable {
     private long version;
     @SerializedName(value = "versionTime")
     private long versionTime;
+    @SerializedName(value = "isTempPartition")
+    private boolean isTempPartition;
 
     public PartitionCommitInfo() {
 
     }
 
-    public PartitionCommitInfo(long partitionId, String partitionRange, long version, long visibleTime) {
+    public PartitionCommitInfo(long partitionId, String partitionRange, long version, long visibleTime,
+            boolean isTempPartition) {
         super();
         this.partitionId = partitionId;
         this.range = partitionRange;
         this.version = version;
         this.versionTime = visibleTime;
+        this.isTempPartition = isTempPartition;
     }
 
     @Override
@@ -85,12 +89,17 @@ public class PartitionCommitInfo implements Writable {
         this.versionTime = versionTime;
     }
 
+    public boolean isTempPartition() {
+        return this.isTempPartition;
+    }
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("partitionid=");
+        StringBuilder sb = new StringBuilder("partitionId=");
         sb.append(partitionId);
         sb.append(", version=").append(version);
         sb.append(", versionTime=").append(versionTime);
+        sb.append(", isTemp=").append(isTempPartition);
         return sb.toString();
     }
 }


### PR DESCRIPTION
## Proposed changes

The ccr-syncer does not support syncing temporary partitions, so this PR adds a field to record whether this upsert record comes from a temporary partition.
