### PR TITLE
[Compatibility](agg-state) do not throw eception when DataTypeAggState meet old be exec version

### DIFF
--- a/be/src/vec/data_types/data_type_agg_state.h
+++ b/be/src/vec/data_types/data_type_agg_state.h
@@ -43,10 +43,12 @@ public:
               _be_exec_version(be_exec_version) {
         _agg_function = AggregateFunctionSimpleFactory::instance().get(_function_name, _sub_types,
                                                                        _result_is_nullable);
-        if (_agg_function == nullptr ||
-            !BeExecVersionManager::check_be_exec_version(be_exec_version)) {
+        if (_agg_function == nullptr) {
             throw Exception(ErrorCode::INVALID_ARGUMENT,
                             "DataTypeAggState function get failed, type={}", do_get_name());
+        }
+        if (!BeExecVersionManager::check_be_exec_version(be_exec_version)) {
+            LOG(WARNING) << "meet old agg-state, be_exec_version=" << be_exec_version;
         }
         _agg_function->set_version(be_exec_version);
         _agg_serialized_type = _agg_function->get_serialized_type();


### PR DESCRIPTION
## Proposed changes
do not throw eception when DataTypeAggState meet old be exec version
this change is used to avoid memtable meet eception and core dump