### PR TITLE
[branch-2.0][improvement](jdbc catalog) Change JdbcExecutor's error reporting from UDF to JDBC

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorException.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcExecutorException.java
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jdbc;
+
+public class JdbcExecutorException extends Exception {
+    public JdbcExecutorException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public JdbcExecutorException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
## Proposed changes

pick #35692

In the initial version, JdbcExecutor directly used UdfRuntimeException, which could lead to misunderstanding of the exception. Therefore, I created a separate Exception for JdbcExecutor to help us view the exception more clearly.

