### PR TITLE
[Fix](Scanner) Fix reinitialization of TabletReader 

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -317,8 +317,7 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             },
             status);
 
-    if (status.is<doris::ErrorCode::MEM_ALLOC_FAILED>() ||
-        status.is<doris::ErrorCode::MEM_LIMIT_EXCEEDED>()) {
+    if (UNLIKELY(!status.ok())) {
         scan_task->set_status(status);
         eos = true;
     }


### PR DESCRIPTION
## Proposed changes

```
F20240628 01:49:16.382710 4183685 delete_handler.cpp:388] Check failed: !_is_inited reinitialize delete handler.
*** Check failure stack trace: ***
    @     0x55700470e3c6  google::LogMessage::SendToLog()
    @     0x55700470ae10  google::LogMessage::Flush()
    @     0x55700470ec09  google::LogMessageFatal::~LogMessageFatal()
    @     0x556fccf40e64  doris::DeleteHandler::init()
    @     0x556fcff46678  doris::TabletReader::_init_delete_condition()
    @     0x556fcff3a2dd  doris::TabletReader::_init_params()
    @     0x556fcff39432  doris::TabletReader::init()
    @     0x556fffb8c2dd  doris::vectorized::BlockReader::init()
    @     0x557002cca96a  doris::vectorized::NewOlapScanner::open()
    @     0x556fe892d565  doris::vectorized::ScannerScheduler::_scanner_scan()
    @     0x556fe8931a0f  _ZNSt17_Function_handlerIFvvEZZN5doris10vectorized16ScannerScheduler6submitESt10shared_ptrINS2_14ScannerContextEES4_INS2_8ScanTaskEEENK3$_1clEvEUlvE_E9_M_invokeERKSt9_Any_data
    @     0x556fd0ed95dc  doris::ThreadPool::dispatch_thread()
    @     0x556fd0eb1288  doris::Thread::supervise_thread()
    @     0x7f95143b5609  start_thread
    @     0x7f9514662133  clone
    @              (nil)  (unknown)
*** Query id: c389fc2a1ff6473c-a06f032b8970810c ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1719510556 (unix time) try "date -d @1719510556" if you are using GNU date ***
*** Current BE git commitID: b13c17de9b ***
*** SIGABRT unknown detail explain (@0x3fca33) received by PID 4180531 (TID 4183685 OR 0x7f89734a5700) from PID 4180531; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F9514586090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x0000557004718C9D in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 5# 0x000055700470B2DA in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 9# doris::DeleteHandler::init(std::shared_ptr<doris::TabletSchema>, std::vector<std::shared_ptr<doris::RowsetMeta>, std::allocator<std::shared_ptr<doris::RowsetMeta> > > const&, long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/olap/delete_handler.cpp:388
10# doris::TabletReader::_init_delete_condition(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:654
11# doris::TabletReader::_init_params(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:295
12# doris::TabletReader::init(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet_reader.cpp:128
13# doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
14# doris::vectorized::NewOlapScanner::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/new_olap_scanner.cpp:219
15# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:250
16# std::_Function_handler<void (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_1::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
18# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:499
19# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
20# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

```

related PRs: https://github.com/apache/doris/pull/36090, https://github.com/apache/doris/pull/36101, https://github.com/apache/doris/pull/36314
