### PR TITLE
[fix](mtmv) Fix that the storage medium specified for the mtmv is SSD, but the partition storage medium for the mtmv is still HDD (#35644)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1512,6 +1512,13 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)) {
                 properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, olapTable.getStoragePolicy());
             }
+            if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
+                TStorageMedium tableStorageMedium = olapTable.getStorageMedium();
+                if (tableStorageMedium != null) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
+                            tableStorageMedium.name().toLowerCase());
+                }
+            }
 
             singlePartitionDesc.analyze(partitionInfo.getPartitionColumns().size(), properties);
             partitionInfo.createAndCheckPartitionItem(singlePartitionDesc, isTempPartition);

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -65,10 +65,8 @@ chunk_reserved_bytes_limit = 134217728
 # sys_log_verbose_modules = *
 log_buffer_level = -1
 enable_stream_load_record = true
-# palo_cgroups
-#storage_root_path=/mnt/hdd01/doris.SSD/NON_VEC_RELEASE;/mnt/hdd01/doris.HDD/NON_VEC_RELEASE;/mnt/hdd02/doris.SSD/NON_VEC_RELEASE;/mnt/hdd02/doris.HDD/NON_VEC_RELEASE;/mnt/hdd03/doris.SSD/NON_VEC_RELEASE;/mnt/hdd03/doris.HDD/NON_VEC_RELEASE;/mnt/hdd04/doris.SSD/NON_VEC_RELEASE;/mnt/hdd04/doris.HDD/NON_VEC_RELEASE;/mnt/hdd05/doris.SSD/NON_VEC_RELEASE;/mnt/hdd05/doris.HDD/NON_VEC_RELEASE;/mnt/hdd06/doris.SSD/NON_VEC_RELEASE;/mnt/hdd06/doris.HDD/NON_VEC_RELEASE;
 
-storage_root_path=/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster1
+storage_root_path=/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster1;/mnt/ssd01/cluster_storage/doris.SSD
 disable_auto_compaction=true
 tablet_map_shard_size=256
 priority_networks=172.19.0.0/24

--- a/regression-test/suites/mtmv_p0/test_storage_medium_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_storage_medium_mtmv.groovy
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Assert;
+
+suite("test_storage_medium_mtmv","mtmv") {
+    String suiteName = "test_storage_medium_mtmv"
+    String tableName = "${suiteName}_table"
+    String mvName = "${suiteName}_mv"
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE TABLE ${tableName}
+        (
+            k2 TINYINT,
+            k3 INT not null
+        )
+        COMMENT "my first table"
+        PARTITION BY LIST(`k3`)
+        (
+            PARTITION `p1` VALUES IN ('1'),
+            PARTITION `p2` VALUES IN ('2'),
+            PARTITION `p3` VALUES IN ('3')
+        )
+        DISTRIBUTED BY HASH(k2) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by(`k3`)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1',
+        'storage_medium' = 'SSD'
+        )
+        AS
+        SELECT * from ${tableName};
+        """
+
+    // test init
+    def res = sql """show partitions from ${mvName}"""
+    logger.info("res: " + res.toString())
+    assertTrue(res.toString().contains("SSD"))
+    assertFalse(res.toString().contains("HDD"))
+
+    sql """
+        insert into ${tableName} values(1,1),(2,2),(3,3);
+        """
+     sql """
+        REFRESH MATERIALIZED VIEW ${mvName} AUTO
+        """
+    waitingMTMVTaskFinishedByMvName(mvName)
+
+    // test after refresh
+    res = sql """show partitions from ${mvName}"""
+    logger.info("res: " + res.toString())
+    assertTrue(res.toString().contains("SSD"))
+    assertFalse(res.toString().contains("HDD"))
+
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+}


### PR DESCRIPTION
…, but the partition storage medium for the mtmv is still HDD (#35644)

pick from master:https://github.com/apache/doris/pull/35644

fix when create mtmv use property `'storage_medium' = 'SSD'`,after refresh mtmv, partition's `storage_medium` is HDD

Not only is there a problem with mtmv, but essentially, when creating partitions, there is no inheritance of the table

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

