### PR TITLE
[Improvementation](runtime-filter) do not sync filter size when rf has local target

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1769,7 +1769,7 @@ RuntimeFilterType IRuntimeFilter::get_real_type() {
 bool IRuntimeFilter::need_sync_filter_size() {
     return (type() == RuntimeFilterType::IN_OR_BLOOM_FILTER ||
             type() == RuntimeFilterType::BLOOM_FILTER) &&
-           _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
+           _wrapper->get_build_bf_cardinality() && !_is_broadcast_join && _has_remote_target;
 }
 
 Status IRuntimeFilter::update_filter(const UpdateRuntimeFilterParams* param) {


### PR DESCRIPTION
## Proposed changes
do not sync filter size when rf has local target