### PR TITLE
[enhance](Vault) Refresh default storage vault info when doing instance check in FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudInstanceStatusChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudInstanceStatusChecker.java
@@ -17,9 +17,11 @@
 
 package org.apache.doris.cloud.catalog;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.MasterDaemon;
 
 import org.apache.logging.log4j.LogManager;
@@ -47,6 +49,9 @@ public class CloudInstanceStatusChecker extends MasterDaemon {
                         + "cloud_unique_id={}, response={}", Config.cloud_unique_id, response);
             } else {
                 cloudSystemInfoService.setInstanceStatus(response.getInstance().getStatus());
+                Env.getCurrentEnv().getStorageVaultMgr().setDefaultStorageVault(
+                        Pair.of(response.getInstance().getDefaultStorageVaultName(),
+                                response.getInstance().getDefaultStorageVaultId()));
             }
         } catch (Exception e) {
             LOG.warn("get instance from ms exception", e);


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Previously the default vault info would only be refreshed when user tries to set default storage vault. The default vault info might be lost if the FE crashed and restarted. This pr tries to add one routine work which would refresh the default vault info.