### PR TITLE
[fix](regression) Fix test_disable_move_memtable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Cast;
@@ -175,9 +176,8 @@ public class GroupCommitInsertExecutor extends AbstractInsertExecutor {
         TStatusCode code = TStatusCode.findByValue(response.getStatus().getStatusCode());
         // TODO: in legacy, there is a retry, we need to implement
         if (code != TStatusCode.OK) {
-            String errMsg = "group commit insert failed. backend id: "
-                    + groupCommitPlanner.getBackend().getId() + ", status: "
-                    + response.getStatus();
+            String errMsg = "group commit insert failed. query_id: " + DebugUtil.printId(ConnectContext.get().queryId())
+                    + ", backend id: " + groupCommitPlanner.getBackend().getId() + ", status: " + response.getStatus();
             ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
         }
         txnStatus = TransactionStatus.PREPARE;

--- a/regression-test/suites/fault_injection_p0/test_disable_move_memtable.groovy
+++ b/regression-test/suites/fault_injection_p0/test_disable_move_memtable.groovy
@@ -265,9 +265,11 @@ suite("test_disable_move_memtable", "nonConcurrent") {
     sql """ set enable_nereids_dml=true """
     insert_into_value_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
     insert_into_value_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
+    sql """ set enable_insert_strict = false """
     sql """ set group_commit = sync_mode """
     insert_into_value_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
     insert_into_value_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
+    sql """ set enable_insert_strict = true """
     sql """ set group_commit = off_mode """
     sql """ set enable_nereids_planner=false """
     sql """ set enable_nereids_dml=false """
@@ -282,18 +284,10 @@ suite("test_disable_move_memtable", "nonConcurrent") {
     sql """ set enable_nereids_dml=true """
     insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
     insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
-    sql """ set group_commit = sync_mode """
-    insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
-    insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
-    sql """ set group_commit = off_mode """
     sql """ set enable_nereids_planner=false """
     sql """ set enable_nereids_dml=false """
     insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
     insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
-    sql """ set group_commit = sync_mode """
-    insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test", "unknown destination tuple descriptor")
-    insert_into_select_with_injection("VTabletWriterV2._init._output_tuple_desc_null", "test1", "success")
-    sql """ set group_commit = off_mode """
     
     sql """ set enable_nereids_planner=true """
     sql """ set enable_nereids_dml=true """


### PR DESCRIPTION
## Proposed changes

when `set enable_fold_constant_by_be = false`, the real error is `too many filtered row`:
```
Reason: column(k10) value is incorrect while strict mode is true, src value is 2022. src line [1 10 1000 1 1 1.000 a 2022 2022 a 1 1 hello 1];
```

