### PR TITLE
[pick](nereids) using mv's derived stats (#35721)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -760,6 +760,21 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     //       2. Consider the influence of runtime filter
     //       3. Get NDV and column data size from StatisticManger, StatisticManager doesn't support it now.
     private Statistics computeCatalogRelation(CatalogRelation catalogRelation) {
+        if (catalogRelation instanceof LogicalOlapScan) {
+            LogicalOlapScan olap = (LogicalOlapScan) catalogRelation;
+            if (olap.getSelectedIndexId() != olap.getTable().getBaseIndexId()) {
+                // mv is selected, return its estimated stats
+                Optional<Statistics> optStats = cascadesContext.getStatementContext()
+                        .getStatistics(olap.getRelationId());
+                if (optStats.isPresent()) {
+                    double actualRowCount = catalogRelation.getTable().getRowCountForNereids();
+                    if (actualRowCount > optStats.get().getRowCount()) {
+                        return optStats.get();
+                    }
+                }
+            }
+        }
+
         List<Slot> output = catalogRelation.getOutput();
         ImmutableSet.Builder<SlotReference> slotSetBuilder = ImmutableSet.builderWithExpectedSize(output.size());
         for (Slot slot : output) {


### PR DESCRIPTION
for a given mv, we have 2 stats. one is generated by stats analyzer, which is accurate, another is derived stats, which is derived when optimizer runs the mv query.
If a query tree contains a mv, we will use the mv's derived stats to derive stats for the whole tree.

(cherry picked from commit a481d79b1e258f7b6711157bb0d5e4c224e680e5)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

