### PR TITLE
[fix](spill) handle possible filesystem exception

### DIFF
--- a/be/src/vec/spill/spill_stream_manager.cpp
+++ b/be/src/vec/spill/spill_stream_manager.cpp
@@ -300,9 +300,15 @@ SpillDataDir::SpillDataDir(std::string path, int64_t capacity_bytes,
 }
 
 bool is_directory_empty(const std::filesystem::path& dir) {
-    return std::filesystem::is_directory(dir) &&
-           std::filesystem::directory_iterator(dir) ==
-                   std::filesystem::end(std::filesystem::directory_iterator {});
+    try {
+        return std::filesystem::is_directory(dir) &&
+               std::filesystem::directory_iterator(dir) ==
+                       std::filesystem::end(std::filesystem::directory_iterator {});
+        // this method is not thread safe, the file referenced by directory_iterator
+        // maybe moved to spill_gc dir during this function call, so need to catch expection
+    } catch (const std::filesystem::filesystem_error&) {
+        return true;
+    }
 }
 
 Status SpillDataDir::init() {


### PR DESCRIPTION
## Proposed changes

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: directory iterator cannot open directory: Bad file descriptor [/mnt/disk1/hezhiqiang/workspace/Release/be_1/storage/spill]
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1719432002 (unix time) try "date -d @1719432002" if you are using GNU date ***
*** Current BE git commitID: 099ac6606c ***
*** SIGABRT unknown detail explain (@0x4870036ec63) received by PID 3599459 (TID 3601713 OR 0x7f293145b700) from PID 3599459; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/hezhiqiang/doris/be/src/common/signal_handler.h:421
 1# 0x00007F2DA6C3AB50 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/[vterminate.cc:75](http://vterminate.cc:75/)
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/[eh_terminate.cc:48](http://eh_terminate.cc:48/)
 6# 0x000055716D024D51 in /mnt/disk1/hezhiqiang/workspace/Release/be_1/lib/doris_be
 7# 0x000055716D024EA4 in /mnt/disk1/hezhiqiang/workspace/Release/be_1/lib/doris_be
 8# std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*) [clone .cold] at ../../../../../libstdc++-v3/src/c++17/[fs_dir.cc:146](http://fs_dir.cc:146/)
 9# doris::vectorized::SpillDataDir::update_capacity() at /mnt/disk1/hezhiqiang/doris/be/src/vec/spill/spill_stream_manager.cpp:370
10# doris::vectorized::SpillStreamManager::_spill_gc_thread_callback() at /mnt/disk1/hezhiqiang/doris/be/src/vec/spill/spill_stream_manager.cpp:95
11# doris::Thread::supervise_thread(void*) at /mnt/disk1/hezhiqiang/doris/be/src/util/thread.cpp:499
12# start_thread in /lib64/libpthread.so.0
13# __clone in /lib64/libc.so.6
```

