### PR TITLE
[improve](cloud) use delete bitmap cache to reduce sync rowset time

### DIFF
--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -154,10 +154,11 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
     DeleteBitmapPtr delete_bitmap;
     RowsetIdUnorderedSet rowset_ids;
     std::shared_ptr<PartialUpdateInfo> partial_update_info;
+    std::shared_ptr<PublishStatus> publish_status;
     int64_t txn_expiration;
     Status status = _engine.txn_delete_bitmap_cache().get_tablet_txn_info(
             _transaction_id, _tablet_id, &rowset, &delete_bitmap, &rowset_ids, &txn_expiration,
-            &partial_update_info);
+            &partial_update_info, &publish_status);
     if (status != Status::OK()) {
         LOG(WARNING) << "failed to get tablet txn info. tablet_id=" << _tablet_id
                      << ", txn_id=" << _transaction_id << ", status=" << status;
@@ -172,8 +173,15 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
     txn_info.delete_bitmap = delete_bitmap;
     txn_info.rowset_ids = rowset_ids;
     txn_info.partial_update_info = partial_update_info;
-    status = CloudTablet::update_delete_bitmap(tablet, &txn_info, _transaction_id, txn_expiration);
-    auto update_delete_bitmap_time_us = MonotonicMicros() - t3;
+    txn_info.publish_status = publish_status;
+    auto update_delete_bitmap_time_us = 0;
+    if (txn_info.publish_status && (*(txn_info.publish_status) == PublishStatus::SUCCEED)) {
+        LOG(INFO) << "tablet=" <<  _tablet_id << ",txn=" << _transaction_id
+                  << ",publish_status=SUCCEED,not need to recalculate and update delete_bitmap.";
+    } else {
+        status = CloudTablet::update_delete_bitmap(tablet, &txn_info, _transaction_id, txn_expiration);
+        update_delete_bitmap_time_us = MonotonicMicros() - t3;
+    }
     if (status != Status::OK()) {
         LOG(WARNING) << "failed to calculate delete bitmap. rowset_id=" << rowset->rowset_id()
                      << ", tablet_id=" << _tablet_id << ", txn_id=" << _transaction_id

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -176,10 +176,11 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
     txn_info.publish_status = publish_status;
     auto update_delete_bitmap_time_us = 0;
     if (txn_info.publish_status && (*(txn_info.publish_status) == PublishStatus::SUCCEED)) {
-        LOG(INFO) << "tablet=" <<  _tablet_id << ",txn=" << _transaction_id
+        LOG(INFO) << "tablet=" << _tablet_id << ",txn=" << _transaction_id
                   << ",publish_status=SUCCEED,not need to recalculate and update delete_bitmap.";
     } else {
-        status = CloudTablet::update_delete_bitmap(tablet, &txn_info, _transaction_id, txn_expiration);
+        status = CloudTablet::update_delete_bitmap(tablet, &txn_info, _transaction_id,
+                                                   txn_expiration);
         update_delete_bitmap_time_us = MonotonicMicros() - t3;
     }
     if (status != Status::OK()) {

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -548,6 +548,38 @@ Status CloudMetaMgr::sync_tablet_rowsets(CloudTablet* tablet, bool warmup_delta_
     }
 }
 
+bool CloudMetaMgr::sync_tablet_delete_bitmap_by_cache(Tablet* tablet, int64_t old_max_version,
+                                                      std::ranges::range auto&& rs_metas,
+                                                      DeleteBitmap* delete_bitmap) {
+    std::set<int64_t> txn_processed;
+    for (auto& rs_meta : rs_metas) {
+        auto txn_id = rs_meta.txn_id();
+        if (txn_processed.find(txn_id) != txn_processed.end()) {
+            continue;
+        }
+        txn_processed.insert(txn_id);
+        DeleteBitmapPtr tmp_delete_bitmap;
+        RowsetIdUnorderedSet tmp_rowset_ids;
+        std::shared_ptr<PublishStatus> publish_status =
+                std::make_shared<PublishStatus>(PublishStatus::INIT);
+        //        Status status = StorageEngine::instance()->delete_bitmap_txn_manager()->get_delete_bitmap(
+        //                txn_id, tablet->tablet_id(), &tmp_delete_bitmap, &tmp_rowset_ids, &publish_status);
+        CloudStorageEngine& engine = ExecEnv::GetInstance()->storage_engine().to_cloud();
+        Status status = engine.txn_delete_bitmap_cache().get_delete_bitmap(
+                txn_id, tablet->tablet_id(), &tmp_delete_bitmap, &tmp_rowset_ids, &publish_status);
+        if (status.ok() && *(publish_status.get()) == PublishStatus::SUCCEED) {
+            delete_bitmap->merge(*tmp_delete_bitmap);
+            engine.txn_delete_bitmap_cache().remove_unused_tablet_txn_info(txn_id,
+                                                                           tablet->tablet_id());
+        } else {
+            LOG(WARNING) << "failed to get tablet txn info. tablet_id=" << tablet->tablet_id()
+                         << ", txn_id=" << txn_id << ", status=" << status;
+            return false;
+        }
+    }
+    return true;
+}
+
 Status CloudMetaMgr::sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_max_version,
                                                std::ranges::range auto&& rs_metas,
                                                const TabletStatsPB& stats, const TabletIndexPB& idx,
@@ -556,37 +588,46 @@ Status CloudMetaMgr::sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_
         return Status::OK();
     }
 
-    {
-        auto txn_id = rs_metas.rbegin()->txn_id();
-        RowsetSharedPtr rowset;
-        DeleteBitmapPtr tmp_delete_bitmap;
-        RowsetIdUnorderedSet rowset_ids;
-        std::shared_ptr<PartialUpdateInfo> partial_update_info;
-        int64_t txn_expiration;
-        CloudStorageEngine& engine = ExecEnv::GetInstance()->storage_engine().to_cloud();
-        Status status = engine.txn_delete_bitmap_cache().get_tablet_txn_info(
-                txn_id, tablet->tablet_id(), &rowset, &tmp_delete_bitmap, &rowset_ids,
-                &txn_expiration, &partial_update_info);
-        if (status.ok()) {
-            DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet->tablet_id());
-            for (auto iter = tmp_delete_bitmap->delete_bitmap.begin();
-                 iter != tmp_delete_bitmap->delete_bitmap.end(); ++iter) {
-                DeleteBitmap::BitmapKey key = {std::get<0>(iter->first), std::get<1>(iter->first),
-                                               old_max_version + 1};
-                auto it = tmp_delete_bitmap->status_map.find(key);
-                if (it != tmp_delete_bitmap->status_map.end() &&
-                    it->second == DeleteBitmap::PublishStatus::FINALIZED) {
-                    new_delete_bitmap->merge(key, iter->second);
-                }
-            }
-            *delete_bitmap = *new_delete_bitmap;
-            engine.txn_delete_bitmap_cache().remove_unused_tablet_txn_info(txn_id,
-                                                                           tablet->tablet_id());
-            return Status::OK();
-        } else {
-            LOG(WARNING) << "failed to get tablet txn info. tablet_id=" << tablet->tablet_id()
-                         << ", txn_id=" << txn_id << ", status=" << status;
-        }
+//    {
+//        auto txn_id = rs_metas.rbegin()->txn_id();
+//        RowsetSharedPtr rowset;
+//        DeleteBitmapPtr tmp_delete_bitmap;
+//        RowsetIdUnorderedSet rowset_ids;
+//        std::shared_ptr<PartialUpdateInfo> partial_update_info;
+//        int64_t txn_expiration;
+//        CloudStorageEngine& engine = ExecEnv::GetInstance()->storage_engine().to_cloud();
+//        Status status = engine.txn_delete_bitmap_cache().get_tablet_txn_info(
+//                txn_id, tablet->tablet_id(), &rowset, &tmp_delete_bitmap, &rowset_ids,
+//                &txn_expiration, &partial_update_info);
+//        if (status.ok()) {
+//            DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet->tablet_id());
+//            for (auto iter = tmp_delete_bitmap->delete_bitmap.begin();
+//                 iter != tmp_delete_bitmap->delete_bitmap.end(); ++iter) {
+//                DeleteBitmap::BitmapKey key = {std::get<0>(iter->first), std::get<1>(iter->first),
+//                                               old_max_version + 1};
+//                auto it = tmp_delete_bitmap->status_map.find(key);
+//                if (it != tmp_delete_bitmap->status_map.end() &&
+//                    it->second == DeleteBitmap::PublishStatus::FINALIZED) {
+//                    new_delete_bitmap->merge(key, iter->second);
+//                }
+//            }
+//            *delete_bitmap = *new_delete_bitmap;
+//            engine.txn_delete_bitmap_cache().remove_unused_tablet_txn_info(txn_id,
+//                                                                           tablet->tablet_id());
+//            return Status::OK();
+//        } else {
+//            LOG(WARNING) << "failed to get tablet txn info. tablet_id=" << tablet->tablet_id()
+//                         << ", txn_id=" << txn_id << ", status=" << status;
+//        }
+//    }
+
+    if (sync_tablet_delete_bitmap_by_cache(tablet, old_max_version, rs_metas, delete_bitmap)) {
+        return Status::OK();
+    } else {
+        LOG(WARNING) << "failed to sync delete bitmap by txn info. tablet_id="
+                     << tablet->tablet_id();
+        DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet->tablet_id());
+        *delete_bitmap = *new_delete_bitmap;
     }
 
     std::shared_ptr<MetaService_Stub> stub;

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -573,8 +573,6 @@ Status CloudMetaMgr::sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_
                  iter != tmp_delete_bitmap->delete_bitmap.end(); ++iter) {
                 DeleteBitmap::BitmapKey key = {std::get<0>(iter->first), std::get<1>(iter->first),
                                                old_max_version + 1};
-                LOG(INFO) << "key " << std::get<0>(iter->first) << "," << std::get<1>(iter->first)
-                          << "," << old_max_version + 1;
                 auto it = tmp_delete_bitmap->status_map.find(key);
                 if (it != tmp_delete_bitmap->status_map.end() &&
                     it->second == DeleteBitmap::PublishStatus::FINALIZED) {

--- a/be/src/cloud/cloud_meta_mgr.h
+++ b/be/src/cloud/cloud_meta_mgr.h
@@ -91,6 +91,10 @@ public:
     Status get_delete_bitmap_update_lock(const CloudTablet& tablet, int64_t lock_id,
                                          int64_t initiator);
 
+    bool sync_tablet_delete_bitmap_by_cache(Tablet* tablet, int64_t old_max_version,
+                                            std::ranges::range auto&& rs_metas,
+                                            DeleteBitmap* delete_bitmap);
+
 private:
     Status sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_max_version,
                                      std::ranges::range auto&& rs_metas, const TabletStatsPB& stats,

--- a/be/src/cloud/cloud_meta_mgr.h
+++ b/be/src/cloud/cloud_meta_mgr.h
@@ -91,11 +91,11 @@ public:
     Status get_delete_bitmap_update_lock(const CloudTablet& tablet, int64_t lock_id,
                                          int64_t initiator);
 
-    bool sync_tablet_delete_bitmap_by_cache(Tablet* tablet, int64_t old_max_version,
+private:
+    bool sync_tablet_delete_bitmap_by_cache(CloudTablet* tablet, int64_t old_max_version,
                                             std::ranges::range auto&& rs_metas,
                                             DeleteBitmap* delete_bitmap);
 
-private:
     Status sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_max_version,
                                      std::ranges::range auto&& rs_metas, const TabletStatsPB& stats,
                                      const TabletIndexPB& idx, DeleteBitmap* delete_bitmap);

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -604,8 +604,8 @@ Status CloudTablet::save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t tx
     RowsetSharedPtr rowset = txn_info->rowset;
     int64_t cur_version = rowset->start_version();
     // update delete bitmap info, in order to avoid recalculation when trying again
-    _engine.txn_delete_bitmap_cache().update_tablet_txn_info(txn_id, tablet_id(), delete_bitmap,
-                                                             cur_rowset_ids);
+    _engine.txn_delete_bitmap_cache().update_tablet_txn_info(
+            txn_id, tablet_id(), delete_bitmap, cur_rowset_ids, PublishStatus::PREPARE);
 
     if (txn_info->partial_update_info && txn_info->partial_update_info->is_partial_update &&
         rowset_writer->num_rows() > 0) {
@@ -613,29 +613,21 @@ Status CloudTablet::save_delete_bitmap(const TabletTxnInfo* txn_info, int64_t tx
         RETURN_IF_ERROR(_engine.meta_mgr().update_tmp_rowset(*rowset_meta));
     }
 
-    RowsetSharedPtr tmp_rowset;
-    DeleteBitmapPtr tmp_delete_bitmap;
-    RowsetIdUnorderedSet tmp_rowset_ids;
-    std::shared_ptr<PartialUpdateInfo> tmp_partial_update_info;
-    int64_t tmp_txn_expiration;
-    RETURN_IF_ERROR(_engine.txn_delete_bitmap_cache().get_tablet_txn_info(
-            txn_id, tablet_id(), &tmp_rowset, &tmp_delete_bitmap, &tmp_rowset_ids,
-            &tmp_txn_expiration, &tmp_partial_update_info));
     DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet_id());
     for (auto iter = delete_bitmap->delete_bitmap.begin();
          iter != delete_bitmap->delete_bitmap.end(); ++iter) {
         // skip sentinel mark, which is used for delete bitmap correctness check
         if (std::get<1>(iter->first) != DeleteBitmap::INVALID_SEGMENT_ID) {
-            DeleteBitmap::BitmapKey key = {std::get<0>(iter->first), std::get<1>(iter->first),
-                                           cur_version};
-            tmp_delete_bitmap->status_map.insert(
-                    std::make_pair(key, DeleteBitmap::PublishStatus::FINALIZED));
-            new_delete_bitmap->merge(key, iter->second);
+            new_delete_bitmap->merge(
+                    {std::get<0>(iter->first), std::get<1>(iter->first), cur_version},
+                    iter->second);
         }
     }
 
     RETURN_IF_ERROR(_engine.meta_mgr().update_delete_bitmap(
             *this, txn_id, COMPACTION_DELETE_BITMAP_LOCK_ID, new_delete_bitmap.get()));
+    _engine.txn_delete_bitmap_cache().update_tablet_txn_info(
+            txn_id, tablet_id(), new_delete_bitmap, cur_rowset_ids, PublishStatus::SUCCEED);
 
     return Status::OK();
 }

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -53,7 +53,8 @@ Status CloudTxnDeleteBitmapCache::init() {
 Status CloudTxnDeleteBitmapCache::get_tablet_txn_info(
         TTransactionId transaction_id, int64_t tablet_id, RowsetSharedPtr* rowset,
         DeleteBitmapPtr* delete_bitmap, RowsetIdUnorderedSet* rowset_ids, int64_t* txn_expiration,
-        std::shared_ptr<PartialUpdateInfo>* partial_update_info) {
+        std::shared_ptr<PartialUpdateInfo>* partial_update_info,
+        std::shared_ptr<PublishStatus>* publish_status) {
     {
         std::shared_lock<std::shared_mutex> rlock(_rwlock);
         TxnKey key(transaction_id, tablet_id);
@@ -66,6 +67,27 @@ Status CloudTxnDeleteBitmapCache::get_tablet_txn_info(
         *rowset = iter->second.rowset;
         *txn_expiration = iter->second.txn_expiration;
         *partial_update_info = iter->second.partial_update_info;
+        *publish_status = iter->second.publish_status;
+    }
+    RETURN_IF_ERROR(
+            get_delete_bitmap(transaction_id, tablet_id, delete_bitmap, rowset_ids, nullptr));
+    return Status::OK();
+}
+
+Status CloudTxnDeleteBitmapCache::get_delete_bitmap(TTransactionId transaction_id, int64_t tablet_id,
+                                                 DeleteBitmapPtr* delete_bitmap,
+                                                 RowsetIdUnorderedSet* rowset_ids,
+                                                 std::shared_ptr<PublishStatus>* publish_status) {
+    if (publish_status) {
+        std::shared_lock<std::shared_mutex> rlock(_rwlock);
+        TxnKey txn_key(transaction_id, tablet_id);
+        auto iter = _txn_map.find(txn_key);
+        if (iter == _txn_map.end()) {
+            return Status::Error<ErrorCode::NOT_FOUND, false>(
+                    "not found txn info, tablet_id={}, transaction_id={}", tablet_id,
+                    transaction_id);
+        }
+        *publish_status = iter->second.publish_status;
     }
     std::string key_str = fmt::format("{}/{}", transaction_id, tablet_id);
     CacheKey key(key_str);
@@ -103,7 +125,10 @@ void CloudTxnDeleteBitmapCache::set_tablet_txn_info(
     {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
         TxnKey txn_key(transaction_id, tablet_id);
-        _txn_map[txn_key] = TxnVal(rowset, txn_expiration, std::move(partial_update_info));
+        std::shared_ptr<PublishStatus> publish_status =
+                std::make_shared<PublishStatus>(PublishStatus::INIT);
+        _txn_map[txn_key] = TxnVal(rowset, txn_expiration, std::move(partial_update_info),
+                                   std::move(publish_status));
         _expiration_txn.emplace(txn_expiration, txn_key);
     }
     std::string key_str = fmt::format("{}/{}", transaction_id, tablet_id);
@@ -128,7 +153,14 @@ void CloudTxnDeleteBitmapCache::set_tablet_txn_info(
 void CloudTxnDeleteBitmapCache::update_tablet_txn_info(TTransactionId transaction_id,
                                                        int64_t tablet_id,
                                                        DeleteBitmapPtr delete_bitmap,
-                                                       const RowsetIdUnorderedSet& rowset_ids) {
+                                                       const RowsetIdUnorderedSet& rowset_ids,
+                                                       PublishStatus publish_status) {
+    {
+        std::unique_lock<std::shared_mutex> wlock(_rwlock);
+        TxnKey txn_key(transaction_id, tablet_id);
+        CHECK(_txn_map.count(txn_key) > 0);
+        *(_txn_map[txn_key].publish_status.get()) = publish_status;
+    }
     std::string key_str = fmt::format("{}/{}", transaction_id, tablet_id);
     CacheKey key(key_str);
 

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -74,10 +74,9 @@ Status CloudTxnDeleteBitmapCache::get_tablet_txn_info(
     return Status::OK();
 }
 
-Status CloudTxnDeleteBitmapCache::get_delete_bitmap(TTransactionId transaction_id, int64_t tablet_id,
-                                                 DeleteBitmapPtr* delete_bitmap,
-                                                 RowsetIdUnorderedSet* rowset_ids,
-                                                 std::shared_ptr<PublishStatus>* publish_status) {
+Status CloudTxnDeleteBitmapCache::get_delete_bitmap(
+        TTransactionId transaction_id, int64_t tablet_id, DeleteBitmapPtr* delete_bitmap,
+        RowsetIdUnorderedSet* rowset_ids, std::shared_ptr<PublishStatus>* publish_status) {
     if (publish_status) {
         std::shared_lock<std::shared_mutex> rlock(_rwlock);
         TxnKey txn_key(transaction_id, tablet_id);

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.h
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.h
@@ -24,6 +24,7 @@
 #include "olap/partial_update_info.h"
 #include "olap/rowset/rowset.h"
 #include "olap/tablet_meta.h"
+#include "olap/txn_manager.h"
 #include "util/countdown_latch.h"
 
 namespace doris {
@@ -40,7 +41,8 @@ public:
     Status get_tablet_txn_info(TTransactionId transaction_id, int64_t tablet_id,
                                RowsetSharedPtr* rowset, DeleteBitmapPtr* delete_bitmap,
                                RowsetIdUnorderedSet* rowset_ids, int64_t* txn_expiration,
-                               std::shared_ptr<PartialUpdateInfo>* partial_update_info);
+                               std::shared_ptr<PartialUpdateInfo>* partial_update_info,
+                               std::shared_ptr<PublishStatus>* publish_status);
 
     void set_tablet_txn_info(TTransactionId transaction_id, int64_t tablet_id,
                              DeleteBitmapPtr delete_bitmap, const RowsetIdUnorderedSet& rowset_ids,
@@ -49,11 +51,16 @@ public:
 
     void update_tablet_txn_info(TTransactionId transaction_id, int64_t tablet_id,
                                 DeleteBitmapPtr delete_bitmap,
-                                const RowsetIdUnorderedSet& rowset_ids);
+                                const RowsetIdUnorderedSet& rowset_ids,
+                                PublishStatus publish_status);
 
     void remove_expired_tablet_txn_info();
 
     void remove_unused_tablet_txn_info(TTransactionId transaction_id, int64_t tablet_id);
+
+    Status get_delete_bitmap(TTransactionId transaction_id, int64_t tablet_id,
+                             DeleteBitmapPtr* delete_bitmap, RowsetIdUnorderedSet* rowset_ids,
+                             std::shared_ptr<PublishStatus>* publish_status);
 
 private:
     void _clean_thread_callback();
@@ -82,12 +89,15 @@ private:
         RowsetSharedPtr rowset;
         int64_t txn_expiration;
         std::shared_ptr<PartialUpdateInfo> partial_update_info;
+        std::shared_ptr<PublishStatus> publish_status = nullptr;
         TxnVal() : txn_expiration(0) {};
         TxnVal(RowsetSharedPtr rowset_, int64_t txn_expiration_,
-               std::shared_ptr<PartialUpdateInfo> partial_update_info_)
+               std::shared_ptr<PartialUpdateInfo> partial_update_info_,
+               std::shared_ptr<PublishStatus> publish_status_)
                 : rowset(std::move(rowset_)),
                   txn_expiration(txn_expiration_),
-                  partial_update_info(std::move(partial_update_info_)) {}
+                  partial_update_info(std::move(partial_update_info_)),
+                  publish_status(std::move(publish_status_)) {}
     };
 
     std::map<TxnKey, TxnVal> _txn_map;

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.h
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.h
@@ -53,6 +53,8 @@ public:
 
     void remove_expired_tablet_txn_info();
 
+    void remove_unused_tablet_txn_info(TTransactionId transaction_id, int64_t tablet_id);
+
 private:
     void _clean_thread_callback();
 

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -371,8 +371,10 @@ public:
     mutable std::shared_mutex lock;
     using SegmentId = uint32_t;
     using Version = uint64_t;
+    enum PublishStatus { NONE = 0, FINALIZED = 1 };
     using BitmapKey = std::tuple<RowsetId, SegmentId, Version>;
     std::map<BitmapKey, roaring::Roaring> delete_bitmap; // Ordered map
+    std::map<BitmapKey, PublishStatus> status_map;
     constexpr static inline uint32_t INVALID_SEGMENT_ID = std::numeric_limits<uint32_t>::max() - 1;
     constexpr static inline uint32_t ROWSET_SENTINEL_MARK =
             std::numeric_limits<uint32_t>::max() - 1;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -371,10 +371,8 @@ public:
     mutable std::shared_mutex lock;
     using SegmentId = uint32_t;
     using Version = uint64_t;
-    enum PublishStatus { NONE = 0, FINALIZED = 1 };
     using BitmapKey = std::tuple<RowsetId, SegmentId, Version>;
     std::map<BitmapKey, roaring::Roaring> delete_bitmap; // Ordered map
-    std::map<BitmapKey, PublishStatus> status_map;
     constexpr static inline uint32_t INVALID_SEGMENT_ID = std::numeric_limits<uint32_t>::max() - 1;
     constexpr static inline uint32_t ROWSET_SENTINEL_MARK =
             std::numeric_limits<uint32_t>::max() - 1;

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -61,6 +61,7 @@ enum class TxnState {
     ABORTED = 4,
     DELETED = 5,
 };
+enum class PublishStatus { INIT = 0, PREPARE = 1, SUCCEED = 2 };
 
 struct TabletTxnInfo {
     PUniqueId load_id;
@@ -73,6 +74,7 @@ struct TabletTxnInfo {
     int64_t creation_time;
     bool ingest {false};
     std::shared_ptr<PartialUpdateInfo> partial_update_info;
+    std::shared_ptr<PublishStatus> publish_status;
     TxnState state {TxnState::PREPARED};
 
     TabletTxnInfo() = default;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

My test show that get_delete_bitmap from metaservice may cost too much time while doing sync_rowset in cloud mode, which may lead to calculating delete bitmap slow on publish phase, we can use the existing delete bitmap cache to slove this problem.