### PR TITLE
[opt](function)Remove input validation in FunctionDateOrDateTimeToSomething.

### DIFF
--- a/be/src/vec/functions/function_date_or_datetime_to_something.h
+++ b/be/src/vec/functions/function_date_or_datetime_to_something.h
@@ -27,7 +27,7 @@
 namespace doris::vectorized {
 
 /// See DateTimeTransforms.h
-template <typename ToDataType, typename Transform>
+template <typename ToDataType, typename Transform, bool need_check_input_valid = true>
 class FunctionDateOrDateTimeToSomething : public IFunction {
 public:
     static constexpr auto name = Transform::name;
@@ -94,8 +94,9 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         return DateTimeTransformImpl<typename Transform::OpArgType, typename ToDataType::FieldType,
-                                     Transform>::execute(block, arguments, result,
-                                                         input_rows_count);
+                                     Transform, need_check_input_valid>::execute(block, arguments,
+                                                                                 result,
+                                                                                 input_rows_count);
     }
 };
 

--- a/be/src/vec/functions/to_time_function.cpp
+++ b/be/src/vec/functions/to_time_function.cpp
@@ -51,8 +51,10 @@ using FunctionSecond = FunctionDateOrDateTimeToSomething<DataTypeInt8, ToSecondI
 using FunctionSecondV2 = FunctionDateOrDateTimeToSomething<DataTypeInt8, ToSecondImpl<UInt32>>;
 using FunctionToDays = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToDaysImpl<Int64>>;
 using FunctionToDaysV2 = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToDaysImpl<UInt32>>;
-using FunctionToDate = FunctionDateOrDateTimeToSomething<DataTypeDateTime, ToDateImpl<Int64>>;
-using FunctionToDateV2 = FunctionDateOrDateTimeToSomething<DataTypeDateV2, ToDateImpl<UInt32>>;
+using FunctionToDate =
+        FunctionDateOrDateTimeToSomething<DataTypeDateTime, ToDateImpl<Int64>, false>;
+using FunctionToDateV2 =
+        FunctionDateOrDateTimeToSomething<DataTypeDateV2, ToDateImpl<UInt32>, false>;
 using FunctionDate = FunctionDateOrDateTimeToSomething<DataTypeDateTime, DateImpl<Int64>>;
 using FunctionDateV2 = FunctionDateOrDateTimeToSomething<DataTypeDateV2, DateImpl<UInt32>>;
 
@@ -74,7 +76,7 @@ using FunctionDateTimeV2MicroSecond =
 using FunctionDateTimeV2ToDays =
         FunctionDateOrDateTimeToSomething<DataTypeInt32, ToDaysImpl<UInt64>>;
 using FunctionDateTimeV2ToDate =
-        FunctionDateOrDateTimeToSomething<DataTypeDateV2, ToDateImpl<UInt64>>;
+        FunctionDateOrDateTimeToSomething<DataTypeDateV2, ToDateImpl<UInt64>, false>;
 using FunctionDateTimeV2Date = FunctionDateOrDateTimeToSomething<DataTypeDateV2, DateImpl<UInt64>>;
 
 using FunctionTimeStamp = FunctionDateOrDateTimeToSomething<DataTypeDateTime, TimeStampImpl<Int64>>;


### PR DESCRIPTION
## Proposed changes

For functions like FunctionDateOrDateTimeToSomething that take date-type inputs, the input data should not contain invalid values. If there are invalid values, they should be set to null.


before
```
mysql [test]>select count(to_date(dt)) from dates;
+--------------------+
| count(to_date(dt)) |
+--------------------+
|           64000000 |
+--------------------+
1 row in set (0.32 sec)
```

now
```
mysql [test]>select count(to_date(dt)) from dates;
+--------------------+
| count(to_date(dt)) |
+--------------------+
|           63985581 |
+--------------------+
1 row in set (0.09 sec)
```
<!--Describe your changes.-->

