### PR TITLE
[fix](group commit) Fix group commit in nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
@@ -95,10 +95,11 @@ public class GroupCommitInsertExecutor extends AbstractInsertExecutor {
         }
         OlapTable targetTable = physicalOlapTableSink.getTargetTable();
         return ctx.getSessionVariable().getSqlMode() != SqlModeHelper.MODE_NO_BACKSLASH_ESCAPES
-                && !ctx.isTxnModel() && isGroupCommitAvailablePlan(physicalOlapTableSink, planner)
-                && physicalOlapTableSink.getPartitionIds().isEmpty() && targetTable.getTableProperty()
-                .getUseSchemaLightChange() && !targetTable.getQualifiedDbName()
-                .equalsIgnoreCase(FeConstants.INTERNAL_DB_NAME);
+                && !ctx.isTxnModel()
+                && physicalOlapTableSink.getPartitionIds().isEmpty()
+                && targetTable.getTableProperty().getUseSchemaLightChange()
+                && !targetTable.getQualifiedDbName().equalsIgnoreCase(FeConstants.INTERNAL_DB_NAME)
+                && isGroupCommitAvailablePlan(physicalOlapTableSink, planner);
     }
 
     private static boolean literalExpr(NereidsPlanner planner) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -315,6 +315,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
     public void processOnce() throws IOException {
         // set status of query to OK.
         ctx.getState().reset();
+        ctx.setGroupCommit(false);
         executor = null;
 
         // reset sequence id of MySQL protocol


### PR DESCRIPTION
## Proposed changes

1. The group commit in nereids use `isGroupCommit` variable in `ConnectContext` to mark if it is a group commit, but not reset. If executes 2 sqls, the first is group_commit, the second is not group_commit, the `isGroupCommit` is true for the second sql and the data_sink is `GroupCommitBlockSink`
2. Move the `isGroupCommitAvailablePlan` to the end when check `canGroupCommit` because it's cpu expensive
