### PR TITLE
[fix](pipeline) Avoid to close task twice

### DIFF
--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -135,6 +135,7 @@ public:
     OperatorXPtr source() const { return _source; }
 
     int task_id() const { return _index; };
+    bool is_finalized() const { return _finalized; }
 
     void clear_blocking_state() {
         // We use a lock to assure all dependencies are not deconstructed here.

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -72,14 +72,14 @@ Status TaskScheduler::schedule_task(PipelineTask* task) {
 
 // after _close_task, task maybe destructed.
 void _close_task(PipelineTask* task, Status exec_status) {
-    if (task->is_finalized()) {
-        task->set_running(false);
-        return;
-    }
     // Has to attach memory tracker here, because the close task will also release some memory.
     // Should count the memory to the query or the query's memory will not decrease when part of
     // task finished.
     SCOPED_ATTACH_TASK(task->runtime_state());
+    if (task->is_finalized()) {
+        task->set_running(false);
+        return;
+    }
     // close_a_pipeline may delete fragment context and will core in some defer
     // code, because the defer code will access fragment context it self.
     auto lock_for_context = task->fragment_context()->shared_from_this();

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -72,6 +72,10 @@ Status TaskScheduler::schedule_task(PipelineTask* task) {
 
 // after _close_task, task maybe destructed.
 void _close_task(PipelineTask* task, Status exec_status) {
+    if (task->is_finalized()) {
+        task->set_running(false);
+        return;
+    }
     // Has to attach memory tracker here, because the close task will also release some memory.
     // Should count the memory to the query or the query's memory will not decrease when part of
     // task finished.


### PR DESCRIPTION
## Proposed changes

*** SIGABRT unknown detail explain (@0xf9fc9) received by PID 1023945 (TID 1079783 OR 0x7f4ebeac1640) from PID 1023945; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F6FA63EA520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 6# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 7# 0x0000559E2308A301 in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 8# 0x0000559E2308A454 in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 9# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:246
10# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:300
11# doris::ThreadPool::dispatch_thread() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
12# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
13# start_thread at ./nptl/pthread_create.c:442
14# 0x00007F6FA64CE850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

<!--Describe your changes.-->

