### PR TITLE
[improvement](mtmv) support nullable sum roll up

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewAggregateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewAggregateRule.java
@@ -128,8 +128,7 @@ public abstract class AbstractMaterializedViewAggregateRule extends AbstractMate
         // Should not rewrite
         List<Expression> queryGroupByExpressions = queryTopPlanAndAggPair.value().getGroupByExpressions();
         List<Expression> viewGroupByExpressions = viewTopPlanAndAggPair.value().getGroupByExpressions();
-        if ((queryGroupByExpressions.isEmpty() && !viewGroupByExpressions.isEmpty())
-                || (!queryGroupByExpressions.isEmpty() && viewGroupByExpressions.isEmpty())) {
+        if (!queryGroupByExpressions.isEmpty() && viewGroupByExpressions.isEmpty()) {
             materializationContext.recordFailReason(queryStructInfo,
                     "only one the of query or view is scalar aggregate and "
                             + "can not rewrite expression meanwhile",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/rollup/DirectRollupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/rollup/DirectRollupHandler.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.agg.NullableAggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.RollUpTrait;
 import org.apache.doris.nereids.trees.expressions.functions.combinator.Combinator;
 
@@ -44,8 +45,11 @@ public class DirectRollupHandler extends AggFunctionRollUpHandler {
                 mvExprToMvScanExprQueryBasedPair)) {
             return false;
         }
-        return queryAggregateFunctionShuttled.equals(viewExpression)
-                && MappingRollupHandler.AGGREGATE_ROLL_UP_EQUIVALENT_FUNCTION_MAP.keySet().stream()
+        boolean isEquals = queryAggregateFunctionShuttled instanceof NullableAggregateFunction
+                && viewExpression instanceof NullableAggregateFunction
+                ? ((NullableAggregateFunction) queryAggregateFunctionShuttled).equalsIgnoreNullable(viewExpression)
+                : queryAggregateFunctionShuttled.equals(viewExpression);
+        return isEquals && MappingRollupHandler.AGGREGATE_ROLL_UP_EQUIVALENT_FUNCTION_MAP.keySet().stream()
                 .noneMatch(aggFunction -> aggFunction.equals(queryAggregateFunction))
                 && !(queryAggregateFunction instanceof Combinator);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/NullableAggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/NullableAggregateFunction.java
@@ -74,6 +74,16 @@ public abstract class NullableAggregateFunction extends AggregateFunction implem
 
     public abstract NullableAggregateFunction withAlwaysNullable(boolean alwaysNullable);
 
+    public boolean equalsIgnoreNullable(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
## Proposed changes

this is draft, Support mv rewrite as following

`create materialized view lineorder_q_1_3 DISTRIBUTED BY RANDOM BUCKETS 2
PROPERTIES ('replication_num' = '1') 
as 
SELECT
l_orderkey,
SUM(l_extendedprice * l_discount) AS revenue
FROM lineitem
GROUP BY
l_orderkey;`

```
explain
SELECT
SUM(l_extendedprice * l_discount) AS revenue
FROM lineitem;

```
