### PR TITLE
[fix](HadoopLz4BlockCompression)Fixed the bug that HadoopLz4BlockCompression creates _decompressor every time it decompresses.

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -25,6 +25,8 @@
         defined(__i386) || defined(_M_IX86)
 #include <libdeflate.h>
 #endif
+#include <glog/log_severity.h>
+#include <glog/logging.h>
 #include <limits.h>
 #include <lz4/lz4.h>
 #include <lz4/lz4frame.h>
@@ -230,12 +232,18 @@ private:
 
 class HadoopLz4BlockCompression : public Lz4BlockCompression {
 public:
+    HadoopLz4BlockCompression() {
+        Status st = Decompressor::create_decompressor(CompressType::LZ4BLOCK, &_decompressor);
+        if (!st.ok()) {
+            LOG(FATAL) << "HadoopLz4BlockCompression construction failed. status = " << st << "\n";
+        }
+    }
+
     static HadoopLz4BlockCompression* instance() {
         static HadoopLz4BlockCompression s_instance;
         return &s_instance;
     }
     Status decompress(const Slice& input, Slice* output) override {
-        RETURN_IF_ERROR(Decompressor::create_decompressor(CompressType::LZ4BLOCK, &_decompressor));
         size_t input_bytes_read = 0;
         size_t decompressed_len = 0;
         size_t more_input_bytes = 0;


### PR DESCRIPTION
## Proposed changes

Problem:
HadoopLz4BlockCompression uses a singleton mode.
Every time its decompression function is called, a new object will be created for its member variable _decompressor. In a multi-threaded scenario, new objects will be created for _decompressor at the same time.

Fix method:
During the construction phase of HadoopLz4BlockCompression, a new object is created for its member variable _decompressor. When calling the decompression function, there is no need to create a new object for _decompressor.




Issue Number: close #xxx

<!--Describe your changes.-->

