### PR TITLE
[pipeline](load) Not blocking in execution threads

### DIFF
--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -86,16 +86,11 @@ Status GroupCommitBlockSinkLocalState::close(RuntimeState* state, Status close_s
         _load_block_queue->remove_load_id(p._load_id);
     }
     // wait to wal
-    auto st = Status::OK();
     if (_load_block_queue && (_load_block_queue->wait_internal_group_commit_finish ||
                               _group_commit_mode == TGroupCommitMode::SYNC_MODE)) {
-        std::unique_lock l(_load_block_queue->mutex);
-        if (!_load_block_queue->process_finish) {
-            return Status::InternalError("_load_block_queue is not finished!");
-        }
-        st = _load_block_queue->status;
+        return _load_block_queue->status;
     }
-    return st;
+    return Status::OK();
 }
 
 Status GroupCommitBlockSinkLocalState::_add_block(RuntimeState* state,

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -64,11 +64,6 @@ Status GroupCommitBlockSinkLocalState::close(RuntimeState* state, Status close_s
     SCOPED_TIMER(_close_timer);
     RETURN_IF_ERROR(Base::close(state, close_status));
     RETURN_IF_ERROR(close_status);
-
-    if (_load_block_queue) {
-        _remove_estimated_wal_bytes();
-        _load_block_queue->remove_load_id(_parent->cast<GroupCommitBlockSinkOperatorX>()._load_id);
-    }
     // wait to wal
     auto st = Status::OK();
     if (_load_block_queue && (_load_block_queue->wait_internal_group_commit_finish ||
@@ -287,6 +282,8 @@ Status GroupCommitBlockSinkOperatorX::sink(RuntimeState* state, vectorized::Bloc
                 }
                 RETURN_IF_ERROR(local_state._add_blocks(state, true));
             }
+            local_state._remove_estimated_wal_bytes();
+            local_state._load_block_queue->remove_load_id(_load_id);
         }
         return Status::OK();
     };

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -170,10 +170,6 @@ Status GroupCommitBlockSinkLocalState::_add_blocks(RuntimeState* state,
             RETURN_IF_ERROR(_state->exec_env()->group_commit_mgr()->get_first_block_load_queue(
                     p._db_id, p._table_id, p._base_schema_version, load_id, _load_block_queue,
                     _state->be_exec_version(), _state->query_mem_tracker()));
-            if (_load_block_queue->wait_internal_group_commit_finish ||
-                _group_commit_mode == TGroupCommitMode::SYNC_MODE) {
-                _load_block_queue->append_dependency(_finish_dependency);
-            }
             if (_group_commit_mode == TGroupCommitMode::ASYNC_MODE) {
                 size_t estimated_wal_bytes =
                         _calculate_estimated_wal_bytes(is_blocks_contain_all_load_data);
@@ -190,6 +186,10 @@ Status GroupCommitBlockSinkLocalState::_add_blocks(RuntimeState* state,
                 } else {
                     _estimated_wal_bytes = estimated_wal_bytes;
                 }
+            }
+            if (_load_block_queue->wait_internal_group_commit_finish ||
+                _group_commit_mode == TGroupCommitMode::SYNC_MODE) {
+                _load_block_queue->append_dependency(_finish_dependency);
             }
             _state->set_import_label(_load_block_queue->label);
             _state->set_wal_id(_load_block_queue->txn_id);

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -170,7 +170,10 @@ Status GroupCommitBlockSinkLocalState::_add_blocks(RuntimeState* state,
             RETURN_IF_ERROR(_state->exec_env()->group_commit_mgr()->get_first_block_load_queue(
                     p._db_id, p._table_id, p._base_schema_version, load_id, _load_block_queue,
                     _state->be_exec_version(), _state->query_mem_tracker()));
-            _load_block_queue->append_dependency(_finish_dependency);
+            if (_load_block_queue->wait_internal_group_commit_finish ||
+                _group_commit_mode == TGroupCommitMode::SYNC_MODE) {
+                _load_block_queue->append_dependency(_finish_dependency);
+            }
             if (_group_commit_mode == TGroupCommitMode::ASYNC_MODE) {
                 size_t estimated_wal_bytes =
                         _calculate_estimated_wal_bytes(is_blocks_contain_all_load_data);

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -82,6 +82,14 @@ Status GroupCommitBlockSinkLocalState::close(RuntimeState* state, Status close_s
     return st;
 }
 
+std::string GroupCommitBlockSinkLocalState::debug_string(int indentation_level) const {
+    fmt::memory_buffer debug_string_buffer;
+    fmt::format_to(debug_string_buffer, "{}", Base::debug_string(indentation_level));
+    fmt::format_to(debug_string_buffer, ", _load_block_queue: ({})",
+                   _load_block_queue ? _load_block_queue->debug_string() : "NULL");
+    return fmt::to_string(debug_string_buffer);
+}
+
 Status GroupCommitBlockSinkLocalState::_add_block(RuntimeState* state,
                                                   std::shared_ptr<vectorized::Block> block) {
     if (block->rows() == 0) {
@@ -218,6 +226,7 @@ Status GroupCommitBlockSinkLocalState::_add_blocks(RuntimeState* state,
 }
 
 Status GroupCommitBlockSinkOperatorX::init(const TDataSink& t_sink) {
+    RETURN_IF_ERROR(Base::init(t_sink));
     DCHECK(t_sink.__isset.olap_table_sink);
     auto& table_sink = t_sink.olap_table_sink;
     _tuple_desc_id = table_sink.tuple_id;
@@ -259,10 +268,33 @@ Status GroupCommitBlockSinkOperatorX::sink(RuntimeState* state, vectorized::Bloc
     SCOPED_CONSUME_MEM_TRACKER(local_state._mem_tracker.get());
     Status status = Status::OK();
 
+    auto wind_up = [&]() -> Status {
+        if (eos) {
+            int64_t total_rows = state->num_rows_load_total();
+            int64_t loaded_rows = state->num_rows_load_total();
+            state->set_num_rows_load_total(loaded_rows + state->num_rows_load_unselected() +
+                                           state->num_rows_load_filtered());
+            state->update_num_rows_load_filtered(local_state._block_convertor->num_filtered_rows() +
+                                                 total_rows - loaded_rows);
+            if (!local_state._is_block_appended) {
+                // if not meet the max_filter_ratio, we should return error status directly
+                int64_t num_selected_rows =
+                        state->num_rows_load_total() - state->num_rows_load_unselected();
+                if (num_selected_rows > 0 &&
+                    (double)state->num_rows_load_filtered() / num_selected_rows >
+                            _max_filter_ratio) {
+                    return Status::DataQualityError("too many filtered rows");
+                }
+                RETURN_IF_ERROR(local_state._add_blocks(state, true));
+            }
+        }
+        return Status::OK();
+    };
+
     auto rows = input_block->rows();
     auto bytes = input_block->bytes();
     if (UNLIKELY(rows == 0)) {
-        return status;
+        return wind_up();
     }
 
     // update incrementally so that FE can get the progress.
@@ -310,26 +342,8 @@ Status GroupCommitBlockSinkOperatorX::sink(RuntimeState* state, vectorized::Bloc
     }
     // add block into block queue
     RETURN_IF_ERROR(local_state._add_block(state, block));
-    if (eos) {
-        int64_t total_rows = state->num_rows_load_total();
-        int64_t loaded_rows = state->num_rows_load_total();
-        state->set_num_rows_load_total(loaded_rows + state->num_rows_load_unselected() +
-                                       state->num_rows_load_filtered());
-        state->update_num_rows_load_filtered(local_state._block_convertor->num_filtered_rows() +
-                                             total_rows - loaded_rows);
-        if (!local_state._is_block_appended) {
-            // if not meet the max_filter_ratio, we should return error status directly
-            int64_t num_selected_rows =
-                    state->num_rows_load_total() - state->num_rows_load_unselected();
-            if (num_selected_rows > 0 &&
-                (double)state->num_rows_load_filtered() / num_selected_rows > _max_filter_ratio) {
-                return Status::DataQualityError("too many filtered rows");
-            }
-            RETURN_IF_ERROR(local_state._add_blocks(state, true));
-        }
-    }
 
-    return Status::OK();
+    return wind_up();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.h
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.h
@@ -37,7 +37,7 @@ public:
             : Base(parent, state), _filter_bitmap(1024) {
         _finish_dependency =
                 std::make_shared<Dependency>(parent->operator_id(), parent->node_id(),
-                                             parent->get_name() + "_FINISH_DEPENDENCY");
+                                             parent->get_name() + "_FINISH_DEPENDENCY", true);
     }
 
     ~GroupCommitBlockSinkLocalState() override;

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.h
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.h
@@ -46,6 +46,7 @@ public:
 
     Status close(RuntimeState* state, Status exec_status) override;
     Dependency* finishdependency() override { return _finish_dependency.get(); }
+    std::string debug_string(int indentation_level) const override;
 
 private:
     friend class GroupCommitBlockSinkOperatorX;

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.h
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.h
@@ -34,13 +34,18 @@ class GroupCommitBlockSinkLocalState final : public PipelineXSinkLocalState<Basi
 
 public:
     GroupCommitBlockSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state)
-            : Base(parent, state), _filter_bitmap(1024) {}
+            : Base(parent, state), _filter_bitmap(1024) {
+        _finish_dependency =
+                std::make_shared<Dependency>(parent->operator_id(), parent->node_id(),
+                                             parent->get_name() + "_FINISH_DEPENDENCY");
+    }
 
     ~GroupCommitBlockSinkLocalState() override;
 
     Status open(RuntimeState* state) override;
 
     Status close(RuntimeState* state, Status exec_status) override;
+    Dependency* finishdependency() override { return _finish_dependency.get(); }
 
 private:
     friend class GroupCommitBlockSinkOperatorX;
@@ -66,6 +71,7 @@ private:
     TGroupCommitMode::type _group_commit_mode;
     Bitmap _filter_bitmap;
     int64_t _table_id;
+    std::shared_ptr<Dependency> _finish_dependency;
 };
 
 class GroupCommitBlockSinkOperatorX final

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -621,10 +621,9 @@ Status LoadBlockQueue::close_wal() {
 
 void LoadBlockQueue::append_dependency(std::shared_ptr<pipeline::Dependency> finish_dep) {
     std::lock_guard<std::mutex> lock(mutex);
-    // If finished, dependencies should be ready.
-    if (process_finish) {
-        finish_dep->set_always_ready();
-    } else {
+    // If not finished, dependencies should be blocked.
+    if (!process_finish) {
+        finish_dep->block();
         dependencies.push_back(finish_dep);
     }
 }

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -26,6 +26,7 @@
 #include "common/compiler_util.h"
 #include "common/config.h"
 #include "common/status.h"
+#include "pipeline/dependency.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "util/debug_points.h"
@@ -459,8 +460,10 @@ Status GroupCommitTable::_finish_group_commit_load(int64_t db_id, int64_t table_
             {
                 std::unique_lock l2(load_block_queue->mutex);
                 load_block_queue->process_finish = true;
+                for (auto dep : load_block_queue->dependencies) {
+                    dep->set_always_ready();
+                }
             }
-            load_block_queue->internal_group_commit_finish_cv.notify_all();
         }
         _load_block_queues.erase(instance_id);
     }
@@ -614,6 +617,16 @@ Status LoadBlockQueue::close_wal() {
         RETURN_IF_ERROR(_v_wal_writer->close());
     }
     return Status::OK();
+}
+
+void LoadBlockQueue::append_dependency(std::shared_ptr<pipeline::Dependency> finish_dep) {
+    std::lock_guard<std::mutex> lock(mutex);
+    // If finished, dependencies should be ready.
+    if (process_finish) {
+        finish_dep->set_always_ready();
+    } else {
+        dependencies.push_back(finish_dep);
+    }
 }
 
 bool LoadBlockQueue::has_enough_wal_disk_space(size_t estimated_wal_bytes) {

--- a/be/src/runtime/group_commit_mgr.h
+++ b/be/src/runtime/group_commit_mgr.h
@@ -41,6 +41,10 @@ class ExecEnv;
 class TUniqueId;
 class RuntimeState;
 
+namespace pipeline {
+class Dependency;
+}
+
 struct BlockData {
     BlockData(const std::shared_ptr<vectorized::Block>& block)
             : block(block), block_bytes(block->bytes()) {};
@@ -79,6 +83,7 @@ public:
                       int be_exe_version);
     Status close_wal();
     bool has_enough_wal_disk_space(size_t estimated_wal_bytes);
+    void append_dependency(std::shared_ptr<pipeline::Dependency> finish_dep);
 
     UniqueId load_instance_id;
     std::string label;
@@ -92,9 +97,9 @@ public:
 
     // the execute status of this internal group commit
     std::mutex mutex;
-    std::condition_variable internal_group_commit_finish_cv;
     bool process_finish = false;
     Status status = Status::OK();
+    std::vector<std::shared_ptr<pipeline::Dependency>> dependencies;
 
 private:
     void _cancel_without_lock(const Status& st);

--- a/be/src/runtime/group_commit_mgr.h
+++ b/be/src/runtime/group_commit_mgr.h
@@ -85,6 +85,18 @@ public:
     bool has_enough_wal_disk_space(size_t estimated_wal_bytes);
     void append_dependency(std::shared_ptr<pipeline::Dependency> finish_dep);
 
+    std::string debug_string() const {
+        fmt::memory_buffer debug_string_buffer;
+        fmt::format_to(debug_string_buffer,
+                       "load_instance_id={}, label={}, txn_id={}, "
+                       "wait_internal_group_commit_finish={}, data_size_condition={}, "
+                       "group_commit_load_count={}, process_finish={}",
+                       load_instance_id.to_string(), label, txn_id,
+                       wait_internal_group_commit_finish, data_size_condition,
+                       group_commit_load_count, process_finish.load());
+        return fmt::to_string(debug_string_buffer);
+    }
+
     UniqueId load_instance_id;
     std::string label;
     int64_t txn_id;
@@ -97,7 +109,7 @@ public:
 
     // the execute status of this internal group commit
     std::mutex mutex;
-    bool process_finish = false;
+    std::atomic<bool> process_finish = false;
     Status status = Status::OK();
     std::vector<std::shared_ptr<pipeline::Dependency>> dependencies;
 


### PR DESCRIPTION
## Proposed changes

In group-commit loading tasks, we will wait for a condition variables in execution threads before finishing. This is harmful for pipeline engine.

<!--Describe your changes.-->

