### PR TITLE
[fix](case)Fix case failure caused by different pipeline configurations

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_partitions_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_partitions_tvf.groovy
@@ -50,8 +50,8 @@ suite("test_partitions_tvf","p0,external,tvf,external_docker") {
     assertEquals("k3", res[0][5]);
     // Buckets
     assertEquals(2, res[0][8]);
-    // ReplicationNum
-    assertEquals(1, res[0][9]);
+    // ReplicationNum: if force_olap_table_replication_num is set to 3,here will be 3
+    // assertEquals(1, res[0][9]);
     // StorageMedium
     assertEquals("HDD", res[0][10]);
     // ReplicaAllocation

--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
@@ -177,6 +177,8 @@ suite("test_s3_tvf_with_resource", "p0") {
     }
 
     // test auth
+    def tokens = context.config.jdbcUrl.split('/')
+    def url=tokens[0] + "//" + tokens[2] + "/" + "information_schema" + "?"
     String user = 'test_s3_tvf_with_resource_user'
     String pwd = 'C123_567p'
     String viewName = "test_s3_tvf_with_resource_view"
@@ -203,7 +205,7 @@ suite("test_s3_tvf_with_resource", "p0") {
         sql """GRANT USAGE_PRIV ON CLUSTER ${validCluster} TO ${user}""";
     }
     // not have usage priv, can not select tvf with resource
-    connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
+    connect(user=user, password="${pwd}", url=url) {
         test {
                 sql """
                     SELECT * FROM S3 (
@@ -218,7 +220,7 @@ suite("test_s3_tvf_with_resource", "p0") {
     }
 
     // only have select_priv of view,can select view with resource
-    connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
+    connect(user=user, password="${pwd}", url=url) {
             sql """SELECT * FROM ${viewName};"""
     }
 


### PR DESCRIPTION
- force_olap_table_replication_num will force a change in the number of copies of the table, resulting in a case failure
- other user login to information_schema db, avoiding unauthorized access
cause by：https://github.com/apache/doris/pull/36479
