### PR TITLE
[enhancement](nereids) speedup sql cache with variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/NereidsSqlCacheManager.java
@@ -48,6 +48,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
+import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.Types.PUniqueId;
 import org.apache.doris.qe.ConnectContext;
@@ -58,6 +59,7 @@ import org.apache.doris.qe.cache.SqlCache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.lang.reflect.Field;
@@ -124,16 +126,14 @@ public class NereidsSqlCacheManager {
         SqlCacheContext sqlCacheContext = sqlCacheContextOpt.get();
         UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
         String key = currentUserIdentity.toString() + ":" + sql.trim();
-        if ((sqlCaches.getIfPresent(key) == null) && sqlCacheContext.getOrComputeCacheKeyMd5() != null
+        if (sqlCaches.getIfPresent(key) == null && sqlCacheContext.getOrComputeCacheKeyMd5() != null
                 && sqlCacheContext.getResultSetInFe().isPresent()) {
             sqlCaches.put(key, sqlCacheContext);
         }
     }
 
-    /** tryAddCache */
-    public void tryAddCache(
-            ConnectContext connectContext, String sql,
-            CacheAnalyzer analyzer, boolean currentMissParseSqlFromSqlCache) {
+    /** tryAddBeCache */
+    public void tryAddBeCache(ConnectContext connectContext, String sql, CacheAnalyzer analyzer) {
         Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
         if (!sqlCacheContextOpt.isPresent()) {
             return;
@@ -144,8 +144,7 @@ public class NereidsSqlCacheManager {
         SqlCacheContext sqlCacheContext = sqlCacheContextOpt.get();
         UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
         String key = currentUserIdentity.toString() + ":" + sql.trim();
-        if ((currentMissParseSqlFromSqlCache || sqlCaches.getIfPresent(key) == null)
-                && sqlCacheContext.getOrComputeCacheKeyMd5() != null) {
+        if (sqlCaches.getIfPresent(key) == null && sqlCacheContext.getOrComputeCacheKeyMd5() != null) {
             SqlCache cache = (SqlCache) analyzer.getCache();
             sqlCacheContext.setSumOfPartitionNum(cache.getSumOfPartitionNum());
             sqlCacheContext.setLatestPartitionId(cache.getLatestId());
@@ -183,9 +182,6 @@ public class NereidsSqlCacheManager {
         if (viewsChanged(env, sqlCacheContext)) {
             return invalidateCache(key);
         }
-        if (usedVariablesChanged(sqlCacheContext)) {
-            return invalidateCache(key);
-        }
 
         LogicalEmptyRelation whateverPlan = new LogicalEmptyRelation(new RelationId(0), ImmutableList.of());
         if (nondeterministicFunctionChanged(whateverPlan, connectContext, sqlCacheContext)) {
@@ -202,7 +198,10 @@ public class NereidsSqlCacheManager {
 
         try {
             Optional<ResultSet> resultSetInFe = sqlCacheContext.getResultSetInFe();
-            if (resultSetInFe.isPresent()) {
+
+            List<Variable> currentVariables = resolveUserVariables(sqlCacheContext);
+            boolean usedVariablesChanged = usedVariablesChanged(currentVariables, sqlCacheContext);
+            if (resultSetInFe.isPresent() && !usedVariablesChanged) {
                 MetricRepo.COUNTER_CACHE_HIT_SQL.increase(1L);
 
                 String cachedPlan = sqlCacheContext.getPhysicalPlan();
@@ -215,7 +214,9 @@ public class NereidsSqlCacheManager {
             }
 
             Status status = new Status();
-            PUniqueId cacheKeyMd5 = sqlCacheContext.getOrComputeCacheKeyMd5();
+            PUniqueId cacheKeyMd5 = usedVariablesChanged
+                    ? sqlCacheContext.doComputeCacheKeyMd5(Utils.fastToImmutableSet(currentVariables))
+                    : sqlCacheContext.getOrComputeCacheKeyMd5();
             InternalService.PFetchCacheResult cacheData =
                     SqlCache.getCacheData(sqlCacheContext.getCacheProxy(),
                             cacheKeyMd5, sqlCacheContext.getLatestPartitionId(),
@@ -236,7 +237,7 @@ public class NereidsSqlCacheManager {
                 );
                 return Optional.of(logicalSqlCache);
             }
-            return invalidateCache(key);
+            return Optional.empty();
         } catch (Throwable t) {
             return invalidateCache(key);
         }
@@ -343,12 +344,24 @@ public class NereidsSqlCacheManager {
         return false;
     }
 
-    private boolean usedVariablesChanged(SqlCacheContext sqlCacheContext) {
-        for (Variable variable : sqlCacheContext.getUsedVariables()) {
+    private List<Variable> resolveUserVariables(SqlCacheContext sqlCacheContext) {
+        List<Variable> cachedUsedVariables = sqlCacheContext.getUsedVariables();
+        List<Variable> currentVariables = Lists.newArrayListWithCapacity(cachedUsedVariables.size());
+        for (Variable cachedVariable : cachedUsedVariables) {
             Variable currentVariable = ExpressionAnalyzer.resolveUnboundVariable(
-                    new UnboundVariable(variable.getName(), variable.getType()));
-            if (!Objects.equals(currentVariable, variable)
-                    || variable.getRealExpression().anyMatch(Nondeterministic.class::isInstance)) {
+                    new UnboundVariable(cachedVariable.getName(), cachedVariable.getType()));
+            currentVariables.add(currentVariable);
+        }
+        return currentVariables;
+    }
+
+    private boolean usedVariablesChanged(List<Variable> currentVariables, SqlCacheContext sqlCacheContext) {
+        List<Variable> cachedUsedVariables = sqlCacheContext.getUsedVariables();
+        for (int i = 0; i < cachedUsedVariables.size(); i++) {
+            Variable currentVariable = currentVariables.get(i);
+            Variable cachedVariable = cachedUsedVariables.get(i);
+            if (!Objects.equals(currentVariable, cachedVariable)
+                    || cachedVariable.getRealExpression().anyMatch(Nondeterministic.class::isInstance)) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -602,8 +602,8 @@ public class NereidsPlanner extends Planner {
             }
         }
 
-        if (physicalPlan instanceof PhysicalResultSink &&
-                physicalPlan.child(0) instanceof PhysicalHashAggregate && !getScanNodes().isEmpty()
+        if (physicalPlan instanceof PhysicalResultSink
+                && physicalPlan.child(0) instanceof PhysicalHashAggregate && !getScanNodes().isEmpty()
                 && getScanNodes().get(0) instanceof IcebergScanNode) {
             List<Column> columns = Lists.newArrayList();
             NamedExpression output = physicalPlan.getOutput().get(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
@@ -329,51 +329,55 @@ public class SqlCacheContext {
                 if (cacheKeyMd5 != null) {
                     return cacheKeyMd5;
                 }
-
-                StringBuilder cacheKey = new StringBuilder(originSql);
-                for (Entry<FullTableName, String> entry : usedViews.entrySet()) {
-                    cacheKey.append("|")
-                            .append(entry.getKey())
-                            .append("=")
-                            .append(entry.getValue());
-                }
-                for (Variable usedVariable : usedVariables) {
-                    cacheKey.append("|")
-                            .append(usedVariable.getType().name())
-                            .append(":")
-                            .append(usedVariable.getName())
-                            .append("=")
-                            .append(usedVariable.getRealExpression().toSql());
-                }
-                for (Pair<Expression, Expression> pair : foldNondeterministicPairs) {
-                    cacheKey.append("|")
-                            .append(pair.key().toSql())
-                            .append("=")
-                            .append(pair.value().toSql());
-                }
-                for (Entry<FullTableName, List<RowFilterPolicy>> entry : rowPolicies.entrySet()) {
-                    List<RowFilterPolicy> policy = entry.getValue();
-                    if (policy.isEmpty()) {
-                        continue;
-                    }
-                    cacheKey.append("|")
-                            .append(entry.getKey())
-                            .append("=")
-                            .append(policy);
-                }
-                for (Entry<FullColumnName, Optional<DataMaskPolicy>> entry : dataMaskPolicies.entrySet()) {
-                    if (!entry.getValue().isPresent()) {
-                        continue;
-                    }
-                    cacheKey.append("|")
-                            .append(entry.getKey())
-                            .append("=")
-                            .append(entry.getValue().map(Object::toString).orElse(""));
-                }
-                cacheKeyMd5 = CacheProxy.getMd5(cacheKey.toString());
+                cacheKeyMd5 = doComputeCacheKeyMd5(usedVariables);
             }
         }
         return cacheKeyMd5;
+    }
+
+    /** doComputeCacheKeyMd5 */
+    public synchronized PUniqueId doComputeCacheKeyMd5(Set<Variable> usedVariables) {
+        StringBuilder cacheKey = new StringBuilder(originSql);
+        for (Entry<FullTableName, String> entry : usedViews.entrySet()) {
+            cacheKey.append("|")
+                    .append(entry.getKey())
+                    .append("=")
+                    .append(entry.getValue());
+        }
+        for (Variable usedVariable : usedVariables) {
+            cacheKey.append("|")
+                    .append(usedVariable.getType().name())
+                    .append(":")
+                    .append(usedVariable.getName())
+                    .append("=")
+                    .append(usedVariable.getRealExpression().toSql());
+        }
+        for (Pair<Expression, Expression> pair : foldNondeterministicPairs) {
+            cacheKey.append("|")
+                    .append(pair.key().toSql())
+                    .append("=")
+                    .append(pair.value().toSql());
+        }
+        for (Entry<FullTableName, List<RowFilterPolicy>> entry : rowPolicies.entrySet()) {
+            List<RowFilterPolicy> policy = entry.getValue();
+            if (policy.isEmpty()) {
+                continue;
+            }
+            cacheKey.append("|")
+                    .append(entry.getKey())
+                    .append("=")
+                    .append(policy);
+        }
+        for (Entry<FullColumnName, Optional<DataMaskPolicy>> entry : dataMaskPolicies.entrySet()) {
+            if (!entry.getValue().isPresent()) {
+                continue;
+            }
+            cacheKey.append("|")
+                    .append(entry.getKey())
+                    .append("=")
+                    .append(entry.getValue().map(Object::toString).orElse(""));
+        }
+        return CacheProxy.getMd5(cacheKey.toString());
     }
 
     public void setOriginSql(String originSql) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
@@ -23,7 +23,28 @@ import org.apache.doris.qe.ResultSet;
 
 import java.util.Optional;
 
-/** ComputeResultSet */
+/**
+  * <p>
+  * This class is used to return result set in fe without send fragment to be.
+  * Some plans support this function, for example:
+  * <li>1. the sql `select 100` will generate a plan, PhysicalOneRowRelation, and PhysicalOneRowRelation implement this
+  *     interface, so fe can send the only row to client immediately.
+  * </li>
+  * <li>2. the sql `select * from tbl limit 0` will generate PhysicalEmptyRelation, which means no any rows returned,
+  *    the PhysicalEmptyRelation implement this interface.
+  * </li>
+  * </p>
+  * <p>
+  * If you want to cache the result set in fe, you can implement this interface and write this code:
+  * </p>
+  * <pre>
+  * sqlCacheContext.get().setResultSetInFe(resultSet);
+  * Env.getCurrentEnv().getSqlCacheManager().tryAddFeSqlCache(
+  * statementContext.getConnectContext(),
+  * statementContext.getOriginStatement().originStmt
+  * );
+  * </pre>
+  */
 public interface ComputeResultSet {
     Optional<ResultSet> computeResultInFe(CascadesContext cascadesContext, Optional<SqlCacheContext> sqlCacheContext);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
@@ -38,11 +38,16 @@ import java.util.Optional;
   * If you want to cache the result set in fe, you can implement this interface and write this code:
   * </p>
   * <pre>
-  * sqlCacheContext.get().setResultSetInFe(resultSet);
-  * Env.getCurrentEnv().getSqlCacheManager().tryAddFeSqlCache(
-  * statementContext.getConnectContext(),
-  * statementContext.getOriginStatement().originStmt
-  * );
+  * StatementContext statementContext = cascadesContext.getStatementContext();
+  * boolean enableSqlCache
+  *         = CacheAnalyzer.canUseSqlCache(statementContext.getConnectContext().getSessionVariable());
+  * if (sqlCacheContext.isPresent() && enableSqlCache) {
+  *     sqlCacheContext.get().setResultSetInFe(resultSet);
+  *     Env.getCurrentEnv().getSqlCacheManager().tryAddFeSqlCache(
+  *             statementContext.getConnectContext(),
+  *             statementContext.getOriginStatement().originStmt
+  *     );
+  * }
   * </pre>
   */
 public interface ComputeResultSet {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ComputeResultSet.java
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans;
+
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
+import org.apache.doris.qe.ResultSet;
+
+import java.util.Optional;
+
+/** ComputeResultSet */
+public interface ComputeResultSet {
+    Optional<ResultSet> computeResultInFe(CascadesContext cascadesContext, Optional<SqlCacheContext> sqlCacheContext);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEmptyRelation.java
@@ -17,20 +17,31 @@
 
 package org.apache.doris.nereids.trees.plans.physical;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.EmptyRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.qe.CommonResultSet;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.qe.ResultSetMetaData;
+import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +52,7 @@ import java.util.Optional;
  * e.g.
  * select * from tbl limit 0
  */
-public class PhysicalEmptyRelation extends PhysicalRelation implements EmptyRelation {
+public class PhysicalEmptyRelation extends PhysicalRelation implements EmptyRelation, ComputeResultSet {
 
     private final List<? extends NamedExpression> projects;
 
@@ -101,5 +112,31 @@ public class PhysicalEmptyRelation extends PhysicalRelation implements EmptyRela
             Statistics statistics) {
         return new PhysicalEmptyRelation(relationId, projects, Optional.empty(),
                 logicalPropertiesSupplier.get(), physicalProperties, statistics);
+    }
+
+    @Override
+    public Optional<ResultSet> computeResultInFe(CascadesContext cascadesContext,
+            Optional<SqlCacheContext> sqlCacheContext) {
+        List<Column> columns = Lists.newArrayList();
+        List<Slot> outputSlots = getOutput();
+        for (int i = 0; i < outputSlots.size(); i++) {
+            NamedExpression output = outputSlots.get(i);
+            columns.add(new Column(output.getName(), output.getDataType().toCatalogDataType()));
+        }
+
+        StatementContext statementContext = cascadesContext.getStatementContext();
+        boolean enableSqlCache
+                = CacheAnalyzer.canUseSqlCache(statementContext.getConnectContext().getSessionVariable());
+
+        ResultSetMetaData metadata = new CommonResultSet.CommonResultSetMetaData(columns);
+        ResultSet resultSet = new CommonResultSet(metadata, ImmutableList.of());
+        if (sqlCacheContext.isPresent() && enableSqlCache) {
+            sqlCacheContext.get().setResultSetInFe(resultSet);
+            Env.getCurrentEnv().getSqlCacheManager().tryAddFeSqlCache(
+                    statementContext.getConnectContext(),
+                    statementContext.getOriginStatement().originStmt
+            );
+        }
+        return Optional.of(resultSet);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
@@ -17,21 +17,35 @@
 
 package org.apache.doris.nereids.trees.plans.physical;
 
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.OneRowRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.qe.CommonResultSet;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.qe.ResultSetMetaData;
+import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -40,7 +54,7 @@ import java.util.Optional;
  * A physical relation that contains only one row consist of some constant expressions.
  * e.g. select 100, 'value'
  */
-public class PhysicalOneRowRelation extends PhysicalRelation implements OneRowRelation {
+public class PhysicalOneRowRelation extends PhysicalRelation implements OneRowRelation, ComputeResultSet {
 
     private final List<NamedExpression> projects;
 
@@ -118,5 +132,38 @@ public class PhysicalOneRowRelation extends PhysicalRelation implements OneRowRe
             Statistics statistics) {
         return new PhysicalOneRowRelation(relationId, projects, groupExpression,
                 logicalPropertiesSupplier.get(), physicalProperties, statistics);
+    }
+
+    @Override
+    public Optional<ResultSet> computeResultInFe(
+            CascadesContext cascadesContext, Optional<SqlCacheContext> sqlCacheContext) {
+        List<Column> columns = Lists.newArrayList();
+        List<String> data = Lists.newArrayList();
+        for (int i = 0; i < projects.size(); i++) {
+            NamedExpression item = projects.get(i);
+            NamedExpression output = getOutput().get(i);
+            Expression expr = item.child(0);
+            if (expr instanceof Literal) {
+                LiteralExpr legacyExpr = ((Literal) expr).toLegacyLiteral();
+                columns.add(new Column(output.getName(), output.getDataType().toCatalogDataType()));
+                data.add(legacyExpr.getStringValueInFe());
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        ResultSetMetaData metadata = new CommonResultSet.CommonResultSetMetaData(columns);
+        ResultSet resultSet = new CommonResultSet(metadata, Collections.singletonList(data));
+        StatementContext statementContext = cascadesContext.getStatementContext();
+        boolean enableSqlCache
+                = CacheAnalyzer.canUseSqlCache(statementContext.getConnectContext().getSessionVariable());
+        if (sqlCacheContext.isPresent() && enableSqlCache) {
+            sqlCacheContext.get().setResultSetInFe(resultSet);
+            Env.getCurrentEnv().getSqlCacheManager().tryAddFeSqlCache(
+                    statementContext.getConnectContext(),
+                    statementContext.getOriginStatement().originStmt
+            );
+        }
+        return Optional.of(resultSet);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSqlCache.java
@@ -19,12 +19,15 @@ package org.apache.doris.nereids.trees.plans.physical;
 
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.SqlCacheContext;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.TreeStringPlan;
@@ -44,7 +47,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /** PhysicalSqlCache */
-public class PhysicalSqlCache extends PhysicalLeaf implements SqlCache, TreeStringPlan {
+public class PhysicalSqlCache extends PhysicalLeaf implements SqlCache, TreeStringPlan, ComputeResultSet {
     private final TUniqueId queryId;
     private final List<String> columnLabels;
     private final List<Expr> resultExprs;
@@ -153,5 +156,11 @@ public class PhysicalSqlCache extends PhysicalLeaf implements SqlCache, TreeStri
     @Override
     public String getChildrenTreeString() {
         return planBody;
+    }
+
+    @Override
+    public Optional<ResultSet> computeResultInFe(
+            CascadesContext cascadesContext, Optional<SqlCacheContext> sqlCacheContext) {
+        return resultSet;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1735,7 +1735,7 @@ public class StmtExecutor {
                 String originStmt = parsedStmt.getOrigStmt().originStmt;
                 NereidsSqlCacheManager sqlCacheManager = context.getEnv().getSqlCacheManager();
                 if (cacheResult != null) {
-                    sqlCacheManager.tryAddCache(context, originStmt, cacheAnalyzer, false);
+                    sqlCacheManager.tryAddBeCache(context, originStmt, cacheAnalyzer);
                 }
             }
         }
@@ -1963,10 +1963,7 @@ public class StmtExecutor {
                 if (cache instanceof SqlCache && !cache.isDisableCache() && planner instanceof NereidsPlanner) {
                     String originStmt = parsedStmt.getOrigStmt().originStmt;
                     LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) queryStmt;
-                    boolean currentMissParseSqlFromSqlCache = !(logicalPlanAdapter.getLogicalPlan()
-                            instanceof org.apache.doris.nereids.trees.plans.algebra.SqlCache);
-                    context.getEnv().getSqlCacheManager().tryAddCache(
-                            context, originStmt, cacheAnalyzer, currentMissParseSqlFromSqlCache);
+                    context.getEnv().getSqlCacheManager().tryAddBeCache(context, originStmt, cacheAnalyzer);
                 }
             }
             if (!isSendFields) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1962,7 +1962,6 @@ public class StmtExecutor {
                 Cache cache = cacheAnalyzer.getCache();
                 if (cache instanceof SqlCache && !cache.isDisableCache() && planner instanceof NereidsPlanner) {
                     String originStmt = parsedStmt.getOrigStmt().originStmt;
-                    LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) queryStmt;
                     context.getEnv().getSqlCacheManager().tryAddBeCache(context, originStmt, cacheAnalyzer);
                 }
             }

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -553,105 +553,105 @@ suite("parse_sql_from_sql_cache") {
                 assertTrue(result1.size() == 1 && result1[0][0].toString().toInteger() == 10)
             }
         }),
-//        extraThread("test_udf", {
-//            def jarPath = """${context.config.suitePath}/javaudf_p0/jars/java-udf-case-jar-with-dependencies.jar"""
-//            scp_udf_file_to_all_be(jarPath)
-//            try_sql("DROP FUNCTION IF EXISTS java_udf_string_test(string, int, int);")
-//            try_sql("DROP TABLE IF EXISTS test_javaudf_string")
-//
-//            sql """ DROP TABLE IF EXISTS test_javaudf_string """
-//            sql """
-//                    CREATE TABLE IF NOT EXISTS test_javaudf_string (
-//                        `user_id`     INT         NOT NULL COMMENT "用户id",
-//                        `char_col`    CHAR        NOT NULL COMMENT "",
-//                        `varchar_col` VARCHAR(10) NOT NULL COMMENT "",
-//                        `string_col`  STRING      NOT NULL COMMENT ""
-//                        )
-//                        DISTRIBUTED BY HASH(user_id) PROPERTIES("replication_num" = "1");
-//                    """
-//
-//            StringBuilder values = new StringBuilder()
-//            int i = 1
-//            for (; i < 9; i ++) {
-//                values.append(" (${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg'),\n")
-//            }
-//            values.append("(${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg')")
-//
-//            sql "INSERT INTO test_javaudf_string VALUES ${values}"
-//            sql "sync"
-//
-//            File path = new File(jarPath)
-//            if (!path.exists()) {
-//                throw new IllegalStateException("""${jarPath} doesn't exist! """)
-//            }
-//
-//            sql """ CREATE FUNCTION java_udf_string_test(string, int, int) RETURNS string PROPERTIES (
-//                        "file"="file://${jarPath}",
-//                        "symbol"="org.apache.doris.udf.StringTest",
-//                        "type"="JAVA_UDF"
-//                    ); """
-//
-//            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
-//            sql "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
-//            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
-//        }),
-//        extraThread("testMultiFrontends", {
-//            def aliveFrontends = sql_return_maparray("show frontends")
-//                    .stream()
-//                    .filter { it["Alive"].toString().equalsIgnoreCase("true") }
-//                    .collect(Collectors.toList())
-//
-//            if (aliveFrontends.size() <= 1) {
-//                return
-//            }
-//
-//            def fe1 = aliveFrontends[0]["Host"] + ":" + aliveFrontends[0]["QueryPort"]
-//            def fe2 = fe1
-//            if (aliveFrontends.size() > 1) {
-//                fe2 = aliveFrontends[1]["Host"] + ":" + aliveFrontends[1]["QueryPort"]
-//            }
-//
-//            log.info("fe1: ${fe1}")
-//            log.info("fe2: ${fe2}")
-//
-//            def dbName = context.config.getDbNameByFile(context.file)
-//
-//            log.info("connect to fe: ${fe1}")
-//            connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = "jdbc:mysql://${fe1}") {
-//                sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
-//
-//                sql "use ${dbName}"
-//
-//                createTestTable "test_use_plan_cache18"
-//
-//                sql "sync"
-//
-//                // after partition changed 10s, the sql cache can be used
-//                sleep(10000)
-//
-//                sql "set enable_nereids_planner=true"
-//                sql "set enable_fallback_to_original_planner=false"
-//                sql "set enable_sql_cache=true"
-//
-//                assertNoCache "select * from test_use_plan_cache18"
-//                sql "select * from test_use_plan_cache18"
-//                assertHasCache "select * from test_use_plan_cache18"
-//            }
-//
-//            log.info("connect to fe: ${fe2}")
-//            connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = "jdbc:mysql://${fe2}") {
-//                sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
-//
-//                sql "use ${dbName}"
-//                sql "set enable_nereids_planner=true"
-//                sql "set enable_fallback_to_original_planner=false"
-//                sql "set enable_sql_cache=true"
-//
-//                assertNoCache "select * from test_use_plan_cache18"
-//                sql "select * from test_use_plan_cache18"
-//                assertHasCache "select * from test_use_plan_cache18"
-//            }
-//        }),
+        extraThread("test_udf", {
+            def jarPath = """${context.config.suitePath}/javaudf_p0/jars/java-udf-case-jar-with-dependencies.jar"""
+            scp_udf_file_to_all_be(jarPath)
+            try_sql("DROP FUNCTION IF EXISTS java_udf_string_test(string, int, int);")
+            try_sql("DROP TABLE IF EXISTS test_javaudf_string")
+
+            sql """ DROP TABLE IF EXISTS test_javaudf_string """
+            sql """
+                    CREATE TABLE IF NOT EXISTS test_javaudf_string (
+                        `user_id`     INT         NOT NULL COMMENT "用户id",
+                        `char_col`    CHAR        NOT NULL COMMENT "",
+                        `varchar_col` VARCHAR(10) NOT NULL COMMENT "",
+                        `string_col`  STRING      NOT NULL COMMENT ""
+                        )
+                        DISTRIBUTED BY HASH(user_id) PROPERTIES("replication_num" = "1");
+                    """
+
+            StringBuilder values = new StringBuilder()
+            int i = 1
+            for (; i < 9; i ++) {
+                values.append(" (${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg'),\n")
+            }
+            values.append("(${i}, '${i}','abcdefg${i}','poiuytre${i}abcdefg')")
+
+            sql "INSERT INTO test_javaudf_string VALUES ${values}"
+            sql "sync"
+
+            File path = new File(jarPath)
+            if (!path.exists()) {
+                throw new IllegalStateException("""${jarPath} doesn't exist! """)
+            }
+
+            sql """ CREATE FUNCTION java_udf_string_test(string, int, int) RETURNS string PROPERTIES (
+                        "file"="file://${jarPath}",
+                        "symbol"="org.apache.doris.udf.StringTest",
+                        "type"="JAVA_UDF"
+                    ); """
+
+            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+            sql "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+            assertNoCache "SELECT java_udf_string_test(varchar_col, 2, 3) result FROM test_javaudf_string ORDER BY result;"
+        }),
+        extraThread("testMultiFrontends", {
+            def aliveFrontends = sql_return_maparray("show frontends")
+                    .stream()
+                    .filter { it["Alive"].toString().equalsIgnoreCase("true") }
+                    .collect(Collectors.toList())
+
+            if (aliveFrontends.size() <= 1) {
+                return
+            }
+
+            def fe1 = aliveFrontends[0]["Host"] + ":" + aliveFrontends[0]["QueryPort"]
+            def fe2 = fe1
+            if (aliveFrontends.size() > 1) {
+                fe2 = aliveFrontends[1]["Host"] + ":" + aliveFrontends[1]["QueryPort"]
+            }
+
+            log.info("fe1: ${fe1}")
+            log.info("fe2: ${fe2}")
+
+            def dbName = context.config.getDbNameByFile(context.file)
+
+            log.info("connect to fe: ${fe1}")
+            connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = "jdbc:mysql://${fe1}") {
+                sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
+
+                sql "use ${dbName}"
+
+                createTestTable "test_use_plan_cache18"
+
+                sql "sync"
+
+                // after partition changed 10s, the sql cache can be used
+                sleep(10000)
+
+                sql "set enable_nereids_planner=true"
+                sql "set enable_fallback_to_original_planner=false"
+                sql "set enable_sql_cache=true"
+
+                assertNoCache "select * from test_use_plan_cache18"
+                sql "select * from test_use_plan_cache18"
+                assertHasCache "select * from test_use_plan_cache18"
+            }
+
+            log.info("connect to fe: ${fe2}")
+            connect(user = context.config.jdbcUser, password = context.config.jdbcPassword, url = "jdbc:mysql://${fe2}") {
+                sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
+
+                sql "use ${dbName}"
+                sql "set enable_nereids_planner=true"
+                sql "set enable_fallback_to_original_planner=false"
+                sql "set enable_sql_cache=true"
+
+                assertNoCache "select * from test_use_plan_cache18"
+                sql "select * from test_use_plan_cache18"
+                assertHasCache "select * from test_use_plan_cache18"
+            }
+        }),
         extraThread("test_dry_run_query", {
             createTestTable "test_use_plan_cache19"
 
@@ -730,8 +730,6 @@ suite("parse_sql_from_sql_cache") {
                        )
                        distributed by hash(id)
                        properties('replication_num'='1')"""
-
-
 
             sql "insert into test_use_plan_cache21 values('2', '2')"
             sleep(100)


### PR DESCRIPTION
## Proposed changes

1. current sql cache will miss cache in fe and process by the fashion path cause low qps, when the variable is changed:
```sql
select *
from tbl
where dt = @dt_var  -- maybe range between 10 days
```

this pr support try to hit sql cache even the variable is changed.

Before this optimize: one thread qps is 300.
After this optimize: one thread qps is 3000.

2. refactor and use `ComputeResultSet` interface to return resultSet if fe can process