### PR TITLE
[Fix] Fix typos in class name

### DIFF
--- a/be/src/agent/cgroup_cpu_ctl.cpp
+++ b/be/src/agent/cgroup_cpu_ctl.cpp
@@ -30,14 +30,14 @@ Status CgroupCpuCtl::init() {
     _doris_cgroup_cpu_path = config::doris_cgroup_cpu_path;
     if (_doris_cgroup_cpu_path.empty()) {
         LOG(INFO) << "doris cgroup cpu path is not specify, path=" << _doris_cgroup_cpu_path;
-        return Status::InternalError<false>("doris cgroup cpu path {} is not specify.",
-                                            _doris_cgroup_cpu_path);
+        return Status::InvalidArgument<false>("doris cgroup cpu path {} is not specify.",
+                                              _doris_cgroup_cpu_path);
     }
 
     if (access(_doris_cgroup_cpu_path.c_str(), F_OK) != 0) {
         LOG(INFO) << "doris cgroup cpu path not exists, path=" << _doris_cgroup_cpu_path;
-        return Status::InternalError<false>("doris cgroup cpu path {} not exists.",
-                                            _doris_cgroup_cpu_path);
+        return Status::InvalidArgument<false>("doris cgroup cpu path {} not exists.",
+                                              _doris_cgroup_cpu_path);
     }
 
     if (_doris_cgroup_cpu_path.back() != '/') {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -73,7 +73,7 @@ class MemTracker;
 class BaseStorageEngine;
 class ResultBufferMgr;
 class ResultQueueMgr;
-class RuntimeQueryStatiticsMgr;
+class RuntimeQueryStatisticsMgr;
 class TMasterInfo;
 class LoadChannelMgr;
 class LoadStreamMgr;
@@ -150,7 +150,7 @@ public:
     pipeline::TaskScheduler* pipeline_task_scheduler() { return _without_group_task_scheduler; }
     WorkloadGroupMgr* workload_group_mgr() { return _workload_group_manager; }
     WorkloadSchedPolicyMgr* workload_sched_policy_mgr() { return _workload_sched_mgr; }
-    RuntimeQueryStatiticsMgr* runtime_query_statistics_mgr() {
+    RuntimeQueryStatisticsMgr* runtime_query_statistics_mgr() {
         return _runtime_query_statistics_mgr;
     }
 
@@ -430,7 +430,7 @@ private:
 
     WorkloadSchedPolicyMgr* _workload_sched_mgr = nullptr;
 
-    RuntimeQueryStatiticsMgr* _runtime_query_statistics_mgr = nullptr;
+    RuntimeQueryStatisticsMgr* _runtime_query_statistics_mgr = nullptr;
 
     std::unique_ptr<pipeline::PipelineTracerContext> _pipeline_tracer_ctx;
     std::unique_ptr<segment_v2::TmpFileDirs> _tmp_file_dirs;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -267,7 +267,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
 
     // NOTE: runtime query statistics mgr could be visited by query and daemon thread
     // so it should be created before all query begin and deleted after all query and daemon thread stoppped
-    _runtime_query_statistics_mgr = new RuntimeQueryStatiticsMgr();
+    _runtime_query_statistics_mgr = new RuntimeQueryStatisticsMgr();
     _file_cache_factory = new io::FileCacheFactory();
     init_file_cache_factory();
     _pipeline_tracer_ctx = std::make_unique<pipeline::PipelineTracerContext>(); // before query

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -438,7 +438,7 @@ TReportExecStatusParams QueryContext::get_realtime_exec_status() const {
         }
     }
 
-    exec_status = RuntimeQueryStatiticsMgr::create_report_exec_status_params(
+    exec_status = RuntimeQueryStatisticsMgr::create_report_exec_status_params(
             this->_query_id, std::move(realtime_query_profile), std::move(load_channel_profiles),
             /*is_done=*/false);
 

--- a/be/src/runtime/runtime_query_statistics_mgr.cpp
+++ b/be/src/runtime/runtime_query_statistics_mgr.cpp
@@ -101,7 +101,7 @@ static Status _do_report_exec_stats_rpc(const TNetworkAddress& coor_addr,
     return Status::OK();
 }
 
-TReportExecStatusParams RuntimeQueryStatiticsMgr::create_report_exec_status_params(
+TReportExecStatusParams RuntimeQueryStatisticsMgr::create_report_exec_status_params(
         const TUniqueId& query_id,
         std::unordered_map<int32, std::vector<std::shared_ptr<TRuntimeProfileTree>>>
                 fragment_id_to_profile,
@@ -169,7 +169,7 @@ TReportExecStatusParams RuntimeQueryStatiticsMgr::create_report_exec_status_para
     return req;
 }
 
-void RuntimeQueryStatiticsMgr::start_report_thread() {
+void RuntimeQueryStatisticsMgr::start_report_thread() {
     if (started.load()) {
         DCHECK(false) << "report thread has been started";
         LOG_ERROR("report thread has been started");
@@ -180,11 +180,11 @@ void RuntimeQueryStatiticsMgr::start_report_thread() {
 
     for (size_t i = 0; i < config::report_exec_status_thread_num; ++i) {
         this->_report_profile_threads.emplace_back(std::make_unique<std::thread>(
-                &RuntimeQueryStatiticsMgr::report_query_profiles_thread, this));
+                &RuntimeQueryStatisticsMgr::report_query_profiles_thread, this));
     }
 }
 
-void RuntimeQueryStatiticsMgr::report_query_profiles_thread() {
+void RuntimeQueryStatisticsMgr::report_query_profiles_thread() {
     while (true) {
         {
             std::unique_lock<std::mutex> lock(_report_profile_mutex);
@@ -207,12 +207,12 @@ void RuntimeQueryStatiticsMgr::report_query_profiles_thread() {
     }
 }
 
-void RuntimeQueryStatiticsMgr::trigger_report_profile() {
+void RuntimeQueryStatisticsMgr::trigger_report_profile() {
     std::unique_lock<std::mutex> lock(_report_profile_mutex);
     _report_profile_cv.notify_one();
 }
 
-void RuntimeQueryStatiticsMgr::stop_report_thread() {
+void RuntimeQueryStatisticsMgr::stop_report_thread() {
     if (!started) {
         return;
     }
@@ -231,7 +231,7 @@ void RuntimeQueryStatiticsMgr::stop_report_thread() {
     LOG_INFO("All report threads stopped");
 }
 
-void RuntimeQueryStatiticsMgr::register_fragment_profile(
+void RuntimeQueryStatisticsMgr::register_fragment_profile(
         const TUniqueId& query_id, const TNetworkAddress& coor_addr, int32_t fragment_id,
         std::vector<std::shared_ptr<TRuntimeProfileTree>> p_profiles,
         std::shared_ptr<TRuntimeProfileTree> load_channel_profile_x) {
@@ -265,7 +265,7 @@ void RuntimeQueryStatiticsMgr::register_fragment_profile(
              fragment_id, p_profiles.size());
 }
 
-void RuntimeQueryStatiticsMgr::_report_query_profiles_function() {
+void RuntimeQueryStatisticsMgr::_report_query_profiles_function() {
     decltype(_profile_map) profile_copy;
     decltype(_load_channel_profile_map) load_channel_profile_copy;
 
@@ -327,10 +327,10 @@ void QueryStatisticsCtx::collect_query_statistics(TQueryStatistics* tq_s) {
     tq_s->__set_workload_group_id(_wg_id);
 }
 
-void RuntimeQueryStatiticsMgr::register_query_statistics(std::string query_id,
-                                                         std::shared_ptr<QueryStatistics> qs_ptr,
-                                                         TNetworkAddress fe_addr,
-                                                         TQueryType::type query_type) {
+void RuntimeQueryStatisticsMgr::register_query_statistics(std::string query_id,
+                                                          std::shared_ptr<QueryStatistics> qs_ptr,
+                                                          TNetworkAddress fe_addr,
+                                                          TQueryType::type query_type) {
     std::lock_guard<std::shared_mutex> write_lock(_qs_ctx_map_lock);
     if (_query_statistics_ctx_map.find(query_id) == _query_statistics_ctx_map.end()) {
         _query_statistics_ctx_map[query_id] =
@@ -339,7 +339,7 @@ void RuntimeQueryStatiticsMgr::register_query_statistics(std::string query_id,
     _query_statistics_ctx_map.at(query_id)->_qs_list.push_back(qs_ptr);
 }
 
-void RuntimeQueryStatiticsMgr::report_runtime_query_statistics() {
+void RuntimeQueryStatisticsMgr::report_runtime_query_statistics() {
     int64_t be_id = ExecEnv::GetInstance()->master_info()->backend_id;
     // 1 get query statistics map
     std::map<TNetworkAddress, std::map<std::string, TQueryStatistics>> fe_qs_map;
@@ -458,7 +458,7 @@ void RuntimeQueryStatiticsMgr::report_runtime_query_statistics() {
     }
 }
 
-void RuntimeQueryStatiticsMgr::set_query_finished(std::string query_id) {
+void RuntimeQueryStatisticsMgr::set_query_finished(std::string query_id) {
     // NOTE: here must be a write lock
     std::lock_guard<std::shared_mutex> write_lock(_qs_ctx_map_lock);
     // when a query get query_ctx succ, but failed before create node/operator,
@@ -470,7 +470,7 @@ void RuntimeQueryStatiticsMgr::set_query_finished(std::string query_id) {
     }
 }
 
-std::shared_ptr<QueryStatistics> RuntimeQueryStatiticsMgr::get_runtime_query_statistics(
+std::shared_ptr<QueryStatistics> RuntimeQueryStatisticsMgr::get_runtime_query_statistics(
         std::string query_id) {
     std::shared_lock<std::shared_mutex> read_lock(_qs_ctx_map_lock);
     if (_query_statistics_ctx_map.find(query_id) == _query_statistics_ctx_map.end()) {
@@ -483,7 +483,7 @@ std::shared_ptr<QueryStatistics> RuntimeQueryStatiticsMgr::get_runtime_query_sta
     return qs_ptr;
 }
 
-void RuntimeQueryStatiticsMgr::get_metric_map(
+void RuntimeQueryStatisticsMgr::get_metric_map(
         std::string query_id, std::map<WorkloadMetricType, std::string>& metric_map) {
     QueryStatistics ret_qs;
     int64_t query_time_ms = 0;
@@ -504,7 +504,7 @@ void RuntimeQueryStatiticsMgr::get_metric_map(
                        std::to_string(ret_qs.get_current_used_memory_bytes()));
 }
 
-void RuntimeQueryStatiticsMgr::set_workload_group_id(std::string query_id, int64_t wg_id) {
+void RuntimeQueryStatisticsMgr::set_workload_group_id(std::string query_id, int64_t wg_id) {
     // wg id just need eventual consistency, read lock is ok
     std::shared_lock<std::shared_mutex> read_lock(_qs_ctx_map_lock);
     if (_query_statistics_ctx_map.find(query_id) != _query_statistics_ctx_map.end()) {
@@ -512,7 +512,7 @@ void RuntimeQueryStatiticsMgr::set_workload_group_id(std::string query_id, int64
     }
 }
 
-void RuntimeQueryStatiticsMgr::get_active_be_tasks_block(vectorized::Block* block) {
+void RuntimeQueryStatisticsMgr::get_active_be_tasks_block(vectorized::Block* block) {
     std::shared_lock<std::shared_mutex> read_lock(_qs_ctx_map_lock);
     int64_t be_id = ExecEnv::GetInstance()->master_info()->backend_id;
 

--- a/be/src/runtime/runtime_query_statistics_mgr.h
+++ b/be/src/runtime/runtime_query_statistics_mgr.h
@@ -64,10 +64,10 @@ public:
     int64_t _query_start_time;
 };
 
-class RuntimeQueryStatiticsMgr {
+class RuntimeQueryStatisticsMgr {
 public:
-    RuntimeQueryStatiticsMgr() = default;
-    ~RuntimeQueryStatiticsMgr() = default;
+    RuntimeQueryStatisticsMgr() = default;
+    ~RuntimeQueryStatisticsMgr() = default;
 
     static TReportExecStatusParams create_report_exec_status_params(
             const TUniqueId& q_id,


### PR DESCRIPTION
## Proposed changes
1 Fix typos in class name.
2 use correct return Status.

