### PR TITLE
[fix](hudi) disable fs.impl.cache to avoid FE OOM

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -66,6 +66,7 @@ import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -826,6 +827,15 @@ public class HiveMetaStoreClientHelper {
     public static HoodieTableMetaClient getHudiClient(HMSExternalTable table) {
         String hudiBasePath = table.getRemoteTable().getSd().getLocation();
         Configuration conf = getConfiguration(table);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("try setting 'fs.xxx.impl.disable.cache' to true for hudi's base path: {}", hudiBasePath);
+        }
+        URI hudiBasePathUri = URI.create(hudiBasePath);
+        String scheme = hudiBasePathUri.getScheme();
+        if (!Strings.isNullOrEmpty(scheme)) {
+            // Avoid using Cache in Hadoop FileSystem, which may cause FE OOM.
+            conf.set("fs." + scheme + ".impl.disable.cache", "true");
+        }
         return HadoopUGI.ugiDoAs(AuthenticationConfig.getKerberosConfig(conf),
                 () -> HoodieTableMetaClient.builder().setConf(conf).setBasePath(hudiBasePath).build());
     }


### PR DESCRIPTION
Sometime when using Hudi Catalog, there will be lots of objects like
`org.apache.hadoop.hdfs.client.impl.DfsClientConf` in FE memory,
which belongs to the Hadoop FileSystem's Cache.

Disable this Cache to avoid FE OOM by setting
`fs.xxx.impl.disable.cache` to true