### PR TITLE
[branch-2.1](jvm) disable BE's jvm metrics

### DIFF
--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -71,5 +71,5 @@ enable_fuzzy_mode=true
 enable_set_in_bitmap_value=true
 enable_feature_binlog=true
 
-enable_jvm_monitor = true
+#enable_jvm_monitor = true
 

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -81,5 +81,5 @@ enable_debug_points=true
 # debug scanner context dead loop
 enable_debug_log_timeout_secs=0
 
-enable_jvm_monitor = true
+#enable_jvm_monitor = true
 


### PR DESCRIPTION
disable  BE's jvm metrics on external p0, because there is some issue with ASAN when BE exit.