### PR TITLE
[improvement](inverted index) Change inverted index field_name from column_name to id in format v2

### DIFF
--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -51,7 +51,7 @@ public:
         return _nested->evaluate(iterator, num_rows, roaring);
     }
 
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* bitmap) const override {
         return _nested->evaluate(name_with_type, iterator, num_rows, bitmap);

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -176,7 +176,7 @@ public:
                             roaring::Roaring* roaring) const = 0;
 
     //evaluate predicate on inverted
-    virtual Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    virtual Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                             InvertedIndexIterator* iterator, uint32_t num_rows,
                             roaring::Roaring* bitmap) const {
         return Status::NotSupported(

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -67,7 +67,7 @@ public:
                                bitmap);
     }
 
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* bitmap) const override {
         if (iterator == nullptr) {

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -49,6 +49,8 @@ public:
               _index_size(column.index_length()),
               _is_nullable(column.is_nullable()),
               _unique_id(column.unique_id()),
+              _parent_col_unique_id(column.parent_unique_id()),
+              _is_extracted_column(column.is_extracted_column()),
               _path(column.path_info_ptr()) {}
 
     virtual ~Field() = default;
@@ -58,6 +60,8 @@ public:
     size_t field_size() const { return size() + 1; }
     size_t index_size() const { return _index_size; }
     int32_t unique_id() const { return _unique_id; }
+    int32_t parent_unique_id() const { return _parent_col_unique_id; }
+    bool is_extracted_column() const { return _is_extracted_column; }
     const std::string& name() const { return _name; }
     const vectorized::PathInDataPtr& path() const { return _path; }
 
@@ -241,6 +245,8 @@ protected:
         other->_precision = this->_precision;
         other->_scale = this->_scale;
         other->_unique_id = this->_unique_id;
+        other->_parent_col_unique_id = this->_parent_col_unique_id;
+        other->_is_extracted_column = this->_is_extracted_column;
         for (const auto& f : _sub_fields) {
             Field* item = f->clone();
             other->add_sub_field(std::unique_ptr<Field>(item));
@@ -258,6 +264,8 @@ private:
     int32_t _precision;
     int32_t _scale;
     int32_t _unique_id;
+    int32_t _parent_col_unique_id;
+    bool _is_extracted_column = false;
     vectorized::PathInDataPtr _path;
 };
 

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -49,7 +49,7 @@ public:
               _index_size(column.index_length()),
               _is_nullable(column.is_nullable()),
               _unique_id(column.unique_id()),
-              _parent_col_unique_id(column.parent_unique_id()),
+              _parent_unique_id(column.parent_unique_id()),
               _is_extracted_column(column.is_extracted_column()),
               _path(column.path_info_ptr()) {}
 
@@ -60,7 +60,7 @@ public:
     size_t field_size() const { return size() + 1; }
     size_t index_size() const { return _index_size; }
     int32_t unique_id() const { return _unique_id; }
-    int32_t parent_unique_id() const { return _parent_col_unique_id; }
+    int32_t parent_unique_id() const { return _parent_unique_id; }
     bool is_extracted_column() const { return _is_extracted_column; }
     const std::string& name() const { return _name; }
     const vectorized::PathInDataPtr& path() const { return _path; }
@@ -245,7 +245,7 @@ protected:
         other->_precision = this->_precision;
         other->_scale = this->_scale;
         other->_unique_id = this->_unique_id;
-        other->_parent_col_unique_id = this->_parent_col_unique_id;
+        other->_parent_unique_id = this->_parent_unique_id;
         other->_is_extracted_column = this->_is_extracted_column;
         for (const auto& f : _sub_fields) {
             Field* item = f->clone();
@@ -264,7 +264,7 @@ private:
     int32_t _precision;
     int32_t _scale;
     int32_t _unique_id;
-    int32_t _parent_col_unique_id;
+    int32_t _parent_unique_id;
     bool _is_extracted_column = false;
     vectorized::PathInDataPtr _path;
 };

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -180,7 +180,7 @@ public:
         return Status::OK();
     }
 
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* result) const override {
         if (iterator == nullptr) {

--- a/be/src/olap/match_predicate.cpp
+++ b/be/src/olap/match_predicate.cpp
@@ -45,7 +45,7 @@ PredicateType MatchPredicate::type() const {
     return PredicateType::MATCH;
 }
 
-Status MatchPredicate::evaluate(const vectorized::NameAndTypePair& name_with_type,
+Status MatchPredicate::evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                                 InvertedIndexIterator* iterator, uint32_t num_rows,
                                 roaring::Roaring* bitmap) const {
     if (iterator == nullptr) {

--- a/be/src/olap/match_predicate.h
+++ b/be/src/olap/match_predicate.h
@@ -60,7 +60,7 @@ public:
     }
 
     //evaluate predicate on inverted
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* bitmap) const override;
 

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -53,7 +53,7 @@ Status NullPredicate::evaluate(BitmapIndexIterator* iterator, uint32_t num_rows,
     return Status::OK();
 }
 
-Status NullPredicate::evaluate(const vectorized::NameAndTypePair& name_with_type,
+Status NullPredicate::evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                                InvertedIndexIterator* iterator, uint32_t num_rows,
                                roaring::Roaring* bitmap) const {
     if (iterator->has_null()) {

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -52,7 +52,7 @@ public:
     Status evaluate(BitmapIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* roaring) const override;
 
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* bitmap) const override;
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
@@ -66,6 +66,7 @@ public:
     void sort_files(std::vector<FileInfo>& file_infos);
     void copyFile(const char* fileName, lucene::store::Directory* dir,
                   lucene::store::IndexOutput* output, uint8_t* buffer, int64_t bufferLength);
+    InvertedIndexStorageFormatPB get_storage_format() const { return _storage_format; }
 
 private:
     InvertedIndexDirectoryMap _indices_dirs;

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <ostream>
 #include <roaring/roaring.hh>
+#include <string>
 #include <vector>
 
 #include "io/fs/local_file_system.h"
@@ -651,7 +652,19 @@ Status InvertedIndexColumnWriter::create(const Field* field,
                                          const TabletIndex* index_meta) {
     const auto* typeinfo = field->type_info();
     FieldType type = typeinfo->type();
-    std::string field_name = field->name();
+    std::string field_name;
+    auto storage_format = index_file_writer->get_storage_format();
+    if (storage_format == InvertedIndexStorageFormatPB::V1) {
+        field_name = field->name();
+    } else {
+        if (field->is_extracted_column()) {
+            // variant sub col
+            // field_name format: parent_unique_id.sub_col_name
+            field_name = std::to_string(field->parent_unique_id()) + "." + field->name();
+        } else {
+            field_name = std::to_string(field->unique_id());
+        }
+    }
     bool single_field = true;
     if (type == FieldType::OLAP_FIELD_TYPE_ARRAY) {
         const auto* array_typeinfo = dynamic_cast<const ArrayTypeInfo*>(typeinfo);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1311,7 +1311,8 @@ Status SegmentIterator::_apply_inverted_index() {
     if (_opts.runtime_state &&
         _opts.runtime_state->enable_common_expr_pushdown_for_inverted_index()) {
         // support expr to evaluate inverted index
-        std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair, InvertedIndexIterator*>>
+        std::unordered_map<ColumnId,
+                           std::pair<vectorized::IndexFieldNameAndTypePair, InvertedIndexIterator*>>
                 iter_map;
         for (auto col_id : _common_expr_columns_for_index) {
             auto tablet_col_id = _schema->column_id(col_id);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -396,6 +396,13 @@ private:
     // read schema from scanner
     SchemaSPtr _schema;
     // storage type schema related to _schema, since column in segment may be different with type in _schema
+    // <field_name, storage_type> , only used in inverted index
+    // field_name is the name of inverted index document's filed
+    //     1. for inverted_index_storage_format_v1, field_name is the `column_name` in Doris
+    //     2. for inverted_index_storage_format_v2
+    //     2.1 for normal column, field_name is the `column_unique_id` in Doris
+    //     2.2 for variant column, field_name is the `parent_column_unique_id.sub_column_name` in Doris
+    // storage_type is the data type in Doris
     std::vector<vectorized::NameAndTypePair> _storage_name_and_type;
     // vector idx -> column iterarator
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -396,14 +396,7 @@ private:
     // read schema from scanner
     SchemaSPtr _schema;
     // storage type schema related to _schema, since column in segment may be different with type in _schema
-    // <field_name, storage_type> , only used in inverted index
-    // field_name is the name of inverted index document's filed
-    //     1. for inverted_index_storage_format_v1, field_name is the `column_name` in Doris
-    //     2. for inverted_index_storage_format_v2
-    //     2.1 for normal column, field_name is the `column_unique_id` in Doris
-    //     2.2 for variant column, field_name is the `parent_column_unique_id.sub_column_name` in Doris
-    // storage_type is the data type in Doris
-    std::vector<vectorized::NameAndTypePair> _storage_name_and_type;
+    std::vector<vectorized::IndexFieldNameAndTypePair> _storage_name_and_type;
     // vector idx -> column iterarator
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
     std::vector<std::unique_ptr<BitmapIndexIterator>> _bitmap_index_iterators;

--- a/be/src/olap/shared_predicate.h
+++ b/be/src/olap/shared_predicate.h
@@ -61,7 +61,7 @@ public:
         return _nested->evaluate(iterator, num_rows, roaring);
     }
 
-    Status evaluate(const vectorized::NameAndTypePair& name_with_type,
+    Status evaluate(const vectorized::IndexFieldNameAndTypePair& name_with_type,
                     InvertedIndexIterator* iterator, uint32_t num_rows,
                     roaring::Roaring* bitmap) const override {
         std::shared_lock<std::shared_mutex> lock(_mtx);

--- a/be/src/vec/core/columns_with_type_and_name.h
+++ b/be/src/vec/core/columns_with_type_and_name.h
@@ -30,6 +30,14 @@
 namespace doris::vectorized {
 
 using ColumnsWithTypeAndName = std::vector<ColumnWithTypeAndName>;
-using NameAndTypePair = std::pair<std::string, DataTypePtr>;
-using NameAndTypePairs = std::vector<NameAndTypePair>;
+// only used in inverted index
+// <field_name, storage_type>
+// field_name is the name of inverted index document's filed
+//     1. for inverted_index_storage_format_v1, field_name is the `column_name` in Doris
+//     2. for inverted_index_storage_format_v2
+//         2.1 for normal column, field_name is the `column_unique_id` in Doris
+//         2.2 for variant column, field_name is the `parent_column_unique_id.sub_column_name` in Doris
+// storage_type is the data type in Doris
+using IndexFieldNameAndTypePair = std::pair<std::string, DataTypePtr>;
+using NameAndTypePairs = std::vector<std::pair<std::string, DataTypePtr>>;
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -59,7 +59,7 @@ public:
     //          but a and array_contains(b, 1), b can be applied inverted index, which b can be extracted
     Status eval_inverted_index(
             VExprContext* context,
-            const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+            const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                          segment_v2::InvertedIndexIterator*>>&
                     colid_to_inverted_index_iter,
             uint32_t num_rows, roaring::Roaring* bitmap) const override {

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -146,7 +146,7 @@ void VectorizedFnCall::close(VExprContext* context, FunctionContext::FunctionSta
 
 Status VectorizedFnCall::eval_inverted_index(
         VExprContext* context,
-        const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+        const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                      segment_v2::InvertedIndexIterator*>>&
                 colid_to_inverted_index_iter,
         uint32_t num_rows, roaring::Roaring* bitmap) const {

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -53,7 +53,7 @@ public:
                                   std::vector<size_t>& args) override;
     Status eval_inverted_index(
             VExprContext* context,
-            const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+            const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                          segment_v2::InvertedIndexIterator*>>&
                     colid_to_inverted_index_iter,
             uint32_t num_rows, roaring::Roaring* bitmap) const override;

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -119,7 +119,7 @@ public:
     // execute current expr with inverted index to filter block. Given a roaringbitmap of match rows
     virtual Status eval_inverted_index(
             VExprContext* context,
-            const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+            const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                          segment_v2::InvertedIndexIterator*>>&
                     colid_to_inverted_index_iter,
             uint32_t num_rows, roaring::Roaring* bitmap) const {

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -120,7 +120,7 @@ int VExprContext::register_function_context(RuntimeState* state, const TypeDescr
     return _fn_contexts.size() - 1;
 }
 Status VExprContext::eval_inverted_index(
-        const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+        const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                      segment_v2::InvertedIndexIterator*>>&
                 colid_to_inverted_index_iter,
         uint32_t num_rows, roaring::Roaring* bitmap) {

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -80,7 +80,7 @@ public:
      * @return status not ok means execute failed.
      */
     [[nodiscard]] Status eval_inverted_index(
-            const std::unordered_map<ColumnId, std::pair<vectorized::NameAndTypePair,
+            const std::unordered_map<ColumnId, std::pair<vectorized::IndexFieldNameAndTypePair,
                                                          segment_v2::InvertedIndexIterator*>>&
                     colid_to_inverted_index_iter,
             uint32_t num_rows, roaring::Roaring* bitmap);

--- a/be/src/vec/functions/array/function_array_index.h
+++ b/be/src/vec/functions/array/function_array_index.h
@@ -119,7 +119,7 @@ public:
      * eval inverted index. we can filter array rows with inverted index iter
      */
     Status eval_inverted_index(FunctionContext* context,
-                               const vectorized::NameAndTypePair& data_type_with_name,
+                               const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
                                segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
                                roaring::Roaring* bitmap) const override {
         std::shared_ptr<roaring::Roaring> roaring = std::make_shared<roaring::Roaring>();

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -186,7 +186,7 @@ public:
     }
 
     virtual Status eval_inverted_index(FunctionContext* context,
-                                       const vectorized::NameAndTypePair& data_type_with_name,
+                                       const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
                                        segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
                                        roaring::Roaring* bitmap) const {
         return Status::NotSupported("eval_inverted_index is not supported in function: ",
@@ -411,7 +411,7 @@ public:
 
     // here are lots of function not extends eval_inverted_index.
     Status eval_inverted_index(FunctionContext* context,
-                               const vectorized::NameAndTypePair& data_type_with_name,
+                               const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
                                segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
                                roaring::Roaring* bitmap) const override {
         return Status::NotSupported("eval_inverted_index is not supported in function: ",
@@ -453,7 +453,7 @@ protected:
     }
 
     Status eval_inverted_index(FunctionContext* context,
-                               const vectorized::NameAndTypePair& data_type_with_name,
+                               const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
                                segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
                                roaring::Roaring* bitmap) const {
         return function->eval_inverted_index(context, data_type_with_name, iter, num_rows, bitmap);
@@ -524,7 +524,7 @@ public:
     }
 
     Status eval_inverted_index(FunctionContext* context,
-                               const vectorized::NameAndTypePair& data_type_with_name,
+                               const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
                                segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
                                roaring::Roaring* bitmap) const override {
         return function->eval_inverted_index(context, data_type_with_name, iter, num_rows, bitmap);

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -185,10 +185,11 @@ public:
                 ->execute(context, block, arguments, result, input_rows_count, dry_run);
     }
 
-    virtual Status eval_inverted_index(FunctionContext* context,
-                                       const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
-                                       segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
-                                       roaring::Roaring* bitmap) const {
+    virtual Status eval_inverted_index(
+            FunctionContext* context,
+            const vectorized::IndexFieldNameAndTypePair& data_type_with_name,
+            segment_v2::InvertedIndexIterator* iter, uint32_t num_rows,
+            roaring::Roaring* bitmap) const {
         return Status::NotSupported("eval_inverted_index is not supported in function: ",
                                     get_name());
     }


### PR DESCRIPTION

## Proposed changes

Currently, when writing a lucene index, the field of the document is column_name, and the column name is bound to the index field. Since version 1.2, the data file storage has been changed from column_name to column_unique_id, allowing the column name to be changed. Due to current limitations, previous inverted index data cannot be used after Doris changes the column name. Column names also support Unicode characters, which may cause other problems with indexing in non-ASCII characters.
After consideration, it was decided to change the field name from column_name to column_unique_id in format V2, while format V1 continues to use column_name.

`field_name` is the name of inverted index document's filed
    1. for inverted_index_storage_format_v1, field_name is the `column_name` in Doris
    2. for inverted_index_storage_format_v2
    2.1 for normal column, field_name is the `column_unique_id` in Doris
    2.2 for variant column, field_name is the `parent_column_unique_id.sub_column_name` in Doris


