### PR TITLE
[Fix](auto-partition) fix auto partition expr change unexpected

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -253,8 +253,9 @@ public class PartitionInfo implements Writable {
         return isAutoCreatePartitions;
     }
 
+    // forbid change metadata.
     public ArrayList<Expr> getPartitionExprs() {
-        return this.partitionExprs;
+        return Expr.cloneList(this.partitionExprs);
     }
 
     public void checkPartitionItemListsMatch(List<PartitionItem> list1, List<PartitionItem> list2) throws DdlException {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionPruneTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionPruneTestBase.java
@@ -34,7 +34,9 @@ public abstract class PartitionPruneTestBase extends TestWithFeService {
     }
 
     private void assertExplainContains(String sql, String subString) throws Exception {
-        Assert.assertTrue(String.format("sql=%s, expectResult=%s", sql, subString),
+        Assert.assertTrue(
+                String.format("sql=%s, expectResult=%s, but got %s", sql, subString,
+                        getSQLPlanOrErrorMsg("explain " + sql)),
                 getSQLPlanOrErrorMsg("explain " + sql).contains(subString));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/RangePartitionPruneTest.java
@@ -206,9 +206,6 @@ public class RangePartitionPruneTest extends PartitionPruneTestBase {
                 "partitions=6/8");
         addCase("select /*+ SET_VAR(enable_nereids_planner=false) */ * from test.test_to_date_trunc where event_day= \"2023-08-07 11:00:00\" ",
                 "partitions=1/2");
-        addCase("select /*+ SET_VAR(enable_nereids_planner=false) */ * from test.test_to_date_trunc where date_trunc(event_day, \"day\")= \"2023-08-07 11:00:00\" ",
-                "partitions=1/2");
-
     }
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

there's a caller used `getPartitionExprs` and modified the result. the result is a reference to a part of metadata. If when we create the table, the number of editlog didn't reach the limit to generate image file, when it reaches, the image will get the wrong metadata of `partitionExprs` from memory which was modified.

when Nereids timeout, we will get into trouble in legacy planner here:
```java
    private void analyzerPartitionExpr(Analyzer analyzer, PartitionInfo partitionInfo) throws AnalysisException {
        ArrayList<Expr> exprs = partitionInfo.getPartitionExprs();
        for (Expr e : exprs) {
            LOG.info("beforeB: {}", e.toSql());
            e.analyze(analyzer);
            LOG.info("afterB: {}", e.toSql());
        }
    }
```

```log
2024-06-18 21:49:07,449 INFO (mysql-nio-pool-154|695) [OlapScanNode.analyzerPartitionExpr():1561] beforeB: date_trunc(Carding_Day, 'MONTH')
2024-06-18 21:49:07,449 INFO (mysql-nio-pool-154|695) [OlapScanNode.analyzerPartitionExpr():1563] afterB: date_trunc(`a`.null, 'MONTH')
```