### PR TITLE
[Fix](Nereids) fix leading with brace can not generate correct plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -99,20 +99,6 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     }
 
     public LogicalJoin(
-            long bitmap,
-            JoinType joinType,
-            List<Expression> hashJoinConjuncts,
-            List<Expression> otherJoinConjuncts,
-            JoinHint hint,
-            Optional<MarkJoinSlotReference> markJoinSlotReference,
-            LEFT_CHILD_TYPE leftChild, RIGHT_CHILD_TYPE rightChild) {
-        this(joinType, hashJoinConjuncts,
-                otherJoinConjuncts, hint, markJoinSlotReference,
-                Optional.empty(), Optional.empty(), leftChild, rightChild);
-        this.bitmap = LongBitmap.or(this.bitmap, bitmap);
-    }
-
-    public LogicalJoin(
             JoinType joinType,
             List<Expression> hashJoinConjuncts,
             List<Expression> otherJoinConjuncts,

--- a/regression-test/data/nereids_p0/hint/fix_leading.out
+++ b/regression-test/data/nereids_p0/hint/fix_leading.out
@@ -16,8 +16,8 @@ PhysicalResultSink
 --------------PhysicalOlapScan[t4]
 
 Hint log:
-Used: leading({ t1 t2 } { t3 t4 })
-UnUsed:
+Used: leading({ t1 t2 } { t3 t4 } )
+UnUsed: 
 SyntaxError:
 
 -- !select2_1_1 --
@@ -248,7 +248,7 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 t2 t3 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 
 -- !select6_1 --
@@ -275,6 +275,6 @@ PhysicalResultSink
 
 Hint log:
 Used: leading(t1 { { t2 t3 } { t4 t5 } } t6 )
-UnUsed:
+UnUsed: 
 SyntaxError:
 

--- a/regression-test/data/nereids_p0/hint/test_leading.out
+++ b/regression-test/data/nereids_p0/hint/test_leading.out
@@ -2214,7 +2214,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle t2 broadcast t3 )
+Used: leading(t1 shuffle t2 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2232,7 +2232,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle { t2 broadcast t3 } )
+Used: leading(t1 shuffle { t2 broadcast t3 } )  
 UnUsed:
 SyntaxError:
 
@@ -2250,7 +2250,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t1 shuffle { t3 broadcast t2 } )
+Used: leading(t1 shuffle { t3 broadcast t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2268,7 +2268,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle t1 broadcast t3 )
+Used: leading(t2 shuffle t1 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2286,7 +2286,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle { t1 broadcast t3 } )
+Used: leading(t2 shuffle { t1 broadcast t3 } )  
 UnUsed:
 SyntaxError:
 
@@ -2304,7 +2304,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t2 shuffle { t3 broadcast t1 } )
+Used: leading(t2 shuffle { t3 broadcast t1 } )  
 UnUsed:
 SyntaxError:
 
@@ -2322,8 +2322,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 t2 broadcast t3 )
-UnUsed:
+Used: leading(t1 t2 broadcast t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_2 --
@@ -2340,8 +2340,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 { t2 broadcast t3 } )
-UnUsed:
+Used: leading(t1 { t2 broadcast t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_3 --
@@ -2358,8 +2358,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t1 { t3 broadcast t2 } )
-UnUsed:
+Used: leading(t1 { t3 broadcast t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_4 --
@@ -2376,8 +2376,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 t1 broadcast t3 )
-UnUsed:
+Used: leading(t2 t1 broadcast t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_5 --
@@ -2394,8 +2394,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 { t1 broadcast t3 } )
-UnUsed:
+Used: leading(t2 { t1 broadcast t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select93_6 --
@@ -2412,8 +2412,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t2 { t3 broadcast t1 } )
-UnUsed:
+Used: leading(t2 { t3 broadcast t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2430,8 +2430,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 shuffle t2 t3 )
-UnUsed:
+Used: leading(t1 shuffle t2 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2448,8 +2448,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 shuffle { t2 t3 } )
-UnUsed:
+Used: leading(t1 shuffle { t2 t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2466,8 +2466,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t1 shuffle { t3 t2 } )
-UnUsed:
+Used: leading(t1 shuffle { t3 t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2484,8 +2484,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 shuffle t1 t3 )
-UnUsed:
+Used: leading(t2 shuffle t1 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2502,8 +2502,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 shuffle { t1 t3 } )
-UnUsed:
+Used: leading(t2 shuffle { t1 t3 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select94_2 --
@@ -2520,8 +2520,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t2 shuffle { t3 t1 } )
-UnUsed:
+Used: leading(t2 shuffle { t3 t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_1 --
@@ -2538,8 +2538,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t1 broadcast t2 t3 )
-UnUsed:
+Used: leading(t1 broadcast t2 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_4 --
@@ -2556,8 +2556,8 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:  leading(t2 broadcast t1 t3 )
-UnUsed:
+Used: leading(t2 broadcast t1 t3 ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_8 --
@@ -2574,8 +2574,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:  leading(t3 broadcast { t1 t2 } )
-UnUsed:
+Used: leading(t3 broadcast { t1 t2 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select95_9 --
@@ -2592,8 +2592,8 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:  leading(t3 broadcast { t2 t1 } )
-UnUsed:
+Used: leading(t3 broadcast { t2 t1 } ) 
+UnUsed: 
 SyntaxError:
 
 -- !select96_1 --
@@ -2610,7 +2610,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 shuffle t2 broadcast t3 )
+Used: leading(t1 shuffle t2 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2628,7 +2628,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 shuffle t1 broadcast t3 )
+Used: leading(t2 shuffle t1 broadcast t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2646,7 +2646,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t3 shuffle { t1 broadcast t2 } )
+Used: leading(t3 shuffle { t1 broadcast t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2664,7 +2664,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t3 shuffle { t2 broadcast t1 } )
+Used: leading(t3 shuffle { t2 broadcast t1 } )  
 UnUsed:
 SyntaxError:
 
@@ -2683,7 +2683,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t1 broadcast t2 shuffle t3 )
+Used: leading(t1 broadcast t2 shuffle t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2701,7 +2701,7 @@ PhysicalResultSink
 ------------PhysicalOlapScan[t3]
 
 Hint log:
-Used:   leading(t2 broadcast t1 shuffle t3 )
+Used: leading(t2 broadcast t1 shuffle t3 )  
 UnUsed:
 SyntaxError:
 
@@ -2719,7 +2719,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t2]
 
 Hint log:
-Used:   leading(t3 broadcast { t1 shuffle t2 } )
+Used: leading(t3 broadcast { t1 shuffle t2 } )  
 UnUsed:
 SyntaxError:
 
@@ -2737,7 +2737,7 @@ PhysicalResultSink
 ----------------PhysicalOlapScan[t1]
 
 Hint log:
-Used:   leading(t3 broadcast { t2 shuffle t1 } )
+Used: leading(t3 broadcast { t2 shuffle t1 } )  
 UnUsed:
 SyntaxError:
 


### PR DESCRIPTION
cherry-pick: #36193 

Problem:
when using leading like:
leading(t1 {t2 t3} {t4 t5} t6)
it would not generate correct plan because levellist can not express enough message of braces
Solved:
remove levellist express of leading levels and use reverse polish expression
Algorithm:
leading(t1 {t2 t3} {t4 t5} t6)
==>
stack top to down(t1 t2 t3 join join t4 t5 join t6 join) when generate leading join, we can pop items in stack, when it's a table, make logicalscan when it's a join
operator, make logical join and push back to stack

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

