### PR TITLE
[enhancement](trash) support skip trash, update trash default expire time

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -322,7 +322,7 @@ DEFINE_mInt32(garbage_sweep_batch_size, "100");
 DEFINE_mInt32(snapshot_expire_time_sec, "172800");
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
-DEFINE_mInt32(trash_file_expire_time_sec, "259200");
+DEFINE_mInt32(trash_file_expire_time_sec, "86400");
 // minimum file descriptor number
 // modify them upon necessity
 DEFINE_Int32(min_file_descriptor_number, "60000");

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -906,8 +906,13 @@ void DataDir::disks_compaction_num_increment(int64_t delta) {
 }
 
 Status DataDir::move_to_trash(const std::string& tablet_path) {
-    Status res = Status::OK();
+    if (0 == config::trash_file_expire_time_sec) {
+        LOG(INFO) << "delete tablet dir " << tablet_path
+                  << " directly due to trash_file_expire_time_sec is 0";
+        return io::global_local_filesystem()->delete_directory(tablet_path);
+    }
 
+    Status res = Status::OK();
     // 1. get timestamp string
     string time_str;
     if ((res = gen_timestamp_string(&time_str)) != Status::OK()) {

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -906,10 +906,11 @@ void DataDir::disks_compaction_num_increment(int64_t delta) {
 }
 
 Status DataDir::move_to_trash(const std::string& tablet_path) {
-    if (0 == config::trash_file_expire_time_sec) {
+    if (config::trash_file_expire_time_sec <= 0) {
         LOG(INFO) << "delete tablet dir " << tablet_path
                   << " directly due to trash_file_expire_time_sec is 0";
-        return io::global_local_filesystem()->delete_directory(tablet_path);
+        RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_path));
+        RETURN_IF_ERROR(delete_tablet_parent_path_if_empty(tablet_path));
     }
 
     Status res = Status::OK();

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -910,7 +910,7 @@ Status DataDir::move_to_trash(const std::string& tablet_path) {
         LOG(INFO) << "delete tablet dir " << tablet_path
                   << " directly due to trash_file_expire_time_sec is 0";
         RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_path));
-        RETURN_IF_ERROR(delete_tablet_parent_path_if_empty(tablet_path));
+        return delete_tablet_parent_path_if_empty(tablet_path);
     }
 
     Status res = Status::OK();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. if user set `trash_file_expire_time_sec` to 0, skip trash directly
2. update trash_file_expire_time_sec default value from 3 days to 1 day

docs PR: https://github.com/apache/doris-website/pull/817

