### PR TITLE
[fix](cloud) Fix missing table ids in TxnRunningPB

### DIFF
--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -293,9 +293,7 @@ void MetaServiceImpl::begin_txn(::google::protobuf::RpcController* controller,
     std::string running_val;
     TxnRunningPB running_pb;
     running_pb.set_timeout_time(prepare_time + txn_info.timeout_ms());
-    for (auto i : txn_info.table_ids()) {
-        running_pb.add_table_ids(i);
-    }
+    running_pb.mutable_table_ids()->CopyFrom(txn_info.table_ids());
     VLOG_DEBUG << "label=" << label << " txn_id=" << txn_id
                << "running_pb=" << running_pb.ShortDebugString();
     if (!running_pb.SerializeToString(&running_val)) {
@@ -467,6 +465,7 @@ void MetaServiceImpl::precommit_txn(::google::protobuf::RpcController* controlle
 
     TxnRunningPB running_pb;
     running_pb.set_timeout_time(precommit_time + txn_info.precommit_timeout_ms());
+    running_pb.mutable_table_ids()->CopyFrom(txn_info.table_ids());
     if (!running_pb.SerializeToString(&running_val)) {
         code = MetaServiceCode::PROTOBUF_SERIALIZE_ERR;
         ss << "failed to serialize running_pb, txn_id=" << txn_id;

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -587,9 +587,9 @@ TEST(TxnKvTest, FullRangeGetIterator) {
             auto [k, v] = *kvp;
             EXPECT_EQ(v, std::to_string(cnt));
             ++cnt;
-            // Total cost: 60ms * 100 = 6s > fdb txn timeout 5s, however we create a new transaction
+            // Total cost: 100ms * 100 = 10s > fdb txn timeout 5s, however we create a new transaction
             // in each inner range get
-            std::this_thread::sleep_for(60ms);
+            std::this_thread::sleep_for(100ms);
         }
         ASSERT_TRUE(it->is_valid());
         EXPECT_EQ(cnt, 100);
@@ -700,8 +700,8 @@ TEST(TxnKvTest, FullRangeGetIterator) {
             auto [k, v] = *kvp;
             EXPECT_EQ(v, std::to_string(cnt));
             ++cnt;
-            // Total cost: 60ms * 100 = 6s > fdb txn timeout 5s
-            std::this_thread::sleep_for(60ms);
+            // Total cost: 100ms * 100 = 10s > fdb txn timeout 5s
+            std::this_thread::sleep_for(100ms);
         }
         // Txn timeout
         ASSERT_FALSE(it->is_valid());

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_with_schema_change.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_with_schema_change.groovy
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_stream_load_2pc_with_schema_change", "p0") {
+    def tableName = "test_2pc_table"
+    InetSocketAddress address = context.config.feHttpInetSocketAddress
+    String user = context.config.feHttpUser
+    String password = context.config.feHttpPassword
+    String db = context.config.getDbNameByFile(context.file)
+
+    def do_streamload_2pc_commit_by_txn_id = { txnId ->
+        def command = "curl -X PUT --location-trusted -u ${context.config.feHttpUser}:${context.config.feHttpPassword}" +
+                " -H txn_id:${txnId}" +
+                " -H txn_operation:commit" +
+                " http://${context.config.feHttpAddress}/api/${db}/${tableName}/_stream_load_2pc"
+        log.info("http_stream execute 2pc: ${command}")
+
+        def process = command.execute()
+        code = process.waitFor()
+        out = process.text
+        log.info("http_stream 2pc result: ${out}".toString())
+        def json2pc = parseJson(out)
+        return json2pc
+    }
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `k1` bigint(20) NULL DEFAULT "1",
+            `k2` bigint(20) NULL ,
+            `v1` tinyint(4) NULL,
+            `v2` tinyint(4) NULL,
+            `v3` tinyint(4) NULL
+        ) ENGINE=OLAP
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    def label = UUID.randomUUID().toString().replaceAll("-", "")
+    def txnId;
+    streamLoad {
+        table "${tableName}"
+
+        set 'label', "${label}"
+        set 'column_separator', '|'
+        set 'columns', 'k1, k2, v1, v2, v3'
+        set 'two_phase_commit', 'true'
+
+        file 'test_two_phase_commit.csv'
+
+        check { result, exception, startTime, endTime ->
+            if (exception != null) {
+                throw exception
+            }
+            log.info("Stream load result: ${result}".toString())
+            def json = parseJson(result)
+            assertEquals("success", json.Status.toLowerCase())
+            assertEquals(2, json.NumberTotalRows)
+            assertEquals(0, json.NumberFilteredRows)
+            assertEquals(0, json.NumberUnselectedRows)
+            txnId = json.TxnId
+        }
+    }
+
+    // Do schema change during 2pc
+    sql """
+            ALTER TABLE ${tableName} 
+            ADD COLUMN k3 INT KEY AFTER k2;
+        """
+
+    Thread.sleep(5000) // 5s
+
+    json2pc = do_streamload_2pc_commit_by_txn_id.call(txnId)
+    assertEquals("success", json2pc.status.toLowerCase())
+
+    waitForSchemaChangeDone {
+        sql """SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1"""
+        time 60
+    }
+
+    sql """
+        INSERT INTO ${tableName} VALUES (114, 115, 116, 1, 1, 1);
+    """
+
+    sql """
+        SELECT count(*) FROM ${tableName};
+    """
+}


### PR DESCRIPTION
## Proposed changes

Fix missing table ids in `TxnRunningPB` in `MetaServiceImpl::precommit_txn`.
The table ids in `TxnRunningPB` will be used to check for running doris transactions. If they are missing, it will cause `check_conflict_txn` to assume that transactions below the watermark have already completed. Then, result in a gap between the alter version obtained by the schema change job (which is used to decide the version range of history data to convert) and the version committed by new doris transcations during schema change job.
