### PR TITLE
[opt](nereids) compute tuple size by output slots

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -290,7 +290,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             return CostV1.of(context.getSessionVariable(),
                     0,
                     0,
-                    intputRowCount * childStatistics.dataSizeFactor() / beNumber);
+                    intputRowCount * childStatistics.dataSizeFactor(
+                            distribute.child().getOutput()) / beNumber);
         }
 
         // replicate
@@ -301,7 +302,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             return CostV1.of(context.getSessionVariable(),
                     0,
                     0,
-                    intputRowCount * childStatistics.dataSizeFactor());
+                    intputRowCount * childStatistics.dataSizeFactor(
+                            distribute.child().getOutput()));
 
         }
 
@@ -310,7 +312,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             return CostV1.of(context.getSessionVariable(),
                     0,
                     0,
-                    intputRowCount * childStatistics.dataSizeFactor() / beNumber);
+                    intputRowCount * childStatistics.dataSizeFactor(
+                            distribute.child().getOutput()) / beNumber);
         }
 
         // any
@@ -318,7 +321,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         return CostV1.of(context.getSessionVariable(),
                 0,
                 0,
-                intputRowCount * childStatistics.dataSizeFactor() * RANDOM_SHUFFLE_TO_HASH_SHUFFLE_FACTOR / beNumber);
+                intputRowCount * childStatistics.dataSizeFactor(distribute.child().getOutput())
+                        * RANDOM_SHUFFLE_TO_HASH_SHUFFLE_FACTOR / beNumber);
     }
 
     @Override
@@ -334,17 +338,17 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     inputStatistics.getRowCount(), 0);
         }
     }
-
-    private double broadCastJoinBalancePenalty(Statistics probeStats, Statistics buildStats) {
-        // if build side is small enough (<1M), broadcast is also good, no penalty
-        if (buildStats.computeSize() < 1024 * 1024) {
-            return 1;
-        }
-        double broadcastJoinPenalty = (BROADCAST_JOIN_SKEW_RATIO * buildStats.getRowCount()) / probeStats.getRowCount();
-        broadcastJoinPenalty = Math.max(1, broadcastJoinPenalty);
-        broadcastJoinPenalty = Math.min(BROADCAST_JOIN_SKEW_PENALTY_LIMIT, broadcastJoinPenalty);
-        return broadcastJoinPenalty;
-    }
+    //
+    // private double broadCastJoinBalancePenalty(Statistics probeStats, Statistics buildStats) {
+    //     // if build side is small enough (<1M), broadcast is also good, no penalty
+    //     if (buildStats.computeSize() < 1024 * 1024) {
+    //         return 1;
+    //     }
+    //     double broadcastJoinPenalty = (BROADCAST_JOIN_SKEW_RATIO * buildStats.getRowCount()) / probeStats.getRowCount();
+    //     broadcastJoinPenalty = Math.max(1, broadcastJoinPenalty);
+    //     broadcastJoinPenalty = Math.min(BROADCAST_JOIN_SKEW_PENALTY_LIMIT, broadcastJoinPenalty);
+    //     return broadcastJoinPenalty;
+    // }
 
     @Override
     public Cost visitPhysicalHashJoin(
@@ -372,7 +376,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                 leftRowCount += 1;
             }
             if (probeStats.getWidthInJoinCluster() == buildStats.getWidthInJoinCluster()
-                    && probeStats.computeTupleSize() < buildStats.computeTupleSize()) {
+                    && probeStats.computeTupleSize(physicalHashJoin.left().getOutput())
+                    < buildStats.computeTupleSize(physicalHashJoin.right().getOutput())) {
                 // When the number of rows and the width on both sides of the join are the same,
                 // we need to consider the cost of materializing the output.
                 // When there is more data on the build side, a greater penalty will be given.
@@ -407,7 +412,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             double buildSideFactor = context.getSessionVariable().getBroadcastRightTableScaleFactor();
             int totalInstanceNumber = parallelInstance * beNumber;
             if (buildSideFactor <= 1.0) {
-                if (buildStats.computeSize() < 1024 * 1024) {
+                if (buildStats.computeSize(physicalHashJoin.right().getOutput()) < 1024 * 1024) {
                     // no penalty to broadcast if build side is small
                     buildSideFactor = 1.0;
                 } else {
@@ -471,7 +476,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         for (int i = 0; i < physicalIntersect.children().size(); i++) {
             cpuCost += context.getChildStatistics(i).getRowCount();
         }
-        double memoryCost = context.getChildStatistics(0).computeSize();
+        double memoryCost = context.getChildStatistics(0).computeSize(
+                physicalIntersect.child(0).getOutput());
         return CostV1.of(context.getSessionVariable(), cpuCost, memoryCost, 0);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -65,13 +65,6 @@ import java.util.List;
 import java.util.Set;
 
 class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
-
-    // for a join, skew = leftRowCount/rightRowCount
-    // the higher skew is, the more we prefer broadcast join than shuffle join
-    // if skew < BROADCAST_JOIN_SKEW_RATIO, broadcast join will be punished,
-    // the penalty factor is no more than BROADCAST_JOIN_SKEW_PENALTY_LIMIT
-    static final double BROADCAST_JOIN_SKEW_RATIO = 30.0;
-    static final double BROADCAST_JOIN_SKEW_PENALTY_LIMIT = 2.0;
     static final double RANDOM_SHUFFLE_TO_HASH_SHUFFLE_FACTOR = 0.1;
     private final int beNumber;
     private final int parallelInstance;
@@ -338,17 +331,6 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     inputStatistics.getRowCount(), 0);
         }
     }
-    //
-    // private double broadCastJoinBalancePenalty(Statistics probeStats, Statistics buildStats) {
-    //     // if build side is small enough (<1M), broadcast is also good, no penalty
-    //     if (buildStats.computeSize() < 1024 * 1024) {
-    //         return 1;
-    //     }
-    //     double broadcastJoinPenalty = (BROADCAST_JOIN_SKEW_RATIO * buildStats.getRowCount()) / probeStats.getRowCount();
-    //     broadcastJoinPenalty = Math.max(1, broadcastJoinPenalty);
-    //     broadcastJoinPenalty = Math.min(BROADCAST_JOIN_SKEW_PENALTY_LIMIT, broadcastJoinPenalty);
-    //     return broadcastJoinPenalty;
-    // }
 
     @Override
     public Cost visitPhysicalHashJoin(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -86,7 +86,8 @@ public class JoinUtils {
         double memLimit = sessionVariable.getMaxExecMemByte();
         double rowsLimit = sessionVariable.getBroadcastRowCountLimit();
         double brMemlimit = sessionVariable.getBroadcastHashtableMemLimitPercentage();
-        double datasize = join.getGroupExpression().get().child(1).getStatistics().computeSize();
+        double datasize = join.getGroupExpression().get().child(1)
+                .getStatistics().computeSize(join.right().getOutput());
         double rowCount = join.getGroupExpression().get().child(1).getStatistics().getRowCount();
         return rowCount <= rowsLimit && datasize <= memLimit * brMemlimit;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -139,8 +139,9 @@ public class Statistics {
     }
 
     public List<Slot> getAllSlotsFromColumnStatsMap() {
-        return expressionToColumnStats.keySet().stream().filter(Slot.class::isInstance).map(expr -> (Slot) expr).collect(
-                Collectors.toList());
+        return expressionToColumnStats.keySet().stream()
+                .filter(Slot.class::isInstance).map(expr -> (Slot) expr)
+                .collect(Collectors.toList());
     }
 
     public double computeSize(List<Slot> slots) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -23,9 +23,11 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 
 import java.text.DecimalFormat;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Statistics {
     private static final int K_BYTES = 1024;
@@ -122,25 +124,33 @@ public class Statistics {
                         && expressionToColumnStats.get(s).isUnKnown);
     }
 
-    public double computeTupleSize() {
+    public double computeTupleSize(List<Slot> slots) {
         if (tupleSize <= 0) {
             double tempSize = 0.0;
-            for (ColumnStatistic s : expressionToColumnStats.values()) {
-                tempSize += s.avgSizeByte;
+            for (Slot slot : slots) {
+                ColumnStatistic s = expressionToColumnStats.get(slot);
+                if (s != null) {
+                    tempSize += s.avgSizeByte;
+                }
             }
             tupleSize = Math.max(1, tempSize);
         }
         return tupleSize;
     }
 
-    public double computeSize() {
-        return computeTupleSize() * rowCount;
+    public List<Slot> getAllSlotsFromColumnStatsMap() {
+        return expressionToColumnStats.keySet().stream().filter(Slot.class::isInstance).map(expr -> (Slot) expr).collect(
+                Collectors.toList());
     }
 
-    public double dataSizeFactor() {
+    public double computeSize(List<Slot> slots) {
+        return computeTupleSize(slots) * rowCount;
+    }
+
+    public double dataSizeFactor(List<Slot> slots) {
         double lowerBound = 0.03;
         double upperBound = 0.07;
-        return Math.min(Math.max(computeTupleSize() / K_BYTES, lowerBound), upperBound);
+        return Math.min(Math.max(computeTupleSize(slots) / K_BYTES, lowerBound), upperBound);
     }
 
     @Override
@@ -202,7 +212,8 @@ public class Statistics {
     public String detail(String prefix) {
         StringBuilder builder = new StringBuilder();
         builder.append(prefix).append("rows=").append(rowCount).append("\n");
-        builder.append(prefix).append("tupleSize=").append(computeTupleSize()).append("\n");
+        builder.append(prefix).append("tupleSize=")
+                .append(computeTupleSize(getAllSlotsFromColumnStatsMap())).append("\n");
         builder.append(prefix).append("width=").append(widthInJoinCluster).append("\n");
         for (Entry<Expression, ColumnStatistic> entry : expressionToColumnStats.entrySet()) {
             builder.append(prefix).append(entry.getKey()).append(" -> ").append(entry.getValue()).append("\n");


### PR DESCRIPTION
## Proposed changes
in previous version, nereids compute output tuple size of an operator by sum all avgSize of column stats in stats.expressionToColumnStats. This is not accurate, because we may put some intermediate expression's column stats into stats.expressionToColumnStats, and hence the tuple size may becomes larger.

Issue Number: close #xxx

<!--Describe your changes.-->

