### PR TITLE
[bugfix](hive)Prevent multiple `fs` from being generated

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopUGI.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopUGI.java
@@ -76,6 +76,16 @@ public class HadoopUGI {
                 ((SimpleAuthenticationConfig) config).setUsername(hadoopUserName);
                 LOG.debug(AuthenticationConfig.HADOOP_USER_NAME + " is unset, use default user: hadoop");
             }
+
+            try {
+                ugi = UserGroupInformation.getLoginUser();
+                if (ugi.getUserName().equals(hadoopUserName)) {
+                    return ugi;
+                }
+            } catch (IOException e) {
+                LOG.warn("A SecurityException occurs with simple, do login immediately.", e);
+            }
+
             ugi = UserGroupInformation.createRemoteUser(hadoopUserName);
             UserGroupInformation.setLoginUser(ugi);
             LOG.debug("Login by proxy user, hadoop.username: {}", hadoopUserName);


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

If the user has already registered, there is no need to register again, otherwise `fs` will generate multiple instances.