### PR TITLE
[fix](tablet scheduler) fix decommission sched exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1193,7 +1193,7 @@ public class TabletScheduler extends MasterDaemon {
                     throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_DECOMMISSION,
                             "wait txn before post watermark txn  " + postWatermarkTxnId + " to be finished");
                 }
-            } catch (Exception e) {
+            } catch (AnalysisException e) {
                 throw new SchedException(Status.UNRECOVERABLE, e.getMessage());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1193,7 +1193,9 @@ public class TabletScheduler extends MasterDaemon {
                     throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_DECOMMISSION,
                             "wait txn before post watermark txn  " + postWatermarkTxnId + " to be finished");
                 }
-            } catch (AnalysisException e) {
+            } catch (SchedException e) {
+                throw e;
+            } catch (Exception e) {
                 throw new SchedException(Status.UNRECOVERABLE, e.getMessage());
             }
         }


### PR DESCRIPTION
BUG:  when there exists running txns,   decommission replica will throw a sched failed exception and enter waiting for decommission status. But pr #30117 changes this behaviour,  it  cause throw a sched unrecovrable exception, then decommission replica will fail immediately.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

