### PR TITLE
[Fix](Nereids) fix distribute hint showing problem in hint log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/DistributeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/DistributeType.java
@@ -47,26 +47,4 @@ public enum DistributeType {
         this.leftHint = leftHint;
         this.rightHint = rightHint;
     }
-
-    public JoinDistributeType getLeftHint() {
-        return leftHint;
-    }
-
-    public JoinDistributeType getRightHint() {
-        return rightHint;
-    }
-
-    /**
-     * Create join hint from join right child's join hint type.
-     */
-    public static DistributeType fromRightPlanHintType(JoinDistributeType hintType) {
-        switch (hintType) {
-            case SHUFFLE:
-                return SHUFFLE_RIGHT;
-            case BROADCAST:
-                return BROADCAST_RIGHT;
-            default:
-                return NONE;
-        }
-    }
 }


### PR DESCRIPTION
Problem:
when using distribute hint and join reorder together it would show distribute hint unused in hint log, but actually it works
Reason:
when new a distribute hint object, optimizer put it to context directly, it should not be copy to a new one, or it would loss
used/unused message
Solved:
when we need to copy a new distribute hint, we can get the original one

