### PR TITLE
[feature](pipelline)add local merge sort exchaner

### DIFF
--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -813,6 +813,8 @@ enum class ExchangeType : uint8_t {
     ADAPTIVE_PASSTHROUGH = 5,
     // Send all data to the first channel.
     PASS_TO_ONE = 6,
+    // merge all data to ont channel.
+    LOCAL_MERGE_SORT = 7,
 };
 
 inline std::string get_exchange_type_name(ExchangeType idx) {
@@ -831,6 +833,8 @@ inline std::string get_exchange_type_name(ExchangeType idx) {
         return "ADAPTIVE_PASSTHROUGH";
     case ExchangeType::PASS_TO_ONE:
         return "PASS_TO_ONE";
+    case ExchangeType::LOCAL_MERGE_SORT:
+        return "LOCAL_MERGE_SORT";
     }
     LOG(FATAL) << "__builtin_unreachable";
     __builtin_unreachable();

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -813,7 +813,7 @@ enum class ExchangeType : uint8_t {
     ADAPTIVE_PASSTHROUGH = 5,
     // Send all data to the first channel.
     PASS_TO_ONE = 6,
-    // merge all data to ont channel.
+    // merge all data to one channel.
     LOCAL_MERGE_SORT = 7,
 };
 

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -657,6 +657,8 @@ Status ExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
 
 DataDistribution ExchangeSinkOperatorX::required_data_distribution() const {
     if (_child_x && _enable_local_merge_sort) {
+        // SORT_OPERATOR -> DATA_STREAM_SINK_OPERATOR
+        // SORT_OPERATOR -> LOCAL_MERGE_SORT -> DATA_STREAM_SINK_OPERATOR
         if (auto sort_source = std::dynamic_pointer_cast<SortSourceOperatorX>(_child_x);
             sort_source && sort_source->use_local_merge()) {
             // Sort the data local

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -26,7 +26,9 @@
 
 #include "common/status.h"
 #include "exchange_sink_buffer.h"
+#include "pipeline/dependency.h"
 #include "pipeline/exec/operator.h"
+#include "pipeline/exec/sort_source_operator.h"
 #include "pipeline/local_exchange/local_exchange_sink_operator.h"
 #include "vec/columns/column_const.h"
 #include "vec/exprs/vexpr.h"
@@ -298,7 +300,8 @@ ExchangeSinkOperatorX::ExchangeSinkOperatorX(
           _tablet_sink_partition(sink.tablet_sink_partition),
           _tablet_sink_location(sink.tablet_sink_location),
           _tablet_sink_tuple_id(sink.tablet_sink_tuple_id),
-          _tablet_sink_txn_id(sink.tablet_sink_txn_id) {
+          _tablet_sink_txn_id(sink.tablet_sink_txn_id),
+          _enable_local_merge_sort(state->enable_local_merge_sort()) {
     DCHECK_GT(destinations.size(), 0);
     DCHECK(sink.output_partition.type == TPartitionType::UNPARTITIONED ||
            sink.output_partition.type == TPartitionType::HASH_PARTITIONED ||
@@ -650,6 +653,17 @@ Status ExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
         _sink_buffer->close();
     }
     return Base::close(state, exec_status);
+}
+
+DataDistribution ExchangeSinkOperatorX::required_data_distribution() const {
+    if (_child_x && _enable_local_merge_sort) {
+        if (auto sort_source = std::dynamic_pointer_cast<SortSourceOperatorX>(_child_x);
+            sort_source && sort_source->use_local_merge()) {
+            // Sort the data local
+            return ExchangeType::LOCAL_MERGE_SORT;
+        }
+    }
+    return DataSinkOperatorX<ExchangeSinkLocalState>::required_data_distribution();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -219,6 +219,7 @@ public:
 
     Status serialize_block(ExchangeSinkLocalState& stete, vectorized::Block* src, PBlock* dest,
                            int num_receivers = 1);
+    DataDistribution required_data_distribution() const override;
 
 private:
     friend class ExchangeSinkLocalState;
@@ -271,6 +272,7 @@ private:
     // Control the number of channels according to the flow, thereby controlling the number of table sink writers.
     size_t _data_processed = 0;
     int _writer_count = 1;
+    const bool _enable_local_merge_sort;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -114,6 +114,7 @@ public:
 
     virtual Status revoke_memory(RuntimeState* state) { return Status::OK(); }
     [[nodiscard]] virtual bool require_data_distribution() const { return false; }
+    OperatorXPtr child_x() { return _child_x; }
 
 protected:
     OperatorXPtr _child_x = nullptr;

--- a/be/src/pipeline/exec/sort_source_operator.cpp
+++ b/be/src/pipeline/exec/sort_source_operator.cpp
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "common/status.h"
 #include "pipeline/exec/operator.h"
 
 namespace doris::pipeline {
@@ -28,7 +29,33 @@ SortLocalState::SortLocalState(RuntimeState* state, OperatorXBase* parent)
 
 SortSourceOperatorX::SortSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode, int operator_id,
                                          const DescriptorTbl& descs)
-        : OperatorX<SortLocalState>(pool, tnode, operator_id, descs) {}
+        : OperatorX<SortLocalState>(pool, tnode, operator_id, descs),
+          _merge_by_exchange(tnode.sort_node.merge_by_exchange),
+          _offset(tnode.sort_node.__isset.offset ? tnode.sort_node.offset : 0) {}
+
+Status SortSourceOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
+    RETURN_IF_ERROR(Base::init(tnode, state));
+    RETURN_IF_ERROR(_vsort_exec_exprs.init(tnode.sort_node.sort_info, _pool));
+    _is_asc_order = tnode.sort_node.sort_info.is_asc_order;
+    _nulls_first = tnode.sort_node.sort_info.nulls_first;
+    return Status::OK();
+}
+
+Status SortSourceOperatorX::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Base::prepare(state));
+    if (_child_x) {
+        RETURN_IF_ERROR(_vsort_exec_exprs.prepare(state, _child_x->row_desc(), _row_descriptor));
+    }
+    return Status::OK();
+}
+
+Status SortSourceOperatorX::open(RuntimeState* state) {
+    RETURN_IF_ERROR(Base::open(state));
+    if (_child_x) {
+        RETURN_IF_ERROR(_vsort_exec_exprs.open(state));
+    }
+    return Status::OK();
+}
 
 Status SortSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* block, bool* eos) {
     auto& local_state = get_local_state(state);
@@ -43,6 +70,17 @@ const vectorized::SortDescription& SortSourceOperatorX::get_sort_description(
         RuntimeState* state) const {
     auto& local_state = get_local_state(state);
     return local_state._shared_state->sorter->get_sort_description();
+}
+
+Status SortSourceOperatorX::build_merger(RuntimeState* state,
+                                         std::unique_ptr<vectorized::VSortedRunMerger>& merger,
+                                         RuntimeProfile* profile) {
+    vectorized::VSortExecExprs vsort_exec_exprs;
+    RETURN_IF_ERROR(_vsort_exec_exprs.clone(state, vsort_exec_exprs));
+    merger = std::make_unique<vectorized::VSortedRunMerger>(
+            vsort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _nulls_first,
+            state->batch_size(), _limit, _offset, profile);
+    return Status::OK();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/sort_source_operator.cpp
+++ b/be/src/pipeline/exec/sort_source_operator.cpp
@@ -19,7 +19,6 @@
 
 #include <string>
 
-#include "common/status.h"
 #include "pipeline/exec/operator.h"
 
 namespace doris::pipeline {

--- a/be/src/pipeline/local_exchange/local_exchange_sink_operator.cpp
+++ b/be/src/pipeline/local_exchange/local_exchange_sink_operator.cpp
@@ -27,6 +27,7 @@ Status LocalExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
     SCOPED_TIMER(_init_timer);
     _compute_hash_value_timer = ADD_TIMER(profile(), "ComputeHashValueTime");
     _distribute_timer = ADD_TIMER(profile(), "DistributeDataTime");
+    _channel_id = info.task_idx;
     return Status::OK();
 }
 

--- a/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
@@ -41,6 +41,13 @@ public:
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state, Status exec_status) override;
     std::string debug_string(int indentation_level) const override;
+    std::vector<Dependency*> dependencies() const override {
+        auto deps = Base::dependencies();
+        if (auto local_state_sink_dep = _exchanger->get_local_state_dependency(_channel_id)) {
+            deps.push_back(local_state_sink_dep.get());
+        }
+        return deps;
+    }
 
 private:
     friend class LocalExchangeSinkOperatorX;

--- a/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_sink_operator.h
@@ -26,6 +26,7 @@ class ShuffleExchanger;
 class PassthroughExchanger;
 class BroadcastExchanger;
 class PassToOneExchanger;
+class LocalMergeSortExchanger;
 class LocalExchangeSinkOperatorX;
 class LocalExchangeSinkLocalState final : public PipelineXSinkLocalState<LocalExchangeSharedState> {
 public:
@@ -48,6 +49,7 @@ private:
     friend class PassthroughExchanger;
     friend class BroadcastExchanger;
     friend class PassToOneExchanger;
+    friend class LocalMergeSortExchanger;
     friend class AdaptivePassthroughExchanger;
 
     Exchanger* _exchanger = nullptr;

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.h
@@ -26,6 +26,7 @@ class ShuffleExchanger;
 class PassthroughExchanger;
 class BroadcastExchanger;
 class PassToOneExchanger;
+class LocalMergeSortExchanger;
 class LocalExchangeSourceOperatorX;
 class LocalExchangeSourceLocalState final : public PipelineXLocalState<LocalExchangeSharedState> {
 public:
@@ -46,6 +47,7 @@ private:
     friend class PassthroughExchanger;
     friend class BroadcastExchanger;
     friend class PassToOneExchanger;
+    friend class LocalMergeSortExchanger;
     friend class AdaptivePassthroughExchanger;
 
     Exchanger* _exchanger = nullptr;

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -38,6 +38,7 @@
 #include "common/status.h"
 #include "exec/data_sink.h"
 #include "io/fs/stream_load_pipe.h"
+#include "pipeline/dependency.h"
 #include "pipeline/exec/aggregation_sink_operator.h"
 #include "pipeline/exec/aggregation_source_operator.h"
 #include "pipeline/exec/analytic_sink_operator.h"
@@ -91,6 +92,7 @@
 #include "pipeline/exec/union_source_operator.h"
 #include "pipeline/local_exchange/local_exchange_sink_operator.h"
 #include "pipeline/local_exchange/local_exchange_source_operator.h"
+#include "pipeline/local_exchange/local_exchanger.h"
 #include "pipeline/task_scheduler.h"
 #include "pipeline_task.h"
 #include "runtime/exec_env.h"
@@ -743,6 +745,21 @@ Status PipelineFragmentContext::_add_local_exchange_impl(
                         ? _runtime_state->query_options().local_exchange_free_blocks_limit
                         : 0);
         break;
+    case ExchangeType::LOCAL_MERGE_SORT: {
+        auto child_op = cur_pipe->sink_x()->child_x();
+        auto sort_source = std::dynamic_pointer_cast<SortSourceOperatorX>(child_op);
+        if (!sort_source) {
+            return Status::InternalError(
+                    "LOCAL_MERGE_SORT must use in SortSourceOperatorX , but now is {} ",
+                    child_op->get_name());
+        }
+        shared_state->exchanger = LocalMergeSortExchanger::create_unique(
+                sort_source, cur_pipe->num_tasks(), _num_instances,
+                _runtime_state->query_options().__isset.local_exchange_free_blocks_limit
+                        ? _runtime_state->query_options().local_exchange_free_blocks_limit
+                        : 0);
+        break;
+    }
     case ExchangeType::ADAPTIVE_PASSTHROUGH:
         shared_state->exchanger = AdaptivePassthroughExchanger::create_unique(
                 cur_pipe->num_tasks(), _num_instances,

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -597,6 +597,11 @@ public:
         return _query_options.__isset.enable_force_spill && _query_options.enable_force_spill;
     }
 
+    bool enable_local_merge_sort() const {
+        return _query_options.__isset.enable_local_merge_sort &&
+               _query_options.enable_local_merge_sort;
+    }
+
     int64_t min_revocable_mem() const {
         if (_query_options.__isset.min_revocable_mem) {
             return _query_options.min_revocable_mem;

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -195,6 +195,9 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
     }
 
     bool has_next_block() override {
+        if (_is_eof) {
+            return false;
+        }
         _block.clear();
         Status status;
         do {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -252,6 +252,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String FORCE_TO_LOCAL_SHUFFLE = "force_to_local_shuffle";
 
+    public static final String ENABLE_LOCAL_MERGE_SORT = "enable_local_merge_sort";
+
     public static final String ENABLE_AGG_STATE = "enable_agg_state";
 
     public static final String ENABLE_BUCKET_SHUFFLE_DOWNGRADE = "enable_bucket_shuffle_downgrade";
@@ -972,6 +974,9 @@ public class SessionVariable implements Serializable, Writable {
                 description = {"是否在pipelineX引擎上强制开启local shuffle优化",
                         "Whether to force to local shuffle on pipelineX engine."})
     private boolean forceToLocalShuffle = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_LOCAL_MERGE_SORT)
+    private boolean enableLocalMergeSort = true;
 
     @VariableMgr.VarAttr(name = ENABLE_AGG_STATE, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL,
             needForward = true)
@@ -3391,6 +3396,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setMinRevocableMem(minRevocableMem);
         tResult.setDataQueueMaxBlocks(dataQueueMaxBlocks);
 
+        tResult.setEnableLocalMergeSort(enableLocalMergeSort);
         return tResult;
     }
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -299,6 +299,8 @@ struct TQueryOptions {
   111: optional bool enable_orc_filter_by_min_max = true
 
   112: optional i32 max_column_reader_num = 0
+
+  113: optional bool enable_local_merge_sort = false;
   
   // For cloud, to control if the content would be written into file cache
   1000: optional bool disable_file_cache = false


### PR DESCRIPTION
## Proposed changes
```
                      DATA_STREAM_SINK_OPERATOR  (id=2,dst_id=2):
                            -  BlocksProduced:  sum  2,  avg  1,  max  2,  min  0
                            -  CloseTime:  avg  50.352us,  max  59.404us,  min  41.300us
                            -  ExecTime:  avg  357.197us,  max  428.119us,  min  286.275us
                            -  InitTime:  avg  103.853us,  max  104.291us,  min  103.416us
                            -  InputRows:  sum  60,  avg  30,  max  60,  min  0
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  128.654us,  max  163.939us,  min  93.370us
                            -  RowsProduced:  sum  60,  avg  30,  max  60,  min  0
                            -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                -  WaitForRpcBufferQueue:  avg  0ns,  max  0ns,  min  0ns
                          LOCAL_EXCHANGE_OPERATOR  (LOCAL_MERGE_SORT)  (id=-3):
                                -  BlocksProduced:  sum  2,  avg  1,  max  2,  min  0
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  873.747us,  max  1.737ms,  min  9.663us
                                -  GetBlockFailedTime:  sum  0,  avg  0,  max  0,  min  0
                                -  InitTime:  avg  466ns,  max  495ns,  min  437ns
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                -  OpenTime:  avg  19.531us,  max  31.460us,  min  7.602us
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  60,  avg  30,  max  60,  min  0
                                -  WaitForDependency[LOCAL_EXCHANGE_OPERATOR_DEPENDENCY]Time:  avg  14.130ms,  max  14.701ms,  min  13.558ms
                  Pipeline  :  1(instance_num=2):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (LOCAL_MERGE_SORT)  (id=-3):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  59.515us,  max  68.50us,  min  50.981us
                            -  InitTime:  avg  8.415us,  max  8.695us,  min  8.135us
                            -  InputRows:  sum  60,  avg  30,  max  30,  min  30
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  1.498us,  max  1.630us,  min  1.366us
                            -  WaitForDependency[LOCAL_EXCHANGE_SINK_DEPENDENCY]Time:  avg  0ns,  max  0ns,  min  0ns
                          SORT_OPERATOR  (id=1  ,  nereids_id=108):
                                -  PlanInfo
                                      -  order  by:  s_suppkey  ASC
                                      -  TOPN  OPT
                                      -  offset:  0
                                      -  limit:  30
                                -  BlocksProduced:  sum  2,  avg  1,  max  1,  min  1
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  10.593us,  max  18.22us,  min  3.165us
                                -  InitTime:  avg  0ns,  max  0ns,  min  0ns
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                -  OpenTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
```
<!--Describe your changes.-->

