### PR TITLE
[improve](fe) Improve checking compatibility mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -227,6 +227,11 @@ public class DorisFE {
     }
 
     private static void checkAllPorts() throws IOException {
+        if (Config.enable_check_compatibility_mode) {
+            // The compatibility mode does not need to listen ports.
+            return;
+        }
+
         if (!NetUtils.isPortAvailable(FrontendOptions.getLocalHostAddress(), Config.edit_log_port,
                 "Edit log port", NetUtils.EDIT_LOG_PORT_SUGGESTION)) {
             throw new IOException("port " + Config.edit_log_port + " already in use");

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -96,8 +96,8 @@ public class BDBEnvironment {
     public void setup(File envHome, String selfNodeName, String selfNodeHostPort,
                       String helperHostPort) {
         // Almost never used, just in case the master can not restart
-        if (metadataFailureRecovery) {
-            if (!isElectable) {
+        if (metadataFailureRecovery || Config.enable_check_compatibility_mode) {
+            if (!isElectable && !Config.enable_check_compatibility_mode) {
                 LOG.error("Current node is not in the electable_nodes list. will exit");
                 System.exit(-1);
             }


### PR DESCRIPTION
1. Reset bdbje group to avoid infinite blocking
2. Skip port available checking
