### PR TITLE
[chore](Regession) Test s3 load without provider property

### DIFF
--- a/regression-test/suites/load_p0/broker_load/test_seq_load.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_seq_load.groovy
@@ -102,8 +102,7 @@ suite("test_seq_load", "load_p0") {
                 "AWS_ACCESS_KEY" = "$ak",
                 "AWS_SECRET_KEY" = "$sk",
                 "AWS_ENDPOINT" = "cos.ap-beijing.myqcloud.com",
-                "AWS_REGION" = "ap-beijing",
-                "provider" = "${getS3Provider()}"
+                "AWS_REGION" = "ap-beijing"
             )
             properties(
                 "use_new_load_scan_node" = "true"


### PR DESCRIPTION
We add one optional S3 load property `provider`, this pr adapts one case to test whether the FE works around without assigning one provider property.