### PR TITLE
[Improvement](ObjectStorage) Retry when encountering TooManyRequest response

### DIFF
--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -38,6 +38,7 @@
 #include "common/util.h"
 #include "cpp/obj_retry_strategy.h"
 #include "cpp/s3_rate_limiter.h"
+#include "recycler/azure_obj_client.h"
 #include "recycler/obj_storage_client.h"
 #include "recycler/s3_obj_client.h"
 #include "recycler/storage_vault_accessor.h"

--- a/common/cpp/obj_retry_strategy.cpp
+++ b/common/cpp/obj_retry_strategy.cpp
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-bvar::Adder<int64_t> too_many_request_retry_times("too_many_request_retry_times");
+bvar::Adder<int64_t> s3_too_many_request_retry_cnt("s3_too_many_request_retry_cnt");
 
 S3CustomRetryStrategy::S3CustomRetryStrategy(int maxRetries) : DefaultRetryStrategy(maxRetries) {}
 
@@ -31,7 +31,7 @@ bool S3CustomRetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client:
                                         long attemptedRetries) const {
     if (attemptedRetries < m_maxRetries &&
         error.GetResponseCode() == Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) {
-        too_many_request_retry_times << 1;
+        s3_too_many_request_retry_cnt << 1;
         return true;
     }
     return Aws::Client::DefaultRetryStrategy::ShouldRetry(error, attemptedRetries);
@@ -48,7 +48,7 @@ std::unique_ptr<Azure::Core::Http::RawResponse> AzureRetryRecordPolicy::Send(
     if (retry_cnt != 0 &&
         resp->GetStatusCode() == Azure::Core::Http::HttpStatusCode::TooManyRequests) {
         retry_cnt--;
-        too_many_request_retry_times << 1;
+        s3_too_many_request_retry_cnt << 1;
     }
     return resp;
 }

--- a/common/cpp/obj_retry_strategy.cpp
+++ b/common/cpp/obj_retry_strategy.cpp
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "obj_retry_strategy.h"
+
+#include <bvar/reducer.h>
+
+namespace doris {
+
+bvar::Adder<int64_t> too_many_request_retry_times("too_many_request_retry_times");
+
+S3CustomRetryStrategy::S3CustomRetryStrategy(int maxRetries) : DefaultRetryStrategy(maxRetries) {}
+
+S3CustomRetryStrategy::~S3CustomRetryStrategy() = default;
+
+bool S3CustomRetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+                                        long attemptedRetries) const {
+    if (attemptedRetries < m_maxRetries &&
+        error.GetResponseCode() == Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) {
+        too_many_request_retry_times << 1;
+        return true;
+    }
+    return Aws::Client::DefaultRetryStrategy::ShouldRetry(error, attemptedRetries);
+}
+
+AzureRetryRecordPolicy::AzureRetryRecordPolicy(int retry_cnt) : retry_cnt(retry_cnt) {}
+
+AzureRetryRecordPolicy::~AzureRetryRecordPolicy() = default;
+
+std::unique_ptr<Azure::Core::Http::RawResponse> AzureRetryRecordPolicy::Send(
+        Azure::Core::Http::Request& request, Azure::Core::Http::Policies::NextHttpPolicy nextPolicy,
+        Azure::Core::Context const& context) const {
+    auto resp = nextPolicy.Send(request, context);
+    if (retry_cnt != 0 &&
+        resp->GetStatusCode() == Azure::Core::Http::HttpStatusCode::TooManyRequests) {
+        retry_cnt--;
+        too_many_request_retry_times << 1;
+    }
+    return resp;
+}
+
+std::unique_ptr<AzureRetryRecordPolicy::HttpPolicy> AzureRetryRecordPolicy::Clone() const {
+    auto ret = std::make_unique<AzureRetryRecordPolicy>(*this);
+    ret->retry_cnt = 0;
+    return ret;
+}
+} // namespace doris

--- a/common/cpp/obj_retry_strategy.h
+++ b/common/cpp/obj_retry_strategy.h
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
+
+#include <azure/core/http/policies/policy.hpp>
+
+namespace doris {
+class S3CustomRetryStrategy final : public Aws::Client::DefaultRetryStrategy {
+public:
+    S3CustomRetryStrategy(int maxRetries);
+    ~S3CustomRetryStrategy() override;
+
+    bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+                     long attemptedRetries) const override;
+};
+
+class AzureRetryRecordPolicy final : public Azure::Core::Http::Policies::HttpPolicy {
+public:
+    AzureRetryRecordPolicy(int retry_cnt);
+    ~AzureRetryRecordPolicy() override;
+    std::unique_ptr<HttpPolicy> Clone() const override;
+    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+            Azure::Core::Http::Request& request,
+            Azure::Core::Http::Policies::NextHttpPolicy nextPolicy,
+            Azure::Core::Context const& context) const override;
+
+private:
+    mutable int retry_cnt;
+};
+} // namespace doris


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

We can do retry for 429 using the embedded utility of corresponding sdk.