### PR TITLE
[fix](audit log) Fix audit plugin run in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.httpv2.rest;
 
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Table;
@@ -519,6 +520,8 @@ public class LoadAction extends RestBaseController {
             ctx.setRemoteIP(request.getRemoteAddr());
             // set user to ADMIN_USER, so that we can get the proper resource tag
             ctx.setQualifiedUser(Auth.ADMIN_USER);
+            // cloud need
+            ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
             ctx.setThreadLocalInfo();
 
             String dbName = db;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Fix audit plugin run in cloud , stream load error 'No cloud cluster name selected'
```
2024-05-30 15:37:54,589 WARN (audit loader thread|63) [AuditStreamLoader.loadBatch():150] failed to load audit via AuditLoader plugin with label: audit_log_20240530_153754_127_0_0_1_8080
java.lang.Exception: status is not TEMPORARY_REDIRECT 307, status: 200, response:

{"status":"FAILED","msg":"errCode = 2, detailMessage = No cloud cluster name selected."}
, request is: curl -v -X PUT \
-H "Authorization":"Basic " \
-H "Expect":"100-continue" \
-H "Content-Type":"text/plain; charset=UTF-8" \
-H "max_filter_ratio":"1.0" \
-H "columns":"query_id,time,client_ip,user,catalog,db,state,error_code,error_message,query_time,scan_bytes,scan_rows,return_rows,stmt_id,is_query,frontend_ip,cpu_time_ms,sql_hash,sql_digest,peak_memory_bytes,workload_group,stmt" \
"http://127.0.0.1:8080/api/__internal_schema/audit_log/_stream_load?"
at org.apache.doris.plugin.audit.AuditStreamLoader.loadBatch(AuditStreamLoader.java:124) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.plugin.audit.AuditLoaderPlugin.loadIfNecessary(AuditLoaderPlugin.java:214) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.plugin.audit.AuditLoaderPlugin.access$300(AuditLoaderPlugin.java:50) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.plugin.audit.AuditLoaderPlugin$LoadWorker.run(AuditLoaderPlugin.java:255) ~[doris-fe.jar:1.2-SNAPSHOT]
at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

