### PR TITLE
[fix](nullfs) fs is null when a resource is deleted for cooldown

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -494,7 +494,7 @@ void BetaRowset::clear_cache() {
     clear_inverted_index_cache();
 
     auto fs = _rowset_meta->fs();
-    for (int i = 0; i < num_segments(); ++i) {
+    for (int i = 0; i < num_segments() && fs != nullptr; ++i) {
         auto seg_path = segment_file_path(i);
         if (fs->type() != io::FileSystemType::LOCAL) {
             auto cache_path = segment_cache_path(i);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

