### PR TITLE
[fix](group commit) Group commit http stream should not begin txn

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/GroupCommitInsertExecutor.java
@@ -81,6 +81,10 @@ public class GroupCommitInsertExecutor extends AbstractInsertExecutor {
      */
     public static boolean canGroupCommit(ConnectContext ctx, DataSink sink,
                                          PhysicalSink physicalSink, NereidsPlanner planner) {
+        // The flag is set to false before execute sql, if it is true, this is a http stream
+        if (ctx.isGroupCommit()) {
+            return false;
+        }
         PhysicalOlapTableSink<?> olapSink = (PhysicalOlapTableSink<?>) physicalSink;
         boolean can = analyzeGroupCommit(ctx, sink, olapSink, planner);
         ctx.setGroupCommit(can);


### PR DESCRIPTION
## Proposed changes

After nereids support group_commit, the http_stream in group commit will also do some check like insert into values, and change the group_commit flag to false. 
Then will begin a txn. This is hang schema change.

