### PR TITLE
[fix](nereids)keep equal predicate as join conjunct even if it can be fold to null literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
 import org.apache.doris.nereids.rules.rewrite.RewriteRuleFactory;
+import org.apache.doris.nereids.trees.expressions.EqualPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
@@ -206,6 +207,10 @@ public class ExpressionRewrite implements RewriteRuleFactory {
             ImmutableList.Builder<Expression> rewrittenConjuncts = new ImmutableList.Builder<>();
             for (Expression expr : conjuncts) {
                 Expression newExpr = rewriter.rewrite(expr, context);
+                newExpr = newExpr.isNullLiteral() && expr instanceof EqualPredicate
+                                ? expr.withChildren(rewriter.rewrite(expr.child(0), context),
+                                        rewriter.rewrite(expr.child(1), context))
+                                : newExpr;
                 isChanged = isChanged || !newExpr.equals(expr);
                 rewrittenConjuncts.addAll(ExpressionUtils.extractConjunction(newExpr));
             }

--- a/regression-test/data/nereids_p0/join/test_mark_join.out
+++ b/regression-test/data/nereids_p0/join/test_mark_join.out
@@ -50,3 +50,6 @@
 2	q	5
 0		6
 
+-- !mark_join_null_conjunct --
+\N
+

--- a/regression-test/suites/nereids_p0/join/test_mark_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_mark_join.groovy
@@ -140,4 +140,6 @@ suite("test_mark_join", "nereids_p0") {
             WHERE EXISTS ( SELECT MIN(`pk`) FROM table_7_undef_partitions2_keys3_properties4_distributed_by5 AS t2 WHERE t1.pk = 6 ) 
             OR EXISTS ( SELECT `pk` FROM table_7_undef_partitions2_keys3_properties4_distributed_by5 AS t2 WHERE t1.pk = 5 ) order by pk ;
     """
+
+    qt_mark_join_null_conjunct """select null in ( select k1 from test_mark_join_t1);"""
 }


### PR DESCRIPTION
consider sql `select null in ( select k1 from t);`
the join conjunct null = k1 would be fold to null. But be doesn't support null literal as join conjunct. This pr keeps null = k1 to make be happy
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

