### PR TITLE
Revert "[feature](cloud) support file cache only cache index pages (#36273)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -999,8 +999,6 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
 DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
-// only cache index pages (prerequisite: enable_file_cache = true)
-DEFINE_Bool(file_cache_index_only, "false");
 
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1045,8 +1045,6 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
 DECLARE_Int64(file_cache_each_block_size);
-// only cache index pages (prerequisite: enable_file_cache = true)
-DECLARE_Bool(file_cache_index_only);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
 DECLARE_Int32(file_cache_enter_disk_resource_limit_mode_percent);

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -342,11 +342,9 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
                                PageHandle* handle, Slice* page_body, PageFooterPB* footer,
                                BlockCompressionCodec* codec) const {
     iter_opts.sanity_check();
-    bool use_page_cache = iter_opts.use_page_cache &&
-                          (!config::file_cache_index_only || iter_opts.type == INDEX_PAGE);
     PageReadOptions opts {
             .verify_checksum = _opts.verify_checksum,
-            .use_page_cache = use_page_cache,
+            .use_page_cache = iter_opts.use_page_cache,
             .kept_in_memory = _opts.kept_in_memory,
             .type = iter_opts.type,
             .file_reader = iter_opts.file_reader,

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -115,9 +115,8 @@ Status IndexedColumnReader::read_page(const PagePointer& pp, PageHandle* handle,
                                       PageFooterPB* footer, PageTypePB type,
                                       BlockCompressionCodec* codec, bool pre_decode) const {
     OlapReaderStatistics tmp_stats;
-    bool use_page_cache = _use_page_cache && (!config::file_cache_index_only || type == INDEX_PAGE);
     PageReadOptions opts {
-            .use_page_cache = use_page_cache,
+            .use_page_cache = _use_page_cache,
             .kept_in_memory = _kept_in_memory,
             .pre_decode = pre_decode,
             .type = type,


### PR DESCRIPTION
This reverts commit f5c40a5c3bac3091707c8324c422889fa7f030c8.
This is a experimental (and buggy) commit. I hava found that caching
index only helps little. With that be the result, I think it is a good time to
revert it.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

