### PR TITLE
[Fix](inverted index) fix index_id wrong size in V2

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.cpp
@@ -28,18 +28,18 @@ const std::string InvertedIndexDescriptor::index_suffix = ".idx";
 const std::string InvertedIndexDescriptor::index_name_separator = "_";
 
 std::string InvertedIndexDescriptor::get_temporary_index_path(
-        const std::string& segment_path, uint64_t uuid, const std::string& index_suffix_path) {
+        const std::string& segment_path, int64_t index_id, const std::string& index_suffix_path) {
     std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
     return StripSuffixString(segment_path, segment_suffix) + index_name_separator +
-           std::to_string(uuid) + suffix;
+           std::to_string(index_id) + suffix;
 }
 
 std::string InvertedIndexDescriptor::get_index_file_name(const std::string& segment_path,
-                                                         uint64_t uuid,
+                                                         int64_t index_id,
                                                          const std::string& index_suffix_path) {
     std::string suffix = index_suffix_path.empty() ? "" : "@" + index_suffix_path;
     return StripSuffixString(segment_path, segment_suffix) + index_name_separator +
-           std::to_string(uuid) + suffix + index_suffix;
+           std::to_string(index_id) + suffix + index_suffix;
 }
 
 std::string InvertedIndexDescriptor::inverted_index_file_path(

--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.h
@@ -31,9 +31,9 @@ public:
     static const std::string segment_suffix;
     static const std::string index_suffix;
     static const std::string index_name_separator;
-    static std::string get_temporary_index_path(const std::string& segment_path, uint64_t uuid,
+    static std::string get_temporary_index_path(const std::string& segment_path, int64_t index_id,
                                                 const std::string& index_suffix_path);
-    static std::string get_index_file_name(const std::string& path, uint64_t uuid,
+    static std::string get_index_file_name(const std::string& path, int64_t index_id,
                                            const std::string& index_suffix_path);
     static std::string get_index_file_name(const std::string& path);
     static const std::string get_temporary_null_bitmap_file_name() { return "null_bitmap"; }

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
@@ -72,7 +72,7 @@ Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
             ReaderFileEntry* entry = nullptr;
 
             for (int32_t i = 0; i < numIndices; ++i) {
-                int64_t indexId = _stream->readInt();       // Read index ID
+                int64_t index_id = _stream->readLong();     // Read index ID
                 int32_t suffix_length = _stream->readInt(); // Read suffix length
                 std::vector<uint8_t> suffix_data(suffix_length);
                 _stream->readBytes(suffix_data.data(), suffix_length);
@@ -99,7 +99,7 @@ Status InvertedIndexFileReader::_init_from_v2(int32_t read_buffer_size) {
                     fileEntries->put(aid, entry);
                 }
 
-                _indices_entries.emplace(std::make_pair(indexId, std::move(suffix_str)),
+                _indices_entries.emplace(std::make_pair(index_id, std::move(suffix_str)),
                                          std::move(fileEntries));
             }
         } else {

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
@@ -100,7 +100,7 @@ size_t InvertedIndexFileWriter::headerLength() {
             sizeof(int) * 2; // Account for the size of the version number and number of indices
     for (const auto& entry : _indices_dirs) {
         auto suffix = entry.first.second;
-        header_size += sizeof(int);     // index id
+        header_size += sizeof(int64_t); // index id
         header_size += 4;               // index suffix name size
         header_size += suffix.length(); // index suffix name
         header_size += sizeof(int);     // index file count
@@ -199,7 +199,7 @@ size_t InvertedIndexFileWriter::write() {
         int32_t file_count = sorted_files.size();
 
         // Write the index ID and the number of files
-        compound_file_output->writeInt(index_id);
+        compound_file_output->writeLong(index_id);
         const auto* index_suffix_str = reinterpret_cast<const uint8_t*>(index_suffix.c_str());
         compound_file_output->writeInt(index_suffix.length());
         compound_file_output->writeBytes(index_suffix_str, index_suffix.length());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
master PR: #35303

This pull request modifies the index_id type in inverted index storage format v2 to int64_t. The index_id is now stored in the inverted index file using 4 bytes.