### PR TITLE
[improve](cloud) The cloudWarmUpJob save/load is supported for image

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaReader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaReader.java
@@ -100,15 +100,6 @@ public class MetaReader {
                     LOG.info("Skip {} module since empty meta length in the end.", metaIndex.name);
                     continue;
                 }
-                // FIXME: pick cloudWarmUpJob and remove below codes.
-                if (metaIndex.name.equals("cloudWarmUpJob")) {
-                    LOG.warn("meta modules {} is not supported yet, ignore and skip it", metaIndex.name);
-                    // If this is the last module, nothing need to do.
-                    if (i < metaFooter.metaIndices.size() - 1) {
-                        IOUtils.skipFully(dis, metaFooter.metaIndices.get(i + 1).offset - metaIndex.offset);
-                    }
-                    continue;
-                }
                 // skip deprecated modules
                 if (PersistMetaModules.DEPRECATED_MODULE_NAMES.contains(metaIndex.name)) {
                     LOG.warn("meta modules {} is deprecated, ignore and skip it", metaIndex.name);


### PR DESCRIPTION
The cloudWarmUpJob save/load is supported in
```
// fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaPersistMethod.java
case "cloudWarmUpJob":
                metaPersistMethod.readMethod =
                        Env.class.getDeclaredMethod("loadCloudWarmUpJob", DataInputStream.class, long.class);
                metaPersistMethod.writeMethod =
                        Env.class.getDeclaredMethod("saveCloudWarmUpJob", CountingDataOutputStream.class, long.class);
                break;
```
Remove the skip code.
