### PR TITLE
[opt](scanner) reduce local scanner thread pool thread num

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -242,7 +242,7 @@ DEFINE_Int32(doris_scanner_thread_pool_thread_num, "-1");
 DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> bool {
     if (config == -1) {
         CpuInfo::init();
-        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 2);
+        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores());
     }
     return true;
 });


### PR DESCRIPTION
## Proposed changes

Based on real perf. data of olap table, the local scanner thread pool thread num(config: doris_scanner_thread_pool_thread_num) setting has big influence on multi-stream running scenarios. Current "std::max(48, CpuInfo::num_cores() * 2)" configuration is too big on the high configuration cluster be, e.g, per-node with 64 cores (the value is 128), under multi-stream testing cases. 

Perf. data shows that 5 be cluster with 8 streams ad-hoc test cases will have 60% improvement if reducing this from "std::max(48, CpuInfo::num_cores() * 2)" to "std::max(48, CpuInfo::num_cores())".  

This pr only updates local scanner thread pool's config and doesn't change remote scanner thread pool thread number config strategy, see get_remote_scan_thread_num().

This change will be initial adjustment and should have more complete adaptive strategy in the future.

