### PR TITLE
[improvement](build index)Make build index and clone mutually exclusive and add timeout for index change job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2985,13 +2985,14 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         try {
+            long timeoutSecond = Config.alter_table_timeout_second;
             for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
                 long originIndexId = entry.getKey();
                 for (Partition partition : olapTable.getPartitions()) {
                     // create job
                     long jobId = Env.getCurrentEnv().getNextId();
                     IndexChangeJob indexChangeJob = new IndexChangeJob(
-                            jobId, db.getId(), olapTable.getId(), olapTable.getName());
+                            jobId, db.getId(), olapTable.getId(), olapTable.getName(), timeoutSecond * 1000);
                     indexChangeJob.setOriginIndexId(originIndexId);
                     indexChangeJob.setAlterInvertedIndexInfo(isDropOp, alterIndexes);
                     long partitionId = partition.getId();

--- a/regression-test/suites/inverted_index_p0/test_build_index_with_clone.groovy
+++ b/regression-test/suites/inverted_index_p0/test_build_index_with_clone.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+import org.apache.doris.regression.suite.SuiteCluster
+
+suite("test_build_index_with_clone"){
+    if (isCloudMode()) {
+        return 
+    }
+    def backends = sql_return_maparray('show backends')
+    // if backens is less than 2, skip this case
+    if (backends.size() < 2) {
+        return
+    }
+    def timeout = 300000
+    def delta_time = 1000
+    def alter_res = "null"
+    def useTime = 0
+
+    def wait_for_last_build_index_on_table_finish = { table_name, OpTimeout ->
+        for(int t = delta_time; t <= OpTimeout; t += delta_time){
+            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY JobId """
+
+            if (alter_res.size() == 0) {
+                logger.info(table_name + " last index job finished")
+                return "SKIPPED"
+            }
+            if (alter_res.size() > 0) {
+                def last_job_state = alter_res[alter_res.size()-1][7];
+                if (last_job_state == "FINISHED" || last_job_state == "CANCELLED") {
+                    sleep(10000) // wait change table state to normal
+                    logger.info(table_name + " last index job finished, state: " + last_job_state + ", detail: " + alter_res)
+                    return last_job_state;
+                }
+            }
+            useTime = t
+            sleep(delta_time)
+        }
+        logger.info("wait_for_last_build_index_on_table_finish debug: " + alter_res)
+        assertTrue(useTime <= OpTimeout, "wait_for_last_build_index_on_table_finish timeout")
+        return "wait_timeout"
+    }
+
+    def tbl = 'test_build_index_with_clone'
+    cluster.injectDebugPoints(NodeType.BE, ['EngineCloneTask.wait_clone' : null])
+    sql """
+        CREATE TABLE ${tbl} (
+        `k1` int(11) NULL,
+        `k2` int(11) NULL
+        )
+        DUPLICATE KEY(`k1`, `k2`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+        PROPERTIES ("replication_num" = "1")
+        """
+    for (def i = 1; i <= 5; i++) {
+        sql "INSERT INTO ${tbl} VALUES (${i}, ${10 * i})"
+    }
+
+    sql """ sync """
+
+    // get tablets and set replica status to DROP
+    def tablet = sql_return_maparray("show tablets from ${tbl}")[0]
+    sql """
+        ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tablet.TabletId}", "backend_id" = "${tablet.BackendId}", "status" = "drop");
+        """
+    // create index on table 
+    sql """ create index idx_k2 on ${tbl}(k2) using inverted """
+    sql """ build index idx_k2 on ${tbl} """
+    // sleep 5s to wait for the build index job report table is unstable
+    sleep(5000)
+    def show_build_index = sql_return_maparray("show build index where TableName = \"${tbl}\"")
+    assertEquals('WAITING_TXN', show_build_index[0].State)
+    assertEquals('table is unstable', show_build_index[0].Msg)
+
+    def state = wait_for_last_build_index_on_table_finish(tbl, timeout)
+    assertEquals(state, "FINISHED")
+}

--- a/regression-test/suites/inverted_index_p0/test_build_index_with_clone_by_docker.groovy
+++ b/regression-test/suites/inverted_index_p0/test_build_index_with_clone_by_docker.groovy
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+import org.apache.doris.regression.suite.SuiteCluster
+
+suite("test_build_index_with_clone_by_docker"){
+    if (isCloudMode()) {
+        return 
+    }
+    def timeout = 300000
+    def delta_time = 1000
+    def alter_res = "null"
+    def useTime = 0
+
+    def wait_for_last_build_index_on_table_finish = { table_name, OpTimeout ->
+        for(int t = delta_time; t <= OpTimeout; t += delta_time){
+            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY JobId """
+
+            if (alter_res.size() == 0) {
+                logger.info(table_name + " last index job finished")
+                return "SKIPPED"
+            }
+            if (alter_res.size() > 0) {
+                def last_job_state = alter_res[alter_res.size()-1][7];
+                if (last_job_state == "FINISHED" || last_job_state == "CANCELLED") {
+                    sleep(10000) // wait change table state to normal
+                    logger.info(table_name + " last index job finished, state: " + last_job_state + ", detail: " + alter_res)
+                    return last_job_state;
+                }
+            }
+            useTime = t
+            sleep(delta_time)
+        }
+        logger.info("wait_for_last_build_index_on_table_finish debug: " + alter_res)
+        assertTrue(useTime <= OpTimeout, "wait_for_last_build_index_on_table_finish timeout")
+        return "wait_timeout"
+    }
+
+    def options = new ClusterOptions()
+    options.enableDebugPoints()
+    options.setFeNum(1)
+    options.setBeNum(3)
+    options.cloudMode = false
+    def tbl = 'test_build_index_with_clone_by_docker'
+    docker(options) {
+        cluster.injectDebugPoints(NodeType.BE, ['EngineCloneTask.wait_clone' : null])
+        sql """
+            CREATE TABLE ${tbl} (
+            `k1` int(11) NULL,
+            `k2` int(11) NULL
+            )
+            DUPLICATE KEY(`k1`, `k2`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+            """
+        for (def i = 1; i <= 5; i++) {
+            sql "INSERT INTO ${tbl} VALUES (${i}, ${10 * i})"
+        }
+
+        sql """ sync """
+
+        // get tablets and set replica status to DROP
+        def tablet = sql_return_maparray("show tablets from ${tbl}")[0]
+        sql """
+            ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tablet.TabletId}", "backend_id" = "${tablet.BackendId}", "status" = "drop");
+            """
+        // create index on table 
+        sql """ create index idx_k2 on ${tbl}(k2) using inverted """
+        sql """ build index idx_k2 on ${tbl} """
+        // sleep 5s to wait for the build index job report table is unstable
+        sleep(5000)
+        def show_build_index = sql_return_maparray("show build index where TableName = \"${tbl}\"")
+        assertEquals('WAITING_TXN', show_build_index[0].State)
+        assertEquals('table is unstable', show_build_index[0].Msg)
+
+        def state = wait_for_last_build_index_on_table_finish(tbl, timeout)
+        assertEquals(state, "FINISHED")
+    }
+}

--- a/regression-test/suites/inverted_index_p0/test_build_index_with_clone_by_docker.groovy
+++ b/regression-test/suites/inverted_index_p0/test_build_index_with_clone_by_docker.groovy
@@ -60,6 +60,7 @@ suite("test_build_index_with_clone_by_docker"){
     def tbl = 'test_build_index_with_clone_by_docker'
     docker(options) {
         cluster.injectDebugPoints(NodeType.BE, ['EngineCloneTask.wait_clone' : null])
+        sql """ DROP TABLE IF EXISTS ${tbl} """
         sql """
             CREATE TABLE ${tbl} (
             `k1` int(11) NULL,
@@ -86,7 +87,7 @@ suite("test_build_index_with_clone_by_docker"){
         sql """ build index idx_k2 on ${tbl} """
         // sleep 5s to wait for the build index job report table is unstable
         sleep(5000)
-        def show_build_index = sql_return_maparray("show build index where TableName = \"${tbl}\"")
+        def show_build_index = sql_return_maparray("show build index where TableName = \"${tbl}\" ORDER BY JobId DESC LIMIT 1")
         assertEquals('WAITING_TXN', show_build_index[0].State)
         assertEquals('table is unstable', show_build_index[0].Msg)
 


### PR DESCRIPTION
## Proposed changes

Currently the index change job and clone task can be executed at the same time. If the clone task gets stuck at this point, it will cause the index change job to get stuck as well and keep retrying.
To solve this problem, we can refer to alter job and make index change job exclusive with clone task, and introduce the timeout to prevent infinite retries of build index.

Add the following checks and status in FE. 
1. Check if table is stable (build index is not allowed when clone is in progress)
1.1. Tablet is HEALTHY.
1.2. Whether the tablet is included in the Tablet scheduler, if so, it means the current tablet is doing clone.
2. When creating the index change job, set the timeout at the same time.




