### PR TITLE
[fix](multi-catalog)the classpath of custom lib should put back of fe jars

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -204,7 +204,7 @@ done
 # add custome_libs to CLASSPATH
 if [[ -d "${DORIS_HOME}/custom_lib" ]]; then
     for f in "${DORIS_HOME}/custom_lib"/*.jar; do
-        CLASSPATH="${f}:${CLASSPATH}"
+        CLASSPATH="${CLASSPATH}:${f}"
     done
 fi
 


### PR DESCRIPTION
## Proposed changes

see https://github.com/apache/doris/pull/34990
user class maybe use some tripartite lib, we should put them back of fe jars to avoid conflicts

