### PR TITLE
[opt](fucntion) improve json_extract function handle const column

### DIFF
--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -831,9 +831,9 @@ struct FunctionJsonExtractImpl {
         rapidjson::Value value;
         rapidjson::Document document;
 
-        const auto& obj = json_col->get_data_at(index_check_const(row, column_is_consts[0]));
+        const auto obj = json_col->get_data_at(index_check_const(row, column_is_consts[0]));
         std::string_view json_string(obj.data, obj.size);
-        const auto& path = path_col->get_data_at(index_check_const(row, column_is_consts[col]));
+        const auto path = path_col->get_data_at(index_check_const(row, column_is_consts[col]));
         std::string_view path_string(path.data, path.size);
         auto* root = get_json_object<JSON_FUN_STRING>(json_string, path_string, &document);
         if (root != nullptr) {
@@ -846,7 +846,7 @@ struct FunctionJsonExtractImpl {
                                           rapidjson::Document* document,
                                           std::vector<JsonPath>& parsed_paths, const int row,
                                           bool is_const_column) {
-        const auto& path = path_col->get_data_at(index_check_const(row, is_const_column));
+        const auto path = path_col->get_data_at(index_check_const(row, is_const_column));
         std::string_view path_string(path.data, path.size);
         //Cannot use '\' as the last character, return NULL
         if (path_string.back() == '\\') {
@@ -860,6 +860,7 @@ struct FunctionJsonExtractImpl {
 #else
         auto tok = get_json_token(path_string);
 #endif
+        // TODO: here maybe could use std::vector<std::string_view> or std::span
         std::vector<std::string> paths(tok.begin(), tok.end());
         get_parsed_paths(paths, &parsed_paths);
         if (parsed_paths.empty()) {


### PR DESCRIPTION
## Proposed changes
VARCHAR json_extract(VARCHAR json_str, VARCHAR path[, VARCHAR path] ...)
```
  for (int i = 0; i < arguments.size(); i++) {
       column_ptrs.push_back(
               block.get_by_position(arguments[i]).column->convert_to_full_column_if_const());
       data_columns.push_back(assert_cast<const ColumnString*>(column_ptrs.back().get()));
   }

before not handle const column, as the input arguments are variadic,
and most user case is like: json_extract(column, '$.fparam.nested_2')
so could special deal with two arguments could reuse json document.

```

```
mysql [test]>select count(json_extract(a, '$.fparam.nested_2')) from json_table_2;
+---------------------------------------------+
| count(json_extract(a, '$.fparam.nested_2')) |
+---------------------------------------------+
|                                    10000001 |
+---------------------------------------------+
1 row in set (1.06 sec)

mysql [test]>select count(json_extract(a, '$.fparam.nested_2')) from json_table_2;
+---------------------------------------------+
| count(json_extract(a, '$.fparam.nested_2')) |
+---------------------------------------------+
|                                    10000001 |
+---------------------------------------------+
1 row in set (1.02 sec)

mysql [test]>
mysql [test]>
mysql [test]>select count(json_extract(a, '$.fparam.nested_2')) from json_table_2;
+---------------------------------------------+
| count(json_extract(a, '$.fparam.nested_2')) |
+---------------------------------------------+
|                                    10000001 |
+---------------------------------------------+
1 row in set (44.22 sec)

mysql [test]>select count(json_extract(a, '$.fparam.nested_2')) from json_table_2;
+---------------------------------------------+
| count(json_extract(a, '$.fparam.nested_2')) |
+---------------------------------------------+
|                                    10000001 |
+---------------------------------------------+
1 row in set (42.80 sec)

```

<!--Describe your changes.-->

