### PR TITLE
[fix](nereids)disable unique key compute for mv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.constraint.PrimaryKeyConstraint;
 import org.apache.doris.catalog.constraint.UniqueConstraint;
@@ -128,23 +127,6 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
     @Override
     public void computeUnique(DataTrait.Builder builder) {
         Set<Slot> outputSet = Utils.fastToImmutableSet(getOutputSet());
-        if (table instanceof OlapTable) {
-            OlapTable olapTable = (OlapTable) table;
-            if (olapTable.getKeysType().isAggregationFamily() && !olapTable.isRandomDistribution()) {
-                ImmutableSet.Builder<Slot> uniqSlots = ImmutableSet.builderWithExpectedSize(outputSet.size());
-                for (Slot slot : outputSet) {
-                    if (!(slot instanceof SlotReference)) {
-                        continue;
-                    }
-                    SlotReference slotRef = (SlotReference) slot;
-                    if (slotRef.getColumn().isPresent() && slotRef.getColumn().get().isKey()) {
-                        uniqSlots.add(slot);
-                    }
-                }
-                builder.addUniqueSlot(uniqSlots.build());
-            }
-        }
-
         for (PrimaryKeyConstraint c : table.getPrimaryKeyConstraints()) {
             Set<Column> columns = c.getPrimaryKeys(table);
             builder.addUniqueSlot((ImmutableSet) findSlotsByColumn(outputSet, columns));


### PR DESCRIPTION
## Proposed changes

computing unique doesn't work for mv, because mv's key may be different from base table and the key can be any expression which is difficult to deduce if it's unique. for example
base table:
```
CREATE TABLE IF NOT EXISTS base(
    siteid INT(11) NOT NULL,
    citycode SMALLINT(6) NOT NULL,
    username VARCHAR(32) NOT NULL,
    pv BIGINT(20) SUM NOT NULL DEFAULT '0'
)
AGGREGATE KEY (siteid,citycode,username)
DISTRIBUTED BY HASH(siteid) BUCKETS 5 properties("replication_num" = "1");
```
case1:
create mv1:
`create materialized view mv1 as select siteid, sum(pv) from base group by siteid;`
the base table siteid + citycode + username is unique but the mv1's agg key siteid is not unique

case2:
create mv2:
`create materialized view mv2 as select citycode * citycode, siteid, username from base;`
the mv2's agg key citycode * citycode is not unique

for simplicity, we disable unique compute for mv

<!--Describe your changes.-->

