### PR TITLE
[fix](cloud) ignore black list in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
@@ -171,13 +171,9 @@ public class SimpleScheduler {
     }
 
     public static void addToBlacklist(Long backendID, String reason) {
-        if (Config.isCloudMode()) {
-            return;
-        }
-
-        if (backendID == null || Config.disable_backend_black_list) {
-            LOG.warn("ignore backend black list for backend: {}, disabled: {}", backendID,
-                    Config.disable_backend_black_list);
+        if (backendID == null || Config.disable_backend_black_list || Config.isCloudMode()) {
+            LOG.warn("ignore backend black list for backend: {}, disabled: {}, is cloud: {}",
+                    backendID, Config.disable_backend_black_list, Config.isCloudMode());
             return;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
@@ -171,6 +171,10 @@ public class SimpleScheduler {
     }
 
     public static void addToBlacklist(Long backendID, String reason) {
+        if (Config.isCloudMode()) {
+            return;
+        }
+
         if (backendID == null || Config.disable_backend_black_list) {
             LOG.warn("ignore backend black list for backend: {}, disabled: {}", backendID,
                     Config.disable_backend_black_list);


### PR DESCRIPTION
Cloud will auto change replica's backend when it found backend is dead. No need to use black list in cloud mode.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

