### PR TITLE
[opt](nereids) recover adoptive bucket shuffle

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.agg.MultiDistinction;
 import org.apache.doris.nereids.trees.plans.AggMode;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.SortPhase;
@@ -39,6 +40,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
@@ -199,12 +201,53 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Boolean, Void> {
         return true;
     }
 
-    private boolean isBucketShuffleDownGrade(DistributionSpecHash srcSideSpec) {
-        boolean isBucketShuffleDownGrade = ConnectContext.get().getSessionVariable().isEnableBucketShuffleDownGrade();
-        if (!isBucketShuffleDownGrade) {
+    private boolean isBucketShuffleDownGrade(Plan oneSidePlan, DistributionSpecHash otherSideSpec) {
+        // improper to do bucket shuffle join:
+        // oneSide:
+        //      - base table and tablets' number is small enough (< paraInstanceNum)
+        // otherSide:
+        //      - ShuffleType.EXECUTION_BUCKETED
+        boolean isEnableBucketShuffleJoin = ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin();
+        if (!isEnableBucketShuffleJoin) {
+            return true;
+        } else if (otherSideSpec.getShuffleType() != ShuffleType.EXECUTION_BUCKETED
+                || !(oneSidePlan instanceof GroupPlan)) {
             return false;
         } else {
-            return srcSideSpec.getShuffleType() == ShuffleType.EXECUTION_BUCKETED;
+            PhysicalOlapScan candidate = findDownGradeBucketShuffleCandidate((GroupPlan) oneSidePlan);
+            if (candidate == null || candidate.getTable() == null
+                    || candidate.getTable().getDefaultDistributionInfo() == null) {
+                return false;
+            } else {
+                int prunedPartNum = candidate.getSelectedPartitionIds().size();
+                int bucketNum = candidate.getTable().getDefaultDistributionInfo().getBucketNum();
+                int totalBucketNum = prunedPartNum * bucketNum;
+                int backEndNum = Math.max(1, ConnectContext.get().getEnv().getClusterInfo()
+                        .getBackendsNumber(true));
+                int paraNum = Math.max(1, ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
+                int totalParaNum = Math.min(10, backEndNum * paraNum);
+                return totalBucketNum < totalParaNum;
+            }
+        }
+    }
+
+    private PhysicalOlapScan findDownGradeBucketShuffleCandidate(GroupPlan groupPlan) {
+        if (groupPlan == null || groupPlan.getGroup() == null
+                || groupPlan.getGroup().getPhysicalExpressions().isEmpty()) {
+            return null;
+        } else {
+            Plan targetPlan = groupPlan.getGroup().getPhysicalExpressions().get(0).getPlan();
+            while (targetPlan != null
+                    && (targetPlan instanceof PhysicalProject || targetPlan instanceof PhysicalFilter)
+                    && !((GroupPlan) targetPlan.child(0)).getGroup().getPhysicalExpressions().isEmpty()) {
+                targetPlan = ((GroupPlan) targetPlan.child(0)).getGroup()
+                        .getPhysicalExpressions().get(0).getPlan();
+            }
+            if (targetPlan == null || !(targetPlan instanceof PhysicalOlapScan)) {
+                return null;
+            } else {
+                return (PhysicalOlapScan) targetPlan;
+            }
         }
     }
 
@@ -241,6 +284,9 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Boolean, Void> {
             throw new RuntimeException("should not come here, two children of shuffle join should all be shuffle");
         }
 
+        Plan leftChild = hashJoin.child(0);
+        Plan rightChild = hashJoin.child(1);
+
         DistributionSpecHash leftHashSpec = (DistributionSpecHash) leftDistributionSpec;
         DistributionSpecHash rightHashSpec = (DistributionSpecHash) rightDistributionSpec;
 
@@ -261,7 +307,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Boolean, Void> {
                     ShuffleType.EXECUTION_BUCKETED, leftHashSpec, rightHashSpec,
                     (DistributionSpecHash) requiredProperties.get(0).getDistributionSpec(),
                     (DistributionSpecHash) requiredProperties.get(1).getDistributionSpec()));
-        } else if (isBucketShuffleDownGrade(rightHashSpec)) {
+        } else if (isBucketShuffleDownGrade(leftChild, rightHashSpec)) {
             updatedForLeft = Optional.of(calAnotherSideRequired(
                     ShuffleType.EXECUTION_BUCKETED, leftHashSpec, leftHashSpec,
                     (DistributionSpecHash) requiredProperties.get(0).getDistributionSpec(),
@@ -270,7 +316,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Boolean, Void> {
                     ShuffleType.EXECUTION_BUCKETED, leftHashSpec, rightHashSpec,
                     (DistributionSpecHash) requiredProperties.get(0).getDistributionSpec(),
                     (DistributionSpecHash) requiredProperties.get(1).getDistributionSpec()));
-        } else if (isBucketShuffleDownGrade(leftHashSpec)) {
+        } else if (isBucketShuffleDownGrade(rightChild, leftHashSpec)) {
             updatedForLeft = Optional.of(calAnotherSideRequired(
                     ShuffleType.EXECUTION_BUCKETED, rightHashSpec, leftHashSpec,
                     (DistributionSpecHash) requiredProperties.get(1).getDistributionSpec(),

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -269,8 +269,6 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_AGG_STATE = "enable_agg_state";
 
-    public static final String ENABLE_BUCKET_SHUFFLE_DOWNGRADE = "enable_bucket_shuffle_downgrade";
-
     public static final String ENABLE_RPC_OPT_FOR_PIPELINE = "enable_rpc_opt_for_pipeline";
 
     public static final String ENABLE_SINGLE_DISTINCT_COLUMN_OPT = "enable_single_distinct_column_opt";
@@ -853,9 +851,6 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_BUCKET_SHUFFLE_JOIN, varType = VariableAnnotation.EXPERIMENTAL_ONLINE)
     public boolean enableBucketShuffleJoin = true;
-
-    @VariableMgr.VarAttr(name = ENABLE_BUCKET_SHUFFLE_DOWNGRADE, needForward = true)
-    public boolean enableBucketShuffleDownGrade = false;
 
     /**
      * explode function row count enlarge factor.
@@ -2571,10 +2566,6 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isEnableBucketShuffleJoin() {
         return enableBucketShuffleJoin;
-    }
-
-    public boolean isEnableBucketShuffleDownGrade() {
-        return enableBucketShuffleDownGrade;
     }
 
     public boolean isEnableOdbcTransaction() {

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query19.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query19.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query44.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN shuffle] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[item] apply RFs: RF1
 ----------------PhysicalProject
@@ -37,7 +37,7 @@ PhysicalResultSink
 --------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
 ----------------------------------------------------PhysicalOlapScan[store_sales]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[item] apply RFs: RF0
 ----------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query56.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query56.out
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query6.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query61.out
@@ -8,7 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
+----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
 ------------------PhysicalProject
 --------------------filter((customer_address.ca_gmt_offset = -7.00))
 ----------------------PhysicalOlapScan[customer_address] apply RFs: RF10

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query68.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query68.out
@@ -5,7 +5,7 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+----------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ------------PhysicalProject
 --------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ------------PhysicalProject
@@ -15,7 +15,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query8.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query8.out
@@ -29,7 +29,7 @@ PhysicalResultSink
 ------------------------------PhysicalDistribute[DistributionSpecHash]
 --------------------------------hashAgg[LOCAL]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
+------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
 --------------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query91.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4 RF5
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.out
@@ -15,7 +15,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------hashAgg[DISTINCT_LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
-----------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF6 ws_order_number->[wr_order_number,ws_order_number]
+----------------hashJoin[RIGHT_SEMI_JOIN colocated] hashCondition=((ws1.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF6 ws_order_number->[wr_order_number,ws_order_number]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_order_number = ws_wh.ws_order_number)) otherCondition=() build RFs:RF5 wr_order_number->[ws_order_number]
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query85.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query85.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF9 ws_web_page_sk->[wp_web_page_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF9 ws_web_page_sk->[wp_web_page_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[web_page] apply RFs: RF9
 --------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query61.out
@@ -27,7 +27,7 @@ PhysicalResultSink
 --------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 ss_promo_sk->[p_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 ss_promo_sk->[p_promo_sk]
 ----------------------------------PhysicalProject
 ------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
 --------------------------------------PhysicalOlapScan[promotion] apply RFs: RF6

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query85.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query85.out
@@ -16,7 +16,7 @@ PhysicalResultSink
 --------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 ----------------------------PhysicalOlapScan[customer_address] apply RFs: RF8
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF7 ws_web_page_sk->[wp_web_page_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF7 ws_web_page_sk->[wp_web_page_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[web_page] apply RFs: RF7
 ----------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query61.out
@@ -27,7 +27,7 @@ PhysicalResultSink
 --------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 ss_promo_sk->[p_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 ss_promo_sk->[p_promo_sk]
 ----------------------------------PhysicalProject
 ------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
 --------------------------------------PhysicalOlapScan[promotion] apply RFs: RF6

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query85.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query85.out
@@ -16,7 +16,7 @@ PhysicalResultSink
 --------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 ----------------------------PhysicalOlapScan[customer_address] apply RFs: RF8
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF7 ws_web_page_sk->[wp_web_page_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF7 ws_web_page_sk->[wp_web_page_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[web_page] apply RFs: RF7
 ----------------------------PhysicalProject

--- a/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
+++ b/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
@@ -18,6 +18,7 @@
 suite("test_bucket_shuffle_join") {
 
     sql "set disable_join_reorder=true"
+    sql "set parallel_pipeline_task_num=1"
 
     sql """ DROP TABLE IF EXISTS `test_colo1` """
     sql """ DROP TABLE IF EXISTS `test_colo2` """

--- a/regression-test/suites/inverted_index_p1/tpcds_sf1_index/sql/q78.sql
+++ b/regression-test/suites/inverted_index_p1/tpcds_sf1_index/sql/q78.sql
@@ -47,7 +47,7 @@ WITH
    WHERE (sr_ticket_number IS NULL)
    GROUP BY d_year, ss_item_sk, ss_customer_sk
 )
-SELECT
+SELECT /*+SET_VAR(experimental_enable_local_shuffle=false)*/
   ss_sold_year
 , ss_item_sk
 , ss_customer_sk

--- a/regression-test/suites/nereids_p0/hint/fix_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/fix_leading.groovy
@@ -26,6 +26,7 @@ suite("fix_leading") {
     // setting planner to nereids
     sql 'set exec_mem_limit=21G'
     sql 'set be_number_for_test=1'
+    sql "set parallel_pipeline_task_num=1"
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/hint/multi_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/multi_leading.groovy
@@ -26,6 +26,7 @@ suite("multi_leading") {
     // setting planner to nereids
     sql 'set exec_mem_limit=21G'
     sql 'set be_number_for_test=1'
+    sql 'set parallel_pipeline_task_num=1'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     sql 'set enable_nereids_planner=true'
     sql "set ignore_shape_nodes='PhysicalProject'"

--- a/regression-test/suites/nereids_p0/hint/test_distribute.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_distribute.groovy
@@ -28,6 +28,7 @@ suite("test_distribute") {
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'
     sql 'set be_number_for_test=1'
+    sql "set parallel_pipeline_task_num=1"
     
     // create tables
     sql """drop table if exists t1;"""

--- a/regression-test/suites/nereids_p0/hint/test_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/test_leading.groovy
@@ -26,6 +26,7 @@ suite("test_leading") {
     // setting planner to nereids
     sql 'set exec_mem_limit=21G'
     sql 'set be_number_for_test=1'
+    sql 'set parallel_pipeline_task_num=1'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     sql 'set enable_nereids_planner=true'
     sql "set ignore_shape_nodes='PhysicalProject'"

--- a/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
+++ b/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
@@ -18,6 +18,8 @@
 suite("bucket-shuffle-join") {
     sql "SET enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
+    sql 'SET be_number_for_test=1'
+    sql 'SET parallel_pipeline_task_num=1'
     order_qt_test_bucket """
     select * from test_bucket_shuffle_join where rectime="2021-12-01 00:00:00" and id in (select k1 from test_join where k1 in (1,2))
     """

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query13.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query13.groovy
@@ -31,7 +31,6 @@ suite("query13") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select avg(ss_quantity)
        ,avg(ss_ext_sales_price)

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query19.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query19.groovy
@@ -31,7 +31,6 @@ suite("query19") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  i_brand_id brand_id, i_brand brand, i_manufact_id, i_manufact,
  	sum(ss_ext_sales_price) ext_price

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query44.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query44.groovy
@@ -31,7 +31,6 @@ suite("query44") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  asceding.rnk, i1.i_product_name best_performing, i2.i_product_name worst_performing
 from(select *

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query45.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query45.groovy
@@ -31,7 +31,6 @@ suite("query45") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  ca_zip, ca_city, sum(ws_sales_price)
  from web_sales, customer, customer_address, date_dim, item

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query54.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query54.groovy
@@ -31,7 +31,6 @@ suite("query54") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """with my_customers as (
  select distinct c_customer_sk

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query56.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query56.groovy
@@ -31,7 +31,6 @@ suite("query56") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """with ss as (
  select i_item_id,sum(ss_ext_sales_price) total_sales

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query6.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query6.groovy
@@ -31,7 +31,6 @@ suite("query6") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  a.ca_state state, count(*) cnt
  from customer_address a

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query61.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query61.groovy
@@ -31,7 +31,6 @@ suite("query61") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  promotions,total,cast(promotions as decimal(15,4))/cast(total as decimal(15,4))*100
 from

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query68.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query68.groovy
@@ -31,7 +31,6 @@ suite("query68") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  c_last_name
        ,c_first_name

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query8.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query8.groovy
@@ -31,7 +31,6 @@ suite("query8") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  s_store_name
       ,sum(ss_net_profit)

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query91.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query91.groovy
@@ -31,7 +31,6 @@ suite("query91") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """select  
         cc_call_center_id Call_Center,

--- a/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf1000_p0/bs_downgrade_shape/query95.groovy
@@ -31,7 +31,6 @@ suite("query95") {
     sql 'set enable_runtime_filter_prune=false'
     sql 'set runtime_filter_type=8'
     sql 'set dump_nereids_memo=false'
-    sql 'set enable_bucket_shuffle_downgrade=true'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
     def ds = """with ws_wh as
 (select ws1.ws_order_number,ws1.ws_warehouse_sk wh1,ws2.ws_warehouse_sk wh2


### PR DESCRIPTION
## Proposed changes

1. Recover adoptive bucket shuffle and re-using the enable_bucket_shuffle_join to control whether to enable it, default remains true. 
2. Remove enable_bucket_shuffle_downgrade option.

<!--Describe your changes.-->

