### PR TITLE
[opt](split) close the batch mode of file split in default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1493,7 +1493,7 @@ public class SessionVariable implements Serializable, Writable {
             description = {"如果分区数量超过阈值，BE将通过batch方式获取scan ranges",
                     "If the number of partitions exceeds the threshold, scan ranges will be got through batch mode."},
             needForward = true)
-    public int numPartitionsInBatchMode = 1024;
+    public int numPartitionsInBatchMode = -1;
 
     @VariableMgr.VarAttr(
             name = ENABLE_PARQUET_LAZY_MAT,


### PR DESCRIPTION
## Proposed changes

follow https://github.com/apache/doris/pull/34032, close the batch mode of file split in default. It's not stable currently.

