### PR TITLE
[fix](compaction) fix null pointer when retrieving CPU load average

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -866,7 +866,10 @@ int get_concurrent_per_disk(int max_score, int thread_per_disk) {
         return thread_per_disk;
     }
 
-    double load_average = DorisMetrics::instance()->system_metrics()->get_load_average_1_min();
+    double load_average = 0;
+    if (DorisMetrics::instance()->system_metrics() != nullptr) {
+        load_average = DorisMetrics::instance()->system_metrics()->get_load_average_1_min();
+    }
     int num_cores = doris::CpuInfo::num_cores();
     bool cpu_usage_high = load_average > num_cores * 0.8;
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -870,7 +870,7 @@ void SystemMetrics::get_disks_io_time(std::map<std::string, int64_t>* map) {
 }
 
 double SystemMetrics::get_load_average_1_min() {
-    if (!_load_average_metrics) {
+    if (_load_average_metrics) {
         return _load_average_metrics->load_average_1_minutes->value();
     } else {
         return 0;

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -870,7 +870,11 @@ void SystemMetrics::get_disks_io_time(std::map<std::string, int64_t>* map) {
 }
 
 double SystemMetrics::get_load_average_1_min() {
-    return _load_average_metrics->load_average_1_minutes->value();
+    if (!_load_average_metrics) {
+        return _load_average_metrics->load_average_1_minutes->value();
+    } else {
+        return 0;
+    }
 }
 
 void SystemMetrics::get_network_traffic(std::map<std::string, int64_t>* send_map,


### PR DESCRIPTION
1 When enable_system_metrics = false, system_metrics is a null pointer
2 When BE exits, system_metrics has been destructed, and the compaction background thread may still be running