### PR TITLE
[fix](memory allocate) Fix reinitialization of TabletReader

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -317,7 +317,8 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             },
             status);
 
-    if (status.is<doris::ErrorCode::MEM_ALLOC_FAILED>() || status.is<doris::ErrorCode::MEM_LIMIT_EXCEEDED>()) {
+    if (status.is<doris::ErrorCode::MEM_ALLOC_FAILED>() ||
+        status.is<doris::ErrorCode::MEM_LIMIT_EXCEEDED>()) {
         scan_task->set_status(status);
         eos = true;
     }

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -31,6 +31,7 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/config.h"
 #include "common/logging.h"
+#include "common/status.h"
 #include "olap/tablet.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
@@ -315,7 +316,8 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
                 eos = true;
             },
             status);
-    if (status.is<doris::ErrorCode::MEM_ALLOC_FAILED>()) {
+
+    if (status.is<doris::ErrorCode::MEM_ALLOC_FAILED>() || status.is<doris::ErrorCode::MEM_LIMIT_EXCEEDED>()) {
         scan_task->set_status(status);
         eos = true;
     }


### PR DESCRIPTION
`ASSIGN_STATUS_IF_CATCH_EXCEPTION` will convert error code from `MEM_ALLOC_FAILED` to `MEM_LIMIT_EXCEEDED`, this will lead to problem like below:

```text
F20240614 16:07:18.529981 3400047 delete_handler.cpp:388] Check failed: !_is_inited reinitialize delete handler.
*** Check failure stack trace: ***
    @     0x561cdc597926  google::LogMessage::SendToLog()
    @     0x561cdc594370  google::LogMessage::Flush()
    @     0x561cdc598169  google::LogMessageFatal::~LogMessageFatal()
    @     0x561cacf6ba70  doris::DeleteHandler::init()
    @     0x561caf6e9298  doris::TabletReader::_init_delete_condition()
    @     0x561caf6e257c  doris::TabletReader::_init_params()
    @     0x561caf6e1a09  doris::TabletReader::init()
    @     0x561cd847917f  doris::vectorized::BlockReader::init()
    @     0x561cdbc466a4  doris::vectorized::NewOlapScanner::open()
    @     0x561cc3a1b623  doris::vectorized::ScannerScheduler::_scanner_scan()
    @     0x561cc3a1fae1  _ZZZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS0_14ScannerContextEES2_INS0_8ScanTaskEEENK3$_1clEvENKUlvE_clEvENKUlvE_clEv
    @     0x561cc3a1f554  _ZZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS0_14ScannerContextEES2_INS0_8ScanTaskEEENK3$_1clEvENKUlvE_clEv
    @     0x561cc3a1f3c5  _ZSt13__invoke_implIvRZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS1_14ScannerContextEES3_INS1_8ScanTaskEEENK3$_1clEvEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @     0x561cc3a1f365  _ZSt10__invoke_rIvRZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS1_14ScannerContextEES3_INS1_8ScanTaskEEENK3$_1clEvEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESC_E4typeEOSD_DpOSE_
    @     0x561cc3a1f18d  _ZNSt17_Function_handlerIFvvEZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS2_14ScannerContextEES4_INS2_8ScanTaskEEENK3$_1clEvEUlvE_E9_M_invokeERKSt9_Any_data
    @     0x561cac9f8023  std::function<>::operator()()
    @     0x561cc3a333b5  _ZZN5doris10vectorized23SimplifiedScanScheduler16submit_scan_taskENS0_18SimplifiedScanTaskEENKUlvE_clEv
    @     0x561cc3a33395  _ZSt13__invoke_implIvRZN5doris10vectorized23SimplifiedScanScheduler16submit_scan_taskENS1_18SimplifiedScanTaskEEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @     0x561cc3a33335  _ZSt10__invoke_rIvRZN5doris10vectorized23SimplifiedScanScheduler16submit_scan_taskENS1_18SimplifiedScanTaskEEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES7_E4typeEOS8_DpOS9_
    @     0x561cc3a3312d  _ZNSt17_Function_handlerIFvvEZN5doris10vectorized23SimplifiedScanScheduler16submit_scan_taskENS2_18SimplifiedScanTaskEEUlvE_E9_M_invokeERKSt9_Any_data
    @     0x561cac9f8023  std::function<>::operator()()
    @     0x561cb095d4e9  doris::FunctionRunnable::run()
    @     0x561cb094913e  doris::ThreadPool::dispatch_thread()
    @     0x561cb0970564  std::__invoke_impl<>()
    @     0x561cb097043d  std::__invoke<>()
    @     0x561cb09703c5  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x561cb097026e  std::_Bind<>::operator()<>()
    @     0x561cb0970185  std::__invoke_impl<>()
    @     0x561cb0970125  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x561cb096fdcd  std::_Function_handler<>::_M_invoke()
    @     0x561cac9f8023  std::function<>::operator()()
    @     0x561cb091666c  doris::Thread::supervise_thread()
```