### PR TITLE
[bug](Compile) Add default value for optional field to pass compile's missing-field-initializers check

### DIFF
--- a/be/src/io/fs/obj_storage_client.h
+++ b/be/src/io/fs/obj_storage_client.h
@@ -37,23 +37,23 @@ enum class ObjStorageType : uint8_t {
 };
 
 struct ObjectStoragePathOptions {
-    Path path;
-    std::string bucket;                                  // blob container in azure
-    std::string key;                                     // blob name in azure
-    std::string prefix;                                  // for batch delete and recursive delete
+    Path path = "";
+    std::string bucket = std::string();                  // blob container in azure
+    std::string key = std::string();                     // blob name in azure
+    std::string prefix = std::string();                  // for batch delete and recursive delete
     std::optional<std::string> upload_id = std::nullopt; // only used for S3 upload
 };
 
 struct ObjectCompleteMultiParts {};
 
 struct ObjectStorageResponse {
-    Status status;
+    Status status = Status::OK();
     std::optional<std::string> upload_id = std::nullopt;
     std::optional<std::string> etag = std::nullopt;
 };
 
 struct ObjectStorageHeadResponse {
-    Status status;
+    Status status = Status::OK();
     long long file_size {0};
 };
 

--- a/be/src/io/fs/obj_storage_client.h
+++ b/be/src/io/fs/obj_storage_client.h
@@ -38,18 +38,18 @@ enum class ObjStorageType : uint8_t {
 
 struct ObjectStoragePathOptions {
     Path path;
-    std::string bucket;                   // blob container in azure
-    std::string key;                      // blob name
-    std::string prefix;                   // for batch delete and recursive delete
-    std::optional<std::string> upload_id; // only used for S3 upload
+    std::string bucket;                                  // blob container in azure
+    std::string key;                                     // blob name in azure
+    std::string prefix;                                  // for batch delete and recursive delete
+    std::optional<std::string> upload_id = std::nullopt; // only used for S3 upload
 };
 
 struct ObjectCompleteMultiParts {};
 
 struct ObjectStorageResponse {
     Status status;
-    std::optional<std::string> upload_id;
-    std::optional<std::string> etag;
+    std::optional<std::string> upload_id = std::nullopt;
+    std::optional<std::string> etag = std::nullopt;
 };
 
 struct ObjectStorageHeadResponse {


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

The former pr #35307 introduces several struct which has fileds with type `std::optional`. The perf compile envrionment has enable missing-field-initializers check, and these structs is not suitable. So this pr tries to fix the compile problem.