### PR TITLE
[chore](be-ut) Fix the issues with BE UT when starting on macOS

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -53,13 +53,14 @@ jobs:
         uses: ./.github/actions/ccache-action
         with:
           key: BE-UT-macOS
-          max-size: "2G"
+          max-size: "5G"
           restore-keys: BE-UT-macOS-
 
       - name: Run UT ${{ github.ref }}
         if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
         run: |
           cellars=(
+            'm4'
             'automake'
             'autoconf'
             'libtool'
@@ -95,4 +96,5 @@ jobs:
           tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
           popd
 
+          export JAVA_HOME="${JAVA_HOME_17_X64%\/}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -281,6 +281,7 @@ done < <(find "${CMAKE_BUILD_DIR}" -name "*gcda")
 setup_java_env() {
     local java_version
 
+    echo "JAVA_HOME: ${JAVA_HOME}"
     if [[ -z "${JAVA_HOME}" ]]; then
         return 1
     fi
@@ -301,6 +302,10 @@ setup_java_env() {
         # JAVA_HOME is jre
     else
         export LD_LIBRARY_PATH="${JAVA_HOME}/lib/${jvm_arch}/server:${JAVA_HOME}/lib/${jvm_arch}:${LD_LIBRARY_PATH}"
+    fi
+
+    if [[ "$(uname -s)" == 'Darwin' ]]; then
+        export DYLD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${DYLD_LIBRARY_PATH}"
     fi
 }
 


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

The workflow BE UT (macOS) failed to be started due to missing `libjvm.dylib`. See [https://github.com/apache/doris/actions/runs/9394949541/job/25873499203](https://github.com/apache/doris/actions/runs/9394949541/job/25873499203)

