### PR TITLE
[opt](cast) Optimize the conversion of numeric types to strings.

### DIFF
--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -97,6 +97,16 @@ Status IDataType::from_string(ReadBuffer& rb, IColumn* column) const {
     return Status::OK();
 }
 
+void IDataType::to_string_batch(const IColumn& column, ColumnString& column_to) const {
+    const auto size = column.size();
+    column_to.reserve(size * 2);
+    VectorBufferWriter write_buffer(column_to);
+    for (size_t i = 0; i < size; ++i) {
+        to_string(column, i, write_buffer);
+        write_buffer.commit();
+    }
+}
+
 void IDataType::insert_default_into(IColumn& column) const {
     column.insert_default();
 }

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -33,6 +33,7 @@
 #include "common/exception.h"
 #include "common/status.h"
 #include "runtime/define_primitive_type.h"
+#include "vec/columns/column_string.h"
 #include "vec/common/cow.h"
 #include "vec/core/types.h"
 #include "vec/data_types/serde/data_type_serde.h"
@@ -86,6 +87,8 @@ public:
 
     virtual void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const;
     virtual std::string to_string(const IColumn& column, size_t row_num) const;
+
+    virtual void to_string_batch(const IColumn& column, ColumnString& column_to) const;
     // only for compound type now.
     virtual Status from_string(ReadBuffer& rb, IColumn* column) const;
 

--- a/be/src/vec/data_types/data_type_date.cpp
+++ b/be/src/vec/data_types/data_type_date.cpp
@@ -41,6 +41,16 @@ bool DataTypeDate::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
+size_t DataTypeDate::number_length() const {
+    return 10;
+}
+void DataTypeDate::push_bumber(ColumnString::Chars& chars, const Int64& num) const {
+    doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(num);
+    char buf[64];
+    char* pos = value.to_string(buf);
+    // DateTime to_string the end is /0
+    chars.insert(buf, pos - 1);
+}
 std::string DataTypeDate::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -60,6 +60,12 @@ public:
     bool equals(const IDataType& rhs) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<Int64>::template to_string_batch_impl<DataTypeDate>(column, column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const Int64& num) const;
     std::string to_string(Int64 int_val) const {
         doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(int_val);
         char buf[64];

--- a/be/src/vec/data_types/data_type_date_time.cpp
+++ b/be/src/vec/data_types/data_type_date_time.cpp
@@ -42,6 +42,20 @@ bool DataTypeDateTime::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
+size_t DataTypeDateTime::number_length() const {
+    //2024-01-01 00:00:00
+    return 20;
+}
+
+void DataTypeDateTime::push_bumber(ColumnString::Chars& chars, const Int64& num) const {
+    doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(num);
+
+    char buf[64];
+    char* pos = value.to_string(buf);
+    // DateTime to_string the end is /0
+    chars.insert(buf, pos - 1);
+}
+
 std::string DataTypeDateTime::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -102,6 +102,13 @@ public:
     }
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<Int64>::template to_string_batch_impl<DataTypeDateTime>(column,
+                                                                                   column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const Int64& num) const;
 
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
 

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -92,6 +92,43 @@ void DataTypeDecimal<T>::to_string(const IColumn& column, size_t row_num,
 }
 
 template <typename T>
+void DataTypeDecimal<T>::to_string_batch(const IColumn& column, ColumnString& column_to) const {
+    // column may be column const
+    const auto& col_ptr = column.get_ptr();
+    const auto& [column_ptr, is_const] = unpack_if_const(col_ptr);
+    if (is_const) {
+        to_string_batch_impl<true>(column_ptr, column_to);
+    } else {
+        to_string_batch_impl<false>(column_ptr, column_to);
+    }
+}
+
+template <typename T>
+template <bool is_const>
+void DataTypeDecimal<T>::to_string_batch_impl(const ColumnPtr& column_ptr,
+                                              ColumnString& column_to) const {
+    auto& col_vec = assert_cast<const ColumnType&>(*column_ptr);
+    const auto size = col_vec.size();
+    auto& chars = column_to.get_chars();
+    auto& offsets = column_to.get_offsets();
+    offsets.resize(size);
+    chars.reserve(4 * sizeof(T));
+    for (int row_num = 0; row_num < size; row_num++) {
+        auto num = is_const ? col_vec.get_element(0) : col_vec.get_element(row_num);
+        if constexpr (!IsDecimalV2<T>) {
+            T value = num;
+            auto str = value.to_string(scale);
+            chars.insert(str.begin(), str.end());
+        } else {
+            auto value = (DecimalV2Value)num;
+            auto str = value.to_string(get_format_scale());
+            chars.insert(str.begin(), str.end());
+        }
+        offsets[row_num] = chars.size();
+    }
+}
+
+template <typename T>
 std::string DataTypeDecimal<T>::to_string(const T& value) const {
     return value.to_string(get_format_scale());
 }

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -253,6 +253,9 @@ public:
 
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const override;
+    template <bool is_const>
+    void to_string_batch_impl(const ColumnPtr& column_ptr, ColumnString& column_to) const;
     std::string to_string(const T& value) const;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {

--- a/be/src/vec/data_types/data_type_ipv4.cpp
+++ b/be/src/vec/data_types/data_type_ipv4.cpp
@@ -32,6 +32,16 @@ bool DataTypeIPv4::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
+size_t DataTypeIPv4::number_length() const {
+    //255.255.255.256
+    return 16;
+}
+void DataTypeIPv4::push_bumber(ColumnString::Chars& chars, const IPv4& num) const {
+    auto value = IPv4Value(num);
+    auto ipv4_str = value.to_string();
+    chars.insert(ipv4_str.begin(), ipv4_str.end());
+}
+
 std::string DataTypeIPv4::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;

--- a/be/src/vec/data_types/data_type_ipv4.cpp
+++ b/be/src/vec/data_types/data_type_ipv4.cpp
@@ -33,7 +33,7 @@ bool DataTypeIPv4::equals(const IDataType& rhs) const {
 }
 
 size_t DataTypeIPv4::number_length() const {
-    //255.255.255.256
+    //255.255.255.255
     return 16;
 }
 void DataTypeIPv4::push_bumber(ColumnString::Chars& chars, const IPv4& num) const {

--- a/be/src/vec/data_types/data_type_ipv4.h
+++ b/be/src/vec/data_types/data_type_ipv4.h
@@ -58,6 +58,12 @@ public:
     bool equals(const IDataType& rhs) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<IPv4>::template to_string_batch_impl<DataTypeIPv4>(column, column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const IPv4& num) const;
     std::string to_string(const IPv4& value) const;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
 

--- a/be/src/vec/data_types/data_type_ipv6.cpp
+++ b/be/src/vec/data_types/data_type_ipv6.cpp
@@ -32,7 +32,15 @@ namespace doris::vectorized {
 bool DataTypeIPv6::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
-
+size_t DataTypeIPv6::number_length() const {
+    //ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    return 40;
+}
+void DataTypeIPv6::push_bumber(ColumnString::Chars& chars, const IPv6& num) const {
+    auto value = IPv6Value(num);
+    auto ipv6_str = value.to_string();
+    chars.insert(ipv6_str.begin(), ipv6_str.end());
+}
 std::string DataTypeIPv6::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;

--- a/be/src/vec/data_types/data_type_ipv6.h
+++ b/be/src/vec/data_types/data_type_ipv6.h
@@ -55,6 +55,12 @@ public:
     std::string do_get_name() const override { return "IPv6"; }
 
     bool equals(const IDataType& rhs) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<IPv6>::template to_string_batch_impl<DataTypeIPv6>(column, column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const IPv6& num) const;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(const IPv6& value) const;

--- a/be/src/vec/data_types/data_type_number.cpp
+++ b/be/src/vec/data_types/data_type_number.cpp
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "data_type_number.h"
+
+#include <fmt/format.h>
+
+#include <cmath>
+#include <type_traits>
+
+#include "gutil/strings/numbers.h"
+#include "util/mysql_global.h"
+#include "vec/data_types/data_type_number_base.h"
+#include "vec/io/io_helper.h"
+
+namespace doris::vectorized {
+
+/// TODO: Currently, only integers have been considered; other types will be added later.
+template <typename T>
+size_t DataTypeNumber<T>::number_length() const {
+    // The maximum number of decimal digits for an integer represented by n bytes:
+    // 1. Each byte = 8 bits, so n bytes = 8n bits.
+    // 2. Maximum value of an 8n-bit integer = 2^(8n) - 1.
+    // 3. Number of decimal digits d = floor(log10(2^(8n) - 1)) + 1.
+    // 4. Approximation: log10(2^(8n)) ≈ 8n * log10(2).
+    // 5. log10(2) ≈ 0.30103, so 8n * log10(2) ≈ 2.40824n.
+    // 6. Therefore, d ≈ floor(2.408 * n) + 1.
+    return size_t(2.408 * sizeof(T)) + 1;
+}
+
+template <typename T>
+void DataTypeNumber<T>::push_bumber(ColumnString::Chars& chars, const T& num) const {
+    if constexpr (std::is_same<T, UInt128>::value) {
+        std::string hex = int128_to_string(num);
+        chars.insert(hex.begin(), hex.end());
+    } else if constexpr (std::is_same_v<T, float>) {
+        char buf[MAX_FLOAT_STR_LENGTH + 2];
+        int len = FloatToBuffer(num, MAX_FLOAT_STR_LENGTH + 2, buf);
+        chars.insert(buf, buf + len);
+    } else if constexpr (std::is_same_v<Int128, T> || std::numeric_limits<T>::is_iec559) {
+        fmt::memory_buffer buffer;
+        fmt::format_to(buffer, "{}", num);
+        chars.insert(buffer.data(), buffer.data() + buffer.size());
+    } else {
+        auto f = fmt::format_int(num);
+        chars.insert(f.data(), f.data() + f.size());
+    }
+}
+
+template class DataTypeNumber<UInt8>;
+template class DataTypeNumber<UInt16>;
+template class DataTypeNumber<UInt32>;
+template class DataTypeNumber<UInt64>;
+template class DataTypeNumber<UInt128>;
+template class DataTypeNumber<Int8>;
+template class DataTypeNumber<Int16>;
+template class DataTypeNumber<Int32>;
+template class DataTypeNumber<Int64>;
+template class DataTypeNumber<Int128>;
+template class DataTypeNumber<Float32>;
+template class DataTypeNumber<Float64>;
+
+} // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_number.h
+++ b/be/src/vec/data_types/data_type_number.h
@@ -20,13 +20,22 @@
 
 #pragma once
 
+#include "vec/columns/column_string.h"
 #include "vec/data_types/data_type_number_base.h"
 
 namespace doris::vectorized {
 
 template <typename T>
 class DataTypeNumber final : public DataTypeNumberBase<T> {
+public:
     bool equals(const IDataType& rhs) const override { return typeid(rhs) == typeid(*this); }
+
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<T>::template to_string_batch_impl<DataTypeNumber<T>>(column, column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const T& num) const;
 };
 
 using DataTypeUInt8 = DataTypeNumber<UInt8>;

--- a/be/src/vec/data_types/data_type_time.cpp
+++ b/be/src/vec/data_types/data_type_time.cpp
@@ -44,6 +44,15 @@ bool DataTypeTime::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
+size_t DataTypeTime::number_length() const {
+    //59:59:59
+    return 8;
+}
+void DataTypeTime::push_bumber(ColumnString::Chars& chars, const Float64& num) const {
+    auto time_str = time_to_buffer_from_double(num);
+    chars.insert(time_str.begin(), time_str.end());
+}
+
 std::string DataTypeTime::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;
@@ -72,6 +81,15 @@ MutableColumnPtr DataTypeTime::create_column() const {
 
 bool DataTypeTimeV2::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
+}
+
+size_t DataTypeTimeV2::number_length() const {
+    //59:59:59:000000
+    return 14;
+}
+void DataTypeTimeV2::push_bumber(ColumnString::Chars& chars, const Float64& num) const {
+    auto timev2_str = timev2_to_buffer_from_double(num, _scale);
+    chars.insert(timev2_str.begin(), timev2_str.end());
 }
 
 std::string DataTypeTimeV2::to_string(const IColumn& column, size_t row_num) const {

--- a/be/src/vec/data_types/data_type_time.h
+++ b/be/src/vec/data_types/data_type_time.h
@@ -63,7 +63,12 @@ public:
     }
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<Float64>::template to_string_batch_impl<DataTypeTime>(column, column_to);
+    }
 
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const Float64& num) const;
     MutableColumnPtr create_column() const override;
 
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
@@ -92,7 +97,13 @@ public:
     }
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<Float64>::template to_string_batch_impl<DataTypeTimeV2>(column,
+                                                                                   column_to);
+    }
 
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const Float64& num) const;
     MutableColumnPtr create_column() const override;
 
     void to_pb_column_meta(PColumnMeta* col_meta) const override;

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -47,6 +47,19 @@ bool DataTypeDateV2::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
+size_t DataTypeDateV2::number_length() const {
+    //2024-01-01
+    return 10;
+}
+void DataTypeDateV2::push_bumber(ColumnString::Chars& chars, const UInt32& num) const {
+    DateV2Value<DateV2ValueType> val = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(num);
+
+    char buf[64];
+    char* pos = val.to_string(buf);
+    // DateTime to_string the end is /0
+    chars.insert(buf, pos - 1);
+}
+
 std::string DataTypeDateV2::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;
@@ -152,6 +165,18 @@ std::string DataTypeDateTimeV2::to_string(UInt64 int_val) const {
     char buf[64];
     val.to_string(buf, _scale);
     return buf; // DateTime to_string the end is /0
+}
+
+size_t DataTypeDateTimeV2::number_length() const {
+    //2024-01-01 00:00:00-000000
+    return 32;
+}
+void DataTypeDateTimeV2::push_bumber(ColumnString::Chars& chars, const UInt64& num) const {
+    DateV2Value<DateTimeV2ValueType> val =
+            binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(num);
+    char buf[64];
+    char* pos = val.to_string(buf, _scale);
+    chars.insert(buf, pos - 1);
 }
 
 void DataTypeDateTimeV2::to_string(const IColumn& column, size_t row_num,

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -81,6 +81,13 @@ public:
         }
     }
     bool equals(const IDataType& rhs) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<UInt32>::template to_string_batch_impl<DataTypeDateV2>(column,
+                                                                                  column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const UInt32& num) const;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(UInt32 int_val) const;
@@ -125,6 +132,13 @@ public:
 
     bool equals(const IDataType& rhs) const override;
     std::string to_string(const IColumn& column, size_t row_num) const override;
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
+        DataTypeNumberBase<UInt64>::template to_string_batch_impl<DataTypeDateTimeV2>(column,
+                                                                                      column_to);
+    }
+
+    size_t number_length() const;
+    void push_bumber(ColumnString::Chars& chars, const UInt64& num) const;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(UInt64 int_val) const;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -544,15 +544,8 @@ struct ConvertImplGenericToString {
         const IDataType& type = *col_with_type_and_name.type;
         const IColumn& col_from = *col_with_type_and_name.column;
 
-        size_t size = col_from.size();
-
         auto col_to = ColumnString::create();
-        col_to->reserve(size * 2);
-        VectorBufferWriter write_buffer(*col_to.get());
-        for (size_t i = 0; i < size; ++i) {
-            type.to_string(col_from, i, write_buffer);
-            write_buffer.commit();
-        }
+        type.to_string_batch(col_from, *col_to);
 
         block.replace_by_position(result, std::move(col_to));
         return Status::OK();


### PR DESCRIPTION
## Proposed changes




before
```
mysql [(none)]>select sum(length(cast(number as string) ))   from numbers("number" = "100000000");
+-----------------------------------+
| sum(length(cast(number as TEXT))) |
+-----------------------------------+
|                         788888890 |
+-----------------------------------+
1 row in set (7.24 sec)
```

now
```
mysql [(none)]>select sum(length(cast(number as string) ))   from numbers("number" = "100000000");
+-----------------------------------+
| sum(length(cast(number as TEXT))) |
+-----------------------------------+
|                         788888890 |
+-----------------------------------+
1 row in set (1.40 sec)

mysql [test]>select sum(length(cast(123 as string) ))   from numbers("number" = "100000000");
+--------------------------------+
| sum(length(cast(123 as TEXT))) |
+--------------------------------+
|                      300000000 |
+--------------------------------+
1 row in set (0.09 sec)
```
More batch functions will be implemented in the future.



<!--Describe your changes.-->

