### PR TITLE
[opt](file cache) write segment data asynchronous and merge small cache files

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -989,17 +989,8 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
-DEFINE_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
-// 4KB <= file_cache_max_file_segment_size <= 256MB
-DEFINE_Validator(file_cache_max_file_segment_size, [](const int64_t config) -> bool {
-    return config >= 4096 && config <= 268435456;
-});
-DEFINE_Int64(file_cache_min_file_segment_size, "4096"); // 4KB
-// 4KB <= file_cache_min_file_segment_size <= 256MB
-DEFINE_Validator(file_cache_min_file_segment_size, [](const int64_t config) -> bool {
-    return config >= 4096 && config <= 268435456 &&
-           config <= config::file_cache_max_file_segment_size;
-});
+DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
+DEFINE_Int64(file_cache_hdfs_block_size, "4096");    // 4KB
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");
 DEFINE_mInt32(file_cache_wait_sec_after_fail, "0"); // // zero for no waiting and retrying

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -994,7 +994,7 @@ DEFINE_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
 DEFINE_Validator(file_cache_max_file_segment_size, [](const int64_t config) -> bool {
     return config >= 4096 && config <= 268435456;
 });
-DEFINE_Int64(file_cache_min_file_segment_size, "1048576"); // 1MB
+DEFINE_Int64(file_cache_min_file_segment_size, "4096"); // 4KB
 // 4KB <= file_cache_min_file_segment_size <= 256MB
 DEFINE_Validator(file_cache_min_file_segment_size, [](const int64_t config) -> bool {
     return config >= 4096 && config <= 268435456 &&

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1039,8 +1039,8 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
-DECLARE_Int64(file_cache_min_file_segment_size);
-DECLARE_Int64(file_cache_max_file_segment_size);
+DECLARE_Int64(file_cache_each_block_size);
+DECLARE_Int64(file_cache_hdfs_block_size);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
 // only for debug, will be removed after finding out the root cause

--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -50,6 +50,18 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         json["released_elements"] = released;
         *json_metrics = json.ToString();
         return Status::OK();
+    } else if (operation == "merge") {
+        std::pair<size_t, size_t> origin_to_merge(0, 0);
+        if (req->param("base_path") != "") {
+            origin_to_merge = io::FileCacheFactory::instance()->try_merge(req->param("base_path"));
+        } else {
+            origin_to_merge = io::FileCacheFactory::instance()->try_merge();
+        }
+        EasyJson json;
+        json["origin_small_elements"] = origin_to_merge.first;
+        json["output_merged_elements"] = origin_to_merge.second;
+        *json_metrics = json.ToString();
+        return Status::OK();
     }
     return Status::InternalError("invalid operation: {}", operation);
 }

--- a/be/src/io/cache/block/block_file_cache.cpp
+++ b/be/src/io/cache/block/block_file_cache.cpp
@@ -89,6 +89,10 @@ std::string IFileCache::get_path_in_local_cache(const Key& key, size_t offset,
     return fmt::format("{}/{}{}", get_path_in_local_cache(key), offset, cache_type_to_string(type));
 }
 
+std::string IFileCache::get_merged_path(const Key& key, size_t offset) const {
+    return fmt::format("{}/{}{}", get_path_in_local_cache(key), offset, "_merged");
+}
+
 std::string IFileCache::get_path_in_local_cache(const Key& key) const {
     auto key_str = key.to_string();
     if constexpr (USE_CACHE_VERSION2) {
@@ -222,7 +226,6 @@ void IFileCache::init() {
               << ", resource hard limit is: " << limit.rlim_max
               << ", config file_cache_max_file_reader_cache_size is: "
               << config::file_cache_max_file_reader_cache_size;
-    return;
 }
 
 } // namespace io

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -91,6 +91,7 @@ public:
     /// version 2.0: cache_base_path / key_prefix / key / offset
     static constexpr bool USE_CACHE_VERSION2 = true;
     static constexpr int KEY_PREFIX_LENGTH = 3;
+    static constexpr size_t MAX_MERGED_SIZE = 16 * 1024 * 1024; // 16MB
 
     struct Key {
         uint128_t key;
@@ -116,7 +117,11 @@ public:
 
     virtual size_t try_release() = 0;
 
+    virtual std::pair<size_t, size_t> try_merge() = 0;
+
     std::string get_path_in_local_cache(const Key& key, size_t offset, CacheType type) const;
+
+    std::string get_merged_path(const Key& key, size_t offset) const;
 
     std::string get_path_in_local_cache(const Key& key) const;
 

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -117,10 +117,14 @@ public:
 
     virtual size_t try_release() = 0;
 
+    /// Merge continuous small segment files into a larger one
+    /// Return the number of origin segment files and the merged files
     virtual std::pair<size_t, size_t> try_merge() = 0;
 
     std::string get_path_in_local_cache(const Key& key, size_t offset, CacheType type) const;
 
+    /// Get the destination file that small segment files merge into
+    /// The file is suffixed by '_merged' and will be rename as normal offset name after merging
     std::string get_merged_path(const Key& key, size_t offset) const;
 
     std::string get_path_in_local_cache(const Key& key) const;

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -121,6 +121,8 @@ public:
     /// Return the number of origin segment files and the merged files
     virtual std::pair<size_t, size_t> try_merge() = 0;
 
+    virtual Status async_merge(const Key& key) = 0;
+
     std::string get_path_in_local_cache(const Key& key, size_t offset, CacheType type) const;
 
     /// Get the destination file that small segment files merge into

--- a/be/src/io/cache/block/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block/block_file_cache_factory.cpp
@@ -58,6 +58,24 @@ size_t FileCacheFactory::try_release(const std::string& base_path) {
     return 0;
 }
 
+std::pair<size_t, size_t> FileCacheFactory::try_merge() {
+    std::pair<size_t, size_t> origin_to_merge(0, 0);
+    for (auto& cache : _caches) {
+        auto res = cache->try_merge();
+        origin_to_merge.first += res.first;
+        origin_to_merge.second += res.second;
+    }
+    return origin_to_merge;
+}
+
+std::pair<size_t, size_t> FileCacheFactory::try_merge(const std::string& base_path) {
+    auto iter = _path_to_cache.find(base_path);
+    if (iter != _path_to_cache.end()) {
+        return iter->second->try_merge();
+    }
+    return {0, 0};
+}
+
 void FileCacheFactory::create_file_cache(const std::string& cache_base_path,
                                          const FileCacheSettings& file_cache_settings,
                                          Status* status) {
@@ -87,7 +105,6 @@ void FileCacheFactory::create_file_cache(const std::string& cache_base_path,
     LOG(INFO) << "[FileCache] path: " << cache_base_path
               << " total_size: " << file_cache_settings.total_size;
     *status = Status::OK();
-    return;
 }
 
 CloudFileCachePtr FileCacheFactory::get_by_path(const IFileCache::Key& key) {

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -46,6 +46,8 @@ public:
 
     size_t try_release(const std::string& base_path);
 
+    /// Merge continuous small segment files into a larger one
+    /// Return the number of origin segment files and the merged files
     std::pair<size_t, size_t> try_merge();
 
     std::pair<size_t, size_t> try_merge(const std::string& base_path);

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -46,6 +46,10 @@ public:
 
     size_t try_release(const std::string& base_path);
 
+    std::pair<size_t, size_t> try_merge();
+
+    std::pair<size_t, size_t> try_merge(const std::string& base_path);
+
     CloudFileCachePtr get_by_path(const IFileCache::Key& key);
     CloudFileCachePtr get_by_path(const std::string& cache_base_path);
     std::vector<IFileCache::QueryFileCacheContextHolderPtr> get_query_context_holders(

--- a/be/src/io/cache/block/block_file_segment.h
+++ b/be/src/io/cache/block/block_file_segment.h
@@ -113,6 +113,8 @@ public:
     /// Write the cached data asynchronously
     Status async_write(std::shared_ptr<char[]> buffer, size_t offset, size_t length);
 
+    void async_remove();
+
     // append data to cache file
     Status append(Slice data);
 

--- a/be/src/io/cache/block/block_file_segment.h
+++ b/be/src/io/cache/block/block_file_segment.h
@@ -75,6 +75,9 @@ public:
     FileBlock(size_t offset, size_t size, const Key& key, IFileCache* cache, State download_state,
               CacheType cache_type);
 
+    FileBlock(size_t offset, size_t size, const Key& key, IFileCache* cache, State download_state,
+              CacheType cache_type, bool is_merged_file);
+
     ~FileBlock();
 
     State state() const;
@@ -147,6 +150,8 @@ public:
 
     State state_unlock(std::lock_guard<std::mutex>&) const;
 
+    void remove_merged_file();
+
     FileBlock& operator=(const FileBlock&) = delete;
     FileBlock(const FileBlock&) = delete;
 
@@ -196,6 +201,7 @@ private:
     std::atomic<bool> _is_downloaded {false};
     CacheType _cache_type;
     Status _status = Status::OK();
+    bool _is_merged_file = false;
 };
 
 struct FileBlocksHolder {

--- a/be/src/io/cache/block/block_file_segment.h
+++ b/be/src/io/cache/block/block_file_segment.h
@@ -110,6 +110,7 @@ public:
 
     State wait();
 
+    /// Write the cached data asynchronously
     Status async_write(std::shared_ptr<char[]> buffer, size_t offset, size_t length);
 
     // append data to cache file

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -553,6 +553,9 @@ std::pair<size_t, size_t> LRUFileCache::merge_continuous_cells(
     std::pair<size_t, size_t> origin_to_merged(0, 0);
     for (auto& [key, continuous_blocks] : merged_files) {
         std::lock_guard<std::mutex> l(_mutex);
+        if (!_files.contains(key)) {
+            continue;
+        }
         FileBlocksByOffset& offset_cells = _files[key];
         bool has_deleted = false;
         for (auto& offsets : continuous_blocks) {

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -479,7 +479,7 @@ std::pair<size_t, size_t> LRUFileCache::try_merge() {
 }
 
 Status LRUFileCache::async_merge(const Key& key) {
-    ThreadPool* merge_pool = ExecEnv::GetInstance()->buffered_reader_prefetch_thread_pool();
+    ThreadPool* merge_pool = ExecEnv::GetInstance()->file_cache_thread_pool();
     return merge_pool->submit_func([file_key = key, this]() {
         std::unordered_map<Key, std::vector<std::vector<size_t>>, HashCachedFileKey> merged_files;
         {

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -131,6 +131,8 @@ private:
 
     std::pair<size_t, size_t> try_merge() override;
 
+    /// Find the continuous segment files for a remote file
+    /// Return the offsets of the continuous files.
     std::vector<std::vector<size_t>> find_continuous_cells(const FileBlocksByOffset& segments);
 
     std::pair<size_t, size_t> merge_continuous_cells(

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -129,6 +129,14 @@ private:
 
     size_t try_release() override;
 
+    std::pair<size_t, size_t> try_merge() override;
+
+    std::vector<std::vector<size_t>> find_continuous_cells(const FileBlocksByOffset& segments);
+
+    std::pair<size_t, size_t> merge_continuous_cells(
+            const std::unordered_map<Key, std::vector<std::vector<size_t>>, HashCachedFileKey>&
+                    merged_files);
+
     LRUFileCache::LRUQueue& get_queue(CacheType type);
     const LRUFileCache::LRUQueue& get_queue(CacheType type) const;
 

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -131,6 +131,8 @@ private:
 
     std::pair<size_t, size_t> try_merge() override;
 
+    Status async_merge(const Key& key) override;
+
     /// Find the continuous segment files for a remote file
     /// Return the offsets of the continuous files.
     std::vector<std::vector<size_t>> find_continuous_cells(const FileBlocksByOffset& segments);

--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -74,7 +74,10 @@ Status CachedRemoteFileReader::close() {
     if (_num_write_blocks > 0 && !_is_doris_table) {
         // try to merge small blocks for external table
         // can't merge the blocks for internal table
-        RETURN_IF_ERROR(_cache->async_merge(_cache_key));
+        Status st = _cache->async_merge(_cache_key);
+        if (!st) {
+            LOG(WARNING) << "Failed to merge small blocks: " << st;
+        }
     }
     return _remote_file_reader->close();
 }

--- a/be/src/io/cache/block/cached_remote_file_reader.h
+++ b/be/src/io/cache/block/cached_remote_file_reader.h
@@ -62,6 +62,8 @@ private:
     std::pair<size_t, size_t> _align_size(size_t offset, size_t size) const;
 
     bool _is_doris_table;
+    bool _is_remote_oss;
+    size_t _num_write_blocks = 0;
     FileReaderSPtr _remote_file_reader;
     IFileCache::Key _cache_key;
     CloudFileCachePtr _cache;

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -281,7 +281,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
 io::FileCacheSettings CachePath::init_settings() const {
     io::FileCacheSettings settings;
     settings.total_size = total_bytes;
-    settings.max_file_segment_size = config::file_cache_max_file_segment_size;
+    settings.max_file_segment_size = config::file_cache_each_block_size;
     settings.max_query_cache_size = query_limit_bytes;
     size_t per_size = settings.total_size / 100;
     settings.disposable_queue_size = per_size * disposable_percent;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -190,6 +190,7 @@ public:
     ThreadPool* buffered_reader_prefetch_thread_pool() {
         return _buffered_reader_prefetch_thread_pool.get();
     }
+    ThreadPool* file_cache_thread_pool() { return _file_cache_thread_pool.get(); }
     ThreadPool* s3_file_upload_thread_pool() { return _s3_file_upload_thread_pool.get(); }
     ThreadPool* send_report_thread_pool() { return _send_report_thread_pool.get(); }
     ThreadPool* join_node_thread_pool() { return _join_node_thread_pool.get(); }
@@ -358,6 +359,8 @@ private:
     std::unique_ptr<ThreadPool> _send_batch_thread_pool;
     // Threadpool used to prefetch remote file for buffered reader
     std::unique_ptr<ThreadPool> _buffered_reader_prefetch_thread_pool;
+    // Threadpool used for file cache
+    std::unique_ptr<ThreadPool> _file_cache_thread_pool;
     // Threadpool used to upload local file to s3
     std::unique_ptr<ThreadPool> _s3_file_upload_thread_pool;
     // Pool used by fragment manager to send profile or status to FE coordinator

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -181,6 +181,12 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_max_threads(64)
                               .build(&_buffered_reader_prefetch_thread_pool));
 
+    static_cast<void>(ThreadPoolBuilder("FileCacheThreadPool")
+                              .set_min_threads(16)
+                              .set_max_threads(64)
+                              .set_max_queue_size(256)
+                              .build(&_file_cache_thread_pool));
+
     static_cast<void>(ThreadPoolBuilder("S3FileUploadThreadPool")
                               .set_min_threads(16)
                               .set_max_threads(64)
@@ -586,6 +592,7 @@ void ExecEnv::destroy() {
     SAFE_STOP(_spill_stream_mgr);
 
     SAFE_SHUTDOWN(_buffered_reader_prefetch_thread_pool);
+    SAFE_SHUTDOWN(_file_cache_thread_pool);
     SAFE_SHUTDOWN(_s3_file_upload_thread_pool);
     SAFE_SHUTDOWN(_join_node_thread_pool);
     SAFE_SHUTDOWN(_lazy_release_obj_pool);
@@ -639,6 +646,7 @@ void ExecEnv::destroy() {
     _lazy_release_obj_pool.reset(nullptr);
     _send_report_thread_pool.reset(nullptr);
     _buffered_reader_prefetch_thread_pool.reset(nullptr);
+    _file_cache_thread_pool.reset(nullptr);
     _s3_file_upload_thread_pool.reset(nullptr);
     _send_batch_thread_pool.reset(nullptr);
     _write_cooldown_meta_executors.reset(nullptr);


### PR DESCRIPTION
## Proposed changes

### Three Optimizations
1. **Default Value Change**: Rename `file_cache_max_file_segment_size` as `file_cache_each_block_size`, and rename `file_cache_min_file_segment_size` as `file_cache_hdfs_block_size`(keep the same as master branch). Changed the default value of `file_cache_hdfs_block_size` from 1MB to 4KB to reduce read amplification. This adjustment aims to enhance read performance by minimizing the unnecessary reading of extra data. While this modification reduces the amount of data read per segment, it also results in the creation of a larger number of small files, which could have implications for file management and performance.
2. **Asynchronous Write**: Introduced an asynchronous write interface async_write in the FileBlock class. This enhancement allows data to be read without having to wait for the completion of writing to the cache file. By decoupling read operations from write operations, this feature significantly improves read efficiency and reduces latency, ensuring that read operations are not blocked by write operations.
3. **Background Merging Process**: Implemented a daemon process that runs when `CachedRemoteFileReader::close()` to check and merge small files. This process is designed to mitigate the potential negative effects introduced by the first optimization, specifically the accumulation of small files. By merging small files into larger ones, this daemon process helps maintain system performance and prevents degradation caused by excessive small file handling.

### Effects
Before Opt.
![image](https://github.com/apache/doris/assets/19337507/a88dd687-f63e-4f2d-b536-42861efc77f1)
After Opt.
![image](https://github.com/apache/doris/assets/19337507/7e5df9d6-f9ee-455f-adb7-4d420d60a045)

### Restful API
```shell
# release all cached files
curl http://${be}:${webserver_port}/api/file_cache?op=release
# merge small cached files
curl http://${be}:${webserver_port}/api/file_cache?op=merge
```

### Test
After extensive stability testing, with scripts running continuously for over 2 hours, no concurrency issues or query errors were detected. When no deletion or merging operations were performed, the total execution time for the test SQL was 7.42 seconds. Under conditions of frequent deletion and merging of cache files, the total execution time for the test SQL was 8.73 seconds. Overall, performance remained consistent with minimal fluctuation.

