### PR TITLE
[Chore](GA) Set the maintainer for the FE ENV file

### DIFF
--- a/tools/maintainers/maintainers.json
+++ b/tools/maintainers/maintainers.json
@@ -7,6 +7,14 @@
          "gavinchou",
          "dataroaring"
        ]
+    },
+    {
+      "path": "fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java",
+      "maintainers": [
+        "CalvinKirs",
+        "morningman",
+        "dataroaring"
+      ]
     }
-  ] 
+  ]
 }


### PR DESCRIPTION

## Proposed changes
we need to set the maintainer for the FE ENV file, which is a critical file for starting FE. We have experienced multiple instances of resource leaks due to incorrect modifications. Therefore, we need to add someone familiar with this file as the maintainer. Any changes to this file must be reviewed and approved by the maintainer before they can be merged.


