### PR TITLE
[fix](nereids)NullSafeEqualToEqual rule should keep <=> unchanged if it has none-literal child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionOptimization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionOptimization.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.rules.expression.rules.DateFunctionRewrite;
 import org.apache.doris.nereids.rules.expression.rules.DistinctPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rules.ExtractCommonFactorRule;
 import org.apache.doris.nereids.rules.expression.rules.LikeToEqualRewrite;
+import org.apache.doris.nereids.rules.expression.rules.NullSafeEqualToEqual;
 import org.apache.doris.nereids.rules.expression.rules.OrToIn;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyComparisonPredicate;
 import org.apache.doris.nereids.rules.expression.rules.SimplifyDecimalV3Comparison;
@@ -51,6 +52,7 @@ public class ExpressionOptimization extends ExpressionRewrite {
                 ArrayContainToArrayOverlap.INSTANCE,
                 CaseWhenToIf.INSTANCE,
                 TopnToMax.INSTANCE,
+                NullSafeEqualToEqual.INSTANCE,
                 LikeToEqualRewrite.INSTANCE
             )
     );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/NullSafeEqualToEqual.java
@@ -24,17 +24,16 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
 /**
- * convert "<=>" to "=", if both sides are not nullable
  * convert "A <=> null" to "A is null"
  * null <=> null : true
  * null <=> 1 : false
+ * 1 <=> 2 : 1 = 2
  */
 public class NullSafeEqualToEqual implements ExpressionPatternRuleFactory {
     public static final NullSafeEqualToEqual INSTANCE = new NullSafeEqualToEqual();
@@ -47,19 +46,14 @@ public class NullSafeEqualToEqual implements ExpressionPatternRuleFactory {
     }
 
     private static Expression rewrite(NullSafeEqual nullSafeEqual) {
-        if (nullSafeEqual.left() instanceof NullLiteral) {
-            if (nullSafeEqual.right().nullable()) {
-                return new IsNull(nullSafeEqual.right());
-            } else {
-                return BooleanLiteral.FALSE;
-            }
-        } else if (nullSafeEqual.right() instanceof NullLiteral) {
-            if (nullSafeEqual.left().nullable()) {
-                return new IsNull(nullSafeEqual.left());
-            } else {
-                return BooleanLiteral.FALSE;
-            }
-        } else if (!nullSafeEqual.left().nullable() && !nullSafeEqual.right().nullable()) {
+        // because the nullable info hasn't been finalized yet, the optimization is limited
+        if (nullSafeEqual.left().isNullLiteral() && nullSafeEqual.right().isNullLiteral()) {
+            return BooleanLiteral.TRUE;
+        } else if (nullSafeEqual.left().isNullLiteral()) {
+            return nullSafeEqual.right().isLiteral() ? BooleanLiteral.FALSE : new IsNull(nullSafeEqual.right());
+        } else if (nullSafeEqual.right().isNullLiteral()) {
+            return nullSafeEqual.left().isLiteral() ? BooleanLiteral.FALSE : new IsNull(nullSafeEqual.left());
+        } else if (nullSafeEqual.left().isLiteral() && nullSafeEqual.right().isLiteral()) {
             return new EqualTo(nullSafeEqual.left(), nullSafeEqual.right());
         }
         return nullSafeEqual;


### PR DESCRIPTION
convert:
 expr <=> null to expr is null
 null <=> null to true
 null <=> 1 to false
 literal <=> literal to literal = literal ( 1 <=> 2 to 1 = 2 )
others are unchanged.
 

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

