### PR TITLE
[enhance](boot) Limit the concurrency of load data dirs

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1289,6 +1289,8 @@ DEFINE_Int64(s3_file_system_local_upload_buffer_size, "5242880");
 //JVM monitoring enable. To prevent be from crashing due to jvm compatibility issues. The default setting is off.
 DEFINE_Bool(enable_jvm_monitor, "false");
 
+DEFINE_Int32(load_data_dirs_threads, "-1");
+
 // Skip loading stale rowset meta when initializing `TabletMeta` from protobuf
 DEFINE_mBool(skip_loading_stale_rowset_meta, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1367,6 +1367,9 @@ DECLARE_Int64(s3_file_system_local_upload_buffer_size);
 //JVM monitoring enable. To prevent be from crashing due to jvm compatibility issues.
 DECLARE_Bool(enable_jvm_monitor);
 
+// Num threads to load data dirs, default value -1 indicates the same number of threads as the number of data dirs
+DECLARE_Int32(load_data_dirs_threads);
+
 // Skip loading stale rowset meta when initializing `TabletMeta` from protobuf
 DECLARE_mBool(skip_loading_stale_rowset_meta);
 // Whether to use file to record log. When starting BE with --console,


### PR DESCRIPTION
## Proposed changes

Limit the concurrency of load data dirs, which can reduce memory usage during BE boot up.

