### PR TITLE
[only test] add local merge sort exchaner 

### DIFF
--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -702,6 +702,8 @@ enum class ExchangeType : uint8_t {
     ADAPTIVE_PASSTHROUGH = 5,
     // Send all data to the first channel.
     PASS_TO_ONE = 6,
+    // merge all data to ont channel.
+    LOCAL_MERGE_SORT = 7,
 };
 
 inline std::string get_exchange_type_name(ExchangeType idx) {
@@ -720,6 +722,8 @@ inline std::string get_exchange_type_name(ExchangeType idx) {
         return "ADAPTIVE_PASSTHROUGH";
     case ExchangeType::PASS_TO_ONE:
         return "PASS_TO_ONE";
+    case ExchangeType::LOCAL_MERGE_SORT:
+        return "LOCAL_MERGE_SORT";
     }
     LOG(FATAL) << "__builtin_unreachable";
     __builtin_unreachable();

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -217,6 +217,7 @@ public:
 
     Status serialize_block(ExchangeSinkLocalState& stete, vectorized::Block* src, PBlock* dest,
                            int num_receivers = 1);
+    DataDistribution required_data_distribution() const override;
 
 private:
     friend class ExchangeSinkLocalState;

--- a/be/src/pipeline/exec/sort_source_operator.cpp
+++ b/be/src/pipeline/exec/sort_source_operator.cpp
@@ -28,7 +28,8 @@ SortLocalState::SortLocalState(RuntimeState* state, OperatorXBase* parent)
 
 SortSourceOperatorX::SortSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode, int operator_id,
                                          const DescriptorTbl& descs)
-        : OperatorX<SortLocalState>(pool, tnode, operator_id, descs) {}
+        : OperatorX<SortLocalState>(pool, tnode, operator_id, descs),
+          _merge_by_exchange(tnode.sort_node.merge_by_exchange) {}
 
 Status SortSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* block, bool* eos) {
     auto& local_state = get_local_state(state);

--- a/be/src/pipeline/exec/sort_source_operator.h
+++ b/be/src/pipeline/exec/sort_source_operator.h
@@ -46,10 +46,12 @@ public:
 
     bool is_source() const override { return true; }
 
+    bool merge_by_exchange() const { return _merge_by_exchange; }
     const vectorized::SortDescription& get_sort_description(RuntimeState* state) const;
 
 private:
     friend class SortLocalState;
+    const bool _merge_by_exchange;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
@@ -26,6 +26,7 @@ class ShuffleExchanger;
 class PassthroughExchanger;
 class BroadcastExchanger;
 class PassToOneExchanger;
+class LocalMergeSortExchanger;
 class LocalExchangeSinkOperatorX;
 class LocalExchangeSinkLocalState final : public PipelineXSinkLocalState<LocalExchangeSharedState> {
 public:
@@ -48,6 +49,7 @@ private:
     friend class PassthroughExchanger;
     friend class BroadcastExchanger;
     friend class PassToOneExchanger;
+    friend class LocalMergeSortExchanger;
     friend class AdaptivePassthroughExchanger;
 
     Exchanger* _exchanger = nullptr;

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.h
@@ -26,6 +26,7 @@ class ShuffleExchanger;
 class PassthroughExchanger;
 class BroadcastExchanger;
 class PassToOneExchanger;
+class LocalMergeSortExchanger;
 class LocalExchangeSourceOperatorX;
 class LocalExchangeSourceLocalState final : public PipelineXLocalState<LocalExchangeSharedState> {
 public:
@@ -46,6 +47,7 @@ private:
     friend class PassthroughExchanger;
     friend class BroadcastExchanger;
     friend class PassToOneExchanger;
+    friend class LocalMergeSortExchanger;
     friend class AdaptivePassthroughExchanger;
 
     Exchanger* _exchanger = nullptr;

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -174,6 +174,25 @@ private:
     std::vector<moodycamel::ConcurrentQueue<vectorized::Block>> _data_queue;
 };
 
+class LocalMergeSortExchanger final : public Exchanger {
+public:
+    ENABLE_FACTORY_CREATOR(LocalMergeSortExchanger);
+    LocalMergeSortExchanger(int running_sink_operators, int num_partitions, int free_block_limit)
+            : Exchanger(running_sink_operators, num_partitions, free_block_limit) {
+        _data_queue.resize(num_partitions);
+    }
+    ~LocalMergeSortExchanger() override = default;
+    Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos,
+                LocalExchangeSinkLocalState& local_state) override;
+
+    Status get_block(RuntimeState* state, vectorized::Block* block, bool* eos,
+                     LocalExchangeSourceLocalState& local_state) override;
+    ExchangeType get_type() const override { return ExchangeType::LOCAL_MERGE_SORT; }
+
+private:
+    std::vector<moodycamel::ConcurrentQueue<vectorized::Block>> _data_queue;
+};
+
 class BroadcastExchanger final : public Exchanger {
 public:
     ENABLE_FACTORY_CREATOR(BroadcastExchanger);


### PR DESCRIPTION
## Proposed changes

```
    DATA_STREAM_SINK_OPERATOR  (id=2,dst_id=2):
                            -  BlocksProduced:  sum  2,  avg  1,  max  2,  min  0
                            -  CloseTime:  avg  50.194us,  max  51.318us,  min  49.71us
                            -  ExecTime:  avg  958.12us,  max  1.625ms,  min  290.750us
                            -  InitTime:  avg  100.283us,  max  102.17us,  min  98.550us
                            -  InputRows:  sum  40,  avg  20,  max  40,  min  0
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  130.241us,  max  150.198us,  min  110.285us
                            -  RowsProduced:  sum  40,  avg  20,  max  40,  min  0
                            -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                -  WaitForRpcBufferQueue:  avg  0ns,  max  0ns,  min  0ns
                          LOCAL_EXCHANGE_OPERATOR  (LOCAL_MERGE_SORT)  (id=-3):
                                -  BlocksProduced:  sum  2,  avg  1,  max  2,  min  0
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  45.937us,  max  82.162us,  min  9.713us
                                -  GetBlockFailedTime:  sum  1,  avg  0,  max  1,  min  0
                                -  InitTime:  avg  295ns,  max  346ns,  min  245ns
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                -  OpenTime:  avg  32.314us,  max  56.419us,  min  8.210us
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  40,  avg  20,  max  40,  min  0
                                -  WaitForDependency[LOCAL_EXCHANGE_OPERATOR_DEPENDENCY]Time:  avg  652.661ms,  max  652.932ms,  min  652.391ms
                  Pipeline  :  1(instance_num=2):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (LOCAL_MERGE_SORT)  (id=-3):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  279.790us,  max  472.726us,  min  86.854us
                            -  InitTime:  avg  8.355us,  max  8.367us,  min  8.344us
                            -  InputRows:  sum  40,  avg  20,  max  20,  min  20
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  5.676us,  max  9.940us,  min  1.412us
                            -  WaitForDependency[LOCAL_EXCHANGE_SINK_DEPENDENCY]Time:  avg  0ns,  max  0ns,  min  0ns
                          SORT_OPERATOR  (id=1):
                                -  PlanInfo
                                      -  order  by:  c_custkey  ASC,  c_name  ASC
                                      -  TOPN  OPT
                                      -  OPT  TWO  PHASE
                                      -  offset:  0
                                      -  limit:  20
                                -  BlocksProduced:  sum  2,  avg  1,  max  1,  min  1
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  3.551us,  max  3.817us,  min  3.285us
                                -  InitTime:  avg  0ns,  max  0ns,  min  0ns
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                -  OpenTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  40,  avg  20,  max  20,  min  20
                                -  WaitForDependency[SORT_OPERATOR_DEPENDENCY]Time:  avg  651.110ms,  max  653.23ms,  min  649.198ms
```

<!--Describe your changes.-->

