### PR TITLE
[fix](protocol) only return multi result when CLIENT_MULTI_STATEMENTS been set (#36759)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
@@ -161,9 +161,13 @@ public class MysqlCapability {
         return (flags & Flag.CLIENT_DEPRECATE_EOF.getFlagBit()) != 0;
     }
 
+    public boolean isClientMultiStatements() {
+        return (flags & Flag.CLIENT_MULTI_STATEMENTS.getFlagBit()) != 0;
+    }
+
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof MysqlCapability)) {
+        if (!(obj instanceof MysqlCapability)) {
             return false;
         }
         if (flags != ((MysqlCapability) obj).flags) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -315,7 +315,13 @@ public abstract class ConnectProcessor {
                         if (i != stmts.size() - 1) {
                             ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
                             if (ctx.getState().getStateType() != MysqlStateType.ERR) {
-                                finalizeCommand();
+                                // here, doris do different with mysql.
+                                // when client not request CLIENT_MULTI_STATEMENTS, mysql treat all query as
+                                // single statement. Doris treat it with multi statement, but only return
+                                // the last statement result.
+                                if (getConnectContext().getCapability().isClientMultiStatements()) {
+                                    finalizeCommand();
+                                }
                             }
                         }
                     } else if (connectType.equals(ConnectType.ARROW_FLIGHT_SQL)) {


### PR DESCRIPTION
pick from master #36759

multi statement support by PR #3050.
But there is a minor issue in implementation.

as MySQL dev doc say in

https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_command_phase_sp.html#sect_protocol_command_phase_sp_multi_statement

server should only process multi statement
when client set CLIENT_MULTI_STATEMENTS.
When client not set CLIENT_MULTI_STATEMENTS, server should treat query as single statement.

but Doris do slightly different with MySQL server. Doris always treat query as multi statement, but only return multi result when client set CLIENT_MULTI_STATEMENTS. When client do not set CLIENT_MULTI_STATEMENTS, Doris will return the last statement result only.
