### PR TITLE
[Bug](QueryStatistics) use std::atomic<int64_t> for returned_rows to save data

### DIFF
--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -64,7 +64,7 @@ void QueryStatistics::to_thrift(TQueryStatistics* statistics) const {
     statistics->__set_scan_bytes(scan_bytes.load(std::memory_order_relaxed));
     statistics->__set_scan_rows(scan_rows.load(std::memory_order_relaxed));
     statistics->__set_cpu_ms(cpu_nanos.load(std::memory_order_relaxed) / NANOS_PER_MILLIS);
-    statistics->__set_returned_rows(returned_rows);
+    statistics->__set_returned_rows(returned_rows.load(std::memory_order_relaxed));
     statistics->__set_max_peak_memory_bytes(max_peak_memory_bytes.load(std::memory_order_relaxed));
     statistics->__set_current_used_memory_bytes(
             current_used_memory_bytes.load(std::memory_order_relaxed));

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -81,7 +81,9 @@ public:
         this->_scan_bytes_from_remote_storage += scan_bytes_from_remote_storage;
     }
 
-    void add_returned_rows(int64_t num_rows) { this->returned_rows += num_rows; }
+    void add_returned_rows(int64_t num_rows) {
+        this->returned_rows.fetch_add(num_rows, std::memory_order_relaxed);
+    }
 
     void set_max_peak_memory_bytes(int64_t max_peak_memory_bytes) {
         this->max_peak_memory_bytes.store(max_peak_memory_bytes, std::memory_order_relaxed);
@@ -106,7 +108,7 @@ public:
         _scan_bytes_from_local_storage.store(0);
         _scan_bytes_from_remote_storage.store(0);
 
-        returned_rows = 0;
+        returned_rows.store(0, std::memory_order_relaxed);
         max_peak_memory_bytes.store(0, std::memory_order_relaxed);
         clearNodeStatistics();
         //clear() is used before collection, so calling "clear" is equivalent to being collected.
@@ -134,7 +136,7 @@ private:
     std::atomic<int64_t> _scan_bytes_from_remote_storage;
     // number rows returned by query.
     // only set once by result sink when closing.
-    int64_t returned_rows;
+    std::atomic<int64_t> returned_rows;
     // Maximum memory peak for all backends.
     // only set once by result sink when closing.
     std::atomic<int64_t> max_peak_memory_bytes;


### PR DESCRIPTION
## Proposed changes

when set enable_parallel_result_sink = true, it's will be plan multi result sink operator,
and if set dry_run_query = true, it's will sum all result sink operator of return rows,
so need use std::atomic<int64_t> for returned_rows to save data.

