### PR TITLE
[bugfix]thread pool resource leak

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -153,14 +153,13 @@ public class HMSTransaction implements Transaction {
 
     @Override
     public void rollback() {
+        if (hmsCommitter == null) {
+            return;
+        }
         try {
-            if (hmsCommitter != null) {
-                hmsCommitter.rollback();
-            }
+            hmsCommitter.rollback();
         } finally {
-            if (hmsCommitter != null) {
-                hmsCommitter.shutdownExecutorService();
-            }
+            hmsCommitter.shutdownExecutorService();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -1530,6 +1530,8 @@ public class HMSTransaction implements Transaction {
             } catch (InterruptedException e) {
                 // (Re-)Cancel if current thread also interrupted
                 updateStatisticsExecutor.shutdownNow();
+                // Preserve interrupt status
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -157,6 +157,7 @@ public class HMSTransaction implements Transaction {
             return;
         }
         try {
+            hmsCommitter.abort();
             hmsCommitter.rollback();
         } finally {
             hmsCommitter.shutdownExecutorService();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -153,8 +153,14 @@ public class HMSTransaction implements Transaction {
 
     @Override
     public void rollback() {
-        if (hmsCommitter != null) {
-            hmsCommitter.rollback();
+        try {
+            if (hmsCommitter != null) {
+                hmsCommitter.rollback();
+            }
+        } finally {
+            if (hmsCommitter != null) {
+                hmsCommitter.shutdownExecutorService();
+            }
         }
     }
 
@@ -1508,7 +1514,9 @@ public class HMSTransaction implements Transaction {
         }
 
         public void shutdownExecutorService() {
-            updateStatisticsExecutor.shutdownNow();
+            if (!updateStatisticsExecutor.isShutdown()) {
+                updateStatisticsExecutor.shutdownNow();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -682,7 +682,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             newTable.setParameters(newParams);
             client.client.alter_table(dbName, tableName, newTable);
         } catch (Exception e) {
-            throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName);
+            throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName, e);
         }
     }
 
@@ -710,7 +710,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             modifiedPartition.setParameters(newParams);
             client.client.alter_partition(dbName, tableName, modifiedPartition);
         } catch (Exception e) {
-            throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName);
+            throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName, e);
         }
     }
 
@@ -731,7 +731,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         try (ThriftHMSClient client = getClient()) {
             client.client.dropPartition(dbName, tableName, partitionValues, deleteData);
         } catch (Exception e) {
-            throw new RuntimeException("failed to drop partition for " + dbName + "." + tableName);
+            throw new RuntimeException("failed to drop partition for " + dbName + "." + tableName, e);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

1. When the thread pool is not needed, you need to manually close the thread pool.
2. Before rolling back, we need to abort the existing task.
3. Add some exception information
