### PR TITLE
[chore](Compile) Fix S3 file writer ut's compile error due to miss cherry-pick

### DIFF
--- a/be/test/io/fs/remote_file_system_test.cpp
+++ b/be/test/io/fs/remote_file_system_test.cpp
@@ -420,7 +420,7 @@ TEST_F(RemoteFileSystemTest, TestS3FileSystem) {
     CHECK_STATUS_OK(s3_uri.parse());
     CHECK_STATUS_OK(S3ClientFactory::convert_properties_to_s3_conf(s3_prop, s3_uri, &s3_conf));
     std::shared_ptr<io::S3FileSystem> fs;
-    CHECK_STATUS_OK(io::S3FileSystem::create(std::move(s3_conf), "", &fs));
+    CHECK_STATUS_OK(io::S3FileSystem::create(std::move(s3_conf), "", nullptr, &fs));
 
     // delete directory
     io::Path delete_path = s3_location + "/tmp1";

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -56,8 +56,8 @@ public:
         s3_conf.region = config::test_s3_region;
         s3_conf.bucket = config::test_s3_bucket;
         s3_conf.prefix = "s3_file_writer_test";
-        static_cast<void>(
-                io::S3FileSystem::create(std::move(s3_conf), "s3_file_writer_test", &s3_fs));
+        static_cast<void>(io::S3FileSystem::create(std::move(s3_conf), "s3_file_writer_test",
+                                                   nullptr, &s3_fs));
         std::cout << "s3 conf: " << s3_conf.to_string() << std::endl;
         ASSERT_EQ(Status::OK(), s3_fs->connect());
 

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -78,9 +78,9 @@ public:
         s3_conf.bucket = config::test_s3_bucket;
         s3_conf.prefix = "remote_rowset_gc_test";
         std::shared_ptr<io::S3FileSystem> s3_fs;
-        ASSERT_TRUE(
-                io::S3FileSystem::create(std::move(s3_conf), std::to_string(kResourceId), &s3_fs)
-                        .ok());
+        ASSERT_TRUE(io::S3FileSystem::create(std::move(s3_conf), std::to_string(kResourceId),
+                                             nullptr, &s3_fs)
+                            .ok());
         put_storage_resource(kResourceId, {s3_fs, 1});
         auto storage_policy = std::make_shared<StoragePolicy>();
         storage_policy->name = "TabletCooldownTest";

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -256,7 +256,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
     s3_conf.prefix = "prefix";
     std::string resource_id = "10000";
     std::shared_ptr<io::S3FileSystem> fs;
-    ASSERT_TRUE(io::S3FileSystem::create(std::move(s3_conf), resource_id, &fs).ok());
+    ASSERT_TRUE(io::S3FileSystem::create(std::move(s3_conf), resource_id, nullptr, &fs).ok());
     // failed to head object
     {
         Aws::Auth::AWSCredentials aws_cred("ak", "sk");


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

The S3 File Writer's ut can't pass ut compile, this pr tries to fix it.