### PR TITLE
[fix](alter) Remove rebuildAlterJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2Factory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2Factory.java
@@ -57,19 +57,4 @@ public class AlterJobV2Factory {
                     baseSchemaHash, rollupSchemaHash, rollupKeysType, rollupShortKeyColumnCount, origStmt);
         }
     }
-
-    public static AlterJobV2 rebuildAlterJobV2(AlterJobV2 job) throws AnalysisException {
-        try {
-            if (Config.isCloudMode()) {
-                if (job.getType() == AlterJobV2.JobType.SCHEMA_CHANGE) {
-                    job = CloudSchemaChangeJobV2.buildCloudSchemaChangeJobV2((SchemaChangeJobV2) job);
-                } else if (job.getType() == AlterJobV2.JobType.ROLLUP) {
-                    job = CloudRollupJobV2.buildCloudRollupJobV2((RollupJobV2) job);
-                }
-            }
-            return job;
-        } catch (IllegalAccessException e) {
-            throw new AnalysisException(e.getMessage());
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -114,7 +114,6 @@ public class MaterializedViewHandler extends AlterHandler {
 
     @Override
     public void addAlterJobV2(AlterJobV2 alterJob) throws AnalysisException {
-        alterJob = AlterJobV2Factory.rebuildAlterJobV2(alterJob);
         super.addAlterJobV2(alterJob);
         addAlterJobV2ToTableNotFinalStateJobMap(alterJob);
     }
@@ -1120,7 +1119,6 @@ public class MaterializedViewHandler extends AlterHandler {
     // replay the alter job v2
     @Override
     public void replayAlterJobV2(AlterJobV2 alterJob) throws AnalysisException {
-        alterJob = AlterJobV2Factory.rebuildAlterJobV2(alterJob);
         super.replayAlterJobV2(alterJob);
         if (!alterJob.isDone()) {
             addAlterJobV2ToTableNotFinalStateJobMap(alterJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2647,7 +2647,6 @@ public class SchemaChangeHandler extends AlterHandler {
 
     @Override
     public void addAlterJobV2(AlterJobV2 alterJob) throws AnalysisException {
-        alterJob = AlterJobV2Factory.rebuildAlterJobV2(alterJob);
         super.addAlterJobV2(alterJob);
         runnableSchemaChangeJobV2.put(alterJob.getJobId(), alterJob);
     }
@@ -2698,7 +2697,6 @@ public class SchemaChangeHandler extends AlterHandler {
 
     @Override
     public void replayAlterJobV2(AlterJobV2 alterJob) throws AnalysisException {
-        alterJob = AlterJobV2Factory.rebuildAlterJobV2(alterJob);
         if (!alterJob.isDone() && !runnableSchemaChangeJobV2.containsKey(alterJob.getJobId())) {
             runnableSchemaChangeJobV2.put(alterJob.getJobId(), alterJob);
         }


### PR DESCRIPTION
The compatible subtype was introduced in #35989, after that the RollupJobV2 and SchemaChangeJobV2 will be instanced to CloudRollupJobV2 and SchemaChangeJobV2. So there is no need to use rebuildAlterJob anymore.
