### PR TITLE
[fix](memory) Refactor LRU cache policy memory tracking

### DIFF
--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -136,7 +136,7 @@ private:
 CloudTabletMgr::CloudTabletMgr(CloudStorageEngine& engine)
         : _engine(engine),
           _tablet_map(std::make_unique<TabletMap>()),
-          _cache(std::make_unique<LRUCachePolicy>(
+          _cache(std::make_unique<LRUCachePolicyTrackingManual>(
                   CachePolicy::CacheType::CLOUD_TABLET_CACHE, config::tablet_cache_capacity,
                   LRUCacheType::NUMBER, 0, config::tablet_cache_shards)) {}
 
@@ -148,9 +148,7 @@ Result<std::shared_ptr<CloudTablet>> CloudTabletMgr::get_tablet(int64_t tablet_i
     class Value : public LRUCacheValueBase {
     public:
         Value(const std::shared_ptr<CloudTablet>& tablet, TabletMap& tablet_map)
-                : LRUCacheValueBase(CachePolicy::CacheType::CLOUD_TABLET_CACHE),
-                  tablet(tablet),
-                  tablet_map(tablet_map) {}
+                : tablet(tablet), tablet_map(tablet_map) {}
         ~Value() override { tablet_map.erase(tablet.get()); }
 
         // FIXME(plat1ko): The ownership of tablet seems to belong to 'TabletMap', while `Value`

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -31,8 +31,8 @@
 namespace doris {
 
 CloudTxnDeleteBitmapCache::CloudTxnDeleteBitmapCache(size_t size_in_bytes)
-        : LRUCachePolicy(CachePolicy::CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE, size_in_bytes,
-                         LRUCacheType::SIZE, 86400, 4),
+        : LRUCachePolicyTrackingManual(CachePolicy::CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE,
+                                       size_in_bytes, LRUCacheType::SIZE, 86400, 4),
           _stop_latch(1) {}
 
 CloudTxnDeleteBitmapCache::~CloudTxnDeleteBitmapCache() {

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.h
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.h
@@ -30,7 +30,7 @@
 namespace doris {
 
 // Record transaction related delete bitmaps using a lru cache.
-class CloudTxnDeleteBitmapCache : public LRUCachePolicy {
+class CloudTxnDeleteBitmapCache : public LRUCachePolicyTrackingManual {
 public:
     CloudTxnDeleteBitmapCache(size_t size_in_bytes);
 
@@ -72,9 +72,7 @@ private:
         RowsetIdUnorderedSet rowset_ids;
 
         DeleteBitmapCacheValue(DeleteBitmapPtr delete_bitmap_, const RowsetIdUnorderedSet& ids_)
-                : LRUCacheValueBase(CachePolicy::CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE),
-                  delete_bitmap(std::move(delete_bitmap_)),
-                  rowset_ids(ids_) {}
+                : delete_bitmap(std::move(delete_bitmap_)), rowset_ids(ids_) {}
     };
 
     struct TxnKey {

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -70,7 +70,7 @@ void StoragePageCache::insert(const CacheKey& key, DataPage* data, PageCacheHand
     }
 
     auto* cache = _get_page_cache(page_type);
-    auto* lru_handle = cache->insert_no_tracking(key.encode(), data, data->capacity(), priority);
+    auto* lru_handle = cache->insert(key.encode(), data, data->capacity(), 0, priority);
     *handle = PageCacheHandle(cache, lru_handle);
 }
 

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -105,34 +105,28 @@ public:
         }
     };
 
-    class DataPageCache : public LRUCachePolicy {
+    class DataPageCache : public LRUCachePolicyTrackingAllocator {
     public:
         DataPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::CacheType::DATA_PAGE_CACHE, capacity,
-                                 LRUCacheType::SIZE, config::data_page_cache_stale_sweep_time_sec,
-                                 num_shards) {
-            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
-        }
+                : LRUCachePolicyTrackingAllocator(
+                          CachePolicy::CacheType::DATA_PAGE_CACHE, capacity, LRUCacheType::SIZE,
+                          config::data_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 
-    class IndexPageCache : public LRUCachePolicy {
+    class IndexPageCache : public LRUCachePolicyTrackingAllocator {
     public:
         IndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::CacheType::INDEXPAGE_CACHE, capacity,
-                                 LRUCacheType::SIZE, config::index_page_cache_stale_sweep_time_sec,
-                                 num_shards) {
-            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
-        }
+                : LRUCachePolicyTrackingAllocator(
+                          CachePolicy::CacheType::INDEXPAGE_CACHE, capacity, LRUCacheType::SIZE,
+                          config::index_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 
-    class PKIndexPageCache : public LRUCachePolicy {
+    class PKIndexPageCache : public LRUCachePolicyTrackingAllocator {
     public:
         PKIndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::CacheType::PK_INDEX_PAGE_CACHE, capacity,
-                                 LRUCacheType::SIZE,
-                                 config::pk_index_page_cache_stale_sweep_time_sec, num_shards) {
-            init_mem_tracker_by_allocator(lru_cache_type_string(LRUCacheType::SIZE));
-        }
+                : LRUCachePolicyTrackingAllocator(
+                          CachePolicy::CacheType::PK_INDEX_PAGE_CACHE, capacity, LRUCacheType::SIZE,
+                          config::pk_index_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 
     static constexpr uint32_t kDefaultNumShards = 16;
@@ -169,7 +163,7 @@ public:
                 segment_v2::PageTypePB page_type, bool in_memory = false);
 
     std::shared_ptr<MemTrackerLimiter> mem_tracker(segment_v2::PageTypePB page_type) {
-        return _get_page_cache(page_type)->mem_tracker_by_allocator();
+        return _get_page_cache(page_type)->mem_tracker();
     }
 
 private:
@@ -183,7 +177,7 @@ private:
     // delete bitmap in unique key with mow
     std::unique_ptr<PKIndexPageCache> _pk_index_page_cache;
 
-    LRUCachePolicy* _get_page_cache(segment_v2::PageTypePB page_type) {
+    LRUCachePolicyTrackingAllocator* _get_page_cache(segment_v2::PageTypePB page_type) {
         switch (page_type) {
         case segment_v2::DATA_PAGE: {
             return _data_page_cache.get();

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
@@ -39,7 +39,7 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
      * @return Status
      */
     Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
-                  const std::shared_ptr<MemTrackerLimiter>& mem_tracker) override {
+                  bool _use_cache, segment_v2::PageTypePB page_type) override {
         size_t num_elements, compressed_size, num_element_after_padding;
         int size_of_element;
 
@@ -67,7 +67,7 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
         decoded_slice.size = size_of_dict_header + BITSHUFFLE_PAGE_HEADER_SIZE +
                              num_element_after_padding * size_of_element + size_of_tail;
         std::unique_ptr<DataPage> decoded_page =
-                std::make_unique<DataPage>(decoded_slice.size, mem_tracker);
+                std::make_unique<DataPage>(decoded_slice.size, _use_cache, page_type);
         decoded_slice.data = decoded_page->data();
 
         if constexpr (USED_IN_DICT_ENCODING) {

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -43,7 +43,7 @@ enum EncodingTypePB : int;
 class DataPagePreDecoder {
 public:
     virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
-                          const std::shared_ptr<MemTrackerLimiter>& mem_tracker) = 0;
+                          bool _use_cache, segment_v2::PageTypePB page_type) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -135,14 +135,10 @@ void InvertedIndexQueryCache::insert(const CacheKey& key, std::shared_ptr<roarin
         return;
     }
 
-    auto* lru_handle = LRUCachePolicy::insert(key.encode(), (void*)cache_value_ptr.release(),
-                                              bitmap->getSizeInBytes(), bitmap->getSizeInBytes(),
-                                              CachePriority::NORMAL);
+    auto* lru_handle = LRUCachePolicyTrackingManual::insert(
+            key.encode(), (void*)cache_value_ptr.release(), bitmap->getSizeInBytes(),
+            bitmap->getSizeInBytes(), CachePriority::NORMAL);
     *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
-}
-
-int64_t InvertedIndexQueryCache::mem_consumption() {
-    return LRUCachePolicy::mem_consumption();
 }
 
 } // namespace doris::segment_v2

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -44,7 +44,7 @@ using SegmentIteratorUPtr = std::unique_ptr<SegmentIterator>;
 // eliminating the need for frequent allocation and deallocation during usage.
 // This caching mechanism proves immensely advantageous, particularly in scenarios
 // with high concurrency, where queries are executed simultaneously.
-class SchemaCache : public LRUCachePolicy {
+class SchemaCache : public LRUCachePolicyTrackingManual {
 public:
     enum class Type { TABLET_SCHEMA = 0, SCHEMA = 1 };
 
@@ -104,8 +104,6 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::SCHEMA_CACHE) {}
-
         Type type;
         // either tablet_schema or schema
         TabletSchemaSPtr tablet_schema = nullptr;
@@ -113,8 +111,9 @@ public:
     };
 
     SchemaCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::SCHEMA_CACHE, capacity, LRUCacheType::NUMBER,
-                             config::schema_cache_sweep_time_sec) {}
+            : LRUCachePolicyTrackingManual(CachePolicy::CacheType::SCHEMA_CACHE, capacity,
+                                           LRUCacheType::NUMBER,
+                                           config::schema_cache_sweep_time_sec) {}
 
 private:
     static constexpr char SCHEMA_DELIMITER = '-';

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -40,9 +40,9 @@ bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle*
 
 void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::CacheValue& value,
                           SegmentCacheHandle* handle) {
-    auto* lru_handle =
-            LRUCachePolicy::insert(key.encode(), &value, value.segment->meta_mem_usage(),
-                                   value.segment->meta_mem_usage(), CachePriority::NORMAL);
+    auto* lru_handle = LRUCachePolicyTrackingManual::insert(
+            key.encode(), &value, value.segment->meta_mem_usage(), value.segment->meta_mem_usage(),
+            CachePriority::NORMAL);
     handle->push_segment(this, lru_handle);
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -55,8 +55,9 @@ class BetaRowset;
 // Make sure that cache_handle is valid during the segment usage period.
 using BetaRowsetSharedPtr = std::shared_ptr<BetaRowset>;
 
-class SegmentCache : public LRUCachePolicy {
+class SegmentCache : public LRUCachePolicyTrackingManual {
 public:
+    using LRUCachePolicyTrackingManual::insert;
     // The cache key or segment lru cache
     struct CacheKey {
         CacheKey(RowsetId rowset_id_, int64_t segment_id_)
@@ -74,15 +75,15 @@ public:
     // Holding all opened segments of a rowset.
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::SEGMENT_CACHE) {}
         ~CacheValue() override { segment.reset(); }
 
         segment_v2::SegmentSharedPtr segment;
     };
 
     SegmentCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, capacity, LRUCacheType::SIZE,
-                             config::tablet_rowset_stale_sweep_time_sec) {}
+            : LRUCachePolicyTrackingManual(CachePolicy::CacheType::SEGMENT_CACHE, capacity,
+                                           LRUCacheType::SIZE,
+                                           config::tablet_rowset_stale_sweep_time_sec) {}
 
     // Lookup the given segment in the cache.
     // If the segment is found, the cache entry will be written into handle.

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -506,7 +506,7 @@ private:
 // lru cache for create tabelt round robin in disks
 // key: partitionId_medium
 // value: index
-class CreateTabletIdxCache : public LRUCachePolicy {
+class CreateTabletIdxCache : public LRUCachePolicyTrackingManual {
 public:
     // get key, delimiter with DELIMITER '-'
     static std::string get_key(int64_t partition_id, TStorageMedium::type medium) {
@@ -520,15 +520,13 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::CREATE_TABLET_RR_IDX_CACHE) {}
-
         int idx = 0;
     };
 
     CreateTabletIdxCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::CREATE_TABLET_RR_IDX_CACHE, capacity,
-                             LRUCacheType::NUMBER,
-                             /*stale_sweep_time_s*/ 30 * 60) {}
+            : LRUCachePolicyTrackingManual(CachePolicy::CacheType::CREATE_TABLET_RR_IDX_CACHE,
+                                           capacity, LRUCacheType::NUMBER,
+                                           /*stale_sweep_time_s*/ 30 * 60) {}
 };
 
 struct DirInfo {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -516,20 +516,19 @@ public:
      */
     std::shared_ptr<roaring::Roaring> get_agg(const BitmapKey& bmk) const;
 
-    class AggCachePolicy : public LRUCachePolicy {
+    class AggCachePolicy : public LRUCachePolicyTrackingManual {
     public:
         AggCachePolicy(size_t capacity)
-                : LRUCachePolicy(CachePolicy::CacheType::DELETE_BITMAP_AGG_CACHE, capacity,
-                                 LRUCacheType::SIZE,
-                                 config::delete_bitmap_agg_cache_stale_sweep_time_sec, 256) {}
+                : LRUCachePolicyTrackingManual(CachePolicy::CacheType::DELETE_BITMAP_AGG_CACHE,
+                                               capacity, LRUCacheType::SIZE,
+                                               config::delete_bitmap_agg_cache_stale_sweep_time_sec,
+                                               256) {}
     };
 
     class AggCache {
     public:
         class Value : public LRUCacheValueBase {
         public:
-            Value() : LRUCacheValueBase(CachePolicy::CacheType::DELETE_BITMAP_AGG_CACHE) {}
-
             roaring::Roaring bitmap;
         };
 

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -40,8 +40,8 @@ std::pair<Cache::Handle*, TabletSchemaSPtr> TabletSchemaCache::insert(const std:
         pb.ParseFromString(key);
         tablet_schema_ptr->init_from_pb(pb);
         value->tablet_schema = tablet_schema_ptr;
-        lru_handle = LRUCachePolicy::insert(key, value, tablet_schema_ptr->num_columns(), 0,
-                                            CachePriority::NORMAL);
+        lru_handle = LRUCachePolicyTrackingManual::insert(
+                key, value, tablet_schema_ptr->num_columns(), 0, CachePriority::NORMAL);
         g_tablet_schema_cache_count << 1;
         g_tablet_schema_cache_columns_count << tablet_schema_ptr->num_columns();
     }

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -23,11 +23,14 @@
 
 namespace doris {
 
-class TabletSchemaCache : public LRUCachePolicy {
+class TabletSchemaCache : public LRUCachePolicyTrackingManual {
 public:
+    using LRUCachePolicyTrackingManual::insert;
+
     TabletSchemaCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::TABLET_SCHEMA_CACHE, capacity,
-                             LRUCacheType::NUMBER, config::tablet_schema_cache_recycle_interval) {}
+            : LRUCachePolicyTrackingManual(CachePolicy::CacheType::TABLET_SCHEMA_CACHE, capacity,
+                                           LRUCacheType::NUMBER,
+                                           config::tablet_schema_cache_recycle_interval) {}
 
     static TabletSchemaCache* create_global_schema_cache(size_t capacity) {
         auto* res = new TabletSchemaCache(capacity);
@@ -45,7 +48,6 @@ public:
 private:
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::TABLET_SCHEMA_CACHE) {}
         ~CacheValue() override;
 
         TabletSchemaSPtr tablet_schema;

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -130,8 +130,6 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::TABLET_VERSION_CACHE) {}
-
         int64_t value;
     };
 
@@ -268,12 +266,13 @@ private:
     void _insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
 
-    class TabletVersionCache : public LRUCachePolicy {
+    class TabletVersionCache : public LRUCachePolicyTrackingManual {
     public:
         TabletVersionCache(size_t capacity)
-                : LRUCachePolicy(CachePolicy::CacheType::TABLET_VERSION_CACHE, capacity,
-                                 LRUCacheType::NUMBER, -1, DEFAULT_LRU_CACHE_NUM_SHARDS,
-                                 DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
+                : LRUCachePolicyTrackingManual(CachePolicy::CacheType::TABLET_VERSION_CACHE,
+                                               capacity, LRUCacheType::NUMBER, -1,
+                                               DEFAULT_LRU_CACHE_NUM_SHARDS,
+                                               DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
     };
 
 private:

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -72,12 +72,13 @@ private:
 
     Status _start_bg_worker();
 
-    class LastSuccessChannelCache : public LRUCachePolicy {
+    class LastSuccessChannelCache : public LRUCachePolicyTrackingManual {
     public:
         LastSuccessChannelCache(size_t capacity)
-                : LRUCachePolicy(CachePolicy::CacheType::LAST_SUCCESS_CHANNEL_CACHE, capacity,
-                                 LRUCacheType::SIZE, -1, DEFAULT_LRU_CACHE_NUM_SHARDS,
-                                 DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
+                : LRUCachePolicyTrackingManual(CachePolicy::CacheType::LAST_SUCCESS_CHANNEL_CACHE,
+                                               capacity, LRUCacheType::SIZE, -1,
+                                               DEFAULT_LRU_CACHE_NUM_SHARDS,
+                                               DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
     };
 
 protected:

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -59,8 +59,6 @@ public:
         LOG(INFO) << "Unregister Cache " << CachePolicy::type_string(type);
     }
 
-    CachePolicy* get_cache(CachePolicy::CacheType type) { return _caches.at(type); }
-
     int64_t for_each_cache_prune_stale_wrap(std::function<void(CachePolicy* cache_policy)> func,
                                             RuntimeProfile* profile = nullptr);
 

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "runtime/exec_env.h"
-#include "runtime/memory/mem_tracker_limiter.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
@@ -102,30 +101,6 @@ public:
     virtual void prune_all(bool force) = 0;
 
     CacheType type() { return _type; }
-    void init_mem_tracker(const std::string& type_name) {
-        _mem_tracker =
-                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
-                                             ExecEnv::GetInstance()->details_mem_tracker_set());
-    }
-    MemTracker* mem_tracker() { return _mem_tracker.get(); }
-    void init_mem_tracker_by_allocator(const std::string& type_name) {
-        _mem_tracker_by_allocator = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::GLOBAL,
-                fmt::format("{}[{}](AllocByAllocator)", type_string(_type), type_name));
-    }
-    std::shared_ptr<MemTrackerLimiter> mem_tracker_by_allocator() const {
-        DCHECK(_mem_tracker_by_allocator != nullptr);
-        return _mem_tracker_by_allocator;
-    }
-    int64_t mem_consumption() {
-        if (_mem_tracker_by_allocator != nullptr) {
-            return _mem_tracker_by_allocator->consumption();
-        } else if (_mem_tracker != nullptr) {
-            return _mem_tracker->consumption();
-        }
-        LOG(FATAL) << "__builtin_unreachable";
-        __builtin_unreachable();
-    }
     bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 
@@ -141,9 +116,6 @@ protected:
     }
 
     CacheType _type;
-
-    std::unique_ptr<MemTracker> _mem_tracker;
-    std::shared_ptr<MemTrackerLimiter> _mem_tracker_by_allocator;
 
     std::unique_ptr<RuntimeProfile> _profile;
     RuntimeProfile::Counter* _prune_stale_number_counter = nullptr;

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -211,7 +211,7 @@ public:
             bool enable_prune = true)
             : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
                              element_count_capacity, enable_prune) {
-        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        _init_mem_tracker(lru_cache_type_string(lru_cache_type));
     }
 
     LRUCachePolicyTrackingAllocator(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
@@ -222,16 +222,10 @@ public:
             : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
                              element_count_capacity, cache_value_time_extractor,
                              cache_value_check_timestamp, enable_prune) {
-        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        _init_mem_tracker(lru_cache_type_string(lru_cache_type));
     }
 
     ~LRUCachePolicyTrackingAllocator() override { reset_cache(); }
-
-    void init_mem_tracker(const std::string& type_name) {
-        _mem_tracker = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::GLOBAL,
-                fmt::format("{}[{}](AllocByAllocator)", type_string(_type), type_name));
-    }
 
     std::shared_ptr<MemTrackerLimiter> mem_tracker() const {
         DCHECK(_mem_tracker != nullptr);
@@ -249,6 +243,12 @@ public:
     }
 
 protected:
+    void _init_mem_tracker(const std::string& type_name) {
+        _mem_tracker = MemTrackerLimiter::create_shared(
+                MemTrackerLimiter::Type::GLOBAL,
+                fmt::format("{}[{}](AllocByAllocator)", type_string(_type), type_name));
+    }
+
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };
 
@@ -261,7 +261,7 @@ public:
             bool enable_prune = true)
             : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
                              element_count_capacity, enable_prune) {
-        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        _init_mem_tracker(lru_cache_type_string(lru_cache_type));
     }
 
     LRUCachePolicyTrackingManual(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
@@ -272,16 +272,10 @@ public:
             : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
                              element_count_capacity, cache_value_time_extractor,
                              cache_value_check_timestamp, enable_prune) {
-        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        _init_mem_tracker(lru_cache_type_string(lru_cache_type));
     }
 
     ~LRUCachePolicyTrackingManual() override { reset_cache(); }
-
-    void init_mem_tracker(const std::string& type_name) {
-        _mem_tracker =
-                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
-                                             ExecEnv::GetInstance()->details_mem_tracker_set());
-    }
 
     MemTracker* mem_tracker() {
         DCHECK(_mem_tracker != nullptr);
@@ -306,6 +300,12 @@ public:
     }
 
 private:
+    void _init_mem_tracker(const std::string& type_name) {
+        _mem_tracker =
+                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
+                                             ExecEnv::GetInstance()->details_mem_tracker_set());
+    }
+
     // LRUCacheType::SIZE equal to total_size.
     size_t _get_bytes_with_handle(const CacheKey& key, size_t charge, size_t bytes) {
         size_t handle_size = sizeof(LRUHandle) - 1 + key.size();

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -24,6 +24,7 @@
 #include "olap/lru_cache.h"
 #include "runtime/memory/cache_policy.h"
 #include "runtime/memory/lru_cache_value_base.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 #include "util/time.h"
 
@@ -45,7 +46,6 @@ public:
             CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
-        init_mem_tracker(lru_cache_type_string(_lru_cache_type));
     }
 
     LRUCachePolicy(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
@@ -63,10 +63,9 @@ public:
             CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
-        init_mem_tracker(lru_cache_type_string(_lru_cache_type));
     }
 
-    ~LRUCachePolicy() override { _cache.reset(); }
+    void reset_cache() { _cache.reset(); }
 
     bool check_capacity(size_t capacity, uint32_t num_shards) {
         if (capacity < num_shards) {
@@ -91,23 +90,11 @@ public:
         }
     }
 
-    // Insert and cache value destroy will be manually consume tracking_bytes to mem tracker.
-    // If lru cache is LRUCacheType::SIZE, tracking_bytes usually equal to charge.
-    Cache::Handle* insert(const CacheKey& key, void* value, size_t charge, size_t tracking_bytes,
-                          CachePriority priority = CachePriority::NORMAL) {
-        size_t bytes_with_handle = _get_bytes_with_handle(key, charge, tracking_bytes);
-        if (value != nullptr) { // if tracking_bytes = 0, only tracking handle size.
-            ((LRUCacheValueBase*)value)->mem_tracker()->consume(bytes_with_handle);
-            ((LRUCacheValueBase*)value)->set_tracking_bytes(bytes_with_handle);
-        }
-        return _cache->insert(key, value, charge, priority);
-    }
+    virtual int64_t mem_consumption() = 0;
 
-    Cache::Handle* insert_no_tracking(const CacheKey& key, void* value, size_t charge,
-                                      CachePriority priority = CachePriority::NORMAL) {
-        DCHECK(_mem_tracker_by_allocator != nullptr); // must be tracking in Allcator.
-        return _cache->insert(key, value, charge, priority);
-    }
+    virtual Cache::Handle* insert(const CacheKey& key, void* value, size_t charge,
+                                  size_t tracking_bytes,
+                                  CachePriority priority = CachePriority::NORMAL) = 0;
 
     Cache::Handle* lookup(const CacheKey& key) { return _cache->lookup(key); }
 
@@ -208,6 +195,116 @@ public:
         }
     }
 
+protected:
+    // if check_capacity failed, will return dummy lru cache,
+    // compatible with ShardedLRUCache usage, but will not actually cache.
+    std::shared_ptr<Cache> _cache;
+    LRUCacheType _lru_cache_type;
+};
+
+class LRUCachePolicyTrackingAllocator : public LRUCachePolicy {
+public:
+    LRUCachePolicyTrackingAllocator(
+            CacheType type, size_t capacity, LRUCacheType lru_cache_type,
+            uint32_t stale_sweep_time_s, uint32_t num_shards = DEFAULT_LRU_CACHE_NUM_SHARDS,
+            uint32_t element_count_capacity = DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY,
+            bool enable_prune = true)
+            : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
+                             element_count_capacity, enable_prune) {
+        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+    }
+
+    LRUCachePolicyTrackingAllocator(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
+                                    uint32_t stale_sweep_time_s, uint32_t num_shards,
+                                    uint32_t element_count_capacity,
+                                    CacheValueTimeExtractor cache_value_time_extractor,
+                                    bool cache_value_check_timestamp, bool enable_prune = true)
+            : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
+                             element_count_capacity, cache_value_time_extractor,
+                             cache_value_check_timestamp, enable_prune) {
+        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+    }
+
+    ~LRUCachePolicyTrackingAllocator() override { reset_cache(); }
+
+    void init_mem_tracker(const std::string& type_name) {
+        _mem_tracker = MemTrackerLimiter::create_shared(
+                MemTrackerLimiter::Type::GLOBAL,
+                fmt::format("{}[{}](AllocByAllocator)", type_string(_type), type_name));
+    }
+
+    std::shared_ptr<MemTrackerLimiter> mem_tracker() const {
+        DCHECK(_mem_tracker != nullptr);
+        return _mem_tracker;
+    }
+
+    int64_t mem_consumption() override {
+        DCHECK(_mem_tracker != nullptr);
+        return _mem_tracker->consumption();
+    }
+
+    Cache::Handle* insert(const CacheKey& key, void* value, size_t charge, size_t tracking_bytes,
+                          CachePriority priority = CachePriority::NORMAL) override {
+        return _cache->insert(key, value, charge, priority);
+    }
+
+protected:
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
+};
+
+class LRUCachePolicyTrackingManual : public LRUCachePolicy {
+public:
+    LRUCachePolicyTrackingManual(
+            CacheType type, size_t capacity, LRUCacheType lru_cache_type,
+            uint32_t stale_sweep_time_s, uint32_t num_shards = DEFAULT_LRU_CACHE_NUM_SHARDS,
+            uint32_t element_count_capacity = DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY,
+            bool enable_prune = true)
+            : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
+                             element_count_capacity, enable_prune) {
+        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+    }
+
+    LRUCachePolicyTrackingManual(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
+                                 uint32_t stale_sweep_time_s, uint32_t num_shards,
+                                 uint32_t element_count_capacity,
+                                 CacheValueTimeExtractor cache_value_time_extractor,
+                                 bool cache_value_check_timestamp, bool enable_prune = true)
+            : LRUCachePolicy(type, capacity, lru_cache_type, stale_sweep_time_s, num_shards,
+                             element_count_capacity, cache_value_time_extractor,
+                             cache_value_check_timestamp, enable_prune) {
+        init_mem_tracker(lru_cache_type_string(lru_cache_type));
+    }
+
+    ~LRUCachePolicyTrackingManual() override { reset_cache(); }
+
+    void init_mem_tracker(const std::string& type_name) {
+        _mem_tracker =
+                std::make_unique<MemTracker>(fmt::format("{}[{}]", type_string(_type), type_name),
+                                             ExecEnv::GetInstance()->details_mem_tracker_set());
+    }
+
+    MemTracker* mem_tracker() {
+        DCHECK(_mem_tracker != nullptr);
+        return _mem_tracker.get();
+    }
+
+    int64_t mem_consumption() override {
+        DCHECK(_mem_tracker != nullptr);
+        return _mem_tracker->consumption();
+    }
+
+    // Insert and cache value destroy will be manually consume tracking_bytes to mem tracker.
+    // If lru cache is LRUCacheType::SIZE, tracking_bytes usually equal to charge.
+    Cache::Handle* insert(const CacheKey& key, void* value, size_t charge, size_t tracking_bytes,
+                          CachePriority priority = CachePriority::NORMAL) override {
+        size_t bytes_with_handle = _get_bytes_with_handle(key, charge, tracking_bytes);
+        if (value != nullptr) { // if tracking_bytes = 0, only tracking handle size.
+            mem_tracker()->consume(bytes_with_handle);
+            ((LRUCacheValueBase*)value)->set_tracking_bytes(bytes_with_handle, mem_tracker());
+        }
+        return _cache->insert(key, value, charge, priority);
+    }
+
 private:
     // LRUCacheType::SIZE equal to total_size.
     size_t _get_bytes_with_handle(const CacheKey& key, size_t charge, size_t bytes) {
@@ -219,10 +316,7 @@ private:
         return _lru_cache_type == LRUCacheType::SIZE ? handle_size + charge : handle_size + bytes;
     }
 
-    // if check_capacity failed, will return dummy lru cache,
-    // compatible with ShardedLRUCache usage, but will not actually cache.
-    std::shared_ptr<Cache> _cache;
-    LRUCacheType _lru_cache_type;
+    std::unique_ptr<MemTracker> _mem_tracker;
 };
 
 } // namespace doris

--- a/be/src/runtime/memory/lru_cache_value_base.h
+++ b/be/src/runtime/memory/lru_cache_value_base.h
@@ -25,20 +25,16 @@ namespace doris {
 // Base of the lru cache value.
 class LRUCacheValueBase {
 public:
-    LRUCacheValueBase() = default;
-    LRUCacheValueBase(CachePolicy::CacheType type) {
-        _mem_tracker = CacheManager::instance()->get_cache(type)->mem_tracker();
-    }
-
     virtual ~LRUCacheValueBase() {
         if (_tracking_bytes > 0) {
             _mem_tracker->consume(-_tracking_bytes);
         }
     }
 
-    void set_tracking_bytes(size_t tracking_bytes) { this->_tracking_bytes = tracking_bytes; }
-
-    MemTracker* mem_tracker() const { return _mem_tracker; }
+    void set_tracking_bytes(size_t tracking_bytes, MemTracker* mem_tracker) {
+        this->_tracking_bytes = tracking_bytes;
+        this->_mem_tracker = mem_tracker;
+    }
 
 protected:
     size_t _tracking_bytes = 0;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -186,9 +186,9 @@ LookupConnectionCache* LookupConnectionCache::create_global_instance(size_t capa
 }
 
 RowCache::RowCache(int64_t capacity, int num_shards)
-        : LRUCachePolicy(CachePolicy::CacheType::POINT_QUERY_ROW_CACHE, capacity,
-                         LRUCacheType::SIZE, config::point_query_row_cache_stale_sweep_time_sec,
-                         num_shards) {}
+        : LRUCachePolicyTrackingManual(
+                  CachePolicy::CacheType::POINT_QUERY_ROW_CACHE, capacity, LRUCacheType::SIZE,
+                  config::point_query_row_cache_stale_sweep_time_sec, num_shards) {}
 
 // Create global instance of this class
 RowCache* RowCache::create_global_cache(int64_t capacity, uint32_t num_shards) {
@@ -218,8 +218,8 @@ void RowCache::insert(const RowCacheKey& key, const Slice& value) {
     auto* row_cache_value = new RowCacheValue;
     row_cache_value->cache_value = cache_value;
     const std::string& encoded_key = key.encode();
-    auto* handle = LRUCachePolicy::insert(encoded_key, row_cache_value, value.size, value.size,
-                                          CachePriority::NORMAL);
+    auto* handle = LRUCachePolicyTrackingManual::insert(encoded_key, row_cache_value, value.size,
+                                                        value.size, CachePriority::NORMAL);
     // handle will released
     auto tmp = CacheHandle {this, handle};
 }

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -121,8 +121,10 @@ private:
 };
 
 // RowCache is a LRU cache for row store
-class RowCache : public LRUCachePolicy {
+class RowCache : public LRUCachePolicyTrackingManual {
 public:
+    using LRUCachePolicyTrackingManual::insert;
+
     // The cache key for row lru cache
     struct RowCacheKey {
         RowCacheKey(int64_t tablet_id, const Slice& key) : tablet_id(tablet_id), key(key) {}
@@ -141,7 +143,6 @@ public:
 
     class RowCacheValue : public LRUCacheValueBase {
     public:
-        RowCacheValue() : LRUCacheValueBase(CachePolicy::CacheType::POINT_QUERY_ROW_CACHE) {}
         ~RowCacheValue() override { free(cache_value); }
         char* cache_value;
     };
@@ -214,7 +215,7 @@ private:
 
 // A cache used for prepare stmt.
 // One connection per stmt perf uuid
-class LookupConnectionCache : public LRUCachePolicy {
+class LookupConnectionCache : public LRUCachePolicyTrackingManual {
 public:
     static LookupConnectionCache* instance() {
         return ExecEnv::GetInstance()->get_lookup_connection_cache();
@@ -225,9 +226,9 @@ public:
 private:
     friend class PointQueryExecutor;
     LookupConnectionCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE, capacity,
-                             LRUCacheType::NUMBER,
-                             config::tablet_lookup_cache_stale_sweep_time_sec) {}
+            : LRUCachePolicyTrackingManual(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE,
+                                           capacity, LRUCacheType::NUMBER,
+                                           config::tablet_lookup_cache_stale_sweep_time_sec) {}
 
     static std::string encode_key(__int128_t cache_id) {
         fmt::memory_buffer buffer;
@@ -259,8 +260,6 @@ private:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue() : LRUCacheValueBase(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE) {}
-
         std::shared_ptr<Reusable> item;
     };
 };

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -20,9 +20,9 @@
 namespace doris {
 
 ObjLRUCache::ObjLRUCache(int64_t capacity, uint32_t num_shards)
-        : LRUCachePolicy(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE, capacity,
-                         LRUCacheType::NUMBER, config::common_obj_lru_cache_stale_sweep_time_sec,
-                         num_shards) {
+        : LRUCachePolicyTrackingManual(
+                  CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE, capacity, LRUCacheType::NUMBER,
+                  config::common_obj_lru_cache_stale_sweep_time_sec, num_shards) {
     _enabled = (capacity > 0);
 }
 

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -71,8 +71,7 @@ public:
 
     class CacheValueWithKey : public LRUCacheValueBase {
     public:
-        CacheValueWithKey(int key, void* value)
-                : LRUCacheValueBase(CachePolicy::CacheType::FOR_UT), key(key), value(value) {}
+        CacheValueWithKey(int key, void* value) : key(key), value(value) {}
         ~CacheValueWithKey() override {
             _s_current->_deleted_keys.push_back(key);
             _s_current->_deleted_values.push_back(DecodeValue(value));
@@ -84,17 +83,16 @@ public:
 
     class CacheValue : public LRUCacheValueBase {
     public:
-        CacheValue(void* value) : LRUCacheValueBase(CachePolicy::CacheType::FOR_UT), value(value) {}
-        ~CacheValue() override = default;
+        CacheValue(void* value) : value(value) {}
 
         void* value;
     };
 
-    class CacheTestPolicy : public LRUCachePolicy {
+    class CacheTestPolicy : public LRUCachePolicyTrackingManual {
     public:
         CacheTestPolicy(size_t capacity)
-                : LRUCachePolicy(CachePolicy::CacheType::FOR_UT, capacity, LRUCacheType::SIZE, -1) {
-        }
+                : LRUCachePolicyTrackingManual(CachePolicy::CacheType::FOR_UT, capacity,
+                                               LRUCacheType::SIZE, -1) {}
     };
 
     // there is 16 shards in ShardedLRUCache

--- a/be/test/olap/page_cache_test.cpp
+++ b/be/test/olap/page_cache_test.cpp
@@ -39,7 +39,6 @@ public:
 
 // All cache space is allocated to data pages
 TEST_F(StoragePageCacheTest, data_page_only) {
-    std::cout << "44444" << std::endl;
     StoragePageCache cache(kNumShards * 2048, 0, 0, kNumShards);
 
     StoragePageCache::CacheKey key("abc", 0, 0);
@@ -50,7 +49,7 @@ TEST_F(StoragePageCacheTest, data_page_only) {
     {
         // insert normal page
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(key, data, &handle, page_type, false);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -63,7 +62,7 @@ TEST_F(StoragePageCacheTest, data_page_only) {
     {
         // insert in_memory page
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(memory_key, data, &handle, page_type, true);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -76,7 +75,7 @@ TEST_F(StoragePageCacheTest, data_page_only) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(key, data, &handle, page_type, false);
     }
 
@@ -106,7 +105,6 @@ TEST_F(StoragePageCacheTest, data_page_only) {
 
 // All cache space is allocated to index pages
 TEST_F(StoragePageCacheTest, index_page_only) {
-    std::cout << "33333" << std::endl;
     StoragePageCache cache(kNumShards * 2048, 100, 0, kNumShards);
 
     StoragePageCache::CacheKey key("abc", 0, 0);
@@ -117,7 +115,7 @@ TEST_F(StoragePageCacheTest, index_page_only) {
     {
         // insert normal page
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(key, data, &handle, page_type, false);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -130,7 +128,7 @@ TEST_F(StoragePageCacheTest, index_page_only) {
     {
         // insert in_memory page
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(memory_key, data, &handle, page_type, true);
 
         EXPECT_EQ(handle.data().data, data->data());
@@ -143,7 +141,7 @@ TEST_F(StoragePageCacheTest, index_page_only) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        auto* data = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type);
         cache.insert(key, data, &handle, page_type, false);
     }
 
@@ -186,8 +184,8 @@ TEST_F(StoragePageCacheTest, mixed_pages) {
     {
         // insert both normal pages
         PageCacheHandle data_handle, index_handle;
-        auto* data = new DataPage(1024, mem_tracker);
-        auto* index = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type_data);
+        auto* index = new DataPage(1024, true, page_type_index);
         cache.insert(data_key, data, &data_handle, page_type_data, false);
         cache.insert(index_key, index, &index_handle, page_type_index, false);
 
@@ -205,8 +203,8 @@ TEST_F(StoragePageCacheTest, mixed_pages) {
     {
         // insert both in_memory pages
         PageCacheHandle data_handle, index_handle;
-        auto* data = new DataPage(1024, mem_tracker);
-        auto* index = new DataPage(1024, mem_tracker);
+        auto* data = new DataPage(1024, true, page_type_data);
+        auto* index = new DataPage(1024, true, page_type_index);
         cache.insert(data_key_mem, data, &data_handle, page_type_data, true);
         cache.insert(index_key_mem, index, &index_handle, page_type_index, true);
 
@@ -223,8 +221,8 @@ TEST_F(StoragePageCacheTest, mixed_pages) {
     for (int i = 0; i < 10 * kNumShards; ++i) {
         StoragePageCache::CacheKey key("bcd", 0, i);
         PageCacheHandle handle;
-        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, mem_tracker);
-        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, mem_tracker);
+        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, true, page_type_data);
+        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, true, page_type_index);
         cache.insert(key, data.release(), &handle, page_type_data, false);
         cache.insert(key, index.release(), &handle, page_type_index, false);
     }
@@ -244,8 +242,8 @@ TEST_F(StoragePageCacheTest, mixed_pages) {
         PageCacheHandle data_handle, index_handle;
         StoragePageCache::CacheKey miss_key_data("data_miss", 0, 1);
         StoragePageCache::CacheKey miss_key_index("index_miss", 0, 1);
-        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, mem_tracker);
-        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, mem_tracker);
+        std::unique_ptr<DataPage> data = std::make_unique<DataPage>(1024, true, page_type_data);
+        std::unique_ptr<DataPage> index = std::make_unique<DataPage>(1024, true, page_type_index);
         cache.insert(miss_key_data, data.release(), &data_handle, page_type_data, false);
         cache.insert(miss_key_index, index.release(), &index_handle, page_type_index, false);
 


### PR DESCRIPTION
## Proposed changes

Fix #35590, CacheManager get CachePolicy should be used lock.
- Add LRUCachePolicyTrackingAllocator and LRUCachePolicyTrackingManual.
- tracking memory in LRUCachePolicy::insert, LRUCacheValueBase not need init `mem_tracker`, so not need to get CachePolicy under lock.

<!--Describe your changes.-->

