### PR TITLE
[fix](stmt) fix show create table consistency

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -271,7 +271,7 @@ public class SlotRef extends Expr {
             // virtual slot of an alias function
             // when we try to translate an alias function to Nereids style, the desc in the place holding slotRef
             // is null, and we just need the name of col.
-            return col;
+            return "`" + col + "`";
         } else if (desc.getSourceExprs() != null) {
             if (!disableTableName && (ToSqlContext.get() == null || ToSqlContext.get().isNeedSlotRefId())) {
                 if (desc.getId().asInt() != 1) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before we may get `AUTO PARTITION BY RANGE (date_trunc(`k0`, 'year'))` or `AUTO PARTITION BY RANGE (date_trunc(k0, 'year'))`

now always `AUTO PARTITION BY RANGE (date_trunc(`k0`, 'year'))`