### PR TITLE
[fix](statistics)Fix select mv with specified partitions bug. (#36817)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -200,8 +200,10 @@ public class MaterializedViewUtils {
                 materializedView,
                 materializedView.getFullQualifiers(),
                 ImmutableList.of(),
+                materializedView.getPartitionIds(),
                 materializedView.getBaseIndexId(),
                 PreAggStatus.on(),
+                ImmutableList.of(),
                 // this must be empty, or it will be used to sample
                 ImmutableList.of(),
                 Optional.empty());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -146,12 +146,12 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     }
 
     public LogicalOlapScan(RelationId id, OlapTable table, List<String> qualifier, List<Long> tabletIds,
-                           long selectedIndexId, PreAggStatus preAggStatus, List<String> hints,
-                           Optional<TableSample> tableSample) {
+                           List<Long> selectedPartitionIds, long selectedIndexId, PreAggStatus preAggStatus,
+                           List<Long> specifiedPartitions, List<String> hints, Optional<TableSample> tableSample) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
-                table.getPartitionIds(), false, tabletIds,
+                selectedPartitionIds, false, tabletIds,
                 selectedIndexId, true, preAggStatus,
-                ImmutableList.of(), hints, Maps.newHashMap(), tableSample, true, ImmutableMap.of());
+                specifiedPartitions, hints, Maps.newHashMap(), tableSample, true, ImmutableMap.of());
     }
 
     /**


### PR DESCRIPTION
There is a bug of direct select mv with specified partitions. Planner will fail to find the mv column name. Because we need to create the LogicalOlapScan object using the given mv instead of the base table.
```
mysql> SELECT mv_id from part8 index mv1 partition p1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Unknown column 'mv_id' in 'table list' in PROJECT clause
```
This pr is to fix this.

backport: https://github.com/apache/doris/pull/36817
