### PR TITLE
[fix](cloud) Fix compatibility issues with old cloud auth code

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -217,7 +217,7 @@ public class GrantStmt extends DdlStmt {
             Map<ColPrivilegeKey, Set<String>> colPrivileges)
             throws AnalysisException {
         // Rule 1
-        checkIncorrectPrivilege(Privilege.notBelongToTablePrivileges, privileges);
+        Privilege.checkIncorrectPrivilege(Privilege.notBelongToTablePrivileges, privileges);
         // Rule 2
         if (tblPattern.getPrivLevel() != PrivLevel.GLOBAL && (privileges.contains(Privilege.ADMIN_PRIV)
                 || privileges.contains(Privilege.NODE_PRIV))) {
@@ -242,17 +242,6 @@ public class GrantStmt extends DdlStmt {
         // Rule 5
         if (!MapUtils.isEmpty(colPrivileges) && "*".equals(tblPattern.getTbl())) {
             throw new AnalysisException("Col auth must specify specific table");
-        }
-    }
-
-    private static void checkIncorrectPrivilege(Privilege[] incorrectPrivileges,
-            Collection<Privilege> privileges) throws AnalysisException {
-        for (int i = 0; i < incorrectPrivileges.length; i++) {
-            if (privileges.contains(incorrectPrivileges[i])) {
-                throw new AnalysisException(
-                        String.format("Can not grant/revoke %s to/from any other users or roles",
-                                incorrectPrivileges[i]));
-            }
         }
     }
 
@@ -283,7 +272,7 @@ public class GrantStmt extends DdlStmt {
 
     public static void checkResourcePrivileges(Collection<Privilege> privileges,
             ResourcePattern resourcePattern) throws AnalysisException {
-        checkIncorrectPrivilege(Privilege.notBelongToResourcePrivileges, privileges);
+        Privilege.checkIncorrectPrivilege(Privilege.notBelongToResourcePrivileges, privileges);
 
         PrivPredicate predicate = getPrivPredicate(privileges);
         AccessControllerManager accessManager = Env.getCurrentEnv().getAccessManager();
@@ -318,7 +307,7 @@ public class GrantStmt extends DdlStmt {
 
     public static void checkWorkloadGroupPrivileges(Collection<Privilege> privileges,
             WorkloadGroupPattern workloadGroupPattern) throws AnalysisException {
-        checkIncorrectPrivilege(Privilege.notBelongToWorkloadGroupPrivileges, privileges);
+        Privilege.checkIncorrectPrivilege(Privilege.notBelongToWorkloadGroupPrivileges, privileges);
 
         PrivPredicate predicate = getPrivPredicate(privileges);
         AccessControllerManager accessManager = Env.getCurrentEnv().getAccessManager();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
@@ -65,9 +65,6 @@ public class ResourcePattern implements Writable, GsonPostProcessable {
         }
     }
 
-    private ResourcePattern() {
-    }
-
     public ResourcePattern(String resourceName, ResourceTypeEnum type) {
         // To be compatible with previous syntax
         if ("*".equals(resourceName)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Privilege.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Privilege.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.mysql.privilege;
 
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -162,5 +164,16 @@ public enum Privilege {
     @Override
     public String toString() {
         return name;
+    }
+
+    public static void checkIncorrectPrivilege(Privilege[] incorrectPrivileges,
+                                               Collection<Privilege> privileges) throws AnalysisException {
+        for (int i = 0; i < incorrectPrivileges.length; i++) {
+            if (privileges.contains(incorrectPrivileges[i])) {
+                throw new AnalysisException(
+                    String.format("Can not grant/revoke %s to/from any other users or roles",
+                        incorrectPrivileges[i]));
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/ResourcePrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/ResourcePrivEntry.java
@@ -45,9 +45,8 @@ public class ResourcePrivEntry extends PrivEntry {
         PatternMatcher resourcePattern = PatternMatcher.createMysqlPattern(
                 resourceName,
                 CaseSensibility.RESOURCE.getCaseSensibility());
-        if (privs.containsNodePriv() || privs.containsDbTablePriv()) {
-            throw new AnalysisException("Resource privilege can not contains node or db table privileges: " + privs);
-        }
+
+        Privilege.checkIncorrectPrivilege(Privilege.notBelongToResourcePrivileges, privs.toPrivilegeList());
         return new ResourcePrivEntry(resourcePattern,
                 resourceName, privs);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -649,11 +649,6 @@ public class Role implements Writable, GsonPostProcessable {
             return;
         }
 
-        if ("%".equals(resourcePattern.getResourceName())) {
-            LOG.info("ignore for compatible, resource name is %, current not exist GLOBAL level in resource");
-            return;
-        }
-
         ResourcePrivEntry entry;
         try {
             entry = ResourcePrivEntry.create(resourcePattern.getResourceName(), privs);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -649,6 +649,11 @@ public class Role implements Writable, GsonPostProcessable {
             return;
         }
 
+        if ("%".equals(resourcePattern.getResourceName())) {
+            LOG.info("ignore for compatible, resource name is %, current not exist GLOBAL level in resource");
+            return;
+        }
+
         ResourcePrivEntry entry;
         try {
             entry = ResourcePrivEntry.create(resourcePattern.getResourceName(), privs);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

fix

```
2024-06-06 03:11:43,633 INFO (main|1) [PrivTable.addEntry():89] add priv entry: database privilege.ctl: internal, db: information_schema, priv: Select_priv                         2024-06-06 03:11:43,633 INFO (main|1) [PrivTable.addEntry():89] add priv entry: origWorkloadGroup:normal, priv:Usage_priv                                                           2024-06-06 03:11:43,634 INFO (main|1) [PrivTable.addEntry():89] add priv entry: Node_priv,Admin_priv                                                                                2024-06-06 03:11:43,641 WARN (main|1) [Role.rebuildPrivTables():1170] grant failed,                                                                                                 org.apache.doris.common.DdlException: errCode = 2, detailMessage = errCode = 2, detailMessage = Resource privilege can not contains node or db table privileges: Node_priv,Admin_priv
        at org.apache.doris.mysql.privilege.Role.grantPrivs(Role.java:656) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.privilege.Role.rebuildPrivTables(Role.java:1168) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.privilege.Role.gsonPostProcess(Role.java:1101) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:772) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.gson.GsonUtils$ExprAdapterFactory$1.read(GsonUtils.java:644) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40) ~[gson-2.10.1.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:186) ~[gson-2.10.1.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:144) ~[gson-2.10.1.jar:?]
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:770) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.gson.GsonUtils$ExprAdapterFactory$1.read(GsonUtils.java:644) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212) ~[gson-2.10.1.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433) ~[gson-2.10.1.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393) ~[gson-2.10.1.jar:?]
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:770) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.gson.GsonUtils$ExprAdapterFactory$1.read(GsonUtils.java:644) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.google.gson.Gson.fromJson(Gson.java:1227) ~[gson-2.10.1.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:1137) ~[gson-2.10.1.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:1047) ~[gson-2.10.1.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:982) ~[gson-2.10.1.jar:?]
        at org.apache.doris.mysql.privilege.RoleManager.read(RoleManager.java:289) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.privilege.Auth.readFields(Auth.java:1824) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.loadAuth(Env.java:2178) ~[doris-fe.jar:1.2-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:135) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.loadImage(Env.java:2006) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.initialize(Env.java:1055) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.DorisFE.start(DorisFE.java:177) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.DorisFE.main(DorisFE.java:94) ~[doris-fe.jar:1.2-SNAPSHOT]
2024-06-06 03:11:43,650 WARN (main|1) [Role.rebuildPrivTables():1180] grant failed exception org.apache.doris.common.DdlException: errCode = 2, detailMessage = errCode = 2, detailMessage = Resource privilege can not contains node or db table privileges: Node_priv,Admin_priv entry %=Node_priv,Admin_priv
2024-06-06 03:11:43,650 WARN (main|1) [Role.rebuildPrivTables():1190] grant failed entry %=Node_priv,Admin_priv
```
