### PR TITLE
[Fix](sql function) memory overflow to the left of string address when do_money_format has small negative value

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -2585,7 +2585,7 @@ static StringRef do_money_format(FunctionContext* context, const string& value) 
     if (!is_positive) {
         *result_data = '-';
     }
-    for (int i = value.size() - 4, j = result_len - 4; i >= 0; i = i - 3, j = j - 4) {
+    for (int i = value.size() - 4, j = result_len - 4; i >= 0; i = i - 3) {
         *(result_data + j) = *(value.data() + i);
         if (i - 1 < 0) {
             break;
@@ -2597,6 +2597,9 @@ static StringRef do_money_format(FunctionContext* context, const string& value) 
         *(result_data + j - 2) = *(value.data() + i - 2);
         if (j - 3 > 1 || (j - 3 == 1 && is_positive)) {
             *(result_data + j - 3) = ',';
+            j -= 4;
+        } else {
+            j -= 3;
         }
     }
     memcpy(result_data + result_len - 3, value.data() + value.size() - 3, 3);

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -511,7 +511,8 @@ TEST(MathFunctionTest, money_format_test) {
         InputTypeSet input_types = {TypeIndex::Float64};
         DataSet data_set = {{{Null()}, Null()},
                             {{DOUBLE(17014116.67)}, VARCHAR("17,014,116.67")},
-                            {{DOUBLE(-17014116.67)}, VARCHAR("-17,014,116.67")}};
+                            {{DOUBLE(-17014116.67)}, VARCHAR("-17,014,116.67")},
+                            {{DOUBLE(-123.45)}, VARCHAR("-123.45")}};
 
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }


### PR DESCRIPTION
see the unit test.
in do_money_format, some case like -123.45，no comma would set in the first loop iteration，but j -= 4 contains comma position.
so next loop iteration would cause buffer overflow. in some condition may corrupt some critical memory then coredump.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

