### PR TITLE
[fix](cloud) Fix compatibility issues with old cloud code

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -92,6 +92,7 @@ import org.apache.doris.cloud.catalog.CloudPartition;
 import org.apache.doris.cloud.catalog.CloudReplica;
 import org.apache.doris.cloud.catalog.CloudTablet;
 import org.apache.doris.cloud.datasource.CloudInternalCatalog;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.util.RangeUtils;
 import org.apache.doris.datasource.CatalogIf;
@@ -292,12 +293,23 @@ public class GsonUtils {
             .registerSubtype(EsResource.class, EsResource.class.getSimpleName());
 
     // runtime adapter for class "AlterJobV2"
-    private static RuntimeTypeAdapterFactory<AlterJobV2> alterJobV2TypeAdapterFactory = RuntimeTypeAdapterFactory
-            .of(AlterJobV2.class, "clazz")
-            .registerSubtype(RollupJobV2.class, RollupJobV2.class.getSimpleName())
-            .registerSubtype(SchemaChangeJobV2.class, SchemaChangeJobV2.class.getSimpleName())
-            .registerSubtype(CloudSchemaChangeJobV2.class, CloudSchemaChangeJobV2.class.getSimpleName())
-            .registerSubtype(CloudRollupJobV2.class, CloudRollupJobV2.class.getSimpleName());
+    private static RuntimeTypeAdapterFactory<AlterJobV2> alterJobV2TypeAdapterFactory;
+
+    static {
+        alterJobV2TypeAdapterFactory = RuntimeTypeAdapterFactory.of(AlterJobV2.class, "clazz")
+                .registerSubtype(CloudSchemaChangeJobV2.class, CloudSchemaChangeJobV2.class.getSimpleName())
+                .registerSubtype(CloudRollupJobV2.class, CloudRollupJobV2.class.getSimpleName());
+        if (Config.isNotCloudMode()) {
+            alterJobV2TypeAdapterFactory
+                    .registerSubtype(RollupJobV2.class, RollupJobV2.class.getSimpleName())
+                    .registerSubtype(SchemaChangeJobV2.class, SchemaChangeJobV2.class.getSimpleName());
+        } else {
+            // compatible with old cloud code.
+            alterJobV2TypeAdapterFactory
+                    .registerCompatibleSubtype(CloudRollupJobV2.class, RollupJobV2.class.getSimpleName())
+                    .registerCompatibleSubtype(CloudSchemaChangeJobV2.class, SchemaChangeJobV2.class.getSimpleName());
+        }
+    }
 
     // runtime adapter for class "SyncJob"
     private static RuntimeTypeAdapterFactory<SyncJob> syncJobTypeAdapterFactory = RuntimeTypeAdapterFactory
@@ -320,26 +332,37 @@ public class GsonUtils {
             .registerSubtype(ForeignKeyConstraint.class, ForeignKeyConstraint.class.getSimpleName())
             .registerSubtype(UniqueConstraint.class, UniqueConstraint.class.getSimpleName());
 
-    private static RuntimeTypeAdapterFactory<CatalogIf> dsTypeAdapterFactory = RuntimeTypeAdapterFactory.of(
-                    CatalogIf.class, "clazz")
-            .registerSubtype(InternalCatalog.class, InternalCatalog.class.getSimpleName())
-            .registerSubtype(CloudInternalCatalog.class, CloudInternalCatalog.class.getSimpleName())
-            .registerSubtype(HMSExternalCatalog.class, HMSExternalCatalog.class.getSimpleName())
-            .registerSubtype(EsExternalCatalog.class, EsExternalCatalog.class.getSimpleName())
-            .registerSubtype(JdbcExternalCatalog.class, JdbcExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergExternalCatalog.class, IcebergExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergHMSExternalCatalog.class, IcebergHMSExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergGlueExternalCatalog.class, IcebergGlueExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergRestExternalCatalog.class, IcebergRestExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergDLFExternalCatalog.class, IcebergDLFExternalCatalog.class.getSimpleName())
-            .registerSubtype(IcebergHadoopExternalCatalog.class, IcebergHadoopExternalCatalog.class.getSimpleName())
-            .registerSubtype(PaimonExternalCatalog.class, PaimonExternalCatalog.class.getSimpleName())
-            .registerSubtype(PaimonHMSExternalCatalog.class, PaimonHMSExternalCatalog.class.getSimpleName())
-            .registerSubtype(PaimonFileExternalCatalog.class, PaimonFileExternalCatalog.class.getSimpleName())
-            .registerSubtype(MaxComputeExternalCatalog.class, MaxComputeExternalCatalog.class.getSimpleName())
-            .registerSubtype(TrinoConnectorExternalCatalog.class, TrinoConnectorExternalCatalog.class.getSimpleName())
-            .registerSubtype(LakeSoulExternalCatalog.class, LakeSoulExternalCatalog.class.getSimpleName())
-            .registerSubtype(TestExternalCatalog.class, TestExternalCatalog.class.getSimpleName());
+    private static RuntimeTypeAdapterFactory<CatalogIf> dsTypeAdapterFactory;
+
+    static {
+        dsTypeAdapterFactory = RuntimeTypeAdapterFactory.of(CatalogIf.class, "clazz")
+                .registerSubtype(CloudInternalCatalog.class, CloudInternalCatalog.class.getSimpleName())
+                .registerSubtype(HMSExternalCatalog.class, HMSExternalCatalog.class.getSimpleName())
+                .registerSubtype(EsExternalCatalog.class, EsExternalCatalog.class.getSimpleName())
+                .registerSubtype(JdbcExternalCatalog.class, JdbcExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergExternalCatalog.class, IcebergExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergHMSExternalCatalog.class, IcebergHMSExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergGlueExternalCatalog.class, IcebergGlueExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergRestExternalCatalog.class, IcebergRestExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergDLFExternalCatalog.class, IcebergDLFExternalCatalog.class.getSimpleName())
+                .registerSubtype(IcebergHadoopExternalCatalog.class, IcebergHadoopExternalCatalog.class.getSimpleName())
+                .registerSubtype(PaimonExternalCatalog.class, PaimonExternalCatalog.class.getSimpleName())
+                .registerSubtype(PaimonHMSExternalCatalog.class, PaimonHMSExternalCatalog.class.getSimpleName())
+                .registerSubtype(PaimonFileExternalCatalog.class, PaimonFileExternalCatalog.class.getSimpleName())
+                .registerSubtype(MaxComputeExternalCatalog.class, MaxComputeExternalCatalog.class.getSimpleName())
+                .registerSubtype(
+                            TrinoConnectorExternalCatalog.class, TrinoConnectorExternalCatalog.class.getSimpleName())
+                .registerSubtype(LakeSoulExternalCatalog.class, LakeSoulExternalCatalog.class.getSimpleName())
+                .registerSubtype(TestExternalCatalog.class, TestExternalCatalog.class.getSimpleName());
+        if (Config.isNotCloudMode()) {
+            dsTypeAdapterFactory
+                    .registerSubtype(InternalCatalog.class, InternalCatalog.class.getSimpleName());
+        } else {
+            // compatible with old cloud code.
+            dsTypeAdapterFactory
+                    .registerCompatibleSubtype(CloudInternalCatalog.class, InternalCatalog.class.getSimpleName());
+        }
+    }
 
     // routine load data source
     private static RuntimeTypeAdapterFactory<AbstractDataSourceProperties> rdsTypeAdapterFactory =
@@ -408,11 +431,20 @@ public class GsonUtils {
             .registerSubtype(Replica.class, Replica.class.getSimpleName())
             .registerSubtype(CloudReplica.class, CloudReplica.class.getSimpleName());
 
-    private static RuntimeTypeAdapterFactory<Tablet> tabletTypeAdapterFactory = RuntimeTypeAdapterFactory
-            .of(Tablet.class, "clazz")
-            .registerDefaultSubtype(Tablet.class)
-            .registerSubtype(Tablet.class, Tablet.class.getSimpleName())
-            .registerSubtype(CloudTablet.class, CloudTablet.class.getSimpleName());
+    private static RuntimeTypeAdapterFactory<Tablet> tabletTypeAdapterFactory;
+
+    static {
+        tabletTypeAdapterFactory = RuntimeTypeAdapterFactory
+                .of(Tablet.class, "clazz")
+                .registerSubtype(Tablet.class, Tablet.class.getSimpleName())
+                .registerSubtype(CloudTablet.class, CloudTablet.class.getSimpleName());
+        if (Config.isNotCloudMode()) {
+            tabletTypeAdapterFactory.registerDefaultSubtype(Tablet.class);
+        } else {
+            // compatible with old cloud code.
+            tabletTypeAdapterFactory.registerDefaultSubtype(CloudTablet.class);
+        }
+    }
 
     // runtime adapter for class "CloudPartition".
     private static RuntimeTypeAdapterFactory<Partition> partitionTypeAdapterFactory = RuntimeTypeAdapterFactory

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
@@ -254,18 +254,30 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
     /**
      * Registers {@code type} for using when label not found
-     *
-     * @throws IllegalArgumentException if {@code type}
-     *     have already been registered on this type adapter.
      */
     public RuntimeTypeAdapterFactory<T> registerDefaultSubtype(Class<? extends T> type) {
         if (type == null) {
             throw new NullPointerException();
         }
-        if (subtypeToLabel.containsKey(type)) {
-            throw new IllegalArgumentException("types must be unique");
-        }
         defaultType = type;
+        return this;
+    }
+
+    /**
+     * Specifies the ${@code type} corresponding to the ${@code label}, which is used to be compatible
+     * with old data when the ${@code label} of the ${@code type} changes.
+     *
+     * @throws IllegalArgumentException if {@code label}
+     *     have already been registered on this type adapter.
+     */
+    public RuntimeTypeAdapterFactory<T> registerCompatibleSubtype(Class<? extends T> type, String label) {
+        if (type == null || label == null) {
+            throw new NullPointerException();
+        }
+        if (labelToSubtype.containsKey(label)) {
+            throw new IllegalArgumentException("labels must be unique");
+        }
+        labelToSubtype.put(label, type);
         return this;
     }
 


### PR DESCRIPTION
Cherry-pick #35958

The old cloud code uses the same clazz label as the native, but these labels were changed during merge codes. This PR makes the RuntimeTypeAdaptor compatible with the old cloud code.

