### PR TITLE
[FIx](trino-connector) Fix the issue with trino-connector catalog replay during FE restart.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalCatalog.java
@@ -112,14 +112,6 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
         super(catalogId, name, Type.TRINO_CONNECTOR, comment);
         Objects.requireNonNull(name, "catalogName is null");
         catalogProperty = new CatalogProperty(resource, props);
-
-        // All properties obtained by this method are used by the trino-connector.
-        // We should not modify this map
-        trinoProperties = ImmutableMap.copyOf(catalogProperty.getProperties().entrySet().stream()
-                .filter(kv -> kv.getKey().startsWith(TRINO_CONNECTOR_PROPERTIES_PREFIX))
-                .collect(Collectors
-                        .toMap(kv1 -> kv1.getKey().substring(TRINO_CONNECTOR_PROPERTIES_PREFIX.length()),
-                                kv1 -> kv1.getValue())));
     }
 
     @Override
@@ -136,6 +128,13 @@ public class TrinoConnectorExternalCatalog extends ExternalCatalog {
     @Override
     protected void initLocalObjectsImpl() {
         this.trinoCatalogHandle = CatalogHandle.createRootCatalogHandle(name, new CatalogVersion("test"));
+        // All properties obtained by this method are used by the trino-connector.
+        // We should not modify this map
+        trinoProperties = ImmutableMap.copyOf(catalogProperty.getProperties().entrySet().stream()
+                .filter(kv -> kv.getKey().startsWith(TRINO_CONNECTOR_PROPERTIES_PREFIX))
+                .collect(Collectors
+                        .toMap(kv1 -> kv1.getKey().substring(TRINO_CONNECTOR_PROPERTIES_PREFIX.length()),
+                                kv1 -> kv1.getValue())));
 
         ConnectorServicesProvider connectorServicesProvider = createConnectorServicesProvider();
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When FE restarts, the TrinoConnectorExternalCatalog constructor is not executed, causing `trinoProperties` to be null. This results in an NPE issue when accessing the catalog.

```
java.lang.NullPointerException: Cannot invoke "com.google.common.collect.ImmutableMap.containsKey(Object)" because "this.trinoProperties" is null
        at org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalCatalog.createConnectorServicesProvider(TrinoConnectorExternalCatalog.java:198) ~[classes/:?]
        at org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalCatalog.initLocalObjectsImpl(TrinoConnectorExternalCatalog.java:140) ~[classes/:?]
        at org.apache.doris.datasource.ExternalCatalog.initLocalObjects(ExternalCatalog.java:263) ~[classes/:?]
        at org.apache.doris.datasource.ExternalCatalog.makeSureInitialized(ExternalCatalog.java:227) ~[classes/:?]
        at org.apache.doris.datasource.ExternalCatalog.getDbNames(ExternalCatalog.java:439) ~[classes/:?]
        at org.apache.doris.qe.ShowExecutor.handleShowDb(ShowExecutor.java:910) ~[classes/:?]
        at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:314) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:2826) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:1018) ~[classes/:?]
```


<!--Describe your changes.-->

