### PR TITLE
[BugFix](TabletInvertedIndex) fix replica not found in TabletInvertedIndex

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -574,8 +574,16 @@ public class TabletInvertedIndex {
                     "tablet " + tabletId + " not exists, backend " + backendId);
             if (replicaMetaTable.containsRow(tabletId)) {
                 Replica replica = replicaMetaTable.remove(tabletId, backendId);
-                replicaToTabletMap.remove(replica.getId());
-                replicaMetaTable.remove(tabletId, backendId);
+                if (replicaMetaTable.containsRow(tabletId)) {
+                    long replicaNum = replicaMetaTable.row(tabletId).values().stream()
+                            .filter(c -> c.getId() == replica.getId()).count();
+                    if (replicaNum == 0) {
+                        replicaToTabletMap.remove(replica.getId());
+                    }
+                } else {
+                    replicaToTabletMap.remove(replica.getId());
+                }
+
                 backingReplicaMetaTable.remove(backendId, tabletId);
                 LOG.debug("delete replica {} of tablet {} in backend {}",
                         replica.getId(), tabletId, backendId);


### PR DESCRIPTION
## Proposed changes

adding and dropping backend in cluster may lead to the different replica in different backend have the same replica id, 

at that time, 'delete from table partition xxx' operation will be failed with exception:'Failed to commit txn 862, cause tablet 11653 succ replica num 1 < quorum replica num 2. ...'

and also, with the above delete operation, drop replica operation(class:TabletInvertedIndex) will be failed with WARN log:
' could not find tablet id for replica xxx, the tablet maybe dropped'

fix in master branch already merged: #34117
