### PR TITLE
[Bug](function) fix week function get wrong result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -697,6 +697,13 @@ public class DateTimeExtractAndTransform {
                 return new TinyIntLiteral((byte) localDateTime.get(WeekFields.ISO.weekOfYear()));
             }
             case 2: {
+                // https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_week
+                // mode 2 is start with a Sunday day as first week in this year.
+                // and special case for 0000-01-01, as it's SATURDAY, calculate result of 52 is
+                // last year, so it's meaningless.
+                if (localDateTime.equals(LocalDateTime.of(0, 1, 1, 0, 0))) {
+                    return new TinyIntLiteral((byte) 1);
+                }
                 return new TinyIntLiteral(
                         (byte) localDateTime.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekOfWeekBasedYear()));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -687,6 +687,9 @@ public class DateTimeExtractAndTransform {
         return week(date.toJavaDateType(), mode.getIntValue());
     }
 
+    /**
+     * the impl of function week(date/datetime, mode)
+     */
     public static Expression week(LocalDateTime localDateTime, int mode) {
         switch (mode) {
             case 0: {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -687,7 +687,7 @@ public class DateTimeExtractAndTransform {
         return week(date.toJavaDateType(), mode.getIntValue());
     }
 
-    private static Expression week(LocalDateTime localDateTime, int mode) {
+    public static Expression week(LocalDateTime localDateTime, int mode) {
         switch (mode) {
             case 0: {
                 return new TinyIntLiteral(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions;
+
+import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeExtractAndTransform;
+import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DateTimeExtractAndTransformTest {
+    @Test
+    void testWeekMode2Function() {
+        LocalDateTime localDateTime = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);
+        Assertions.assertEquals(new TinyIntLiteral((byte) 1), DateTimeExtractAndTransform.week(localDateTime, 2));
+        LocalDateTime localDateTime2 = localDateTime.plusDays(1);
+        Assertions.assertEquals(new TinyIntLiteral((byte) 1), DateTimeExtractAndTransform.week(localDateTime2, 2));
+        LocalDateTime localDateTime3 = LocalDateTime.of(0, 1, 9, 0, 0, 0, 0);
+        Assertions.assertEquals(new TinyIntLiteral((byte) 2), DateTimeExtractAndTransform.week(localDateTime3, 2));
+
+        LocalDateTime localDateTime4 = LocalDateTime.of(0, 12, 30, 0, 0, 0, 0);
+        Assertions.assertEquals(new TinyIntLiteral((byte) 52), DateTimeExtractAndTransform.week(localDateTime4, 2));
+        LocalDateTime localDateTime5 = localDateTime4.plusDays(1);
+        Assertions.assertEquals(new TinyIntLiteral((byte) 53), DateTimeExtractAndTransform.week(localDateTime5, 2));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
@@ -20,10 +20,10 @@ package org.apache.doris.nereids.trees.expressions.functions;
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeExtractAndTransform;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 
-import java.time.LocalDateTime;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
 
 class DateTimeExtractAndTransformTest {
     @Test

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -68,4 +68,10 @@ suite("nereids_explain") {
 
     def explainStr = sql("select sum(if(lo_tax=1,lo_tax,0)) from lineorder where false").toString()
     assertTrue(!explainStr.contains("projections"))
+
+    explain {
+        sql("select week(cast('0000-01-01' as DATEV2), cast(2 as INT));")
+        notContains "week"
+        contains "1"
+    }
 }


### PR DESCRIPTION
## Proposed changes

before:
```
select week(cast('0000-01-01' as DATEV2), cast(2 as INT));
+----------------------------------------------------+
| week(cast('0000-01-01' as DATEV2), cast(2 as INT)) |
+----------------------------------------------------+
|                                                 52 |
+----------------------------------------------------+
1 row in set (0.00 sec)
```
 but it's should return 1 as result,
 mode 2 is start with a Sunday day as first week in this year.
 and special case for 0000-01-01, as it's SATURDAY, calculate result of 52 is
 last year, so it's meaningless.

<!--Describe your changes.-->

