### PR TITLE
[fix](nereids) fix topn-filter expr bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -120,7 +120,7 @@ public class CastExpr extends Expr {
      */
     public CastExpr(Type targetType, Expr e, Void v) {
         Preconditions.checkArgument(targetType.isValid());
-        Preconditions.checkNotNull(e);
+        Preconditions.checkNotNull(e, "cast child is null");
         opcode = TExprOpcode.CAST;
         type = targetType;
         targetTypeDef = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopnFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopnFilterPushDownVisitor.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalWindow;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.types.VariantType;
 
 import com.google.common.collect.Maps;
 
@@ -214,7 +215,9 @@ public class TopnFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownCont
     public Boolean visitPhysicalRelation(PhysicalRelation relation, PushDownContext ctx) {
         if (supportPhysicalRelations(relation)
                 && relation.getOutputSet().containsAll(ctx.probeExpr.getInputSlots())) {
-            if (relation.getOutputSet().containsAll(ctx.probeExpr.getInputSlots())) {
+            if (relation.getOutputSet().containsAll(ctx.probeExpr.getInputSlots())
+                    && ctx.probeExpr.getInputSlots().stream().noneMatch(
+                            slot -> slot.getDataType() instanceof VariantType)) {
                 topnFilterContext.addTopnFilter(ctx.topn, relation, ctx.probeExpr);
                 return true;
             }


### PR DESCRIPTION
## Proposed changes
in previous version, topn-filter requires the first order key is a base table column. this restriction is abolished now

Issue Number: close #xxx

<!--Describe your changes.-->

