### PR TITLE
[Fix](inverted index) try not to delete entries in DorisCompoundReader::close

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -203,6 +203,7 @@ DorisCompoundReader::~DorisCompoundReader() {
             LOG(ERROR) << "DorisCompoundReader finalize error:" << err.what();
         }
     }
+    _CLDELETE(entries)
 }
 
 const char* DorisCompoundReader::getClassName() {
@@ -294,7 +295,6 @@ void DorisCompoundReader::close() {
     }
     if (entries != nullptr) {
         entries->clear();
-        _CLDELETE(entries)
     }
     if (ram_dir) {
         ram_dir->close();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Deleting entries in DorisCompoundReader::close() might lead to a coredump in certain cases, especially with problematic inverted index files.  A coredump stack as an example as follows:
```
*** SIGSEGV address not mapped to object (@0x20) received by PID 11696 (TID 14029 OR 0x7fe5edc8f700) from PID 32; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007FEFF3CEA090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::segment_v2::DorisCompoundReader::fileExists(char const*) const at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp:223
 6# lucene::index::SegmentInfos::_FindSegmentsFile::doRun() at /root/doris/be/src/clucene/src/core/CLucene/index/SegmentInfos.cpp:1074
 7# lucene::index::SegmentInfos::FindSegmentsFile<lucene::index::DirectoryIndexReader*>::run() at /root/doris/be/src/clucene/src/core/CLucene/index/_SegmentInfos.h:508
 8# lucene::index::DirectoryIndexReader::open(lucene::store::Directory*, int, bool, lucene::index::IndexDeletionPolicy*) at /root/doris/be/src/clucene/src/core/CLucene/index/DirectoryIndexReader.cpp:189
 9# lucene::index::IndexReader::open(lucene::store::Directory*, int, bool, lucene::index::IndexDeletionPolicy*) at /root/doris/be/src/clucene/src/core/CLucene/index/IndexReader.cpp:131
10# doris::segment_v2::FulltextIndexSearcherBuilder::build(lucene::store::Directory*, std::optional<std::variant<std::shared_ptr<lucene::search::IndexSearcher>, std::shared_ptr<lucene::util::bkd::bkd_reader> > >&) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11# doris::segment_v2::IndexSearcherBuilder::get_index_searcher(lucene::store::Directory*) at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_searcher.cpp:101
12# doris::segment_v2::InvertedIndexReader::create_index_searcher(lucene::store::Directory*, std::variant<std::shared_ptr<lucene::search::IndexSearcher>, std::shared_ptr<lucene::util::bkd::bkd_reader> >*, doris::MemTracker*, doris::segment_v2::InvertedIndexReaderType) at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp:237
13# doris::segment_v2::InvertedIndexReader::handle_searcher_cache(doris::segment_v2::InvertedIndexCacheHandle*, doris::OlapReaderStatistics*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
14# doris::segment_v2::FullTextIndexReader::query(doris::OlapReaderStatistics*, doris::RuntimeState*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void const*, doris::segment_v2::InvertedIndexQueryType, std::shared_ptr<roaring::Roaring>&) at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp:340
15# doris::segment_v2::InvertedIndexIterator::read_from_inverted_index(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void const*, doris::segment_v2::InvertedIndexQueryType, unsigned int, std::shared_ptr<roaring::Roaring>&, bool) at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp:1180
16# doris::MatchPredicate::evaluate(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<doris::vectorized::IDataType const> > const&, doris::segment_v2::InvertedIndexIterator*, unsigned int, roaring::Roaring*) const at /root/doris/be/src/olap/match_predicate.cpp:69
17# doris::segment_v2::SegmentIterator::_apply_inverted_index_on_column_predicate(doris::ColumnPredicate*, std::vector<doris::ColumnPredicate*, std::allocator<doris::ColumnPredicate*> >&, bool*) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1008
18# doris::segment_v2::SegmentIterator::_apply_inverted_index() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
19# doris::segment_v2::SegmentIterator::_get_row_ranges_by_column_conditions() at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:516
20# doris::segment_v2::SegmentIterator::_lazy_init() at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:365
21# doris::segment_v2::SegmentIterator::_next_batch_internal(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:2176
22# doris::segment_v2::SegmentIterator::next_batch(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:2090
23# doris::segment_v2::LazyInitSegmentIterator::next_batch(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/lazy_init_segment_iterator.h:45
24# doris::BetaRowsetReader::next_block(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/beta_rowset_reader.cpp:372
```
