### PR TITLE
[fix](hint) fix hint tests with different be instances

### DIFF
--- a/regression-test/suites/nereids_p0/hint/fix_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/fix_leading.groovy
@@ -24,6 +24,9 @@ suite("fix_leading") {
     sql 'use fix_leading'
 
     // setting planner to nereids
+    sql 'set exec_mem_limit=21G'
+    sql 'set be_number_for_test=1'
+    sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'

--- a/regression-test/suites/nereids_p0/hint/test_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_leading.groovy
@@ -24,6 +24,9 @@ suite("test_leading") {
     sql 'use test_leading'
 
     // setting planner to nereids
+    sql 'set exec_mem_limit=21G'
+    sql 'set be_number_for_test=1'
+    sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     sql 'set enable_nereids_planner=true'
     sql "set ignore_shape_nodes='PhysicalProject'"
     sql 'set enable_fallback_to_original_planner=false'


### PR DESCRIPTION
cherry-pick: #35188 
Problem:
When using multiple be to test hint with distribute hint, the result would be unstable Solved:
Add ordered hint to every distribute hint and move some leading hint cases to check containing of hint infomation

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

