### PR TITLE
[improvement](batch delete) remove outdated enable_batch_delete_by_default config

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1379,12 +1379,6 @@ public class Config extends ConfigBase {
     public static boolean recover_with_empty_tablet = false;
 
     /**
-     * Whether to add a delete sign column when create unique table
-     */
-    @ConfField(mutable = true, masterOnly = true)
-    public static boolean enable_batch_delete_by_default = true;
-
-    /**
      * Whether to add a version column when create unique table
      */
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -439,8 +439,7 @@ public class CreateTableStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLE_MUST_HAVE_COLUMNS);
         }
         // add a hidden column as delete flag for unique table
-        if (Config.enable_batch_delete_by_default && keysDesc != null
-                && keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
+        if (keysDesc != null && keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
             if (enableUniqueKeyMergeOnWrite) {
                 columnDefs.add(ColumnDef.newDeleteSignColumnDef(AggregateType.NONE));
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -402,7 +402,7 @@ public class CreateTableInfo {
             }
 
             // add hidden column
-            if (Config.enable_batch_delete_by_default && keysType.equals(KeysType.UNIQUE_KEYS)) {
+            if (keysType.equals(KeysType.UNIQUE_KEYS)) {
                 if (isEnableMergeOnWrite) {
                     columns.add(ColumnDefinition.newDeleteSignColumnDefinition(AggregateType.NONE));
                 } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/QueryStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/QueryStmtTest.java
@@ -51,7 +51,6 @@ public class QueryStmtTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        Config.enable_batch_delete_by_default = true;
         UtFrameUtils.createDorisCluster(runningDir);
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/QueryStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/QueryStmtTest.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -65,7 +65,6 @@ public class SelectStmtTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        Config.enable_batch_delete_by_default = true;
         Config.enable_http_server_v2 = false;
         UtFrameUtils.createDorisCluster(runningDir);
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32),"

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/TableNameComparedLowercaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/TableNameComparedLowercaseTest.java
@@ -49,7 +49,6 @@ public class TableNameComparedLowercaseTest {
     @BeforeClass
     public static void setUp() throws Exception {
         Config.lower_case_table_names = 2;
-        Config.enable_batch_delete_by_default = true;
         Config.enable_http_server_v2 = false;
         UtFrameUtils.createDorisCluster(runningDir);
         String table1 = "CREATE TABLE db1.TABLE1 (\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/TableNameStoredLowercaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/TableNameStoredLowercaseTest.java
@@ -48,7 +48,6 @@ public class TableNameStoredLowercaseTest {
     @BeforeClass
     public static void setUp() throws Exception {
         Config.lower_case_table_names = 1;
-        Config.enable_batch_delete_by_default = true;
         Config.enable_http_server_v2 = false;
         UtFrameUtils.createDorisCluster(runningDir);
         String table1 = "CREATE TABLE db1.TABLE1 (\n"

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_debug_data.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_debug_data.groovy
@@ -19,7 +19,6 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_unique_table_debug_data") {
 
-    sql "ADMIN SET FRONTEND CONFIG ('enable_batch_delete_by_default' = 'true')"
     sql "SET show_hidden_columns=false"
     sql "SET skip_delete_predicate=false"
     sql "SET skip_storage_engine_merge=false"

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_like.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_like.groovy
@@ -24,7 +24,6 @@ suite("test_unique_table_like") {
     // test uniq table like 
     def tbNameA = "test_uniq"
     def tbNameB = "test_uniq_like"
-    sql "ADMIN SET FRONTEND CONFIG ('enable_batch_delete_by_default' = 'true')"
     sql "SET show_hidden_columns=true"
     sql "DROP TABLE IF EXISTS ${tbNameA}"
     sql """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

batch delete is enabled by default since 0.15, we don't need the config `enable_batch_delete_by_default` any more, remove it

related document PR : https://github.com/apache/doris-website/pull/759

