### PR TITLE
[fix](snappy) avoid potential buffer overflow (#35537)

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -625,7 +625,7 @@ public:
     // REQUIRES: Available() >= n
     void Skip(size_t n) override {
         _available -= n;
-        do {
+        while (n > 0) {
             auto left = _slices[_cur_slice].size - _slice_off;
             if (left > n) {
                 // n can be digest in current slice
@@ -635,7 +635,7 @@ public:
             _slice_off = 0;
             _cur_slice++;
             n -= left;
-        } while (n > 0);
+        }
     }
 
 private:


### PR DESCRIPTION
pick #35537

If skip more than once when available is zero, then a buffer overflow occurs.

![photo-size-5-6244711526321733357-y](https://github.com/apache/doris/assets/98214048/b0bb9c79-df22-4582-8e7a-1a214e9b69bb)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

