### PR TITLE
[feature](statistics)Support clear stale partition stats.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -1109,7 +1109,7 @@ public class AnalysisManager implements Writable {
                     Database database = dbOption.get();
                     Optional<Table> tableOption = database.getTable(record.getKey());
                     if (!tableOption.isPresent()) {
-                        LOG.warn("Table {} does not exist in DB {}.", event.getDbId(), event.getDbId());
+                        LOG.warn("Table {} does not exist in DB {}.", record.getKey(), event.getDbId());
                         continue;
                     }
                     Table table = tableOption.get();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCleaner.java
@@ -52,9 +52,10 @@ public class StatisticsCleaner extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsCleaner.class);
 
     private OlapTable colStatsTbl;
+    private OlapTable partitionColStatsTbl;
 
     private Map<Long, CatalogIf<? extends DatabaseIf<? extends TableIf>>> idToCatalog;
-    private Map<Long, DatabaseIf> idToDb;
+    private Map<Long, DatabaseIf<? extends TableIf>> idToDb;
     private Map<Long, TableIf> idToTbl;
 
     private Map<Long, MaterializedIndexMeta> idToMVIdx;
@@ -77,7 +78,8 @@ public class StatisticsCleaner extends MasterDaemon {
             if (!init()) {
                 return;
             }
-            clearStats(colStatsTbl);
+            clearStats(colStatsTbl, true);
+            clearStats(partitionColStatsTbl, false);
         } finally {
             colStatsTbl = null;
             idToCatalog = null;
@@ -87,24 +89,23 @@ public class StatisticsCleaner extends MasterDaemon {
         }
     }
 
-    private void clearStats(OlapTable statsTbl) {
-        ExpiredStats expiredStats = null;
+    private void clearStats(OlapTable statsTbl, boolean isTableColumnStats) {
+        ExpiredStats expiredStats;
         long offset = 0;
         do {
             expiredStats = new ExpiredStats();
-            offset = findExpiredStats(statsTbl, expiredStats, offset);
-            deleteExpiredStats(expiredStats, statsTbl.getName());
+            offset = findExpiredStats(statsTbl, expiredStats, offset, isTableColumnStats);
+            deleteExpiredStats(expiredStats, statsTbl.getName(), isTableColumnStats);
         } while (!expiredStats.isEmpty());
     }
 
     private boolean init() {
         try {
             String dbName = FeConstants.INTERNAL_DB_NAME;
-            colStatsTbl =
-                    (OlapTable) StatisticsUtil
-                            .findTable(InternalCatalog.INTERNAL_CATALOG_NAME,
-                                    dbName,
-                                    StatisticConstants.TABLE_STATISTIC_TBL_NAME);
+            colStatsTbl = (OlapTable) StatisticsUtil.findTable(InternalCatalog.INTERNAL_CATALOG_NAME,
+                dbName, StatisticConstants.TABLE_STATISTIC_TBL_NAME);
+            partitionColStatsTbl = (OlapTable) StatisticsUtil.findTable(InternalCatalog.INTERNAL_CATALOG_NAME,
+                dbName, StatisticConstants.PARTITION_STATISTIC_TBL_NAME);
         } catch (Throwable t) {
             LOG.warn("Failed to init stats cleaner", t);
             return false;
@@ -117,10 +118,10 @@ public class StatisticsCleaner extends MasterDaemon {
         return true;
     }
 
-    private Map<Long, DatabaseIf> constructDbMap() {
-        Map<Long, DatabaseIf> idToDb = Maps.newHashMap();
-        for (CatalogIf<? extends DatabaseIf> ctl : idToCatalog.values()) {
-            for (DatabaseIf db : ctl.getAllDbs()) {
+    private Map<Long, DatabaseIf<? extends TableIf>> constructDbMap() {
+        Map<Long, DatabaseIf<? extends TableIf>> idToDb = Maps.newHashMap();
+        for (CatalogIf<? extends DatabaseIf<? extends TableIf>> ctl : idToCatalog.values()) {
+            for (DatabaseIf<? extends TableIf> db : ctl.getAllDbs()) {
                 idToDb.put(db.getId(), db);
             }
         }
@@ -152,28 +153,33 @@ public class StatisticsCleaner extends MasterDaemon {
         return idToMVIdx;
     }
 
-    private void deleteExpiredStats(ExpiredStats expiredStats, String tblName) {
+    private void deleteExpiredStats(ExpiredStats expiredStats, String tblName, boolean isTableColumnStats) {
         doDelete("catalog_id", expiredStats.expiredCatalog.stream()
                         .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
+                FeConstants.INTERNAL_DB_NAME + "." + tblName);
         doDelete("db_id", expiredStats.expiredDatabase.stream()
                         .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
+                FeConstants.INTERNAL_DB_NAME + "." + tblName);
         doDelete("tbl_id", expiredStats.expiredTable.stream()
                         .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
+                FeConstants.INTERNAL_DB_NAME + "." + tblName);
         doDelete("idx_id", expiredStats.expiredIdxId.stream()
                         .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
-        doDelete("part_id", expiredStats.expiredPartitionId.stream()
-                        .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
-        doDelete("id", expiredStats.ids.stream()
-                        .map(String::valueOf).collect(Collectors.toList()),
-                FeConstants.INTERNAL_DB_NAME + "." + tblName, false);
+                FeConstants.INTERNAL_DB_NAME + "." + tblName);
+        // Partition level column stats doesn't need to do the following deletion.
+        // 1. For invalid part id, do it in next analyze
+        // 2. Partition stats table doesn't have id column.
+        if (isTableColumnStats) {
+            doDelete("part_id", expiredStats.expiredPartitionId.stream()
+                    .map(String::valueOf).collect(Collectors.toList()),
+                    FeConstants.INTERNAL_DB_NAME + "." + tblName);
+            doDelete("id", expiredStats.ids.stream()
+                    .map(String::valueOf).collect(Collectors.toList()),
+                    FeConstants.INTERNAL_DB_NAME + "." + tblName);
+        }
     }
 
-    private void doDelete(String colName, List<String> pred, String tblName, boolean taskOnly) {
+    private void doDelete(String colName, List<String> pred, String tblName) {
         String deleteTemplate = "DELETE FROM " + tblName + " WHERE ${left} IN (${right})";
         if (CollectionUtils.isEmpty(pred)) {
             return;
@@ -183,9 +189,6 @@ public class StatisticsCleaner extends MasterDaemon {
         params.put("left", colName);
         params.put("right", right);
         String sql = new StringSubstitutor(params).replace(deleteTemplate);
-        if (taskOnly) {
-            sql += " AND task_id != -1";
-        }
         try {
             StatisticsUtil.execUpdate(sql);
         } catch (Exception e) {
@@ -193,11 +196,12 @@ public class StatisticsCleaner extends MasterDaemon {
         }
     }
 
-    private long findExpiredStats(OlapTable statsTbl, ExpiredStats expiredStats, long offset) {
+    private long findExpiredStats(OlapTable statsTbl, ExpiredStats expiredStats,
+                                  long offset, boolean isTableColumnStats) {
         long pos = offset;
-        while (pos < statsTbl.getRowCount()
-                && !expiredStats.isFull()) {
-            List<ResultRow> rows = StatisticsRepository.fetchStatsFullName(StatisticConstants.FETCH_LIMIT, pos);
+        while (pos < statsTbl.getRowCount() && !expiredStats.isFull()) {
+            List<ResultRow> rows = StatisticsRepository.fetchStatsFullName(
+                    StatisticConstants.FETCH_LIMIT, pos, isTableColumnStats);
             pos += StatisticConstants.FETCH_LIMIT;
             for (ResultRow r : rows) {
                 try {
@@ -234,14 +238,12 @@ public class StatisticsCleaner extends MasterDaemon {
                     if (!(t instanceof OlapTable)) {
                         continue;
                     }
-                    OlapTable olapTable = (OlapTable) t;
+                    // part_id should always be NULL in column_statistics table.
                     String partId = statsId.partId;
                     if (partId == null) {
                         continue;
                     }
-                    if (!olapTable.getPartitionIds().contains(Long.parseLong(partId))) {
-                        expiredStats.expiredPartitionId.add(Long.parseLong(partId));
-                    }
+                    expiredStats.expiredPartitionId.add(partId);
                 } catch (Exception e) {
                     LOG.warn("Error occurred when retrieving expired stats", e);
                 }
@@ -256,7 +258,7 @@ public class StatisticsCleaner extends MasterDaemon {
         Set<Long> expiredDatabase = new HashSet<>();
         Set<Long> expiredTable = new HashSet<>();
         Set<Long> expiredIdxId = new HashSet<>();
-        Set<Long> expiredPartitionId = new HashSet<>();
+        Set<String> expiredPartitionId = new HashSet<>();
         Set<String> ids = new HashSet<>();
 
         public boolean isFull() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -35,10 +35,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -108,21 +106,17 @@ public class StatisticsRepository {
                     + " ORDER BY update_time DESC LIMIT "
                     + Config.stats_cache_size;
 
-    private static final String FETCH_STATS_FULL_NAME =
+    private static final String FETCH_TABLE_STATS_FULL_NAME =
             "SELECT id, catalog_id, db_id, tbl_id, idx_id, col_id, part_id FROM "
                     + FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.TABLE_STATISTIC_TBL_NAME
                     + " ORDER BY update_time "
                     + "LIMIT ${limit} OFFSET ${offset}";
 
-    private static final String FETCH_STATS_PART_ID = "SELECT * FROM "
-            + FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.TABLE_STATISTIC_TBL_NAME
-            + " WHERE tbl_id = ${tblId} AND `catalog_id` = '${catalogId}' AND `db_id` = '${dbId}'"
-            + " AND part_id IS NOT NULL";
-
-    private static final String QUERY_PARTITION_STATISTICS = "SELECT * FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.TABLE_STATISTIC_TBL_NAME + " WHERE "
-            + " ${inPredicate} AND `catalog_id` = '${catalogId}' AND `db_id` = '${dbId}'"
-            + " AND part_id IS NOT NULL";
+    private static final String FETCH_PARTITION_STATS_FULL_NAME =
+            "SELECT \"\" as id, catalog_id, db_id, tbl_id, idx_id, col_id, part_id FROM "
+                    + FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.PARTITION_STATISTIC_TBL_NAME
+                    + " ORDER BY update_time "
+                    + "LIMIT ${limit} OFFSET ${offset}";
 
     private static final String FETCH_TABLE_STATISTICS = "SELECT * FROM "
             + FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.TABLE_STATISTIC_TBL_NAME
@@ -372,38 +366,12 @@ public class StatisticsRepository {
         return StatisticsUtil.execStatisticQuery(FETCH_RECENT_STATS_UPDATED_COL);
     }
 
-    public static List<ResultRow> fetchStatsFullName(long limit, long offset) {
+    public static List<ResultRow> fetchStatsFullName(long limit, long offset, boolean isTableStats) {
         Map<String, String> params = new HashMap<>();
         params.put("limit", String.valueOf(limit));
         params.put("offset", String.valueOf(offset));
-        return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params).replace(FETCH_STATS_FULL_NAME));
-    }
-
-    public static Map<String, Set<String>> fetchColAndPartsForStats(long ctlId, long dbId, long tblId) {
-        Map<String, String> params = Maps.newHashMap();
-        params.put("tblId", String.valueOf(tblId));
-        StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
-        generateCtlDbIdParams(ctlId, dbId, params);
-        String partSql = stringSubstitutor.replace(FETCH_STATS_PART_ID);
-        List<ResultRow> resultRows = StatisticsUtil.execStatisticQuery(partSql);
-
-        Map<String, Set<String>> columnToPartitions = Maps.newHashMap();
-
-        resultRows.forEach(row -> {
-            try {
-                StatsId statsId = new StatsId(row);
-                if (statsId.partId == null) {
-                    return;
-                }
-                columnToPartitions.computeIfAbsent(String.valueOf(statsId.colId),
-                        k -> new HashSet<>()).add(statsId.partId);
-            } catch (NumberFormatException e) {
-                LOG.warn("Failed to obtain the column and partition for statistics.",
-                        e);
-            }
-        });
-
-        return columnToPartitions;
+        String template = isTableStats ? FETCH_TABLE_STATS_FULL_NAME : FETCH_PARTITION_STATS_FULL_NAME;
+        return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params).replace(template));
     }
 
     public static List<ResultRow> loadColStats(long ctlId, long dbId, long tableId, long idxId, String colName) {
@@ -425,24 +393,6 @@ public class StatisticsRepository {
         params.put("columnId", colName);
         return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
             .replace(FETCH_PARTITION_STATISTIC_TEMPLATE));
-    }
-
-    public static List<ResultRow> loadPartStats(Collection<StatisticsCacheKey> keys) {
-        String inPredicate = "CONCAT(tbl_id, '-', idx_id, '-', col_id) in (%s)";
-        StringJoiner sj = new StringJoiner(",");
-        long ctlId = -1;
-        long dbId = -1;
-        // ATTN: ctlId and dbId should be same in all keys
-        for (StatisticsCacheKey statisticsCacheKey : keys) {
-            sj.add("'" + statisticsCacheKey.toString() + "'");
-            ctlId = statisticsCacheKey.catalogId;
-            dbId = statisticsCacheKey.dbId;
-        }
-        Map<String, String> params = new HashMap<>();
-        params.put("inPredicate", String.format(inPredicate, sj.toString()));
-        generateCtlDbIdParams(ctlId, dbId, params);
-        return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
-                .replace(QUERY_PARTITION_STATISTICS));
     }
 
     private static void generateCtlDbIdParams(long ctdId, long dbId, Map<String, String> params) {


### PR DESCRIPTION
## Proposed changes
Support clear stale partition stats.

<!--Describe your changes.-->

When catalog/db/table was dropped, the partition level stats for those dropped tables should be removed in background. This pr is to support this.