### PR TITLE
[improvement](partition rebalance) improve partition rebalance choose candidate speed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -303,7 +303,7 @@ public class PartitionRebalancer extends Rebalancer {
             List<Long> availPath = paths.stream().filter(path -> path.getStorageMedium() == tabletCtx.getStorageMedium()
                             && path.isFit(tabletCtx.getTabletSize(), false) == BalanceStatus.OK)
                     .map(RootPathLoadStatistic::getPathHash).collect(Collectors.toList());
-            long pathHash = slot.takeAnAvailBalanceSlotFrom(availPath);
+            long pathHash = slot.takeAnAvailBalanceSlotFrom(availPath, tabletCtx.getStorageMedium());
             if (pathHash == -1) {
                 throw new SchedException(SchedException.Status.SCHEDULE_FAILED, SubCode.WAITING_SLOT,
                         "paths has no available balance slot: " + availPath);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -162,7 +162,7 @@ public class PartitionRebalancer extends Rebalancer {
                 for (int i = 0; i < startIdx; i++) {
                     long tabletId = tabletIds.get(i);
                     TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
-                    if (canMoveTablet.test(tabletId)) {
+                    if (canMoveTablet.test(tabletId, tabletMeta)) {
                         pickedTabletId = tabletId;
                         pickedTabletMeta = tabletMeta;
                         break;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -30,7 +30,6 @@ import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
@@ -43,6 +42,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 /*
@@ -123,44 +123,63 @@ public class PartitionRebalancer extends Rebalancer {
 
         List<TabletSchedCtx> alternativeTablets = Lists.newArrayList();
         Set<Long> inProgressIds = movesInProgressList.stream().map(m -> m.tabletId).collect(Collectors.toSet());
+        Random rand = new SecureRandom();
         for (TwoDimensionalGreedyRebalanceAlgo.PartitionMove move : moves) {
             // Find all tablets of the specified partition that would have a replica at the source be,
             // but would not have a replica at the destination be. That is to satisfy the restriction
             // of having no more than one replica of the same tablet per be.
             List<Long> tabletIds = invertedIndex.getTabletIdsByBackendIdAndStorageMedium(move.fromBe, medium);
-            Set<Long> invalidIds = Sets.newHashSet(
-                    invertedIndex.getTabletIdsByBackendIdAndStorageMedium(move.toBe, medium));
-
-            Map<Long, TabletMeta> tabletCandidates = Maps.newHashMap();
-            for (long tabletId : tabletIds) {
-                if (invalidIds.contains(tabletId) || inProgressIds.contains(tabletId)) {
-                    continue;
-                }
-                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
-                if (tabletMeta != null && tabletMeta.getPartitionId() == move.partitionId
-                        && tabletMeta.getIndexId() == move.indexId) {
-                    tabletCandidates.put(tabletId, tabletMeta);
-                }
-            }
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Find {} candidates for move {}", tabletCandidates.size(), move);
-            }
-            if (tabletCandidates.isEmpty()) {
+            if (tabletIds.isEmpty()) {
                 continue;
             }
 
+            Set<Long> invalidIds = Sets.newHashSet(
+                    invertedIndex.getTabletIdsByBackendIdAndStorageMedium(move.toBe, medium));
+
+            BiPredicate<Long, TabletMeta> canMoveTablet = (Long tabletId, TabletMeta tabletMeta) -> {
+                return tabletMeta != null
+                        && tabletMeta.getPartitionId() == move.partitionId
+                        && tabletMeta.getIndexId() == move.indexId
+                        && !invalidIds.contains(tabletId)
+                        && !inProgressIds.contains(tabletId);
+            };
+
             // Random pick one candidate to create tabletSchedCtx
-            Random rand = new SecureRandom();
-            Object[] keys = tabletCandidates.keySet().toArray();
-            long pickedTabletId = (long) keys[rand.nextInt(keys.length)];
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Picked tablet id for move {}: {}", move, pickedTabletId);
+            int startIdx = rand.nextInt(tabletIds.size());
+            long pickedTabletId = -1L;
+            TabletMeta pickedTabletMeta = null;
+            for (int i = startIdx; i < tabletIds.size(); i++) {
+                long tabletId = tabletIds.get(i);
+                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                if (canMoveTablet.test(tabletId, tabletMeta)) {
+                    pickedTabletId = tabletId;
+                    pickedTabletMeta = tabletMeta;
+                    break;
+                }
             }
 
-            TabletMeta tabletMeta = tabletCandidates.get(pickedTabletId);
+            if (pickedTabletId == -1L) {
+                for (int i = 0; i < startIdx; i++) {
+                    long tabletId = tabletIds.get(i);
+                    TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                    if (canMoveTablet.test(tabletId)) {
+                        pickedTabletId = tabletId;
+                        pickedTabletMeta = tabletMeta;
+                        break;
+                    }
+                }
+            }
+
+            if (pickedTabletId == -1L) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Cann't picked tablet id for move {}", move);
+                }
+                continue;
+            }
+
             TabletSchedCtx tabletCtx = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE,
-                    tabletMeta.getDbId(), tabletMeta.getTableId(), tabletMeta.getPartitionId(),
-                    tabletMeta.getIndexId(), pickedTabletId, null /* replica alloc is not used for balance*/,
+                    pickedTabletMeta.getDbId(), pickedTabletMeta.getTableId(), pickedTabletMeta.getPartitionId(),
+                    pickedTabletMeta.getIndexId(), pickedTabletId, null /* replica alloc is not used for balance*/,
                     System.currentTimeMillis());
             tabletCtx.setTag(clusterStat.getTag());
             // Balance task's priority is always LOW

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -351,6 +351,11 @@ public class PartitionRebalancer extends Rebalancer {
     }
 
     @Override
+    public void invalidateToDeleteReplicaId(TabletSchedCtx tabletCtx) {
+        movesCacheMap.invalidateTablet(tabletCtx);
+    }
+
+    @Override
     public void updateLoadStatistic(Map<Tag, LoadStatisticForTag> statisticMap) {
         super.updateLoadStatistic(statisticMap);
         movesCacheMap.updateMapping(statisticMap, Config.partition_rebalance_move_expire_after_access);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -129,6 +129,9 @@ public abstract class Rebalancer {
         return -1L;
     }
 
+    public void invalidateToDeleteReplicaId(TabletSchedCtx tabletCtx) {
+    }
+
     public void onTabletFailed(TabletSchedCtx tabletCtx) {
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -994,7 +994,9 @@ public class TabletScheduler extends MasterDaemon {
         if (chosenReplica == null) {
             return false;
         }
+
         deleteReplicaInternal(tabletCtx, chosenReplica, "src replica of rebalance", force);
+        rebalancer.invalidateToDeleteReplicaId(tabletCtx);
 
         return true;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/PathSlotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/PathSlotTest.java
@@ -39,10 +39,11 @@ class PathSlotTest {
         List<Long> availPathHashs = Lists.newArrayList();
         List<Long> expectPathHashs = Lists.newArrayList();
         List<Long> gotPathHashs = Lists.newArrayList();
+        TStorageMedium medium = TStorageMedium.HDD;
         long startPath = 10001L;
         long endPath = 10006L;
         for (long pathHash = startPath; pathHash < endPath; pathHash++) {
-            paths.put(pathHash, TStorageMedium.HDD);
+            paths.put(pathHash, medium);
             availPathHashs.add(pathHash);
             expectPathHashs.add(pathHash);
         }
@@ -56,7 +57,7 @@ class PathSlotTest {
         PathSlot ps = new PathSlot(paths, 1L);
         for (int i = 0; i < expectPathHashs.size(); i++) {
             Collections.shuffle(availPathHashs);
-            gotPathHashs.add(ps.takeAnAvailBalanceSlotFrom(availPathHashs));
+            gotPathHashs.add(ps.takeAnAvailBalanceSlotFrom(availPathHashs, medium));
         }
         Assert.assertEquals(expectPathHashs, gotPathHashs);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
@@ -49,7 +49,6 @@ public class DecommissionBackendTest extends TestWithFeService {
     @Override
     protected void beforeCluster() {
         FeConstants.runningUnitTest = true;
-        needCleanDir = false;
     }
 
     @BeforeAll


### PR DESCRIPTION
When partition reblancer choose candidate tablets,   it will call tabletListOfA.removeAll(tabletListOfB),  but list.removeAll(list)'s runtime is O(n^2). Then if each BE contains 10w+ tablets,  it's rather slow.  And we found a online case the tablet scheduler thread is busy at it.

So need improve this search.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

