### PR TITLE
[fix](regression) Fix the issue of table naming conflicts causing case failures

### DIFF
--- a/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_with_schema_change.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_with_schema_change.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_stream_load_2pc_with_schema_change", "p0") {
-    def tableName = "test_2pc_table"
+    def tableName = "test_2pc_table_with_sc"
     InetSocketAddress address = context.config.feHttpInetSocketAddress
     String user = context.config.feHttpUser
     String password = context.config.feHttpPassword


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
 There is a table naming conflict between test_stream_load_2pc  and test_stream_load_2pc_with_schema_change.
<!--Describe your changes.-->

