### PR TITLE
[Fix](Variant) fix checksum task read with unmatched column type

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -540,15 +540,17 @@ Status Segment::new_column_iterator_with_path(const TabletColumn& tablet_column,
                                ? _sparse_column_tree.find_exact(*tablet_column.path_info_ptr())
                                : nullptr;
 
-    auto is_compaction = [](ReaderType type) {
+    // Currently only compaction and checksum need to read flat leaves
+    // They both use tablet_schema_with_merged_max_schema_version as read schema
+    auto type_to_read_flat_leaves = [](ReaderType type) {
         return type == ReaderType::READER_BASE_COMPACTION ||
                type == ReaderType::READER_CUMULATIVE_COMPACTION ||
                type == ReaderType::READER_COLD_DATA_COMPACTION ||
                type == ReaderType::READER_SEGMENT_COMPACTION ||
-               type == ReaderType::READER_FULL_COMPACTION;
+               type == ReaderType::READER_FULL_COMPACTION || type == ReaderType::READER_CHECKSUM;
     };
 
-    if (opt != nullptr && is_compaction(opt->io_ctx.reader_type)) {
+    if (opt != nullptr && type_to_read_flat_leaves(opt->io_ctx.reader_type)) {
         // compaction need to read flat leaves nodes data to prevent from amplification
         const auto* node = tablet_column.has_path_info()
                                    ? _sub_column_tree.find_leaf(*tablet_column.path_info_ptr())


### PR DESCRIPTION
```
Bad cast from type:doris::vectorized::ColumnVector to doris::vectorized::ColumnObject

Check failure stack trace: ***
@ 0x562dcebca976 google::LogMessage::SendToLog()
@ 0x562dcebc73c0 google::LogMessage::Flush()
@ 0x562dcebcb1b9 google::LogMessageFatal::~LogMessageFatal()
@ 0x562d9ded39e6 assert_cast<>()
@ 0x562d9df1e599 doris::segment_v2::HierarchicalDataReader::process_read<>()
@ 0x562d9df1e106 doris::segment_v2::HierarchicalDataReader::next_batch()
@ 0x562d9df3373e doris::segment_v2::ColumnIterator::next_batch()
....
@ 0x562d9ea56d31 doris::EngineChecksumTask::_compute_checksum()
@ 0x562d9ea55cc2 doris::EngineChecksumTask::execute()
@ 0x562d9b558355 doris::check_consistency_callback()
```

introduced by #34925

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

