### PR TITLE
[fix](local shuffle) Fix wrong partitioned expr in local exchanger

### DIFF
--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -445,6 +445,7 @@ Status AggSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* blo
     // dispose the having clause, should not be execute in prestreaming agg
     RETURN_IF_ERROR(vectorized::VExprContext::filter_block(_conjuncts, block, block->columns()));
     local_state.do_agg_limit(block, eos);
+    local_state.reached_limit(block, eos);
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -445,7 +445,6 @@ Status AggSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* blo
     // dispose the having clause, should not be execute in prestreaming agg
     RETURN_IF_ERROR(vectorized::VExprContext::filter_block(_conjuncts, block, block->columns()));
     local_state.do_agg_limit(block, eos);
-    local_state.reached_limit(block, eos);
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -148,8 +148,8 @@ public:
         return _join_distribution == TJoinDistributionType::PARTITIONED;
     }
     bool require_data_distribution() const override {
-        return _join_distribution == TJoinDistributionType::COLOCATE ||
-               _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE;
+        return _join_distribution != TJoinDistributionType::BROADCAST &&
+               _join_distribution != TJoinDistributionType::NONE;
     }
 
 private:

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -159,8 +159,8 @@ public:
         return _join_distribution == TJoinDistributionType::PARTITIONED;
     }
     bool require_data_distribution() const override {
-        return _join_distribution == TJoinDistributionType::COLOCATE ||
-               _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE;
+        return _join_distribution != TJoinDistributionType::BROADCAST &&
+               _join_distribution != TJoinDistributionType::NONE;
     }
 
 private:


### PR DESCRIPTION
## Proposed changes

Now partitioned expressions in HASH-SHUFFLE local exchanger may be wrong. This PR fix it.

<!--Describe your changes.-->

