### PR TITLE
[fix](default value) change throw AnalysisException order

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -480,8 +480,30 @@ public class ColumnDef {
         ScalarType scalarType = (ScalarType) type;
 
         // check if default value is valid.
-        // if not, some literal constructor will throw AnalysisException
+        // first, check if the type of defaultValue matches primitiveType.
+        // if not check it first, some literal constructor will throw AnalysisException,
+        // and it is not intuitive to users.
         PrimitiveType primitiveType = scalarType.getPrimitiveType();
+        if (null != defaultValueExprDef && defaultValueExprDef.getExprName().equals("now")) {
+            switch (primitiveType) {
+                case DATETIME:
+                case DATETIMEV2:
+                    break;
+                default:
+                    throw new AnalysisException("Types other than DATETIME and DATETIMEV2 "
+                            + "cannot use current_timestamp as the default value");
+            }
+        } else if (null != defaultValueExprDef
+                && defaultValueExprDef.getExprName().equals(DefaultValue.CURRENT_DATE.toLowerCase())) {
+            switch (primitiveType) {
+                case DATE:
+                case DATEV2:
+                    break;
+                default:
+                    throw new AnalysisException("Types other than DATE and DATEV2 "
+                            + "cannot use current_date as the default value");
+            }
+        }
         switch (primitiveType) {
             case TINYINT:
             case SMALLINT:
@@ -566,26 +588,6 @@ public class ColumnDef {
                 break;
             default:
                 throw new AnalysisException("Unsupported type: " + type);
-        }
-        if (null != defaultValueExprDef && defaultValueExprDef.getExprName().equals("now")) {
-            switch (primitiveType) {
-                case DATETIME:
-                case DATETIMEV2:
-                    break;
-                default:
-                    throw new AnalysisException("Types other than DATETIME and DATETIMEV2 "
-                            + "cannot use current_timestamp as the default value");
-            }
-        } else if (null != defaultValueExprDef
-                && defaultValueExprDef.getExprName().equals(DefaultValue.CURRENT_DATE.toLowerCase())) {
-            switch (primitiveType) {
-                case DATE:
-                case DATEV2:
-                    break;
-                default:
-                    throw new AnalysisException("Types other than DATE and DATEV2 "
-                            + "cannot use current_date as the default value");
-            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -484,7 +484,7 @@ public class ColumnDef {
         // if not check it first, some literal constructor will throw AnalysisException,
         // and it is not intuitive to users.
         PrimitiveType primitiveType = scalarType.getPrimitiveType();
-        if (null != defaultValueExprDef && defaultValueExprDef.getExprName().equals("now")) {
+        if (null != defaultValueExprDef && defaultValueExprDef.getExprName().equalsIgnoreCase("now")) {
             switch (primitiveType) {
                 case DATETIME:
                 case DATETIMEV2:
@@ -494,7 +494,7 @@ public class ColumnDef {
                             + "cannot use current_timestamp as the default value");
             }
         } else if (null != defaultValueExprDef
-                && defaultValueExprDef.getExprName().equals(DefaultValue.CURRENT_DATE.toLowerCase())) {
+                && defaultValueExprDef.getExprName().equalsIgnoreCase(DefaultValue.CURRENT_DATE)) {
             switch (primitiveType) {
                 case DATE:
                 case DATEV2:

--- a/regression-test/suites/correctness_p0/test_current_date.groovy
+++ b/regression-test/suites/correctness_p0/test_current_date.groovy
@@ -65,9 +65,26 @@ suite("test_current_date") {
     qt_stream_load_csv1 """ select count(*) from ${tableName} where id > 4 and dt_0 = dt_1; """
     qt_stream_load_csv2 """ select count(*) from ${tableName} where id > 4 and dt_2 = dt_3; """
 
-    sql "DROP TABLE IF EXISTS test_default10"
+    // test varchar with default current_date
+    sql "DROP TABLE IF EXISTS test_varchar_default"
     test {
-        sql """create table test_default10(a int, b varchar(100) default current_date) 
+        sql """create table test_varchar_default(a int, b varchar(100) default current_date)
+        distributed by hash(a) properties('replication_num'="1");"""
+        exception "Types other than DATE and DATEV2 cannot use current_date as the default value"
+    }
+
+    // test int with default current_date
+    sql "DROP TABLE IF EXISTS test_int_default"
+    test {
+        sql """create table test_int_default(a int, b int default current_date)
+        distributed by hash(a) properties('replication_num'="1");"""
+        exception "Types other than DATE and DATEV2 cannot use current_date as the default value"
+    }
+
+    // test double with default current_date
+    sql "DROP TABLE IF EXISTS test_double_default"
+    test {
+        sql """create table test_int_default(a int, b double default current_date)
         distributed by hash(a) properties('replication_num'="1");"""
         exception "Types other than DATE and DATEV2 cannot use current_date as the default value"
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #35758 

<!--Describe your changes.-->
when types other than DATE and DATEV2 use current_date as the default value during creating a table, throw an AnalysisException similar to the following:
```sql
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = Types other than DATE and DATEV2 cannot use current_date as the default value
```
but not this AnalysisException:
```sql
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = Invalid floating-point literal: CURRENT_DATE

``` 