### PR TITLE
[fix](nereids) the stop watch is not reset

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -137,7 +137,7 @@ public class NereidsPlanner extends Planner {
         setParsedPlan(parsedPlan);
 
         PhysicalProperties requireProperties = buildInitRequireProperties();
-        statementContext.getStopwatch().start();
+        statementContext.getStopwatch().reset().start();
         Plan resultPlan = null;
         try {
             boolean showPlanProcess = showPlanProcess(queryStmt.getExplainOptions());


### PR DESCRIPTION
## Proposed changes

When use JDBC to insert into Doris, after execute several sqls, will get `Nereids cost too much time (> 30s )`, but the audit log shows that the sql only cost several  milliseconds. The reason is that the stop watch is never reset.
