### PR TITLE
[Fix](hive-writer) Fixed the issue where `uncompletedMpuPendingUploads` did not remove objects correctly.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -103,6 +103,24 @@ public class HMSTransaction implements Transaction {
             this.s3MPUPendingUpload = s3MPUPendingUpload;
             this.path = path;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            UncompletedMpuPendingUpload that = (UncompletedMpuPendingUpload) o;
+            return Objects.equals(s3MPUPendingUpload, that.s3MPUPendingUpload) && Objects.equals(path,
+                    that.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(s3MPUPendingUpload, path);
+        }
     }
 
     private Set<UncompletedMpuPendingUpload> uncompletedMpuPendingUploads = new HashSet<>();


### PR DESCRIPTION
## Proposed changes

[Fix](hive-writer) Fixed the issue where `uncompletedMpuPendingUploads` did not remove objects correctly.

