### PR TITLE
[Bug](function) fix yearweek function get wrong result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -704,7 +704,7 @@ public class DateTimeExtractAndTransform {
                 // mode 2 is start with a Sunday day as first week in this year.
                 // and special case for 0000-01-01, as it's SATURDAY, calculate result of 52 is
                 // last year, so it's meaningless.
-                if (localDateTime.equals(LocalDateTime.of(0, 1, 1, 0, 0))) {
+                if (checkIsSpecificDate(localDateTime)) {
                     return new TinyIntLiteral((byte) 1);
                 }
                 return new TinyIntLiteral(
@@ -767,9 +767,15 @@ public class DateTimeExtractAndTransform {
         return yearWeek(dateTime.toJavaDateType(), 0);
     }
 
-    private static Expression yearWeek(LocalDateTime localDateTime, int mode) {
+    /**
+     * the impl of function yearWeek(date/datetime, mode)
+     */
+    public static Expression yearWeek(LocalDateTime localDateTime, int mode) {
         switch (mode) {
             case 0: {
+                if (checkIsSpecificDate(localDateTime)) {
+                    return new IntegerLiteral(1);
+                }
                 return new IntegerLiteral(
                         localDateTime.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekBasedYear()) * 100
                                 + localDateTime.get(
@@ -780,6 +786,9 @@ public class DateTimeExtractAndTransform {
                         + localDateTime.get(WeekFields.ISO.weekOfWeekBasedYear()));
             }
             case 2: {
+                if (checkIsSpecificDate(localDateTime)) {
+                    return new IntegerLiteral(1);
+                }
                 return new IntegerLiteral(
                         localDateTime.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekBasedYear()) * 100
                                 + localDateTime.get(
@@ -818,6 +827,13 @@ public class DateTimeExtractAndTransform {
                         String.format("unknown mode %d in week function", mode));
             }
         }
+    }
+
+    /**
+     * 0000-01-01 is specific date, sometime need handle it alone.
+     */
+    private static boolean checkIsSpecificDate(LocalDateTime localDateTime) {
+        return localDateTime.getYear() == 0 && localDateTime.getMonthValue() == 1 && localDateTime.getDayOfMonth() == 1;
     }
 
     @ExecFunction(name = "weekofyear", argTypes = {"DATETIMEV2"}, returnType = "TINYINT")

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/DateTimeExtractAndTransformTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeExtractAndTransform;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 
 import org.junit.jupiter.api.Assertions;
@@ -39,5 +40,20 @@ class DateTimeExtractAndTransformTest {
         Assertions.assertEquals(new TinyIntLiteral((byte) 52), DateTimeExtractAndTransform.week(localDateTime4, 2));
         LocalDateTime localDateTime5 = localDateTime4.plusDays(1);
         Assertions.assertEquals(new TinyIntLiteral((byte) 53), DateTimeExtractAndTransform.week(localDateTime5, 2));
+    }
+
+    @Test
+    void testYearWeekMode2Function() {
+        LocalDateTime localDateTime = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);
+        Assertions.assertEquals(new IntegerLiteral(1), DateTimeExtractAndTransform.yearWeek(localDateTime, 2));
+        LocalDateTime localDateTime2 = localDateTime.plusDays(1);
+        Assertions.assertEquals(new IntegerLiteral(1), DateTimeExtractAndTransform.yearWeek(localDateTime2, 2));
+        LocalDateTime localDateTime3 = LocalDateTime.of(0, 1, 9, 0, 0, 0, 0);
+        Assertions.assertEquals(new IntegerLiteral(2), DateTimeExtractAndTransform.yearWeek(localDateTime3, 2));
+
+        LocalDateTime localDateTime4 = LocalDateTime.of(0, 12, 30, 0, 0, 0, 0);
+        Assertions.assertEquals(new IntegerLiteral(52), DateTimeExtractAndTransform.yearWeek(localDateTime4, 2));
+        LocalDateTime localDateTime5 = localDateTime4.plusDays(1);
+        Assertions.assertEquals(new IntegerLiteral(53), DateTimeExtractAndTransform.yearWeek(localDateTime5, 2));
     }
 }


### PR DESCRIPTION
## Proposed changes
before:
```
mysql [(none)]>select yearweek(cast('0000-01-01-00:00:00.00001' as DATETIMEV2(5)), cast(2 as INT));
+------------------------------------------------------------------------------+
| yearweek(cast('0000-01-01-00:00:00.00001' as DATETIMEV2(5)), cast(2 as INT)) |
+------------------------------------------------------------------------------+
|                                                                          -48 |
+------------------------------------------------------------------------------+
```
but it's should return 1 as result,
and special case for 0000-01-01, calculate result of -48 is last year, so it's meaningless.

<!--Describe your changes.-->

