### PR TITLE
[fix](statistics)Fix AnalysisTaskExecutor unit test timeout.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskExecutor.java
@@ -106,4 +106,9 @@ public class AnalysisTaskExecutor {
         executors.getQueue().clear();
         taskQueue.clear();
     }
+
+    // For unit test only.
+    public BlockingQueue<AnalysisTaskWrapper> getTaskQueue() {
+        return taskQueue;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AnalysisTaskExecutorTest extends TestWithFeService {
@@ -105,14 +104,12 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
         OlapAnalysisTask analysisJob = new OlapAnalysisTask(analysisJobInfo);
 
         AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
-        BlockingQueue<AnalysisTaskWrapper> b = Deencapsulation.getField(analysisTaskExecutor, "taskQueue");
         AnalysisTaskWrapper analysisTaskWrapper = new AnalysisTaskWrapper(analysisTaskExecutor, analysisJob);
         Deencapsulation.setField(analysisTaskWrapper, "startTime", 5);
-        b.put(analysisTaskWrapper);
+        analysisTaskExecutor.putJob(analysisTaskWrapper);
         analysisTaskExecutor.tryToCancel();
         Assertions.assertTrue(cancelled.get());
-        Assertions.assertTrue(b.isEmpty());
-
+        Assertions.assertEquals(0, analysisTaskExecutor.getTaskQueue().size());
     }
 
     @Test


### PR DESCRIPTION
Deencapsulation.getField sometime doesn't work as expected, which may cause FE unit test timeout. Add get function in source code to make it easier.