### PR TITLE
[fix](build) fix include for macOS compile

### DIFF
--- a/be/src/io/fs/s3_obj_storage_client.cpp
+++ b/be/src/io/fs/s3_obj_storage_client.cpp
@@ -60,7 +60,9 @@
 #include <aws/s3/model/PutObjectResult.h>
 #include <aws/s3/model/UploadPartRequest.h>
 #include <aws/s3/model/UploadPartResult.h>
-#include <bits/ranges_algo.h>
+
+#include <algorithm>
+#include <ranges>
 
 #include "common/logging.h"
 #include "common/status.h"


### PR DESCRIPTION
## Proposed changes

Mac compiler toolchain does not have <bits/ranges_algo.h>, use <algorithm> instead
