### PR TITLE
[fix](build) fix std::min usage for macOS compilation

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -150,7 +150,8 @@ Status LoadBlockQueue::get_block(RuntimeState* runtime_state, vectorized::Block*
                           << ", runtime_state=" << runtime_state;
             }
         }
-        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000L)));
+        _get_cond.wait_for(l, std::chrono::milliseconds(
+                                      std::min(left_milliseconds, static_cast<int64_t>(10000L))));
     }
     if (runtime_state->is_cancelled()) {
         auto st = runtime_state->cancel_reason();


### PR DESCRIPTION
This PR resolves a compilation error on macOS by ensuring type consistency in std::min function calls.