### PR TITLE
[fix](Nereids): Add Primary Key by Primary Relation Instead of Foreign Relation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
@@ -67,6 +67,7 @@ public class ForeignKeyContext {
             public Void visitLogicalRelation(LogicalRelation relation, ForeignKeyContext context) {
                 if (relation instanceof LogicalCatalogRelation) {
                     context.putAllForeignKeys(((LogicalCatalogRelation) relation).getTable());
+                    context.putAllPrimaryKeys(((LogicalCatalogRelation) relation).getTable());
                     relation.getOutput().stream()
                             .filter(SlotReference.class::isInstance)
                             .map(SlotReference.class::cast)
@@ -101,7 +102,13 @@ public class ForeignKeyContext {
             Map<Column, Column> constraint = c.getForeignToPrimary(table);
             constraints.add(c.getForeignToPrimary(table));
             foreignKeys.addAll(constraint.keySet());
-            primaryKeys.addAll(constraint.values());
+        });
+    }
+
+    void putAllPrimaryKeys(TableIf table) {
+        table.getPrimaryKeyConstraints().forEach(c -> {
+            Set<Column> primaryKey = c.getPrimaryKeys(table);
+            primaryKeys.addAll(primaryKey);
         });
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
@@ -58,6 +58,17 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
     }
 
     @Test
+    void testPriWithJoin() {
+        String sql = "select pri.id1 from (select p1.id1 from pri as p1 cross join pri as p2) pri "
+                + "inner join foreign_not_null on pri.id1 = foreign_not_null.id2";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin())
+                .printlnTree();
+    }
+
+    @Test
     void testNotNull() {
         String sql = "select pri.id1 from pri inner join foreign_not_null on pri.id1 = foreign_not_null.id2";
         PlanChecker.from(connectContext)


### PR DESCRIPTION
## Proposed changes

Ensure the primary key is added by the primary relation, enhancing efficiency by expiring keys post joins to avoid eliminating redundant joins based on primary-foreign key relationships.

