### PR TITLE
[fix](statistics)Fix AnalysisTaskExecutor unit test timeout.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -105,6 +105,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -146,7 +147,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf {
     @SerializedName("partitionInfo")
     private PartitionInfo partitionInfo;
     @SerializedName("idToPartition")
-    private Map<Long, Partition> idToPartition = new HashMap<>();
+    private Map<Long, Partition> idToPartition = new ConcurrentHashMap<>();
     private Map<String, Partition> nameToPartition = Maps.newTreeMap();
 
     @SerializedName(value = "distributionInfo")
@@ -660,7 +661,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf {
         // reset partition info and idToPartition map
         Map<Long, Long> partitionMap = Maps.newHashMap();
         Map<Long, Partition> origIdToPartition = idToPartition;
-        idToPartition = Maps.newHashMap();
+        idToPartition = Maps.newConcurrentMap();
         for (Map.Entry<String, Long> entry : origPartNameToId.entrySet()) {
             long newPartId = env.getNextId();
             idToPartition.put(newPartId, origIdToPartition.get(entry.getValue()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskExecutor.java
@@ -106,4 +106,9 @@ public class AnalysisTaskExecutor {
         executors.getQueue().clear();
         taskQueue.clear();
     }
+
+    // For unit test only.
+    public BlockingQueue<AnalysisTaskWrapper> getTaskQueue() {
+        return taskQueue;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AnalysisTaskExecutorTest extends TestWithFeService {
@@ -105,14 +104,12 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
         OlapAnalysisTask analysisJob = new OlapAnalysisTask(analysisJobInfo);
 
         AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
-        BlockingQueue<AnalysisTaskWrapper> b = Deencapsulation.getField(analysisTaskExecutor, "taskQueue");
         AnalysisTaskWrapper analysisTaskWrapper = new AnalysisTaskWrapper(analysisTaskExecutor, analysisJob);
         Deencapsulation.setField(analysisTaskWrapper, "startTime", 5);
-        b.put(analysisTaskWrapper);
+        analysisTaskExecutor.putJob(analysisTaskWrapper);
         analysisTaskExecutor.tryToCancel();
         Assertions.assertTrue(cancelled.get());
-        Assertions.assertTrue(b.isEmpty());
-
+        Assertions.assertEquals(0, analysisTaskExecutor.getTaskQueue().size());
     }
 
     @Test


### PR DESCRIPTION
Fix AnalysisTaskExecutor unit test timeout. 
Deencapsulation.getField() doesn't work as expected, use simple put and get function to do the unit test instead.