### PR TITLE
[improve](group commit) Modify group commit case and modify cancel status

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -154,7 +154,8 @@ Status LoadBlockQueue::get_block(RuntimeState* runtime_state, vectorized::Block*
     if (runtime_state->is_cancelled()) {
         auto st = runtime_state->cancel_reason();
         _cancel_without_lock(st);
-        return st;
+        return Status::Cancelled("cancel group_commit, label=" + label +
+                                 ", status=" + st.to_string());
     }
     if (!_block_queue.empty()) {
         const BlockData block_data = _block_queue.front();

--- a/regression-test/suites/insert_p0/insert_group_commit_into_max_filter_ratio.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into_max_filter_ratio.groovy
@@ -93,7 +93,7 @@ suite("insert_group_commit_into_max_filter_ratio") {
                 logger.warn("insert result: " + result + ", expected_row_count: " + expected_row_count + ", sql: " + sql)
             }
             // assertEquals(result, expected_row_count)
-            assertTrue(serverInfo.contains("'status':'ABORTED'") || serverInfo.contains("too many filtered rows"))
+            assertTrue(serverInfo.contains("'status':'ABORTED'")/* || serverInfo.contains("too many filtered rows")*/)
             // assertFalse(serverInfo.contains("'label':'group_commit_"))
         } catch (Exception e) {
             logger.info("exception: " + e)
@@ -184,8 +184,6 @@ suite("insert_group_commit_into_max_filter_ratio") {
     for (item in ["legacy", "nereids"]) {
         sql """ truncate table ${tableName} """
         connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = context.config.jdbcUrl) {
-            // TODO: pipeline need to be implemented
-            sql """ set experimental_enable_nereids_dml_with_pipeline = false; """
             if (item == "nereids") {
                 sql """ set enable_nereids_dml = true; """
                 sql """ set enable_nereids_planner=true; """
@@ -235,7 +233,8 @@ suite("insert_group_commit_into_max_filter_ratio") {
             sql """ set group_commit = async_mode; """
             sql """ set enable_insert_strict = true; """
             if (item == "nereids") {
-                // sql """ insert into ${dbTableName} values (8, 'a', 'a'); """, 1
+                // will write [8, a, null]
+                // group_commit_insert """ insert into ${dbTableName} values (8, 'a', 'a'); """, 1
             } else {
                 fail_group_commit_insert """ insert into ${dbTableName} values (8, 'a', 'a'); """, 0
             }

--- a/regression-test/suites/insert_p0/insert_group_commit_into_unique_sync_mode.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into_unique_sync_mode.groovy
@@ -218,8 +218,6 @@ suite("insert_group_commit_into_unique_sync_mode") {
 
             // 1. insert into
             connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = context.config.jdbcUrl) {
-            // TODO: pipeline need to be implemented
-            sql """ set experimental_enable_nereids_dml_with_pipeline = false; """
                 sql """ set group_commit = sync_mode; """
                 if (item == "nereids") {
                     sql """ set enable_nereids_dml = true; """

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_client.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_client.groovy
@@ -103,7 +103,6 @@ PROPERTIES (
 );
         """
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
     }
 
     def do_insert_into = { exp_str, num ->
@@ -126,7 +125,6 @@ PROPERTIES (
     def insert_file = { file_name ->
         logger.info("file:" + file_name)
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
         //read and insert
         BufferedReader reader;
         try {

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_table.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_table.groovy
@@ -102,7 +102,6 @@ PROPERTIES (
 );
         """
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
     }
 
     def do_insert_into = { exp_str, num ->
@@ -124,7 +123,6 @@ PROPERTIES (
 
     def insert_file = { file_name, table_name ->
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
         logger.info("file:" + file_name)
         //read and insert
         BufferedReader reader;

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_normal.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_normal.groovy
@@ -98,7 +98,6 @@ PROPERTIES (
 );
         """
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
     }
 
     def do_insert_into = { exp_str, num ->
@@ -113,7 +112,6 @@ PROPERTIES (
                 Thread.sleep(5000)
                 context.reconnectFe()
                 sql """ set group_commit = async_mode; """
-                sql """ set enable_nereids_dml = false; """
             }
             i++;
             if (i >= 30) {

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
@@ -133,7 +133,6 @@ PROPERTIES (
 );
         """
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
     }
 
     def create_insert_table_less_column = { table_name ->
@@ -166,7 +165,6 @@ PROPERTIES (
 );
         """
         sql """ set group_commit = async_mode; """
-        sql """ set enable_nereids_dml = false; """
 
     }
 


### PR DESCRIPTION
## Proposed changes

1. Modify group commit p2 case to use nereids since https://github.com/apache/doris/pull/32523 support it.
2. We get many same logs when group commit is cancelled: 
    ```
    group_commit_mgr.cpp:182] cancel group commit, instance_id=xx, label=xx, status=[OK]
    ```
    the problem is that `runtime_state->is_cancelled` is true, but `runtime_state->cancel_reason()` is `OK`