### PR TITLE
[chore](planner) use NotFallbackInPasrser to label stmt impl in Nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterViewStmt.java
@@ -33,7 +33,8 @@ import org.apache.doris.qe.ConnectContext;
 import java.util.List;
 
 // Alter view statement
-public class AlterViewStmt extends BaseViewStmt {
+@Deprecated
+public class AlterViewStmt extends BaseViewStmt implements NotFallbackInParser {
 
     public AlterViewStmt(TableName tbl, List<ColWithComment> cols, QueryStmt queryStmt) {
         super(tbl, cols, queryStmt);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
@@ -41,7 +41,8 @@ import java.util.List;
  * CREATE TABLE table_name [( column_name_list )]
  * opt_engine opt_partition opt_properties KW_AS query_stmt
  */
-public class CreateTableAsSelectStmt extends DdlStmt {
+@Deprecated
+public class CreateTableAsSelectStmt extends DdlStmt implements NotFallbackInParser {
 
     @Getter
     private final CreateTableStmt createTableStmt;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableLikeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableLikeStmt.java
@@ -39,7 +39,8 @@ import java.util.ArrayList;
  * @version 1.0
  * @date 2020/10/7 10:32 上午
  */
-public class CreateTableLikeStmt extends DdlStmt {
+@Deprecated
+public class CreateTableLikeStmt extends DdlStmt implements NotFallbackInParser {
     private static final Logger LOG = LogManager.getLogger(CreateTableLikeStmt.class);
 
     private final boolean ifNotExists;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -70,7 +70,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-public class CreateTableStmt extends DdlStmt {
+@Deprecated
+public class CreateTableStmt extends DdlStmt implements NotFallbackInParser {
     private static final Logger LOG = LogManager.getLogger(CreateTableStmt.class);
 
     protected static final String DEFAULT_ENGINE_NAME = "olap";

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateViewStmt.java
@@ -33,7 +33,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public class CreateViewStmt extends BaseViewStmt {
+@Deprecated
+public class CreateViewStmt extends BaseViewStmt implements NotFallbackInParser {
     private static final Logger LOG = LogManager.getLogger(CreateViewStmt.class);
 
     private final boolean ifNotExists;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -52,7 +52,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class DeleteStmt extends DdlStmt {
+@Deprecated
+public class DeleteStmt extends DdlStmt implements NotFallbackInParser {
 
     private static final List<ExprRewriteRule> EXPR_NORMALIZE_RULES = ImmutableList.of(
             BetweenToCompoundRule.INSTANCE

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -43,7 +43,8 @@ import java.util.Set;
  * Currently this abstract class keep the native insert methods for compatibility, and will eventually be moved
  * to {@link NativeInsertStmt}
  */
-public abstract class InsertStmt extends DdlStmt {
+@Deprecated
+public abstract class InsertStmt extends DdlStmt implements NotFallbackInParser {
 
     public static class Properties {
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -102,6 +102,7 @@ import java.util.stream.Collectors;
  * The only difference is that non-streaming will record the load info in LoadManager and return label.
  * User can check the load info by show load stmt.
  */
+@Deprecated
 public class NativeInsertStmt extends InsertStmt {
 
     private static final Logger LOG = LogManager.getLogger(InsertStmt.class);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NotFallbackInParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NotFallbackInParser.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+/**
+ * this interface means do not fall back to legacy planner when parse failed in Nereids.
+ */
+public interface NotFallbackInParser {
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -54,7 +54,8 @@ import java.util.stream.Collectors;
  * Used for sharing members/methods and some of the analysis code, in particular the
  * analysis of the ORDER BY and LIMIT clauses.
  */
-public abstract class QueryStmt extends StatementBase implements Queriable {
+@Deprecated
+public abstract class QueryStmt extends StatementBase implements Queriable, NotFallbackInParser {
     private static final Logger LOG = LogManager.getLogger(QueryStmt.class);
 
     /////////////////////////////////////////

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -79,6 +79,7 @@ import java.util.stream.Collectors;
  * Representation of a single select block, including GROUP BY, ORDER BY and HAVING
  * clauses.
  */
+@Deprecated
 public class SelectStmt extends QueryStmt {
     private static final Logger LOG = LogManager.getLogger(SelectStmt.class);
     public static final String DEFAULT_VALUE = "__DEFAULT_VALUE__";

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
  * used is in materializeRequiredSlots() because that is called before plan generation
  * and we need to mark the slots of resolved exprs as materialized.
  */
+@Deprecated
 public class SetOperationStmt extends QueryStmt {
     private static final Logger LOG = LogManager.getLogger(SetOperationStmt.class);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
@@ -56,7 +56,8 @@ import java.util.TreeSet;
  * value:
  *     {expr}
  */
-public class UpdateStmt extends DdlStmt {
+@Deprecated
+public class UpdateStmt extends DdlStmt implements NotFallbackInParser {
     private TableRef targetTableRef;
     private TableName tableName;
     private final List<BinaryPredicate> setExprs;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -17,21 +17,15 @@
 
 package org.apache.doris.qe;
 
-import org.apache.doris.analysis.AlterViewStmt;
-import org.apache.doris.analysis.CreateTableAsSelectStmt;
-import org.apache.doris.analysis.CreateTableLikeStmt;
-import org.apache.doris.analysis.CreateTableStmt;
-import org.apache.doris.analysis.CreateViewStmt;
-import org.apache.doris.analysis.DeleteStmt;
 import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.InsertStmt;
 import org.apache.doris.analysis.KillStmt;
 import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.NotFallbackInParser;
 import org.apache.doris.analysis.QueryStmt;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.analysis.StatementBase;
-import org.apache.doris.analysis.UpdateStmt;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
@@ -324,15 +318,7 @@ public abstract class ConnectProcessor {
         if (mysqlCommand == MysqlCommand.COM_QUERY
                 && ctx.getSessionVariable().isEnableNereidsPlanner()
                 && !ctx.getSessionVariable().enableFallbackToOriginalPlanner
-                && stmts.stream().allMatch(s -> s instanceof QueryStmt
-                || s instanceof InsertStmt
-                || s instanceof UpdateStmt
-                || s instanceof DeleteStmt
-                || s instanceof CreateTableAsSelectStmt
-                || s instanceof CreateTableStmt
-                || s instanceof CreateTableLikeStmt
-                || s instanceof CreateViewStmt
-                || s instanceof AlterViewStmt)) {
+                && stmts.stream().allMatch(s -> s instanceof NotFallbackInParser)) {
             String errMsg;
             Throwable exception = null;
             if (nereidsParseException != null) {


### PR DESCRIPTION
add a interface named NotFallbackInPasrser.
If we already impl same stmt in Nereids, we let the stmt in legacy planner implement it.
When stmt implement NotFallbackInPasrser, it could not fall back to legacy planner when parse failed in Nereids.