### PR TITLE
[branch-1.2](complex type) forbid MAP type and STRUCT type in v1.2

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/MapType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/MapType.java
@@ -57,6 +57,11 @@ public class MapType extends Type {
     }
 
     @Override
+    public boolean isSupported() {
+        return false;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!(other instanceof MapType)) {
             return false;

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
@@ -52,6 +52,11 @@ public class StructType extends Type {
     }
 
     @Override
+    public boolean isSupported() {
+        return false;
+    }
+
+    @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
             return "STRUCT<...>";


### PR DESCRIPTION
## Proposed changes

There are lots of basic usage problems for MAP and STRUCT in v1.2, so we forbid them on v1.2

such as:
```
CREATE TABLE `test` (
  `k1` varchar(20) NULL COMMENT "",
  `v` MAP<varchar(20),varchar(200)> NULL COMMENT ""
) ENGINE = OLAP
DISTRIBUTED BY HASH(`k1`)
BUCKETS 1
PROPERTIES ("replication_num"  =  "1");

```

```
> desc test;
+-------+------------------------------------------+------+-------+---------+-------+
| Field | Type                                     | Null | Key   | Default | Extra |
+-------+------------------------------------------+------+-------+---------+-------+
| k1    | VARCHAR(20)                              | Yes  | true  | NULL    |       |
| v     | org.apache.doris.catalog.MapType@7c62f50 | Yes  | false | NULL    | NONE  |
+-------+------------------------------------------+------+-------+---------+-------+
```


<!--Describe your changes.-->

