### PR TITLE
[Optimize](Cooldown) Remove the time limit for table creation and specified time cooling strategy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -390,11 +390,6 @@ public class PropertyAnalyzer {
             }
             // check remote storage cool down timestamp
             if (storagePolicy.getCooldownTimestampMs() != -1) {
-                if (storagePolicy.getCooldownTimestampMs() <= currentTimeMs) {
-                    throw new AnalysisException(
-                            "remote storage cool down time: " + storagePolicy.getCooldownTimestampMs()
-                                    + " should later than now: " + currentTimeMs);
-                }
                 if (hasCooldown && storagePolicy.getCooldownTimestampMs() <= cooldownTimestamp) {
                     throw new AnalysisException(
                             "remote storage cool down time: " + storagePolicy.getCooldownTimestampMs()


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Because some users migrated to doris from other products, they do not need to query some historical data, but it needs to be stored in doris for future query. At this time, they need to cool down directly without specifying a future time.