### PR TITLE
[fix](cloud) Fix replication_num properties when create table and MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -189,6 +189,7 @@ public class CreateTableStmt extends DdlStmt {
         this.partitionDesc = partitionDesc;
         this.distributionDesc = distributionDesc;
         this.properties = properties;
+        PropertyAnalyzer.getInstance().rewriteForceProperties(this.properties);
         this.extProperties = extProperties;
         this.columnDefs = Lists.newArrayList();
         this.comment = Strings.nullToEmpty(comment);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -166,6 +166,7 @@ public class CreateTableStmt extends DdlStmt {
         this.partitionDesc = partitionDesc;
         this.distributionDesc = distributionDesc;
         this.properties = properties;
+        PropertyAnalyzer.getInstance().rewriteForceProperties(this.properties);
         this.extProperties = extProperties;
         this.isExternal = isExternal;
         this.ifNotExists = ifNotExists;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -1474,6 +1474,9 @@ public class PropertyAnalyzer {
     }
 
     public void rewriteForceProperties(Map<String, String> properties) {
+        if (properties == null) {
+            return;
+        }
         forceProperties.forEach(property -> property.rewrite(properties));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -131,6 +131,7 @@ public class CreateTableInfo {
         this.distribution = distribution;
         this.rollups = Utils.copyRequiredList(rollups);
         this.properties = properties;
+        PropertyAnalyzer.getInstance().rewriteForceProperties(this.properties);
         this.extProperties = extProperties;
         this.clusterKeysColumnNames = Utils.copyRequiredList(clusterKeyColumnNames);
     }
@@ -161,6 +162,7 @@ public class CreateTableInfo {
         this.distribution = distribution;
         this.rollups = Utils.copyRequiredList(rollups);
         this.properties = properties;
+        PropertyAnalyzer.getInstance().rewriteForceProperties(this.properties);
         this.extProperties = extProperties;
         this.clusterKeysColumnNames = Utils.copyRequiredList(clusterKeyColumnNames);
     }

--- a/regression-test/suites/mtmv_p0/test_cloud_n_replicas_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_cloud_n_replicas_mtmv.groovy
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.Random;
+
+// This test is to test compatibility of property "replication_num" in cloud mode
+// it should be ignored
+suite("test_mtmv_n_replicas") {
+    def tableName = "mtmv_n_replicas_table"
+    def mvName = "mv_n_replicas"
+    def dbName = "regression_test_mtmv_p0"
+    def numReplicas = isCloudMode() ? new Random().nextInt(10) /* including 0 */ : 1
+
+    sql """ create database if not exists ${dbName}; """
+
+    sql """ drop table if exists ${dbName}.${tableName}; """
+    sql """
+        CREATE TABLE ${dbName}.${tableName} (
+        id INT,
+        name varchar(255),
+        score INT SUM
+        )
+        AGGREGATE KEY(id, name)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        properties ("replication_num" = "${numReplicas}")
+        """
+
+    sql """ insert into ${dbName}.${tableName} (id, name, score) values (1, "aaa", 11); """
+    sql """ insert into ${dbName}.${tableName} (id, name, score) values (1, "aaa", 11); """
+    sql """ insert into ${dbName}.${tableName} (id, name, score) values (2, "aaa", 12); """
+    sql """ insert into ${dbName}.${tableName} (id, name, score) values (2, "aaa", 12); """
+
+    sql """ drop materialized view if exists ${dbName}.${mvName}; """
+    sql """
+        create materialized view ${dbName}.${mvName}
+        build immediate refresh complete on manual distributed by random buckets 15
+        properties ("replication_num" = "${numReplicas}")
+        as select name,id,score from ${dbName}.${tableName};
+        """
+
+    sql """ refresh materialized view ${dbName}.${mvName} complete; """
+
+    def n = 100
+    while (n > 0) {
+        n = n - 1
+        sleep(1000)
+        def result = sql_return_maparray """ select * from ${dbName}.${mvName} """
+        logger.info("result: ${result}")
+        if (result.size() == 2) {
+            // [score:22, name:aaa, id:1], [score:24, name:aaa, id:2]
+            assertEquals(result[0].id, 1)
+            assertEquals(result[0].name, "aaa")
+            assertEquals(result[0].score, 22)
+            assertEquals(result[1].id, 2)
+            assertEquals(result[1].name, "aaa")
+            assertEquals(result[1].score, 24)
+            break;
+        } else if (n < 0) {
+            assertEquals(result.size(), 2)
+        }
+    }
+}


### PR DESCRIPTION
The properties rewrite policy is not applied for CreateTableStmt and CreateMTMVStmt because the `analyze()` of CreateTableStmt is not called when executed by nereids.

There are some properties, e.g. replication_num, are not correctly processed in cloud mode, which will cause the following error

```
2024-06-09 02:30:42,602 WARN (mtmv-task-execute-1-thread-1|139) [OlapInsertExecutor.onFail():218] insert [label_87cd2cb386774f4a_a14a00e9c7d93a51] with query id 87cd2cb386774f4a-a14a00e9c7d93a51 failed
org.apache.doris.nereids.exceptions.AnalysisException: errCode = 3, detailMessage = tablet 469525 alive replica num 1 < load required replica num 2, alive backends: [10002], detail: Visible Replicas:Visible version: 1, Replicas: [replicaId=469526, backendId=-1, backend=null, version=1, state=NORMAL]. or you may not have permission to access the current cluster = gavin_cluster_name0
        at org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutor.finalizeSink(OlapInsertExecutor.java:152) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.initPlan(InsertIntoTableCommand.java:200) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.runInternal(InsertIntoTableCommand.java:219) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.run(InsertIntoTableCommand.java:103) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.runInsertCommand(InsertOverwriteTableCommand.java:185) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.insertInto(InsertOverwriteTableCommand.java:235) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.run(InsertOverwriteTableCommand.java:164) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.exec(MTMVTask.java:235) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.run(MTMVTask.java:200) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.task.AbstractTask.runTask(AbstractTask.java:167) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.runTask(MTMVTask.java:310) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:50) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:33) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.lmax.disruptor.WorkProcessor.run(WorkProcessor.java:143) ~[disruptor-3.4.4.jar:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.doris.common.UserException: errCode = 3, detailMessage = tablet 469525 alive replica num 1 < load required replica num 2, alive backends: [10002], detail: Visible Replicas:Visible version: 1, Replicas: [replicaId=469526, backendId=-1, backend=null, version=1, state=NORMAL]. or you may not have permission to access the current cluster = gavin_cluster_name0
        at org.apache.doris.planner.OlapTableSink.createLocation(OlapTableSink.java:642) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.OlapTableSink.complete(OlapTableSink.java:226) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutor.finalizeSink(OlapInsertExecutor.java:126) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 14 more
```