### PR TITLE
[fix](Nereids)Fix bug of external table didn't set row count in StatsCalculator.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -1049,7 +1049,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             builder.putColumnStatistics(slot, colStatsBuilder.build());
         }
         checkIfUnknownStatsUsedAsKey(builder);
-        return builder.build();
+        return builder.setRowCount(rowCount).build();
     }
 
     private Statistics computeTopN(TopN topN) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
@@ -36,6 +36,12 @@ suite("test_hive_statistics_p0", "all_types,p0,external,hive,external_docker,ext
             sql """use `${catalog_name}`.`stats_test`"""
             sql """analyze database stats_test with sync"""
 
+            // Test hive scan node cardinality.
+            sql """analyze table `${catalog_name}`.`statistics`.`statistics` with sync"""
+            explain {
+                sql "select count(2) from `${catalog_name}`.`statistics`.`statistics`;"
+                contains "cardinality=100"
+            }
 
             def result = sql """show catalog ${catalog_name}"""
             for (int i = 0; i < result.size(); i++) {


### PR DESCRIPTION
When build statistic object for external table in LogicalFileScan, we didn't set the row count to statistic, cause it always be 0.