### PR TITLE
[Revert](stream-load)Revert fix stream load stuck under high concurrency #36772

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -33,7 +33,6 @@
 #include <time.h>
 
 #include <algorithm>
-#include <functional>
 #include <future>
 #include <map>
 #include <sstream>
@@ -109,67 +108,20 @@ void StreamLoadAction::handle(HttpRequest* req) {
 
     // status already set to fail
     if (ctx->status.ok()) {
-        ctx->status = _handle(ctx, req);
+        ctx->status = _handle(ctx);
         if (!ctx->status.ok() && !ctx->status.is<PUBLISH_TIMEOUT>()) {
             LOG(WARNING) << "handle streaming load failed, id=" << ctx->id
                          << ", errmsg=" << ctx->status;
-            _send_reply(ctx, req);
         }
     }
-}
-
-Status StreamLoadAction::_handle(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req) {
-    if (ctx->body_bytes > 0 && ctx->receive_bytes != ctx->body_bytes) {
-        LOG(WARNING) << "recevie body don't equal with body bytes, body_bytes=" << ctx->body_bytes
-                     << ", receive_bytes=" << ctx->receive_bytes << ", id=" << ctx->id;
-        return Status::InternalError("receive body don't equal with body bytes");
-    }
-
-    // if we use non-streaming, MessageBodyFileSink.finish will close the file
-    RETURN_IF_ERROR(ctx->body_sink->finish());
-    if (!ctx->use_streaming) {
-        // we need to close file first, then execute_plan_fragment here
-        ctx->body_sink.reset();
-        RETURN_IF_ERROR(_exec_env->stream_load_executor()->execute_plan_fragment(
-                ctx,
-                [req, this](std::shared_ptr<StreamLoadContext> ctx) { _on_finish(ctx, req); }));
-    }
-
-    return Status::OK();
-}
-
-void StreamLoadAction::_on_finish(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req) {
-    ctx->status = ctx->future.get();
-    if (ctx->status.ok()) {
-        if (ctx->group_commit) {
-            LOG(INFO) << "skip commit because this is group commit, pipe_id="
-                      << ctx->id.to_string();
-        } else if (ctx->two_phase_commit) {
-            int64_t pre_commit_start_time = MonotonicNanos();
-            ctx->status = _exec_env->stream_load_executor()->pre_commit_txn(ctx.get());
-            ctx->pre_commit_txn_cost_nanos = MonotonicNanos() - pre_commit_start_time;
-        } else {
-            // If put file success we need commit this load
-            int64_t commit_and_publish_start_time = MonotonicNanos();
-            ctx->status = _exec_env->stream_load_executor()->commit_txn(ctx.get());
-            ctx->commit_and_publish_txn_cost_nanos =
-                    MonotonicNanos() - commit_and_publish_start_time;
-        }
-    }
-    _send_reply(ctx, req);
-}
-
-void StreamLoadAction::_send_reply(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req) {
     ctx->load_cost_millis = UnixMillis() - ctx->start_millis;
 
     if (!ctx->status.ok() && !ctx->status.is<PUBLISH_TIMEOUT>()) {
-        LOG(WARNING) << "handle streaming load failed, id=" << ctx->id
-                     << ", errmsg=" << ctx->status;
         if (ctx->need_rollback) {
             _exec_env->stream_load_executor()->rollback_txn(ctx.get());
             ctx->need_rollback = false;
         }
-        if (ctx->body_sink != nullptr) {
+        if (ctx->body_sink.get() != nullptr) {
             ctx->body_sink->cancel(ctx->status.to_string());
         }
     }
@@ -187,6 +139,42 @@ void StreamLoadAction::_send_reply(std::shared_ptr<StreamLoadContext> ctx, HttpR
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
+}
+
+Status StreamLoadAction::_handle(std::shared_ptr<StreamLoadContext> ctx) {
+    if (ctx->body_bytes > 0 && ctx->receive_bytes != ctx->body_bytes) {
+        LOG(WARNING) << "recevie body don't equal with body bytes, body_bytes=" << ctx->body_bytes
+                     << ", receive_bytes=" << ctx->receive_bytes << ", id=" << ctx->id;
+        return Status::InternalError("receive body don't equal with body bytes");
+    }
+
+    // if we use non-streaming, MessageBodyFileSink.finish will close the file
+    RETURN_IF_ERROR(ctx->body_sink->finish());
+    if (!ctx->use_streaming) {
+        // we need to close file first, then execute_plan_fragment here
+        ctx->body_sink.reset();
+        RETURN_IF_ERROR(_exec_env->stream_load_executor()->execute_plan_fragment(ctx));
+    }
+
+    // wait stream load finish
+    RETURN_IF_ERROR(ctx->future.get());
+
+    if (ctx->group_commit) {
+        LOG(INFO) << "skip commit because this is group commit, pipe_id=" << ctx->id.to_string();
+        return Status::OK();
+    }
+
+    if (ctx->two_phase_commit) {
+        int64_t pre_commit_start_time = MonotonicNanos();
+        RETURN_IF_ERROR(_exec_env->stream_load_executor()->pre_commit_txn(ctx.get()));
+        ctx->pre_commit_txn_cost_nanos = MonotonicNanos() - pre_commit_start_time;
+    } else {
+        // If put file success we need commit this load
+        int64_t commit_and_publish_start_time = MonotonicNanos();
+        RETURN_IF_ERROR(_exec_env->stream_load_executor()->commit_txn(ctx.get()));
+        ctx->commit_and_publish_txn_cost_nanos = MonotonicNanos() - commit_and_publish_start_time;
+    }
+    return Status::OK();
 }
 
 int StreamLoadAction::on_header(HttpRequest* req) {
@@ -693,10 +681,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         return Status::OK();
     }
 
-    return _exec_env->stream_load_executor()->execute_plan_fragment(
-            ctx, [http_req, this](std::shared_ptr<StreamLoadContext> ctx) {
-                _on_finish(ctx, http_req);
-            });
+    return _exec_env->stream_load_executor()->execute_plan_fragment(ctx);
 }
 
 Status StreamLoadAction::_data_saved_path(HttpRequest* req, std::string* file_path) {

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -46,13 +46,11 @@ public:
 
 private:
     Status _on_header(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
-    Status _handle(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req);
+    Status _handle(std::shared_ptr<StreamLoadContext> ctx);
     Status _data_saved_path(HttpRequest* req, std::string* file_path);
     Status _process_put(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
     void _save_stream_load_record(std::shared_ptr<StreamLoadContext> ctx, const std::string& str);
     Status _handle_group_commit(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
-    void _on_finish(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req);
-    void _send_reply(std::shared_ptr<StreamLoadContext> ctx, HttpRequest* req);
 
 private:
     ExecEnv* _exec_env;

--- a/be/src/runtime/stream_load/stream_load_executor.h
+++ b/be/src/runtime/stream_load/stream_load_executor.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 
 #include "common/factory_creator.h"
@@ -51,10 +50,6 @@ public:
     virtual void rollback_txn(StreamLoadContext* ctx);
 
     Status execute_plan_fragment(std::shared_ptr<StreamLoadContext> ctx);
-
-    Status execute_plan_fragment(
-            std::shared_ptr<StreamLoadContext> ctx,
-            const std::function<void(std::shared_ptr<StreamLoadContext> ctx)>& cb);
 
 protected:
     // collect the load statistics from context and set them to stat


### PR DESCRIPTION
Reverts apache/doris#36772
It may cause some regression cases to fail. The general reason is that there were some abnormal when load load, this modification will return the HTTP response to the client in advance, but the client data has not been sent yet, which may cause some problems at this time.