### PR TITLE
[Performance](opt) opt the memcpy and string compare performance

### DIFF
--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -15,12 +15,17 @@
 //     2012-01-30
 
 #pragma once
+#ifdef __AVX2__
+#include <emmintrin.h>
+#include <immintrin.h>
+#endif
 
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "common/compiler_util.h"
 #include "gutil/integral_types.h"
 #include "gutil/port.h"
 
@@ -94,65 +99,113 @@ inline int fastmemcmp_inlined(const void* a_void, const void* b_void, size_t n) 
     return 0;
 }
 
-// The standard memcpy operation is slow for variable small sizes.
-// This implementation inlines the optimal realization for sizes 1 to 16.
-// To avoid code bloat don't use it in case of not performance-critical spots,
-// nor when you don't expect very frequent values of size <= 16.
-inline void memcpy_inlined(void* dst, const void* src, size_t size) {
-    // Compiler inlines code with minimal amount of data movement when third
-    // parameter of memcpy is a constant.
-    switch (size) {
-    case 1:
-        memcpy(dst, src, 1);
-        break;
-    case 2:
-        memcpy(dst, src, 2);
-        break;
-    case 3:
-        memcpy(dst, src, 3);
-        break;
-    case 4:
-        memcpy(dst, src, 4);
-        break;
-    case 5:
-        memcpy(dst, src, 5);
-        break;
-    case 6:
-        memcpy(dst, src, 6);
-        break;
-    case 7:
-        memcpy(dst, src, 7);
-        break;
-    case 8:
-        memcpy(dst, src, 8);
-        break;
-    case 9:
-        memcpy(dst, src, 9);
-        break;
-    case 10:
-        memcpy(dst, src, 10);
-        break;
-    case 11:
-        memcpy(dst, src, 11);
-        break;
-    case 12:
-        memcpy(dst, src, 12);
-        break;
-    case 13:
-        memcpy(dst, src, 13);
-        break;
-    case 14:
-        memcpy(dst, src, 14);
-        break;
-    case 15:
-        memcpy(dst, src, 15);
-        break;
-    case 16:
-        memcpy(dst, src, 16);
-        break;
-    default:
+ALWAYS_INLINE inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src,
+                                         size_t size) {
+    auto dst = static_cast<uint8_t*>(_dst);
+    auto src = static_cast<const uint8_t*>(_src);
+
+[[maybe_unused]]tail:
+    /// Small sizes and tails after the loop for large sizes.
+    /// The order of branches is important but in fact the optimal order depends on the distribution of sizes in your application.
+    /// This order of branches is from the disassembly of glibc's code.
+    /// We copy chunks of possibly uneven size with two overlapping movs.
+    /// Example: to copy 5 bytes [0, 1, 2, 3, 4] we will copy tail [1, 2, 3, 4] first and then head [0, 1, 2, 3].
+    if (size <= 16) {
+        if (size >= 8) {
+            /// Chunks of 8..16 bytes.
+            __builtin_memcpy(dst + size - 8, src + size - 8, 8);
+            __builtin_memcpy(dst, src, 8);
+        } else if (size >= 4) {
+            /// Chunks of 4..7 bytes.
+            __builtin_memcpy(dst + size - 4, src + size - 4, 4);
+            __builtin_memcpy(dst, src, 4);
+        } else if (size >= 2) {
+            /// Chunks of 2..3 bytes.
+            __builtin_memcpy(dst + size - 2, src + size - 2, 2);
+            __builtin_memcpy(dst, src, 2);
+        } else if (size >= 1) {
+            /// A single byte.
+            *dst = *src;
+        }
+        /// No bytes remaining.
+    } else {
+#ifdef __AVX2__
+        if (size <= 256) {
+            if (size <= 32) {
+                __builtin_memcpy(dst, src, 8);
+                __builtin_memcpy(dst + 8, src + 8, 8);
+                size -= 16;
+                dst += 16;
+                src += 16;
+                goto tail;
+            }
+
+            /// Then we will copy every 16 bytes from the beginning in a loop.
+            /// The last loop iteration will possibly overwrite some part of already copied last 32 bytes.
+            /// This is Ok, similar to the code for small sizes above.
+            while (size > 32) {
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst),
+                                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)));
+                dst += 32;
+                src += 32;
+                size -= 32;
+            }
+
+            _mm256_storeu_si256(
+                    reinterpret_cast<__m256i*>(dst + size - 32),
+                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + size - 32)));
+        } else {
+            if (size >= 512 * 1024 && size <= 2048 * 1024) {
+                asm volatile("rep movsb"
+                             : "=D"(dst), "=S"(src), "=c"(size)
+                             : "0"(dst), "1"(src), "2"(size)
+                             : "memory");
+            } else {
+                size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
+
+                if (padding > 0) {
+                    __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
+                    dst += padding;
+                    src += padding;
+                    size -= padding;
+                }
+
+                /// Aligned unrolled copy. We will use half of available AVX registers.
+                /// It's not possible to have both src and dst aligned.
+                /// So, we will use aligned stores and unaligned loads.
+                __m256i c0, c1, c2, c3, c4, c5, c6, c7;
+
+                while (size >= 256) {
+                    c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+                    c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
+                    c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
+                    c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
+                    c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
+                    c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
+                    c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
+                    src += 256;
+
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
+                    dst += 256;
+
+                    size -= 256;
+                }
+
+                goto tail;
+            }
+        }
+#else
         memcpy(dst, src, size);
-        break;
+#endif
     }
 }
 

--- a/be/src/gutil/strings/stringpiece.h
+++ b/be/src/gutil/strings/stringpiece.h
@@ -114,14 +114,14 @@
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
-#include <iosfwd>
-#include <string>
-#include <cstddef>
-#include <iterator>
-#include <string_view>
-#include <limits> // IWYU pragma: keep
 
-#include "gutil/strings/fastmem.h"
+#include <cstddef>
+#include <iosfwd>
+#include <iterator>
+#include <limits> // IWYU pragma: keep
+#include <string>
+#include <string_view>
+
 #include "gutil/hash/string_hash.h"
 #include "gutil/int128.h"
 
@@ -296,7 +296,7 @@ inline bool operator==(StringPiece x, StringPiece y) {
         return false;
     }
 
-    return x.data() == y.data() || len <= 0 || strings::memeq(x.data(), y.data(), len);
+    return x.data() == y.data() || len <= 0 || 0 == memcmp(x.data(), y.data(), len);
 }
 
 inline bool operator!=(StringPiece x, StringPiece y) {

--- a/be/src/util/bitmap.h
+++ b/be/src/util/bitmap.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include "gutil/port.h"
-#include "gutil/strings/fastmem.h"
 #include "util/bit_util.h"
 
 namespace doris {
@@ -105,9 +104,8 @@ inline bool BitmapIsAllZero(const uint8_t* bitmap, size_t offset, size_t bitmap_
 //
 // It is assumed that both bitmaps have 'bitmap_size' number of bits.
 inline bool BitmapEquals(const uint8_t* bm1, const uint8_t* bm2, size_t bitmap_size) {
-    // Use memeq() to check all of the full bytes.
     size_t num_full_bytes = bitmap_size >> 3;
-    if (!strings::memeq(bm1, bm2, num_full_bytes)) {
+    if (memcmp(bm1, bm2, num_full_bytes)) {
         return false;
     }
 

--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -25,7 +25,7 @@
 
 #include "gutil/dynamic_annotations.h"
 #include "gutil/port.h"
-#include "gutil/strings/fastmem.h"
+#include "util/memcpy_inlined.h"
 #include "util/slice.h"
 #include "vec/common/allocator.h"
 
@@ -123,7 +123,7 @@ public:
                 *p++ = *src++;
             }
         } else {
-            strings::memcpy_inlined(&data_[len_], src, count);
+            memcpy_inlined(&data_[len_], src, count);
         }
         len_ += count;
     }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -24,7 +24,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <ostream>
 
-#include "gutil/strings/fastmem.h"
+#include "util/memcpy_inlined.h"
 #include "util/simd/bits.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/arena.h"
@@ -197,8 +197,7 @@ void ColumnStr<T>::insert_indices_from(const IColumn& src, const uint32_t* indic
                     src_offset_data[src_offset] - src_offset_data[src_offset - 1];
             const size_t offset = src_offset_data[src_offset - 1];
 
-            strings::memcpy_inlined(dst_data_ptr + dst_chars_pos, src_data_ptr + offset,
-                                    size_to_append);
+            memcpy_inlined(dst_data_ptr + dst_chars_pos, src_data_ptr + offset, size_to_append);
 
             dst_chars_pos += size_to_append;
         }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -24,6 +24,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <ostream>
 
+#include "gutil/strings/fastmem.h"
 #include "util/simd/bits.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/arena.h"
@@ -195,8 +196,10 @@ void ColumnStr<T>::insert_indices_from(const IColumn& src, const uint32_t* indic
             const size_t size_to_append =
                     src_offset_data[src_offset] - src_offset_data[src_offset - 1];
             const size_t offset = src_offset_data[src_offset - 1];
-            memcpy_small_allow_read_write_overflow15(dst_data_ptr + dst_chars_pos,
-                                                     src_data_ptr + offset, size_to_append);
+
+            strings::memcpy_inlined(dst_data_ptr + dst_chars_pos, src_data_ptr + offset,
+                                    size_to_append);
+
             dst_chars_pos += size_to_append;
         }
     };

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -270,13 +270,7 @@ struct StringRef {
 
     // ==
     bool eq(const StringRef& other) const {
-        if (this->size != other.size) {
-            return false;
-        }
-#if defined(__SSE2__) || defined(__aarch64__)
-        return memequalSSE2Wide(this->data, other.data, this->size);
-#endif
-        return string_compare(this->data, this->size, other.data, other.size, this->size) == 0;
+        return (size == other.size) && (memcmp(data, other.data, size) == 0);
     }
 
     bool operator==(const StringRef& other) const { return eq(other); }

--- a/be/test/util/mysql_row_buffer_test.cpp
+++ b/be/test/util/mysql_row_buffer_test.cpp
@@ -24,11 +24,8 @@
 #include <string>
 
 #include "gtest/gtest_pred_impl.h"
-#include "gutil/strings/fastmem.h"
 
 namespace doris {
-
-using namespace strings;
 
 TEST(MysqlRowBufferTest, basic) {
     MysqlRowBuffer mrb;


### PR DESCRIPTION
## Proposed changes

Before：
```
select count(cust_id) from     ( select * from rpt where dt = '2023-06-19' and dkye>0) a         join     ( select * from rpt1 where dt = '2023-06-19') b     on b.cust_id = a.hxkhh;
+----------------+
| count(cust_id) |
+----------------+
|      515127559 |
+----------------+
1 row in set (5.85 sec)

```

after:
```
select count(cust_id) from     ( select * from rpt where dt = '2023-06-19' and dkye>0) a         join     ( select * from rpt1 where dt = '2023-06-19') b     on b.cust_id = a.hxkhh;
+----------------+
| count(cust_id) |
+----------------+
|      515127559 |
+----------------+
1 row in set (4.25 sec)

```

<!--Describe your changes.-->

opt the memcpy and string compare performance

