### PR TITLE
[Bugfix] Fix nullptr cache object because init file cache concurrently

### DIFF
--- a/be/src/io/cache/block_file_cache_factory.h
+++ b/be/src/io/cache/block_file_cache_factory.h
@@ -75,6 +75,7 @@ public:
     FileCacheFactory(const FileCacheFactory&) = delete;
 
 private:
+    std::mutex _mtx;
     std::vector<std::unique_ptr<BlockFileCache>> _caches;
     std::unordered_map<std::string, BlockFileCache*> _path_to_cache;
     size_t _capacity = 0;


### PR DESCRIPTION
The file caches are inited in be/src/runtime/exec_env_init.cpp:init_file_cache_factory concurrently. The field `_path_to_cache` and `_caches` is not protected by lock. So BE may coredump because the cache object is nullptr.