### PR TITLE
[Bug](drop) fix drop function has error when it's not exists

### DIFF
--- a/be/src/vec/functions/function_fake.cpp
+++ b/be/src/vec/functions/function_fake.cpp
@@ -51,11 +51,9 @@ struct FunctionFakeBaseImpl {
 
 struct FunctionExplode {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        auto remove_nullable_arg = remove_nullable(arguments[0]);
-        DCHECK(is_array(remove_nullable_arg))
-                << remove_nullable_arg->get_name() << " not supported";
-        return make_nullable(check_and_get_data_type<DataTypeArray>(remove_nullable_arg.get())
-                                     ->get_nested_type());
+        DCHECK(is_array(arguments[0])) << arguments[0]->get_name() << " not supported";
+        return make_nullable(
+                check_and_get_data_type<DataTypeArray>(arguments[0].get())->get_nested_type());
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
@@ -63,13 +61,10 @@ struct FunctionExplode {
 // explode map: make map k,v as struct field
 struct FunctionExplodeMap {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        auto remove_nullable_arg = remove_nullable(arguments[0]);
-        DCHECK(is_map(remove_nullable_arg)) << remove_nullable_arg->get_name() << " not supported";
+        DCHECK(is_map(arguments[0])) << arguments[0]->get_name() << " not supported";
         DataTypes fieldTypes(2);
-        fieldTypes[0] =
-                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_key_type();
-        fieldTypes[1] =
-                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_value_type();
+        fieldTypes[0] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_key_type();
+        fieldTypes[1] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_value_type();
         return make_nullable(std::make_shared<vectorized::DataTypeStruct>(fieldTypes));
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }

--- a/be/src/vec/functions/function_fake.cpp
+++ b/be/src/vec/functions/function_fake.cpp
@@ -51,9 +51,11 @@ struct FunctionFakeBaseImpl {
 
 struct FunctionExplode {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        DCHECK(is_array(arguments[0])) << arguments[0]->get_name() << " not supported";
-        return make_nullable(
-                check_and_get_data_type<DataTypeArray>(arguments[0].get())->get_nested_type());
+        auto remove_nullable_arg = remove_nullable(arguments[0]);
+        DCHECK(is_array(remove_nullable_arg))
+                << remove_nullable_arg->get_name() << " not supported";
+        return make_nullable(check_and_get_data_type<DataTypeArray>(remove_nullable_arg.get())
+                                     ->get_nested_type());
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
@@ -61,10 +63,13 @@ struct FunctionExplode {
 // explode map: make map k,v as struct field
 struct FunctionExplodeMap {
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
-        DCHECK(is_map(arguments[0])) << arguments[0]->get_name() << " not supported";
+        auto remove_nullable_arg = remove_nullable(arguments[0]);
+        DCHECK(is_map(remove_nullable_arg)) << remove_nullable_arg->get_name() << " not supported";
         DataTypes fieldTypes(2);
-        fieldTypes[0] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_key_type();
-        fieldTypes[1] = check_and_get_data_type<DataTypeMap>(arguments[0].get())->get_value_type();
+        fieldTypes[0] =
+                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_key_type();
+        fieldTypes[1] =
+                check_and_get_data_type<DataTypeMap>(remove_nullable_arg.get())->get_value_type();
         return make_nullable(std::make_shared<vectorized::DataTypeStruct>(fieldTypes));
     }
     static std::string get_error_msg() { return "Fake function do not support execute"; }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -748,14 +748,16 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
 
     public synchronized void dropFunction(FunctionSearchDesc function, boolean ifExists) throws UserException {
         Function udfFunction = null;
-        if (ifExists) {
-            try {
-                // here we must first getFunction, as dropFunctionImpl will remove it
-                udfFunction = getFunction(function);
-            } catch (AnalysisException e) {
-                // ignore it, as drop it if exist, so can't sure it must exist
+        try {
+            // here we must first getFunction, as dropFunctionImpl will remove it
+            udfFunction = getFunction(function);
+        } catch (AnalysisException e) {
+            if (!ifExists) {
+                throw new UserException(e);
             }
+            // ignore it, as drop it if exist, so can't sure it must exist
         }
+
         dropFunctionImpl(function, ifExists);
         if (udfFunction != null && udfFunction.isUDTFunction()) {
             // all of the table function in doris will have two function

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -754,8 +754,10 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         } catch (AnalysisException e) {
             if (!ifExists) {
                 throw new UserException(e);
+            } else {
+                // ignore it, as drop it if exist, so can't sure it must exist
+                return;
             }
-            // ignore it, as drop it if exist, so can't sure it must exist
         }
 
         dropFunctionImpl(function, ifExists);


### PR DESCRIPTION
## Proposed changes

```
drop function xxx
drop function if exists xxx
```
as when drop UDTF function, we need drop two function, one is normal, another is the _outer function.
getFunction() should call firstly and always.  as dropFunctionImpl() will remove it from env, then we can't find it anymore.
so can't check if (ifExists) firstly, when it's false, we have no change call getFunction()
ifExists should only used to check whether throw execption.


Issue Number: close #xxx

<!--Describe your changes.-->

