### PR TITLE
[fix](multi-catalog) Revert #36575 and check nullptr of data column

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -704,8 +704,10 @@ void Block::clear_column_data(int column_size) noexcept {
         }
     }
     for (auto& d : data) {
-        DCHECK_EQ(d.column->use_count(), 1) << " " << print_use_count();
-        (*std::move(d.column)).assume_mutable()->clear();
+        if (d.column) {
+            DCHECK_EQ(d.column->use_count(), 1) << " " << print_use_count();
+            (*std::move(d.column)).assume_mutable()->clear();
+        }
     }
     row_same_bit.clear();
 }

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -1594,6 +1594,7 @@ Status OrcReader::get_next_block_impl(Block* block, size_t* read_rows, bool* eof
             } catch (std::exception& e) {
                 std::string _err_msg = e.what();
                 if (_io_ctx && _io_ctx->should_stop && _err_msg == "stop") {
+                    block->clear_column_data();
                     *eof = true;
                     *read_rows = 0;
                     return Status::OK();
@@ -1663,6 +1664,7 @@ Status OrcReader::get_next_block_impl(Block* block, size_t* read_rows, bool* eof
             } catch (std::exception& e) {
                 std::string _err_msg = e.what();
                 if (_io_ctx && _io_ctx->should_stop && _err_msg == "stop") {
+                    block->clear_column_data();
                     *eof = true;
                     *read_rows = 0;
                     return Status::OK();

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -525,6 +525,7 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
     Status batch_st =
             _current_group_reader->next_batch(block, _batch_size, read_rows, &_row_group_eof);
     if (batch_st.is<ErrorCode::END_OF_FILE>()) {
+        block->clear_column_data();
         _current_group_reader.reset(nullptr);
         *read_rows = 0;
         *eof = true;


### PR DESCRIPTION
## Proposed changes

Revert #36575, because `VScanner::get_block` will check `DCHECK(block->rows() == 0)`, so block should be cleared when `eof = true`.