### PR TITLE
[fix](profile) Fix concurrent access to runtime profile

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -55,7 +55,18 @@ RuntimeProfile::RuntimeProfile(const std::string& name, bool is_averaged_profile
     _counter_map["TotalTime"] = &_counter_total_time;
 }
 
-RuntimeProfile::~RuntimeProfile() = default;
+RuntimeProfile::~RuntimeProfile() {
+    {
+        std::lock_guard<std::mutex> l(_counter_map_lock);
+        _counter_map.clear();
+        _child_counter_map.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> l(_children_lock);
+        _child_map.clear();
+    }
+}
 
 void RuntimeProfile::merge(RuntimeProfile* other) {
     DCHECK(other != nullptr);


### PR DESCRIPTION
## Proposed changes

```
*** Query id: 27484923f63e82b4-1da5d6972b9c996 ****** is nereids: 1 ****** tablet id: 0 ****** Aborted at 1719487939 (unix time) try "date -d @1719487939" if you are using GNU date ****** Current BE git commitID: 23b0b7b28d ****** SIGSEGV address not mapped to object (@0x7f0073757479) received by PID 1641007 (TID 1661076 OR 0x7f61c8142700) from PID 1937077369; stack trace: *** 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/xujianxu/doris/be/src/common/signal_handler.h:421 

1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so 
2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so 
3# 0x00007F6AB6E29090 in /lib/x86_64-linux-gnu/libc.so.6 
4# std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::_Identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_erase(std::_Rb_tree_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*) at /mnt/disk2/xujianxu/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_tree.h:1936 
5# std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::_Identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_erase(std::_Rb_tree_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*) at /mnt/disk2/xujianxu/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_tree.h:1937 
6# std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >*) at /mnt/disk2/xujianxu/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_tree.h:1938 
7# doris::RuntimeProfile::~RuntimeProfile() at /mnt/disk2/xujianxu/doris/be/src/util/runtime_profile.cpp:58 
8# std::_Sp_counted_ptr<doris::RuntimeProfile*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /mnt/disk2/xujianxu/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:428 
9# doris::pipeline::ScanLocalStateBase::~ScanLocalStateBase() at /mnt/disk2/xujianxu/doris/be/src/pipeline/exec/scan_operator.h:69
10# doris::pipeline::ScanLocalState<doris::pipeline::FileScanLocalState>::~ScanLocalState() at /mnt/disk2/xujianxu/doris/be/src/pipeline/exec/scan_operator.h:140
11# doris::pipeline::FileScanLocalState::~FileScanLocalState() at /mnt/disk2/xujianxu/doris/be/src/pipeline/exec/file_scan_operator.h:40
12# doris::RuntimeState::~RuntimeState() at /mnt/disk2/xujianxu/doris/be/src/runtime/runtime_state.cpp:278
13# doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() at /mnt/disk2/xujianxu/doris/be/src/pipeline/pipeline_fragment_context.cpp:140
14# std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold() at /mnt/disk2/xujianxu/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:199
15# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/STRESS_ENV/be/lib/doris_be16# doris::Thread::supervise_thread(void*) at /mnt/disk2/xujianxu/doris/be/src/util/thread.cpp:49917# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:47818# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97 
```

<!--Describe your changes.-->

