### PR TITLE
[fix](proc) fix keyword case sensitive issue for stmt show_frontends_disks

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
@@ -52,7 +52,7 @@ public class ShowFrontendsStmt extends ShowStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
         }
 
-        if (detail != null && !detail.equals("disks")) {
+        if (detail != null && !detail.equalsIgnoreCase("disks")) {
             throw new AnalysisException("Show frontends with extra info only support show frontends disks");
         }
     }
@@ -62,7 +62,7 @@ public class ShowFrontendsStmt extends ShowStmt {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
 
         ImmutableList<String> titles = FrontendsProcNode.TITLE_NAMES;
-        if (detail != null && detail.equals("disks")) {
+        if (detail != null && detail.equalsIgnoreCase("disks")) {
             titles = FrontendsProcNode.DISK_TITLE_NAMES;
         }
         for (String title : titles) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
@@ -83,7 +83,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
     public static void getFrontendsInfo(Env env, String detailType, List<List<String>> infos) {
         if (detailType == null) {
             getFrontendsInfo(env, infos);
-        } else if (detailType.equals("disks")) {
+        } else if (detailType.equalsIgnoreCase("disks")) {
             getFrontendsDiskInfo(env, infos);
         }
     }

--- a/regression-test/suites/node_p0/test_frontend.groovy
+++ b/regression-test/suites/node_p0/test_frontend.groovy
@@ -39,4 +39,10 @@ suite("test_frontend") {
         result = sql """SHOW FRONTENDS;"""
         logger.debug("result:${result}")
     }
+
+    def res = sql """SHOW FRONTENDS DISKS"""
+    assertTrue(res.size() != 0)
+
+    def res2 = sql """SHOW FRONTENDS Disks"""
+    assertTrue(res2.size() != 0)
 }


### PR DESCRIPTION
bp #35921

keyword in a statement should be case insensitive.
Issue:
```sql
mysql> SHOW FRONTENDS DISKS;                                                                                               
ERROR 1105 (HY000): errCode = 2, detailMessage = Show frontends with extra info only support show frontends disks          

mysql> SHOW FRONTENDS disks;                                                                                               
+-----------------------------------------+------------+-----------+--------------------------------+------------+----------+------+-----------+---------+-----------+                                                                                
| Name                                    | Host       | DirType   | Dir                            | Filesystem | Capacity | Used | Available | UseRate | MountOn   |                                                                                
+-----------------------------------------+------------+-----------+--------------------------------+------------+----------+------+-----------+---------+-----------+                                                                                
| fe_cee06fa5_53d7_4e7b_95cc_a6832a43a528 | 172.17.0.3 | meta      | /data/d21/output/fe/doris-meta | /dev/vda1  | 492G    | 426G | 45G       | 91%     | /data/d21 |                                                                                
| fe_cee06fa5_53d7_4e7b_95cc_a6832a43a528 | 172.17.0.3 | log       | /data/d21/output/fe/log        | /dev/vda1  | 492G     | 426G | 45G       | 91%     | /data/d21 |                                                                                
| fe_cee06fa5_53d7_4e7b_95cc_a6832a43a528 | 172.17.0.3 | audit-log | /data/d21/output/fe/log        | /dev/vda1  | 492G
 | 426G | 45G       | 91%     | /data/d21 |                                                                                
| fe_cee06fa5_53d7_4e7b_95cc_a6832a43a528 | 172.17.0.3 | temp      | /data/d21/output/fe/temp_dir   | /dev/vda1  | 492G    
 | 426G | 45G       | 91%     | /data/d21 |
| fe_cee06fa5_53d7_4e7b_95cc_a6832a43a528 | 172.17.0.3 | deploy    | /data/d21/output/fe            | /dev/vda1  | 492G
 | 426G | 45G       | 91%     | /data/d21 |
+-----------------------------------------+------------+-----------+--------------------------------+------------+---------
-+------+-----------+---------+-----------+
5 rows in set (0.00 sec)
```

