### PR TITLE
[opt](function)Optimize BinaryArithmetic by handling the null column internally.

### DIFF
--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -424,6 +424,7 @@ private:
 
 ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable = false);
 ColumnPtr remove_nullable(const ColumnPtr& column);
+ColumnPtr remove_nullalbe_with_default(const ColumnPtr& column, bool need_to_default);
 // check if argument column is nullable. If so, extract its concrete column and set null_map.
 //TODO: use this to replace inner usages.
 // is_single: whether null_map is null map of a ColumnConst


### PR DESCRIPTION
## Proposed changes

The default implementation of null handling requires the following steps:

1. Construct a new block, removing nullable.
2. Execute.
3. Generate a null map based on input parameters.
4. Destroy the new block.

These processes do not have significant overhead, but because the BinaryArithmetic series of functions are very fast, they might seem slow in comparison. Therefore, an optimization is made here: moving the null handling into BinaryArithmetic can reduce the overhead of steps 1 and 4.

expr time from 2.222s to 2.045s

<!--Describe your changes.-->

