### PR TITLE
[Fix](autoinc) Hanlde the processing of auto_increment column on exchange node rather than on TabletWriter when using `TABLET_SINK_SHUFFLE_PARTITIONED`

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -193,9 +193,12 @@ Status ExchangeSinkLocalState::open(RuntimeState* state) {
                 std::make_unique<vectorized::OlapTabletFinder>(_vpartition.get(), find_tablet_mode);
         _tablet_sink_tuple_desc = _state->desc_tbl().get_tuple_descriptor(p._tablet_sink_tuple_id);
         _tablet_sink_row_desc = p._pool->add(new RowDescriptor(_tablet_sink_tuple_desc, false));
-        //_block_convertor no need init_autoinc_info here
+        // if _part_type == TPartitionType::TABLET_SINK_SHUFFLE_PARTITIONED, we handle the processing of auto_increment column
+        // on exchange node rather than on TabletWriter
         _block_convertor =
                 std::make_unique<vectorized::OlapTableBlockConvertor>(_tablet_sink_tuple_desc);
+        _block_convertor->init_autoinc_info(_schema->db_id(), _schema->table_id(),
+                                            _state->batch_size());
         _location = p._pool->add(new OlapTableLocationParam(p._tablet_sink_location));
         _row_distribution.init(
                 {.state = _state,

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -183,8 +183,9 @@ DecimalType OlapTableBlockConvertor::_get_decimalv3_min_or_max(const TypeDescrip
 }
 
 Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const TypeDescriptor& type,
-                                                 bool is_nullable, vectorized::ColumnPtr column,
-                                                 size_t slot_index, bool* stop_processing,
+                                                 bool is_nullable, bool is_auto_inc,
+                                                 vectorized::ColumnPtr column, size_t slot_index,
+                                                 bool* stop_processing,
                                                  fmt::memory_buffer& error_prefix,
                                                  const uint32_t row_count,
                                                  vectorized::IColumn::Permutation* rows) {
@@ -383,7 +384,7 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
             }
         }
         fmt::format_to(error_prefix, "ARRAY type failed: ");
-        RETURN_IF_ERROR(_validate_column(state, nested_type, type.contains_nulls[0],
+        RETURN_IF_ERROR(_validate_column(state, nested_type, type.contains_nulls[0], false,
                                          column_array->get_data_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
         break;
@@ -401,10 +402,10 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
             }
         }
         fmt::format_to(error_prefix, "MAP type failed: ");
-        RETURN_IF_ERROR(_validate_column(state, key_type, type.contains_nulls[0],
+        RETURN_IF_ERROR(_validate_column(state, key_type, type.contains_nulls[0], false,
                                          column_map->get_keys_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
-        RETURN_IF_ERROR(_validate_column(state, val_type, type.contains_nulls[1],
+        RETURN_IF_ERROR(_validate_column(state, val_type, type.contains_nulls[1], false,
                                          column_map->get_values_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
         break;
@@ -416,7 +417,7 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
         fmt::format_to(error_prefix, "STRUCT type failed: ");
         for (size_t sc = 0; sc < column_struct->tuple_size(); ++sc) {
             RETURN_IF_ERROR(_validate_column(state, type.children[sc], type.contains_nulls[sc],
-                                             column_struct->get_column_ptr(sc), slot_index,
+                                             false, column_struct->get_column_ptr(sc), slot_index,
                                              stop_processing, error_prefix,
                                              column_struct->get_column_ptr(sc)->size()));
         }
@@ -435,9 +436,9 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
 
     // Dispose the column should do not contain the NULL value
     // Only two case:
-    // 1. column is nullable but the desc is not nullable
+    // 1. column is nullable but the desc is not nullable (column is not auto-increment column)
     // 2. desc->type is BITMAP
-    if ((!is_nullable || type == TYPE_OBJECT) && column_ptr) {
+    if ((!is_nullable || type == TYPE_OBJECT) && column_ptr && !is_auto_inc) {
         for (int j = 0; j < row_count; ++j) {
             auto row = rows ? (*rows)[j] : j;
             if (null_map[j] && !_filter_map[row]) {
@@ -462,8 +463,9 @@ Status OlapTableBlockConvertor::_validate_data(RuntimeState* state, vectorized::
 
         fmt::memory_buffer error_prefix;
         fmt::format_to(error_prefix, "column_name[{}], ", desc->col_name());
-        RETURN_IF_ERROR(_validate_column(state, desc->type(), desc->is_nullable(), column, i,
-                                         stop_processing, error_prefix, rows));
+        RETURN_IF_ERROR(_validate_column(state, desc->type(), desc->is_nullable(),
+                                         desc->is_auto_increment(), column, i, stop_processing,
+                                         error_prefix, rows));
     }
 
     filtered_rows = 0;
@@ -476,6 +478,9 @@ Status OlapTableBlockConvertor::_validate_data(RuntimeState* state, vectorized::
 void OlapTableBlockConvertor::_convert_to_dest_desc_block(doris::vectorized::Block* block) {
     for (int i = 0; i < _output_tuple_desc->slots().size() && i < block->columns(); ++i) {
         SlotDescriptor* desc = _output_tuple_desc->slots()[i];
+        if (desc->is_auto_increment()) {
+            continue;
+        }
         if (desc->is_nullable() != block->get_by_position(i).type->is_nullable()) {
             if (desc->is_nullable()) {
                 block->get_by_position(i).type =
@@ -505,8 +510,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
 
     vectorized::ColumnPtr src_column_ptr = block->get_by_position(idx).column;
-    if (const vectorized::ColumnConst* const_column =
-                check_and_get_column<vectorized::ColumnConst>(src_column_ptr)) {
+    if (const auto* const_column = check_and_get_column<vectorized::ColumnConst>(src_column_ptr)) {
         // for insert stmt like "insert into tbl1 select null,col1,col2,... from tbl2" or
         // "insert into tbl1 select 1,col1,col2,... from tbl2", the type of literal's column
         // will be `ColumnConst`
@@ -529,7 +533,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
             int64_t value = const_column->get_int(0);
             dst_values.resize_fill(rows, value);
         }
-    } else if (const vectorized::ColumnNullable* src_nullable_column =
+    } else if (const auto* src_nullable_column =
                        check_and_get_column<vectorized::ColumnNullable>(src_column_ptr)) {
         auto src_nested_column_ptr = src_nullable_column->get_nested_column_ptr();
         const auto& null_map_data = src_nullable_column->get_null_map_data();

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -183,9 +183,8 @@ DecimalType OlapTableBlockConvertor::_get_decimalv3_min_or_max(const TypeDescrip
 }
 
 Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const TypeDescriptor& type,
-                                                 bool is_nullable, bool is_auto_inc,
-                                                 vectorized::ColumnPtr column, size_t slot_index,
-                                                 bool* stop_processing,
+                                                 bool is_nullable, vectorized::ColumnPtr column,
+                                                 size_t slot_index, bool* stop_processing,
                                                  fmt::memory_buffer& error_prefix,
                                                  const uint32_t row_count,
                                                  vectorized::IColumn::Permutation* rows) {
@@ -384,7 +383,7 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
             }
         }
         fmt::format_to(error_prefix, "ARRAY type failed: ");
-        RETURN_IF_ERROR(_validate_column(state, nested_type, type.contains_nulls[0], false,
+        RETURN_IF_ERROR(_validate_column(state, nested_type, type.contains_nulls[0],
                                          column_array->get_data_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
         break;
@@ -402,10 +401,10 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
             }
         }
         fmt::format_to(error_prefix, "MAP type failed: ");
-        RETURN_IF_ERROR(_validate_column(state, key_type, type.contains_nulls[0], false,
+        RETURN_IF_ERROR(_validate_column(state, key_type, type.contains_nulls[0],
                                          column_map->get_keys_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
-        RETURN_IF_ERROR(_validate_column(state, val_type, type.contains_nulls[1], false,
+        RETURN_IF_ERROR(_validate_column(state, val_type, type.contains_nulls[1],
                                          column_map->get_values_ptr(), slot_index, stop_processing,
                                          error_prefix, permutation.size(), &permutation));
         break;
@@ -417,7 +416,7 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
         fmt::format_to(error_prefix, "STRUCT type failed: ");
         for (size_t sc = 0; sc < column_struct->tuple_size(); ++sc) {
             RETURN_IF_ERROR(_validate_column(state, type.children[sc], type.contains_nulls[sc],
-                                             false, column_struct->get_column_ptr(sc), slot_index,
+                                             column_struct->get_column_ptr(sc), slot_index,
                                              stop_processing, error_prefix,
                                              column_struct->get_column_ptr(sc)->size()));
         }
@@ -436,9 +435,9 @@ Status OlapTableBlockConvertor::_validate_column(RuntimeState* state, const Type
 
     // Dispose the column should do not contain the NULL value
     // Only two case:
-    // 1. column is nullable but the desc is not nullable (column is not auto-increment column)
+    // 1. column is nullable but the desc is not nullable
     // 2. desc->type is BITMAP
-    if ((!is_nullable || type == TYPE_OBJECT) && column_ptr && !is_auto_inc) {
+    if ((!is_nullable || type == TYPE_OBJECT) && column_ptr) {
         for (int j = 0; j < row_count; ++j) {
             auto row = rows ? (*rows)[j] : j;
             if (null_map[j] && !_filter_map[row]) {
@@ -463,9 +462,8 @@ Status OlapTableBlockConvertor::_validate_data(RuntimeState* state, vectorized::
 
         fmt::memory_buffer error_prefix;
         fmt::format_to(error_prefix, "column_name[{}], ", desc->col_name());
-        RETURN_IF_ERROR(_validate_column(state, desc->type(), desc->is_nullable(),
-                                         desc->is_auto_increment(), column, i, stop_processing,
-                                         error_prefix, rows));
+        RETURN_IF_ERROR(_validate_column(state, desc->type(), desc->is_nullable(), column, i,
+                                         stop_processing, error_prefix, rows));
     }
 
     filtered_rows = 0;
@@ -478,9 +476,6 @@ Status OlapTableBlockConvertor::_validate_data(RuntimeState* state, vectorized::
 void OlapTableBlockConvertor::_convert_to_dest_desc_block(doris::vectorized::Block* block) {
     for (int i = 0; i < _output_tuple_desc->slots().size() && i < block->columns(); ++i) {
         SlotDescriptor* desc = _output_tuple_desc->slots()[i];
-        if (desc->is_auto_increment()) {
-            continue;
-        }
         if (desc->is_nullable() != block->get_by_position(i).type->is_nullable()) {
             if (desc->is_nullable()) {
                 block->get_by_position(i).type =

--- a/be/src/vec/sink/vtablet_block_convertor.h
+++ b/be/src/vec/sink/vtablet_block_convertor.h
@@ -67,9 +67,8 @@ private:
     DecimalType _get_decimalv3_min_or_max(const TypeDescriptor& type);
 
     Status _validate_column(RuntimeState* state, const TypeDescriptor& type, bool is_nullable,
-                            bool is_auto_inc, vectorized::ColumnPtr column, size_t slot_index,
-                            bool* stop_processing, fmt::memory_buffer& error_prefix,
-                            const uint32_t row_count,
+                            vectorized::ColumnPtr column, size_t slot_index, bool* stop_processing,
+                            fmt::memory_buffer& error_prefix, const uint32_t row_count,
                             vectorized::IColumn::Permutation* rows = nullptr);
 
     // make input data valid for OLAP table

--- a/be/src/vec/sink/vtablet_block_convertor.h
+++ b/be/src/vec/sink/vtablet_block_convertor.h
@@ -67,8 +67,9 @@ private:
     DecimalType _get_decimalv3_min_or_max(const TypeDescriptor& type);
 
     Status _validate_column(RuntimeState* state, const TypeDescriptor& type, bool is_nullable,
-                            vectorized::ColumnPtr column, size_t slot_index, bool* stop_processing,
-                            fmt::memory_buffer& error_prefix, const uint32_t row_count,
+                            bool is_auto_inc, vectorized::ColumnPtr column, size_t slot_index,
+                            bool* stop_processing, fmt::memory_buffer& error_prefix,
+                            const uint32_t row_count,
                             vectorized::IColumn::Permutation* rows = nullptr);
 
     // make input data valid for OLAP table

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1197,6 +1197,8 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
     }
 
     _block_convertor = std::make_unique<OlapTableBlockConvertor>(_output_tuple_desc);
+    // if partition_type is TABLET_SINK_SHUFFLE_PARTITIONED, we handle the processing of auto_increment column
+    // on exchange node rather than on TabletWriter
     _block_convertor->init_autoinc_info(
             _schema->db_id(), _schema->table_id(), _state->batch_size(),
             _schema->is_partial_update() && !_schema->auto_increment_coulumn().empty(),

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -214,6 +214,8 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
     }
 
     _block_convertor = std::make_unique<OlapTableBlockConvertor>(_output_tuple_desc);
+    // if partition_type is TABLET_SINK_SHUFFLE_PARTITIONED, we handle the processing of auto_increment column
+    // on exchange node rather than on TabletWriter
     _block_convertor->init_autoinc_info(
             _schema->db_id(), _schema->table_id(), _state->batch_size(),
             _schema->is_partial_update() && !_schema->auto_increment_coulumn().empty(),

--- a/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
+++ b/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
@@ -223,26 +223,32 @@ NNereids	9998
 3	C
 
 -- !sql --
-1	A
-2	B
-3	C
-4	b
-5	c
-6	a
+6	6
 
 -- !sql --
-1	A
-2	B
-3	C
-4	b
-5	c
-6	a
-7	Jack
-8	Jack
-9	Jack
-10	Jack
-11	Jack
-12	Jack
+A
+B
+C
+a
+b
+c
+
+-- !sql --
+12	12
+
+-- !sql --
+A
+B
+C
+Jack
+Jack
+Jack
+Jack
+Jack
+Jack
+a
+b
+c
 
 -- !ql --
 \N	Alice
@@ -252,21 +258,24 @@ NNereids	9998
 300	Bob
 
 -- !sql --
-1	A
-2	B
-3	C
-4	b
-5	c
-6	a
-7	Jack
-8	Jack
-9	Jack
-10	Jack
-11	Jack
-12	Jack
-13	Steve
-14	Alice
-15	Mick
-100	John
-300	Bob
+17	17
+
+-- !sql --
+A
+Alice
+B
+Bob
+C
+Jack
+Jack
+Jack
+Jack
+Jack
+Jack
+John
+Mick
+Steve
+a
+b
+c
 

--- a/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
+++ b/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
@@ -217,3 +217,56 @@ NNereids	9998
 3	test1	test2
 4	test3	test4
 
+-- !sql --
+1	A
+2	B
+3	C
+
+-- !sql --
+1	A
+2	B
+3	C
+4	b
+5	c
+6	a
+
+-- !sql --
+1	A
+2	B
+3	C
+4	b
+5	c
+6	a
+7	Jack
+8	Jack
+9	Jack
+10	Jack
+11	Jack
+12	Jack
+
+-- !ql --
+\N	Alice
+\N	Mick
+\N	Steve
+100	John
+300	Bob
+
+-- !sql --
+1	A
+2	B
+3	C
+4	b
+5	c
+6	a
+7	Jack
+8	Jack
+9	Jack
+10	Jack
+11	Jack
+12	Jack
+13	Steve
+14	Alice
+15	Mick
+100	John
+300	Bob
+

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
@@ -425,5 +425,40 @@ suite("test_unique_table_auto_inc") {
     sql """insert into ${table12} select r_regionkey, "test3", "test4" from ${table12} where r_regionkey=4;"""
     qt_sql "select * from ${table12} order by r_regionkey;"
     sql "drop table if exists ${table12};"
+
+
+    def table13 = "test_unique_tab_auto_inc_col_insert_select3"
+    sql "drop table if exists ${table13}"
+    sql """ CREATE TABLE ${table13} (
+        mykey BIGINT NOT NULL AUTO_INCREMENT,
+        name VARCHAR(64)
+        ) UNIQUE KEY(mykey)
+        DISTRIBUTED BY HASH(mykey)
+        BUCKETS AUTO PROPERTIES("replication_num" = "1"); """
+    def table14 = "test_unique_tab_auto_inc_col_insert_select4"
+    sql "drop table if exists ${table14}"
+    sql """ CREATE TABLE ${table14} (
+        mykey BIGINT NULL,
+        name VARCHAR(64)
+        ) DUPLICATE KEY(mykey)
+        DISTRIBUTED BY HASH(mykey)
+        BUCKETS AUTO PROPERTIES("replication_num" = "1"); """
+    
+    sql """insert into ${table13}(name) values("A"), ("B"), ("C")"""
+    qt_sql "select * from ${table13} order by mykey;"
+    sql """insert into ${table13}(name) select lower(name) from ${table13};"""
+    qt_sql "select * from ${table13} order by mykey;"
+    sql """ insert into ${table13}(name) select "Jack" as name from ${table13};"""
+    qt_sql "select * from ${table13} order by mykey;"
+    
+    sql """ insert into ${table14} values
+    (100,"John"), (null, "Mick"), (300, "Bob"), (null, "Alice"), (null, "Steve");"""
+    qt_ql "select * from ${table14} order by mykey, name;"
+    sql """ insert into ${table13} select mykey, name from ${table14};"""
+    qt_sql "select * from ${table13} order by mykey;"
+
+    sql "drop table if exists ${table13};"
+    sql "drop table if exists ${table14};"
+    
 }
 

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
@@ -447,15 +447,18 @@ suite("test_unique_table_auto_inc") {
     sql """insert into ${table13}(name) values("A"), ("B"), ("C")"""
     qt_sql "select * from ${table13} order by mykey;"
     sql """insert into ${table13}(name) select lower(name) from ${table13};"""
-    qt_sql "select * from ${table13} order by mykey;"
+    qt_sql """ select count(mykey), count(distinct mykey) from ${table13}"""
+    qt_sql "select name from ${table13} order by name;"
     sql """ insert into ${table13}(name) select "Jack" as name from ${table13};"""
-    qt_sql "select * from ${table13} order by mykey;"
+    qt_sql """ select count(mykey), count(distinct mykey) from ${table13}"""
+    qt_sql "select name from ${table13} order by name;"
     
     sql """ insert into ${table14} values
     (100,"John"), (null, "Mick"), (300, "Bob"), (null, "Alice"), (null, "Steve");"""
     qt_ql "select * from ${table14} order by mykey, name;"
     sql """ insert into ${table13} select mykey, name from ${table14};"""
-    qt_sql "select * from ${table13} order by mykey;"
+    qt_sql """ select count(mykey), count(distinct mykey) from ${table13}"""
+    qt_sql "select name from ${table13} order by name;"
 
     sql "drop table if exists ${table13};"
     sql "drop table if exists ${table14};"


### PR DESCRIPTION
## Proposed changes

Issue Number: close #36638

https://github.com/apache/doris/pull/30914 add partition tablet sink shuffle and the processing of auto_increment column should be handled on exchange node raher than TabletWriter when using partition tablet sink shuffle.

branch-2.1-pick: https://github.com/apache/doris/pull/37029

