### PR TITLE
[fix](mtmv)fix when related table drop partition,mv partition is sync

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
@@ -325,6 +325,11 @@ public class MTMVPartitionUtil {
         if (!relatedTable.needAutoRefresh()) {
             return true;
         }
+        // check if partitions of related table if changed
+        Set<String> snapshotPartitions = mtmv.getRefreshSnapshot().getSnapshotPartitions(mtmvPartitionName);
+        if (!Objects.equals(relatedPartitionNames, snapshotPartitions)) {
+            return false;
+        }
         for (String relatedPartitionName : relatedPartitionNames) {
             MTMVSnapshotIf relatedPartitionCurrentSnapshot = relatedTable
                     .getPartitionSnapshot(relatedPartitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRefreshSnapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRefreshSnapshot.java
@@ -18,6 +18,7 @@
 package org.apache.doris.mtmv;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections.MapUtils;
 
@@ -44,6 +45,14 @@ public class MTMVRefreshSnapshot {
             return false;
         }
         return relatedPartitionSnapshot.equals(relatedPartitionCurrentSnapshot);
+    }
+
+    public Set<String> getSnapshotPartitions(String mtmvPartitionName) {
+        MTMVRefreshPartitionSnapshot partitionSnapshot = partitionSnapshots.get(mtmvPartitionName);
+        if (partitionSnapshot == null) {
+            return Sets.newHashSet();
+        }
+        return partitionSnapshot.getPartitions().keySet();
     }
 
     public boolean equalsWithBaseTable(String mtmvPartitionName, long baseTableId,

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
@@ -130,6 +130,10 @@ public class MTMVPartitionUtilTest {
                 refreshSnapshot.equalsWithRelatedPartition(anyString, anyString, (MTMVSnapshotIf) any);
                 minTimes = 0;
                 result = true;
+
+                refreshSnapshot.getSnapshotPartitions(anyString);
+                minTimes = 0;
+                result = Sets.newHashSet("name2");
             }
         };
     }
@@ -158,6 +162,20 @@ public class MTMVPartitionUtilTest {
         boolean isSyncWithPartition = MTMVPartitionUtil
                 .isSyncWithPartitions(mtmv, "name1", baseOlapTable, Sets.newHashSet("name2"));
         Assert.assertTrue(isSyncWithPartition);
+    }
+
+    @Test
+    public void testIsSyncWithPartitionNotEqual() throws AnalysisException {
+        new Expectations() {
+            {
+                refreshSnapshot.getSnapshotPartitions(anyString);
+                minTimes = 0;
+                result = Sets.newHashSet("name2", "name3");
+            }
+        };
+        boolean isSyncWithPartition = MTMVPartitionUtil
+                .isSyncWithPartitions(mtmv, "name1", baseOlapTable, Sets.newHashSet("name2"));
+        Assert.assertFalse(isSyncWithPartition);
     }
 
     @Test


### PR DESCRIPTION
for example:
if mv's partition [mv_p1] is related with t1's partition [p1,p2]

when p2 dropped,
mv_p1'isSync should be false

