### PR TITLE
[test](mtmv)add increment create mtmv case

### DIFF
--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_list_str_increment_create.groovy
@@ -238,6 +238,24 @@ suite("cross_join_list_str_increment_create") {
         cross join orders_cross_1 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_1.L_SHIPDATE order by lineitem_cross_1.L_ORDERKEY) as window_count 
+        from lineitem_cross_1 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_1.l_orderkey order by lineitem_cross_1.l_orderkey) as window_count
+        from lineitem_cross_1
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_1.l_orderkey) as window_count 
+        from lineitem_cross_1 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_cross_1.O_ORDERDATE) over (partition by orders_cross_1.O_ORDERDATE order by lineitem_cross_1.L_ORDERKEY) as window_count 
@@ -256,6 +274,24 @@ suite("cross_join_list_str_increment_create") {
         from lineitem_cross_1 
         cross join orders_cross_1 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_cross_1.L_ORDERKEY) as window_count 
+        from lineitem_cross_1 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_cross_1.l_orderkey) as window_count
+        from lineitem_cross_1
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_1.l_orderkey) as window_count 
+        from lineitem_cross_1 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_1 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -307,54 +343,59 @@ suite("cross_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list, partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list, partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list, partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list, partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 
 }

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
@@ -229,6 +229,24 @@ suite("cross_join_range_date_increment_create") {
         cross join orders_cross_2 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_2.L_SHIPDATE order by lineitem_cross_2.L_ORDERKEY) as window_count 
+        from lineitem_cross_2 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_2.l_orderkey order by lineitem_cross_2.l_orderkey) as window_count
+        from lineitem_cross_2
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_2.l_orderkey) as window_count 
+        from lineitem_cross_2 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_cross_2.O_ORDERDATE) over (partition by orders_cross_2.O_ORDERDATE order by lineitem_cross_2.L_ORDERKEY) as window_count 
@@ -247,6 +265,24 @@ suite("cross_join_range_date_increment_create") {
         from lineitem_cross_2 
         cross join orders_cross_2 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_cross_2.L_ORDERKEY) as window_count 
+        from lineitem_cross_2 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_cross_2.l_orderkey) as window_count
+        from lineitem_cross_2
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_2.l_orderkey) as window_count 
+        from lineitem_cross_2 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_2 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -298,57 +334,62 @@ suite("cross_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_number_increment_create.groovy
@@ -238,6 +238,24 @@ suite("cross_join_range_number_increment_create") {
         cross join orders_cross_3  
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_3.L_SHIPDATE order by lineitem_cross_3.L_ORDERKEY) as window_count 
+        from lineitem_cross_3 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_cross_3.l_orderkey order by lineitem_cross_3.l_orderkey) as window_count
+        from lineitem_cross_3
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_3.l_orderkey) as window_count 
+        from lineitem_cross_3 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_cross_3.O_ORDERDATE) over (partition by orders_cross_3.O_ORDERDATE order by lineitem_cross_3.L_ORDERKEY) as window_count 
@@ -256,6 +274,24 @@ suite("cross_join_range_number_increment_create") {
         from lineitem_cross_3 
         cross join orders_cross_3 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_cross_3.L_ORDERKEY) as window_count 
+        from lineitem_cross_3 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_cross_3.l_orderkey) as window_count
+        from lineitem_cross_3
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_cross_3.l_orderkey) as window_count 
+        from lineitem_cross_3 
+        cross join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_cross_3 group by O_ORDERDATE, o_orderkey) as t 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -307,57 +343,62 @@ suite("cross_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_list_str_increment_create.groovy
@@ -245,6 +245,27 @@ suite("full_join_list_str_increment_create") {
         on lineitem_full_1.l_orderkey = orders_full_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_1.L_SHIPDATE order by lineitem_full_1.L_ORDERKEY) as window_count 
+        from lineitem_full_1 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_1.l_orderkey order by lineitem_full_1.l_orderkey) as window_count
+        from lineitem_full_1
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_1.l_orderkey) as window_count 
+        from lineitem_full_1 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_full_1.O_ORDERDATE) over (partition by orders_full_1.O_ORDERDATE order by lineitem_full_1.L_ORDERKEY) as window_count 
@@ -266,6 +287,27 @@ suite("full_join_list_str_increment_create") {
         full join orders_full_1 
         on lineitem_full_1.l_orderkey = orders_full_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_full_1.L_ORDERKEY) as window_count 
+        from lineitem_full_1 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_full_1.l_orderkey) as window_count
+        from lineitem_full_1
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_1.l_orderkey) as window_count 
+        from lineitem_full_1 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -317,13 +359,15 @@ suite("full_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("full_join_range_date_increment_create") {
         on lineitem_full_2.l_orderkey = orders_full_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_2.L_SHIPDATE order by lineitem_full_2.L_ORDERKEY) as window_count 
+        from lineitem_full_2 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_2.l_orderkey order by lineitem_full_2.l_orderkey) as window_count
+        from lineitem_full_2
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_2.l_orderkey) as window_count 
+        from lineitem_full_2 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_full_2.O_ORDERDATE) over (partition by orders_full_2.O_ORDERDATE order by lineitem_full_2.L_ORDERKEY) as window_count 
@@ -257,6 +278,27 @@ suite("full_join_range_date_increment_create") {
         full join orders_full_2 
         on lineitem_full_2.l_orderkey = orders_full_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_full_2.L_ORDERKEY) as window_count 
+        from lineitem_full_2 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_full_2.l_orderkey) as window_count
+        from lineitem_full_2
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_2.l_orderkey) as window_count 
+        from lineitem_full_2 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -308,13 +350,15 @@ suite("full_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/full_join_range_number_increment_create.groovy
@@ -245,6 +245,27 @@ suite("full_join_range_number_increment_create") {
         on lineitem_full_3.l_orderkey = orders_full_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_3.L_SHIPDATE order by lineitem_full_3.L_ORDERKEY) as window_count 
+        from lineitem_full_3 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_full_3.l_orderkey order by lineitem_full_3.l_orderkey) as window_count
+        from lineitem_full_3
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_3.l_orderkey) as window_count 
+        from lineitem_full_3 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_full_3.O_ORDERDATE) over (partition by orders_full_3.O_ORDERDATE order by lineitem_full_3.L_ORDERKEY) as window_count 
@@ -266,6 +287,27 @@ suite("full_join_range_number_increment_create") {
         full join orders_full_3 
         on lineitem_full_3.l_orderkey = orders_full_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_full_3.L_ORDERKEY) as window_count 
+        from lineitem_full_3 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_full_3.l_orderkey) as window_count
+        from lineitem_full_3
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_full_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_full_3.l_orderkey) as window_count 
+        from lineitem_full_3 
+        full join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_full_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_full_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -317,13 +359,15 @@ suite("full_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_list_str_increment_create.groovy
@@ -245,6 +245,27 @@ suite("inner_join_list_str_increment_create") {
         on lineitem_inner_1.l_orderkey = orders_inner_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_1.L_SHIPDATE order by lineitem_inner_1.L_ORDERKEY) as window_count 
+        from lineitem_inner_1 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_1.l_orderkey order by lineitem_inner_1.l_orderkey) as window_count
+        from lineitem_inner_1
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_1.l_orderkey) as window_count 
+        from lineitem_inner_1 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_inner_1.O_ORDERDATE) over (partition by orders_inner_1.O_ORDERDATE order by lineitem_inner_1.L_ORDERKEY) as window_count 
@@ -266,6 +287,27 @@ suite("inner_join_list_str_increment_create") {
         inner join orders_inner_1 
         on lineitem_inner_1.l_orderkey = orders_inner_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_inner_1.L_ORDERKEY) as window_count 
+        from lineitem_inner_1 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_inner_1.l_orderkey) as window_count
+        from lineitem_inner_1
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_1.l_orderkey) as window_count 
+        from lineitem_inner_1 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -317,57 +359,63 @@ suite("inner_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
+
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("inner_join_range_date_increment_create") {
         on lineitem_inner_2.l_orderkey = orders_inner_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_2.L_SHIPDATE order by lineitem_inner_2.L_ORDERKEY) as window_count 
+        from lineitem_inner_2 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_2.l_orderkey order by lineitem_inner_2.l_orderkey) as window_count
+        from lineitem_inner_2
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_2.l_orderkey) as window_count 
+        from lineitem_inner_2 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_inner_2.O_ORDERDATE) over (partition by orders_inner_2.O_ORDERDATE order by lineitem_inner_2.L_ORDERKEY) as window_count 
@@ -257,6 +278,27 @@ suite("inner_join_range_date_increment_create") {
         inner join orders_inner_2 
         on lineitem_inner_2.l_orderkey = orders_inner_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_inner_2.L_ORDERKEY) as window_count 
+        from lineitem_inner_2 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_inner_2.l_orderkey) as window_count
+        from lineitem_inner_2
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_2.l_orderkey) as window_count 
+        from lineitem_inner_2 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -308,57 +350,62 @@ suite("inner_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_number_increment_create.groovy
@@ -246,6 +246,27 @@ suite("inner_join_range_number_increment_create") {
         on lineitem_inner_3.l_orderkey = orders_inner_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_3.L_SHIPDATE order by lineitem_inner_3.L_ORDERKEY) as window_count 
+        from lineitem_inner_3 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_inner_3.l_orderkey order by lineitem_inner_3.l_orderkey) as window_count
+        from lineitem_inner_3
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_3.l_orderkey) as window_count 
+        from lineitem_inner_3 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_inner_3.O_ORDERDATE) over (partition by orders_inner_3.O_ORDERDATE order by lineitem_inner_3.L_ORDERKEY) as window_count 
@@ -267,6 +288,27 @@ suite("inner_join_range_number_increment_create") {
         inner join orders_inner_3 
         on lineitem_inner_3.l_orderkey = orders_inner_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_inner_3.L_ORDERKEY) as window_count 
+        from lineitem_inner_3 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_inner_3.l_orderkey) as window_count
+        from lineitem_inner_3
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_inner_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_inner_3.l_orderkey) as window_count 
+        from lineitem_inner_3 
+        inner join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_inner_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_inner_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -318,57 +360,62 @@ suite("inner_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_list_str_increment_create.groovy
@@ -244,6 +244,27 @@ suite("left_anti_join_list_str_increment_create") {
         on lineitem_left_anti_1.l_orderkey = orders_left_anti_1.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_1.l_shipdate) over (partition by lineitem_left_anti_1.L_SHIPDATE order by lineitem_left_anti_1.L_ORDERKEY) as window_count 
+        from lineitem_left_anti_1 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_anti_1.l_shipdate) over (partition by lineitem_left_anti_1.l_orderkey order by lineitem_left_anti_1.l_orderkey) as window_count
+        from lineitem_left_anti_1
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_1.l_shipdate) over (order by lineitem_left_anti_1.l_orderkey) as window_count 
+        from lineitem_left_anti_1 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_anti_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -280,53 +301,53 @@ suite("left_anti_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_date_increment_create.groovy
@@ -221,6 +221,27 @@ suite("left_anti_join_range_date_increment_create") {
         on lineitem_left_anti_2.l_orderkey = orders_left_anti_2.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_2.l_shipdate) over (partition by lineitem_left_anti_2.L_SHIPDATE order by lineitem_left_anti_2.L_ORDERKEY) as window_count 
+        from lineitem_left_anti_2 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_anti_2.l_shipdate) over (partition by lineitem_left_anti_2.l_orderkey order by lineitem_left_anti_2.l_orderkey) as window_count
+        from lineitem_left_anti_2
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_2.l_shipdate) over (order by lineitem_left_anti_2.l_orderkey) as window_count 
+        from lineitem_left_anti_2 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_anti_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -271,53 +292,53 @@ suite("left_anti_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_number_increment_create.groovy
@@ -243,6 +243,27 @@ suite("left_anti_join_range_number_increment_create") {
         on lineitem_left_anti_3.l_orderkey = orders_left_anti_3.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_3.l_shipdate) over (partition by lineitem_left_anti_3.L_SHIPDATE order by lineitem_left_anti_3.L_ORDERKEY) as window_count 
+        from lineitem_left_anti_3 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_anti_3.l_shipdate) over (partition by lineitem_left_anti_3.l_orderkey order by lineitem_left_anti_3.l_orderkey) as window_count
+        from lineitem_left_anti_3
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_anti_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_anti_3.l_shipdate) over (order by lineitem_left_anti_3.l_orderkey) as window_count 
+        from lineitem_left_anti_3 
+        left anti join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_anti_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_anti_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -279,51 +300,51 @@ suite("left_anti_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_list_str_increment_create.groovy
@@ -244,6 +244,27 @@ suite("left_join_list_str_increment_create") {
         on lineitem_left_1.l_orderkey = orders_left_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (partition by lineitem_left_1.L_SHIPDATE order by lineitem_left_1.L_ORDERKEY) as window_count 
+        from lineitem_left_1 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, O_ORDERDATE,
+        count(t.O_ORDERDATE) over (partition by lineitem_left_1.l_orderkey order by lineitem_left_1.l_orderkey) as window_count
+        from lineitem_left_1
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (order by lineitem_left_1.l_orderkey) as window_count 
+        from lineitem_left_1 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -280,53 +301,53 @@ suite("left_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_date_increment_create.groovy
@@ -221,6 +221,27 @@ suite("left_join_range_date_increment_create") {
         on lineitem_left_2.l_orderkey = orders_left_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (partition by lineitem_left_2.L_SHIPDATE order by lineitem_left_2.L_ORDERKEY) as window_count 
+        from lineitem_left_2 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, O_ORDERDATE,
+        count(t.O_ORDERDATE) over (partition by lineitem_left_2.l_orderkey order by lineitem_left_2.l_orderkey) as window_count
+        from lineitem_left_2
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (order by lineitem_left_2.l_orderkey) as window_count 
+        from lineitem_left_2 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -271,53 +292,53 @@ suite("left_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_number_increment_create.groovy
@@ -243,6 +243,27 @@ suite("left_join_range_number_increment_create") {
         on lineitem_left_3.l_orderkey = orders_left_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (partition by lineitem_left_3.L_SHIPDATE order by lineitem_left_3.L_ORDERKEY) as window_count 
+        from lineitem_left_3 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, O_ORDERDATE,
+        count(t.O_ORDERDATE) over (partition by lineitem_left_3.l_orderkey order by lineitem_left_3.l_orderkey) as window_count
+        from lineitem_left_3
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, O_ORDERDATE, 
+        count(t.O_ORDERDATE) over (order by lineitem_left_3.l_orderkey) as window_count 
+        from lineitem_left_3 
+        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, O_ORDERDATE"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -279,51 +300,51 @@ suite("left_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_list_str_increment_create.groovy
@@ -244,6 +244,27 @@ suite("left_semi_join_list_str_increment_create") {
         on lineitem_left_semi_1.l_orderkey = orders_left_semi_1.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_1.l_shipdate) over (partition by lineitem_left_semi_1.L_SHIPDATE order by lineitem_left_semi_1.L_ORDERKEY) as window_count 
+        from lineitem_left_semi_1 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_semi_1.l_shipdate) over (partition by lineitem_left_semi_1.l_orderkey order by lineitem_left_semi_1.l_orderkey) as window_count
+        from lineitem_left_semi_1
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_semi_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_1.l_shipdate) over (order by lineitem_left_semi_1.l_orderkey) as window_count 
+        from lineitem_left_semi_1 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -280,53 +301,53 @@ suite("left_semi_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_date_increment_create.groovy
@@ -221,6 +221,27 @@ suite("left_semi_join_range_date_increment_create") {
         on lineitem_left_semi_2.l_orderkey = orders_left_semi_2.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_2.l_shipdate) over (partition by lineitem_left_semi_2.L_SHIPDATE order by lineitem_left_semi_2.L_ORDERKEY) as window_count 
+        from lineitem_left_semi_2 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_semi_2.l_shipdate) over (partition by lineitem_left_semi_2.l_orderkey order by lineitem_left_semi_2.l_orderkey) as window_count
+        from lineitem_left_semi_2
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_semi_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_2.l_shipdate) over (order by lineitem_left_semi_2.l_orderkey) as window_count 
+        from lineitem_left_semi_2 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -271,53 +292,53 @@ suite("left_semi_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_number_increment_create.groovy
@@ -243,6 +243,27 @@ suite("left_semi_join_range_number_increment_create") {
         on lineitem_left_semi_3.l_orderkey = orders_left_semi_3.o_orderkey 
         group by l_shipdate, l_orderkey, l_partkey"""
 
+    def mv_sql_10 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_3.l_shipdate) over (partition by lineitem_left_semi_3.L_SHIPDATE order by lineitem_left_semi_3.L_ORDERKEY) as window_count 
+        from lineitem_left_semi_3 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_11 = """select l_shipdate, l_orderkey, l_partkey,
+        count(lineitem_left_semi_3.l_shipdate) over (partition by lineitem_left_semi_3.l_orderkey order by lineitem_left_semi_3.l_orderkey) as window_count
+        from lineitem_left_semi_3
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_left_semi_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, l_partkey"""
+
+    def mv_sql_12 = """select l_shipdate, l_orderkey, l_partkey, 
+        count(lineitem_left_semi_3.l_shipdate) over (order by lineitem_left_semi_3.l_orderkey) as window_count 
+        from lineitem_left_semi_3 
+        left semi join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_semi_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_left_semi_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, l_partkey"""
+
     def list_judgement = { def all_list, def increment_list, def complete_list,
                            def error_list, def cur_col, Closure date_change, Closure judge_func ->
         for (int i = 0; i < all_list.size(); i++) {
@@ -279,51 +300,51 @@ suite("left_semi_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_list_str_increment_create.groovy
@@ -245,6 +245,27 @@ suite("right_anti_join_list_str_increment_create") {
         on lineitem_right_anti_1.l_orderkey = orders_right_anti_1.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_1 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_1.l_orderkey = t.o_orderkey 
+        group by t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_anti_1
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_1.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_1 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_anti_1.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -295,57 +316,57 @@ suite("right_anti_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("right_anti_join_range_date_increment_create") {
         on lineitem_right_anti_2.l_orderkey = orders_right_anti_2.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_2 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_2.l_orderkey = t.o_orderkey 
+        group by t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_anti_2
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_2.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_2 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_anti_2.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -286,57 +307,57 @@ suite("right_anti_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_13]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_11, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_error_list = [mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_13]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_anti_join_range_number_increment_create.groovy
@@ -245,6 +245,27 @@ suite("right_anti_join_range_number_increment_create") {
         on lineitem_right_anti_3.l_orderkey = orders_right_anti_3.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_3 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_3.l_orderkey = t.o_orderkey 
+        group by t.o_custkey, t.o_totalprice, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_anti_3
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_anti_3.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_anti_3 
+        right anti join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_anti_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_anti_3.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -295,57 +316,57 @@ suite("right_anti_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_list_str_increment_create.groovy
@@ -245,6 +245,27 @@ suite("right_join_list_str_increment_create") {
         on lineitem_right_1.l_orderkey = orders_right_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_1.L_SHIPDATE order by lineitem_right_1.L_ORDERKEY) as window_count 
+        from lineitem_right_1 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_1.l_orderkey order by lineitem_right_1.l_orderkey) as window_count
+        from lineitem_right_1
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_1.l_orderkey) as window_count 
+        from lineitem_right_1 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_right_1.O_ORDERDATE) over (partition by orders_right_1.O_ORDERDATE order by lineitem_right_1.L_ORDERKEY) as window_count 
@@ -266,6 +287,27 @@ suite("right_join_list_str_increment_create") {
         right join orders_right_1 
         on lineitem_right_1.l_orderkey = orders_right_1.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_right_1.L_ORDERKEY) as window_count 
+        from lineitem_right_1 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_right_1.l_orderkey) as window_count
+        from lineitem_right_1
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_1.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_1.l_orderkey) as window_count 
+        from lineitem_right_1 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_1 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_1.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -317,57 +359,64 @@ suite("right_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("right_join_range_date_increment_create") {
         on lineitem_right_2.l_orderkey = orders_right_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_2.L_SHIPDATE order by lineitem_right_2.L_ORDERKEY) as window_count 
+        from lineitem_right_2 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_2.l_orderkey order by lineitem_right_2.l_orderkey) as window_count
+        from lineitem_right_2
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_2.l_orderkey) as window_count 
+        from lineitem_right_2 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_right_2.O_ORDERDATE) over (partition by orders_right_2.O_ORDERDATE order by lineitem_right_2.L_ORDERKEY) as window_count 
@@ -257,6 +278,27 @@ suite("right_join_range_date_increment_create") {
         right join orders_right_2 
         on lineitem_right_2.l_orderkey = orders_right_2.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_right_2.L_ORDERKEY) as window_count 
+        from lineitem_right_2 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_right_2.l_orderkey) as window_count
+        from lineitem_right_2
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_2.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_2.l_orderkey) as window_count 
+        from lineitem_right_2 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_2 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_2.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -308,57 +350,64 @@ suite("right_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_17, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_16]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_join_range_number_increment_create.groovy
@@ -245,6 +245,27 @@ suite("right_join_range_number_increment_create") {
         on lineitem_right_3.l_orderkey = orders_right_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_3.L_SHIPDATE order by lineitem_right_3.L_ORDERKEY) as window_count 
+        from lineitem_right_3 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_14 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by lineitem_right_3.l_orderkey order by lineitem_right_3.l_orderkey) as window_count
+        from lineitem_right_3
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_15 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_3.l_orderkey) as window_count 
+        from lineitem_right_3 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
     // window func + right col
     def mv_sql_10 = """select l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey, 
         count(orders_right_3.O_ORDERDATE) over (partition by orders_right_3.O_ORDERDATE order by lineitem_right_3.L_ORDERKEY) as window_count 
@@ -266,6 +287,27 @@ suite("right_join_range_number_increment_create") {
         right join orders_right_3 
         on lineitem_right_3.l_orderkey = orders_right_3.o_orderkey 
         group by l_shipdate, l_orderkey, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_16 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by lineitem_right_3.L_ORDERKEY) as window_count 
+        from lineitem_right_3 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_17 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by lineitem_right_3.l_orderkey) as window_count
+        from lineitem_right_3
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_3.l_orderkey = t.o_orderkey
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
+
+    def mv_sql_18 = """select l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey, 
+        count(t.O_ORDERDATE) over (order by lineitem_right_3.l_orderkey) as window_count 
+        from lineitem_right_3 
+        right join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_3 group by O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_3.l_orderkey = t.o_orderkey 
+        group by l_shipdate, l_orderkey, t.O_ORDERDATE, t.o_orderkey"""
 
     def compare_res = { def stmt ->
         def origin_res = sql stmt
@@ -317,57 +359,64 @@ suite("right_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                      mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_list_str_increment_create.groovy
@@ -244,6 +244,27 @@ suite("right_semi_join_list_str_increment_create") {
         on lineitem_right_semi_1.l_orderkey = orders_right_semi_1.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_1 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_1.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_semi_1
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_1.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_1 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_1 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_semi_1.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -294,57 +315,57 @@ suite("right_semi_join_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("right_semi_join_range_date_increment_create") {
         on lineitem_right_semi_2.l_orderkey = orders_right_semi_2.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_2 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_2.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_semi_2
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_2.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_2 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_2 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_semi_2.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -286,57 +307,57 @@ suite("right_semi_join_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_13]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_11, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10]
+    sql_error_list = [mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_13]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/right_semi_join_range_number_increment_create.groovy
@@ -245,6 +245,27 @@ suite("right_semi_join_range_number_increment_create") {
         on lineitem_right_semi_3.l_orderkey = orders_right_semi_3.o_orderkey 
         group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
 
+    def mv_sql_13 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.O_ORDERDATE order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_3 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_3.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_14 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (partition by t.o_orderkey order by t.o_orderkey) as window_count
+        from lineitem_right_semi_3
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t
+        on lineitem_right_semi_3.l_orderkey = t.o_orderkey
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
+    def mv_sql_15 = """select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, 
+        count(t.O_ORDERDATE) over (order by t.o_orderkey) as window_count 
+        from lineitem_right_semi_3 
+        right semi join (select o_custkey, o_totalprice, O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_right_semi_3 group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey) as t 
+        on lineitem_right_semi_3.l_orderkey = t.o_orderkey 
+        group by o_custkey, o_totalprice, O_ORDERDATE, o_orderkey"""
+
     def compare_res = { def stmt ->
         def origin_res = sql stmt
         logger.info("origin_res: " + origin_res)
@@ -295,57 +316,57 @@ suite("right_semi_join_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     def sql_increment_list = []
-    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    def sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_10, mv_sql_12]
+    def sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, primary_tb_change, is_complete_change_right)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, primary_tb_change, is_complete_change)
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_10, mv_sql_12]
-    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11]
+    sql_error_list = [mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15]
+    sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_14]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     sql_increment_list = []
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col_right, slave_tb_change, is_complete_change)
 
     // create mv base on right table with no partition col
-    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_list_str_increment_create.groovy
@@ -245,6 +245,27 @@ suite("self_conn_list_str_increment_create") {
         on t1.l_orderkey = t2.l_orderkey 
         group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
 
+    def mv_sql_13 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.L_SHIPDATE order by t1.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_14 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.l_orderkey order by t1.l_orderkey) as window_count
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_15 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (order by t1.l_orderkey) as window_count 
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
     // window func + right col
     def mv_sql_10 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
         count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
@@ -264,6 +285,27 @@ suite("self_conn_list_str_increment_create") {
         count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
         from lineitem_selt_conn_1 t1 
         join lineitem_selt_conn_1 t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_16 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_17 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_orderkey order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_18 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_1 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_1 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
         on t1.l_orderkey = t2.l_orderkey  
         group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
 
@@ -317,13 +359,15 @@ suite("self_conn_list_str_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_range_date_increment_create.groovy
@@ -236,6 +236,27 @@ suite("self_conn_range_date_increment_create") {
         on t1.l_orderkey = t2.l_orderkey 
         group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
 
+    def mv_sql_13 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.L_SHIPDATE order by t1.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_14 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.l_orderkey order by t1.l_orderkey) as window_count
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_15 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (order by t1.l_orderkey) as window_count 
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
     // window func + right col
     def mv_sql_10 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
         count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
@@ -255,6 +276,27 @@ suite("self_conn_range_date_increment_create") {
         count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
         from lineitem_selt_conn_2 t1 
         join lineitem_selt_conn_2 t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_16 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_17 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_orderkey order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_18 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_2 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_2 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
         on t1.l_orderkey = t2.l_orderkey  
         group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
 
@@ -308,13 +350,15 @@ suite("self_conn_range_date_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/self_conn_range_number_increment_create.groovy
@@ -246,6 +246,27 @@ suite("self_conn_range_number_increment_create") {
         on t1.l_orderkey = t2.l_orderkey 
         group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
 
+    def mv_sql_13 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.L_SHIPDATE order by t1.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_14 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (partition by t1.l_orderkey order by t1.l_orderkey) as window_count
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
+    def mv_sql_15 = """select t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey, 
+        count(t1.l_shipdate) over (order by t1.l_orderkey) as window_count 
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t1.l_shipdate, t1.l_orderkey, t1.l_partkey, t1.l_suppkey"""
+
     // window func + right col
     def mv_sql_10 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
         count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
@@ -265,6 +286,27 @@ suite("self_conn_range_number_increment_create") {
         count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
         from lineitem_selt_conn_3 t1 
         join lineitem_selt_conn_3 t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_16 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_shipdate order by t2.L_ORDERKEY) as window_count 
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey 
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_17 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (partition by t2.l_orderkey order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
+        on t1.l_orderkey = t2.l_orderkey  
+        group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
+
+    def mv_sql_18 = """select t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey,
+        count(t2.l_shipdate) over (order by t2.l_orderkey) as window_count
+        from lineitem_selt_conn_3 t1 
+        join (select l_shipdate, l_orderkey, l_partkey, l_suppkey, count(l_shipdate) over (partition by l_shipdate order by l_orderkey) from lineitem_selt_conn_3 group by l_shipdate, l_orderkey, l_partkey, l_suppkey) as t2 
         on t1.l_orderkey = t2.l_orderkey  
         group by t2.l_shipdate, t2.l_orderkey, t2.l_partkey, t2.l_suppkey"""
 
@@ -318,13 +360,15 @@ suite("self_conn_range_number_increment_create") {
         }
     }
 
-    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                        mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     def sql_increment_list = []
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
+                          mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 


### PR DESCRIPTION
More examples of the derivation of the partition mapping of the materialized view have been supplemented. The change situation of the right table of the join that was missed before has been added this time.

Existing mtmv examples:
select l_shipdate, l_orderkey, O_ORDERDATE, 
        count(orders_left_2.O_ORDERDATE) over (partition by lineitem_left_2.L_SHIPDATE order by lineitem_left_2.L_ORDERKEY) as window_count 
        from lineitem_left_2 
        left join orders_left_2 
        on lineitem_left_2.l_orderkey = orders_left_2.o_orderkey 
        group by l_shipdate, l_orderkey, O_ORDERDATE;

This time supplement examples in the right table that contain special operators:
select l_shipdate, l_orderkey, t.O_ORDERDATE, 
        count(t.O_ORDERDATE) over (partition by lineitem_left_2.L_SHIPDATE order by lineitem_left_2.L_ORDERKEY) as window_count 
        from lineitem_left_2 
        left join (select O_ORDERDATE, o_orderkey, count(O_ORDERDATE) over (partition by O_ORDERDATE order by o_orderkey) from orders_left_2 group by O_ORDERDATE, o_orderkey) as t
        on lineitem_left_2.l_orderkey = t.o_orderkey 
        group by l_shipdate, l_orderkey, t.O_ORDERDATE