### PR TITLE
[fix](group commit) Fix the incorrect group commit count in log; fix the core in get_first_block

### DIFF
--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -28,7 +28,6 @@ GroupCommitBlockSinkLocalState::~GroupCommitBlockSinkLocalState() {
     if (_load_block_queue) {
         _remove_estimated_wal_bytes();
         _load_block_queue->remove_load_id(_parent->cast<GroupCommitBlockSinkOperatorX>()._load_id);
-        _load_block_queue->group_commit_load_count.fetch_add(1);
     }
 }
 

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -205,6 +205,7 @@ Status LoadBlockQueue::add_load_id(const UniqueId& load_id) {
                                             load_instance_id.to_string());
     }
     _load_ids.emplace(load_id);
+    group_commit_load_count.fetch_add(1);
     return Status::OK();
 }
 

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -273,7 +273,7 @@ Status GroupCommitTable::get_first_block_load_queue(
             }
             if (!_is_creating_plan_fragment) {
                 _is_creating_plan_fragment = true;
-                RETURN_IF_ERROR(_thread_pool->submit_func([&] {
+                RETURN_IF_ERROR(_thread_pool->submit_func([this, be_exe_version, mem_tracker] {
                     auto st = _create_group_commit_load(be_exe_version, mem_tracker);
                     if (!st.ok()) {
                         LOG(WARNING) << "create group commit load error, st=" << st.to_string();


### PR DESCRIPTION
## Proposed changes
1. For group commit in sync_mode, we always get `this group commit includes 0 loads` when finish inener load, because the destruction of inner load is before the user load
2. Fix:
```
*** SIGSEGV invalid permissions for mapped object (@0x55ee31bf2585) received by PID 2459843 (TID 2460361 OR 0x7f5702977700) from PID 834610565; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/jdk-17.0.2/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/jdk-17.0.2/lib/server/libjvm.so
 3# 0x00007F580B170090 in /lib/x86_64-linux-gnu/libc.so.6
 4# std::_Function_handler<void (), doris::GroupCommitTable::get_first_block_load_queue(long, long, doris::UniqueId const&, std::shared_ptr<doris::LoadBlockQueue>&, int, std::shared_ptr<doris::MemTrackerLimiter>)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 5# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
```
