### PR TITLE
[fix](set) fix coredump caused by intersect of nullable and not nullable children

### DIFF
--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -242,6 +242,7 @@ Status VSetOperationNode<is_intersect>::open(RuntimeState* state) {
         RETURN_IF_ERROR(child(i)->open(state));
         eos = false;
 
+        _probe_block.clear();
         while (!eos) {
             release_block_memory(_probe_block, i);
             RETURN_IF_CANCELLED(state);

--- a/regression-test/data/query_p0/set_operations/sql/intersect_nullable_not_nullable.out
+++ b/regression-test/data/query_p0/set_operations/sql/intersect_nullable_not_nullable.out
@@ -5,3 +5,15 @@ c
 -- !intersect_nullable_not_nullable_2 --
 c
 
+-- !intersect_nullable_not_nullable_3 --
+a
+
+-- !intersect_nullable_not_nullable_4 --
+a
+
+-- !intersect_nullable_not_nullable_5 --
+a
+
+-- !intersect_nullable_not_nullable_6 --
+a
+

--- a/regression-test/suites/query_p0/set_operations/sql/intersect_nullable_not_nullable.groovy
+++ b/regression-test/suites/query_p0/set_operations/sql/intersect_nullable_not_nullable.groovy
@@ -29,28 +29,28 @@ suite("intersect_nullable_not_nullable") {
     drop table if exists intersect_nullable_not_nullable_t4; 
     """
     sql """
-    create table intersect_nullable_not_nullable_t1 (k1 char(16) not null) distributed by hash(k1) properties("replication_num"="1");
+    create table intersect_nullable_not_nullable_t1 (k1 char(255) not null) distributed by hash(k1) properties("replication_num"="1");
     """
     sql """
     insert into intersect_nullable_not_nullable_t1 values("a"), ("b"), ("c"), ("d"), ("e");
     """
     
     sql """
-    create table intersect_nullable_not_nullable_t2 (kk0 int, kk1 char(16) not null) distributed by hash(kk0) properties("replication_num"="1");
+    create table intersect_nullable_not_nullable_t2 (kk0 int, kk1 char(100) not null) distributed by hash(kk0) properties("replication_num"="1");
     """
     sql """
     insert into intersect_nullable_not_nullable_t2 values(1, "b"), (2, "c"), (3, "d"), (4, "e");
     """
     
     sql """
-    create table intersect_nullable_not_nullable_t3 (kkk1 char(16) ) distributed by hash(kkk1) properties("replication_num"="1");
+    create table intersect_nullable_not_nullable_t3 (kkk0 int, kkk1 char(100) ) distributed by hash(kkk0) properties("replication_num"="1");
     """
     sql """
-    insert into intersect_nullable_not_nullable_t3 values("c"), ("d"), ("e");
+    insert into intersect_nullable_not_nullable_t3 values(1, "c"), (2, "d"), (3, "e");
     """
     
     sql """
-    create table intersect_nullable_not_nullable_t4 (kkkk1 char(16) ) distributed by hash(kkkk1) properties("replication_num"="1");
+    create table intersect_nullable_not_nullable_t4 (kkkk1 char(100) ) distributed by hash(kkkk1) properties("replication_num"="1");
     """
     sql """
     insert into intersect_nullable_not_nullable_t4 values("d"), ("e");
@@ -58,7 +58,7 @@ suite("intersect_nullable_not_nullable") {
     
     order_qt_intersect_nullable_not_nullable_1 """
         (
-            select * from intersect_nullable_not_nullable_t1
+            select k1 from intersect_nullable_not_nullable_t1
         )
         intersect
         (
@@ -67,27 +67,27 @@ suite("intersect_nullable_not_nullable") {
         intersect
         (
             (
-                select * from intersect_nullable_not_nullable_t3
+                select kkk1 from intersect_nullable_not_nullable_t3
             )
             except
             (
-                select * from intersect_nullable_not_nullable_t4
+                select kkkk1 from intersect_nullable_not_nullable_t4
             )
         );
     """
     
     order_qt_intersect_nullable_not_nullable_2 """
         (
-            select * from intersect_nullable_not_nullable_t1
+            select k1 from intersect_nullable_not_nullable_t1
         )
         intersect
         (
             (
-                select * from intersect_nullable_not_nullable_t3
+                select kkk1 from intersect_nullable_not_nullable_t3
             )
             except
             (
-                select * from intersect_nullable_not_nullable_t4
+                select kkkk1 from intersect_nullable_not_nullable_t4
             )
         )
         intersect
@@ -95,4 +95,65 @@ suite("intersect_nullable_not_nullable") {
             select distinct kk1 from intersect_nullable_not_nullable_t2
         );
     """
+
+    sql """
+    set experimental_enable_pipeline_engine = true;
+    """
+    order_qt_intersect_nullable_not_nullable_3 """
+        (
+            select * from intersect_nullable_not_nullable_t1
+        )
+        except
+        (
+            select distinct kk1 from intersect_nullable_not_nullable_t2
+        )
+        except
+        (
+            select distinct kkk1 from intersect_nullable_not_nullable_t3
+        );
+    """
+    order_qt_intersect_nullable_not_nullable_4 """
+        (
+            select * from intersect_nullable_not_nullable_t1
+        )
+        except
+        (
+            select distinct kkk1 from intersect_nullable_not_nullable_t3
+        )
+        except
+        (
+            select distinct kk1 from intersect_nullable_not_nullable_t2
+        );
+    """
+
+    sql """
+    set experimental_enable_pipeline_engine = false;
+    """
+    order_qt_intersect_nullable_not_nullable_5 """
+        (
+            select * from intersect_nullable_not_nullable_t1
+        )
+        except
+        (
+            select distinct kk1 from intersect_nullable_not_nullable_t2
+        )
+        except
+        (
+            select distinct kkk1 from intersect_nullable_not_nullable_t3
+        );
+    """
+    order_qt_intersect_nullable_not_nullable_6 """
+        (
+            select * from intersect_nullable_not_nullable_t1
+        )
+        except
+        (
+            select distinct kkk1 from intersect_nullable_not_nullable_t3
+        )
+        except
+        (
+            select distinct kk1 from intersect_nullable_not_nullable_t2
+        );
+    """
+
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Bug of block reuse of set operator.

```
*** tablet id: 0 ***
*** Aborted at 1719221462 (unix time) try "date -d @1719221462" if you are using GNU date ***
*** Current BE git commitID: fe750497af ***
*** SIGSEGV address not mapped to object (@0x4000000108) received by PID 560 (TID 1133 OR 0x7f6371eff640) from PID 264; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/selectdb-core/be/src/common/signal_handler.h:435
 1# 0x00007F64A638042F in /lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F64A63790FC in /lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F64AB726520 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::vectorized::ColumnNullable::insert_range_from_not_nullable(doris::vectorized::IColumn const&, unsigned long, unsigned long) at /root/selectdb-core/be/src/vec/columns/column_nullable.cpp:348
 6# doris::ExecNode::do_projections(doris::vectorized::Block*, doris::vectorized::Block*) at /root/selectdb-core/be/src/exec/exec_node.cpp:572
 7# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)> const&, bool) at /root/selectdb-core/be/src/exec/exec_node.cpp:594
 8# doris::vectorized::VSetOperationNode<true>::open(doris::RuntimeState*) at /root/selectdb-core/be/src/vec/exec/vset_operation_node.cpp:248
 9# doris::vectorized::VSortNode::open(doris::RuntimeState*) at /root/selectdb-core/be/src/vec/exec/vsort_node.cpp:172
10# doris::PlanFragmentExecutor::open_vectorized_internal() at /root/selectdb-core/be/src/runtime/plan_fragment_executor.cpp:308
11# doris::PlanFragmentExecutor::open() at /root/selectdb-core/be/src/runtime/plan_fragment_executor.cpp:265
12# doris::FragmentExecState::execute() at /root/selectdb-core/be/src/runtime/fragment_mgr.cpp:281
13# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/selectdb-core/be/src/runtime/fragment_mgr.cpp:554
14# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /root/tools/ldb-16/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
15# doris::ThreadPool::dispatch_thread() in /opt/selectdb/be/lib/doris_be
16# doris::Thread::supervise_thread(void*) at /root/selectdb-core/be/src/util/thread.cpp:499
17# 0x00007F64AB778AC3 in /lib/x86_64-linux-gnu/libc.so.6
18# __clone in /lib/x86_64-linux-gnu/libc.so.6 
```
