### PR TITLE
[fix](statistics)Fix partition table health rate evaluation bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -35,11 +35,11 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AnalysisInfo implements Writable {
 
@@ -191,7 +191,7 @@ public class AnalysisInfo implements Writable {
     @SerializedName("updateRows")
     public final long updateRows;
 
-    public final Map<Long, Long> partitionUpdateRows = new HashMap();
+    public final Map<Long, Long> partitionUpdateRows = new ConcurrentHashMap<>();
 
     @SerializedName("tblUpdateTime")
     public final long tblUpdateTime;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
@@ -42,7 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-public class TableStatsMeta implements Writable {
+public class TableStatsMeta implements Writable, GsonPostProcessable {
 
     @SerializedName("tblId")
     public final long tblId;
@@ -178,5 +179,12 @@ public class TableStatsMeta implements Writable {
 
     public void convertDeprecatedColStatsToNewVersion() {
         deprecatedColNameToColStatsMeta = null;
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (partitionUpdateRows == null) {
+            partitionUpdateRows = new ConcurrentHashMap<>();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -984,7 +984,7 @@ public class StatisticsUtil {
         }
         // Partition table partition stats never been collected.
         if (StatisticsUtil.enablePartitionAnalyze() && table.isPartitionedTable()
-                && (columnStatsMeta.partitionUpdateRows == null || columnStatsMeta.partitionUpdateRows.isEmpty())) {
+                && columnStatsMeta.partitionUpdateRows == null) {
             return true;
         }
         if (table instanceof OlapTable) {
@@ -1061,16 +1061,14 @@ public class StatisticsUtil {
             if (!partitionUpdateRows.containsKey(id)) {
                 return true;
             }
-            long currentUpdateRows = tableStatsStatus.partitionUpdateRows.get(id);
+            long currentUpdateRows = tableStatsStatus.partitionUpdateRows.getOrDefault(id, 0L);
             long lastUpdateRows = partitionUpdateRows.get(id);
-            if (currentUpdateRows != 0) {
-                long changedRows = currentUpdateRows - lastUpdateRows;
-                if (changedRows > 0) {
-                    changedPartitions++;
-                    // Too much partition changed, need to reanalyze.
-                    if (changedPartitions > UPDATED_PARTITION_THRESHOLD) {
-                        return true;
-                    }
+            long changedRows = currentUpdateRows - lastUpdateRows;
+            if (changedRows > 0) {
+                changedPartitions++;
+                // Too much partition changed, need to reanalyze.
+                if (changedPartitions > UPDATED_PARTITION_THRESHOLD) {
+                    return true;
                 }
                 double changeRate = ((double) changedRows) / currentUpdateRows;
                 // One partition changed too much, need to reanalyze.


### PR DESCRIPTION
The older Doris version doesn't support partition stats collection, so when user upgrade their cluster, the metadata doesn't contain partition level update rows for each table. In this case, auto collector thought this table haven't collect partition stats,  which will trigger a new collection. Since the partition level update rows are only updated after load operation, if user stop loading, auto analyzing will keep collecting this table for ever. 
This pr is to fix this problem, set the partition update rows to 0 for the old version tables.
