### PR TITLE
[fix](Nereids) unix_timestamp compute signature and fold const is wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UnixTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UnixTimestamp.java
@@ -46,7 +46,7 @@ public class UnixTimestamp extends ScalarFunction
     // we got changes when computeSignature
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(IntegerType.INSTANCE).args(),
-            FunctionSignature.ret(DecimalV3Type.createDecimalV3Type(16, 6)).args(DateTimeV2Type.SYSTEM_DEFAULT),
+            FunctionSignature.ret(DecimalV3Type.WILDCARD).args(DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(IntegerType.INSTANCE).args(DateV2Type.INSTANCE),
             FunctionSignature.ret(IntegerType.INSTANCE).args(DateTimeType.INSTANCE),
             FunctionSignature.ret(IntegerType.INSTANCE).args(DateType.INSTANCE),
@@ -102,6 +102,7 @@ public class UnixTimestamp extends ScalarFunction
 
     @Override
     public FunctionSignature computeSignature(FunctionSignature signature) {
+        signature = super.computeSignature(signature);
         if (arity() != 1) {
             return signature;
         }
@@ -120,7 +121,7 @@ public class UnixTimestamp extends ScalarFunction
      */
     @Override
     public UnixTimestamp withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() == 0
+        Preconditions.checkArgument(children.isEmpty()
                 || children.size() == 1
                 || children.size() == 2);
         if (children.isEmpty() && arity() == 0) {


### PR DESCRIPTION
1. compute signature should call super#computeSignature first
2. fold const return type not changed after signature changed in #26827

we already have p0 for this case, but our regression framework has bug
that it report success when compare decimal type if real result lose scale