### PR TITLE
[fix](cloud) Fix cloud metrics loss multi cluster infos

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/CloudMetrics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/CloudMetrics.java
@@ -42,61 +42,29 @@ public class CloudMetrics {
         if (Config.isNotCloudMode()) {
             return;
         }
-        CLUSTER_REQUEST_ALL_COUNTER = new AutoMappedMetric<>(name -> {
-            LongCounterMetric counter  = new LongCounterMetric("request_total", MetricUnit.REQUESTS,
-                    "total request");
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
-            return counter;
-        });
+        CLUSTER_REQUEST_ALL_COUNTER = new AutoMappedMetric<>(name -> new LongCounterMetric("request_total",
+            MetricUnit.REQUESTS, "total request"));
 
-        CLUSTER_QUERY_ALL_COUNTER = new AutoMappedMetric<>(name -> {
-            LongCounterMetric counter  = new LongCounterMetric("query_total", MetricUnit.REQUESTS,
-                    "total query");
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
-            return counter;
-        });
+        CLUSTER_QUERY_ALL_COUNTER = new AutoMappedMetric<>(name -> new LongCounterMetric("query_total",
+            MetricUnit.REQUESTS, "total query"));
 
-        CLUSTER_QUERY_ERR_COUNTER = new AutoMappedMetric<>(name -> {
-            LongCounterMetric counter  = new LongCounterMetric("query_err", MetricUnit.REQUESTS,
-                    "total error query");
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
-            return counter;
-        });
+        CLUSTER_QUERY_ERR_COUNTER = new AutoMappedMetric<>(name -> new LongCounterMetric("query_err",
+            MetricUnit.REQUESTS, "total error query"));
 
-        CLUSTER_REQUEST_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> {
-            GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("rps", MetricUnit.NOUNIT,
-                    "request per second", 0.0);
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
-            return gauge;
-        });
+        CLUSTER_REQUEST_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> new GaugeMetricImpl<Double>("rps",
+            MetricUnit.NOUNIT, "request per second", 0.0));
 
-        CLUSTER_QUERY_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> {
-            GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("qps", MetricUnit.NOUNIT,
-                    "query per second", 0.0);
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
-            return gauge;
-        });
+        CLUSTER_QUERY_PER_SECOND_GAUGE = new AutoMappedMetric<>(name -> new GaugeMetricImpl<Double>("qps",
+            MetricUnit.NOUNIT, "query per second", 0.0));
 
-        CLUSTER_QUERY_ERR_RATE_GAUGE = new AutoMappedMetric<>(name -> {
-            GaugeMetricImpl<Double> gauge  = new GaugeMetricImpl<Double>("query_err_rate", MetricUnit.NOUNIT,
-                    "query error rate", 0.0);
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
-            return gauge;
-        });
+        CLUSTER_QUERY_ERR_RATE_GAUGE = new AutoMappedMetric<>(name -> new GaugeMetricImpl<Double>("query_err_rate",
+            MetricUnit.NOUNIT, "query error rate", 0.0));
 
-        CLUSTER_BACKEND_ALIVE = new AutoMappedMetric<>(name -> {
-            GaugeMetricImpl<Integer> gauge  = new GaugeMetricImpl<Integer>("backend_alive", MetricUnit.NOUNIT,
-                    "backend alive or not", 0);
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
-            return gauge;
-        });
+        CLUSTER_BACKEND_ALIVE = new AutoMappedMetric<>(name -> new GaugeMetricImpl<Integer>("backend_alive",
+            MetricUnit.NOUNIT, "backend alive or not", 0));
 
-        CLUSTER_BACKEND_ALIVE_TOTAL = new AutoMappedMetric<>(name -> {
-            GaugeMetricImpl<Integer> gauge  = new GaugeMetricImpl<Integer>("backend_alive_total", MetricUnit.NOUNIT,
-                    "backend alive num in cluster", 0);
-            MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
-            return gauge;
-        });
+        CLUSTER_BACKEND_ALIVE_TOTAL = new AutoMappedMetric<>(name -> new GaugeMetricImpl<Integer>("backend_alive_total",
+            MetricUnit.NOUNIT, "backend alive num in cluster", 0));
 
         CLUSTER_QUERY_LATENCY_HISTO = new AutoMappedMetric<>(key -> {
             String[] values = key.split(CLOUD_CLUSTER_DELIMITER);

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricCalculator.java
@@ -96,6 +96,7 @@ public class MetricCalculator extends TimerTask {
         if (requsetAllMetrics != null) {
             requsetAllMetrics.forEach((clusterId, metric) -> {
                 clusterLastRequestCounter.put(clusterId, metric.getValue());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
             });
         }
 
@@ -103,6 +104,7 @@ public class MetricCalculator extends TimerTask {
         if (queryAllMetrics != null) {
             queryAllMetrics.forEach((clusterId, metric) -> {
                 clusterLastQueryCounter.put(clusterId, metric.getValue());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
             });
         }
 
@@ -110,6 +112,7 @@ public class MetricCalculator extends TimerTask {
         if (queryErrMetrics != null) {
             queryErrMetrics.forEach((clusterId, metric) -> {
                 clusterLastQueryErrCounter.put(clusterId, metric.getValue());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
             });
         }
     }
@@ -126,6 +129,7 @@ public class MetricCalculator extends TimerTask {
                         / interval;
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterRequestPerSecond(clusterId, rps,  metric.getLabels());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
                 clusterLastRequestCounter.replace(clusterId, metric.getValue());
             });
         }
@@ -137,6 +141,7 @@ public class MetricCalculator extends TimerTask {
                         / interval;
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterQueryPerSecond(clusterId, rps,  metric.getLabels());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
                 clusterLastQueryCounter.replace(clusterId, metric.getValue());
             });
         }
@@ -148,6 +153,7 @@ public class MetricCalculator extends TimerTask {
                         / interval;
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterQueryErrRate(clusterId, rps, metric.getLabels());
+                MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
                 clusterLastQueryCounter.replace(clusterId, metric.getValue());
             });
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -748,22 +748,28 @@ public final class MetricRepo {
 
         LongCounterMetric requestAllCounter = CloudMetrics.CLUSTER_REQUEST_ALL_COUNTER.getOrAdd(clusterId);
         requestAllCounter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(requestAllCounter);
 
         LongCounterMetric queryAllCounter = CloudMetrics.CLUSTER_QUERY_ALL_COUNTER.getOrAdd(clusterId);
         queryAllCounter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(queryAllCounter);
 
         LongCounterMetric queryErrCounter = CloudMetrics.CLUSTER_QUERY_ERR_COUNTER.getOrAdd(clusterId);
         queryErrCounter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(queryErrCounter);
 
         GaugeMetricImpl<Double> requestPerSecondGauge = CloudMetrics.CLUSTER_REQUEST_PER_SECOND_GAUGE
                 .getOrAdd(clusterId);
         requestPerSecondGauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(requestPerSecondGauge);
 
         GaugeMetricImpl<Double> queryPerSecondGauge = CloudMetrics.CLUSTER_QUERY_PER_SECOND_GAUGE.getOrAdd(clusterId);
         queryPerSecondGauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(queryPerSecondGauge);
 
         GaugeMetricImpl<Double> queryErrRateGauge = CloudMetrics.CLUSTER_QUERY_ERR_RATE_GAUGE.getOrAdd(clusterId);
         queryErrRateGauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(queryErrRateGauge);
 
         String key = clusterId + CloudMetrics.CLOUD_CLUSTER_DELIMITER + clusterName;
         CloudMetrics.CLUSTER_QUERY_LATENCY_HISTO.getOrAdd(key);
@@ -784,6 +790,7 @@ public final class MetricRepo {
         labels.add(new MetricLabel("cluster_id", clusterId));
         labels.add(new MetricLabel("cluster_name", clusterName));
         counter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
     }
 
     public static void increaseClusterQueryAll(String clusterName) {
@@ -801,6 +808,7 @@ public final class MetricRepo {
         labels.add(new MetricLabel("cluster_id", clusterId));
         labels.add(new MetricLabel("cluster_name", clusterName));
         counter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
     }
 
     public static void increaseClusterQueryErr(String clusterName) {
@@ -818,6 +826,7 @@ public final class MetricRepo {
         labels.add(new MetricLabel("cluster_id", clusterId));
         labels.add(new MetricLabel("cluster_name", clusterName));
         counter.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(counter);
     }
 
     public static void updateClusterRequestPerSecond(String clusterId, double value, List<MetricLabel> labels) {
@@ -827,6 +836,7 @@ public final class MetricRepo {
         GaugeMetricImpl<Double> gauge = CloudMetrics.CLUSTER_REQUEST_PER_SECOND_GAUGE.getOrAdd(clusterId);
         gauge.setValue(value);
         gauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
     public static void updateClusterQueryPerSecond(String clusterId, double value, List<MetricLabel> labels) {
@@ -836,6 +846,7 @@ public final class MetricRepo {
         GaugeMetricImpl<Double> gauge = CloudMetrics.CLUSTER_QUERY_PER_SECOND_GAUGE.getOrAdd(clusterId);
         gauge.setValue(value);
         gauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
     public static void updateClusterQueryErrRate(String clusterId, double value, List<MetricLabel> labels) {
@@ -845,6 +856,7 @@ public final class MetricRepo {
         GaugeMetricImpl<Double> gauge = CloudMetrics.CLUSTER_QUERY_ERR_RATE_GAUGE.getOrAdd(clusterId);
         gauge.setValue(value);
         gauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
     public static void updateClusterBackendAlive(String clusterName, String clusterId, String ipAddress,
@@ -861,6 +873,7 @@ public final class MetricRepo {
         labels.add(new MetricLabel("cluster_name", clusterName));
         labels.add(new MetricLabel("address", ipAddress));
         metric.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
     }
 
     public static void updateClusterBackendAliveTotal(String clusterName, String clusterId, int aliveNum) {
@@ -874,6 +887,7 @@ public final class MetricRepo {
         labels.add(new MetricLabel("cluster_id", clusterId));
         labels.add(new MetricLabel("cluster_name", clusterName));
         gauge.setLabels(labels);
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
     public static void updateClusterQueryLatency(String clusterName, long elapseMs) {


### PR DESCRIPTION
metrics function DORIS_METRIC_REGISTER.addMetrics must after setLabels function，because addMetrics use lables calc lableId， detail see function computeLabelId
