### PR TITLE
[fix](bitmap) incorrect type of BitmapValue with fastunion

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1307,7 +1307,6 @@ public:
             case SINGLE: {
                 _set.insert(_sv);
                 _type = SET;
-                _convert_to_bitmap_if_need();
                 break;
             }
             case BITMAP:
@@ -1318,9 +1317,11 @@ public:
                 _type = BITMAP;
                 break;
             case SET: {
-                _convert_to_bitmap_if_need();
                 break;
             }
+            }
+            if (_type == SET) {
+                _convert_to_bitmap_if_need();
             }
         }
 

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -871,6 +871,29 @@ TEST(BitmapValueTest, bitmap_union) {
     EXPECT_EQ(3, bitmap3.cardinality());
     bitmap3.fastunion({&bitmap});
     EXPECT_EQ(5, bitmap3.cardinality());
+
+    const auto old_config = config::enable_set_in_bitmap_value;
+    config::enable_set_in_bitmap_value = true;
+    BitmapValue bitmap4; // empty
+
+    BitmapValue bitmap_set1;
+    BitmapValue bitmap_set2;
+    BitmapValue bitmap_set3;
+
+    const int set_data1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    bitmap_set1.add_many(set_data1, 15);
+
+    const int set_data2[] = {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
+    bitmap_set2.add_many(set_data2, 15);
+
+    const int set_data3[] = {31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45};
+    bitmap_set3.add_many(set_data3, 15);
+
+    bitmap4.fastunion({&bitmap_set1, &bitmap_set2, &bitmap_set3});
+
+    EXPECT_EQ(bitmap4.cardinality(), 45);
+    EXPECT_EQ(bitmap4.get_type_code(), BitmapTypeCode::BITMAP32);
+    config::enable_set_in_bitmap_value = old_config;
 }
 
 TEST(BitmapValueTest, bitmap_intersect) {


### PR DESCRIPTION
## Proposed changes

```
*** Query id: de527a3dee814cda-84ccf1d0532e016c ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1719287583 (unix time) try "date -d @1719287583" if you are using GNU date ***
*** Current BE git commitID: d2b0cd5c18 ***
*** SIGABRT unknown detail explain (@0x19a1) received by PID 6561 (TID 8834 OR 0x7f5135bb2640) from PID 6561; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
 1# 0x00007F5BF6477520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055F384EFC2FD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# 0x000055F384EEE93A in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# doris::BitmapValue::deserialize(char const*) at /root/doris/be/src/util/bitmap_value.h:1916
11# doris::vectorized::DataTypeBitMap::deserialize(char const*, doris::vectorized::IColumn*, int) const at /root/doris/be/src/vec/data_types/data_type_bitmap.cpp:87
12# doris::vectorized::Block::deserialize(doris::PBlock const&) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
13# doris::vectorized::VDataStreamRecvr::SenderQueue::add_block(doris::PBlock const&, int, long, google::protobuf::Closure**) at /root/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:167
14# doris::vectorized::VDataStreamRecvr::add_block(doris::PBlock const&, int, int, long, google::protobuf::Closure**) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
15# doris::vectorized::VDataStreamMgr::transmit_block(doris::PTransmitDataParams const*, google::protobuf::Closure**) at /root/doris/be/src/vec/runtime/vdata_stream_mgr.cpp:139
16# doris::PInternalService::_transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*, doris::Status const&) at /root/doris/be/src/service/internal_service.cpp:1542
17# doris::PInternalService::transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*) at /root/doris/be/src/service/internal_service.cpp:1491
18# doris::PBackendService::CallMethod(google::protobuf::MethodDescriptor const*, google::protobuf::RpcController*, google::protobuf::Message const*, google::protobuf::Message*, google::protobuf::Closure*) at /root/doris/gensrc/build/gen_cpp/internal_service.pb.cc:42040
19# brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
20# brpc::ProcessInputMessage(void*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
21# brpc::InputMessenger::InputMessageClosure::~InputMessageClosure() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
22# brpc::InputMessenger::OnNewMessages(brpc::Socket*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
23# brpc::Socket::ProcessEvent(void*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
24# bthread::TaskGroup::task_runner(long) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
25# bthread_make_fcontext in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
```

<!--Describe your changes.-->

