### PR TITLE
[fix](statistics)Skip large partition while calculate healthy value.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -64,6 +64,7 @@ public final class GlobalVariable {
             = "default_using_meta_cache_for_external_catalog";
 
     public static final String PARTITION_ANALYZE_BATCH_SIZE = "partition_analyze_batch_size";
+    public static final String HUGE_PARTITION_LOWER_BOUND_ROWS = "huge_partition_lower_bound_rows";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = "Doris version "
@@ -162,6 +163,12 @@ public final class GlobalVariable {
                 "批量收集分区信息的分区数",
                 "Number of partitions to collect in one batch."})
     public static int partitionAnalyzeBatchSize = 10;
+
+    @VariableMgr.VarAttr(name = HUGE_PARTITION_LOWER_BOUND_ROWS, flag = VariableMgr.GLOBAL,
+            description = {
+                "行数超过该值的分区将跳过自动分区收集",
+                "This defines the lower size bound for large partitions, which will skip auto partition analyze."})
+    public static long hugePartitionLowerBoundRows = 100000000L;
 
     // Don't allow creating instance.
     private GlobalVariable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -518,7 +518,6 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String HUGE_TABLE_DEFAULT_SAMPLE_ROWS = "huge_table_default_sample_rows";
     public static final String HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES = "huge_table_lower_bound_size_in_bytes";
-    public static final String HUGE_PARTITION_LOWER_BOUND_ROWS = "huge_partition_lower_bound_rows";
 
     // for spill to disk
     public static final String EXTERNAL_SORT_BYTES_THRESHOLD = "external_sort_bytes_threshold";
@@ -1708,12 +1707,6 @@ public class SessionVariable implements Serializable, Writable {
                             + "larger than this value will automatically collect "
                             + "statistics through sampling"})
     public long hugeTableLowerBoundSizeInBytes = 0;
-
-    @VariableMgr.VarAttr(name = HUGE_PARTITION_LOWER_BOUND_ROWS, flag = VariableMgr.GLOBAL,
-            description = {
-                "行数超过该值的分区将跳过自动分区收集",
-                "This defines the lower size bound for large partitions, which will skip auto partition analyze."})
-    public long hugePartitionLowerBoundRows = 100000000L;
 
     @VariableMgr.VarAttr(name = HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS, flag = VariableMgr.GLOBAL,
             description = {"控制对大表的自动ANALYZE的最小时间间隔，"

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ExternalAnalysisTask.java
@@ -53,7 +53,7 @@ public class ExternalAnalysisTask extends BaseAnalysisTask {
     }
 
     @Override
-    protected void deleteNotExistPartitionStats() throws DdlException {
+    protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
     }
 
     protected void doFull() throws Exception {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/FollowerColumnSender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/FollowerColumnSender.java
@@ -127,7 +127,7 @@ public class FollowerColumnSender extends MasterDaemon {
             try {
                 table = StatisticsUtil.findTable(column.catalogId, column.dbId, column.tblId);
             } catch (Exception e) {
-                LOG.warn("Failed to find table for column {}", column.colName, e);
+                LOG.warn("Failed to find table for column {}", column.colName);
                 continue;
             }
             if (StatisticsUtil.isUnsupportedType(table.getColumn(column.colName).getType())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
@@ -277,7 +277,7 @@ public class HMSAnalysisTask extends ExternalAnalysisTask {
     }
 
     @Override
-    protected void deleteNotExistPartitionStats() throws DdlException {
+    protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
         TableStatsMeta tableStats = Env.getServingEnv().getAnalysisManager().findTableStatsStatus(tbl.getId());
         if (tableStats == null) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -79,7 +79,7 @@ public class HistogramTask extends BaseAnalysisTask {
     }
 
     @Override
-    protected void deleteNotExistPartitionStats() throws DdlException {
+    protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
     }
 
     private String getSampleRateFunction() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -208,7 +208,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     }
 
     @Override
-    protected void deleteNotExistPartitionStats() throws DdlException {
+    protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
         TableStatsMeta tableStats = Env.getServingEnv().getAnalysisManager().findTableStatsStatus(tbl.getId());
         // When a partition was dropped, newPartitionLoaded will set to true.
         // So we don't need to check dropped partition if newPartitionLoaded is false.
@@ -228,6 +228,8 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             Partition partition = table.getPartition(partId);
             if (partition == null) {
                 columnStats.partitionUpdateRows.remove(partId);
+                tableStats.partitionUpdateRows.remove(partId);
+                jobInfo.partitionUpdateRows.remove(partId);
                 expiredPartition.add(partId);
                 if (expiredPartition.size() == Config.max_allowed_in_element_num_of_delete) {
                     String partitionCondition = " AND part_id in (" + Joiner.on(", ").join(expiredPartition) + ")";

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -88,7 +88,6 @@ public class StatisticConstants {
 
     public static final long HUGE_TABLE_DEFAULT_SAMPLE_ROWS = 4194304;
     public static final long HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES = 0;
-    public static final long HUGE_PARTITION_LOWER_BOUND_ROWS = 100000000L;
 
     public static final long HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS = TimeUnit.HOURS.toMillis(0);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobAppender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobAppender.java
@@ -66,6 +66,10 @@ public class StatisticsJobAppender extends MasterDaemon {
         if (!Env.getCurrentEnv().isMaster()) {
             return;
         }
+        if (!StatisticsUtil.statsTblAvailable()) {
+            LOG.info("Stats table not available, skip");
+            return;
+        }
         if (Env.isCheckpointThread()) {
             return;
         }
@@ -94,7 +98,7 @@ public class StatisticsJobAppender extends MasterDaemon {
                 table = StatisticsUtil.findTable(column.catalogId, column.dbId, column.tblId);
             } catch (Exception e) {
                 LOG.warn("Fail to find table {}.{}.{} for column {}",
-                        column.catalogId, column.dbId, column.tblId, column.colName, e);
+                        column.catalogId, column.dbId, column.tblId, column.colName);
                 continue;
             }
             if (StatisticConstants.SYSTEM_DBS.contains(table.getDatabase().getFullName())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -868,13 +868,7 @@ public class StatisticsUtil {
     }
 
     public static long getHugePartitionLowerBoundRows() {
-        try {
-            return findConfigFromGlobalSessionVar(SessionVariable.HUGE_PARTITION_LOWER_BOUND_ROWS)
-                .hugePartitionLowerBoundRows;
-        } catch (Exception e) {
-            LOG.warn("Failed to get value of huge_partition_lower_bound_rows, return default", e);
-        }
-        return StatisticConstants.HUGE_PARTITION_LOWER_BOUND_ROWS;
+        return GlobalVariable.hugePartitionLowerBoundRows;
     }
 
     public static int getPartitionAnalyzeBatchSize() {
@@ -1074,10 +1068,19 @@ public class StatisticsUtil {
             return true;
         }
         int changedPartitions = 0;
+        long hugePartitionLowerBoundRows = getHugePartitionLowerBoundRows();
         for (Partition p : partitions) {
             long id = p.getId();
+            // Skip partition that is too large.
+            if (p.getBaseIndex().getRowCount() > hugePartitionLowerBoundRows) {
+                continue;
+            }
             // New partition added.
             if (!partitionUpdateRows.containsKey(id)) {
+                return true;
+            }
+            // Former skipped large partition is not large anymore. Need to analyze it.
+            if (partitionUpdateRows.get(id) == -1) {
                 return true;
             }
             long currentUpdateRows = tableStatsStatus.partitionUpdateRows.getOrDefault(id, 0L);

--- a/regression-test/suites/statistics/test_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_partition_stats.groovy
@@ -309,7 +309,7 @@ suite("test_partition_stats") {
     result = sql """show column stats part3"""
     assertEquals(0, result.size())
 
-    // Test skip big partitions and fallback to sample analyze
+    // Test skip big partitions and fallback to sample analyze (manual analyze doesn't skip)
     sql """CREATE TABLE `part4` (
         `id` INT NULL,
         `colint` INT NULL,
@@ -353,11 +353,20 @@ suite("test_partition_stats") {
     assertEquals("24.0", result[6][2])
     assertEquals("24.0", result[7][2])
     assertEquals("24.0", result[8][2])
+    assertEquals("FULL", result[0][9])
+    assertEquals("FULL", result[1][9])
+    assertEquals("FULL", result[2][9])
+    assertEquals("FULL", result[3][9])
+    assertEquals("FULL", result[4][9])
+    assertEquals("FULL", result[5][9])
+    assertEquals("FULL", result[6][9])
+    assertEquals("FULL", result[7][9])
+    assertEquals("FULL", result[8][9])
     result = sql """show column stats part4 partition(*)"""
     logger.info("partition result" + result)
-    assertEquals(18, result.size())
+    assertEquals(27, result.size())
     result = sql """show column stats part4 partition(p1)"""
-    assertEquals(0, result.size())
+    assertEquals(9, result.size())
 
     sql """set global huge_partition_lower_bound_rows = 100000000"""
     sql """analyze table part4 with sync;"""


### PR DESCRIPTION
1. Skip large partition while calculate column healthy value, because large partition may be skipped while analyzing. This could avoid keep adding the column to analyze job queue.
2. Move huge_partition_lower_bound_rows to GlobalSession
3. Fix sample job doesn't record correct start time bug.
4. Manual full analyze for partition table doesn't need to skip large partition and fallback to sample collection.