### PR TITLE
[branch-2.0][improvement](sqlserver catalog) Can configure whether to use encryption when connecting to SQL Server using the catalog

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -148,6 +148,10 @@ public class Config extends ConfigBase {
                     + "The default is * to allow all, if set to empty, all are not allowed"})
     public static String jdbc_driver_secure_path = "*";
 
+    @ConfField(description = {"强制 SQLServer Jdbc Catalog 加密为 false",
+            "Force SQLServer Jdbc Catalog encrypt to false"})
+    public static boolean force_sqlserver_jdbc_encrypt_false = false;
+
     @ConfField(mutable = true, masterOnly = true, description = {"broker load 时，单个节点上 load 执行计划的默认并行度",
             "The default parallelism of the load execution plan on a single node when the broker load is submitted"})
     public static int default_load_parallelism = 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -360,6 +360,9 @@ public class JdbcResource extends Resource {
             newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "reWriteBatchedInserts", "false", "true");
         }
         if (dbType.equals(SQLSERVER)) {
+            if (Config.force_sqlserver_jdbc_encrypt_false) {
+                newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "encrypt", "true", "false");
+            }
             newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "useBulkCopyForBatchInsert", "false", "true");
         }
         return newJdbcUrl;


### PR DESCRIPTION
pick #36659
pick #37015
In previous versions, we used druid as the default JDBC connection pool, which can use custom decryption to parse the certificate when SQL Server encryption is turned on. However, in the new version, after changing HikariCP as the default connection pool, the SQLServer certificate cannot be parsed, so encryption needs to be turned off for normal use. Therefore, a parameter is added to decide whether to disable SQLServer encryption. It is not disabled by default.