### PR TITLE
[chore](third-party) Add a workflow: Build Third Party Libraries (macOS-arm64)

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -32,7 +32,7 @@ jobs:
       thirdparty_changes: ${{ steps.filter.outputs.thirdparty_changes }}
     steps:
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
@@ -67,7 +67,7 @@ jobs:
             remove-docker-images: 'true'
 
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download
         run: |
@@ -129,10 +129,10 @@ jobs:
     name: Build Third Party Libraries (macOS)
     needs: changes
     if: ${{ needs.changes.outputs.thirdparty_changes == 'true' }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download
         run: |
@@ -144,6 +144,58 @@ jobs:
       - name: Prepare
         run: |
           packages=(
+            'm4'
+            'automake'
+            'autoconf'
+            'libtool'
+            'pkg-config'
+            'texinfo'
+            'coreutils'
+            'gnu-getopt'
+            'python@3'
+            'cmake'
+            'ninja'
+            'ccache'
+            'bison'
+            'byacc'
+            'gettext'
+            'wget'
+            'pcre'
+            'openjdk@11'
+            'maven'
+            'node'
+            'llvm@16'
+          )
+
+          brew install "${packages[@]}" || true
+
+      - name: Build
+        run: |
+          export MACOSX_DEPLOYMENT_TARGET=12.0
+
+          cd thirdparty
+          ./build-thirdparty.sh -j "$(nproc)"
+
+  build_macos_arm64:
+    name: Build Third Party Libraries (macOS-arm64)
+    needs: changes
+    if: ${{ needs.changes.outputs.thirdparty_changes == 'true' }}
+    runs-on: macos-14
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v4
+
+      - name: Download
+        run: |
+          cd thirdparty
+          curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-source.tgz \
+            -o doris-thirdparty-source.tgz
+          tar -zxvf doris-thirdparty-source.tgz
+
+      - name: Prepare
+        run: |
+          packages=(
+            'm4'
             'automake'
             'autoconf'
             'libtool'


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Recently, GitHub actions provide macOS arm64 environment to run workflows. Therefore, we can use this environment to build our macOS arm64 packages.

We should add a check in the main repository in order to make the workflows in [apache/doris-thirdparty](https://github.com/apache/doris-thirdparty) work well.

