### PR TITLE
[fix](nereids)disable NullSafeEqualToEqual rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionOptimization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionOptimization.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.rules.expression.rules.DateFunctionRewrite;
 import org.apache.doris.nereids.rules.expression.rules.DistinctPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rules.ExtractCommonFactorRule;
 import org.apache.doris.nereids.rules.expression.rules.LikeToEqualRewrite;
-import org.apache.doris.nereids.rules.expression.rules.NullSafeEqualToEqual;
 import org.apache.doris.nereids.rules.expression.rules.OrToIn;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyComparisonPredicate;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyDecimalV3Comparison;
@@ -52,7 +51,6 @@ public class ExpressionOptimization extends ExpressionRewrite {
                 ArrayContainToArrayOverlap.INSTANCE,
                 CaseWhenToIf.INSTANCE,
                 TopnToMax.INSTANCE,
-                NullSafeEqualToEqual.INSTANCE,
                 LikeToEqualRewrite.INSTANCE
             )
     );


### PR DESCRIPTION
## Proposed changes

NullSafeEqualToEqual depends on join conjunct's nullable info. But the nullable value may change after this rule. So convert from <=> to = may be wrong. We disable this rule for now and fix it later

<!--Describe your changes.-->

