### PR TITLE
[improvement](jdbc catalog)Rename config from `disable_jdbc_sqlserver_encrypt` to `force_sqlserver_jdbc_encrypt_false`

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -162,9 +162,9 @@ public class Config extends ConfigBase {
             "MySQL Jdbc Catalog mysql does not support pushdown functions"})
     public static String[] jdbc_mysql_unsupported_pushdown_functions = {"date_trunc", "money_format", "negative"};
 
-    @ConfField(description = {"SQLServer Jdbc Catalog 关闭加密",
-            "SQLServer Jdbc Catalog close encrypt"})
-    public static boolean disable_jdbc_sqlserver_encrypt = false;
+    @ConfField(description = {"强制 SQLServer Jdbc Catalog 加密为 false",
+            "Force SQLServer Jdbc Catalog encrypt to false"})
+    public static boolean force_sqlserver_jdbc_encrypt_false = false;
 
     @ConfField(mutable = true, masterOnly = true, description = {"broker load 时，单个节点上 load 执行计划的默认并行度",
             "The default parallelism of the load execution plan on a single node when the broker load is submitted"})

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -361,7 +361,7 @@ public class JdbcResource extends Resource {
             newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "reWriteBatchedInserts", "false", "true");
         }
         if (dbType.equals(SQLSERVER)) {
-            if (Config.disable_jdbc_sqlserver_encrypt) {
+            if (Config.force_sqlserver_jdbc_encrypt_false) {
                 newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "encrypt", "true", "false");
             }
             newJdbcUrl = checkAndSetJdbcBoolParam(dbType, newJdbcUrl, "useBulkCopyForBatchInsert", "false", "true");


### PR DESCRIPTION
Front #36659
Renamed the configuration parameter `disable_jdbc_sqlserver_encrypt` to `force_sqlserver_jdbc_encrypt_false` to make its purpose clearer and more explicit. This new name better indicates that the parameter forces the JDBC URL to set `encrypt=false` when enabled.