### PR TITLE
[fix](fe) Add check editlog size mechanism for backupJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -615,6 +615,13 @@ public class BackupJob extends AbstractJob {
 
     private void waitingAllSnapshotsFinished() {
         if (unfinishedTaskIds.isEmpty()) {
+
+            if (env.getEditLog().exceedMaxJournalSize(this)) {
+                status = new Status(ErrCode.COMMON_ERROR, "backupJob is too large ");
+                return;
+            }
+
+
             snapshotFinishedTime = System.currentTimeMillis();
             state = BackupJobState.UPLOAD_SNAPSHOT;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/Journal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/Journal.java
@@ -66,4 +66,6 @@ public interface Journal {
     // Get all the dbs' name
     public List<Long> getDatabaseNames();
 
+    public boolean exceedMaxJournalSize(short op, Writable writable) throws IOException;
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -707,4 +707,27 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         }
         return bdbEnvironment.getNotReadyReason();
     }
+
+    @Override
+    public boolean exceedMaxJournalSize(short op, Writable writable) throws IOException {
+        JournalEntity entity = new JournalEntity();
+        entity.setOpCode(op);
+        entity.setData(writable);
+
+        DataOutputBuffer buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
+        entity.write(buffer);
+
+        DatabaseEntry theData = new DatabaseEntry(buffer.getData());
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("opCode = {}, journal size = {}", op, theData.getSize());
+        }
+
+        // 1GB
+        if (theData.getSize() > (1 << 30)) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/local/LocalJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/local/LocalJournal.java
@@ -210,4 +210,9 @@ public class LocalJournal implements Journal {
     public List<Long> getDatabaseNames() {
         throw new RuntimeException("Not Support");
     }
+
+    @Override
+    public boolean exceedMaxJournalSize(short op, Writable writable) throws IOException  {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -2102,4 +2102,17 @@ public class EditLog {
         }
         return "";
     }
+
+    public boolean exceedMaxJournalSize(BackupJob job) {
+        try {
+            return exceedMaxJournalSize(OperationType.OP_BACKUP_JOB, job);
+        } catch (Exception e) {
+            LOG.warn("exceedMaxJournalSize exception:", e);
+        }
+        return true;
+    }
+
+    private boolean exceedMaxJournalSize(short op, Writable writable) throws IOException {
+        return journal.exceedMaxJournalSize(op, writable);
+    }
 }


### PR DESCRIPTION
* When creating a backupJob with huge of tables in a database, it can cause backupJob editlog size over 2GB and bdbje will throw exception because of ByteBuffer overflow

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

