### PR TITLE
[fix](statistics) External table partition stats improve and add test case.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -247,8 +247,8 @@ public class ShowColumnStatsStmt extends ShowStmt {
             row.add(String.valueOf(value.count)); // count
             row.add(String.valueOf(value.ndv.estimateCardinality())); // ndv
             row.add(String.valueOf(value.numNulls)); // num_null
-            row.add(String.valueOf(value.minValue)); // min
-            row.add(String.valueOf(value.maxValue)); // max
+            row.add(String.valueOf(value.minExpr == null ? "N/A" : value.minExpr.toSql())); // min
+            row.add(String.valueOf(value.maxExpr == null ? "N/A" : value.maxExpr.toSql())); // max
             row.add(String.valueOf(value.dataSize)); // data_size
             row.add(value.updatedTime); // updated_time
             row.add("N/A"); // update_rows

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HMSAnalysisTask.java
@@ -19,7 +19,6 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
@@ -282,8 +281,7 @@ public class HMSAnalysisTask extends ExternalAnalysisTask {
         if (tableStats == null) {
             return;
         }
-        OlapTable table = (OlapTable) tbl;
-        String indexName = info.indexId == -1 ? table.getName() : table.getIndexNameById(info.indexId);
+        String indexName = table.getName();
         ColStatsMeta columnStats = tableStats.findColumnStatsMeta(indexName, info.colName);
         if (columnStats == null) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -105,7 +105,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         double scaleFactor = (double) totalRowCount / (double) pair.second;
         // might happen if row count in fe metadata hasn't been updated yet
         if (Double.isInfinite(scaleFactor) || Double.isNaN(scaleFactor)) {
-            LOG.warn("Scale factor is infinite or Nan, will set scale factor to 1.");
+            LOG.debug("Scale factor is infinite or Nan, will set scale factor to 1.");
             scaleFactor = 1;
             tabletIds = Collections.emptyList();
             pair.second = totalRowCount;

--- a/regression-test/suites/statistics/test_external_partition.groovy
+++ b/regression-test/suites/statistics/test_external_partition.groovy
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_external_partition") {
+
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disabled Hive test.")
+        return;
+    }
+
+    def enabled_partition = sql """show variables like "%enable_partition_analyze%" """
+    if (enabled_partition[0][1].equalsIgnoreCase("false")) {
+        logger.info("partition analyze disabled. " + enabled_partition)
+        return;
+    }
+
+    String hms_port = context.config.otherConfigs.get("hive2HmsPort")
+    String catalog_name = "${hivePrefix}_test_partitions"
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+
+    sql """drop catalog if exists ${catalog_name}"""
+    sql """create catalog if not exists ${catalog_name} properties (
+        "type"="hms",
+        'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+    );"""
+    sql """use `${catalog_name}`.`default`"""
+    sql """analyze table partition_table with sync"""
+    def result = sql """show column stats partition_table;"""
+    assertEquals(18, result.size())
+    result = sql """show column cached stats partition_table;"""
+    assertEquals(18, result.size())
+    result = sql """show column stats partition_table partition(*);"""
+    assertEquals(108, result.size())
+    result = sql """show column cached stats partition_table partition(*);"""
+    assertEquals(108, result.size())
+
+    result = sql """show column stats partition_table(l_orderkey)"""
+    assertEquals(1, result.size())
+    assertEquals("9995.0", result[0][2])
+    assertEquals("2506.0", result[0][3])
+    assertEquals("0.0", result[0][4])
+    assertEquals("1", result[0][7])
+    assertEquals("10050", result[0][8])
+
+    result = sql """show column stats partition_table(l_orderkey) partition(`nation=cn/city=beijing`);"""
+    assertEquals(1, result.size())
+    assertEquals("l_orderkey", result[0][0])
+    assertEquals("nation=cn/city=beijing", result[0][1])
+    assertEquals("partition_table", result[0][2])
+    assertEquals("2003", result[0][3])
+    assertEquals("501", result[0][4])
+    assertEquals("0", result[0][5])
+    assertEquals("1", result[0][6])
+    assertEquals("1991", result[0][7])
+
+    result = sql """show column cached stats partition_table(l_orderkey) partition(`nation=cn/city=beijing`);"""
+    assertEquals(1, result.size())
+    assertEquals("l_orderkey", result[0][0])
+    assertEquals("nation=cn/city=beijing", result[0][1])
+    assertEquals("partition_table", result[0][2])
+    assertEquals("2003.0", result[0][3])
+    assertEquals("534", result[0][4])
+    assertEquals("0.0", result[0][5])
+    assertEquals("1", result[0][6])
+    assertEquals("1991", result[0][7])
+
+    sql """drop stats partition_table partition(`nation=cn/city=beijing`)"""
+    result = sql """show column stats partition_table  partition(`nation=cn/city=beijing`)"""
+    assertEquals(0, result.size())
+    result = sql """show column cached stats partition_table  partition(`nation=cn/city=beijing`)"""
+    assertEquals(0, result.size())
+
+    sql """drop stats partition_table"""
+    sql """analyze table partition_table partition(`nation=cn/city=beijing`) with sync"""
+    result = sql """show column stats partition_table  partition(`nation=cn/city=beijing`)"""
+    assertEquals(18, result.size())
+    result = sql """show column cached stats partition_table  partition(`nation=cn/city=beijing`)"""
+    assertEquals(18, result.size())
+    result = sql """show column stats partition_table  partition(*)"""
+    assertEquals(18, result.size())
+    result = sql """show column cached stats partition_table  partition(*)"""
+    assertEquals(18, result.size())
+
+    sql """drop catalog if exists ${catalog_name}"""
+}
+

--- a/regression-test/suites/statistics/test_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_partition_stats.groovy
@@ -128,8 +128,8 @@ suite("test_partition_stats") {
     assertEquals("6.0", result[0][3])
     assertEquals("6", result[0][4])
     assertEquals("0.0", result[0][5])
-    assertEquals("1.0", result[0][6])
-    assertEquals("6.0", result[0][7])
+    assertEquals("1", result[0][6])
+    assertEquals("6", result[0][7])
     assertEquals("24.0", result[0][8])
     assertEquals("N/A", result[0][10])
     assertEquals("N/A", result[0][11])
@@ -516,8 +516,8 @@ suite("test_partition_stats") {
     assertEquals("12.0", result[0][3])
     assertEquals("6", result[0][4])
     assertEquals("0.0", result[0][5])
-    assertEquals("1.0", result[0][6])
-    assertEquals("6.0", result[0][7])
+    assertEquals("1", result[0][6])
+    assertEquals("6", result[0][7])
     assertEquals("48.0", result[0][8])
     sql """drop stats part5 partition(p1)"""
     result = sql """show column cached stats part5(id) partition(p1)"""


### PR DESCRIPTION
Add test case for analyze hive external partition table.
Fix a bug of cast HMSExternalTable to OlapTable