### PR TITLE
[fix](planner)remove constant expr in window function's partition and order exprs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -475,22 +475,8 @@ public class AnalyticExpr extends Expr {
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         fnCall.analyze(analyzer);
         type = getFnCall().getType();
-
-        for (Expr e : partitionExprs) {
-            if (e.isLiteral()) {
-                throw new AnalysisException(
-                    "Expressions in the PARTITION BY clause must not be constant: "
-                    + e.toSql() + " (in " + toSql() + ")");
-            }
-        }
-
-        for (OrderByElement e : orderByElements) {
-            if (e.getExpr().isLiteral()) {
-                throw new AnalysisException(
-                    "Expressions in the ORDER BY clause must not be constant: "
-                            + e.getExpr().toSql() + " (in " + toSql() + ")");
-            }
-        }
+        partitionExprs.removeIf(expr -> expr.isConstant());
+        orderByElements.removeIf(expr -> expr.getExpr().isConstant());
 
         if (getFnCall().getParams().isDistinct()) {
             throw new AnalysisException(


### PR DESCRIPTION
the legacy planner reports error if there is constant expr in window function's partition or order by keys. This pr just remove these unnecessary constant exprs and make planner happy.
now:
`SELECT row_number() OVER (partition by 1 order by 2) from t`
will be changed to 
`SELECT row_number() OVER () from t  `

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

