### PR TITLE
[fix](statistics)Use ConcurrentHashMap to avoid ConcurrentModificationException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -108,6 +108,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -151,7 +152,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
     private PartitionInfo partitionInfo;
     @SerializedName("idToPartition")
     @Getter
-    private Map<Long, Partition> idToPartition = new HashMap<>();
+    private ConcurrentHashMap<Long, Partition> idToPartition = new ConcurrentHashMap<>();
     // handled in postgsonprocess
     @Getter
     private Map<String, Partition> nameToPartition = Maps.newTreeMap();
@@ -669,7 +670,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         // reset partition info and idToPartition map
         Map<Long, Long> partitionMap = Maps.newHashMap();
         Map<Long, Partition> origIdToPartition = idToPartition;
-        idToPartition = Maps.newHashMap();
+        idToPartition = new ConcurrentHashMap<>();
         for (Map.Entry<String, Long> entry : origPartNameToId.entrySet()) {
             long newPartId = env.getNextId();
             idToPartition.put(newPartId, origIdToPartition.get(entry.getValue()));


### PR DESCRIPTION
OlapTable idToPartition Map should use ConcurrentHashMap to avoid ConcurrentModificationException.