### PR TITLE
[fix](statistics)Fix analyze twice after drop stats bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -208,9 +208,10 @@ public class ShowColumnStatsStmt extends ShowStmt {
             row.add(r.get(9)); // updated_time
             String updateRows = "N/A";
             TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(tableIf.getId());
+            ColStatsMeta columnStatsMeta = null;
             if (tableStats != null && tableIf instanceof OlapTable) {
                 OlapTable olapTable = (OlapTable) tableIf;
-                ColStatsMeta columnStatsMeta = tableStats.findColumnStatsMeta(indexName, r.get(0));
+                columnStatsMeta = tableStats.findColumnStatsMeta(indexName, r.get(0));
                 if (columnStatsMeta != null && columnStatsMeta.partitionUpdateRows != null) {
                     Partition partition = olapTable.getPartition(r.get(1));
                     if (partition != null) {
@@ -222,7 +223,7 @@ public class ShowColumnStatsStmt extends ShowStmt {
                 }
             }
             row.add(updateRows); // update_rows
-            row.add("Manual"); // trigger. Manual or System
+            row.add(columnStatsMeta == null ? "N/A" : columnStatsMeta.jobType.name()); // trigger. Manual or System
             result.add(row);
         }
         return new ShowResultSet(getMetaData(), result);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -55,6 +55,10 @@ public class StatisticsAutoCollector extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsAutoCollector.class);
 
     protected final AnalysisTaskExecutor analysisTaskExecutor;
+    // Waited flag. Wait once when FE started for TabletStatMgr has received BE report at least once.
+    // This couldn't guarantee getRowCount will return up-to-date value,
+    // but could reduce the chance to get wrong row count. e.g. 0 after FE restart.
+    private boolean waited = false;
 
     public StatisticsAutoCollector() {
         super("Automatic Analyzer", TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_minutes));
@@ -74,7 +78,16 @@ public class StatisticsAutoCollector extends MasterDaemon {
         if (Env.isCheckpointThread()) {
             return;
         }
-        collect();
+        if (waited) {
+            collect();
+        } else {
+            try {
+                Thread.sleep((long) Config.tablet_stat_update_interval_second * 1000 * 2);
+                waited = true;
+            } catch (InterruptedException e) {
+                LOG.info("Wait Sleep interrupted.", e);
+            }
+        }
     }
 
     protected void collect() {


### PR DESCRIPTION
1. After drop stats when partition analyze function enabled. Auto collector will collect the dropped table twice. Because int the first time analyzing, it doesn't write the partition update rows record to tableStats. In this case, the collector will consider the table has not collect partition level stats, which will trigger the second time collection. This pr is to fix this bug.
2. Set correct trigger type for partition analyze.
3. Sleep for 2 minutes before auto collection thread begin to work. This is waiting for BEs report tablet row count.