### PR TITLE
[branch-2.0][fix](jdbc catalog) fix jdbc mysql client match jsonb type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -436,6 +436,7 @@ public class JdbcMySQLClient extends JdbcClient {
             case "TEXT":
                 return ScalarType.createStringType();
             case "JSON":
+            case "JSONB":
                 return ScalarType.createJsonbType();
             case "HLL":
                 return ScalarType.createHllType();


### PR DESCRIPTION
When using mysql catalog to connect to Doris, some lower versions of Doris's Json type will be displayed as JsonB, and we need to be compatible with it

bp #36177