### PR TITLE
[bugfix](hive)fix the error message when creating hive table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
@@ -204,10 +204,10 @@ public class PartitionTableInfo {
                 }
                 List<ColumnDefinition> partitionInSchema = columns.subList(
                         columns.size() - partitionColumns.size(), columns.size());
+                if (partitionInSchema.stream().anyMatch(p -> !partitionColumns.contains(p.getName()))) {
+                    throw new AnalysisException("The partition field must be at the end of the schema.");
+                }
                 for (int i = 0; i < partitionInSchema.size(); i++) {
-                    if (!partitionColumns.contains(partitionInSchema.get(i).getName())) {
-                        throw new AnalysisException("The partition field must be at the end of the schema.");
-                    }
                     if (!partitionInSchema.get(i).getName().equals(partitionColumns.get(i))) {
                         throw new AnalysisException("The order of partition fields in the schema "
                             + "must be consistent with the order defined in `PARTITIONED BY LIST()`");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/CreateTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/CreateTableCommandTest.java
@@ -884,5 +884,19 @@ public class CreateTableCommandTest extends TestWithFeService {
         } catch (Exception e) {
             Assertions.assertEquals("partition key par1 is not exists", e.getMessage());
         }
+
+        try {
+            getCreateTableStmt("CREATE TABLE `tb11`(\n"
+                    + "    `c1` bigint,\n"
+                    + "    `par1` int,\n"
+                    + "    `par2` int,\n"
+                    + "    `par3` int\n"
+                    + ") ENGINE = hive PARTITION BY LIST (\n"
+                    + "    par1, par2\n"
+                    + ")();");
+            Assertions.assertTrue(false);
+        } catch (Exception e) {
+            Assertions.assertEquals("The partition field must be at the end of the schema.", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes


<!--Describe your changes.-->

```
create table tb (id int, pt1 string, pt2 string, pt3 string) partition by list (pt1,pt2)();
```
error message before：
     `The order of partition fields in the schema must be consistent with the order defined in PARTITIONED BY LIST()` 
error message after: 
     `The partition field must be at the end of the schema`