### PR TITLE
[Bug](exchange) fix dcheck fail when VDataStreamRecvr input empty block (#22992)

### DIFF
--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -57,8 +57,7 @@ bool SharedHashTableController::should_build_hash_table(const TUniqueId& fragmen
 
 SharedHashTableContextPtr SharedHashTableController::get_context(int my_node_id) {
     std::lock_guard<std::mutex> lock(_mutex);
-    auto it = _shared_contexts.find(my_node_id);
-    if (it == _shared_contexts.cend()) {
+    if (!_shared_contexts.count(my_node_id)) {
         _shared_contexts.insert({my_node_id, std::make_shared<SharedHashTableContext>()});
     }
     return _shared_contexts[my_node_id];

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -239,7 +239,9 @@ public:
     }
 
     void add_block(Block* block, bool use_move) override {
-        if (block->rows() == 0) return;
+        if (block->rows() == 0) {
+            return;
+        }
         {
             std::unique_lock<std::mutex> l(_lock);
             if (_is_cancelled) {


### PR DESCRIPTION
fix dcheck fail when VDataStreamRecvr input empty block

pick #22992

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

