### PR TITLE
[fix](ubsan) Set default value for enable_unique_key_merge_on_write

### DIFF
--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -269,7 +269,7 @@ struct AlterMaterializedViewParam {
 
 struct SchemaChangeParams {
     AlterTabletType alter_tablet_type;
-    bool enable_unique_key_merge_on_write;
+    bool enable_unique_key_merge_on_write = false;
     std::vector<RowsetReaderSharedPtr> ref_rowset_readers;
     DeleteHandler* delete_handler = nullptr;
     std::unordered_map<std::string, AlterMaterializedViewParam> materialized_params_map;


### PR DESCRIPTION
Fix undefined behavior problem. The detail is SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp:559:19 in
/home/zcp/repo_center/doris_master/doris/be/src/olap/schema_change.cpp:1301:19: runtime error: load of value 192, which is not a valid value for type 'bool'.


