### PR TITLE
[Fix](case) set test_index_compaction_with_multi_index_segments_arr to nonConcurrent group

### DIFF
--- a/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_with_multi_index_segments_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_with_multi_index_segments_arr.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_index_compaction_with_multi_index_segments_arr", "array_contains_inverted_index") {
+suite("test_index_compaction_with_multi_index_segments_arr", "nonConcurrent") {
     // here some variable to control inverted index query
     sql """ set enable_profile=true"""
     sql """ set enable_pipeline_x_engine=true;"""


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

set be config inverted_index_max_buffered_docs=5 will cause other case too slow, make it non-concurrent
