### PR TITLE
[fix](load) fix NPE in LoadManager#jobRemovedTrigger()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -453,15 +453,21 @@ public class LoadManager implements Writable {
     }
 
     private void jobRemovedTrigger(LoadJob job) {
-        Map<String, List<LoadJob>> map = dbIdToLabelToLoadJobs.get(job.getDbId());
-        List<LoadJob> list = map.get(job.getLabel());
-        list.remove(job);
         if (job instanceof SparkLoadJob) {
             ((SparkLoadJob) job).clearSparkLauncherLog();
         }
         if (job instanceof BulkLoadJob) {
             ((BulkLoadJob) job).recycleProgress();
         }
+        Map<String, List<LoadJob>> map = dbIdToLabelToLoadJobs.get(job.getDbId());
+        if (map == null) {
+            return;
+        }
+        List<LoadJob> list = map.get(job.getLabel());
+        if (list == null) {
+            return;
+        }
+        list.remove(job);
         if (list.isEmpty()) {
             map.remove(job.getLabel());
         }


### PR DESCRIPTION
## Proposed changes

fix NPE

```
LoadManager.removeLoadJobIf():490] end to removeOldLoadJob, 
removeJobNum:6 cost:0 ms
2024-06-11 15:09:58,188 ERROR (LoadLabelCleaner|100) [Daemon.run():118] daemon thread got exception. name: LoadLabelCleaner
java.lang.NullPointerException: Cannot invoke "java.util.List.remove(Object)" because "list" is null
        at org.apache.doris.load.loadv2.LoadManager.jobRemovedTrigger(LoadManager.java:458) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.load.loadv2.LoadManager.removeLoadJobIf(LoadManager.java:483) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.load.loadv2.LoadManager.removeOldLoadJob(LoadManager.java:426) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env$1.runAfterCatalogReady(Env.java:2619) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```