### PR TITLE
[opt](nereids)using mv's derived stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -754,12 +754,15 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     //       2. Consider the influence of runtime filter
     //       3. Get NDV and column data size from StatisticManger, StatisticManager doesn't support it now.
     private Statistics computeCatalogRelation(CatalogRelation catalogRelation) {
-        if (catalogRelation instanceof LogicalOlapScan && ((LogicalOlapScan) catalogRelation).isIndexSelected()) {
-            // mv is selected, return its estimated stats
-            Optional<Statistics> optStats = cascadesContext.getStatementContext()
-                    .getStatistics(((LogicalOlapScan) catalogRelation).getRelationId());
-            if (optStats.isPresent()) {
-                return optStats.get();
+        if (catalogRelation instanceof LogicalOlapScan) {
+            LogicalOlapScan olap = (LogicalOlapScan) catalogRelation;
+            if (olap.getSelectedIndexId() != olap.getTable().getBaseIndexId()) {
+                // mv is selected, return its estimated stats
+                Optional<Statistics> optStats = cascadesContext.getStatementContext()
+                        .getStatistics(olap.getRelationId());
+                if (optStats.isPresent()) {
+                    return optStats.get();
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -761,7 +761,10 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 Optional<Statistics> optStats = cascadesContext.getStatementContext()
                         .getStatistics(olap.getRelationId());
                 if (optStats.isPresent()) {
-                    return optStats.get();
+                    double actualRowCount = catalogRelation.getTable().getRowCountForNereids();
+                    if (actualRowCount > optStats.get().getRowCount()) {
+                        return optStats.get();
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -754,6 +754,15 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     //       2. Consider the influence of runtime filter
     //       3. Get NDV and column data size from StatisticManger, StatisticManager doesn't support it now.
     private Statistics computeCatalogRelation(CatalogRelation catalogRelation) {
+        if (catalogRelation instanceof LogicalOlapScan && ((LogicalOlapScan) catalogRelation).isIndexSelected()) {
+            // mv is selected, return its estimated stats
+            Optional<Statistics> optStats = cascadesContext.getStatementContext()
+                    .getStatistics(((LogicalOlapScan) catalogRelation).getRelationId());
+            if (optStats.isPresent()) {
+                return optStats.get();
+            }
+        }
+
         List<Slot> output = catalogRelation.getOutput();
         ImmutableSet.Builder<SlotReference> slotSetBuilder = ImmutableSet.builderWithExpectedSize(output.size());
         for (Slot slot : output) {


### PR DESCRIPTION
## Proposed changes
for a given mv, we have 2 stats. one is generated by stats analyzer, which is accurate, another is derived stats, which is derived when optimizer runs the mv query.
If a query tree contains a mv, we will use the mv's derived stats to derive stats for the whole tree.

Issue Number: close #xxx

<!--Describe your changes.-->

