### PR TITLE
[fix](restore) avoid NPE for restore job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -743,12 +743,14 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         }
 
         // reset the indexes and update the indexes in materialized index meta too.
-        List<Index> indexes = this.indexes.getIndexes();
-        for (Index idx : indexes) {
-            idx.setIndexId(env.getNextId());
-        }
-        for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
-            entry.getValue().setIndexes(indexes);
+        if (this.indexes != null) {
+            List<Index> indexes = this.indexes.getIndexes();
+            for (Index idx : indexes) {
+                idx.setIndexId(env.getNextId());
+            }
+            for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
+                entry.getValue().setIndexes(indexes);
+            }
         }
 
         return Status.OK;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
The indexes of OlapTable may not be assigned in method `readFields`:
```
@Override
public void readFields(DataInput in) throws IOException {
    ...
    // read indexes
    if (in.readBoolean()) {
        this.indexes = TableIndexes.read(in);
    }
    ...
}
```
So indexes may be null.
<!--Describe your changes.-->

