### PR TITLE
[spill](logs) add logs to debug spill bugs

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -82,9 +82,10 @@ Dependency* Dependency::is_blocked_by(PipelineTask* task) {
 
 std::string Dependency::debug_string(int indentation_level) {
     fmt::memory_buffer debug_string_buffer;
-    fmt::format_to(debug_string_buffer, "{}{}: id={}, block task = {}, ready={}, _always_ready={}",
-                   std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(),
-                   _ready, _always_ready);
+    fmt::format_to(debug_string_buffer,
+                   "{}this={}, {}: id={}, block task = {}, ready={}, _always_ready={}",
+                   std::string(indentation_level * 2, ' '), (void*)this, _name, _node_id,
+                   _blocked_task.size(), _ready, _always_ready);
     return fmt::to_string(debug_string_buffer);
 }
 

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -455,6 +455,7 @@ Status PipelineFragmentContext::_build_pipeline_tasks(
                                                            task_runtime_state.get(), this,
                                                            pipeline_id_to_profile[pip_idx].get(),
                                                            get_local_exchange_state(pipeline), i);
+                task_runtime_state->set_task(task.get());
                 pipeline_id_to_task.insert({pipeline->id(), task.get()});
                 _tasks[i].emplace_back(std::move(task));
             }

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -254,6 +254,11 @@ bool PipelineTask::_is_blocked() {
             }
             // If all dependencies are ready for this operator, we can execute this task if no datum is needed from upstream operators.
             if (!_operators[i]->need_more_input_data(_state)) {
+                if (VLOG_DEBUG_IS_ON) {
+                    VLOG_DEBUG << "query: " << print_id(_state->query_id())
+                               << ", task id: " << _index << ", operator " << i
+                               << " not need_more_input_data";
+                }
                 break;
             }
         }
@@ -471,13 +476,13 @@ std::string PipelineTask::debug_string() {
 
     auto* cur_blocked_dep = _blocked_dep;
     auto elapsed = _fragment_context->elapsed_time() / 1000000000.0;
-    fmt::format_to(
-            debug_string_buffer,
-            "PipelineTask[this = {}, open = {}, eos = {}, finish = {}, dry run = {}, elapse time "
-            "= {}s], block dependency = {}, is running = {}\noperators: ",
-            (void*)this, _opened, _eos, _finalized, _dry_run, elapsed,
-            cur_blocked_dep && !_finalized ? cur_blocked_dep->debug_string() : "NULL",
-            is_running());
+    fmt::format_to(debug_string_buffer,
+                   "PipelineTask[this = {}, id = {}, open = {}, eos = {}, finish = {}, dry run = "
+                   "{}, elapse time "
+                   "= {}s], block dependency = {}, is running = {}\noperators: ",
+                   (void*)this, _index, _opened, _eos, _finalized, _dry_run, elapsed,
+                   cur_blocked_dep && !_finalized ? cur_blocked_dep->debug_string() : "NULL",
+                   is_running());
     for (size_t i = 0; i < _operators.size(); i++) {
         fmt::format_to(debug_string_buffer, "\n{}",
                        _opened && !_finalized ? _operators[i]->debug_string(_state, i)

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -617,6 +617,10 @@ public:
 
     void set_task_id(int id) { _task_id = id; }
 
+    void set_task(pipeline::PipelineTask* task) { _task = task; }
+
+    pipeline::PipelineTask* get_task() const { return _task; }
+
     int task_id() const { return _task_id; }
 
     void set_task_num(int task_num) { _task_num = task_num; }
@@ -721,6 +725,7 @@ private:
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TErrorTabletInfo> _error_tablet_infos;
     int _max_operator_id = 0;
+    pipeline::PipelineTask* _task = nullptr;
     int _task_id = -1;
     int _task_num = 0;
 


### PR DESCRIPTION
Add logs to debug spill hash join bugs:
```
*** Query id: d7f1126be4e948c6-87f1a80ed3cbd69e ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1719291313 (unix time) try "date -d @1719291313" if you are using GNU date ***
*** Current BE git commitID: 5f5262a885 ***
*** SIGSEGV address not mapped to object (@0x8) received by PID 1419021 (TID 1421288 OR 0x7f0212b43640) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F06BD506520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::vectorized::SpillReader::read(doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/spill/spill_reader.cpp:96
 5# doris::vectorized::SpillStream::read_next_block_sync(doris::vectorized::Block*, bool*) in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 6# std::_Function_handler<void (), doris::pipeline::PartitionedHashJoinProbeLocalState::recovery_build_blocks_from_disk(doris::RuntimeState*, unsigned int, bool&)::$_1>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 7# doris::ThreadPool::dispatch_thread() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 8# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:499
 9# start_thread at ./nptl/pthread_create.c:442
10# 0x00007F06BD5EA850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

