### PR TITLE
[fix](decimal256) fix coredump when enable decimal256 but fallback to old planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3373,7 +3373,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setInvertedIndexConjunctionOptThreshold(invertedIndexConjunctionOptThreshold);
         tResult.setInvertedIndexMaxExpansions(invertedIndexMaxExpansions);
 
-        tResult.setEnableDecimal256(enableNereidsPlanner && enableDecimal256);
+        tResult.setEnableDecimal256(getEnableDecimal256());
 
         tResult.setSkipMissingVersion(skipMissingVersion);
 
@@ -3769,7 +3769,7 @@ public class SessionVariable implements Serializable, Writable {
             return false;
         }
         SessionVariable sessionVariable = connectContext.getSessionVariable();
-        return sessionVariable.isEnableNereidsPlanner() && sessionVariable.isEnableDecimal256();
+        return connectContext.getState().isNereids() && sessionVariable.isEnableDecimal256();
     }
 
     public boolean isEnableDecimal256() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

BE coredump when enable decimal256 but fallback to old planner.
When enable_decimal256 =true and falls back to the old optimizer, the sum result type become decimal128, but BE receives enable_decimal256=true, thinking that the sum result type is still decimal256.

```
20240530 18:01:40.713162 72530 assert_cast.h:57] Bad cast from type:doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3> to doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >
*** Check failure stack trace: ***
    @     0x564c51b56e86  google::LogMessage::SendToLog()
    @     0x564c51b538d0  google::LogMessage::Flush()
    @     0x564c51b576c9  google::LogMessageFatal::~LogMessageFatal()
    @     0x564c266f6880  assert_cast<>()
    @     0x564c3361ebe8  doris::vectorized::AggregateFunctionSum<>::insert_result_into()
    @     0x564c33633cee  doris::vectorized::AggregateFunctionNullBaseInline<>::insert_result_into()
    @     0x564c33633f48  doris::vectorized::IAggregateFunctionHelper<>::insert_result_into_vec()
F20240530 18:01:40.986271 72538 assert_cast.h:57] Bad cast from type:doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3> to doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >

*** Query id: 6ba2b0c5b10249d4-a36d87744741db1d ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1717063302 (unix time) try "date -d @1717063302" if you are using GNU date ***
*** Current BE git commitID: b130df2488 ***
*** SIGABRT unknown detail explain (@0x10fd5) received by PID 69589 (TID 72530 OR 0x7f61a04bb700) from PID 69589; stack trace: ***
    @     0x564c3bafab38  std::_Function_handler<>::_M_invoke()
    @     0x564c2489325f  std::function<>::operator()()
    @     0x564c3b82da6d  doris::vectorized::AggregationNode::pull()
    @     0x564c3b82d6cc  doris::vectorized::AggregationNode::get_next()
    @     0x564c2487329d  std::__invoke_impl<>()
    @     0x564c24872fb0  std::__invoke<>()
    @     0x564c24872ea7  _ZNSt5_BindIFMN5doris8ExecNodeEFNS0_6StatusEPNS0_12RuntimeStateEPNS0_10vectorized5BlockEPbEPS1_St12_PlaceholderILi1EESC_ILi2EESC_ILi3EEEE6__callIS2_JOS4_OS7_OS8_EJLm0ELm1ELm2ELm3EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x564c24872c38  std::_Bind<>::operator()<>()
    @     0x564c24872ae8  std::__invoke_impl<>()
    @     0x564c24872a58  _ZSt10__invoke_rIN5doris6StatusERSt5_BindIFMNS0_8ExecNodeEFS1_PNS0_12RuntimeStateEPNS0_10vectorized5BlockEPbEPS3_St12_PlaceholderILi1EESD_ILi2EESD_ILi3EEEEJS5_S8_S9_EENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESL_E4typeEOSM_DpOSN_
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/tengjianping/doris-38/be/src/common/signal_handler.h:421
 1# 0x00007F6C0F5AD400 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# 0x0000564C51B616FD in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 5# 0x0000564C51B53D9A in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 6# google::LogMessage::SendToLog() in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 7# google::LogMessage::Flush() in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 9# doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >& assert_cast<doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >&, doris::vectorized::IColumn&>(doris::vectorized::IColumn&) in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
10# doris::vectorized::AggregateFunctionSum<doris::vectorized::Decimal128V3, doris::vectorized::Decimal<wide::integer<256ul, int> >, doris::vectorized::AggregateFunctionSumData<doris::vectorized::Decimal<wide::integer<256ul, int> > > >::insert_result_into(char const*, doris::vectorized::IColumn&) const at /mnt/disk2/tengjianping/doris-38/be/src/vec/aggregate_functions/aggregate_function_sum.h:124
11# doris::vectorized::AggregateFunctionNullBaseInline<doris::vectorized::AggregateFunctionSum<doris::vectorized::Decimal128V3, doris::vectorized::Decimal<wide::integer<256ul, int> >, doris::vectorized::AggregateFunctionSumData<doris::vectorized::Decimal<wide::integer<256ul, int> > > >, true, doris::vectorized::AggregateFunctionNullUnaryInline<doris::vectorized::AggregateFunctionSum<doris::vectorized::Decimal128V3, doris::vectorized::Decimal<wide::integer<256ul, int> >, doris::vectorized::AggregateFunctionSumData<doris::vectorized::Decimal<wide::integer<256ul, int> > > >, true> >::insert_result_into(char const*, doris::vectorized::IColumn&) const at /mnt/disk2/tengjianping/doris-38/be/src/vec/aggregate_functions/aggregate_function_null.h:171
12# doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionNullUnaryInline<doris::vectorized::AggregateFunctionSum<doris::vectorized::Decimal128V3, doris::vectorized::Decimal<wide::integer<256ul, int> >, doris::vectorized::AggregateFunctionSumData<doris::vectorized::Decimal<wide::integer<256ul, int> > > >, true> >::insert_result_into_vec(std::vector<char*, std::allocator<char*> > const&, unsigned long, doris::vectorized::IColumn&, unsigned long) const at /mnt/disk2/tengjianping/doris-38/be/src/vec/aggregate_functions/aggregate_function.h:315
13# doris::vectorized::AggFnEvaluator::insert_result_info_vec(std::vector<char*, std::allocator<char*> > const&, unsigned long, doris::vectorized::IColumn*, unsigned long) at /mnt/disk2/tengjianping/doris-38/be/src/vec/exprs/vectorized_agg_fn.cpp:273
14# void doris::vectorized::AggregationNode::_get_result_with_serialized_key_non_spill(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0::operator()<doris::vectorized::MethodSingleNullableColumn<doris::vectorized::MethodStringNoCache<doris::vectorized::DataWithNullKey<doris::StringHashMap<char*, Allocator<true, true, false> > > > >&>(doris::vectorized::MethodSingleNullableColumn<doris::vectorized::MethodStringNoCache<doris::vectorized::DataWithNullKey<doris::StringHashMap<char*, Allocator<true, true, false> > > > >&) const at /mnt/disk2/tengjianping/doris-38/be/src/vec/exec/vaggregation_node.cpp:1296
15# void std::__invoke_impl<void, doris::vectorized::AggregationNode::_get_result_with_serialized_key_non_spill(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0, doris::vectorized::MethodSingleNullableColumn<doris::vectorized::MethodStringNoCache<doris::vectorized::DataWithNullKey<doris::StringHashMap<char*, Allocator<true, true, false> > > > >&>(std::__invoke_other, doris::vectorized::AggregationNode::_get_result_with_serialized_key_non_spill(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::MethodSingleNullableColumn<doris::vectorized::MethodStringNoCache<doris::vectorized::DataWithNullKey<doris::StringHashMap<char*, Allocator<true, true, false> > > > >&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61

20# doris::vectorized::AggregationNode::_get_result_with_serialized_key_non_spill(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/tengjianping/doris-38/be/src/vec/exec/vaggregation_node.cpp:1264
21# doris::vectorized::AggregationNode::_get_with_serialized_key_result(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /usr/local/doris/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
22# doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::AggregationNode*&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_memfun_deref, doris::Status (doris::vectorized::AggregationNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::AggregationNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
23# std::enable_if<is_invocable_r_v<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::AggregationNode*&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::AggregationNode*&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(doris::Status (doris::vectorized::AggregationNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::AggregationNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
24# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::__call<doris::Status, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&, 0ul, 1ul, 2ul, 3ul>(std::tuple<doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
25# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()<doris::RuntimeState*, doris::vectorized::Block*, bool*>(doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
26# doris::Status std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_other, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
27# std::enable_if<is_invocable_r_v<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
28# std::_Function_handler<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)> >::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
29# std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
30# doris::vectorized::AggregationNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/tengjianping/doris-38/be/src/vec/exec/vaggregation_node.cpp:494
31# doris::vectorized::AggregationNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/tengjianping/doris-38/be/src/vec/exec/vaggregation_node.cpp:487
```
