### PR TITLE
[fix](nereids)should not push down constant output expr in window expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -100,7 +100,8 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
 
         // 1. handle bottom projects
         Set<Alias> existedAlias = ExpressionUtils.collect(outputs, Alias.class::isInstance);
-        Set<Expression> toBePushedDown = collectExpressionsToBePushedDown(outputs);
+        Set<Expression> toBePushedDown = collectExpressionsToBePushedDown(
+                outputs.stream().filter(expr -> !expr.isConstant()).collect(Collectors.toList()));
         NormalizeToSlotContext context = NormalizeToSlotContext.buildContext(existedAlias, toBePushedDown);
         // set toBePushedDown exprs as NamedExpression, e.g. (a+1) -> Alias(a+1)
         Set<NamedExpression> bottomProjects = context.pushDownToNamedExpression(toBePushedDown);

--- a/regression-test/suites/nereids_p0/aggregate/agg_window_project.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/agg_window_project.groovy
@@ -109,4 +109,18 @@ suite("agg_window_project") {
     sql """select a, a aa, row_number() over (partition by b) from test_window_table2;"""
 
     sql "DROP TABLE IF EXISTS test_window_table2;"
+
+    sql """DROP TABLE IF EXISTS test_window_union_t1;"""
+    sql """DROP TABLE IF EXISTS test_window_union_t2;"""
+    sql """create table test_window_union_t1 (item_code int) distributed by hash(item_code) properties("replication_num"="1");"""
+    sql """insert into test_window_union_t1 values(1), (11), (111);"""
+
+    sql """create table test_window_union_t2 (orderamount_lj_tq decimalv3(38,5)) distributed by hash(orderamount_lj_tq) properties("replication_num"="1");"""
+    sql """insert into test_window_union_t2 values(123456.12345), (223456.12345), (323456.12345);"""
+
+    sql """
+        SELECT 0 AS `amount_dh_real_tq`, (CASE WHEN `t`.`item_code` IS NOT NULL THEN (1.0 / count(1) OVER (PARTITION BY `t`.`item_code`)) ELSE 0.0 END) AS `item_qty_dh_order` FROM `test_window_union_t1` t
+        UNION ALL
+        SELECT `t`.`orderamount_lj_tq` AS `amount_dh_real_tq`, 0 AS `item_qty_dh_order` FROM `test_window_union_t2` t  ;
+    """
 }


### PR DESCRIPTION
`SELECT 0 AS x1, (CASE WHEN t.a IS NOT NULL THEN 1.0 / count(1) OVER (PARTITION BY t.b) ELSE 0 END) AS x2 FROM t`

0 AS x1 was pushed down to bottom project. Then it will be used to normalize case when expr, and change it to
(CASE WHEN t.a IS NOT NULL THEN 1.0 / count(1) OVER (PARTITION BY t.b) ELSE **x1** END) AS x2

the literal 0 was replaced by x1 accidentally. This pr fix it by keep constant expr in output list

Issue Number: close #xxx

<!--Describe your changes.-->

