### PR TITLE
[chore](Regression) Add provider conf in regression's pipeline conf

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
@@ -74,3 +74,5 @@ enableKafkaTest=true
 
 // trino-connector catalog test config
 enableTrinoConnectorTest = false
+
+s3Provider = "COS"

--- a/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
@@ -21,3 +21,4 @@ excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line 
 
 max_failure_num = 50
 
+s3Provider = "COS"

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -139,6 +139,7 @@ cacheDataPath = "/data/regression/"
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
+s3Provider = "COS"
 
 max_failure_num=50
 

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -73,6 +73,7 @@ cacheDataPath="/data/regression/"
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
+s3Provider = "COS"
 
 max_failure_num=0
 


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Previously the conf of pipeline doesn't contain the provider of the Object Storage it uses. When adding azure's support like #35990, user should specify the vendor they use or just doesn't set the "provider" property when using S3-like object storage. So i add this conf.