### PR TITLE
[fix](array)fix array_except/union for left const return only one row result

### DIFF
--- a/be/src/vec/functions/array/function_array_set.h
+++ b/be/src/vec/functions/array/function_array_set.h
@@ -181,7 +181,11 @@ private:
         constexpr auto execute_left_column_first = Impl::Action::execute_left_column_first;
         size_t current = 0;
         Impl impl;
-        for (size_t row = 0; row < left_data.offsets_ptr->size(); ++row) {
+        size_t row_size = left_data.offsets_ptr->size();
+        if constexpr (LCONST) {
+            row_size = right_data.offsets_ptr->size();
+        }
+        for (size_t row = 0; row < row_size; ++row) {
             size_t count = 0;
             size_t left_off = (*left_data.offsets_ptr)[index_check_const(row, LCONST) - 1];
             size_t left_len = (*left_data.offsets_ptr)[index_check_const(row, LCONST)] - left_off;

--- a/regression-test/data/query_p0/sql_functions/array_functions/test_array_functions.out
+++ b/regression-test/data/query_p0/sql_functions/array_functions/test_array_functions.out
@@ -1659,11 +1659,23 @@
 10005	[10005, null, null]	[null, 3, 10005, 2, 1]
 10006	[60002, 60002, 60003, null, 60005]	[null, 3, 60002, 60005, 60003, 2, 1]
 
+-- !select_union_left_const --
+10005	[10005, null, null]	[null, 3, 10005, 2, 1]
+10006	[60002, 60002, 60003, null, 60005]	[null, 3, 60002, 60005, 60003, 2, 1]
+
 -- !select_except --
 10005	[10005, null, null]	[10005, null]
 10006	[60002, 60002, 60003, null, 60005]	[60002, 60003, null, 60005]
 
+-- !select_except_left_const --
+10005	[10005, null, null]	[1, 2, 3]
+10006	[60002, 60002, 60003, null, 60005]	[1, 2, 3]
+
 -- !select_intersect --
+10005	[10005, null, null]	[null]
+10006	[60002, 60002, 60003, null, 60005]	[null]
+
+-- !select_intersect_left_const --
 10005	[10005, null, null]	[null]
 10006	[60002, 60002, 60003, null, 60005]	[null]
 

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions.groovy
@@ -272,8 +272,11 @@ suite("test_array_functions") {
     sql """ insert into ${tableName3} values (10006,'bbbbb',[60002,60002,60003,null,60005]) """
     
     qt_select_union "select class_id, student_ids, array_union(student_ids,[1,2,3]) from ${tableName3} order by class_id;"
+    qt_select_union_left_const "select class_id, student_ids, array_union([1,2,3], student_ids,[1,2,3]) from ${tableName3} order by class_id;"
     qt_select_except "select class_id, student_ids, array_except(student_ids,[1,2,3]) from ${tableName3} order by class_id;"
+    qt_select_except_left_const "select class_id, student_ids, array_except([1,2,3], student_ids) from ${tableName3} order by class_id;"
     qt_select_intersect "select class_id, student_ids, array_intersect(student_ids,[1,2,3,null]) from ${tableName3} order by class_id;"
+    qt_select_intersect_left_const "select class_id, student_ids, array_intersect([1,2,3,null], student_ids) from ${tableName3} order by class_id;"
 
     def tableName4 = "tbl_test_array_datetimev2_functions"
 


### PR DESCRIPTION
## Proposed changes
if left param in array_except/union is const, it will make ret column only has one row column which will make result wrong

Issue Number: close #xxx

<!--Describe your changes.-->

