### PR TITLE
[fix](catalog) fix wrong check when using "use_meta_cache=true"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -726,9 +726,9 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         HMSExternalCatalog hmsCatalog = (HMSExternalCatalog) catalog;
         long dbId;
         if (hmsCatalog.getUseMetaCache().get()) {
-            dbId = Env.getCurrentEnv().getExternalMetaIdMgr().getDbId(catalog.getId(), dbName);
-        } else {
             dbId = Util.genTableIdByName(dbName);
+        } else {
+            dbId = Env.getCurrentEnv().getExternalMetaIdMgr().getDbId(catalog.getId(), dbName);
         }
         // -1L means it will be dropped later, ignore
         if (dbId == ExternalMetaIdMgr.META_ID_FOR_NOT_EXISTS) {


### PR DESCRIPTION
This is PR #33610 introduce a new feature of `use_meta_cache=true`.
And made a wrong check when checking this config.
And if user enable the hive metastore even listener for hive catalog,
it may causing FE unable to restart due to meta data replay error:
```
2024-06-19 14:25:32,536 ERROR (stateListener|118) [EditLog.loadJournal():1231] Operation Type 325
java.util.NoSuchElementException: No value present
        at java.util.Optional.get(Optional.java:135) ~[?:1.8.0_341]
        at org.apache.doris.datasource.ExternalCatalog.replayInitCatalog(ExternalCatalog.java:594) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.CatalogMgr.replayInitCatalog(CatalogMgr.java:584) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:1012) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.replayJournal(Env.java:2779) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.transferToMaster(Env.java:1473) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.access$1400(Env.java:324) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env$5.runOneCycle(Env.java:2670) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

TODO:
add hive event listener test suit in external p0