### PR TITLE
[feat](Nereids): Optimize Join Penalty Calculation Based on Build Side Data Volume

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -365,11 +365,11 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                 leftRowCount += 1;
             }
             if (probeStats.getWidthInJoinCluster() == buildStats.getWidthInJoinCluster()
-                    && probeStats.computeSize() < buildStats.computeSize()) {
+                    && probeStats.computeTupleSize() < buildStats.computeTupleSize()) {
                 // When the number of rows and the width on both sides of the join are the same,
                 // we need to consider the cost of materializing the output.
                 // When there is more data on the build side, a greater penalty will be given.
-                rightRowCount += 1;
+                leftRowCount += 1e-3;
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -364,6 +364,13 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             } else if (probeStats.getWidthInJoinCluster() < buildStats.getWidthInJoinCluster()) {
                 leftRowCount += 1;
             }
+            if (probeStats.getWidthInJoinCluster() == buildStats.getWidthInJoinCluster()
+                    && probeStats.computeSize() < buildStats.computeSize()) {
+                // When the number of rows and the width on both sides of the join are the same,
+                // we need to consider the cost of materializing the output.
+                // When there is more data on the build side, a greater penalty will be given.
+                rightRowCount += 1;
+            }
         }
 
         /*

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -118,7 +118,7 @@ public class Statistics {
                         && expressionToColumnStats.get(s).isUnKnown);
     }
 
-    private double computeTupleSize() {
+    public double computeTupleSize() {
         if (tupleSize <= 0) {
             double tempSize = 0.0;
             for (ColumnStatistic s : expressionToColumnStats.values()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/cost/CostModelV1Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/cost/CostModelV1Test.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.cost;
+
+import org.apache.doris.nereids.sqltest.SqlTestBase;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
+import org.apache.doris.nereids.util.PlanChecker;
+
+import org.junit.jupiter.api.Test;
+
+class CostModelV1Test extends SqlTestBase {
+
+    @Test
+    void testMaterializingCost() {
+        String sql = "select T1.id, T2.id, T2.score from T1 left join T2 "
+                + "on T1.id = T2.id";
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        Plan p = PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .deriveStats()
+                .optimize()
+                .getBestPlanTree();
+        p.anyMatch(j -> j instanceof PhysicalHashJoin && ((PhysicalHashJoin<?, ?>) j).getJoinType().isRightJoin());
+    }
+}

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/basic.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/basic.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----hashAgg[LOCAL]
 ------hashJoin[INNER_JOIN] hashCondition=((a.device_id = b.device_id)) otherCondition=()
 --------hashAgg[LOCAL]
-----------filter((a.event_id = 'ad_click'))
-------------PhysicalOlapScan[com_dd_library]
---------hashAgg[LOCAL]
 ----------filter((cast(experiment_id as DOUBLE) = 37.0))
 ------------PhysicalOlapScan[shunt_log_com_dd_library]
+--------hashAgg[LOCAL]
+----------filter((a.event_id = 'ad_click'))
+------------PhysicalOlapScan[com_dd_library]
 
 -- !2 --
 PhysicalResultSink
@@ -37,7 +37,7 @@ PhysicalResultSink
 ----hashAgg[LOCAL]
 ------hashJoin[INNER_JOIN] hashCondition=((a.device_id = b.device_id)) otherCondition=()
 --------hashAgg[LOCAL]
-----------PhysicalOlapScan[com_dd_library]
---------hashAgg[LOCAL]
 ----------PhysicalOlapScan[shunt_log_com_dd_library]
+--------hashAgg[LOCAL]
+----------PhysicalOlapScan[com_dd_library]
 

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join.out
@@ -21,7 +21,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[count_t]
 --------PhysicalOlapScan[count_t]
 
@@ -272,7 +272,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[count_t]
 --------PhysicalOlapScan[count_t]
 

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[count_t_one_side]
 --------PhysicalOlapScan[count_t_one_side]
 
@@ -257,7 +257,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[count_t_one_side]
 --------PhysicalOlapScan[count_t_one_side]
 

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_max_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_max_through_join.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[max_t]
 --------PhysicalOlapScan[max_t]
 

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_min_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_min_through_join.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[min_t]
 --------PhysicalOlapScan[min_t]
 

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join.out
@@ -21,7 +21,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[sum_t]
 --------PhysicalOlapScan[sum_t]
 
@@ -122,14 +122,14 @@ PhysicalResultSink
 ----hashJoin[INNER_JOIN] hashCondition=((t1.name = t3.name)) otherCondition=()
 ------hashAgg[GLOBAL]
 --------hashAgg[LOCAL]
+----------PhysicalOlapScan[sum_t]
+------hashAgg[GLOBAL]
+--------hashAgg[LOCAL]
 ----------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ------------hashAgg[LOCAL]
 --------------PhysicalOlapScan[sum_t]
 ------------hashAgg[LOCAL]
 --------------PhysicalOlapScan[sum_t]
-------hashAgg[GLOBAL]
---------hashAgg[LOCAL]
-----------PhysicalOlapScan[sum_t]
 
 -- !groupby_pushdown_with_order_by --
 PhysicalResultSink

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------PhysicalOlapScan[sum_t_one_side]
 --------PhysicalOlapScan[sum_t_one_side]
 

--- a/regression-test/data/nereids_rules_p0/eliminate_outer_join/eliminate_outer_join.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_outer_join/eliminate_outer_join.out
@@ -163,7 +163,7 @@ PhysicalResultSink
 ----PhysicalProject
 ------filter((count(id) > 1))
 --------hashAgg[LOCAL]
-----------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+----------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ------------PhysicalProject
 --------------PhysicalOlapScan[t]
 ------------PhysicalProject
@@ -219,7 +219,7 @@ PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
 ----hashAgg[LOCAL]
 ------PhysicalProject
---------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+--------hashJoin[RIGHT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ----------PhysicalProject
 ------------PhysicalOlapScan[t]
 ----------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query4.out
@@ -69,11 +69,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
+--------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
+--------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query74.out
@@ -45,11 +45,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.00))
+------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
+------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.00))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query95.out
@@ -24,20 +24,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_ship_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[ws_ship_addr_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_ship_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ws_ship_date_sk]
-------------------------------hashJoin[LEFT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=()
---------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = ws_wh.ws_order_number)) otherCondition=()
-----------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF3 ws_order_number->[ws_order_number]
+--------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
+--------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF2 ws_order_number->[wr_order_number];RF7 ws_order_number->[ws_order_number,ws_order_number]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=()
+--------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF2
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5 RF6
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF7 wr_order_number->[ws_order_number]
-------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[web_returns]
 ------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------PhysicalProject
 ----------------------------------filter((date_dim.d_date <= '1999-04-02') and (date_dim.d_date >= '1999-02-01'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query95.out
@@ -24,20 +24,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_ship_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_ship_addr_sk];RF11 ca_address_sk->[ws_ship_addr_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((ws1.ws_ship_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[ws_ship_date_sk];RF9 d_date_sk->[ws_ship_date_sk]
-------------------------------hashJoin[LEFT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF6 wr_order_number->[ws_order_number,ws_order_number];RF7 wr_order_number->[ws_order_number,ws_order_number]
---------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF4 ws_order_number->[ws_order_number];RF5 ws_order_number->[ws_order_number]
-----------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5 RF6 RF7
+------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF6 ws_order_number->[ws_order_number];RF7 ws_order_number->[ws_order_number]
+--------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6 RF7
+--------------------------------hashJoin[RIGHT_SEMI_JOIN] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF4 ws_order_number->[wr_order_number];RF5 ws_order_number->[wr_order_number];RF14 ws_order_number->[ws_order_number,ws_order_number];RF15 ws_order_number->[ws_order_number,ws_order_number]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF2 wr_order_number->[ws_order_number];RF3 wr_order_number->[ws_order_number]
+--------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF3
+--------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF4 RF5
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7 RF8 RF9 RF10 RF11 RF12 RF13
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF14 wr_order_number->[ws_order_number,ws_order_number];RF15 wr_order_number->[ws_order_number,ws_order_number]
-------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[web_returns]
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF8 RF9 RF10 RF11 RF12 RF13
 ------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------PhysicalProject
 ----------------------------------filter((date_dim.d_date <= '1999-04-02') and (date_dim.d_date >= '1999-02-01'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query4.out
@@ -69,11 +69,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
+--------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
+--------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query74.out
@@ -45,11 +45,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.0))
+------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
+------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.0))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
@@ -69,11 +69,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
+--------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------filter((t_s_secyear.dyear = 2000) and (t_s_secyear.sale_type = 's'))
+--------------------------------filter((t_s_firstyear.dyear = 1999) and (t_s_firstyear.sale_type = 's') and (t_s_firstyear.year_total > 0.000000))
 ----------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
@@ -45,11 +45,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.0))
+------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
+------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0.0))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject


### PR DESCRIPTION
## Proposed changes

This PR introduces an optimization that adjusts the penalty applied during join operations based on the volume of data on the build side. Specifically, when the number of rows and width of the tables being joined are equal, the materialization costs are now considered more accurately. The update ensures that joins with a larger dataset on the build side incur a higher penalty, improving overall query performance and resource allocation.