### PR TITLE
[branch-2.1](test) fix some tests in external p0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTableSinkCreator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTableSinkCreator.java
@@ -105,9 +105,6 @@ public class UnboundTableSinkCreator {
                     isPartialUpdate, dmlCommandType, Optional.empty(),
                     Optional.empty(), plan);
         } else if (curCatalog instanceof HMSExternalCatalog && !isAutoDetectPartition) {
-            if (!partitions.isEmpty()) {
-                throw new AnalysisException("Not support insert with partition spec in hive catalog.");
-            }
             return new UnboundHiveTableSink<>(nameParts, colNames, hints, partitions,
                     dmlCommandType, Optional.empty(), Optional.empty(), plan);
         } else if (curCatalog instanceof IcebergExternalCatalog && !isAutoDetectPartition) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -391,6 +391,10 @@ public class BindSink implements AnalysisRuleFactory {
         HMSExternalTable table = pair.second;
         LogicalPlan child = ((LogicalPlan) sink.child());
 
+        if (!sink.getPartitions().isEmpty()) {
+            throw new AnalysisException("Not support insert with partition spec in hive catalog.");
+        }
+
         List<Column> bindColumns;
         if (sink.getColNames().isEmpty()) {
             bindColumns = table.getBaseSchema(true).stream().collect(ImmutableList.toImmutableList());
@@ -399,7 +403,7 @@ public class BindSink implements AnalysisRuleFactory {
                 Column column = table.getColumn(cn);
                 if (column == null) {
                     throw new AnalysisException(String.format("column %s is not found in table %s",
-                        cn, table.getName()));
+                            cn, table.getName()));
                 }
                 return column;
             }).collect(ImmutableList.toImmutableList());

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
@@ -393,6 +393,7 @@ suite("test_hive_write_insert", "p0,external,hive,external_docker,external_docke
 
         logger.info("hive sql: " + """ truncate table all_types_${format_compression}; """)
         hive_docker """ truncate table all_types_${format_compression}; """
+        sql """refresh catalog ${catalog_name};"""
         order_qt_q06 """ select * from all_types_${format_compression};
         """
     }
@@ -444,6 +445,7 @@ suite("test_hive_write_insert", "p0,external,hive,external_docker,external_docke
 
         logger.info("hive sql: " + """ truncate table all_types_${format_compression}; """)
         hive_docker """ truncate table all_types_${format_compression}; """
+        sql """refresh catalog ${catalog_name};"""
         order_qt_q05 """
         select * from all_types_${format_compression};
         """

--- a/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
@@ -23,6 +23,7 @@ suite("test_external_catalog_hive", "p2,external,hive,external_remote,external_r
         String extHiveHmsPort = context.config.otherConfigs.get("extHiveHmsPort")
         String catalog_name = "test_external_catalog_hive"
 
+        sql """set enable_fallback_to_original_planner=false"""
         sql """drop catalog if exists ${catalog_name};"""
 
         sql """
@@ -47,7 +48,7 @@ suite("test_external_catalog_hive", "p2,external,hive,external_remote,external_r
         sql """switch ${catalog_name};"""
         // test small table(text format)
         def q01 = {
-            qt_q01 """ select name, count(1) as c from student group by name order by c desc;"""
+            qt_q01 """ select name, count(1) as c from student group by name order by name desc;"""
             qt_q02 """ select lo_orderkey, count(1) as c from lineorder group by lo_orderkey order by lo_orderkey asc;"""
             qt_q03 """ select * from test1 order by col_1;"""
             qt_q04 """ select * from string_table order by p_partkey desc;"""
@@ -148,7 +149,7 @@ suite("test_external_catalog_hive", "p2,external,hive,external_remote,external_r
                     'type'='hms',
                     'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}',
                     'access_controller.properties.ranger.service.name' = 'hive_wrong',
-                    'access_controller.class' = 'org.apache.doris.catalog.authorizer.RangerHiveAccessControllerFactory'
+                    'access_controller.class' = 'org.apache.doris.catalog.authorizer.ranger.hive.RangerHiveAccessControllerFactory'
                 );
             """
             exception "Failed to init access controller: bound must be positive"


### PR DESCRIPTION
Also move the analysis exception of "Not support insert with partition spec in hive catalog."
from create sink phase to bind sink phase.
So that when `set enable_fallback_to_original_planner=false;`, the return error will be correct.

master: #36149