### PR TITLE
[fix](statistics)Fix partition record update rows bug. Remove useless code.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
@@ -20,7 +20,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 import org.apache.doris.statistics.util.StatisticsUtil;
@@ -55,10 +54,6 @@ public class AnalyzeStmt extends StatementBase {
 
     public Map<String, String> getProperties() {
         return analyzeProperties.getProperties();
-    }
-
-    public AnalysisMode getAnalysisMode() {
-        return analyzeProperties.isIncremental() ? AnalysisMode.INCREMENTAL : AnalysisMode.FULL;
     }
 
     public AnalysisType getAnalysisType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowAnalyzeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowAnalyzeStmt.java
@@ -63,6 +63,7 @@ public class ShowAnalyzeStmt extends ShowStmt {
             .add("start_time")
             .add("end_time")
             .add("priority")
+            .add("enable_partition")
             .build();
 
     private long jobId;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2914,7 +2914,7 @@ public class ShowExecutor {
 
     private void handleShowAnalyze() {
         ShowAnalyzeStmt showStmt = (ShowAnalyzeStmt) stmt;
-        List<AnalysisInfo> results = Env.getCurrentEnv().getAnalysisManager().showAnalysisJob(showStmt);
+        List<AnalysisInfo> results = Env.getCurrentEnv().getAnalysisManager().findAnalysisJobs(showStmt);
         List<List<String>> resultRows = Lists.newArrayList();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         for (AnalysisInfo analysisInfo : results) {
@@ -2951,6 +2951,7 @@ public class ShowExecutor {
                 row.add(startTime.format(formatter));
                 row.add(endTime.format(formatter));
                 row.add(analysisInfo.priority.name());
+                row.add(String.valueOf(analysisInfo.enablePartition));
                 resultRows.add(row);
             } catch (Exception e) {
                 LOG.warn("Failed to get analyze info for table {}.{}.{}, reason: {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -45,12 +45,6 @@ public class AnalysisInfo implements Writable {
 
     private static final Logger LOG = LogManager.getLogger(AnalysisInfo.class);
 
-    // TODO: useless, remove it later
-    public enum AnalysisMode {
-        INCREMENTAL,
-        FULL
-    }
-
     public enum AnalysisMethod {
         SAMPLE,
         FULL
@@ -110,9 +104,6 @@ public class AnalysisInfo implements Writable {
 
     @SerializedName("jobType")
     public final JobType jobType;
-
-    @SerializedName("analysisMode")
-    public final AnalysisMode analysisMode;
 
     @SerializedName("analysisMethod")
     public final AnalysisMethod analysisMethod;
@@ -202,15 +193,18 @@ public class AnalysisInfo implements Writable {
     @SerializedName("priority")
     public final JobPriority priority;
 
+    @SerializedName("ep")
+    public final boolean enablePartition;
+
     public AnalysisInfo(long jobId, long taskId, List<Long> taskIds, long catalogId, long dbId, long tblId,
             Set<Pair<String, String>> jobColumns, Set<String> partitionNames, String colName, Long indexId,
-            JobType jobType, AnalysisMode analysisMode, AnalysisMethod analysisMethod, AnalysisType analysisType,
+            JobType jobType, AnalysisMethod analysisMethod, AnalysisType analysisType,
             int samplePercent, long sampleRows, int maxBucketNum, long periodTimeInMs, String message,
             long lastExecTimeInMs, long timeCostInMs, AnalysisState state, ScheduleType scheduleType,
             boolean partitionOnly, boolean samplingPartition,
             boolean isAllPartition, long partitionCount, CronExpression cronExpression, boolean forceFull,
             boolean usingSqlForExternalTable, long tblUpdateTime, long rowCount, boolean userInject,
-            long updateRows, JobPriority priority, Map<Long, Long> partitionUpdateRows) {
+            long updateRows, JobPriority priority, Map<Long, Long> partitionUpdateRows, boolean enablePartition) {
         this.jobId = jobId;
         this.taskId = taskId;
         this.taskIds = taskIds;
@@ -222,7 +216,6 @@ public class AnalysisInfo implements Writable {
         this.colName = colName;
         this.indexId = indexId;
         this.jobType = jobType;
-        this.analysisMode = analysisMode;
         this.analysisMethod = analysisMethod;
         this.analysisType = analysisType;
         this.samplePercent = samplePercent;
@@ -252,6 +245,7 @@ public class AnalysisInfo implements Writable {
         if (partitionUpdateRows != null) {
             this.partitionUpdateRows.putAll(partitionUpdateRows);
         }
+        this.enablePartition = enablePartition;
     }
 
     @Override
@@ -263,7 +257,6 @@ public class AnalysisInfo implements Writable {
         sj.add("TableName: " + tblId);
         sj.add("ColumnName: " + colName);
         sj.add("TaskType: " + analysisType);
-        sj.add("TaskMode: " + analysisMode);
         sj.add("TaskMethod: " + analysisMethod);
         sj.add("Message: " + message);
         sj.add("CurrentState: " + state);
@@ -297,6 +290,7 @@ public class AnalysisInfo implements Writable {
         sj.add("userInject: " + userInject);
         sj.add("updateRows: " + updateRows);
         sj.add("priority: " + priority.name());
+        sj.add("enablePartition: " + enablePartition);
         return sj.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -19,7 +19,6 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.common.Pair;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
@@ -42,7 +41,6 @@ public class AnalysisInfoBuilder {
     private String colName;
     private long indexId = -1L;
     private JobType jobType;
-    private AnalysisMode analysisMode;
     private AnalysisMethod analysisMethod;
     private AnalysisType analysisType;
     private int maxBucketNum;
@@ -67,6 +65,7 @@ public class AnalysisInfoBuilder {
     private long updateRows;
     private JobPriority priority;
     private Map<Long, Long> partitionUpdateRows;
+    private boolean enablePartition;
 
     public AnalysisInfoBuilder() {
     }
@@ -83,7 +82,6 @@ public class AnalysisInfoBuilder {
         colName = info.colName;
         indexId = info.indexId;
         jobType = info.jobType;
-        analysisMode = info.analysisMode;
         analysisMethod = info.analysisMethod;
         analysisType = info.analysisType;
         samplePercent = info.samplePercent;
@@ -108,6 +106,7 @@ public class AnalysisInfoBuilder {
         updateRows = info.updateRows;
         priority = info.priority;
         partitionUpdateRows = info.partitionUpdateRows;
+        enablePartition = info.enablePartition;
     }
 
     public AnalysisInfoBuilder setJobId(long jobId) {
@@ -162,11 +161,6 @@ public class AnalysisInfoBuilder {
 
     public AnalysisInfoBuilder setJobType(JobType jobType) {
         this.jobType = jobType;
-        return this;
-    }
-
-    public AnalysisInfoBuilder setAnalysisMode(AnalysisMode analysisMode) {
-        this.analysisMode = analysisMode;
         return this;
     }
 
@@ -290,13 +284,18 @@ public class AnalysisInfoBuilder {
         return this;
     }
 
+    public AnalysisInfoBuilder setEnablePartition(boolean enablePartition) {
+        this.enablePartition = enablePartition;
+        return this;
+    }
+
     public AnalysisInfo build() {
         return new AnalysisInfo(jobId, taskId, taskIds, catalogId, dbId, tblId, jobColumns, partitionNames,
-                colName, indexId, jobType, analysisMode, analysisMethod, analysisType, samplePercent,
+                colName, indexId, jobType, analysisMethod, analysisType, samplePercent,
                 sampleRows, maxBucketNum, periodTimeInMs, message, lastExecTimeInMs, timeCostInMs, state, scheduleType,
                 partitionOnly, samplingPartition, isAllPartition, partitionCount,
                 cronExpression, forceFull, usingSqlForExternalTable, tblUpdateTime, rowCount, userInject, updateRows,
-                priority, partitionUpdateRows);
+                priority, partitionUpdateRows, enablePartition);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -63,7 +63,6 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.qe.ShowResultSetMetaData;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
@@ -330,12 +329,12 @@ public class AnalysisManager implements Writable {
         int samplePercent = stmt.getSamplePercent();
         int sampleRows = stmt.getSampleRows();
         AnalysisType analysisType = stmt.getAnalysisType();
-        AnalysisMode analysisMode = stmt.getAnalysisMode();
         AnalysisMethod analysisMethod = stmt.getAnalysisMethod();
         ScheduleType scheduleType = stmt.getScheduleType();
         CronExpression cronExpression = stmt.getCron();
 
         infoBuilder.setJobId(jobId);
+        infoBuilder.setTaskId(-1);
         infoBuilder.setCatalogId(stmt.getCatalogId());
         infoBuilder.setDBId(stmt.getDbId());
         infoBuilder.setTblId(stmt.getTable().getId());
@@ -348,7 +347,6 @@ public class AnalysisManager implements Writable {
         infoBuilder.setState(AnalysisState.PENDING);
         infoBuilder.setLastExecTimeInMs(System.currentTimeMillis());
         infoBuilder.setAnalysisType(analysisType);
-        infoBuilder.setAnalysisMode(analysisMode);
         infoBuilder.setAnalysisMethod(analysisMethod);
         infoBuilder.setScheduleType(scheduleType);
         infoBuilder.setCronExpression(cronExpression);
@@ -385,6 +383,7 @@ public class AnalysisManager implements Writable {
         infoBuilder.setUpdateRows(tableStatsStatus == null ? 0 : tableStatsStatus.updatedRows.get());
         infoBuilder.setPriority(JobPriority.MANUAL);
         infoBuilder.setPartitionUpdateRows(tableStatsStatus == null ? null : tableStatsStatus.partitionUpdateRows);
+        infoBuilder.setEnablePartition(StatisticsUtil.enablePartitionAnalyze());
         return infoBuilder.build();
     }
 
@@ -393,10 +392,7 @@ public class AnalysisManager implements Writable {
         if (jobInfo.scheduleType == ScheduleType.PERIOD && jobInfo.lastExecTimeInMs > 0) {
             return;
         }
-        // TODO: why create a new info object?
-        AnalysisInfoBuilder jobInfoBuilder = new AnalysisInfoBuilder(jobInfo);
-        AnalysisInfo analysisInfo = jobInfoBuilder.setTaskId(-1).build();
-        replayCreateAnalysisJob(analysisInfo);
+        replayCreateAnalysisJob(jobInfo);
     }
 
     public void createTaskForEachColumns(AnalysisInfo jobInfo, Map<Long, BaseAnalysisTask> analysisTasks,
@@ -568,11 +564,7 @@ public class AnalysisManager implements Writable {
         return result;
     }
 
-    public List<AnalysisInfo> showAnalysisJob(ShowAnalyzeStmt stmt) {
-        return findShowAnalyzeResult(stmt);
-    }
-
-    private List<AnalysisInfo> findShowAnalyzeResult(ShowAnalyzeStmt stmt) {
+    public List<AnalysisInfo> findAnalysisJobs(ShowAnalyzeStmt stmt) {
         String state = stmt.getStateValue();
         TableName tblName = stmt.getDbTableName();
         TableIf tbl = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -214,7 +214,6 @@ public class StatisticsAutoCollector extends MasterDaemon {
                 .setColName(stringJoiner.toString())
                 .setJobColumns(jobColumns)
                 .setAnalysisType(AnalysisInfo.AnalysisType.FUNDAMENTALS)
-                .setAnalysisMode(AnalysisInfo.AnalysisMode.INCREMENTAL)
                 .setAnalysisMethod(analysisMethod)
                 .setPartitionNames(Collections.emptySet())
                 .setSampleRows(analysisMethod.equals(AnalysisMethod.SAMPLE)
@@ -229,6 +228,7 @@ public class StatisticsAutoCollector extends MasterDaemon {
                 .setUpdateRows(tableStatsStatus == null ? 0 : tableStatsStatus.updatedRows.get())
                 .setPriority(priority)
                 .setPartitionUpdateRows(tableStatsStatus == null ? null : tableStatsStatus.partitionUpdateRows)
+                .setEnablePartition(StatisticsUtil.enablePartitionAnalyze())
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -137,7 +137,7 @@ public class TableStatsMeta implements Writable, GsonPostProcessable {
             if (colStatsMeta == null) {
                 colToColStatsMeta.put(colPair, new ColStatsMeta(analyzedJob.createTime, analyzedJob.analysisMethod,
                         analyzedJob.analysisType, analyzedJob.jobType, 0, analyzedJob.rowCount,
-                        analyzedJob.updateRows, analyzedJob.partitionUpdateRows));
+                        analyzedJob.updateRows, analyzedJob.enablePartition ? analyzedJob.partitionUpdateRows : null));
             } else {
                 colStatsMeta.updatedTime = analyzedJob.tblUpdateTime;
                 colStatsMeta.analysisType = analyzedJob.analysisType;
@@ -145,10 +145,12 @@ public class TableStatsMeta implements Writable, GsonPostProcessable {
                 colStatsMeta.jobType = analyzedJob.jobType;
                 colStatsMeta.updatedRows = analyzedJob.updateRows;
                 colStatsMeta.rowCount = analyzedJob.rowCount;
-                if (colStatsMeta.partitionUpdateRows == null) {
-                    colStatsMeta.partitionUpdateRows = new ConcurrentHashMap<>();
+                if (analyzedJob.enablePartition) {
+                    if (colStatsMeta.partitionUpdateRows == null) {
+                        colStatsMeta.partitionUpdateRows = new ConcurrentHashMap<>();
+                    }
+                    colStatsMeta.partitionUpdateRows.putAll(analyzedJob.partitionUpdateRows);
                 }
-                colStatsMeta.partitionUpdateRows.putAll(analyzedJob.partitionUpdateRows);
             }
         }
         jobType = analyzedJob.jobType;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -326,7 +326,7 @@ public class AnalysisManagerTest {
             3L, new AnalysisInfoBuilder().setJobId(3).setJobType(JobType.SYSTEM).setState(AnalysisState.FINISHED).build());
         analysisManager.analysisJobInfoMap.put(
             4L, new AnalysisInfoBuilder().setJobId(4).setJobType(JobType.SYSTEM).setState(AnalysisState.FAILED).build());
-        List<AnalysisInfo> analysisInfos = analysisManager.showAnalysisJob(stmt);
+        List<AnalysisInfo> analysisInfos = analysisManager.findAnalysisJobs(stmt);
         Assertions.assertEquals(3, analysisInfos.size());
         Assertions.assertEquals(AnalysisState.RUNNING, analysisInfos.get(0).getState());
         Assertions.assertEquals(AnalysisState.FINISHED, analysisInfos.get(1).getState());

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -27,7 +27,6 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.DBObjects;
@@ -97,7 +96,6 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
                 .setDBId(0)
                 .setTblId(0)
                 .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMode(AnalysisMode.FULL)
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.FUNDAMENTALS)
                 .build();
@@ -160,7 +158,6 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
         AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
                 .setCatalogId(0).setDBId(0).setTblId(0)
                 .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMode(AnalysisMode.FULL)
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.FUNDAMENTALS)
                 .setState(AnalysisState.RUNNING)

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalyzeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalyzeTest.java
@@ -29,7 +29,6 @@ import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.DBObjects;
@@ -167,7 +166,6 @@ public class AnalyzeTest extends TestWithFeService {
                 .setDBId(0)
                 .setTblId(0)
                 .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMode(AnalysisMode.FULL)
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.FUNDAMENTALS)
                 .setJobColumns(colList)

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTaskTest.java
@@ -27,7 +27,6 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
-import org.apache.doris.statistics.AnalysisInfo.AnalysisMode;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.DBObjects;
@@ -118,7 +117,6 @@ public class HistogramTaskTest extends TestWithFeService {
                 .setDBId(0)
                 .setTblId(0)
                 .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMode(AnalysisMode.FULL)
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.HISTOGRAM)
                 .build();

--- a/regression-test/suites/statistics/test_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_partition_stats.groovy
@@ -105,10 +105,14 @@ suite("test_partition_stats") {
     // Don't record partition update rows until first analyze finish.
     def result = sql """show table stats part partition(*)"""
     assertEquals(0, result.size())
-    sql """analyze table part with sync;"""
+    sql """analyze table part properties("use.auto.analyzer"="true");"""
     result = sql """show table stats part"""
     assertEquals(1, result.size())
     assertEquals("0", result[0][0])
+    result = sql """show auto analyze part"""
+    assertEquals(1, result.size())
+    assertEquals("true", result[0][15])
+
 
     // Test show cached partition stats.
     sql """analyze table part with sync;"""


### PR DESCRIPTION
Fix partition record update rows bug. 
When enable_partition_analyze set to false, we shouldn't update column's update rows map, only update it when enable_partition_analyze is true. Because when it's false, the analyze task didn't collect partition level stats. If we update column's update rows in this case, it will cause auto analyze failed to trigger partition collection because the health checker thought the update rows are update-to-date.