### PR TITLE
[fix](regression) Fix data_model_p0/unique/test_unique_table in cloud mode

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -497,7 +497,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params) {
         stream_load_ctx->table = params.txn_conf.tbl;
         stream_load_ctx->txn_id = params.txn_conf.txn_id;
         stream_load_ctx->id = UniqueId(params.query_id);
-        stream_load_ctx->put_result.pipeline_params = params;
+        stream_load_ctx->put_result.__set_pipeline_params(params);
         stream_load_ctx->use_streaming = true;
         stream_load_ctx->load_type = TLoadType::MANUL_LOAD;
         stream_load_ctx->load_src_type = TLoadSourceType::RAW;


### PR DESCRIPTION
## Proposed changes

The txn insert into mow table failed, because the commit_txn for mow table is doing by fe, but the `StreamLoadContext::is_mow_table()` return false, cause the commit_txn is doing by be. The`StreamLoadContext::is_mow_table()` return false because `put_result.__isset.pipeline_params` is false. 
