### PR TITLE
[fix](cloud) Fix loss some tag info in cloud

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -20,6 +20,7 @@ package org.apache.doris.system;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.DiskInfo.DiskState;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.io.Text;
@@ -184,7 +185,7 @@ public class Backend implements Writable {
     }
 
     public String getCloudClusterStatus() {
-        return tagMap.getOrDefault(Tag.CLOUD_CLUSTER_STATUS, "");
+        return tagMap.getOrDefault(Tag.CLOUD_CLUSTER_STATUS, String.valueOf(Cloud.ClusterStatus.UNKNOWN));
     }
 
     public void setCloudClusterStatus(final String clusterStatus) {


### PR DESCRIPTION
in cloud， rarely encountered online, but does exist

1. new cluster's bes before added by cloudclusterchecker
2. user use sql `use @cluster`
    2. 1 add be(taginfo) to system (miss info)
3. cluster's bes will not be added again by cloudclusterchecker
