### PR TITLE
[improvement](statistics)Use real base index id to fetch stats cache. (#36914)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -18,6 +18,8 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
@@ -79,6 +81,12 @@ public class StatisticsCache {
         if (ctx != null && ctx.getSessionVariable().internalSession) {
             return ColumnStatistic.UNKNOWN;
         }
+        // Need to change base index id to -1 for OlapTable.
+        try {
+            idxId = changeBaseIndexId(catalogId, dbId, tblId, idxId);
+        } catch (Exception e) {
+            return ColumnStatistic.UNKNOWN;
+        }
         StatisticsCacheKey k = new StatisticsCacheKey(catalogId, dbId, tblId, idxId, colName);
         try {
             CompletableFuture<Optional<ColumnStatistic>> f = columnStatisticsCache.get(k);
@@ -89,6 +97,21 @@ public class StatisticsCache {
             LOG.warn("Unexpected exception while returning ColumnStatistic", e);
         }
         return ColumnStatistic.UNKNOWN;
+    }
+
+    // Base index id should be set to -1 for OlapTable. Because statistics tables use -1 for base index.
+    // TODO: Need to use the real index id in statistics table in later version.
+    private long changeBaseIndexId(long catalogId, long dbId, long tblId, long idxId) {
+        if (idxId != -1) {
+            TableIf table = StatisticsUtil.findTable(catalogId, dbId, tblId);
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                if (idxId == olapTable.getBaseIndexId()) {
+                    idxId = -1;
+                }
+            }
+        }
+        return idxId;
     }
 
     public Histogram getHistogram(long ctlId, long dbId, long tblId, String colName) {


### PR DESCRIPTION
For historical reason, statistics tables use -1 for OlapTable base index id. This brings many if/else branch for stats calculate. This pr is to screen the -1 for Nereids. The stats user could use the real base index id to fetch stats cache. Will do the id translation inside the get cache api.

backport: https://github.com/apache/doris/pull/36914
