### PR TITLE
[fix](inverted index)Delete tmp dirs when BE starts to avoid tmp files left by last crash

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.h
@@ -106,11 +106,9 @@ public:
 
     Status init() {
         for (auto& tmp_file_dir : _tmp_file_dirs) {
-            bool exists = true;
-            RETURN_IF_ERROR(io::global_local_filesystem()->exists(tmp_file_dir, &exists));
-            if (!exists) {
-                RETURN_IF_ERROR(io::global_local_filesystem()->create_directory(tmp_file_dir));
-            }
+            // delete the tmp dir to avoid the tmp files left by last crash
+            RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tmp_file_dir));
+            RETURN_IF_ERROR(io::global_local_filesystem()->create_directory(tmp_file_dir));
         }
         return Status::OK();
     };


### PR DESCRIPTION
When BE crashes, there may be tmp files left in the tmp dir, so we remove and rebuild the tmp dir every time we start BE to prevent rubbish data from occupying the disk.

pick from master #35951 



