### PR TITLE
[ub](pod array) fix  applying non-zero offset 16 to null pointer

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -445,7 +445,8 @@ public:
       */
     template <typename... Args>
     void emplace_back(Args&&... args) {
-        if (UNLIKELY(this->c_end + sizeof(T) > this->c_end_of_storage)) {
+        if (UNLIKELY(this->c_end == nullptr ||
+                     (this->c_end + sizeof(T) > this->c_end_of_storage))) {
             this->reserve_for_next_size();
         }
 


### PR DESCRIPTION
## Proposed changes

```
/root/doris/be/src/vec/common/pod_array.h:448:13: runtime error: applying non-zero offset 16 to null pointer
    #0 0x562f904159f3 in void doris::vectorized::PODArray<doris::vectorized::AggregateFunctionSequenceMatchData<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long, doris::vectorized::AggregateFunctionSequenceMatch<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long> >::PatternAction, 64ul, AllocatorWithStackMemory<Allocator<false, false, false>, 64ul, 8ul>, 0ul, 0ul>::emplace_back<doris::vectorized::AggregateFunctionSequenceMatchData<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long, doris::vectorized::AggregateFunctionSequenceMatch<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long> >::PatternActionType>(doris::vectorized::AggregateFunctionSequenceMatchData<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long, doris::vectorized::AggregateFunctionSequenceMatch<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long> >::PatternActionType&&) /root/doris/be/src/vec/common/pod_array.h:448:13
    #1 0x562f90412d6a in doris::vectorized::AggregateFunctionSequenceMatchData<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long, doris::vectorized::AggregateFunctionSequenceMatch<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long> >::parse_pattern() /root/doris/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h:208:17
    #2 0x562f9040a824 in doris::vectorized::AggregateFunctionSequenceMatchData<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long, doris::vectorized::AggregateFunctionSequenceMatch<doris::DateV2Value<doris::DateTimeV2ValueType>, unsigned long> >::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long) /root/doris/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h:95:13
```

this->c_end may be nullptr 

<!--Describe your changes.-->

