### PR TITLE
[Fix](Nereids) fix leading with brace can not generate correct plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/hint/LeadingHint.java
@@ -53,9 +53,9 @@ import java.util.Stack;
 public class LeadingHint extends Hint {
     private String originalString = "";
 
-    private List<String> parameters;
+    private List<String> addJoinParameters;
+    private List<String> normalizedParameters;
     private final List<String> tablelist = new ArrayList<>();
-    private final List<Integer> levelList = new ArrayList<>();
 
     private final Map<Integer, DistributeHint> distributeHints = new HashMap<>();
 
@@ -87,79 +87,81 @@ public class LeadingHint extends Hint {
     public LeadingHint(String hintName, List<String> parameters, String originalString) {
         super(hintName);
         this.originalString = originalString;
-        this.parameters = parameters;
-        int level = 0;
-        Stack<Boolean> brace = new Stack<>();
-        String lastParameter = "";
-        for (String parameter : parameters) {
-            if (parameter.equals("{")) {
-                if (lastParameter.equals("}")) {
-                    level += 2;
-                    brace.push(true);
-                } else {
-                    ++level;
-                    brace.push(false);
-                }
-            } else if (parameter.equals("}")) {
-                if (brace.pop().equals(true)) {
-                    level -= 2;
-                } else {
-                    level--;
-                }
-            } else if (parameter.equals("shuffle")) {
-                DistributeHint distributeHint = new DistributeHint(DistributeType.SHUFFLE_RIGHT);
-                distributeHints.put(tablelist.size(), distributeHint);
-                if (!ConnectContext.get().getStatementContext().getHints().contains(distributeHint)) {
-                    ConnectContext.get().getStatementContext().addHint(distributeHint);
-                }
-            } else if (parameter.equals("broadcast")) {
-                DistributeHint distributeHint = new DistributeHint(DistributeType.BROADCAST_RIGHT);
-                distributeHints.put(tablelist.size(), distributeHint);
-                if (!ConnectContext.get().getStatementContext().getHints().contains(distributeHint)) {
-                    ConnectContext.get().getStatementContext().addHint(distributeHint);
-                }
+        addJoinParameters = insertJoinIntoParameters(parameters);
+        normalizedParameters = parseIntoReversePolishNotation(addJoinParameters);
+    }
+
+    /**
+     * insert join string into leading string
+     * @param list of sql input leading string
+     * @return list of string adding joins into tables
+     */
+    public static List<String> insertJoinIntoParameters(List<String> list) {
+        List<String> output = new ArrayList<>();
+
+        for (String item : list) {
+            if (item.equals("shuffle") || item.equals("broadcast")) {
+                output.remove(output.size() - 1);
+                output.add(item);
+                continue;
+            } else if (item.equals("{")) {
+                output.add(item);
+                continue;
+            } else if (item.equals("}")) {
+                output.remove(output.size() - 1);
+                output.add(item);
             } else {
-                tablelist.add(parameter);
-                levelList.add(level);
+                output.add(item);
             }
-            lastParameter = parameter;
+            output.add("join");
         }
-        normalizeLevelList();
+        output.remove(output.size() - 1);
+        return output;
     }
 
-    private void removeGap(int left, int right, int gap) {
-        for (int i = left; i <= right; i++) {
-            levelList.set(i, levelList.get(i) - (gap - 1));
-        }
-    }
+    /**
+     * parse list string of original leading string with join string to Reverse Polish notation
+     * @param list of leading with join string
+     * @return Reverse Polish notation which can be used directly changed into logical join
+     */
+    public List<String> parseIntoReversePolishNotation(List<String> list) {
+        Stack<String> s1 = new Stack<>();
+        List<String> s2 = new ArrayList<>();
 
-    // when we write leading like: leading(t1 {{t2 t3} {t4 t5}} t6)
-    // levelList would like 0 2 2 3 3 0, it could be reduced to 0 1 1 2 2 0 like leading(t1 {t2 t3 {t4 t5}} t6)
-    // gap is like 0 to 2 or 3 to 0 in upper example, and this function is to remove gap when we use a lot of braces
-    private void normalizeLevelList() {
-        int leftIndex = 0;
-        // at lease two tables were needed
-        for (int i = 1; i < levelList.size(); i++) {
-            if ((levelList.get(i) - levelList.get(leftIndex)) > 1) {
-                int rightIndex = i;
-                for (int j = i; j < levelList.size(); j++) {
-                    if ((levelList.get(rightIndex) - levelList.get(j)) > 1) {
-                        removeGap(i, rightIndex, Math.min(levelList.get(i) - levelList.get(leftIndex),
-                                levelList.get(rightIndex) - levelList.get(j)));
-                    }
-                    rightIndex = j;
+        for (String item : list) {
+            if (!(item.equals("shuffle") || item.equals("broadcast") || item.equals("{")
+                    || item.equals("}") || item.equals("join"))) {
+                tablelist.add(item);
+                s2.add(item);
+            } else if (item.equals("{")) {
+                s1.push(item);
+            } else if (item.equals("}")) {
+                while (!s1.peek().equals("{")) {
+                    String pop = s1.pop();
+                    s2.add(pop);
                 }
+                s1.pop();
+            } else {
+                if (item.equals("shuffle")) {
+                    distributeHints.put(item.hashCode(), new DistributeHint(DistributeType.SHUFFLE_RIGHT));
+                } else if (item.equals("broadcast")) {
+                    distributeHints.put(item.hashCode(), new DistributeHint(DistributeType.BROADCAST_RIGHT));
+                }
+
+                while (s1.size() != 0 && !s1.peek().equals("{")) {
+                    s2.add(s1.pop());
+                }
+                s1.push(item);
             }
-            leftIndex = i;
         }
+        while (s1.size() > 0) {
+            s2.add(s1.pop());
+        }
+        return s2;
     }
 
     public List<String> getTablelist() {
         return tablelist;
-    }
-
-    public List<Integer> getLevelList() {
-        return levelList;
     }
 
     public Map<RelationId, LogicalPlan> getRelationIdToScanMap() {
@@ -172,18 +174,18 @@ public class LeadingHint extends Hint {
             return originalString;
         }
         StringBuilder out = new StringBuilder();
-        int tableIndex = 0;
-        for (String parameter : parameters) {
+        for (String parameter : addJoinParameters) {
             if (parameter.equals("{") || parameter.equals("}") || parameter.equals("[") || parameter.equals("]")) {
                 out.append(parameter + " ");
             } else if (parameter.equals("shuffle") || parameter.equals("broadcast")) {
-                DistributeHint distributeHint = distributeHints.get(tableIndex);
+                DistributeHint distributeHint = distributeHints.get(parameter.hashCode());
                 if (distributeHint.isSuccess()) {
                     out.append(parameter + " ");
                 }
+            } else if (parameter.equals("join")) {
+                continue;
             } else {
                 out.append(parameter + " ");
-                tableIndex++;
             }
         }
         return "leading(" + out.toString() + ")";
@@ -504,96 +506,75 @@ public class LeadingHint extends Hint {
         return JoinType.INNER_JOIN;
     }
 
+    private DistributeHint getDistributeJoinHint(String distributeJoinType) {
+        DistributeHint distributeHint = null;
+        if (distributeJoinType.equals("join")) {
+            distributeHint = new DistributeHint(DistributeType.NONE);
+        } else if (distributeJoinType.equals("shuffle") || distributeJoinType.equals("broadcast")) {
+            distributeHint = distributeHints.get(distributeJoinType.hashCode());
+        }
+        distributeHint.setSuccessInLeading(true);
+        if (!ConnectContext.get().getStatementContext().getHints().contains(distributeHint)) {
+            ConnectContext.get().getStatementContext().addHint(distributeHint);
+        }
+        distributeHints.put(0, distributeHint);
+        return distributeHint;
+    }
+
+    private LogicalPlan makeJoinPlan(LogicalPlan leftChild, LogicalPlan rightChild, String distributeJoinType) {
+        List<Expression> conditions = getJoinConditions(
+                getFilters(), leftChild, rightChild);
+        Pair<List<Expression>, List<Expression>> pair = JoinUtils.extractExpressionForHashTable(
+                leftChild.getOutput(), rightChild.getOutput(), conditions);
+        // leading hint would set status inside if not success
+        JoinType joinType = computeJoinType(getBitmap(leftChild),
+                getBitmap(rightChild), conditions);
+        if (joinType == null) {
+            this.setStatus(HintStatus.SYNTAX_ERROR);
+            this.setErrorMessage("JoinType can not be null");
+        } else if (!isConditionJoinTypeMatched(conditions, joinType)) {
+            this.setStatus(HintStatus.UNUSED);
+            this.setErrorMessage("condition does not matched joinType");
+        }
+        if (!this.isSuccess()) {
+            return null;
+        }
+        // get joinType
+        DistributeHint distributeHint = getDistributeJoinHint(distributeJoinType);
+        LogicalJoin logicalJoin = new LogicalJoin<>(joinType, pair.first,
+                pair.second,
+                distributeHint,
+                Optional.empty(),
+                leftChild,
+                rightChild, null);
+        logicalJoin.getJoinReorderContext().setLeadingJoin(true);
+        logicalJoin.setBitmap(LongBitmap.or(getBitmap(leftChild), getBitmap(rightChild)));
+        return logicalJoin;
+    }
+
     /**
      * using leading to generate plan, it could be failed, if failed set leading status to unused or syntax error
      * @return plan
      */
     public Plan generateLeadingJoinPlan() {
-        Stack<Pair<Integer, Pair<LogicalPlan, Integer>>> stack = new Stack<>();
-        int index = 0;
-        LogicalPlan logicalPlan = getLogicalPlanByName(getTablelist().get(index));
-        if (logicalPlan == null) {
-            return null;
-        }
-        logicalPlan = makeFilterPlanIfExist(getFilters(), logicalPlan);
-        assert (logicalPlan != null);
-        stack.push(Pair.of(getLevelList().get(index), Pair.of(logicalPlan, index)));
-        int stackTopLevel = getLevelList().get(index++);
-        while (index < getTablelist().size()) {
-            int currentLevel = getLevelList().get(index);
-            if (currentLevel == stackTopLevel) {
-                // should return error if can not found table
-                logicalPlan = getLogicalPlanByName(getTablelist().get(index++));
-                int distributeIndex = index - 1;
-                if (logicalPlan == null) {
+        Stack<LogicalPlan> stack = new Stack<>();
+        for (String item : normalizedParameters) {
+            if (item.equals("join") || item.equals("shuffle") || item.equals("broadcast")) {
+                LogicalPlan rightChild = stack.pop();
+                LogicalPlan leftChild = stack.pop();
+                LogicalPlan joinPlan = makeJoinPlan(leftChild, rightChild, item);
+                if (joinPlan == null) {
                     return null;
                 }
-                logicalPlan = makeFilterPlanIfExist(getFilters(), logicalPlan);
-                Pair<Integer, Pair<LogicalPlan, Integer>> newStackTop = stack.peek();
-                while (!(stack.isEmpty() || stackTopLevel != newStackTop.first)) {
-                    // check join is legal and get join type
-                    newStackTop = stack.pop();
-                    List<Expression> conditions = getJoinConditions(
-                            getFilters(), newStackTop.second.first, logicalPlan);
-                    Pair<List<Expression>, List<Expression>> pair = JoinUtils.extractExpressionForHashTable(
-                            newStackTop.second.first.getOutput(), logicalPlan.getOutput(), conditions);
-                    // leading hint would set status inside if not success
-                    JoinType joinType = computeJoinType(getBitmap(newStackTop.second.first),
-                            getBitmap(logicalPlan), conditions);
-                    if (joinType == null) {
-                        this.setStatus(HintStatus.SYNTAX_ERROR);
-                        this.setErrorMessage("JoinType can not be null");
-                    } else if (!isConditionJoinTypeMatched(conditions, joinType)) {
-                        this.setStatus(HintStatus.UNUSED);
-                        this.setErrorMessage("condition does not matched joinType");
-                    }
-                    if (!this.isSuccess()) {
-                        return null;
-                    }
-                    // get joinType
-                    DistributeHint distributeHint = getJoinHint(distributeIndex);
-                    LogicalJoin logicalJoin = new LogicalJoin<>(joinType, pair.first,
-                            pair.second,
-                            distributeHint,
-                            Optional.empty(),
-                            newStackTop.second.first,
-                            logicalPlan, null);
-                    logicalJoin.getJoinReorderContext().setLeadingJoin(true);
-                    distributeIndex = newStackTop.second.second;
-                    logicalJoin.setBitmap(LongBitmap.or(getBitmap(newStackTop.second.first), getBitmap(logicalPlan)));
-                    if (stackTopLevel > 0) {
-                        if (index < getTablelist().size()) {
-                            if (stackTopLevel > getLevelList().get(index)) {
-                                stackTopLevel--;
-                            }
-                        } else {
-                            stackTopLevel--;
-                        }
-                    }
-                    if (!stack.isEmpty()) {
-                        newStackTop = stack.peek();
-                    }
-                    logicalPlan = logicalJoin;
-                }
-                stack.push(Pair.of(stackTopLevel, Pair.of(logicalPlan, distributeIndex)));
+                stack.push(joinPlan);
             } else {
-                // push
-                logicalPlan = getLogicalPlanByName(getTablelist().get(index++));
-                if (logicalPlan == null) {
-                    return null;
-                }
+                LogicalPlan logicalPlan = getLogicalPlanByName(item);
                 logicalPlan = makeFilterPlanIfExist(getFilters(), logicalPlan);
-                stack.push(Pair.of(currentLevel, Pair.of(logicalPlan, index - 1)));
-                stackTopLevel = currentLevel;
+                stack.push(logicalPlan);
             }
         }
-        if (stack.size() > 1) {
-            this.setStatus(HintStatus.SYNTAX_ERROR);
-            this.setErrorMessage("please check your brace pairs in leading");
-            return null;
-        }
 
-        LogicalJoin finalJoin = (LogicalJoin) stack.pop().second.first;
+        LogicalJoin finalJoin = (LogicalJoin) stack.pop();
         // we want all filters been remove
         assert (filters.isEmpty());
         if (finalJoin != null) {

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query1.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query1.out
@@ -40,7 +40,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------PhysicalOlapScan[store]
 
 Hint log:
-Used:  leading(store_returns broadcast date_dim )
+Used: leading(store_returns broadcast date_dim ) 
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query24.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query24.out
@@ -59,7 +59,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 
 Hint log:
-Used:   leading(store_sales broadcast store shuffle { customer shuffle customer_address } shuffle item shuffle store_returns )
+Used: leading(store_sales broadcast store shuffle { customer shuffle customer_address } shuffle item shuffle store_returns )  
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query64.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query64.out
@@ -17,13 +17,13 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF8 i_item_sk->[ss_item_sk]
 ------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_first_shipto_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[c_first_shipto_date_sk]
 --------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF6 cd_demo_sk->[ss_cdemo_sk]
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
-------------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF4 RF6 RF8 RF9 RF10 RF11 RF12 RF16 RF17 RF18 RF19
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF8 RF9 RF10 RF11 RF12 RF16 RF17 RF18 RF19
+------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
 --------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[c_first_sales_date_sk]
-----------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF5 RF7 RF13 RF14
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF7 RF13 RF14
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------------filter((item.i_current_price <= 58.00) and (item.i_current_price >= 49.00) and i_color IN ('blush', 'lace', 'lawn', 'misty', 'orange', 'pink'))
@@ -56,7 +56,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------------PhysicalCteConsumer ( cteId=CTEId#1 )
 
 Hint log:
-Used:  leading(catalog_sales shuffle catalog_returns ) leading({ store_sales { { customer d2 } cd2 } } cd1 d3 item { hd1 ib1 } store_returns ad1 hd2 ad2 ib2 d1 store promotion cs_ui ) leading(cs1 shuffle cs2 )
-UnUsed:
+Used: leading(catalog_sales shuffle catalog_returns )  leading({ store_sales { { customer d2 } cd2 } } cd1 d3 item { hd1 ib1 } store_returns ad1 hd2 ad2 ib2 d1 store promotion cs_ui ) leading(cs1 shuffle cs2 )
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query67.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query67.out
@@ -34,7 +34,7 @@ PhysicalResultSink
 ------------------------------------PhysicalOlapScan[item]
 
 Hint log:
-Used:  leading(store_sales broadcast date_dim broadcast store broadcast item )
+Used: leading(store_sales broadcast date_dim broadcast store broadcast item ) 
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query72.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query72.out
@@ -68,7 +68,7 @@ PhysicalResultSink
 ----------------------PhysicalOlapScan[warehouse]
 
 Hint log:
-Used:  leading(inventory shuffle { catalog_returns shuffle { catalog_sales shuffle { d3 d1 } broadcast household_demographics shuffle customer_demographics broadcast promotion shuffle item } broadcast d2 } broadcast warehouse )
-UnUsed: 
+Used: leading(inventory shuffle { catalog_returns shuffle { catalog_sales shuffle { d3 broadcast d1 } broadcast household_demographics shuffle customer_demographics broadcast promotion shuffle item } broadcast d2 } broadcast warehouse )  
+UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpcds_p0/shape/query78.out
+++ b/regression-test/data/nereids_hint_tpcds_p0/shape/query78.out
@@ -59,7 +59,7 @@ PhysicalResultSink
 ----------------------------PhysicalOlapScan[catalog_returns]
 
 Hint log:
-Used:  leading(web_sales broadcast date_dim web_returns ) leading(catalog_sales broadcast date_dim catalog_returns ) leading(store_sales broadcast date_dim store_returns )  leading(ss shuffle ws shuffle cs )
-UnUsed:
+Used: leading(web_sales broadcast date_dim web_returns )  leading(catalog_sales broadcast date_dim catalog_returns ) leading(store_sales broadcast date_dim store_returns ) leading(ss shuffle ws shuffle cs ) 
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q10.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q10.out
@@ -28,7 +28,7 @@ PhysicalResultSink
 ----------------------------PhysicalOlapScan[nation]
 
 Hint log:
-Used:   leading(lineitem shuffle { { customer shuffle orders } broadcast nation } )
+Used: leading(lineitem shuffle { { customer shuffle orders } broadcast nation } )  
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q11.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q11.out
@@ -48,6 +48,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(partsupp { supplier nation } ) leading(partsupp { supplier nation } )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q12.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q12.out
@@ -17,6 +17,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(orders lineitem )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q13.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q13.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 --------------------------PhysicalOlapScan[customer]
 
 Hint log:
-Used:  leading(orders shuffle customer )
+Used: leading(orders shuffle customer ) 
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q14.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q14.out
@@ -16,6 +16,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(part lineitem )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q15.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q15.out
@@ -33,6 +33,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(supplier revenue0 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q17.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q17.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[part]
 
 Hint log:
-Used:  leading(lineitem broadcast part )
+Used: leading(lineitem broadcast part ) 
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q19.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q19.out
@@ -15,7 +15,7 @@ PhysicalResultSink
 ------------------PhysicalOlapScan[part]
 
 Hint log:
-Used:  leading(lineitem broadcast part )
+Used: leading(lineitem broadcast part ) 
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q3.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q3.out
@@ -23,7 +23,7 @@ PhysicalResultSink
 --------------------------PhysicalOlapScan[customer]
 
 Hint log:
-Used:  leading(lineitem { orders shuffle customer } )
-UnUsed:
+Used: leading(lineitem { orders shuffle customer } ) 
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q5.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q5.out
@@ -38,7 +38,7 @@ PhysicalResultSink
 ----------------------PhysicalOlapScan[customer]
 
 Hint log:
-Used:   leading(lineitem orders broadcast { supplier broadcast { nation broadcast region } } shuffle customer )
-UnUsed:
+Used: leading(lineitem orders broadcast { supplier broadcast { nation broadcast region } } shuffle customer )  
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q7.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q7.out
@@ -8,13 +8,13 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((orders.o_orderkey = lineitem.l_orderkey) and (supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
+----------------hashJoin[INNER_JOIN] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=((((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE'))))
 ------------------PhysicalProject
---------------------filter((lineitem.l_shipdate <= '1996-12-31') and (lineitem.l_shipdate >= '1995-01-01'))
-----------------------PhysicalOlapScan[lineitem]
-------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------PhysicalProject
-----------------------NestedLoopJoin[INNER_JOIN](((n_name = 'FRANCE') AND (n_name = 'GERMANY')) OR ((n_name = 'GERMANY') AND (n_name = 'FRANCE')))
+--------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
+----------------------PhysicalProject
+------------------------filter((lineitem.l_shipdate <= '1996-12-31') and (lineitem.l_shipdate >= '1995-01-01'))
+--------------------------PhysicalOlapScan[lineitem]
+----------------------PhysicalDistribute[DistributionSpecReplicated]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_nationkey = n1.n_nationkey)) otherCondition=()
 ----------------------------PhysicalProject
@@ -23,24 +23,24 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------filter(n_name IN ('FRANCE', 'GERMANY'))
 ----------------------------------PhysicalOlapScan[nation]
-------------------------PhysicalDistribute[DistributionSpecReplicated]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=()
+------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=()
-------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------PhysicalOlapScan[orders]
+------------------------PhysicalDistribute[DistributionSpecHash]
+--------------------------PhysicalProject
+----------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = n2.n_nationkey)) otherCondition=()
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[customer]
+------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[orders]
-------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = n2.n_nationkey)) otherCondition=()
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[customer]
-------------------------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------------------------PhysicalProject
-----------------------------------------filter(n_name IN ('FRANCE', 'GERMANY'))
-------------------------------------------PhysicalOlapScan[nation]
+----------------------------------filter(n_name IN ('FRANCE', 'GERMANY'))
+------------------------------------PhysicalOlapScan[nation]
 
 Hint log:
-Used:   leading(lineitem broadcast { supplier broadcast n1 } { orders shuffle { customer broadcast n2 } } )
-UnUsed:
+Used: leading(lineitem broadcast { supplier broadcast n1 } { orders shuffle { customer broadcast n2 } } )  
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q8.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q8.out
@@ -16,39 +16,41 @@ PhysicalResultSink
 --------------------------PhysicalOlapScan[supplier]
 ------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((lineitem.l_orderkey = orders.o_orderkey) and (orders.o_custkey = customer.c_custkey)) otherCondition=()
-------------------------------PhysicalProject
---------------------------------filter((orders.o_orderdate <= '1996-12-31') and (orders.o_orderdate >= '1995-01-01'))
-----------------------------------PhysicalOlapScan[orders]
-------------------------------NestedLoopJoin[CROSS_JOIN]
+----------------------------hashJoin[INNER_JOIN] hashCondition=((orders.o_custkey = customer.c_custkey)) otherCondition=()
+------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=()
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((lineitem.l_orderkey = orders.o_orderkey)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[lineitem]
+--------------------------------------filter((orders.o_orderdate <= '1996-12-31') and (orders.o_orderdate >= '1995-01-01'))
+----------------------------------------PhysicalOlapScan[orders]
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[INNER_JOIN] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=()
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[lineitem]
+----------------------------------------PhysicalDistribute[DistributionSpecReplicated]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((part.p_type = 'ECONOMY ANODIZED STEEL'))
+----------------------------------------------PhysicalOlapScan[part]
+------------------------------PhysicalDistribute[DistributionSpecHash]
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = n1.n_nationkey)) otherCondition=()
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[customer]
 ------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------PhysicalProject
-----------------------------------------filter((part.p_type = 'ECONOMY ANODIZED STEEL'))
-------------------------------------------PhysicalOlapScan[part]
---------------------------------PhysicalDistribute[DistributionSpecReplicated]
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_nationkey = n1.n_nationkey)) otherCondition=()
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[customer]
---------------------------------------PhysicalDistribute[DistributionSpecReplicated]
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN] hashCondition=((n1.n_regionkey = region.r_regionkey)) otherCondition=()
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((n1.n_regionkey = region.r_regionkey)) otherCondition=()
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[nation]
+------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[nation]
---------------------------------------------PhysicalDistribute[DistributionSpecReplicated]
-----------------------------------------------PhysicalProject
-------------------------------------------------filter((region.r_name = 'AMERICA'))
---------------------------------------------------PhysicalOlapScan[region]
+----------------------------------------------filter((region.r_name = 'AMERICA'))
+------------------------------------------------PhysicalOlapScan[region]
 --------------------PhysicalDistribute[DistributionSpecReplicated]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[nation]
 
 Hint log:
-Used:  leading(supplier { orders { lineitem broadcast part } { customer broadcast { n1 broadcast region } } } broadcast n2 )
-UnUsed:
+Used: leading(supplier { orders { lineitem broadcast part } { customer broadcast { n1 broadcast region } } } broadcast n2 ) 
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_hint_tpch_p0/shape/q9.out
+++ b/regression-test/data/nereids_hint_tpch_p0/shape/q9.out
@@ -9,38 +9,37 @@ PhysicalResultSink
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN] hashCondition=((partsupp.ps_partkey = lineitem.l_partkey) and (partsupp.ps_suppkey = lineitem.l_suppkey)) otherCondition=()
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=()
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
+----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[orders]
-------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_nationkey = nation.n_nationkey)) otherCondition=()
+--------------------------hashJoin[INNER_JOIN] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=()
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[orders]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=()
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=()
-----------------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[lineitem]
-----------------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------------PhysicalProject
---------------------------------------------filter((p_name like '%green%'))
-----------------------------------------------PhysicalOlapScan[part]
+--------------------------------------PhysicalOlapScan[lineitem]
 ----------------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[supplier]
-------------------------------PhysicalDistribute[DistributionSpecReplicated]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[nation]
+--------------------------------------filter((p_name like '%green%'))
+----------------------------------------PhysicalOlapScan[part]
+----------------------PhysicalDistribute[DistributionSpecHash]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN] hashCondition=((supplier.s_nationkey = nation.n_nationkey)) otherCondition=()
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[supplier]
+----------------------------PhysicalDistribute[DistributionSpecReplicated]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[nation]
 ------------------PhysicalDistribute[DistributionSpecHash]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[partsupp]
 
 Hint log:
-Used:   leading(orders shuffle { lineitem shuffle part } shuffle { supplier broadcast nation } shuffle partsupp )
+Used: leading(orders shuffle { lineitem shuffle part } shuffle { supplier broadcast nation } shuffle partsupp )  
 UnUsed:
 SyntaxError:
 

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -16,7 +16,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading({ t1 t2 } { t3 t4 } )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !select2_1_1 --
@@ -248,7 +248,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 t2 t3 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !select6_1 --
@@ -275,6 +275,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 { { t2 t3 } { t4 t5 } } t6 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_p0/hint/multi_leading.out
+++ b/regression-test/data/nereids_p0/hint/multi_leading.out
@@ -33,7 +33,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 ) leading(t1 cte )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql1_3 --
@@ -53,7 +53,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 t2 ) leading(t1 cte )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql1_4 --
@@ -73,7 +73,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 t2 ) leading(t1 cte )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql1_res_1 --
@@ -116,7 +116,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t3 alias1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql2_3 --
@@ -134,7 +134,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql2_4 --
@@ -152,7 +152,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 ) leading(t3 alias1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql2_res_1 --
@@ -207,7 +207,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 ) leading(t3 alias1 cte )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql3_3 --
@@ -231,7 +231,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql3_4 --
@@ -255,7 +255,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t2 t1 ) leading(t2 t1 ) leading(t3 alias1 cte )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql3_res_1 --
@@ -304,7 +304,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t3 alias1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql4_2 --
@@ -325,7 +325,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(alias2 t1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql4_3 --
@@ -346,7 +346,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t4 t2 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql4_4 --
@@ -367,7 +367,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(alias2 t1 ) leading(t3 alias1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !sql4_res_0 --
@@ -439,6 +439,6 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 
 Hint log:
 Used: leading(cte t1 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_p0/hint/test_distribute.out
+++ b/regression-test/data/nereids_p0/hint/test_distribute.out
@@ -443,7 +443,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t3 { t1 t2 } )
-UnUsed: [shuffle]_2
+UnUsed: [shuffle]_2 
 SyntaxError:
 
 -- !select6_2 --

--- a/regression-test/data/nereids_p0/hint/test_leading.out
+++ b/regression-test/data/nereids_p0/hint/test_leading.out
@@ -2214,7 +2214,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle t2 broadcast t3 )
+Used: leading(t1 shuffle t2 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2232,7 +2232,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle { t2 broadcast t3 } )
+Used: leading(t1 shuffle { t2 broadcast t3 } )  
 UnUsed:
 SyntaxError:
 
@@ -2250,7 +2250,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t1 shuffle { t3 broadcast t2 } )
+Used: leading(t1 shuffle { t3 broadcast t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2268,7 +2268,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle t1 broadcast t3 )
+Used: leading(t2 shuffle t1 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2286,7 +2286,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle { t1 broadcast t3 } )
+Used: leading(t2 shuffle { t1 broadcast t3 } )  
 UnUsed:
 SyntaxError:
 
@@ -2304,7 +2304,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t2 shuffle { t3 broadcast t1 } )
+Used: leading(t2 shuffle { t3 broadcast t1 } )  
 UnUsed:
 SyntaxError:
 
@@ -2322,8 +2322,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 t2 broadcast t3 )
-UnUsed:
+Used: leading(t1 t2 broadcast t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_2 --
@@ -2340,8 +2340,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 { t2 broadcast t3 } )
-UnUsed:
+Used: leading(t1 { t2 broadcast t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_3 --
@@ -2358,8 +2358,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t1 { t3 broadcast t2 } )
-UnUsed:
+Used: leading(t1 { t3 broadcast t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_4 --
@@ -2376,8 +2376,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 t1 broadcast t3 )
-UnUsed:
+Used: leading(t2 t1 broadcast t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_5 --
@@ -2394,8 +2394,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 { t1 broadcast t3 } )
-UnUsed:
+Used: leading(t2 { t1 broadcast t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_6 --
@@ -2412,8 +2412,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t2 { t3 broadcast t1 } )
-UnUsed:
+Used: leading(t2 { t3 broadcast t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2430,8 +2430,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 shuffle t2 t3 )
-UnUsed:
+Used: leading(t1 shuffle t2 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2448,8 +2448,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 shuffle { t2 t3 } )
-UnUsed:
+Used: leading(t1 shuffle { t2 t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2466,8 +2466,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t1 shuffle { t3 t2 } )
-UnUsed:
+Used: leading(t1 shuffle { t3 t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2484,8 +2484,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 shuffle t1 t3 )
-UnUsed:
+Used: leading(t2 shuffle t1 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2502,8 +2502,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 shuffle { t1 t3 } )
-UnUsed:
+Used: leading(t2 shuffle { t1 t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2520,8 +2520,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t2 shuffle { t3 t1 } )
-UnUsed:
+Used: leading(t2 shuffle { t3 t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_1 --
@@ -2538,8 +2538,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 broadcast t2 t3 )
-UnUsed:
+Used: leading(t1 broadcast t2 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_4 --
@@ -2556,8 +2556,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 broadcast t1 t3 )
-UnUsed:
+Used: leading(t2 broadcast t1 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_8 --
@@ -2574,8 +2574,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t3 broadcast { t1 t2 } )
-UnUsed:
+Used: leading(t3 broadcast { t1 t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_9 --
@@ -2592,8 +2592,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t3 broadcast { t2 t1 } )
-UnUsed:
+Used: leading(t3 broadcast { t2 t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select96_1 --
@@ -2610,7 +2610,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle t2 broadcast t3 )
+Used: leading(t1 shuffle t2 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2628,7 +2628,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle t1 broadcast t3 )
+Used: leading(t2 shuffle t1 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2646,7 +2646,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t3 shuffle { t1 broadcast t2 } )
+Used: leading(t3 shuffle { t1 broadcast t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2664,7 +2664,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t3 shuffle { t2 broadcast t1 } )
+Used: leading(t3 shuffle { t2 broadcast t1 } )  
 UnUsed:
 SyntaxError:
 
@@ -2683,7 +2683,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 broadcast t2 shuffle t3 )
+Used: leading(t1 broadcast t2 shuffle t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2701,7 +2701,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 broadcast t1 shuffle t3 )
+Used: leading(t2 broadcast t1 shuffle t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2719,7 +2719,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t3 broadcast { t1 shuffle t2 } )
+Used: leading(t3 broadcast { t1 shuffle t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2737,7 +2737,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t3 broadcast { t2 shuffle t1 } )
+Used: leading(t3 broadcast { t2 shuffle t1 } )  
 UnUsed:
 SyntaxError:
 

--- a/regression-test/suites/nereids_p0/hint/test_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_leading.groovy
@@ -1002,24 +1002,24 @@ suite("test_leading") {
     qt_select95_1 """explain shape plan select /*+ leading(t1 broadcast t2 t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t1 broadcast {t2 t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 leading(t1 broadcast { t2 t3 })")
+        contains("UnUsed: leading(t1 broadcast { t2 t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t1 broadcast {t3 t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 leading(t1 broadcast { t3 t2 })")
+        contains("UnUsed: leading(t1 broadcast { t3 t2 })")
     }
     qt_select95_4 """explain shape plan select /*+ leading(t2 broadcast t1 t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t2 broadcast {t1 t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 leading(t2 broadcast { t1 t3 })")
+        contains("UnUsed: leading(t2 broadcast { t1 t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t2 broadcast {t3 t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 leading(t2 broadcast { t3 t1 })")
+        contains("UnUsed: leading(t2 broadcast { t3 t1 })")
     }
     explain {
         sql """shape plan select /*+ leading(t3 broadcast t1 t2) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed:  leading(t3 broadcast t1 t2)")
+        contains("UnUsed: leading(t3 broadcast t1 t2)")
     }
     qt_select95_8 """explain shape plan select /*+ leading(t3 broadcast {t1 t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     qt_select95_9 """explain shape plan select /*+ leading(t3 broadcast {t2 t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
@@ -1027,24 +1027,24 @@ suite("test_leading") {
     qt_select96_1 """explain shape plan select /*+ leading(t1 shuffle t2 broadcast t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t1 shuffle {t2 broadcast t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [shuffle]_2 [broadcast]_3 leading(t1 shuffle { t2 broadcast t3 })")
+        contains("UnUsed: leading(t1 shuffle { t2 broadcast t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t1 shuffle {t3 broadcast t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [shuffle]_2 [broadcast]_3 leading(t1 shuffle { t3 broadcast t2 })")
+        contains("UnUsed: leading(t1 shuffle { t3 broadcast t2 })")
     }
     qt_select96_4 """explain shape plan select /*+ leading(t2 shuffle t1 broadcast t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t2 shuffle {t1 broadcast t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [shuffle]_2  leading(t2 shuffle { t1 broadcast t3 })")
+        contains("UnUsed: leading(t2 shuffle { t1 broadcast t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t2 shuffle {t3 broadcast t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [shuffle]_2  leading(t2 shuffle { t3 broadcast t1 })")
+        contains("UnUsed: leading(t2 shuffle { t3 broadcast t1 })")
     }
     explain {
         sql """shape plan select /*+ leading(t3 shuffle t1 broadcast t2) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed:  [broadcast]_3 leading(t3 shuffle t1 broadcast t2)")
+        contains("UnUsed: leading(t3 shuffle t1 broadcast t2)")
     }
     qt_select96_8 """explain shape plan select /*+ leading(t3 shuffle {t1 broadcast t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     qt_select96_9 """explain shape plan select /*+ leading(t3 shuffle {t2 broadcast t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
@@ -1052,24 +1052,24 @@ suite("test_leading") {
     qt_select97_1 """explain shape plan select /*+ leading(t1 broadcast t2 shuffle t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t1 broadcast {t2 shuffle t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 [shuffle]_3 leading(t1 broadcast { t2 shuffle t3 })")
+        contains("UnUsed: leading(t1 broadcast { t2 shuffle t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t1 broadcast {t3 shuffle t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2 [shuffle]_3 leading(t1 broadcast { t3 shuffle t2 })")
+        contains("UnUsed: leading(t1 broadcast { t3 shuffle t2 })")
     }
     qt_select97_4 """explain shape plan select /*+ leading(t2 broadcast t1 shuffle t3) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     explain {
         sql """shape plan select /*+ leading(t2 broadcast {t1 shuffle t3}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2  leading(t2 broadcast { t1 shuffle t3 })")
+        contains("UnUsed: leading(t2 broadcast { t1 shuffle t3 })")
     }
     explain {
         sql """shape plan select /*+ leading(t2 broadcast {t3 shuffle t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed: [broadcast]_2  leading(t2 broadcast { t3 shuffle t1 })")
+        contains("UnUsed: leading(t2 broadcast { t3 shuffle t1 })")
     }
     explain {
         sql """shape plan select /*+ leading(t3 broadcast t1 shuffle t2) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
-        contains("UnUsed:  [shuffle]_3 leading(t3 broadcast t1 shuffle t2)")
+        contains("UnUsed: leading(t3 broadcast t1 shuffle t2)")
     }
     qt_select97_8 """explain shape plan select /*+ leading(t3 broadcast {t1 shuffle t2}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""
     qt_select97_9 """explain shape plan select /*+ leading(t3 broadcast {t2 shuffle t1}) */ count(*) from t1 left outer join t2 on c1 = c2 join t3 on c2 = c3;"""


### PR DESCRIPTION
cherry-pick #36193

Problem:
when using leading like:
leading(t1 {t2 t3} {t4 t5} t6)
it would not generate correct plan because levellist can not express enough message of braces
Solved:
remove levellist express of leading levels and use reverse polish expression
Algorithm:
leading(t1 {t2 t3} {t4 t5} t6)
==>
stack top to down(t1 t2 t3 join join t4 t5 join t6 join) when generate leading join, we can pop items in stack, when it's a table, make logicalscan when it's a join
operator, make logical join and push back to stack

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

