### PR TITLE
[fix](cloud) cloud mode don't start collect partition info thread

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1726,7 +1726,7 @@ public class Env {
             getConsistencyChecker().start();
             // Backup handler
             getBackupHandler().start();
-            // collect partition version && isInMemory
+            // start daemon thread to update global partition version and in memory information periodically
             partitionInfoCollector.start();
         }
         jobManager.start();
@@ -1754,7 +1754,6 @@ public class Env {
         dynamicPartitionScheduler.start();
         // start daemon thread to update db used data quota for db txn manager periodically
         dbUsedDataQuotaInfoCollector.start();
-        // start daemon thread to update global partition in memory information periodically
         if (Config.enable_storage_policy) {
             cooldownConfHandler.start();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1726,6 +1726,8 @@ public class Env {
             getConsistencyChecker().start();
             // Backup handler
             getBackupHandler().start();
+            // collect partition version && isInMemory
+            partitionInfoCollector.start();
         }
         jobManager.start();
         // transient task manager
@@ -1753,7 +1755,6 @@ public class Env {
         // start daemon thread to update db used data quota for db txn manager periodically
         dbUsedDataQuotaInfoCollector.start();
         // start daemon thread to update global partition in memory information periodically
-        partitionInfoCollector.start();
         if (Config.enable_storage_policy) {
             cooldownConfHandler.start();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -102,6 +102,7 @@ public class TabletInvertedIndex {
     // partition id -> partition info.
     // notice partition info update every Config.partition_info_update_interval_secs seconds,
     // so it may be stale.
+    // Notice only none-cloud use it for be reporting tablets. This map is empty in cloud mode.
     private volatile ImmutableMap<Long, PartitionCollectInfo> partitionCollectInfoMap = ImmutableMap.of();
 
     private ForkJoinPool taskPool = new ForkJoinPool(Runtime.getRuntime().availableProcessors());


### PR DESCRIPTION
Collect partition info thread only use for sync info when be report tablet,  cloud mode no need to start it.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

