### PR TITLE
[BugFix](VScanner) fix file scanner is still running when the query is timeout/killed

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -235,6 +235,7 @@ void VFileScanner::_get_slot_ids(VExpr* expr, std::vector<int>* slot_ids) {
 }
 
 Status VFileScanner::open(RuntimeState* state) {
+    RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(VScanner::open(state));
     RETURN_IF_ERROR(_init_expr_ctxes());
 
@@ -271,6 +272,7 @@ Status VFileScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eo
 // _convert_to_output_block     -     -    -  -                 -                -      x
 Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool* eof) {
     do {
+        RETURN_IF_CANCELLED(state);
         if (_cur_reader == nullptr || _cur_reader_eof) {
             RETURN_IF_ERROR(_get_next_reader());
         }


### PR DESCRIPTION
## Proposed changes

fix file scanner is still running when the query is timeout/killed. (master branch is fixed)
<!--Describe your changes.-->

