### PR TITLE
[fix](shuffle) fix tablets num calculation in shuffle condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapTableSink.java
@@ -199,11 +199,13 @@ public class PhysicalOlapTableSink<CHILD_TYPE extends Plan> extends PhysicalTabl
      */
     public PhysicalProperties getRequirePhysicalProperties() {
         if (targetTable.isPartitionDistributed()) {
+            final long partitionNums = targetTable.getPartitionInfo().getAllPartitions().size();
+            final long tabletNums = partitionNums * distributionInfo.getBucketNum();
             DistributionInfo distributionInfo = targetTable.getDefaultDistributionInfo();
             if (distributionInfo instanceof HashDistributionInfo) {
                 // Do not enable shuffle for duplicate key tables when its tablet num is less than threshold.
                 if (targetTable.getKeysType() == KeysType.DUP_KEYS
-                        && distributionInfo.getBucketNum() < Config.min_tablets_for_dup_table_shuffle) {
+                        && tabletNums < Config.min_tablets_for_dup_table_shuffle) {
                     return PhysicalProperties.ANY;
                 }
                 return PhysicalProperties.TABLET_ID_SHUFFLE;


### PR DESCRIPTION
## Proposed changes

For tables with multiple partitions, `tablet num` should be `bucket num * parition num`.

