### PR TITLE
[build](docker) add repo for new version of git

### DIFF
--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -18,7 +18,7 @@
 FROM centos:7 AS builder
 
 # install epel repo for ccache
-RUN yum install epel-release -y && yum clean all && yum makecache
+RUN yum install epel-release -y && yum install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm -y && yum clean all && yum makecache
 
 # install dependencies
 RUN yum install -y byacc patch automake libtool perf vim make which file ncurses-devel gettext-devel unzip bzip2 zip util-linux \


### PR DESCRIPTION
This PR #35208 introduce azure core C++ sdk, it needs a higher version of git to compile.
This PR add new repo for centos7 to be able to `yum install git` with newer version.