### PR TITLE
[Fix](regression) Fix cluster privilege for workload group case in cloud mode

### DIFF
--- a/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
+++ b/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
@@ -282,6 +282,15 @@ suite("test_crud_wlg") {
     sql """drop user if exists test_wlg_user"""
     sql "CREATE USER 'test_wlg_user'@'%' IDENTIFIED BY '12345';"
     sql """grant SELECT_PRIV on *.*.* to test_wlg_user;"""
+
+    //cloud-mode
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER ${validCluster} TO test_wlg_user""";
+    }
+
     connect(user = 'test_wlg_user', password = '12345', url = context.config.jdbcUrl) {
             sql """ select count(1) from information_schema.backend_active_tasks; """
     }


### PR DESCRIPTION
## Proposed changes
When regression test test a cloud mode Doris cluster, non-root user should set a cluster name, otherwise query may failed.