### PR TITLE
[fix](cloud-mow) duplicate key occured when StreamLoad commit failed and retry

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -294,7 +294,9 @@ void StreamLoadExecutor::get_commit_request(StreamLoadContext* ctx,
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.sync = true;
-    request.commitInfos = std::move(ctx->commit_infos);
+    // When number loaded rows > 0, ctx->commit_infos can't be empty
+    DCHECK(ctx->number_loaded_rows = 0 || !ctx->commit_infos.empty());
+    request.commitInfos = ctx->commit_infos;
     request.__isset.commitInfos = true;
     request.__set_thrift_rpc_timeout_ms(config::txn_commit_rpc_timeout_ms);
     request.tbls = ctx->table_list;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -294,8 +294,6 @@ void StreamLoadExecutor::get_commit_request(StreamLoadContext* ctx,
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.sync = true;
-    // When number loaded rows > 0, ctx->commit_infos can't be empty
-    DCHECK(ctx->number_loaded_rows = 0 || !ctx->commit_infos.empty());
     request.commitInfos = ctx->commit_infos;
     request.__isset.commitInfos = true;
     request.__set_thrift_rpc_timeout_ms(config::txn_commit_rpc_timeout_ms);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In our stress test environment, we found that for cloud mow table, when stream load commit failed and retry, the StreamLoadContext->commit_infos is cleared, and FE skipped the delete bitmap calculation task and commit success directly, in such case, the delete bitmap is not calculated correctly

