### PR TITLE
[improvement](mysql catalog) disable mysql AbandonedConnectionCleanup Thread

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/MySQLJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/MySQLJdbcExecutor.java
@@ -48,6 +48,7 @@ public class MySQLJdbcExecutor extends BaseJdbcExecutor {
 
     public MySQLJdbcExecutor(byte[] thriftParams) throws Exception {
         super(thriftParams);
+        System.setProperty("com.mysql.cj.disableAbandonedConnectionCleanup", "true");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -45,6 +45,8 @@ public class JdbcMySQLClient extends JdbcClient {
 
     protected JdbcMySQLClient(JdbcClientConfig jdbcClientConfig) {
         super(jdbcClientConfig);
+        // Disable abandoned connection cleanup
+        System.setProperty("com.mysql.cj.disableAbandonedConnectionCleanup", "true");
         convertDateToNull = isConvertDatetimeToNull(jdbcClientConfig);
         Connection conn = null;
         Statement stmt = null;


### PR DESCRIPTION
When using mysql catalog, mysql jdbc driver will generate an `AbandonedConnectionCleanupThread` for each database connection. This is a virtual reference, which will accumulate over time as database connections are constantly created, eventually causing OOM. Therefore, in our usage scenario, we need to turn off this thread because our database connection recycling depends on the connection pool.
But please note that this switch is only for MySQL JDBC Driver versions greater than 8.0.22
