### PR TITLE
[feature](cloud) support get load state by HTTP API in cloud mode

### DIFF
--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -1480,7 +1480,8 @@ void MetaServiceImpl::get_txn(::google::protobuf::RpcController* controller,
     RPC_PREPROCESS(get_txn);
     int64_t txn_id = request->has_txn_id() ? request->txn_id() : -1;
     int64_t db_id = request->has_db_id() ? request->db_id() : -1;
-    if (txn_id < 0) {
+    std::string label = request->has_label() ? request->label() : "";
+    if (txn_id < 0 && label.empty()) {
         code = MetaServiceCode::INVALID_ARGUMENT;
         ss << "invalid txn_id, it may be not given or set properly, txn_id=" << txn_id;
         msg = ss.str();
@@ -1505,6 +1506,42 @@ void MetaServiceImpl::get_txn(::google::protobuf::RpcController* controller,
         ss << "failed to create txn, txn_id=" << txn_id << " err=" << err;
         msg = ss.str();
         return;
+    }
+
+    if (!label.empty()) {
+        //step 1: get label
+        const std::string label_key = txn_label_key({instance_id, db_id, label});
+        std::string label_val;
+        err = txn->get(label_key, &label_val);
+        if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            code = cast_as<ErrCategory::READ>(err);
+            ss << "txn->get failed(), err=" << err << " label=" << label;
+            msg = ss.str();
+            return;
+        }
+        LOG(INFO) << "txn->get label_key=" << hex(label_key) << " label=" << label
+                  << " err=" << err;
+        // step 2: get txn info from label pb
+        TxnLabelPB label_pb;
+        if (err == TxnErrorCode::TXN_OK) {
+            if (label_val.size() <= VERSION_STAMP_LEN ||
+                !label_pb.ParseFromArray(label_val.data(), label_val.size() - VERSION_STAMP_LEN)) {
+                code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+                ss << "label_pb->ParseFromString() failed, txn_id=" << txn_id << " label=" << label;
+                msg = ss.str();
+                return;
+            }
+            for (auto& cur_txn_id : label_pb.txn_ids()) {
+                if (cur_txn_id > txn_id) {
+                    txn_id = cur_txn_id;
+                }
+            }
+        } else {
+            code = MetaServiceCode::TXN_ID_NOT_FOUND;
+            ss << "Label [" << label << "] has not found";
+            msg = ss.str();
+            return;
+        }
     }
 
     //not provide db_id, we need read from disk.

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1123,7 +1123,38 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
 
     @Override
     public TransactionStatus getLabelState(long dbId, String label) throws AnalysisException {
-        throw new AnalysisException(NOT_SUPPORTED_MSG);
+        GetTxnRequest.Builder builder = GetTxnRequest.newBuilder();
+        builder.setDbId(dbId).setCloudUniqueId(Config.cloud_unique_id).setLabel(label);
+        final GetTxnRequest getTxnRequest = builder.build();
+        GetTxnResponse getTxnResponse = null;
+        int retryTime = 0;
+
+        try {
+            while (retryTime < 3) {
+                getTxnResponse = MetaServiceProxy.getInstance().getTxn(getTxnRequest);
+                if (getTxnResponse.getStatus().getCode() != MetaServiceCode.KV_TXN_CONFLICT) {
+                    break;
+                }
+                LOG.info("getLabelState KV_TXN_CONFLICT, dbId:{}, label:{}, retryTime:{}", dbId, label, retryTime);
+                backoff();
+                retryTime++;
+                continue;
+            }
+
+            Preconditions.checkNotNull(getTxnResponse);
+            Preconditions.checkNotNull(getTxnResponse.getStatus());
+        } catch (Exception e) {
+            LOG.warn("getLabelState failed, dbId:{}, exception:", dbId, e);
+            throw new AnalysisException("getLabelState failed, errMsg:" + e.getMessage());
+        }
+
+        if (getTxnResponse.getStatus().getCode() != MetaServiceCode.OK) {
+            LOG.warn("getLabelState failed, dbId:{} label:{} retryTime:{} getTxnResponse:{}",
+                    dbId, label, retryTime, getTxnResponse);
+            throw new AnalysisException("getLabelState failed, errMsg:" + getTxnResponse.getStatus().getMsg());
+        }
+
+        return TxnUtil.transactionStateFromPb(getTxnResponse.getTxnInfo()).getTransactionStatus();
     }
 
     @Override

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -683,6 +683,7 @@ message GetTxnRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 db_id = 2;
     optional int64 txn_id = 3;
+    optional string label = 4;
 }
 
 message GetTxnResponse {

--- a/regression-test/suites/load_p0/stream_load/test_get_stream_load_state.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_get_stream_load_state.groovy
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_get_stream_load_state", "p0") {
+    def tableName = "test_get_stream_load_state"
+    String db = context.config.getDbNameByFile(context.file)
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `k1` bigint(20) NULL DEFAULT "1",
+            `k2` bigint(20) NULL ,
+            `v1` tinyint(4) NULL,
+            `v2` tinyint(4) NULL,
+            `v3` tinyint(4) NULL,
+            `v4` DATETIME NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=OLAP
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    def label = UUID.randomUUID().toString().replaceAll("-", "")
+    streamLoad {
+        table "${tableName}"
+
+        set 'column_separator', '|'
+        set 'columns', 'k2, v1, v2, v3'
+        set 'strict_mode', 'true'
+        set 'label', "${label}"
+
+        file 'test_default_value.csv'
+        time 10000 // limit inflight 10s
+
+        check { result, exception, startTime, endTime ->
+            if (exception != null) {
+                throw exception
+            }
+            log.info("Stream load result: ${result}".toString())
+            def json = parseJson(result)
+            assertEquals("success", json.Status.toLowerCase())
+            assertEquals(2, json.NumberTotalRows)
+            assertEquals(0, json.NumberFilteredRows)
+            assertEquals(0, json.NumberUnselectedRows)
+        }
+    }
+
+    def command = "curl --location-trusted -u ${context.config.feHttpUser}:${context.config.feHttpPassword} http://${context.config.feHttpAddress}/api/${db}/get_load_state?label=${label}"
+    log.info("test_get_stream_load_state: ${command}")
+    def process = command.execute()
+    code = process.waitFor()
+    out = process.text
+    json = parseJson(out)
+    log.info("test_get_stream_load_state: ${out}".toString())
+    assertEquals("success", json.msg.toLowerCase())
+    assertEquals("VISIBLE", json.data)
+
+    def label1 = UUID.randomUUID().toString().replaceAll("-", "")
+    command = "curl --location-trusted -u ${context.config.feHttpUser}:${context.config.feHttpPassword} http://${context.config.feHttpAddress}/api/${db}/get_load_state?label=${label1}"
+    log.info("test_get_stream_load_state: ${command}")
+    process = command.execute()
+    code = process.waitFor()
+    out = process.text
+    json = parseJson(out)
+    log.info("test_get_stream_load_state: ${out}".toString())
+}


### PR DESCRIPTION
## Proposed changes

use label 125 load data
```
{
    "TxnId": 163088604293120,
    "Label": "125",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Success",
    "Message": "OK",
    "NumberTotalRows": 1,
    "NumberLoadedRows": 1,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 4,
    "LoadTimeMs": 441,
    "BeginTxnTimeMs": 60,
    "StreamLoadPutTimeMs": 246,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 126,
    "CommitAndPublishTimeMs": 6
}
```

curl --location-trusted -u root:"" http://127.0.0.1:8239/api/db/get_load_state?label=125
```
{
    "msg": "success",
    "code": 0,
    "data": "VISIBLE",
    "count": 0
}
```

curl --location-trusted -u root:"" http://127.0.0.1:8239/api/db/get_load_state?label=126
```
{
    "msg": "success",
    "code": 0,
    "data": "UNKNOWN",
    "count": 0
}
```
