### PR TITLE
[fix](eq_for_null) Fix eq_for_null when both column is NOT only_null

### DIFF
--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -73,6 +73,9 @@ public:
         const bool right_const = is_column_const(*col_right.column);
         bool left_only_null = col_left.column->only_null();
         bool right_only_null = col_right.column->only_null();
+        std::cerr << "left_only_null: " << left_only_null
+                  << ", right_only_null: " << right_only_null << ", left const: " << left_const
+                  << ", right const: " << right_const << std::endl;
         if (left_only_null && right_only_null) {
             // TODO: return ColumnConst after function.cpp::default_implementation_for_constant_arguments supports it.
             auto result_column = ColumnVector<UInt8>::create(input_rows_count, 1);
@@ -152,27 +155,39 @@ public:
 
         if (left_nullable == right_nullable) {
             auto return_type = std::make_shared<DataTypeUInt8>();
-
+            auto left_column_tmp =
+                    left_nullable ? left_column->get_nested_column_ptr() : col_left.column;
+            auto right_column_tmp =
+                    right_nullable ? right_column->get_nested_column_ptr() : col_right.column;
             ColumnsWithTypeAndName eq_columns {
                     ColumnWithTypeAndName {
-                            left_nullable ? left_column->get_nested_column_ptr() : col_left.column,
+                            left_const ? ColumnConst::create(left_column_tmp, input_rows_count)
+                                       : left_column_tmp,
                             left_nullable
                                     ? assert_cast<const DataTypeNullable*>(col_left.type.get())
                                               ->get_nested_type()
                                     : col_left.type,
                             ""},
-                    ColumnWithTypeAndName {left_nullable ? right_column->get_nested_column_ptr()
-                                                         : col_right.column,
-                                           left_nullable ? assert_cast<const DataTypeNullable*>(
-                                                                   col_right.type.get())
-                                                                   ->get_nested_type()
-                                                         : col_right.type,
-                                           ""}};
+                    ColumnWithTypeAndName {
+                            right_const ? ColumnConst::create(right_column_tmp, input_rows_count)
+                                        : right_column_tmp,
+                            left_nullable
+                                    ? assert_cast<const DataTypeNullable*>(col_right.type.get())
+                                              ->get_nested_type()
+                                    : col_right.type,
+                            ""}};
             Block temporary_block(eq_columns);
+
+            std::cerr << "Left nullable: " << left_nullable
+                      << ", right nullable: " << right_nullable << ", left size "
+                      << eq_columns.at(0).column->size() << ", right size "
+                      << eq_columns.at(1).column->size() << std::endl;
 
             auto func_eq =
                     SimpleFunctionFactory::instance().get_function("eq", eq_columns, return_type);
-            DCHECK(func_eq);
+            DCHECK(func_eq) << fmt::format("Left type {} right type {} return type {}",
+                                           col_left.type->get_name(), col_right.type->get_name(),
+                                           return_type->get_name());
             temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
             RETURN_IF_ERROR(
                     func_eq->execute(context, temporary_block, {0, 1}, 2, input_rows_count));
@@ -219,13 +234,24 @@ public:
             auto res_nullable_column = assert_cast<ColumnNullable*>(
                     std::move(*temporary_block.get_by_position(2).column).mutate().get());
             auto& null_map = res_nullable_column->get_null_map_data();
-            auto& res_map =
+            auto& res_nested_col =
                     assert_cast<ColumnVector<UInt8>&>(res_nullable_column->get_nested_column())
                             .get_data();
 
-            auto* __restrict res = res_map.data();
-            auto* __restrict l = null_map.data();
-            _exec_nullable_inequal(res, l, input_rows_count, left_const);
+            // Input of eq_for_null:
+            // Left: [1, 1, 1, 1](ColumnConst(ColumnInt32))
+            // Right: [1, 1, 1, 1] & [0, 1, 0, 1] (ColumnNullable(ColumnInt32))
+            // Above input will be passed to function eq, and result will be
+            // Result: [1, x, 1, x] & [0, 1, 0, 1] (ColumnNullable(ColumnUInt8)), x means default value.
+            // The expceted result of eq_for_null is:
+            // Except: [1, 0, 1, 0] (ColumnUInt8)
+            // We already have assumption that there is only one nullable column in input.
+            // So if one row of res_nullable_column is null, the result row of eq_for_null should be 0.
+            // For others, the result will be same with function eq.
+
+            for (int i = 0; i < input_rows_count; ++i) {
+                res_nested_col[i] &= (null_map[i] != 1);
+            }
 
             block.get_by_position(result).column = res_nullable_column->get_nested_column_ptr();
         }
@@ -247,18 +273,6 @@ private:
         } else {
             for (int i = 0; i < rows; ++i) {
                 result[i] = (left[i] == right[i]) & (left[i] | result[i]);
-            }
-        }
-    }
-    static void _exec_nullable_inequal(unsigned char* result, const unsigned char* left,
-                                       size_t rows, bool left_const) {
-        if (left_const) {
-            for (int i = 0; i < rows; ++i) {
-                result[i] &= (left[0] != 1);
-            }
-        } else {
-            for (int i = 0; i < rows; ++i) {
-                result[i] &= (left[i] != 1);
             }
         }
     }

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -73,9 +73,7 @@ public:
         const bool right_const = is_column_const(*col_right.column);
         bool left_only_null = col_left.column->only_null();
         bool right_only_null = col_right.column->only_null();
-        std::cerr << "left_only_null: " << left_only_null
-                  << ", right_only_null: " << right_only_null << ", left const: " << left_const
-                  << ", right const: " << right_const << std::endl;
+
         if (left_only_null && right_only_null) {
             // TODO: return ColumnConst after function.cpp::default_implementation_for_constant_arguments supports it.
             auto result_column = ColumnVector<UInt8>::create(input_rows_count, 1);
@@ -177,11 +175,6 @@ public:
                                     : col_right.type,
                             ""}};
             Block temporary_block(eq_columns);
-
-            std::cerr << "Left nullable: " << left_nullable
-                      << ", right nullable: " << right_nullable << ", left size "
-                      << eq_columns.at(0).column->size() << ", right size "
-                      << eq_columns.at(1).column->size() << std::endl;
 
             auto func_eq =
                     SimpleFunctionFactory::instance().get_function("eq", eq_columns, return_type);

--- a/be/test/vec/function/function_eq_for_null_test.cpp
+++ b/be/test/vec/function/function_eq_for_null_test.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest.h>
+
 #include <cassert>
 #include <cstddef>
 #include <string>
@@ -39,8 +41,8 @@ namespace doris::vectorized {
 TEST(EqForNullFunctionTest, both_only_null) {
     const size_t input_rows_count = 100;
 
-    auto left_i32 = ColumnInt32::create(1, 1);
-    auto right_i32 = ColumnInt32::create(1, 1);
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
     auto null_map_for_all_null = ColumnUInt8::create(1, 1);
 
     ColumnWithTypeAndName left {
@@ -75,9 +77,9 @@ TEST(EqForNullFunctionTest, both_only_null) {
 TEST(EqForNullFunctionTest, both_only_null_const) {
     const size_t input_rows_count = 100;
 
-    auto left_i32 = ColumnInt32::create(1, 1);
-    auto right_i32 = ColumnInt32::create(1, 1);
-    auto null_map_for_all_null = ColumnUInt8::create(1, 1);
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
 
     ColumnWithTypeAndName left {
             ColumnConst::create(ColumnNullable::create(left_i32->clone_resized(1),
@@ -113,16 +115,15 @@ TEST(EqForNullFunctionTest, both_only_null_const) {
 
 TEST(EqForNullFunctionTest, left_only_null_right_const) {
     const size_t input_rows_count = 100;
-    // Input [NULL, NULL, NULL, NULL] & [NULL, NULL, NULL, NULL]
-    auto left_i32 = ColumnInt32::create(1, 1);
-    auto right_i32 = ColumnInt32::create(1, 1);
-    auto null_map_for_all_null = ColumnUInt8::create(1, 1);
+    // Input [NULL, NULL, NULL, NULL] & [1, 1, 1, 1]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
 
     ColumnWithTypeAndName left {
-            ColumnNullable::create(left_i32->clone_resized(1),
-                                   null_map_for_all_null->clone_resized(1)),
+            ColumnNullable::create(left_i32->clone_resized(1), ColumnUInt8::create(1, 1)),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
-
+    std::cout << "left only null " << left.column->only_null() << std::endl;
     ColumnWithTypeAndName right {
             ColumnConst::create(
                     ColumnNullable::create(right_i32->clone_resized(1), ColumnUInt8::create(1, 0)),
@@ -154,20 +155,18 @@ TEST(EqForNullFunctionTest, left_only_null_right_const) {
 TEST(EqForNullFunctionTest, left_const_right_only_null) {
     const size_t input_rows_count = 100;
 
-    auto left_i32 = ColumnInt32::create(1, 1);
-    auto right_i32 = ColumnInt32::create(1, 1);
-    auto null_map_for_all_null = ColumnUInt8::create(1, 1);
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
 
     ColumnWithTypeAndName left {
             ColumnConst::create(
                     ColumnNullable::create(left_i32->clone_resized(1), ColumnUInt8::create(1, 0)),
                     input_rows_count),
-
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
 
     ColumnWithTypeAndName right {
-            ColumnNullable::create(right_i32->clone_resized(1),
-                                   null_map_for_all_null->clone_resized(1)),
+            ColumnNullable::create(right_i32->clone_resized(1), ColumnUInt8::create(1, 1)),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
 
     auto return_type = std::make_shared<DataTypeUInt8>();
@@ -196,9 +195,9 @@ TEST(EqForNullFunctionTest, left_const_right_only_null) {
 TEST(EqForNullFunctionTest, left_only_null_right_nullable) {
     const size_t input_rows_count = 100;
 
-    auto left_i32 = ColumnInt32::create(1, 1);
-    auto right_i32 = ColumnInt32::create(1, 1);
-    auto null_map_for_all_null = ColumnUInt8::create(1, 1);
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
     auto common_null_map = ColumnUInt8::create();
     for (size_t i = 0; i < input_rows_count; ++i) {
         if (i % 2 == 0) {
@@ -209,11 +208,11 @@ TEST(EqForNullFunctionTest, left_only_null_right_nullable) {
     }
 
     ColumnWithTypeAndName left {
-            ColumnNullable::create(left_i32->clone_resized(1), null_map_for_all_null->clone()),
+            ColumnNullable::create(left_i32->clone_resized(1), ColumnUInt8::create(1, 1)),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
 
     ColumnWithTypeAndName right {
-            ColumnNullable::create(std::move(right_i32), std::move(common_null_map)),
+            ColumnNullable::create(right_i32->clone(), common_null_map->clone()),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
 
     auto return_type = std::make_shared<DataTypeUInt8>();
@@ -239,6 +238,47 @@ TEST(EqForNullFunctionTest, left_only_null_right_nullable) {
     }
 }
 
+TEST(EqForNullFunctionTest, left_only_null_right_not_nullable) {
+    const size_t input_rows_count = 100;
+    // left [NULL, NULL, NULL, NULL] & right [1, 1, 1, 1]
+    // result [0, 0, 0, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {
+            ColumnNullable::create(left_i32->clone_resized(1), ColumnUInt8::create(1, 1)),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
+
+    ColumnWithTypeAndName right {right_i32->clone(), std::make_shared<DataTypeInt32>(), "right"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        ASSERT_EQ(result_column->get_data()[i], 0);
+    }
+}
+
 TEST(EqForNullFunctionTest, left_nullable_right_only_null) {
     const size_t input_rows_count = 100;
     // LEFT: [1, NULL, 1, NULL] & RIGHT: [NULL, NULL, NULL, NULL]
@@ -255,7 +295,7 @@ TEST(EqForNullFunctionTest, left_nullable_right_only_null) {
     }
 
     ColumnWithTypeAndName left {
-            ColumnNullable::create(std::move(left_i32), std::move(common_null_map)),
+            ColumnNullable::create(left_i32->clone(), common_null_map->clone()),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
 
     ColumnWithTypeAndName right {
@@ -286,6 +326,48 @@ TEST(EqForNullFunctionTest, left_nullable_right_only_null) {
     }
 }
 
+TEST(EqForNullFunctionTest, left_not_nullable_right_only_null) {
+    const size_t input_rows_count = 100;
+    // LEFT: [1, 1, 1, 1] & RIGHT: [NULL, NULL, NULL, NULL]
+    // output [0, 0, 0, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto null_map_for_all_null = ColumnUInt8::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {left_i32->clone(), std::make_shared<DataTypeInt32>(), "left"};
+
+    ColumnWithTypeAndName right {
+            ColumnNullable::create(right_i32->clone_resized(1),
+                                   null_map_for_all_null->clone_resized(1)),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        ASSERT_EQ(result_column->get_data()[i], 0);
+    }
+}
+
 TEST(EqForNullFunctionTest, left_nullable_right_nullable) {
     const size_t input_rows_count = 100;
     // input: [NULL, 1, NULL, 1] & [NULL, 1, NULL, 1]
@@ -302,11 +384,11 @@ TEST(EqForNullFunctionTest, left_nullable_right_nullable) {
     }
 
     ColumnWithTypeAndName left {
-            ColumnNullable::create(std::move(left_i32), common_null_map->clone()),
+            ColumnNullable::create(left_i32->clone(), common_null_map->clone()),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
 
     ColumnWithTypeAndName right {
-            ColumnNullable::create(std::move(right_i32), common_null_map->clone()),
+            ColumnNullable::create(right_i32->clone(), common_null_map->clone()),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
 
     auto return_type = std::make_shared<DataTypeUInt8>();
@@ -345,10 +427,199 @@ TEST(EqForNullFunctionTest, left_nullable_right_not_nullable) {
     }
 
     ColumnWithTypeAndName left {
-            ColumnNullable::create(std::move(left_i32), std::move(common_null_map)),
+            ColumnNullable::create(left_i32->clone(), common_null_map->clone()),
             std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
 
-    ColumnWithTypeAndName right {std::move(right_i32), std::make_shared<DataTypeInt32>(), "right"};
+    ColumnWithTypeAndName right {right_i32->clone(), std::make_shared<DataTypeInt32>(), "right"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(result_column->get_data()[i], 1);
+        } else {
+            ASSERT_EQ(result_column->get_data()[i], 0);
+        }
+    }
+}
+
+TEST(EqForNullFunctionTest, left_not_nullable_right_nullable) {
+    const size_t input_rows_count = 100;
+    // input        [1, 1, 1, 1] & [1, NULL, 1, NULL]
+    // output       [1, 0, 1, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {left_i32->clone(), std::make_shared<DataTypeInt32>(), "right"};
+    ColumnWithTypeAndName right {
+            ColumnNullable::create(right_i32->clone(), common_null_map->clone()),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(result_column->get_data()[i], 1);
+        } else {
+            ASSERT_EQ(result_column->get_data()[i], 0);
+        }
+    }
+}
+
+TEST(EqForNullFunctionTest, left_const_not_nullable_right_nullable) {
+    const size_t input_rows_count = 10;
+    // input        [1, 1, 1, 1] & [1, NULL, 1, NULL]
+    // output       [1, 0, 1, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {ColumnConst::create(left_i32->clone_resized(1), input_rows_count),
+                                std::make_shared<DataTypeInt32>(), "right"};
+    ColumnWithTypeAndName right {
+            ColumnNullable::create(right_i32->clone(), common_null_map->clone()),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            EXPECT_EQ(result_column->get_data()[i], 1)
+                    << fmt::format("i {} value {}", i, result_column->get_data()[i]);
+        } else {
+            EXPECT_EQ(result_column->get_data()[i], 0)
+                    << fmt::format("i {} value {}", i, result_column->get_data()[i]);
+        }
+    }
+}
+
+TEST(EqForNullFunctionTest, left_const_nullable_right_nullable) {
+    const size_t input_rows_count = 100;
+    // input        [1, 1, 1, 1] & [1, NULL, 1, NULL]
+    // output       [1, 0, 1, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {
+            ColumnConst::create(
+                    ColumnNullable::create(left_i32->clone_resized(1), ColumnUInt8::create(1, 0)),
+                    input_rows_count),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
+
+    ColumnWithTypeAndName right {
+            ColumnNullable::create(right_i32->clone(), common_null_map->clone()),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
+
+    auto return_type = std::make_shared<DataTypeUInt8>();
+    auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null", ColumnsWithTypeAndName {left, right}, return_type);
+
+    Block temporary_block(ColumnsWithTypeAndName {left, right});
+    temporary_block.insert(ColumnWithTypeAndName {nullptr, return_type, ""});
+    FunctionContext* context = nullptr;
+    auto status = func_eq_for_null->execute(context, temporary_block, {0, 1}, 2, input_rows_count);
+
+    ASSERT_TRUE(status.ok());
+
+    auto result_column =
+            assert_cast<const ColumnUInt8*>(temporary_block.get_by_position(2).column.get());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(result_column->get_data()[i], 1);
+        } else {
+            ASSERT_EQ(result_column->get_data()[i], 0);
+        }
+    }
+}
+
+TEST(EqForNullFunctionTest, left_nullable_right_const_nullable) {
+    const size_t input_rows_count = 100;
+    // input        [1, NULL, 1, NULL] & [1, 1, 1, 1]
+    // output       [1, 0, 1, 0]
+    auto left_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto right_i32 = ColumnInt32::create(input_rows_count, 1);
+    auto common_null_map = ColumnUInt8::create();
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if (i % 2 == 0) {
+            common_null_map->insert(0);
+        } else {
+            common_null_map->insert(1);
+        }
+    }
+
+    ColumnWithTypeAndName left {
+            ColumnNullable::create(left_i32->clone(), common_null_map->clone()),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "left"};
+
+    ColumnWithTypeAndName right {
+            ColumnConst::create(
+                    ColumnNullable::create(right_i32->clone_resized(1), ColumnUInt8::create(1, 0)),
+                    input_rows_count),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), "right"};
 
     auto return_type = std::make_shared<DataTypeUInt8>();
     auto func_eq_for_null = SimpleFunctionFactory::instance().get_function(


### PR DESCRIPTION
Previous PR https://github.com/apache/doris/pull/36004 fixed eq_for_null processing at least one column is only-null, this pr fixed the problem when eq_for_null processing neither column is only-null.

1. ut on be is modified, make sure test block is valid.
2. when eq_for_null is not short circuited by property only_null, we should not discard Const properties before passing them to function eq.
3. more ut, now the test coverage percentage of `comparison_equal_for_null.cpp` is 100%.