### PR TITLE
[feat](Nereids) Enhance filter processing in foreign key context to exclude hidden conjuncts

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
@@ -136,13 +136,32 @@ public class ForeignKeyContext {
         }
     }
 
+    private boolean isHiddenConjunct(Expression expression) {
+        for (Slot slot : expression.getInputSlots()) {
+            if (slot instanceof SlotReference) {
+                SlotReference slotReference = (SlotReference) slot;
+                if (slotReference.getColumn().isPresent()) {
+                    Column column = slotReference.getColumn().get();
+                    if (column.isDeleteSignColumn() || column.isVersionColumn()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     private void addFilter(LogicalFilter<?> filter) {
-        filter.getOutput().stream()
-                .filter(slotToColumn::containsKey)
-                .forEach(slot -> {
-                    slotWithPredicates.computeIfAbsent(slot, v -> new HashSet<>());
-                    slotWithPredicates.get(slot).addAll(filter.getConjuncts());
-                });
+        for (Slot s : filter.getOutput()) {
+            if (slotToColumn.containsKey(s)) {
+                slotWithPredicates.computeIfAbsent(s, v -> new HashSet<>());
+                for (Expression conjunct : filter.getConjuncts()) {
+                    if (!isHiddenConjunct(conjunct)) {
+                        slotWithPredicates.get(s).add(conjunct);
+                    }
+                }
+            }
+        }
     }
 
     private void expirePrimaryKey(Plan plan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ForeignKeyContext.java
@@ -138,14 +138,10 @@ public class ForeignKeyContext {
 
     private boolean isHiddenConjunct(Expression expression) {
         for (Slot slot : expression.getInputSlots()) {
-            if (slot instanceof SlotReference) {
-                SlotReference slotReference = (SlotReference) slot;
-                if (slotReference.getColumn().isPresent()) {
-                    Column column = slotReference.getColumn().get();
-                    if (column.isDeleteSignColumn() || column.isVersionColumn()) {
-                        return true;
-                    }
-                }
+            if (slot instanceof SlotReference
+                    && ((SlotReference) slot).getColumn().isPresent()
+                    && ((SlotReference) slot).getColumn().get().isDeleteSignColumn()) {
+                return true;
             }
         }
         return false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
@@ -33,19 +33,19 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
                 "CREATE TABLE IF NOT EXISTS pri (\n"
                         + "    id1 int not null\n"
                         + ")\n"
-                        + "DUPLICATE KEY(id1)\n"
+                        + "UNIQUE KEY(id1)\n"
                         + "DISTRIBUTED BY HASH(id1) BUCKETS 10\n"
                         + "PROPERTIES (\"replication_num\" = \"1\")\n",
                 "CREATE TABLE IF NOT EXISTS foreign_not_null (\n"
                         + "    id2 int not null\n"
                         + ")\n"
-                        + "DUPLICATE KEY(id2)\n"
+                        + "UNIQUE KEY(id2)\n"
                         + "DISTRIBUTED BY HASH(id2) BUCKETS 10\n"
                         + "PROPERTIES (\"replication_num\" = \"1\")\n",
                 "CREATE TABLE IF NOT EXISTS foreign_null (\n"
                         + "    id3 int\n"
                         + ")\n"
-                        + "DUPLICATE KEY(id3)\n"
+                        + "UNIQUE KEY(id3)\n"
                         + "DISTRIBUTED BY HASH(id3) BUCKETS 10\n"
                         + "PROPERTIES (\"replication_num\" = \"1\")\n"
         );
@@ -94,7 +94,7 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
                 .rewrite()
                 .nonMatch(logicalJoin())
                 .matches(logicalFilter().when(f -> {
-                    Assertions.assertEquals("(id2 = 1)", f.getPredicate().toSql());
+                    Assertions.assertTrue(f.getPredicate().toSql().contains("(id2 = 1)"));
                     return true;
                 }))
                 .printlnTree();
@@ -105,7 +105,7 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
                 .rewrite()
                 .nonMatch(logicalJoin())
                 .matches(logicalFilter().when(f -> {
-                    Assertions.assertEquals("(id2 = 1)", f.getPredicate().toSql());
+                    Assertions.assertTrue(f.getPredicate().toSql().contains("(id2 = 1)"));
                     return true;
                 }))
                 .printlnTree();
@@ -119,7 +119,7 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
                 .rewrite()
                 .nonMatch(logicalJoin())
                 .matches(logicalFilter().when(f -> {
-                    Assertions.assertEquals("( not id3 IS NULL)", f.getPredicate().toSql());
+                    Assertions.assertTrue(f.getPredicate().toSql().contains("( not id3 IS NULL)"));
                     return true;
                 }))
                 .printlnTree();
@@ -129,7 +129,7 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
                 .rewrite()
                 .nonMatch(logicalJoin())
                 .matches(logicalFilter().when(f -> {
-                    Assertions.assertEquals("( not id3 IS NULL)", f.getPredicate().toSql());
+                    Assertions.assertTrue(f.getPredicate().toSql().contains("( not id3 IS NULL)"));
                     return true;
                 }))
                 .printlnTree();


### PR DESCRIPTION
## Proposed changes

Implement a new method isHiddenConjunct to identify hidden conjuncts based on delete sign and version columns. Update addFilter method to skip these hidden conjuncts when adding predicates to slotWithPredicates.

