### PR TITLE
[fix](nereids)decimal and datetime literal comparison should compare datatype too

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -66,8 +66,7 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
 
             // 1. handle bottom projects
             Set<Alias> existedAlias = ExpressionUtils.collect(outputs, Alias.class::isInstance);
-            Set<Expression> toBePushedDown = collectExpressionsToBePushedDown(outputs.stream()
-                    .filter(expr -> !expr.isConstant()).collect(Collectors.toList()));
+            Set<Expression> toBePushedDown = collectExpressionsToBePushedDown(outputs);
             NormalizeToSlotContext context = NormalizeToSlotContext.buildContext(existedAlias, toBePushedDown);
             // set toBePushedDown exprs as NamedExpression, e.g. (a+1) -> Alias(a+1)
             Set<NamedExpression> bottomProjects = context.pushDownToNamedExpression(toBePushedDown);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.util.StandardDateFormat;
 import com.google.common.base.Preconditions;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 /**
  * date time v2 literal for nereids
@@ -218,5 +219,20 @@ public class DateTimeV2Literal extends DateTimeLiteral {
                         dateTime.getMonthValue(), dateTime.getDayOfMonth(), dateTime.getHour(),
                         dateTime.getMinute(), dateTime.getSecond(),
                         (dateTime.getNano() / 1000) / value * value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DateTimeV2Literal literal = (DateTimeV2Literal) o;
+        return Objects.equals(dataType, literal.dataType);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -95,4 +95,19 @@ public class DecimalLiteral extends Literal {
                             precision, scale, realPrecision, realScale));
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DecimalLiteral literal = (DecimalLiteral) o;
+        return Objects.equals(dataType, literal.dataType);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -106,4 +106,19 @@ public class DecimalV3Literal extends Literal {
                             precision, scale, realPrecision, realScale));
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DecimalV3Literal literal = (DecimalV3Literal) o;
+        return Objects.equals(dataType, literal.dataType);
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -200,13 +200,13 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
 
         // decimal literal
         assertRewrite(new Cast(new TinyIntLiteral((byte) 1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal("1.000000000")));
+                new DecimalLiteral(DecimalV2Type.createDecimalV2Type(15, 9), new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new SmallIntLiteral((short) 1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal("1.000000000")));
+                new DecimalLiteral(DecimalV2Type.createDecimalV2Type(15, 9), new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new IntegerLiteral(1), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal("1.000000000")));
+                new DecimalLiteral(DecimalV2Type.createDecimalV2Type(15, 9), new BigDecimal("1.000000000")));
         assertRewrite(new Cast(new BigIntLiteral(1L), DecimalV2Type.createDecimalV2Type(15, 9)),
-                new DecimalLiteral(new BigDecimal("1.000000000")));
+                new DecimalLiteral(DecimalV2Type.createDecimalV2Type(15, 9), new BigDecimal("1.000000000")));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -426,32 +426,32 @@ class DateTimeLiteralTest {
     void testDateTimeV2Scale() {
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(3), "2016-07-02 00:00:00.123"),
-                new DateTimeV2Literal("2016-07-02 00:00:00.123"));
+                new DateTimeV2Literal(DateTimeV2Type.of(3), "2016-07-02 00:00:00.123"));
 
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(3), "2016-07-02 00:00:00.123456"),
-                new DateTimeV2Literal("2016-07-02 00:00:00.123"));
+                new DateTimeV2Literal(DateTimeV2Type.of(3), "2016-07-02 00:00:00.123"));
 
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(4), "2016-07-02 00:00:00.12345"),
-                new DateTimeV2Literal("2016-07-02 00:00:00.12345"));
+                new DateTimeV2Literal(DateTimeV2Type.of(4), "2016-07-02 00:00:00.1235"));
 
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(0), "2016-07-02 00:00:00.12345"),
-                new DateTimeV2Literal("2016-07-02 00:00:00.0"));
+                new DateTimeV2Literal(DateTimeV2Type.of(0), "2016-07-02 00:00:00"));
 
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(0), "2016-07-02 00:00:00.5123"),
-                new DateTimeV2Literal("2016-07-02 00:00:01.0"));
+                new DateTimeV2Literal(DateTimeV2Type.of(0), "2016-07-02 00:00:01"));
 
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(5), "2016-07-02 00:00:00.999999"),
-                new DateTimeV2Literal("2016-07-02 00:00:01.0"));
+                new DateTimeV2Literal(DateTimeV2Type.of(5), "2016-07-02 00:00:01.00000"));
 
         // test overflow
         Assertions.assertEquals(
                 new DateTimeV2Literal(DateTimeV2Type.of(5), "2016-12-31 23:59:59.999999"),
-                new DateTimeV2Literal("2017-01-01 00:00:00.0"));
+                new DateTimeV2Literal(DateTimeV2Type.of(5), "2017-01-01 00:00:00.00000"));
     }
 
     @Test


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/36055
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

