### PR TITLE
[fix](nereids) fix wrong resut of function ifnull/coalesce caused by mixed use multiple columns with type of datetime/datetimev2/date/datev2 of function coalesce when enable nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/SearchSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/SearchSignature.java
@@ -23,6 +23,8 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.DateV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
@@ -194,6 +196,9 @@ public class SearchSignature {
             if (!IdenticalSignature.isIdentical(sigArgType, realType)) {
                 nonStrictMatched++;
                 if (sigArgType instanceof DateV2Type && realType instanceof DateType) {
+                    dateToDateV2Count++;
+                } else if (sigArgType instanceof DateTimeV2Type && (realType instanceof DateTimeType
+                        || realType instanceof DateV2Type || realType instanceof DateType)) {
                     dateToDateV2Count++;
                 }
             }

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_coalesce_new.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_coalesce_new.groovy
@@ -60,6 +60,40 @@ suite("test_coalesce_new") {
     """
     assertEquals(result12.size(), 2);
 
+    //test enable_date_conversion=true and enable_nereids
+    sql """
+        admin set frontend config ("enable_date_conversion"="true")
+        """
+    sql """
+        SET enable_nereids_planner=true
+        """
+    sql """
+        SET enable_fallback_to_original_planner=false
+        """
+    def result13 = try_sql """
+        select dt from test_cls where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result13.size(), 2);
+    def result14 = try_sql """
+        select dt from test_cls where coalesce (dt, dt, str_to_date(concat('202306', '01'), '%Y%m%d')) < '2023-06-01'
+    """
+    assertEquals(result14.size(), 1);
+    def result15 = try_sql """
+        select dt from test_cls where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d'), str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-02'
+    """
+    assertEquals(result15.size(), 1);
+    def result16 = try_sql """
+        select dt from test_cls where ifnull(dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result16.size(), 2);
+    def result17 = try_sql """
+        select dt from test_cls where coalesce(str_to_date(concat('202306', '01'), '%Y%m%d'),dt) < '2023-06-02'
+    """
+    assertEquals(result17.size(), 3);
+    def result18 = try_sql """
+        select dt from test_cls where ifnull(str_to_date(concat('202306', '01'), '%Y%m%d'),dt) < '2023-06-03'
+    """
+    assertEquals(result18.size(), 3);
 
     // test parameter:datetimev2, datev2
     sql """
@@ -105,6 +139,37 @@ suite("test_coalesce_new") {
     """
     assertEquals(result22.size(), 2);
 
+    //test enable_date_conversion=true and enable_nereids
+    sql """
+        SET enable_nereids_planner=true
+        """
+    sql """
+        SET enable_fallback_to_original_planner=false
+        """
+    def result23 = try_sql """
+        select dt from test_cls_dtv2 where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-01'
+    """
+    assertEquals(result23.size(), 2);
+    def result24 = try_sql """
+        select dt from test_cls_dtv2 where coalesce (dt, dt, str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-02'
+    """
+    assertEquals(result24.size(), 1);
+    def result25 = try_sql """
+        select dt from test_cls_dtv2 where coalesce (dt, str_to_date(concat('202306', '01'), '%Y%m%d'), str_to_date(concat('202306', '01'), '%Y%m%d')) >= '2023-06-02'
+    """
+    assertEquals(result25.size(), 1);
+    def result26 = try_sql """
+        select dt from test_cls_dtv2 where ifnull(dt, str_to_date(concat('202306', '01'), '%Y%m%d')) < '2023-06-01'
+    """
+    assertEquals(result26.size(), 1);
+    def result27 = try_sql """
+        select dt from test_cls_dtv2 where coalesce(str_to_date(concat('202306', '01'), '%Y%m%d'),dt) < '2023-06-01'
+    """
+    assertEquals(result27.size(), 0);
+    def result28 = try_sql """
+        select dt from test_cls_dtv2 where ifnull(str_to_date(concat('202306', '01'), '%Y%m%d'),dt) < '2023-06-01'
+    """
+    assertEquals(result28.size(), 0);
 
     sql """
         drop table test_cls


### PR DESCRIPTION
similar issue with #36640, under config:
```
admin set frontend config ("enable_date_conversion"="true");
SET enable_nereids_planner=true;
```

