### PR TITLE
[enhancement](nereids)eliminate repeat node if there is only 1 grouping set and no grouping scalar function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
@@ -82,6 +82,12 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     public Rule build() {
         return RuleType.NORMALIZE_REPEAT.build(
             logicalRepeat(any()).when(LogicalRepeat::canBindVirtualSlot).then(repeat -> {
+                if (repeat.getGroupingSets().size() == 1
+                        && ExpressionUtils.collect(repeat.getOutputExpressions(),
+                        GroupingScalarFunction.class::isInstance).isEmpty()) {
+                    return new LogicalAggregate<>(repeat.getGroupByExpressions(),
+                            repeat.getOutputExpressions(), repeat.child());
+                }
                 checkRepeatLegality(repeat);
                 repeat = removeDuplicateColumns(repeat);
                 // add virtual slot, LogicalAggregate and LogicalProject for normalize
@@ -116,11 +122,6 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     }
 
     private LogicalAggregate<Plan> normalizeRepeat(LogicalRepeat<Plan> repeat) {
-        if (repeat.getGroupingSets().size() == 1 && ExpressionUtils
-                .collect(repeat.getOutputExpressions(), GroupingScalarFunction.class::isInstance).isEmpty()) {
-            return new LogicalAggregate<>(repeat.getGroupByExpressions(),
-                    repeat.getOutputExpressions(), Optional.empty(), repeat.child());
-        }
         Set<Expression> needToSlotsGroupingExpr = collectNeedToSlotGroupingExpr(repeat);
         NormalizeToSlotContext groupingExprContext = buildContext(repeat, needToSlotsGroupingExpr);
         Map<Expression, NormalizeToSlotTriplet> groupingExprMap = groupingExprContext.getNormalizeToSlotMap();
@@ -321,9 +322,6 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
      */
     private LogicalAggregate<Plan> dealSlotAppearBothInAggFuncAndGroupingSets(
             @NotNull LogicalAggregate<Plan> aggregate) {
-        if (!(aggregate.child() instanceof LogicalRepeat)) {
-            return aggregate;
-        }
         LogicalRepeat<Plan> repeat = (LogicalRepeat<Plan>) aggregate.child();
         Map<Slot, Alias> commonSlotToAliasMap = getCommonSlotToAliasMap(repeat, aggregate);
         if (commonSlotToAliasMap.isEmpty()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.analysis;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
@@ -49,6 +50,42 @@ public class NormalizeRepeatTest implements MemoPatternMatchSupported {
                 .applyTopDown(new NormalizeRepeat())
                 .matches(
                         logicalRepeat().when(repeat -> repeat.getOutputExpressions().get(0).nullable())
+                );
+    }
+
+    @Test
+    public void testEliminateRepeat() {
+        Slot id = scan1.getOutput().get(0);
+        Slot idNotNull = id.withNullable(true);
+        Slot name = scan1.getOutput().get(1);
+        Alias alias = new Alias(new Sum(name), "sum(name)");
+        Plan plan = new LogicalRepeat<>(
+                ImmutableList.of(ImmutableList.of(id)),
+                ImmutableList.of(idNotNull, alias),
+                scan1
+        );
+        PlanChecker.from(MemoTestUtils.createCascadesContext(plan))
+                .applyTopDown(new NormalizeRepeat())
+                .matchesFromRoot(
+                        logicalAggregate(logicalOlapScan())
+                );
+    }
+
+    @Test
+    public void testNoEliminateRepeat() {
+        Slot id = scan1.getOutput().get(0);
+        Slot idNotNull = id.withNullable(true);
+        Slot name = scan1.getOutput().get(1);
+        Alias alias = new Alias(new GroupingId(name), "grouping_id(name)");
+        Plan plan = new LogicalRepeat<>(
+                ImmutableList.of(ImmutableList.of(id)),
+                ImmutableList.of(idNotNull, alias),
+                scan1
+        );
+        PlanChecker.from(MemoTestUtils.createCascadesContext(plan))
+                .applyTopDown(new NormalizeRepeat())
+                .matchesFromRoot(
+                        logicalAggregate(logicalRepeat(logicalOlapScan()))
                 );
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
@@ -41,7 +41,7 @@ public class NormalizeRepeatTest implements MemoPatternMatchSupported {
         Slot name = scan1.getOutput().get(1);
         Alias alias = new Alias(new Sum(name), "sum(name)");
         Plan plan = new LogicalRepeat<>(
-                ImmutableList.of(ImmutableList.of(id)),
+                ImmutableList.of(ImmutableList.of(id), ImmutableList.of(name)),
                 ImmutableList.of(idNotNull, alias),
                 scan1
         );

--- a/regression-test/suites/nereids_rules_p0/grouping_sets/grouping_normalize_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/grouping_sets/grouping_normalize_test.groovy
@@ -39,4 +39,9 @@ suite("grouping_normalize_test"){
     SELECT  ROUND( SUM(pk  +  1)  -  3)  col_alias1,  MAX( DISTINCT  col_int_undef_signed  -  5)   AS col_alias2, pk  +  1  AS col_alias3
     FROM grouping_normalize_test  GROUP BY  GROUPING SETS ((col_int_undef_signed,col_int_undef_signed2,pk),()) order by 1,2,3;
     """
+
+    explain {
+            sql("SELECT col_int_undef_signed, col_int_undef_signed2, SUM(pk) FROM grouping_normalize_test GROUP BY GROUPING SETS ((col_int_undef_signed, col_int_undef_signed2));")
+            notContains("VREPEAT_NODE")
+    }
 }

--- a/regression-test/suites/nereids_rules_p0/grouping_sets/grouping_normalize_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/grouping_sets/grouping_normalize_test.groovy
@@ -44,4 +44,14 @@ suite("grouping_normalize_test"){
             sql("SELECT col_int_undef_signed, col_int_undef_signed2, SUM(pk) FROM grouping_normalize_test GROUP BY GROUPING SETS ((col_int_undef_signed, col_int_undef_signed2));")
             notContains("VREPEAT_NODE")
     }
+
+    explain {
+            sql("SELECT col_int_undef_signed, col_int_undef_signed2, SUM(pk), grouping_id(col_int_undef_signed2) FROM grouping_normalize_test GROUP BY GROUPING SETS ((col_int_undef_signed, col_int_undef_signed2),());")
+            contains("VREPEAT_NODE")
+    }
+
+    explain {
+            sql("SELECT col_int_undef_signed, col_int_undef_signed2, SUM(pk) FROM grouping_normalize_test GROUP BY GROUPING SETS ((col_int_undef_signed, col_int_undef_signed2));")
+            notContains("VREPEAT_NODE")
+    }
 }


### PR DESCRIPTION
## Proposed changes

convert
`SELECT k1, k2, SUM(k3) FROM d_table GROUP BY GROUPING SETS ((k1, k2));`
to
`SELECT k1, k2, SUM(k3) FROM d_table GROUP BY (k1, k2);`

<!--Describe your changes.-->

