### PR TITLE
[fix](statistics)Fix sync analyze job timeout block bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -208,7 +208,7 @@ public abstract class BaseAnalysisTask {
         int retriedTimes = 0;
         while (retriedTimes < StatisticConstants.ANALYZE_TASK_RETRY_TIMES) {
             if (killed) {
-                break;
+                throw new RuntimeException("Task is Killed or Timeout");
             }
             try {
                 doExecute();


### PR DESCRIPTION
Fix sync analyze job timeout block bug. When a task of a analyze job timeout, it should throw an exception instead of finish silently.

