### PR TITLE
[improvement](statistics)Use real base index id to fetch stats cache.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -350,7 +350,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     private ColumnStatistic getColumnStatsFromTableCache(CatalogRelation catalogRelation, SlotReference slot) {
         long idxId = -1;
         if (catalogRelation instanceof OlapScan) {
-            idxId = ((OlapScan) catalogRelation).getSelectedIndexIdForMV();
+            idxId = ((OlapScan) catalogRelation).getSelectedIndexId();
         }
         return getColumnStatistic(catalogRelation.getTable(), slot.getName(), idxId);
     }
@@ -359,7 +359,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             List<String> partitionNames) {
         long idxId = -1;
         if (catalogRelation instanceof OlapScan) {
-            idxId = ((OlapScan) catalogRelation).getSelectedIndexIdForMV();
+            idxId = ((OlapScan) catalogRelation).getSelectedIndexId();
         }
         return getColumnStatistic(catalogRelation.getTable(), slot.getName(), idxId, partitionNames);
     }
@@ -434,7 +434,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             for (Slot slot : olapScan.getOutput()) {
                 if (isVisibleSlotReference(slot)) {
                     ColumnStatistic cache = getColumnStatistic(olapTable, slot.getName(),
-                            olapScan.getSelectedIndexIdForMV());
+                            olapScan.getSelectedIndexId());
                     rowCount = Math.max(rowCount, cache.count);
                 }
                 builder.putColumnStatistics(slot,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/OlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/OlapScan.java
@@ -28,12 +28,6 @@ public interface OlapScan {
 
     long getSelectedIndexId();
 
-    /**
-     * if this is mv, return selectedIndexId, o.w -1
-     * @return -1 or selectedIndexId
-     */
-    long getSelectedIndexIdForMV();
-
     List<Long> getSelectedPartitionIds();
 
     List<Long> getSelectedTabletIds();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
@@ -94,11 +94,6 @@ public class LogicalDeferMaterializeOlapScan extends LogicalCatalogRelation impl
     }
 
     @Override
-    public long getSelectedIndexIdForMV() {
-        return logicalOlapScan.getSelectedIndexIdForMV();
-    }
-
-    @Override
     public List<Long> getSelectedPartitionIds() {
         return logicalOlapScan.getSelectedPartitionIds();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -333,14 +333,6 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
         return selectedIndexId;
     }
 
-    @Override
-    public long getSelectedIndexIdForMV() {
-        if (getTable().getBaseIndexId() != selectedIndexId) {
-            return selectedIndexId;
-        }
-        return -1;
-    }
-
     public boolean isIndexSelected() {
         return indexSelected;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeOlapScan.java
@@ -91,11 +91,6 @@ public class PhysicalDeferMaterializeOlapScan extends PhysicalCatalogRelation im
     }
 
     @Override
-    public long getSelectedIndexIdForMV() {
-        return physicalOlapScan.getSelectedIndexIdForMV();
-    }
-
-    @Override
     public List<Long> getSelectedPartitionIds() {
         return physicalOlapScan.getSelectedPartitionIds();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
@@ -91,14 +91,6 @@ public class PhysicalOlapScan extends PhysicalCatalogRelation implements OlapSca
     }
 
     @Override
-    public long getSelectedIndexIdForMV() {
-        if (getTable().getBaseIndexId() != selectedIndexId) {
-            return selectedIndexId;
-        }
-        return -1;
-    }
-
-    @Override
     public List<Long> getSelectedTabletIds() {
         return selectedTabletIds;
     }


### PR DESCRIPTION
For historical reason, statistics tables use -1 for OlapTable base index id. This brings many if/else branch for stats calculate. This pr is to screen the -1 for Nereids. The stats user could use the real base index id to fetch stats cache. Will do the id translation inside the get cache api.