### PR TITLE
[feature](statistics)Fallback to sample analyze when one partition contains too many rows.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -510,6 +510,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String HUGE_TABLE_DEFAULT_SAMPLE_ROWS = "huge_table_default_sample_rows";
     public static final String HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES = "huge_table_lower_bound_size_in_bytes";
+    public static final String HUGE_PARTITION_LOWER_BOUND_ROWS = "huge_partition_lower_bound_rows";
+
 
     // for spill to disk
     public static final String EXTERNAL_SORT_BYTES_THRESHOLD = "external_sort_bytes_threshold";
@@ -1689,6 +1691,12 @@ public class SessionVariable implements Serializable, Writable {
                             + "larger than this value will automatically collect "
                             + "statistics through sampling"})
     public long hugeTableLowerBoundSizeInBytes = 0;
+
+    @VariableMgr.VarAttr(name = HUGE_PARTITION_LOWER_BOUND_ROWS, flag = VariableMgr.GLOBAL,
+            description = {
+                "行数超过该值的分区将跳过自动分区收集",
+                "This defines the lower size bound for large partitions, which will skip auto partition analyze."})
+    public long hugePartitionLowerBoundRows = 100000000L;
 
     @VariableMgr.VarAttr(name = HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS, flag = VariableMgr.GLOBAL,
             description = {"控制对大表的自动ANALYZE的最小时间间隔，"

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -32,6 +32,7 @@ import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.util.DBObjects;
 import org.apache.doris.statistics.util.StatisticsUtil;
@@ -254,6 +255,8 @@ public abstract class BaseAnalysisTask {
 
     public abstract void doExecute() throws Exception;
 
+    protected abstract void doSample() throws Exception;
+
     protected void afterExecution() {}
 
     protected void setTaskStateToRunning() {
@@ -352,6 +355,7 @@ public abstract class BaseAnalysisTask {
      * 2. Get stats of each partition
      * 3. insert partition in batch
      * 4. calculate column stats based on partition stats
+     * 5. Skip large partition and fallback to sample analyze if large partition exists.
      */
     protected void doPartitionTable() throws Exception {
         deleteNotExistPartitionStats();
@@ -362,24 +366,35 @@ public abstract class BaseAnalysisTask {
         int count = 0;
         AnalysisManager analysisManager = Env.getServingEnv().getAnalysisManager();
         TableStatsMeta tableStatsStatus = analysisManager.findTableStatsStatus(tbl.getId());
+        String idxName = info.indexId == -1 ? tbl.getName() : ((OlapTable) tbl).getIndexNameById(info.indexId);
+        ColStatsMeta columnStatsMeta = tableStatsStatus == null
+                ? null : tableStatsStatus.findColumnStatsMeta(idxName, col.getName());
+        boolean hasHughPartition = false;
+        long hugePartitionThreshold = StatisticsUtil.getHugePartitionLowerBoundRows();
+        // Find jobInfo for this task.
+        AnalysisInfo jobInfo = analysisManager.findJobInfo(job.getJobInfo().jobId);
+        // For sync job, get jobInfo from job.jobInfo.
+        boolean isSync = jobInfo == null;
+        jobInfo = isSync ? job.jobInfo : jobInfo;
         for (String part : partitionNames) {
+            // External table partition is null.
             Partition partition = tbl.getPartition(part);
-            params.put("partId", partition == null ? "-1" : String.valueOf(partition.getId()));
             if (partition != null) {
+                // For huge partition, skip analyze it.
+                if (partition.getBaseIndex().getRowCount() > hugePartitionThreshold) {
+                    hasHughPartition = true;
+                    LOG.info("Partition {} in table {} is too large, skip it.", part, tbl.getName());
+                    continue;
+                }
                 // For cluster upgrade compatible (older version metadata doesn't have partition update rows map)
                 // and insert before first analyze, set partition update rows to 0.
-                //
-                // findJobInfo will return null when doing sync analyzing.
-                AnalysisInfo jobInfo = analysisManager.findJobInfo(job.getJobInfo().jobId);
-                jobInfo = jobInfo == null ? job.jobInfo : jobInfo;
                 jobInfo.partitionUpdateRows.putIfAbsent(partition.getId(), 0L);
             }
+            params.put("partId", partition == null ? "-1" : String.valueOf(partition.getId()));
             // Skip partitions that not changed after last analyze.
             // External table getPartition always return null. So external table doesn't skip any partitions.
             if (partition != null && tableStatsStatus != null && tableStatsStatus.partitionUpdateRows != null) {
                 ConcurrentMap<Long, Long> tableUpdateRows = tableStatsStatus.partitionUpdateRows;
-                String idxName = info.indexId == -1 ? tbl.getName() : ((OlapTable) tbl).getIndexNameById(info.indexId);
-                ColStatsMeta columnStatsMeta = tableStatsStatus.findColumnStatsMeta(idxName, col.getName());
                 if (columnStatsMeta != null && columnStatsMeta.partitionUpdateRows != null) {
                     ConcurrentMap<Long, Long> columnUpdateRows = columnStatsMeta.partitionUpdateRows;
                     long id = partition.getId();
@@ -408,11 +423,23 @@ public abstract class BaseAnalysisTask {
                     + Joiner.on(" UNION ALL ").join(sqls);
             runInsert(sql);
         }
-        params = buildSqlParams();
-        params.put("min", castToNumeric("min"));
-        params.put("max", castToNumeric("max"));
-        StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
-        runQuery(stringSubstitutor.replace(MERGE_PARTITION_TEMPLATE));
+        if (hasHughPartition) {
+            tableSample = new TableSample(false, StatisticsUtil.getHugeTableSampleRows());
+            if (!isSync) {
+                jobInfo = new AnalysisInfoBuilder(jobInfo).setAnalysisMethod(AnalysisMethod.SAMPLE).build();
+                analysisManager.replayCreateAnalysisJob(jobInfo);
+            }
+            if (tableStatsStatus == null || columnStatsMeta == null
+                    || tableStatsStatus.updatedRows.get() > columnStatsMeta.updatedRows) {
+                doSample();
+            }
+        } else {
+            params = buildSqlParams();
+            params.put("min", castToNumeric("min"));
+            params.put("max", castToNumeric("max"));
+            StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
+            runQuery(stringSubstitutor.replace(MERGE_PARTITION_TEMPLATE));
+        }
     }
 
     protected abstract void deleteNotExistPartitionStats() throws DdlException;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -75,6 +75,10 @@ public class HistogramTask extends BaseAnalysisTask {
     }
 
     @Override
+    protected void doSample() {
+    }
+
+    @Override
     protected void deleteNotExistPartitionStats() throws DdlException {
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -91,6 +91,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
      * 2. estimate partition stats
      * 3. insert col stats and partition stats
      */
+    @Override
     protected void doSample() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Will do sample collection for column {}", col.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -88,6 +88,7 @@ public class StatisticConstants {
 
     public static final long HUGE_TABLE_DEFAULT_SAMPLE_ROWS = 4194304;
     public static final long HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES = 0;
+    public static final long HUGE_PARTITION_LOWER_BOUND_ROWS = 100000000L;
 
     public static final long HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS = TimeUnit.HOURS.toMillis(0);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -863,6 +863,16 @@ public class StatisticsUtil {
         return StatisticConstants.HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES;
     }
 
+    public static long getHugePartitionLowerBoundRows() {
+        try {
+            return findConfigFromGlobalSessionVar(SessionVariable.HUGE_PARTITION_LOWER_BOUND_ROWS)
+                .hugePartitionLowerBoundRows;
+        } catch (Exception e) {
+            LOG.warn("Failed to get value of huge_partition_lower_bound_rows, return default", e);
+        }
+        return StatisticConstants.HUGE_PARTITION_LOWER_BOUND_ROWS;
+    }
+
     public static long getHugeTableAutoAnalyzeIntervalInMillis() {
         try {
             return findConfigFromGlobalSessionVar(SessionVariable.HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS)

--- a/regression-test/suites/statistics/test_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_partition_stats.groovy
@@ -186,7 +186,7 @@ suite("test_partition_stats") {
     sql """drop database if exists test_partition_stats"""
     sql """create database test_partition_stats"""
     sql """use test_partition_stats"""
-    sql """CREATE TABLE `part` (
+    sql """CREATE TABLE `part2` (
         `id` INT NULL,
         `colint` INT NULL,
         `coltinyint` tinyint NULL,
@@ -210,10 +210,10 @@ suite("test_partition_stats") {
         "replication_allocation" = "tag.location.default: 1"
     )
     """
-    sql """analyze table part with sync;"""
-    sql """Insert into part values (1, 1, 1, 1, 1, 1, 1.1, 1.1, 1.1), (2, 2, 2, 2, 2, 2, 2.2, 2.2, 2.2), (3, 3, 3, 3, 3, 3, 3.3, 3.3, 3.3),(4, 4, 4, 4, 4, 4, 4.4, 4.4, 4.4),(5, 5, 5, 5, 5, 5, 5.5, 5.5, 5.5),(6, 6, 6, 6, 6, 6, 6.6, 6.6, 6.6),(10001, 10001, 10001, 10001, 10001, 10001, 10001.10001, 10001.10001, 10001.10001),(10002, 10002, 10002, 10002, 10002, 10002, 10002.10002, 10002.10002, 10002.10002),(10003, 10003, 10003, 10003, 10003, 10003, 10003.10003, 10003.10003, 10003.10003),(10004, 10004, 10004, 10004, 10004, 10004, 10004.10004, 10004.10004, 10004.10004),(10005, 10005, 10005, 10005, 10005, 10005, 10005.10005, 10005.10005, 10005.10005),(10006, 10006, 10006, 10006, 10006, 10006, 10006.10006, 10006.10006, 10006.10006),(20001, 20001, 20001, 20001, 20001, 20001, 20001.20001, 20001.20001, 20001.20001),(20002, 20002, 20002, 20002, 20002, 20002, 20002.20002, 20002.20002, 20002.20002),(20003, 20003, 20003, 20003, 20003, 20003, 20003.20003, 20003.20003, 20003.20003),(20004, 20004, 20004, 20004, 20004, 20004, 20004.20004, 20004.20004, 20004.20004),(20005, 20005, 20005, 20005, 20005, 20005, 20005.20005, 20005.20005, 20005.20005),(20006, 20006, 20006, 20006, 20006, 20006, 20006.20006, 20006.20006, 20006.20006)"""
-    sql """analyze table part with sync;"""
-    result = sql """show column stats part"""
+    sql """analyze table part2 with sync;"""
+    sql """Insert into part2 values (1, 1, 1, 1, 1, 1, 1.1, 1.1, 1.1), (2, 2, 2, 2, 2, 2, 2.2, 2.2, 2.2), (3, 3, 3, 3, 3, 3, 3.3, 3.3, 3.3),(4, 4, 4, 4, 4, 4, 4.4, 4.4, 4.4),(5, 5, 5, 5, 5, 5, 5.5, 5.5, 5.5),(6, 6, 6, 6, 6, 6, 6.6, 6.6, 6.6),(10001, 10001, 10001, 10001, 10001, 10001, 10001.10001, 10001.10001, 10001.10001),(10002, 10002, 10002, 10002, 10002, 10002, 10002.10002, 10002.10002, 10002.10002),(10003, 10003, 10003, 10003, 10003, 10003, 10003.10003, 10003.10003, 10003.10003),(10004, 10004, 10004, 10004, 10004, 10004, 10004.10004, 10004.10004, 10004.10004),(10005, 10005, 10005, 10005, 10005, 10005, 10005.10005, 10005.10005, 10005.10005),(10006, 10006, 10006, 10006, 10006, 10006, 10006.10006, 10006.10006, 10006.10006),(20001, 20001, 20001, 20001, 20001, 20001, 20001.20001, 20001.20001, 20001.20001),(20002, 20002, 20002, 20002, 20002, 20002, 20002.20002, 20002.20002, 20002.20002),(20003, 20003, 20003, 20003, 20003, 20003, 20003.20003, 20003.20003, 20003.20003),(20004, 20004, 20004, 20004, 20004, 20004, 20004.20004, 20004.20004, 20004.20004),(20005, 20005, 20005, 20005, 20005, 20005, 20005.20005, 20005.20005, 20005.20005),(20006, 20006, 20006, 20006, 20006, 20006, 20006.20006, 20006.20006, 20006.20006)"""
+    sql """analyze table part2 with sync;"""
+    result = sql """show column stats part2"""
     assertEquals(9, result.size())
     assertEquals("18.0", result[0][2])
     assertEquals("18.0", result[1][2])
@@ -224,23 +224,23 @@ suite("test_partition_stats") {
     assertEquals("18.0", result[6][2])
     assertEquals("18.0", result[7][2])
     assertEquals("18.0", result[8][2])
-    result = sql """show column stats part partition(*)"""
+    result = sql """show column stats part2 partition(*)"""
     assertEquals(27, result.size())
-    sql """alter table part drop partition p3"""
-    result = sql """show table stats part"""
+    sql """alter table part2 drop partition p3"""
+    result = sql """show table stats part2"""
     assertEquals("true", result[0][6])
-    sql """analyze table part with sync;"""
-    result = sql """show table stats part"""
+    sql """analyze table part2 with sync;"""
+    result = sql """show table stats part2"""
     assertEquals("false", result[0][6])
-    result = sql """show column stats part partition(*)"""
+    result = sql """show column stats part2 partition(*)"""
     assertEquals(18, result.size())
-    result = sql """show column stats part partition(p3)"""
+    result = sql """show column stats part2 partition(p3)"""
     assertEquals(0, result.size())
-    result = sql """show column stats part partition(p1)"""
+    result = sql """show column stats part2 partition(p1)"""
     assertEquals(9, result.size())
-    result = sql """show column stats part partition(p2)"""
+    result = sql """show column stats part2 partition(p2)"""
     assertEquals(9, result.size())
-    result = sql """show column stats part"""
+    result = sql """show column stats part2"""
     assertEquals(9, result.size())
     assertEquals("12.0", result[0][2])
     assertEquals("12.0", result[1][2])
@@ -251,6 +251,64 @@ suite("test_partition_stats") {
     assertEquals("12.0", result[6][2])
     assertEquals("12.0", result[7][2])
     assertEquals("12.0", result[8][2])
+
+    // Test skip big partitions and fallback to sample analyze
+    sql """CREATE TABLE `part3` (
+        `id` INT NULL,
+        `colint` INT NULL,
+        `coltinyint` tinyint NULL,
+        `colsmallint` smallINT NULL,
+        `colbigint` bigINT NULL,
+        `collargeint` largeINT NULL,
+        `colfloat` float NULL,
+        `coldouble` double NULL,
+        `coldecimal` decimal(27, 9) NULL
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`id`)
+    COMMENT 'OLAP'
+    PARTITION BY RANGE(`id`)
+    (
+        PARTITION p1 VALUES [("-2147483648"), ("10000")),
+        PARTITION p2 VALUES [("10000"), ("20000")),
+        PARTITION p3 VALUES [("20000"), ("30000"))
+    )
+    DISTRIBUTED BY HASH(`id`) BUCKETS 3
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    )
+    """
+    sql """Insert into part3 values (1, 1, 1, 1, 1, 1, 1.1, 1.1, 1.1), (2, 2, 2, 2, 2, 2, 2.2, 2.2, 2.2), (3, 3, 3, 3, 3, 3, 3.3, 3.3, 3.3),(4, 4, 4, 4, 4, 4, 4.4, 4.4, 4.4),(5, 5, 5, 5, 5, 5, 5.5, 5.5, 5.5),(6, 6, 6, 6, 6, 6, 6.6, 6.6, 6.6),(1, 1, 1, 1, 1, 1, 1.1, 1.1, 1.1), (2, 2, 2, 2, 2, 2, 2.2, 2.2, 2.2), (3, 3, 3, 3, 3, 3, 3.3, 3.3, 3.3),(4, 4, 4, 4, 4, 4, 4.4, 4.4, 4.4),(5, 5, 5, 5, 5, 5, 5.5, 5.5, 5.5),(6, 6, 6, 6, 6, 6, 6.6, 6.6, 6.6),(10001, 10001, 10001, 10001, 10001, 10001, 10001.10001, 10001.10001, 10001.10001),(10002, 10002, 10002, 10002, 10002, 10002, 10002.10002, 10002.10002, 10002.10002),(10003, 10003, 10003, 10003, 10003, 10003, 10003.10003, 10003.10003, 10003.10003),(10004, 10004, 10004, 10004, 10004, 10004, 10004.10004, 10004.10004, 10004.10004),(10005, 10005, 10005, 10005, 10005, 10005, 10005.10005, 10005.10005, 10005.10005),(10006, 10006, 10006, 10006, 10006, 10006, 10006.10006, 10006.10006, 10006.10006),(20001, 20001, 20001, 20001, 20001, 20001, 20001.20001, 20001.20001, 20001.20001),(20002, 20002, 20002, 20002, 20002, 20002, 20002.20002, 20002.20002, 20002.20002),(20003, 20003, 20003, 20003, 20003, 20003, 20003.20003, 20003.20003, 20003.20003),(20004, 20004, 20004, 20004, 20004, 20004, 20004.20004, 20004.20004, 20004.20004),(20005, 20005, 20005, 20005, 20005, 20005, 20005.20005, 20005.20005, 20005.20005),(20006, 20006, 20006, 20006, 20006, 20006, 20006.20006, 20006.20006, 20006.20006)"""
+    wait_row_count_reported("test_partition_stats", "part3", 0, 4, "24")
+    result = sql """show tablets from part3"""
+    logger.info("tablets: " + result)
+    sql """set global huge_partition_lower_bound_rows = 10"""
+    result = sql """ show variables like \"huge_partition_lower_bound_rows\""""
+    logger.info("huge partition bound: " + result)
+    sql """analyze table part3 with sync;"""
+    result = sql """show column stats part3"""
+    logger.info("column result" + result)
+    assertEquals(9, result.size())
+    assertEquals("24.0", result[0][2])
+    assertEquals("24.0", result[1][2])
+    assertEquals("24.0", result[2][2])
+    assertEquals("24.0", result[3][2])
+    assertEquals("24.0", result[4][2])
+    assertEquals("24.0", result[5][2])
+    assertEquals("24.0", result[6][2])
+    assertEquals("24.0", result[7][2])
+    assertEquals("24.0", result[8][2])
+    result = sql """show column stats part3 partition(*)"""
+    logger.info("partition result" + result)
+    assertEquals(18, result.size())
+    result = sql """show column stats part3 partition(p1)"""
+    assertEquals(0, result.size())
+
+    sql """set global huge_partition_lower_bound_rows = 100000000"""
+    sql """analyze table part3 with sync;"""
+    result = sql """show column stats part3 partition(*)"""
+    assertEquals(27, result.size())
+    result = sql """show column stats part3 partition(p1)"""
+    assertEquals(9, result.size())
 
     sql """drop database test_partition_stats"""
 }


### PR DESCRIPTION
Fallback to sample analyze when one partition contains too many rows.
Partition level stats are collected by full scan of each partition, when a single partition contains too much data, it may consume too much BE io/cpu resource. This pr is to set a threshold for single partition, when the row count of a partition is more than the threshold, skip collect it and collect the table level stats in sample way.