### PR TITLE
 [Fix] Fix generated column, static variables should not be used in ExpressionToExpr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -732,14 +732,13 @@ public class CreateTableStmt extends DdlStmt {
             ColumnDef columnDef = columnDefs.get(i);
             nameToColumnDef.put(columnDef.getName(), Pair.of(columnDef, i));
         }
-        SlotRefRewriteRule.initializeslotRefMap(nameToColumnDef);
         List<GeneratedColumnUtil.ExprAndname> exprAndnames = Lists.newArrayList();
         for (int i = 0; i < columnDefs.size(); i++) {
             ColumnDef columnDef = columnDefs.get(i);
             if (!columnDef.getGeneratedColumnInfo().isPresent()) {
                 continue;
             }
-            SlotRefRewriteRule slotRefRewriteRule = new SlotRefRewriteRule(i);
+            SlotRefRewriteRule slotRefRewriteRule = new SlotRefRewriteRule(i, nameToColumnDef);
             ExprRewriter rewriter = new ExprRewriter(slotRefRewriteRule);
             GeneratedColumnInfo generatedColumnInfo = columnDef.getGeneratedColumnInfo().get();
             Expr expr = rewriter.rewrite(generatedColumnInfo.getExpr(), analyzer);
@@ -830,15 +829,12 @@ public class CreateTableStmt extends DdlStmt {
     }
 
     public static final class SlotRefRewriteRule implements ExprRewriteRule {
-        private static Map<String, Pair<ColumnDef, Integer>> nameToColumnDefMap = new HashMap<>();
+        private final Map<String, Pair<ColumnDef, Integer>> nameToColumnDefMap;
         private final int index;
 
-        public SlotRefRewriteRule(int index) {
+        public SlotRefRewriteRule(int index, Map<String, Pair<ColumnDef, Integer>> nameToColumnDefMap) {
             this.index = index;
-        }
-
-        public static void initializeslotRefMap(Map<String, Pair<ColumnDef, Integer>>  map) {
-            nameToColumnDefMap = map;
+            this.nameToColumnDefMap = nameToColumnDefMap;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -874,7 +874,6 @@ public class CreateTableInfo {
             slotRef.setType(column.getType().toCatalogDataType());
             translateMap.put(slot, new SlotRefAndIdx(slotRef, i, column.getGeneratedColumnDesc().isPresent()));
         }
-        ExpressionToExpr.initializeslotRefMap(translateMap);
         PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
         List<Slot> slots = Lists.newArrayList(columnToSlotReference.values());
         List<GeneratedColumnUtil.ExprAndname> exprAndnames = Lists.newArrayList();
@@ -898,7 +897,7 @@ public class CreateTableInfo {
             }
             checkExpressionInGeneratedColumn(expr, column, nameToColumnDefinition);
             TypeCoercionUtils.checkCanCastTo(expr.getDataType(), column.getType());
-            ExpressionToExpr translator = new ExpressionToExpr(i);
+            ExpressionToExpr translator = new ExpressionToExpr(i, translateMap);
             Expr e = expr.accept(translator, planTranslatorContext);
             info.get().setExpr(e);
             exprAndnames.add(new GeneratedColumnUtil.ExprAndname(e.clone(), column.getName()));
@@ -998,15 +997,12 @@ public class CreateTableInfo {
     }
 
     private static class ExpressionToExpr extends ExpressionTranslator {
-        private static Map<Slot, SlotRefAndIdx> slotRefMap;
+        private final Map<Slot, SlotRefAndIdx> slotRefMap;
         private final int index;
 
-        public ExpressionToExpr(int index) {
+        public ExpressionToExpr(int index, Map<Slot, SlotRefAndIdx> slotRefMap) {
             this.index = index;
-        }
-
-        public static void initializeslotRefMap(Map<Slot, SlotRefAndIdx> map) {
-            slotRefMap = map;
+            this.slotRefMap = slotRefMap;
         }
 
         @Override


### PR DESCRIPTION
introduced by #35284
Fix generated column, static variables should not be used in ExpressionToExpr. There is only one static variable slotRefMap in the ExpressionToExpr class globally. It may be used by multiple threads at the same time and assigned repeatedly, which is problematic. The same reason applies to the modification of class slotRefRewriteRule.
No regression case added because this problem does not occur every time.
