### PR TITLE
[opt](profile) Better profile eject strategy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -76,8 +76,6 @@ public class ExecutionProfile {
     private Map<Integer, RuntimeProfile> fragmentProfiles;
     // Profile for load channels. Only for load job.
     private RuntimeProfile loadChannelProfile;
-    // FragmentId -> InstanceId -> RuntimeProfile
-    private Map<PlanFragmentId, Map<TUniqueId, RuntimeProfile>> fragmentInstancesProfiles;
 
     // use to merge profile from multi be
     private Map<Integer, Map<TNetworkAddress, List<RuntimeProfile>>> multiBeProfile = null;
@@ -85,8 +83,6 @@ public class ExecutionProfile {
     // Not serialize this property, it is only used to get profile id.
     private SummaryProfile summaryProfile;
 
-    // BE only has instance id, does not have fragmentid, so should use this map to find fragmentid.
-    private Map<TUniqueId, PlanFragmentId> instanceIdToFragmentId;
     private Map<Integer, Integer> fragmentIdBeNum;
     private Map<Integer, Integer> seqNoToFragmentId;
 
@@ -112,8 +108,6 @@ public class ExecutionProfile {
         }
         loadChannelProfile = new RuntimeProfile("LoadChannels");
         root.addChild(loadChannelProfile);
-        fragmentInstancesProfiles = Maps.newHashMap();
-        instanceIdToFragmentId = Maps.newHashMap();
     }
 
     private List<List<RuntimeProfile>> getMultiBeProfile(int fragmentId) {
@@ -299,23 +293,6 @@ public class ExecutionProfile {
         multiBeProfile.get(params.fragment_id).put(backend.getHeartbeatAddress(), taskProfile);
     }
 
-    // MultiInstances may update the profile concurrently
-    public synchronized void addInstanceProfile(PlanFragmentId fragmentId, TUniqueId instanceId,
-            RuntimeProfile instanceProfile) {
-        Map<TUniqueId, RuntimeProfile> instanceProfiles = fragmentInstancesProfiles.get(fragmentId);
-        if (instanceProfiles == null) {
-            instanceProfiles = Maps.newHashMap();
-            fragmentInstancesProfiles.put(fragmentId, instanceProfiles);
-        }
-        RuntimeProfile existingInstanceProfile = instanceProfiles.get(instanceId);
-        if (existingInstanceProfile == null) {
-            instanceProfiles.put(instanceId, instanceProfile);
-            instanceIdToFragmentId.put(instanceId, fragmentId);
-            fragmentProfiles.get(fragmentId.asInt()).addChild(instanceProfile);
-            return;
-        }
-    }
-
     public synchronized void addFragmentBackend(PlanFragmentId fragmentId, Long backendId) {
         fragmentIdBeNum.put(fragmentId.asInt(), fragmentIdBeNum.get(fragmentId.asInt()) + 1);
     }
@@ -359,4 +336,14 @@ public class ExecutionProfile {
     public void setSummaryProfile(SummaryProfile summaryProfile) {
         this.summaryProfile = summaryProfile;
     }
+
+    // This method is for test only
+    public void setFragmentProfiles(Map<Integer, RuntimeProfile> fragmentProfiles) {
+        this.fragmentProfiles = fragmentProfiles;
+    }
+    
+    public void setFragmentIdBeNum(Map<Integer, Integer> fragmentIdBeNum) {
+        this.fragmentIdBeNum = fragmentIdBeNum;
+    }
+    
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -58,10 +58,15 @@ public class Profile {
     private final String name;
     private SummaryProfile summaryProfile;
     private List<ExecutionProfile> executionProfiles = Lists.newArrayList();
-    private boolean isFinished;
+    private boolean isFinished = false;
     private Map<Integer, String> planNodeMap;
 
     private int profileLevel = 3;
+
+    // The constructor is for UT usage
+    public Profile(String name) {
+        this.name = name;
+    }
 
     public Profile(String name, boolean isEnable, int profileLevel) {
         this.name = name;
@@ -198,5 +203,19 @@ public class Profile {
         RuntimeProfile rootProfile = composeRootProfile();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(rootProfile.toBrief());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    // If there is no execution profile, it will be regarded as completed.
+    public boolean isComplete() {
+        return this.executionProfiles.stream().allMatch(ExecutionProfile::isCompleted);
+    }
+
+    // For UT
+    public void setSummaryProfile(SummaryProfile summaryProfile) {
+        this.summaryProfile = summaryProfile;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -58,10 +58,15 @@ public class Profile {
     private final String name;
     private SummaryProfile summaryProfile;
     private List<ExecutionProfile> executionProfiles = Lists.newArrayList();
-    private boolean isFinished;
+    private boolean isFinished = false;
     private Map<Integer, String> planNodeMap;
 
     private int profileLevel = 3;
+
+    // The constructor is for UT usage
+    public Profile(String name) {
+        this.name = name;
+    }
 
     public Profile(String name, boolean isEnable, int profileLevel) {
         this.name = name;
@@ -198,5 +203,10 @@ public class Profile {
         RuntimeProfile rootProfile = composeRootProfile();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(rootProfile.toBrief());
+    }
+
+    // For UT
+    public void setSummaryProfile(SummaryProfile summaryProfile) {
+        this.summaryProfile = summaryProfile;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -147,7 +147,7 @@ public class SummaryProfile {
             WRITE_RESULT_TIME,
             DORIS_VERSION,
             IS_NEREIDS,
-                    IS_CACHED,
+            IS_CACHED,
             TOTAL_INSTANCES_NUM,
             INSTANCES_NUM_PER_BE,
             PARALLEL_FRAGMENT_EXEC_INSTANCE,
@@ -276,6 +276,18 @@ public class SummaryProfile {
         }
         for (String key : EXECUTION_SUMMARY_KEYS) {
             executionSummaryProfile.addInfoString(key, "N/A");
+        }
+    }
+
+    // This method is for UT usage
+    public void fuzzyInit() {
+        for (String key : SUMMARY_KEYS) {
+            String randomId = String.valueOf(TimeUtils.getStartTimeMs());
+            summaryProfile.addInfoString(key, randomId);
+        }
+        for (String key : EXECUTION_SUMMARY_KEYS) {
+            String randomId = String.valueOf(TimeUtils.getStartTimeMs());
+            executionSummaryProfile.addInfoString(key, randomId);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -279,6 +279,18 @@ public class SummaryProfile {
         }
     }
 
+    // This method is for UT usage
+    public void fuzzyInit() {
+        for (String key : SUMMARY_KEYS) {
+            String randomId = String.valueOf(TimeUtils.getStartTimeMs());
+            summaryProfile.addInfoString(key, randomId);
+        }
+        for (String key : EXECUTION_SUMMARY_KEYS) {
+            String randomId = String.valueOf(TimeUtils.getStartTimeMs());
+            executionSummaryProfile.addInfoString(key, randomId);
+        }
+    }
+
     public void prettyPrint(StringBuilder builder) {
         summaryProfile.prettyPrint(builder, "");
         executionSummaryProfile.prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -45,7 +45,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import cfjd.com.google.common.collect.Sets;
 
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
@@ -57,13 +56,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -44,8 +44,6 @@ import org.apache.doris.thrift.TUniqueId;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -44,6 +44,9 @@ import org.apache.doris.thrift.TUniqueId;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import cfjd.com.google.common.collect.Sets;
+
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,11 +57,13 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -199,6 +204,20 @@ public class ProfileManager {
         return this.queryIdToExecutionProfiles.get(queryId);
     }
 
+    public String debugAllProfile() {
+        StringBuilder sb = new StringBuilder();
+        readLock.lock();
+        try {
+            for (Map.Entry<String, ProfileElement> entry : queryIdToProfileMap.entrySet()) {
+                sb.append("ProfileId: ").append(entry.getKey()).append("\n");
+                // sb.append(entry.getValue().getProfileContent()).append("\n");
+            }
+        } finally {
+            readLock.unlock();
+        }
+        return sb.toString();
+    }
+
     public void pushProfile(Profile profile) {
         if (profile == null) {
             return;
@@ -220,20 +239,57 @@ public class ProfileManager {
         try {
             if (!queryIdDeque.contains(key)) {
                 if (queryIdDeque.size() >= Config.max_query_profile_num) {
-                    ProfileElement profileElementRemoved = queryIdToProfileMap.remove(queryIdDeque.getFirst());
-                    // If the Profile object is removed from manager, then related execution profile is also useless.
-                    if (profileElementRemoved != null) {
-                        for (ExecutionProfile executionProfile : profileElementRemoved.profile.getExecutionProfiles()) {
-                            this.queryIdToExecutionProfiles.remove(executionProfile.getQueryId());
-                        }
+                    List<String> toEject = collectProfilesNeedToBeEjected();
+                    for (String tmp : toEject) {
+                        LOG.info("Eject outdated profile: {}", tmp);
+                        queryIdToProfileMap.remove(tmp);
+                        queryIdDeque.remove(tmp);
                     }
-                    queryIdDeque.removeFirst();
                 }
                 queryIdDeque.addLast(key);
             }
         } finally {
             writeLock.unlock();
         }
+    }
+
+    private List<String> collectProfilesNeedToBeEjected() {
+        if (!writeLock.isHeldByCurrentThread()) {
+            return Lists.newArrayList();
+        }
+
+        int count = queryIdDeque.size() - Config.max_query_profile_num;
+
+        if (count <= 0) {
+            return Lists.newArrayList();
+        }
+        
+        List<String> toEject = Lists.newArrayList();
+        Iterator<String> profileIter = queryIdDeque.iterator();
+
+        while (profileIter.hasNext() && count > 0) {
+            String profileId = profileIter.next();
+            ProfileElement profileElem = queryIdToProfileMap.get(profileId);
+            if (profileElem == null)  {
+                LOG.warn("null profile element found in queryIdToProfileMap, profileId: {}", profileId);
+                continue;
+            }
+
+            AtomicBoolean reportFinished = new AtomicBoolean(true);
+
+            profileElem.profile.getExecutionProfiles().forEach((
+                    executionProfile -> {
+                        if (!executionProfile.isCompleted()) {
+                            reportFinished.set(false);
+                        }
+                    }));
+
+            if (reportFinished.get()) {
+                toEject.add(profileId);
+                count--;
+            }
+        }
+        return toEject;
     }
 
     public void removeProfile(String profileId) {
@@ -360,7 +416,7 @@ public class ProfileManager {
             try {
                 loadJobId = Long.parseLong(id);
             } catch (Exception e) {
-                throw new IllegalArgumentException("Invalid profile id: " + id);
+                return futures;
             }
 
             LoadJob loadJob = Env.getCurrentEnv().getLoadManager().getLoadJob(loadJobId);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/ProfileManagerEjectOutdatedProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/ProfileManagerEjectOutdatedProfileTest.java
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.profile.ExecutionProfile;
+import org.apache.doris.common.profile.Profile;
+import org.apache.doris.common.profile.SummaryProfile;
+import org.apache.doris.common.profile.SummaryProfile.SummaryBuilder;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+import org.wildfly.common.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+
+public class ProfileManagerEjectOutdatedProfileTest {
+    private static final Logger LOG = LogManager.getLogger(ProfileManagerEjectOutdatedProfileTest.class);
+
+    private static SummaryProfile constructRandomSummaryProfile(String name, boolean finished) {
+
+        // Construct a summary profile
+        SummaryBuilder builder = new SummaryBuilder();
+        builder.profileId(name);
+        builder.taskType(System.currentTimeMillis() % 2 == 0 ? "QUERY" : "LOAD");
+        long currentTimestampSeconds = System.currentTimeMillis() / 1000;
+        builder.startTime(TimeUtils.longToTimeString(currentTimestampSeconds));
+        builder.endTime(TimeUtils.longToTimeString(currentTimestampSeconds + 10));
+        builder.totalTime(DebugUtil.getPrettyStringMs(10));
+        builder.taskState(finished ? "FINISHED" : "RUNNING");
+
+        SummaryProfile summaryProfile = new SummaryProfile();
+        summaryProfile.fuzzyInit();
+        summaryProfile.update(builder.build());
+
+        return summaryProfile;
+    }
+
+
+    private static Profile constructRandomProfile(String name, boolean finished, int executionProfileNum,
+            int framgnetNum) {
+        Profile profile = new Profile(name);
+        SummaryProfile summaryProfile = constructRandomSummaryProfile(name, finished);
+        profile.setSummaryProfile(summaryProfile);
+
+        for (int i = 0; i < executionProfileNum; i++) {
+            TUniqueId qUniqueId = new TUniqueId();
+            UUID uuid = UUID.randomUUID();
+            qUniqueId.setHi(uuid.getMostSignificantBits());
+            qUniqueId.setLo(uuid.getLeastSignificantBits());
+
+            List<PlanFragment> fragments = new ArrayList<>();
+            ExecutionProfile executionProfile = new ExecutionProfile(qUniqueId, fragments);
+            Map<Integer, RuntimeProfile> fragmentProfiles = Maps.newHashMap();
+            Map<Integer, Integer> fragmentIdBeNum = Maps.newHashMap();
+
+            for (int j = 0; j < framgnetNum; j++) {
+                RuntimeProfile fragmentRuntimeProfile = new RuntimeProfile("Fragment " + j);
+                RuntimeProfile pipelineRuntimeProfile = null;
+                pipelineRuntimeProfile = new RuntimeProfile("PipelineProfile");
+                if (j == 0) {
+                    pipelineRuntimeProfile.setIsDone(true);
+                } else {
+                    pipelineRuntimeProfile.setIsDone(finished);
+                }
+
+                fragmentRuntimeProfile.addChild(pipelineRuntimeProfile);
+
+                fragmentIdBeNum.put(j, 1);
+                fragmentProfiles.put(j, fragmentRuntimeProfile);
+            }
+
+            executionProfile.setFragmentProfiles(fragmentProfiles);
+            executionProfile.setFragmentIdBeNum(fragmentIdBeNum);
+            profile.addExecutionProfile(executionProfile);
+        }
+        return profile;
+    }
+
+    @Test
+    public void normalTest() {
+        // Insert N profiles into ProfileManager
+        // Half of them is finished
+        ProfileManager profileManager = ProfileManager.getInstance();
+        profileManager.cleanProfile();
+
+        for (int i = 0; i < Config.max_query_profile_num; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_For_Eject_" + String.valueOf(i),
+                    i % 2 == 0 ? true : false,
+                    executionProfileNum, 2);
+            profileManager.pushProfile(profile);
+        }
+
+        // Insert 50 profiles into ProfileManager
+        for (int i = 0; i < 50; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_New_" + String.valueOf(i), true,
+                    executionProfileNum, 2);
+            profileManager.pushProfile(profile);
+        }
+
+        // Make sure profiles are ejected by design.
+        // Ejected profile must be reported finished.
+        for (int i = 0; i < 50; i++) {
+            String profileName = "Profile_For_Eject_" + String.valueOf(i);
+            String profileString = profileManager.getProfile(profileName);
+
+            if (i % 2 == 0) {
+                Assert.assertTrue(profileString == null);
+            } else {
+                Assert.assertTrue(profileString != null);
+            }
+        }
+    }
+
+    @Test
+    public void allPorfilesAreNotFinishedTest() {
+        // Insert N profiles into ProfileManager
+        // All of them are not finished
+        Config.max_query_profile_num = 10;
+        ProfileManager profileManager = ProfileManager.getInstance();
+        profileManager.cleanProfile();
+
+        for (int i = 0; i < Config.max_query_profile_num; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_For_Eject_" + String.valueOf(i), false,
+                    executionProfileNum, 2);
+            LOG.info("Profile {} is complete: {}", profile.getName(), profile.isComplete());
+            profileManager.pushProfile(profile);
+        }
+
+        // Insert 50 profiles into ProfileManager
+        // All of them are finished
+        for (int i = 0; i < 10; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_New_" + String.valueOf(i), true,
+                    executionProfileNum, 2);
+            profileManager.pushProfile(profile);
+        }
+
+        // Make sure profiles are ejected by design.
+        // Ejected profile must be reported finished.
+        for (int i = 0; i < Config.max_query_profile_num; i++) {
+            String profileName = "Profile_For_Eject_" + String.valueOf(i);
+            String profileString = profileManager.getProfile(profileName);
+            if (i == 0) {
+                // Although the first profile is not finished, it will still be ejected when first finished profile is inserted.
+                Assert.assertTrue(profileString == null);
+            } else {
+                // The rest profiles are not finished, and already have new finished profile, so they will not be ejected.
+                Assert.assertTrue(profileString != null);
+            }
+        }
+
+        for (int i = 0; i < 10; i++) {
+            String profileName = "Profile_New_" + String.valueOf(i);
+
+            String profileString2 = profileManager.getProfile(profileName);
+            if (i == 9) {
+                // The last finished profile will not be ejected
+                Assert.assertTrue(profileString2 != null);
+            } else {
+                // The rest finished profiles will not eject any outdated profiles.
+                Assert.assertTrue(profileString2 == null);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/ProfileManagerEjectOutdatedProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/ProfileManagerEjectOutdatedProfileTest.java
@@ -1,0 +1,123 @@
+package org.apache.doris.common.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.profile.ExecutionProfile;
+import org.apache.doris.common.profile.Profile;
+import org.apache.doris.common.profile.SummaryProfile;
+import org.apache.doris.common.profile.SummaryProfile.SummaryBuilder;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+import org.checkerframework.com.google.common.collect.Maps;
+import org.junit.Test;
+import org.wildfly.common.Assert;
+
+import java.util.Map;
+import java.util.UUID;
+
+
+public class ProfileManagerEjectOutdatedProfileTest {
+    private static final Logger LOG = LogManager.getLogger(ProfileManagerEjectOutdatedProfileTest.class);
+
+    private static SummaryProfile constructRandomSummaryProfile(boolean finished) {
+        TUniqueId qUniqueId = new TUniqueId();
+        UUID uuid = UUID.randomUUID();
+        qUniqueId.setHi(uuid.getMostSignificantBits());
+        qUniqueId.setLo(uuid.getLeastSignificantBits());
+        // Construct a summary profile
+        SummaryBuilder builder = new SummaryBuilder();
+        builder.profileId(DebugUtil.printId(qUniqueId));
+        builder.taskType(System.currentTimeMillis() % 2 == 0 ? "QUERY" : "LOAD");
+        long currentTimestampSeconds = System.currentTimeMillis() / 1000;
+        builder.startTime(TimeUtils.longToTimeString(currentTimestampSeconds));
+        builder.endTime(TimeUtils.longToTimeString(currentTimestampSeconds + 10));
+        builder.totalTime(DebugUtil.getPrettyStringMs(10));
+        builder.taskState(finished ? "FINISHED" : "RUNNING");
+        builder.user(DebugUtil.printId(qUniqueId) + "-user");
+        builder.defaultDb(DebugUtil.printId(qUniqueId) + "-db");
+
+        SummaryProfile summaryProfile = new SummaryProfile();
+        summaryProfile.fuzzyInit();
+        summaryProfile.update(builder.build());
+
+        return summaryProfile;
+    }
+
+
+    private static Profile constructRandomProfile(String name, boolean finished, int executionProfileNum, int framgnetNum) {
+        Profile profile = new Profile(name);
+        SummaryProfile summaryProfile = constructRandomSummaryProfile(finished);
+        String stringUniqueId = summaryProfile.getProfileId();
+        TUniqueId thriftUniqueId = DebugUtil.parseTUniqueIdFromString(stringUniqueId);
+        profile.setSummaryProfile(summaryProfile);
+
+        for (int i = 0; i < executionProfileNum; i++) {
+            List<PlanFragment> fragments = new ArrayList<>();
+            ExecutionProfile executionProfile = new ExecutionProfile(thriftUniqueId, fragments);
+            Map<Integer, RuntimeProfile> fragmentProfiles = Maps.newHashMap();
+            Map<Integer, Integer> fragmentIdBeNum = Maps.newHashMap();
+
+            for (int j = 0; j < framgnetNum; j++) {
+                RuntimeProfile fragmentRuntimeProfile = new RuntimeProfile("Fragment " + j);
+                fragmentProfiles.put(j, fragmentRuntimeProfile);
+
+                RuntimeProfile pipelineRuntimeProfile1 = new RuntimeProfile("PipelineProfile1");
+                pipelineRuntimeProfile1.setIsDone(true);
+
+                RuntimeProfile pipelineRuntimeProfile2 = new RuntimeProfile("PipelineProfile2");
+                pipelineRuntimeProfile2.setIsDone(finished);
+
+                fragmentRuntimeProfile.addChild(pipelineRuntimeProfile1);
+                fragmentRuntimeProfile.addChild(pipelineRuntimeProfile1);
+
+                fragmentIdBeNum.put(j, 1);
+            }
+
+            executionProfile.setFragmentProfiles(fragmentProfiles);
+            executionProfile.setFragmentIdBeNum(fragmentIdBeNum);
+            profile.addExecutionProfile(executionProfile);
+        }
+        return profile;
+    }
+    
+    @Test
+    public void test1() {
+        Config.max_query_profile_num = 10;
+        ProfileManager profileManager = ProfileManager.getInstance();
+
+        for (int i = 0; i < Config.max_query_profile_num; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_For_Eject_" + String.valueOf(i), i % 2 == 0 ? true : false,
+                                                    executionProfileNum, 2);
+            profileManager.pushProfile(profile);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            int executionProfileNum = i;
+            Profile profile = constructRandomProfile("Profile_New_" + String.valueOf(i), true,
+                                                    executionProfileNum, 2);
+            profileManager.pushProfile(profile);
+        }
+
+        LOG.info("Debug profile manager {}", profileManager.debugAllProfile());
+
+        for (int i = 0; i < 10; i++) {
+            String profileName = "Profile_For_Eject_" + String.valueOf(i);
+            String profileString = profileManager.getProfile(profileName);
+
+            if (i % 2 == 0) {
+                Assert.assertTrue(profileString == null);
+            } else {
+                Assert.assertTrue(profileString != null);
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
In the past, when num of profile exceeds the max_query_profile_num, the oldest profile will be ejected, even though it is still running.
In this pr, the profile eject strategy is updated, we will try to eject finished query profile first.
If all profiles are not finished, then eject an oldest one.

