### PR TITLE
[fix](spill) Adjust the logic for triggering spilling

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -402,7 +402,7 @@ bool PipelineTask::should_revoke_memory(RuntimeState* state, int64_t revocable_m
         int64_t query_weighted_limit = 0;
         int64_t query_weighted_consumption = 0;
         query_ctx->get_weighted_mem_info(query_weighted_limit, query_weighted_consumption);
-        if (query_weighted_consumption < query_weighted_limit) {
+        if (query_weighted_limit == 0 || query_weighted_consumption < query_weighted_limit) {
             return false;
         }
         auto big_memory_operator_num = query_ctx->get_running_big_mem_op_num();
@@ -419,7 +419,12 @@ bool PipelineTask::should_revoke_memory(RuntimeState* state, int64_t revocable_m
                              << PrettyPrinter::print_bytes(revocable_mem_bytes)
                              << ", mem_limit_of_op: " << PrettyPrinter::print_bytes(mem_limit_of_op)
                              << ", min_revocable_mem_bytes: "
-                             << PrettyPrinter::print_bytes(min_revocable_mem_bytes);
+                             << PrettyPrinter::print_bytes(min_revocable_mem_bytes)
+                             << ", query_weighted_consumption: "
+                             << PrettyPrinter::print_bytes(query_weighted_consumption)
+                             << ", query_weighted_limit: "
+                             << PrettyPrinter::print_bytes(query_weighted_limit)
+                             << ", big_memory_operator_num: " << big_memory_operator_num;
         return (revocable_mem_bytes > mem_limit_of_op ||
                 revocable_mem_bytes > min_revocable_mem_bytes);
     } else {

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -17,6 +17,7 @@
 
 #include "workload_group_manager.h"
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -177,21 +178,18 @@ void WorkloadGroupMgr::refresh_wg_memory_info() {
         wgs_mem_info[wg_id] = {wg_total_mem_used};
     }
 
-    // *TODO*, modify to use doris::GlobalMemoryArbitrator::process_memory_usage().
-    auto proc_vm_rss = PerfCounters::get_vm_rss();
+    auto process_memory_usage = GlobalMemoryArbitrator::process_memory_usage();
     if (all_queries_mem_used <= 0) {
         return;
     }
 
-    if (proc_vm_rss < all_queries_mem_used) {
-        all_queries_mem_used = proc_vm_rss;
-    }
+    all_queries_mem_used = std::min(process_memory_usage, all_queries_mem_used);
 
     // process memory used is actually bigger than all_queries_mem_used,
     // because memory of page cache, allocator cache, segment cache etc. are included
     // in proc_vm_rss.
     // we count these cache memories equally on workload groups.
-    double ratio = (double)proc_vm_rss / (double)all_queries_mem_used;
+    double ratio = (double)process_memory_usage / (double)all_queries_mem_used;
     if (ratio <= 1.25) {
         std::string debug_msg =
                 fmt::format("\nProcess Memory Summary: {}, {}, all quries mem: {}",


### PR DESCRIPTION
## Proposed changes

1. If 'query_weighted_limit` was not set, do not trigger spilling.
2. Using `process_memory_usage` to represent the process memory usage is more reasonable.
