### PR TITLE
[opt](binlog) support rename binlog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -32,6 +32,7 @@ import org.apache.doris.persist.DropPartitionInfo;
 import org.apache.doris.persist.ModifyTablePropertyOperationLog;
 import org.apache.doris.persist.ReplacePartitionOperationLog;
 import org.apache.doris.persist.TableAddOrDropColumnsInfo;
+import org.apache.doris.persist.TableInfo;
 import org.apache.doris.persist.TruncateTableInfo;
 import org.apache.doris.thrift.TBinlog;
 import org.apache.doris.thrift.TBinlogType;
@@ -316,6 +317,16 @@ public class BinlogManager {
         TruncateTableRecord record = new TruncateTableRecord(info);
         String data = record.toJson();
 
+        addBinlog(dbId, tableIds, commitSeq, timestamp, type, data, false);
+    }
+
+    public void addTableRename(TableInfo info, long commitSeq) {
+        long dbId = info.getDbId();
+        List<Long> tableIds = Lists.newArrayList();
+        tableIds.add(info.getTableId());
+        long timestamp = -1;
+        TBinlogType type = TBinlogType.RENAME_TABLE;
+        String data = info.toJson();
         addBinlog(dbId, tableIds, commitSeq, timestamp, type, data, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4637,7 +4637,7 @@ public class Env {
                 db.unregisterTable(oldTableName);
                 db.registerTable(table);
 
-                TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), table.getId(), newTableName);
+                TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), table.getId(), oldTableName, newTableName);
                 editLog.logTableRename(tableInfo);
                 LOG.info("rename table[{}] to {}", oldTableName, newTableName);
             } finally {
@@ -4824,7 +4824,8 @@ public class Env {
             indexNameToIdMap.put(newRollupName, indexId);
 
             // log
-            TableInfo tableInfo = TableInfo.createForRollupRename(db.getId(), table.getId(), indexId, newRollupName);
+            TableInfo tableInfo = TableInfo.createForRollupRename(db.getId(), table.getId(), indexId,
+                    rollupName, newRollupName);
             editLog.logRollupRename(tableInfo);
             LOG.info("rename rollup[{}] to {}", rollupName, newRollupName);
         } finally {
@@ -4883,7 +4884,7 @@ public class Env {
 
             // log
             TableInfo tableInfo = TableInfo.createForPartitionRename(db.getId(), table.getId(), partition.getId(),
-                    newPartitionName);
+                    partitionName, newPartitionName);
             editLog.logPartitionRename(tableInfo);
             LOG.info("rename partition[{}] to {}", partitionName, newPartitionName);
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4638,7 +4638,7 @@ public class Env {
                 db.registerTable(table);
 
                 TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), table.getId(), oldTableName,
-			newTableName);
+                        newTableName);
                 editLog.logTableRename(tableInfo);
                 LOG.info("rename table[{}] to {}", oldTableName, newTableName);
             } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4637,7 +4637,8 @@ public class Env {
                 db.unregisterTable(oldTableName);
                 db.registerTable(table);
 
-                TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), table.getId(), oldTableName, newTableName);
+                TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), table.getId(), oldTableName,
+			newTableName);
                 editLog.logTableRename(tableInfo);
                 LOG.info("rename table[{}] to {}", oldTableName, newTableName);
             } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1535,7 +1535,9 @@ public class EditLog {
     }
 
     public void logTableRename(TableInfo tableInfo) {
-        logEdit(OperationType.OP_RENAME_TABLE, tableInfo);
+        long logId = logEdit(OperationType.OP_RENAME_TABLE, tableInfo);
+        LOG.info("log table rename, logId : {}, infos: {}", logId, tableInfo);
+        Env.getCurrentEnv().getBinlogManager().addTableRename(tableInfo, logId);
     }
 
     public void logModifyViewDef(AlterViewInfo alterViewInfo) {
@@ -1543,11 +1545,15 @@ public class EditLog {
     }
 
     public void logRollupRename(TableInfo tableInfo) {
-        logEdit(OperationType.OP_RENAME_ROLLUP, tableInfo);
+        long logId = logEdit(OperationType.OP_RENAME_ROLLUP, tableInfo);
+        LOG.info("log rollup rename, logId : {}, infos: {}", logId, tableInfo);
+        Env.getCurrentEnv().getBinlogManager().addTableRename(tableInfo, logId);
     }
 
     public void logPartitionRename(TableInfo tableInfo) {
-        logEdit(OperationType.OP_RENAME_PARTITION, tableInfo);
+        long logId = logEdit(OperationType.OP_RENAME_PARTITION, tableInfo);
+        LOG.info("log partition rename, logId : {}, infos: {}", logId, tableInfo);
+        Env.getCurrentEnv().getBinlogManager().addTableRename(tableInfo, logId);
     }
 
     public void logColumnRename(TableRenameColumnInfo info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableInfo.java
@@ -42,10 +42,16 @@ public class TableInfo implements Writable {
 
     @SerializedName("nT")
     private String newTableName;
+    @SerializedName("oT")
+    private String oldTableName;
     @SerializedName("nR")
     private String newRollupName;
+    @SerializedName("oR")
+    private String oldRollupName;
     @SerializedName("nP")
     private String newPartitionName;
+    @SerializedName("oP")
+    private String oldPartitionName;
 
     public TableInfo() {
         // for persist
@@ -63,17 +69,38 @@ public class TableInfo implements Writable {
         this.newPartitionName = newPartitionName;
     }
 
+    private TableInfo(long dbId, long tableId, long indexId, long partitionId,
+                      String newTableName, String oldTableName, String newRollupName, String oldRollupName,
+                      String newPartitionName, String oldPartitionName) {
+        this.dbId = dbId;
+        this.tableId = tableId;
+        this.indexId = indexId;
+        this.partitionId = partitionId;
+
+        this.newTableName = newTableName;
+        this.oldTableName = oldTableName;
+        this.newRollupName = newRollupName;
+        this.oldRollupName = oldRollupName;
+        this.newPartitionName = newPartitionName;
+        this.oldPartitionName = oldPartitionName;
+    }
+
     public static TableInfo createForTableRename(long dbId, long tableId, String newTableName) {
         return new TableInfo(dbId, tableId, -1L, -1L, newTableName, "", "");
     }
 
-    public static TableInfo createForRollupRename(long dbId, long tableId, long indexId, String newRollupName) {
-        return new TableInfo(dbId, tableId, indexId, -1L, "", newRollupName, "");
+    public static TableInfo createForTableRename(long dbId, long tableId, String oldTableName, String newTableName) {
+        return new TableInfo(dbId, tableId, -1L, -1L, newTableName, oldTableName, "", "", "", "");
+    }
+
+    public static TableInfo createForRollupRename(long dbId, long tableId, long indexId, String oldRollupName,
+                                                  String newRollupName) {
+        return new TableInfo(dbId, tableId, indexId, -1L, "", "", newRollupName, oldRollupName, "", "");
     }
 
     public static TableInfo createForPartitionRename(long dbId, long tableId, long partitionId,
-                                                     String newPartitionName) {
-        return new TableInfo(dbId, tableId, -1L, partitionId, "", "", newPartitionName);
+                                                     String oldPartitionName, String newPartitionName) {
+        return new TableInfo(dbId, tableId, -1L, partitionId, "", "", "", "", newPartitionName, oldPartitionName);
     }
 
     public static TableInfo createForModifyDistribution(long dbId, long tableId) {
@@ -100,12 +127,24 @@ public class TableInfo implements Writable {
         return newTableName;
     }
 
+    public String getOldTableName() {
+        return oldTableName;
+    }
+
     public String getNewRollupName() {
         return newRollupName;
     }
 
+    public String getOldRollupName() {
+        return oldRollupName;
+    }
+
     public String getNewPartitionName() {
         return newPartitionName;
+    }
+
+    public String getOldPartitionName() {
+        return oldPartitionName;
     }
 
     @Override
@@ -131,7 +170,14 @@ public class TableInfo implements Writable {
         partitionId = in.readLong();
 
         newTableName = Text.readString(in);
+        oldTableName = Text.readString(in);
         newRollupName = Text.readString(in);
+        oldRollupName = Text.readString(in);
         newPartitionName = Text.readString(in);
+        oldPartitionName = Text.readString(in);
+    }
+
+    public String toJson() {
+        return GsonUtils.GSON.toJson(this);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableInfo.java
@@ -127,24 +127,12 @@ public class TableInfo implements Writable {
         return newTableName;
     }
 
-    public String getOldTableName() {
-        return oldTableName;
-    }
-
     public String getNewRollupName() {
         return newRollupName;
     }
 
-    public String getOldRollupName() {
-        return oldRollupName;
-    }
-
     public String getNewPartitionName() {
         return newPartitionName;
-    }
-
-    public String getOldPartitionName() {
-        return oldPartitionName;
     }
 
     @Override
@@ -170,11 +158,8 @@ public class TableInfo implements Writable {
         partitionId = in.readLong();
 
         newTableName = Text.readString(in);
-        oldTableName = Text.readString(in);
         newRollupName = Text.readString(in);
-        oldRollupName = Text.readString(in);
         newPartitionName = Text.readString(in);
-        oldPartitionName = Text.readString(in);
     }
 
     public String toJson() {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1143,6 +1143,7 @@ enum TBinlogType {
   MODIFY_PARTITIONS = 11,
   REPLACE_PARTITIONS = 12,
   TRUNCATE_TABLE = 13,
+  RENAME_TABLE = 14,
 }
 
 struct TBinlog {


### PR DESCRIPTION
## Proposed changes

Rename operator doesn't have binlog now. This PR will create binlog when execute rename. The rename operator means : 
1. rename table : ALTER TABLE table1 RENAME table2;
2. rename rollup : ALTER TABLE example_table RENAME ROLLUP rollup1 rollup2;
3. rename partition : ALTER TABLE example_table RENAME PARTITION p1 p2;

After SQL analyzing, we can get the old and new table name (rollup name or partition name) , then record the info to binlog, so we can use the info from binlog. 


