### PR TITLE
[Fix](JournalEntity) re-add a line of code that is accidentally removed in #19917

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -861,6 +861,7 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_DELETE_ANALYSIS_TASK: {
                 data = AnalyzeDeletionLog.read(in);
+                isRead = true;
                 break;
             }
             case OperationType.OP_UPDATE_AUTO_INCREMENT_ID: {


### PR DESCRIPTION
## Proposed changes

`isRead = true;` is accidentally removed in #19917 for `OperationType.OP_DELETE_ANALYSIS_TASK`


![bug](https://github.com/apache/doris/assets/68336428/acbcde92-9a64-4c3e-8ae9-86b1a45dfb7f)

