### PR TITLE
[fix](nereids) do not generate runtime filter on schema-scan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -51,6 +51,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSchemaScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.ExpressionUtils;
@@ -482,6 +483,9 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
 
     @Override
     public PhysicalRelation visitPhysicalRelation(PhysicalRelation relation, CascadesContext context) {
+        if (relation instanceof PhysicalSchemaScan) {
+            return relation;
+        }
         // add all the slots in map.
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
         relation.getOutput().forEach(slot -> ctx.aliasTransferMapPut(slot, Pair.of(relation, slot)));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalSchemaScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalWindow;
@@ -188,6 +189,9 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
 
     @Override
     public Boolean visitPhysicalRelation(PhysicalRelation scan, PushDownContext ctx) {
+        if (scan instanceof PhysicalSchemaScan) {
+            return false;
+        }
         Preconditions.checkArgument(ctx.isValid(),
                 "runtime filter pushDownContext is invalid");
         PhysicalRelation relation = ctx.finalTarget.first;

--- a/regression-test/suites/nereids_syntax_p0/runtime_filter.groovy
+++ b/regression-test/suites/nereids_syntax_p0/runtime_filter.groovy
@@ -116,4 +116,20 @@ suite("runtime_filter") {
         INNER JOIN table_9_undef_partitions2_keys3_properties4_distributed_by5 AS alias2
         INNER JOIN table_20_undef_partitions2_keys3_properties4_distributed_by5 AS alias3 ON alias2.`pk` = alias3.`pk`;    
      """
+
+    // do not generate rf on schemaScan. if rf generated, following sql is blocked
+     multi_sql """
+     set runtime_filter_mode=true;
+     SELECT *
+        FROM(
+        SELECT tab.TABLE_SCHEMA, tab.TABLE_NAME
+        FROM information_schema.TABLES tab
+        WHERE TABLE_TYPE in ('BASE TABLE', 'SYSTEM VIEW')
+        AND tab.TABLE_SCHEMA in ('__internal_schema')
+        AND tab.TABLE_NAME IN ('audit_log')
+        ORDER BY tab.TABLE_SCHEMA, tab.TABLE_NAME LIMIT 0, 100) t inner join information_schema.COLUMNS col on t.TABLE_SCHEMA=col.TABLE_SCHEMA
+        AND t.TABLE_NAME=col.TABLE_NAME
+        ORDER BY col.TABLE_SCHEMA,col.TABLE_NAME,col.ORDINAL_POSITION;
+    """
+
 }


### PR DESCRIPTION
## Proposed changes
schema-scan node does not support runtime filter

Issue Number: close #xxx

<!--Describe your changes.-->

