### PR TITLE
[fix](nereids)fix Group print bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -396,8 +396,13 @@ public class NereidsPlanner extends Planner {
             GroupExpression groupExpression = rootGroup.getLowestCostPlan(physicalProperties).orElseThrow(
                     () -> new AnalysisException("lowestCostPlans with physicalProperties("
                             + physicalProperties + ") doesn't exist in root group")).second;
-            rootGroup.setChosenProperties(physicalProperties);
-            rootGroup.setChosenGroupExpressionId(groupExpression.getId().asInt());
+            if (rootGroup.getEnforcers().contains(groupExpression)) {
+                rootGroup.addChosenEnforcerId(groupExpression.getId().asInt());
+                rootGroup.addChosenEnforcerProperties(physicalProperties);
+            } else {
+                rootGroup.setChosenProperties(physicalProperties);
+                rootGroup.setChosenGroupExpressionId(groupExpression.getId().asInt());
+            }
             List<PhysicalProperties> inputPropertiesList = groupExpression.getInputPropertiesList(physicalProperties);
             List<Plan> planChildren = Lists.newArrayList();
             for (int i = 0; i < groupExpression.arity(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -396,6 +396,8 @@ public class NereidsPlanner extends Planner {
             GroupExpression groupExpression = rootGroup.getLowestCostPlan(physicalProperties).orElseThrow(
                     () -> new AnalysisException("lowestCostPlans with physicalProperties("
                             + physicalProperties + ") doesn't exist in root group")).second;
+            rootGroup.setChosenProperties(physicalProperties);
+            rootGroup.setChosenGroupExpressionId(groupExpression.getId().asInt());
             List<PhysicalProperties> inputPropertiesList = groupExpression.getInputPropertiesList(physicalProperties);
             List<Plan> planChildren = Lists.newArrayList();
             for (int i = 0; i < groupExpression.arity(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -75,6 +75,9 @@ public class Group {
 
     private int chosenGroupExpressionId = -1;
 
+    private List<PhysicalProperties> chosenEnforcerPropertiesList = new ArrayList<>();
+    private List<Integer> chosenEnforcerIdList = new ArrayList<>();
+
     private StructInfoMap structInfoMap = new StructInfoMap();
 
     /**
@@ -458,6 +461,13 @@ public class Group {
         for (GroupExpression enforcer : enforcers) {
             str.append("    ").append(enforcer).append("\n");
         }
+        if (!chosenEnforcerIdList.isEmpty()) {
+            str.append("  chosen enforcer(id, requiredProperties):\n");
+            for (int i = 0; i < chosenEnforcerIdList.size(); i++) {
+                str.append("      (").append(i).append(")").append(chosenEnforcerIdList.get(i)).append(",  ")
+                        .append(chosenEnforcerPropertiesList.get(i)).append("\n");
+            }
+        }
         if (chosenGroupExpressionId != -1) {
             str.append("  chosen expression id: ").append(chosenGroupExpressionId).append("\n");
             str.append("  chosen properties: ").append(chosenProperties).append("\n");
@@ -559,11 +569,17 @@ public class Group {
         this.chosenProperties = chosenProperties;
     }
 
-    public int getChosenGroupExpressionId() {
-        return chosenGroupExpressionId;
+    public void setChosenGroupExpressionId(int chosenGroupExpressionId) {
+        Preconditions.checkArgument(this.chosenGroupExpressionId == -1,
+                "chosenGroupExpressionId is already set");
+        this.chosenGroupExpressionId = chosenGroupExpressionId;
     }
 
-    public void setChosenGroupExpressionId(int chosenGroupExpressionId) {
-        this.chosenGroupExpressionId = chosenGroupExpressionId;
+    public void addChosenEnforcerProperties(PhysicalProperties chosenEnforcerProperties) {
+        this.chosenEnforcerPropertiesList.add(chosenEnforcerProperties);
+    }
+
+    public void addChosenEnforcerId(int chosenEnforcerId) {
+        this.chosenEnforcerIdList.add(chosenEnforcerId);
     }
 }


### PR DESCRIPTION
## Proposed changes
Group.chosenGroupExpressionId is designed to record the group expression which is used in physical plan.
the choose expression is set when Group.getLowestCostPlan(prop) is invoked. this is wrong, because when we print memo, getLowestCostPlan(prop) is invoked multiple times

  chosen properties: 
Issue Number: close #xxx

<!--Describe your changes.-->

