### PR TITLE
[improvement](JDBC Catalog) Properly release resources in JdbcClient

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -34,6 +34,7 @@ import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -166,6 +167,14 @@ public abstract class JdbcClient {
 
     public void closeClient() {
         dataSource.close();
+        if (classLoader instanceof URLClassLoader) {
+            try {
+                ((URLClassLoader) classLoader).close();
+            } catch (IOException e) {
+                LOG.error("Failed to close class loader", e);
+            }
+        }
+        classLoader = null;
     }
 
     public Connection getConnection() throws JdbcClientException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -166,15 +166,20 @@ public abstract class JdbcClient {
     }
 
     public void closeClient() {
-        dataSource.close();
-        if (classLoader instanceof URLClassLoader) {
-            try {
-                ((URLClassLoader) classLoader).close();
-            } catch (IOException e) {
-                LOG.error("Failed to close class loader", e);
+        if (dataSource != null) {
+            dataSource.close();
+        }
+        if (classLoader != null) {
+            if (classLoader instanceof URLClassLoader) {
+                try {
+                    ((URLClassLoader) classLoader).close();
+                } catch (IOException e) {
+                    LOG.warn("Failed to close class loader", e);
+                } finally {
+                    classLoader = null;
+                }
             }
         }
-        classLoader = null;
     }
 
     public Connection getConnection() throws JdbcClientException {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request introduces modifications to the `closeClient` method in the `JdbcClient` class to ensure proper cleanup of the custom class loader used for loading JDBC drivers. The existing implementation does not address the potential memory leak associated with class loaders when they are not properly closed after their usage ends.

### Why are the changes needed?

Class loaders, when not closed properly, can lead to memory leaks as the objects they load may not be eligible for garbage collection. This is especially critical in environments where multiple JDBC drivers are loaded and unloaded during the lifecycle of the application, such as in database federated queries or multi-tenant databases.

### Changes made:

- Added a check to close the `URLClassLoader` instance explicitly if it is not null.
- Nullified the class loader reference to aid the garbage collection process, thereby reducing the risk of memory leaks.

These changes help in ensuring that all resources are properly released when the JDBC client is closed, maintaining the robustness and efficiency of the resource management within the application.
