### PR TITLE
[fix](inverted index)Delete tmp dirs when BE starts to avoid tmp file…

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -663,8 +663,7 @@ Status Compaction::do_inverted_index_compaction() {
         }
     }
 
-    // we choose the first destination segment name as the temporary index writer path
-    // Used to distinguish between different index compaction
+    // use tmp file dir to store index files
     auto tmp_file_dir = ExecEnv::GetInstance()->get_tmp_file_dirs()->get_tmp_file_dir();
     auto index_tmp_path = tmp_file_dir / dest_rowset_id.to_string();
     LOG(INFO) << "start index compaction"

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.h
@@ -106,11 +106,9 @@ public:
 
     Status init() {
         for (auto& tmp_file_dir : _tmp_file_dirs) {
-            bool exists = true;
-            RETURN_IF_ERROR(io::global_local_filesystem()->exists(tmp_file_dir, &exists));
-            if (!exists) {
-                RETURN_IF_ERROR(io::global_local_filesystem()->create_directory(tmp_file_dir));
-            }
+            // delete the tmp dir to avoid the tmp files left by last crash
+            RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tmp_file_dir));
+            RETURN_IF_ERROR(io::global_local_filesystem()->create_directory(tmp_file_dir));
         }
         return Status::OK();
     };


### PR DESCRIPTION
…s left by last crash

## Proposed changes

When BE crashes, there may be tmp files left in the tmp dir, so we remove and rebuild the tmp dir every time we start BE to prevent rubbish data from occupying the disk.

