### PR TITLE
[bug](prepared statement) Fix an analysis bug in legacy planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BoolLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BoolLiteral.java
@@ -88,6 +88,9 @@ public class BoolLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -629,6 +629,9 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -242,6 +242,9 @@ public class DecimalLiteral extends NumericLiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -119,6 +119,9 @@ public class FloatLiteral extends NumericLiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
@@ -254,6 +254,9 @@ public class IntLiteral extends NumericLiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
@@ -174,6 +174,9 @@ public class LargeIntLiteral extends NumericLiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -358,6 +358,7 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
                 break;
             case 5: // MYSQL_TYPE_DOUBLE
                 literalExpr = LiteralExpr.create("0", Type.DOUBLE);
+                literalExpr.setType(Type.DOUBLE);
                 break;
             case 0: // MYSQL_TYPE_DECIMAL
             case 246: // MYSQL_TYPE_NEWDECIMAL

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -358,7 +358,6 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
                 break;
             case 5: // MYSQL_TYPE_DOUBLE
                 literalExpr = LiteralExpr.create("0", Type.DOUBLE);
-                literalExpr.setType(Type.DOUBLE);
                 break;
             case 0: // MYSQL_TYPE_DECIMAL
             case 246: // MYSQL_TYPE_NEWDECIMAL

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NullLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NullLiteral.java
@@ -84,6 +84,9 @@ public class NullLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 0;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -77,6 +77,9 @@ public class StringLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
         if (expr instanceof NullLiteral) {
             return 1;
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
java.lang.ClassCastException: org.apache.doris.analysis.PlaceHolderExpr cannot be cast to org.apache.doris.analysis.LargeIntLiteral
        at org.apache.doris.analysis.LargeIntLiteral.compareLiteral(LargeIntLiteral.java:181) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.PlaceHolderExpr.compareLiteral(PlaceHolderExpr.java:112) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.LiteralExpr.equals(LiteralExpr.java:310) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.Pair.equals(Pair.java:66) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
        at java.util.HashMap.getNode(HashMap.java:572) ~[?:1.8.0_272]
        at java.util.HashMap.containsKey(HashMap.java:596) ~[?:1.8.0_272]
        at java.util.HashSet.contains(HashSet.java:204) ~[?:1.8.0_272]
        at org.apache.doris.rewrite.InferFiltersRule.initAllStructure(InferFiltersRule.java:184) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.InferFiltersRule.initAllStructure(InferFiltersRule.java:170) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.InferFiltersRule.apply(InferFiltersRule.java:117) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExprRewriter.applyRuleOnce(ExprRewriter.java:178) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExprRewriter.rewrite(ExprRewriter.java:171) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.SelectStmt.rewriteExprs(SelectStmt.java:1856) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyzeAndGenerateQueryPlan(StmtExecutor.java:1165) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:1060) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:735) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:510) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:475) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleExecute(ConnectProcessor.java:263) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:592) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:852) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_272]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_272]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_272]
```

<!--Describe your changes.-->

