### PR TITLE
[Fix](feut) Fix distribute hint test with reorder cross join

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/DistributeHintTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/DistributeHintTest.java
@@ -117,21 +117,20 @@ class DistributeHintTest extends TestWithFeService implements MemoPatternMatchSu
             MatchingUtils.assertMatches(plan,
                     physicalResultSink(
                             physicalDistribute(
-                                    physicalProject(
-                                            physicalHashJoin(
-                                                    physicalHashJoin(physicalDistribute().when(dis -> {
-                                                        DistributionSpec spec = dis.getDistributionSpec();
-                                                        Assertions.assertTrue(spec instanceof DistributionSpecHash);
-                                                        DistributionSpecHash hashSpec = (DistributionSpecHash) spec;
-                                                        Assertions.assertEquals(ShuffleType.EXECUTION_BUCKETED,
-                                                                hashSpec.getShuffleType());
-                                                        return true;
-                                                    }), physicalDistribute()),
-                                                    physicalDistribute()
-                                            ).when(join -> join.getDistributeHint().distributeType == DistributeType.SHUFFLE_RIGHT)
+                                    physicalHashJoin(
+                                            physicalHashJoin(physicalDistribute().when(dis -> {
+                                                DistributionSpec spec = dis.getDistributionSpec();
+                                                Assertions.assertTrue(spec instanceof DistributionSpecHash);
+                                                DistributionSpecHash hashSpec = (DistributionSpecHash) spec;
+                                                Assertions.assertEquals(ShuffleType.EXECUTION_BUCKETED,
+                                                        hashSpec.getShuffleType());
+                                                return true;
+                                            }), physicalDistribute()),
+                                            physicalDistribute()).when(join -> join.getDistributeHint().distributeType
+                                                    == DistributeType.SHUFFLE_RIGHT)
                                     )
                             )
-                    ));
+            );
         });
     }
 


### PR DESCRIPTION
when checking plan shape of distribute hint test, the shape of it does not changed but projection has changed. So it needed to be updated

