### PR TITLE
[fix](multicatalog) fix npe issue when alter property for a non-exist catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -348,10 +348,10 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         writeLock();
         try {
             CatalogIf catalog = nameToCatalog.get(stmt.getCatalogName());
-            Map<String, String> oldProperties = catalog.getProperties();
             if (catalog == null) {
                 throw new DdlException("No catalog found with name: " + stmt.getCatalogName());
             }
+            Map<String, String> oldProperties = catalog.getProperties();
             if (stmt.getNewProperties().containsKey("type") && !catalog.getType()
                     .equalsIgnoreCase(stmt.getNewProperties().get("type"))) {
                 throw new DdlException("Can't modify the type of catalog property with name: " + stmt.getCatalogName());

--- a/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
@@ -153,7 +153,7 @@ suite("test_external_catalog_hive", "p2") {
             exception "Failed to init access controller: bound must be positive"
         }
 
-	 sql """DROP CATALOG if exists ctl_not_exist_not_exist"""
+	sql """DROP CATALOG if exists ctl_not_exist_not_exist"""
         def res4 = sql """ALTER CATALOG ctl_not_exist_not_exist SET PROPERTIES ('s3.access_key' = 'xxxx')"""
         assertTrue(res4.contains("No catalog found with name"))
     }

--- a/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
@@ -152,5 +152,9 @@ suite("test_external_catalog_hive", "p2") {
             """
             exception "Failed to init access controller: bound must be positive"
         }
+
+	 sql """DROP CATALOG if exists ctl_not_exist_not_exist"""
+        def res4 = sql """ALTER CATALOG ctl_not_exist_not_exist SET PROPERTIES ('s3.access_key' = 'xxxx')"""
+        assertTrue(res4.contains("No catalog found with name"))
     }
 }


### PR DESCRIPTION
Issue:
```sql
mysql> ALTER CATALOG ctl_not_exist_not_exist SET PROPERTIES ('s3.access_key' = 'xxxx');                                    
ERROR 1105 (HY000): Unexpected exception: null 
```


