### PR TITLE
[fix](nereids) ColStatsMeta.partitionUpdateRows npe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -312,7 +312,9 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
         if (tableMeta != null) {
             ColStatsMeta colMeta = tableMeta.findColumnStatsMeta(
                     olapScan.getTable().getIndexNameById(olapScan.getSelectedIndexId()), slot.getName());
-            if (colMeta != null) {
+            if (colMeta != null && colMeta.partitionUpdateRows != null) {
+                // when fe upgraded from old version, colMeta object may be deserialized from json,
+                // and colMeta.partitionUpdateRows could be null
                 if (olapScan.getSelectedPartitionIds().isEmpty()) {
                     deltaRowCount = tableMeta.updatedRows.get() - colMeta.updatedRows;
                 } else {


### PR DESCRIPTION
when fe upgraded from old version, colMeta object may be deserialized from json,and colMeta.partitionUpdateRows could be null

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

