### PR TITLE
[fix](planner) fix result wrong caused by mixed use multiple columns with type of datetime/datetimev2/date/datev2 of function coalesce

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1557,6 +1557,14 @@ public class FunctionCallExpr extends Expr {
                         argTypes[i] = assignmentCompatibleType;
                     }
                 }
+            } else if (assignmentCompatibleType.isDateV2OrDateTimeV2()) {
+                for (int i = 0; i < childTypes.length; i++) {
+                    if (assignmentCompatibleType.isDateV2OrDateTimeV2()
+                            && !childTypes[i].equals(assignmentCompatibleType)) {
+                        uncheckedCastChild(assignmentCompatibleType, i);
+                        argTypes[i] = assignmentCompatibleType;
+                    }
+                }
             }
             fn = getBuiltinFunction(fnName.getFunction(), argTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_coalesce_new.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_coalesce_new.groovy
@@ -51,6 +51,14 @@ suite("test_coalesce_new") {
         select dt from test_cls where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
     """
     assertEquals(result1.size(), 2);
+    def result11 = try_sql """
+        select dt from test_cls where coalesce (dt, dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result11.size(), 2);
+    def result12 = try_sql """
+        select dt from test_cls where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d'), str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result12.size(), 2);
 
 
     // test parameter:datetimev2, datev2
@@ -88,6 +96,15 @@ suite("test_coalesce_new") {
         select dt from test_cls_dtv2 where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
     """
     assertEquals(result2.size(), 2);
+    def result21 = try_sql """
+        select dt from test_cls_dtv2 where coalesce (dt, dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result21.size(), 2);
+    def result22 = try_sql """
+        select dt from test_cls_dtv2 where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d'), str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result22.size(), 2);
+
 
     sql """
         drop table test_cls
@@ -97,5 +114,8 @@ suite("test_coalesce_new") {
         """
     sql """
         admin set frontend config ("disable_datev1"="false")
+        """
+    sql """
+        admin set frontend config ("enable_date_conversion"="true")
         """
 }


### PR DESCRIPTION
similar issue with #36583, extend it to multiple parameters.
Steps to reproduce:
```sql
admin set frontend config ("enable_date_conversion"="false");
admin set frontend config ("disable_datev1"="false");

drop table test_cls;
CREATE TABLE `test_cls` (
    `id` int(11) NOT NULL COMMENT '',
    `name` varchar(32) NOT NULL COMMENT '',
    `dt` datetime NOT NULL
) ENGINE=OLAP
UNIQUE KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 2
PROPERTIES(
    "replication_allocation" = "tag.location.default: 1"
);
SET enable_nereids_planner=false;

error sql:
select dt from test_cls where coalesce (dt, dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01';
```

explain it and find wrong predicate:
```
CAST(coalesce(CAST(`dt` AS BIGINT), CAST(`dt` AS BIGINT), 20230601) AS DOUBLE) >= NULL
```

after fix:
explain it 
```
coalesce(CAST(`dt` AS DATETIMEV2(0)), CAST(`dt` AS DATETIMEV2(0)), '2023-06-01 00:00:00') >= '2023-06-01 00:00:00'
```

