### PR TITLE
[fix](cloud) Allow access to MS during the replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -112,10 +112,6 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
             return;
         }
 
-        if (Env.isCheckpointThread()) {
-            return;
-        }
-
         List<Long> shadowIdxList = indexIdMap.keySet().stream().collect(Collectors.toList());
         dropIndex(shadowIdxList);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.cloud.rpc;
 
-import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.common.Config;
 import org.apache.doris.rpc.RpcException;
@@ -101,11 +100,6 @@ public class MetaServiceProxy {
     }
 
     private MetaServiceClient getProxy() {
-        if (Env.isCheckpointThread()) {
-            LOG.error("You should not use RPC in the checkpoint thread");
-            throw new RuntimeException("use RPC in the checkpoint thread");
-        }
-
         if (Config.enable_check_compatibility_mode) {
             LOG.error("Should not use RPC in check compatibility mode");
             throw new RuntimeException("use RPC in the check compatibility mode");


### PR DESCRIPTION
In some metadata designs, the process involves writing to the edit log first and then calling RPC to delete the data. The latter might fail, so it is reasonable to continue calling RPC to delete the data during replay. PR #36856 argues that not calling RPC in the checkpoint thread is problematic.


