### PR TITLE
[improvement](statistics)Disable fetch stats for iceberg table through Iceberg api by default.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -573,10 +573,14 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
             case HIVE:
                 return getHiveColumnStats(colName);
             case ICEBERG:
-                return StatisticsUtil.getIcebergColumnStats(colName,
+                if (GlobalVariable.enableFetchIcebergStats) {
+                    return StatisticsUtil.getIcebergColumnStats(colName,
                         Env.getCurrentEnv().getExtMetaCacheMgr().getIcebergMetadataCache().getIcebergTable(
-                                catalog, dbName, name
+                            catalog, dbName, name
                         ));
+                } else {
+                    break;
+                }
             default:
                 LOG.warn("get column stats for dlaType {} is not supported.", dlaType);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -66,6 +66,9 @@ public final class GlobalVariable {
     public static final String PARTITION_ANALYZE_BATCH_SIZE = "partition_analyze_batch_size";
     public static final String HUGE_PARTITION_LOWER_BOUND_ROWS = "huge_partition_lower_bound_rows";
 
+    public static final String ENABLE_FETCH_ICEBERG_STATS = "enable_fetch_iceberg_stats";
+
+
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = "Doris version "
             + Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH;
@@ -169,6 +172,12 @@ public final class GlobalVariable {
                 "行数超过该值的分区将跳过自动分区收集",
                 "This defines the lower size bound for large partitions, which will skip auto partition analyze."})
     public static long hugePartitionLowerBoundRows = 100000000L;
+
+    @VariableMgr.VarAttr(name = ENABLE_FETCH_ICEBERG_STATS, flag = VariableMgr.GLOBAL,
+            description = {
+                "当HMS catalog中的Iceberg表没有统计信息时，是否通过Iceberg Api获取统计信息",
+                "Enable fetch stats for HMS Iceberg table when it's not analyzed."})
+    public static boolean enableFetchIcebergStats = false;
 
     // Don't allow creating instance.
     private GlobalVariable() {


### PR DESCRIPTION
Disable fetch iceberg table stats through iceberg api by default. Because it could be very heavy and external table performs fine without column stats.
Could enable it by : set global enable_fetch_iceberg_stats=true