### PR TITLE
[memory](config) Set enable_use_cgroup_memory_info to false by default

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -78,7 +78,7 @@ DEFINE_String(priority_networks, "");
 // performance or compact
 DEFINE_String(memory_mode, "moderate");
 
-DEFINE_mBool(enable_use_cgroup_memory_info, "true");
+DEFINE_mBool(enable_use_cgroup_memory_info, "false");
 
 // process memory limit specified as number of bytes
 // ('<int>[bB]?'), megabytes ('<float>[mM]'), gigabytes ('<float>[gG]'),


### PR DESCRIPTION
It does not work correctly on ubuntu (may be more Linux release builds) due to missing certain files, and it will be fixed and tested in the future and we will turn it on again.

