### PR TITLE
[fix](compile) fix compile failed caused by std::min on MacOS

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -150,7 +150,8 @@ Status LoadBlockQueue::get_block(RuntimeState* runtime_state, vectorized::Block*
                           << ", runtime_state=" << runtime_state;
             }
         }
-        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000L)));
+        _get_cond.wait_for(l, std::chrono::milliseconds(
+                                      std::min(left_milliseconds, static_cast<int64_t>(10000))));
     }
     if (runtime_state->is_cancelled()) {
         auto st = runtime_state->cancel_reason();


### PR DESCRIPTION
```
doris/be/src/runtime/group_commit_mgr.cpp:153:57: error: no matching function for call to 'min'
        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000L)));
                                                        ^~~~~~~~
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:40:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('int64_t' (aka 'long long') vs. 'long')
min(const _Tp& __a, const _Tp& __b)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:51:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'int64_t' (aka 'long long')
min(initializer_list<_Tp> __t, _Compare __comp)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:60:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
min(initializer_list<_Tp> __t)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:31:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
1 error generated.
[364/961] Building CXX object src/olap/CMakeFiles/Olap.dir/tablet_reader.cpp.o
ninja: build stopped: subcommand failed.
```
