### PR TITLE
[fix](exception) throw std::runtime_error leads to BE coredump

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -36,6 +36,7 @@
 #include <utility>
 
 #include "common/config.h"
+#include "common/exception.h"
 #include "common/logging.h"
 #include "gutil/integral_types.h"
 #include "udf/udf.h"
@@ -315,9 +316,9 @@ public:
      */
     uint64_t cardinality() const {
         if (isFull()) {
-            throw std::length_error(
-                    "bitmap is full, cardinality is 2^64, "
-                    "unable to represent in a 64-bit integer");
+            throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+                                   "bitmap is full, cardinality is 2^64, "
+                                   "unable to represent in a 64-bit integer");
         }
         return std::accumulate(roarings.cbegin(), roarings.cend(), (uint64_t)0,
                                [](uint64_t previous,

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -116,7 +116,8 @@ public:
     ReturnType stored_result() const {
         if (!has_called()) {
             // Could not return status if the method not called.
-            throw std::exception();
+            throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+                                   "calling stored_result while has not been called");
         }
         if (_eptr) {
             std::rethrow_exception(_eptr);

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -215,7 +215,7 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
             MergeSortCursorImpl::reset(_block);
             return status.ok();
         } else if (!status.ok()) {
-            throw std::runtime_error(std::string(status.msg()));
+            throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR, status.msg());
         }
         return false;
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`std::runtime_error` is not caught which leads to be coredump.
