### PR TITLE
[feature](statistics)Remove not exist partition stats while analyzing.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
@@ -177,7 +177,7 @@ public class ShowTableStatsStmt extends ShowStmt {
         row.add(formattedDateTime);
         row.add(tableStatistic.analyzeColumns().toString());
         row.add(tableStatistic.jobType.toString());
-        row.add(String.valueOf(tableStatistic.newPartitionLoaded.get()));
+        row.add(String.valueOf(tableStatistic.partitionChanged.get()));
         row.add(String.valueOf(tableStatistic.userInjected));
         result.add(row);
         return new ShowResultSet(getMetaData(), result);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -78,7 +78,9 @@ public class InternalSchema {
                 ColumnNullableType.NOT_NULLABLE));
         PARTITION_STATS_SCHEMA.add(new ColumnDef("idx_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN),
                 ColumnNullableType.NOT_NULLABLE));
-        PARTITION_STATS_SCHEMA.add(new ColumnDef("part_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN),
+        PARTITION_STATS_SCHEMA.add(new ColumnDef("part_name", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN),
+                ColumnNullableType.NOT_NULLABLE));
+        PARTITION_STATS_SCHEMA.add(new ColumnDef("part_id", TypeDef.create(PrimitiveType.BIGINT),
                 ColumnNullableType.NOT_NULLABLE));
         PARTITION_STATS_SCHEMA.add(new ColumnDef("col_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN),
                 ColumnNullableType.NOT_NULLABLE));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -169,7 +169,7 @@ public class InternalSchemaInitializer extends Thread {
                     Lists.newArrayList("id", "catalog_id", "db_id", "tbl_id", "idx_id", "col_id", "part_id")));
         Env.getCurrentEnv().getInternalCatalog().createTable(
                 buildStatisticsTblStmt(StatisticConstants.PARTITION_STATISTIC_TBL_NAME,
-                    Lists.newArrayList("catalog_id", "db_id", "tbl_id", "idx_id", "part_id", "col_id")));
+                    Lists.newArrayList("catalog_id", "db_id", "tbl_id", "idx_id", "part_name", "part_id", "col_id")));
         // audit table
         Env.getCurrentEnv().getInternalCatalog().createTable(buildAuditTblStmt());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -657,7 +657,7 @@ public class AnalysisManager implements Writable {
         invalidateLocalStats(catalogId, dbId, tblId, cols, tableStats);
         // Drop stats ddl is master only operation.
         invalidateRemoteStats(catalogId, dbId, tblId, cols);
-        StatisticsRepository.dropStatistics(catalogId, dbId, tblId, cols, null);
+        StatisticsRepository.dropStatistics(catalogId, dbId, tblId, cols);
     }
 
     public void dropStats(TableIf table) throws DdlException {
@@ -671,7 +671,7 @@ public class AnalysisManager implements Writable {
         invalidateLocalStats(catalogId, dbId, tableId, null, tableStats);
         // Drop stats ddl is master only operation.
         invalidateRemoteStats(catalogId, dbId, tableId, null);
-        StatisticsRepository.dropStatistics(catalogId, dbId, table.getId(), null, null);
+        StatisticsRepository.dropStatistics(catalogId, dbId, table.getId(), null);
     }
 
     public void invalidateLocalStats(long catalogId, long dbId, long tableId,
@@ -1054,7 +1054,7 @@ public class AnalysisManager implements Writable {
         for (long tableId : tableIds) {
             TableStatsMeta statsStatus = idToTblStats.get(tableId);
             if (statsStatus != null) {
-                statsStatus.newPartitionLoaded.set(true);
+                statsStatus.partitionChanged.set(true);
             }
         }
         logNewPartitionLoadedEvent(new NewPartitionLoadedEvent(tableIds));
@@ -1189,7 +1189,7 @@ public class AnalysisManager implements Writable {
         for (long tableId : event.getTableIds()) {
             TableStatsMeta statsStatus = idToTblStats.get(tableId);
             if (statsStatus != null) {
-                statsStatus.newPartitionLoaded.set(true);
+                statsStatus.partitionChanged.set(true);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.qe.AuditLogHelper;
@@ -162,6 +163,7 @@ public abstract class BaseAnalysisTask {
             + "${dbId} AS `db_id`, "
             + "${tblId} AS `tbl_id`, "
             + "${idxId} AS `idx_id`, "
+            + "${partName} AS `part_name`, "
             + "${partId} AS `part_id`, "
             + "'${colId}' AS `col_id`, "
             + "COUNT(1) AS `row_count`, "
@@ -346,11 +348,13 @@ public abstract class BaseAnalysisTask {
     }
 
     /**
-     * 1. Get stats of each partition
-     * 2. insert partition in batch
-     * 3. calculate column stats based on partition stats
+     * 1. Remove not exist partition stats
+     * 2. Get stats of each partition
+     * 3. insert partition in batch
+     * 4. calculate column stats based on partition stats
      */
     protected void doPartitionTable() throws Exception {
+        deleteNotExistPartitionStats();
         Map<String, String> params = buildSqlParams();
         params.put("dataSizeFunction", getDataSizeFunction(col, false));
         Set<String> partitionNames = tbl.getPartitionNames();
@@ -359,6 +363,7 @@ public abstract class BaseAnalysisTask {
         TableStatsMeta tableStatsStatus = Env.getServingEnv().getAnalysisManager().findTableStatsStatus(tbl.getId());
         for (String part : partitionNames) {
             Partition partition = tbl.getPartition(part);
+            params.put("partId", partition == null ? "-1" : String.valueOf(partition.getId()));
             // Skip partitions that not changed after last analyze.
             // External table getPartition always return null. So external table doesn't skip any partitions.
             if (partition != null && tableStatsStatus != null && tableStatsStatus.partitionUpdateRows != null) {
@@ -375,7 +380,7 @@ public abstract class BaseAnalysisTask {
                     }
                 }
             }
-            params.put("partId", "'" + StatisticsUtil.escapeColumnName(part) + "'");
+            params.put("partName", "'" + StatisticsUtil.escapeColumnName(part) + "'");
             params.put("partitionInfo", getPartitionInfo(part));
             StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
             sqls.add(stringSubstitutor.replace(PARTITION_ANALYZE_TEMPLATE));
@@ -399,6 +404,8 @@ public abstract class BaseAnalysisTask {
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
         runQuery(stringSubstitutor.replace(MERGE_PARTITION_TEMPLATE));
     }
+
+    protected abstract void deleteNotExistPartitionStats() throws DdlException;
 
     protected String getPartitionInfo(String partitionName) {
         return "";

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.NotImplementedException;
 import org.apache.doris.datasource.ExternalTable;
@@ -49,6 +50,10 @@ public class ExternalAnalysisTask extends BaseAnalysisTask {
         } else {
             doFull();
         }
+    }
+
+    @Override
+    protected void deleteNotExistPartitionStats() throws DdlException {
     }
 
     protected void doFull() throws Exception {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
@@ -18,7 +18,10 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable;
@@ -271,6 +274,24 @@ public class HMSAnalysisTask extends ExternalAnalysisTask {
         } else {
             super.doFull();
         }
+    }
+
+    @Override
+    protected void deleteNotExistPartitionStats() throws DdlException {
+        TableStatsMeta tableStats = Env.getServingEnv().getAnalysisManager().findTableStatsStatus(tbl.getId());
+        if (tableStats == null) {
+            return;
+        }
+        OlapTable table = (OlapTable) tbl;
+        String indexName = info.indexId == -1 ? table.getName() : table.getIndexNameById(info.indexId);
+        ColStatsMeta columnStats = tableStats.findColumnStatsMeta(indexName, info.colName);
+        if (columnStats == null) {
+            return;
+        }
+        // For external table, simply remove all partition stats for the given column and re-analyze it again.
+        String columnCondition = "AND col_id = " + StatisticsUtil.quote(col.getName());
+        StatisticsRepository.dropPartitionsColumnStatistics(info.catalogId, info.dbId, info.tblId,
+                columnCondition, "");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -18,6 +18,7 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.util.StatisticsUtil;
@@ -71,6 +72,10 @@ public class HistogramTask extends BaseAnalysisTask {
         StatisticsUtil.execUpdate(stringSubstitutor.replace(ANALYZE_HISTOGRAM_SQL_TEMPLATE_TABLE));
         Env.getCurrentEnv().getStatisticsCache().refreshHistogramSync(
                 tbl.getDatabase().getCatalog().getId(), tbl.getDatabase().getId(), tbl.getId(), -1, col.getName());
+    }
+
+    @Override
+    protected void deleteNotExistPartitionStats() throws DdlException {
     }
 
     private String getSampleRateFunction() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -19,11 +19,14 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.DebugUtil;
@@ -33,6 +36,8 @@ import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import org.apache.commons.text.StringSubstitutor;
 
 import java.security.SecureRandom;
@@ -198,6 +203,43 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         } else {
             StringSubstitutor stringSubstitutor = new StringSubstitutor(buildSqlParams());
             runQuery(stringSubstitutor.replace(FULL_ANALYZE_TEMPLATE));
+        }
+    }
+
+    @Override
+    protected void deleteNotExistPartitionStats() throws DdlException {
+        TableStatsMeta tableStats = Env.getServingEnv().getAnalysisManager().findTableStatsStatus(tbl.getId());
+        // When a partition was dropped, newPartitionLoaded will set to true.
+        // So we don't need to check dropped partition if newPartitionLoaded is false.
+        if (tableStats == null || !tableStats.partitionChanged.get()) {
+            return;
+        }
+        OlapTable table = (OlapTable) tbl;
+        String indexName = info.indexId == -1 ? table.getName() : table.getIndexNameById(info.indexId);
+        ColStatsMeta columnStats = tableStats.findColumnStatsMeta(indexName, info.colName);
+        if (columnStats == null || columnStats.partitionUpdateRows == null
+                || columnStats.partitionUpdateRows.isEmpty()) {
+            return;
+        }
+        Set<Long> expiredPartition = Sets.newHashSet();
+        String columnCondition = "AND col_id = " + StatisticsUtil.quote(col.getName());
+        for (long partId : columnStats.partitionUpdateRows.keySet()) {
+            Partition partition = table.getPartition(partId);
+            if (partition == null) {
+                columnStats.partitionUpdateRows.remove(partId);
+                expiredPartition.add(partId);
+                if (expiredPartition.size() == Config.max_allowed_in_element_num_of_delete) {
+                    String partitionCondition = " AND part_id in (" + Joiner.on(", ").join(expiredPartition) + ")";
+                    StatisticsRepository.dropPartitionsColumnStatistics(info.catalogId, info.dbId, info.tblId,
+                            columnCondition, partitionCondition);
+                    expiredPartition.clear();
+                }
+            }
+        }
+        if (expiredPartition.size() > 0) {
+            String partitionCondition = " AND part_id in (" + Joiner.on(", ").join(expiredPartition) + ")";
+            StatisticsRepository.dropPartitionsColumnStatistics(info.catalogId, info.dbId, info.tblId,
+                    columnCondition, partitionCondition);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -153,7 +153,7 @@ public class StatisticsAutoCollector extends MasterDaemon {
         }
         AnalysisManager manager = Env.getServingEnv().getAnalysisManager();
         TableStatsMeta tableStatsStatus = manager.findTableStatsStatus(table.getId());
-        if (tableStatsStatus != null && tableStatsStatus.newPartitionLoaded.get()) {
+        if (tableStatsStatus != null && tableStatsStatus.partitionChanged.get()) {
             OlapTable olapTable = (OlapTable) table;
             columns.addAll(olapTable.getColumnIndexPairs(olapTable.getPartitionColumnNames()));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -74,7 +74,7 @@ public class TableStatsMeta implements Writable {
     public JobType jobType;
 
     @SerializedName("newPartitionLoaded")
-    public AtomicBoolean newPartitionLoaded = new AtomicBoolean(false);
+    public AtomicBoolean partitionChanged = new AtomicBoolean(false);
 
     @SerializedName("userInjected")
     public boolean userInjected;
@@ -163,14 +163,14 @@ public class TableStatsMeta implements Writable {
                     tableIf.getSchemaAllIndexes(false).stream()
                             .filter(c -> !StatisticsUtil.isUnsupportedType(c.getType()))
                             .map(Column::getName).collect(Collectors.toSet())))) {
-                newPartitionLoaded.set(false);
+                partitionChanged.set(false);
                 userInjected = false;
             } else if (tableIf instanceof OlapTable) {
                 PartitionInfo partitionInfo = ((OlapTable) tableIf).getPartitionInfo();
                 if (partitionInfo != null && analyzedJob.jobColumns
                         .containsAll(tableIf.getColumnIndexPairs(partitionInfo.getPartitionColumns().stream()
                             .map(Column::getName).collect(Collectors.toSet())))) {
-                    newPartitionLoaded.set(false);
+                    partitionChanged.set(false);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -990,7 +990,7 @@ public class StatisticsUtil {
         if (table instanceof OlapTable) {
             OlapTable olapTable = (OlapTable) table;
             // 0. Check new partition first time loaded flag.
-            if (olapTable.isPartitionColumn(column.second) && tableStatsStatus.newPartitionLoaded.get()) {
+            if (olapTable.isPartitionColumn(column.second) && tableStatsStatus.partitionChanged.get()) {
                 return true;
             }
             // 1. Check row count.

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -221,7 +221,7 @@ class StatisticsUtilTest {
                 return true;
             }
         };
-        tableMeta.newPartitionLoaded.set(true);
+        tableMeta.partitionChanged.set(true);
         Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test empty table to non-empty table.
@@ -231,7 +231,7 @@ class StatisticsUtilTest {
                 return 100;
             }
         };
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test non-empty table to empty table.
@@ -247,7 +247,7 @@ class StatisticsUtilTest {
                 return new ColStatsMeta(0, null, null, null, 0, 100, 0, null);
             }
         };
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test table still empty.
@@ -257,7 +257,7 @@ class StatisticsUtilTest {
                 return new ColStatsMeta(0, null, null, null, 0, 0, 0, null);
             }
         };
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test row count changed more than threshold.
@@ -273,7 +273,7 @@ class StatisticsUtilTest {
                 return new ColStatsMeta(0, null, null, null, 0, 500, 0, null);
             }
         };
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test update rows changed more than threshold.
@@ -289,12 +289,12 @@ class StatisticsUtilTest {
                 return new ColStatsMeta(0, null, null, null, 0, 100, 80, null);
             }
         };
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         tableMeta.updatedRows.set(200);
         Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
         // Test update rows changed less than threshold
-        tableMeta.newPartitionLoaded.set(false);
+        tableMeta.partitionChanged.set(false);
         tableMeta.updatedRows.set(100);
         Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 


### PR DESCRIPTION
## Proposed changes
Remove not exist partition stats while analyzing.

<!--Describe your changes.-->
When doing full analyze, we need to drop not existing partition's statistics before analyzing. Because user may drop partition at any time. If we don't drop expired partition stats, we may get wrong table level stats by merging all partition stats.
