### PR TITLE
[enhance](mtmv)when calculating the availability of MTMV, no longer consider refresh state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
@@ -20,7 +20,6 @@ package org.apache.doris.mtmv;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
 import org.apache.doris.qe.ConnectContext;
 
@@ -62,8 +61,7 @@ public class MTMVRewriteUtil {
             return res;
         }
         // check mv is normal
-        if (!(mtmv.getStatus().getState() == MTMVState.NORMAL
-                && mtmv.getStatus().getRefreshState() == MTMVRefreshState.SUCCESS)) {
+        if (!(mtmv.getStatus().getState() == MTMVState.NORMAL)) {
             return res;
         }
         Map<String, Set<String>> partitionMappings = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
@@ -61,7 +61,7 @@ public class MTMVRewriteUtil {
             return res;
         }
         // check mv is normal
-        if (!(mtmv.getStatus().getState() == MTMVState.NORMAL)) {
+        if (mtmv.getStatus().getState() != MTMVState.NORMAL) {
             return res;
         }
         Map<String, Set<String>> partitionMappings = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
@@ -20,6 +20,7 @@ package org.apache.doris.mtmv;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
 import org.apache.doris.qe.ConnectContext;
 
@@ -61,7 +62,8 @@ public class MTMVRewriteUtil {
             return res;
         }
         // check mv is normal
-        if (mtmv.getStatus().getState() != MTMVState.NORMAL) {
+        if (mtmv.getStatus().getState() != MTMVState.NORMAL
+                || mtmv.getStatus().getRefreshState() == MTMVRefreshState.INIT) {
             return res;
         }
         Map<String, Set<String>> partitionMappings = null;

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
@@ -259,4 +259,17 @@ public class MTMVRewriteUtilTest {
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
+    @Test
+    public void testGetMTMVCanRewritePartitionsRefreshStateInit() {
+        new Expectations() {
+            {
+                status.getRefreshState();
+                minTimes = 0;
+                result = MTMVRefreshState.INIT;
+            }
+        };
+        Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
+                .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills);
+        Assert.assertEquals(0, mtmvCanRewritePartitions.size());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
@@ -256,7 +256,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills);
-        Assert.assertEquals(0, mtmvCanRewritePartitions.size());
+        Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
 }


### PR DESCRIPTION
Before the modification, if the last refresh of the materialized view failed, the entire materialized view cannot be used for transparent rewriting. In fact, many partitions may be available, so this modification was made

