### PR TITLE
[bugfix](iceberg)Fixed missing type of iceberg table for timetravel

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -593,6 +593,9 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             }
         } else if (table instanceof IcebergExternalTable) {
             scanNode = new IcebergScanNode(context.nextPlanNodeId(), tupleDescriptor, false);
+            if (fileScan.getTableSnapshot().isPresent()) {
+                ((IcebergScanNode) scanNode).setTableSnapshot(fileScan.getTableSnapshot().get());
+            }
         } else if (table instanceof PaimonExternalTable) {
             scanNode = new PaimonScanNode(context.nextPlanNodeId(), tupleDescriptor, false);
         } else if (table instanceof TrinoConnectorExternalTable) {


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Related:  #34681

34681 supports the time function, but supports the type `HMSExternalTable`.

This PR add support for `IcebergExternalTable` type.