### PR TITLE
[Fix](show data) fix show data total size wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -143,8 +143,8 @@ public class TabletStatMgr extends MasterDaemon {
 
                                     if (replica.getDataSize() > tabletDataSize) {
                                         tabletDataSize = replica.getDataSize();
-                                        tableTotalReplicaDataSize += replica.getDataSize();
                                     }
+                                    tableTotalReplicaDataSize += replica.getDataSize();
 
                                     if (replica.getRemoteDataSize() > tabletRemoteDataSize) {
                                         tabletRemoteDataSize = replica.getRemoteDataSize();

--- a/regression-test/suites/inverted_index_p0/test_show_data.groovy
+++ b/regression-test/suites/inverted_index_p0/test_show_data.groovy
@@ -101,17 +101,18 @@ suite("test_show_data", "p0") {
     }
 
     def wait_for_show_data_finish = { table_name, OpTimeout, origin_size ->
+        def size = origin_size;
         for(int t = delta_time; t <= OpTimeout; t += delta_time){
             def result = sql """show data from ${database}.${table_name};"""
             if (result.size() > 0) {
                 logger.info(table_name + " show data, detail: " + result[0].toString())
-                def size = result[0][2].replace(" KB", "").toDouble()
-                if (size != origin_size) {
-                    return size
-                }
+                size = result[0][2].replace(" KB", "").toDouble()
             }
             useTime = t
             Thread.sleep(delta_time)
+        }
+        if (size != origin_size) {
+            return size;
         }
         assertTrue(useTime <= OpTimeout, "wait_for_show_data_finish timeout, useTime=${useTime}")
         return "wait_timeout"
@@ -162,7 +163,7 @@ suite("test_show_data", "p0") {
         load_httplogs_data.call(testTableWithoutIndex, 'test_httplogs_load_without_index', 'true', 'json', 'documents-1000.json')
 
         sql "sync"
-        def no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 300000, 0)
+        def no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 120000, 0)
         assertTrue(no_index_size != "wait_timeout")
         sql """ ALTER TABLE ${testTableWithoutIndex} ADD INDEX idx_request (`request`) USING INVERTED PROPERTIES("parser" = "english") """
         wait_for_latest_op_on_table_finish(testTableWithoutIndex, timeout)
@@ -173,19 +174,19 @@ suite("test_show_data", "p0") {
             state = wait_for_last_build_index_on_table_finish(testTableWithoutIndex, timeout)
             assertEquals(state, "FINISHED")
         }
-        def with_index_size = wait_for_show_data_finish(testTableWithoutIndex, 300000, no_index_size)
+        def with_index_size = wait_for_show_data_finish(testTableWithoutIndex, 120000, no_index_size)
         assertTrue(with_index_size != "wait_timeout")
 
         sql """ ALTER TABLE ${testTableWithoutIndex} DROP INDEX idx_request """
         wait_for_latest_op_on_table_finish(testTableWithoutIndex, timeout)
-        def another_no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 300000, with_index_size)
+        def another_no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 120000, with_index_size)
         if (!isCloudMode()) {
             assertEquals(another_no_index_size, no_index_size)
         }
         sql "DROP TABLE IF EXISTS ${testTableWithIndex}"
         create_httplogs_table_with_index.call(testTableWithIndex)
         load_httplogs_data.call(testTableWithIndex, 'test_httplogs_load_with_index', 'true', 'json', 'documents-1000.json')
-        def another_with_index_size = wait_for_show_data_finish(testTableWithIndex, 300000, 0)
+        def another_with_index_size = wait_for_show_data_finish(testTableWithIndex, 120000, 0)
         if (!isCloudMode()) {
             assertEquals(another_with_index_size, with_index_size)
         }
@@ -280,17 +281,18 @@ suite("test_show_data_for_bkd", "p0") {
     }
 
     def wait_for_show_data_finish = { table_name, OpTimeout, origin_size ->
+        def size = origin_size;
         for(int t = delta_time; t <= OpTimeout; t += delta_time){
             def result = sql """show data from ${database}.${table_name};"""
             if (result.size() > 0) {
                 logger.info(table_name + " show data, detail: " + result[0].toString())
-                def size = result[0][2].replace(" KB", "").toDouble()
-                if (size != origin_size) {
-                    return size
-                }
+                size = result[0][2].replace(" KB", "").toDouble()
             }
             useTime = t
             Thread.sleep(delta_time)
+        }
+        if (size != origin_size) {
+            return size;
         }
         assertTrue(useTime <= OpTimeout, "wait_for_show_data_finish timeout, useTime=${useTime}")
         return "wait_timeout"
@@ -340,7 +342,7 @@ suite("test_show_data_for_bkd", "p0") {
         load_httplogs_data.call(testTableWithoutBKDIndex, 'test_httplogs_load_without_bkd_index', 'true', 'json', 'documents-1000.json')
 
         sql "sync"
-        def no_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 300000, 0)
+        def no_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 120000, 0)
         assertTrue(no_index_size != "wait_timeout")
         sql """ ALTER TABLE ${testTableWithoutBKDIndex} ADD INDEX idx_status (`status`) USING INVERTED; """
         wait_for_latest_op_on_table_finish(testTableWithoutBKDIndex, timeout)
@@ -351,12 +353,12 @@ suite("test_show_data_for_bkd", "p0") {
             def state = wait_for_last_build_index_on_table_finish(testTableWithoutBKDIndex, timeout)
             assertEquals(state, "FINISHED")
         }
-        def with_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 300000, no_index_size)
+        def with_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 120000, no_index_size)
         assertTrue(with_index_size != "wait_timeout")
 
         sql """ ALTER TABLE ${testTableWithoutBKDIndex} DROP INDEX idx_status """
         wait_for_latest_op_on_table_finish(testTableWithoutBKDIndex, timeout)
-        def another_no_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 300000, with_index_size)
+        def another_no_index_size = wait_for_show_data_finish(testTableWithoutBKDIndex, 120000, with_index_size)
         if (!isCloudMode()) {
             assertEquals(another_no_index_size, no_index_size)
         }
@@ -364,7 +366,7 @@ suite("test_show_data_for_bkd", "p0") {
         sql "DROP TABLE IF EXISTS ${testTableWithBKDIndex}"
         create_httplogs_table_with_bkd_index.call(testTableWithBKDIndex)
         load_httplogs_data.call(testTableWithBKDIndex, 'test_httplogs_load_with_bkd_index', 'true', 'json', 'documents-1000.json')
-        def another_with_index_size = wait_for_show_data_finish(testTableWithBKDIndex, 300000, 0)
+        def another_with_index_size = wait_for_show_data_finish(testTableWithBKDIndex, 120000, 0)
         if (!isCloudMode()) {
             assertEquals(another_with_index_size, with_index_size)
         }
@@ -460,17 +462,18 @@ suite("test_show_data_multi_add", "p0") {
     }
 
     def wait_for_show_data_finish = { table_name, OpTimeout, origin_size ->
+        def size = origin_size;
         for(int t = delta_time; t <= OpTimeout; t += delta_time){
             def result = sql """show data from ${database}.${table_name};"""
             if (result.size() > 0) {
                 logger.info(table_name + " show data, detail: " + result[0].toString())
-                def size = result[0][2].replace(" KB", "").toDouble()
-                if (size != origin_size) {
-                    return size
-                }
+                size = result[0][2].replace(" KB", "").toDouble()
             }
             useTime = t
             Thread.sleep(delta_time)
+        }
+        if (size != origin_size) {
+            return size;
         }
         assertTrue(useTime <= OpTimeout, "wait_for_show_data_finish timeout, useTime=${useTime}")
         return "wait_timeout"
@@ -520,7 +523,7 @@ suite("test_show_data_multi_add", "p0") {
         load_httplogs_data.call(testTableWithoutIndex, 'test_show_data_httplogs_multi_add_without_index', 'true', 'json', 'documents-1000.json')
 
         sql "sync"
-        def no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 300000, 0)
+        def no_index_size = wait_for_show_data_finish(testTableWithoutIndex, 120000, 0)
         assertTrue(no_index_size != "wait_timeout")
         sql """ ALTER TABLE ${testTableWithoutIndex} ADD INDEX idx_status (`status`) USING INVERTED; """
         wait_for_latest_op_on_table_finish(testTableWithoutIndex, timeout)
@@ -531,7 +534,7 @@ suite("test_show_data_multi_add", "p0") {
             def state = wait_for_last_build_index_on_table_finish(testTableWithoutIndex, timeout)
             assertEquals(state, "FINISHED")
         }
-        def with_index_size1 = wait_for_show_data_finish(testTableWithoutIndex, 300000, no_index_size)
+        def with_index_size1 = wait_for_show_data_finish(testTableWithoutIndex, 120000, no_index_size)
         assertTrue(with_index_size1 != "wait_timeout")
 
         sql """ ALTER TABLE ${testTableWithoutIndex} ADD INDEX request_idx (`request`) USING INVERTED; """
@@ -543,13 +546,13 @@ suite("test_show_data_multi_add", "p0") {
             def state2 = wait_for_last_build_index_on_table_finish(testTableWithoutIndex, timeout)
             assertEquals(state2, "FINISHED")
         }
-        def with_index_size2 = wait_for_show_data_finish(testTableWithoutIndex, 300000, with_index_size1)
+        def with_index_size2 = wait_for_show_data_finish(testTableWithoutIndex, 120000, with_index_size1)
         assertTrue(with_index_size2 != "wait_timeout")
 
         sql "DROP TABLE IF EXISTS ${testTableWithIndex}"
         create_httplogs_table_with_index.call(testTableWithIndex)
         load_httplogs_data.call(testTableWithIndex, 'test_show_data_httplogs_multi_add_with_index', 'true', 'json', 'documents-1000.json')
-        def another_with_index_size = wait_for_show_data_finish(testTableWithIndex, 300000, 0)
+        def another_with_index_size = wait_for_show_data_finish(testTableWithIndex, 120000, 0)
         if (!isCloudMode()) {
             assertEquals(another_with_index_size, with_index_size2)
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When setting replica = 3, the show data command returns an incorrect data size. This issue arises because the total size calculation only accounts for the maximum replica data size.


