### PR TITLE
[Feature](multi-catalog) Add memory tracker for orc reader/writer and arrow parquet writer。

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -36,6 +36,13 @@
 #include "runtime/frontend_info.h" // TODO(zhiqiang): find a way to remove this include header
 #include "util/threadpool.h"
 
+namespace orc {
+class MemoryPool;
+}
+namespace arrow {
+class MemoryPool;
+}
+
 namespace doris {
 namespace vectorized {
 class VDataStreamMgr;
@@ -305,6 +312,9 @@ public:
     segment_v2::TmpFileDirs* get_tmp_file_dirs() { return _tmp_file_dirs.get(); }
     io::FDCache* file_cache_open_fd_cache() const { return _file_cache_open_fd_cache.get(); }
 
+    orc::MemoryPool* orc_memory_pool() { return _orc_memory_pool; }
+    arrow::MemoryPool* arrow_memory_pool() { return _arrow_memory_pool; }
+
 private:
     ExecEnv();
 
@@ -435,6 +445,9 @@ private:
     std::unique_ptr<pipeline::PipelineTracerContext> _pipeline_tracer_ctx;
     std::unique_ptr<segment_v2::TmpFileDirs> _tmp_file_dirs;
     doris::vectorized::SpillStreamManager* _spill_stream_mgr = nullptr;
+
+    orc::MemoryPool* _orc_memory_pool = nullptr;
+    arrow::MemoryPool* _arrow_memory_pool = nullptr;
 };
 
 template <>

--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -35,7 +35,7 @@ namespace doris {
 // common use cases (in particular, resize() will fill with uninitialized data
 // instead of memsetting to \0)
 // only build() can transfer data to the outside.
-class faststring : private Allocator<false, false, false> {
+class faststring : private Allocator<false, false, false, DefaultMemoryAllocator> {
 public:
     enum { kInitialCapacity = 32 };
 

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -340,7 +340,7 @@ struct SliceMap {
 //
 // only receive the memory allocated by Allocator and disables mmap,
 // otherwise the memory may not be freed correctly, currently only be constructed by faststring.
-class OwnedSlice : private Allocator<false, false, false> {
+class OwnedSlice : private Allocator<false, false, false, DefaultMemoryAllocator> {
 public:
     OwnedSlice() : _slice((uint8_t*)nullptr, 0) {}
 

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -23,6 +23,10 @@
 // TODO: Readable
 
 #include <fmt/format.h>
+#if defined(USE_JEMALLOC)
+#include <jemalloc/jemalloc.h>
+#endif // defined(USE_JEMALLOC)
+#include <malloc.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -68,6 +72,128 @@ static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;
 // is always a multiple of sixteen. (https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html)
 static constexpr int ALLOCATOR_ALIGNMENT_16 = 16;
 
+class DefaultMemoryAllocator {
+public:
+    static void* malloc(size_t size) __THROW { return std::malloc(size); }
+
+    static void* calloc(size_t n, size_t size) __THROW { return std::calloc(n, size); }
+
+    static constexpr bool need_record_actual_size() { return false; }
+
+    static int posix_memalign(void** ptr, size_t alignment, size_t size) __THROW {
+        return ::posix_memalign(ptr, alignment, size);
+    }
+
+    static void* realloc(void* ptr, size_t size) __THROW { return std::realloc(ptr, size); }
+
+    static void free(void* p) __THROW { std::free(p); }
+
+    static void release_unused() {
+#if defined(USE_JEMALLOC)
+        jemallctl(fmt::format("arena.{}.purge", MALLCTL_ARENAS_ALL).c_str(), NULL, NULL, NULL, 0);
+#endif // defined(USE_JEMALLOC)
+    }
+};
+
+/** It would be better to put these Memory Allocators where they are used, such as in the orc memory pool and arrow memory pool.
+  * But currently allocators use templates in .cpp instead of all in .h, so they can only be placed here.
+  */
+class ORCMemoryAllocator {
+public:
+    static void* malloc(size_t size) __THROW { return reinterpret_cast<char*>(std::malloc(size)); }
+
+    static void* calloc(size_t n, size_t size) __THROW { return std::calloc(n, size); }
+
+    static constexpr bool need_record_actual_size() { return true; }
+
+    static size_t allocated_size(void* ptr) { return malloc_usable_size(ptr); }
+
+    static int posix_memalign(void** ptr, size_t alignment, size_t size) __THROW {
+        return ::posix_memalign(ptr, alignment, size);
+    }
+
+    static void* realloc(void* ptr, size_t size) __THROW {
+        LOG(FATAL) << "__builtin_unreachable";
+        __builtin_unreachable();
+    }
+
+    static void free(void* p) __THROW { std::free(p); }
+
+    static void release_unused() {}
+};
+
+class RecordSizeMemoryAllocator {
+public:
+    static void* malloc(size_t size) __THROW {
+        void* p = std::malloc(size);
+        if (p) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _allocated_sizes[p] = size;
+        }
+        return p;
+    }
+
+    static void* calloc(size_t n, size_t size) __THROW {
+        void* p = std::calloc(n, size);
+        if (p) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _allocated_sizes[p] = n * size;
+        }
+        return p;
+    }
+
+    static constexpr bool need_record_actual_size() { return false; }
+
+    static size_t allocated_size(void* ptr) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _allocated_sizes.find(ptr);
+        if (it != _allocated_sizes.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+    static int posix_memalign(void** ptr, size_t alignment, size_t size) __THROW {
+        int ret = ::posix_memalign(ptr, alignment, size);
+        if (ret == 0 && *ptr) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _allocated_sizes[*ptr] = size;
+        }
+        return ret;
+    }
+
+    static void* realloc(void* ptr, size_t size) __THROW {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        auto it = _allocated_sizes.find(ptr);
+        if (it != _allocated_sizes.end()) {
+            _allocated_sizes.erase(it);
+        }
+
+        void* p = std::realloc(ptr, size);
+
+        if (p) {
+            _allocated_sizes[p] = size;
+        }
+
+        return p;
+    }
+
+    static void free(void* p) __THROW {
+        if (p) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _allocated_sizes.erase(p);
+            std::free(p);
+        }
+    }
+
+    static void release_unused() {}
+
+private:
+    static std::unordered_map<void*, size_t> _allocated_sizes;
+    static std::mutex _mutex;
+};
+
 /** Responsible for allocating / freeing memory. Used, for example, in PODArray, Arena.
   * Also used in hash tables.
   * The interface is different from std::allocator
@@ -78,7 +204,7 @@ static constexpr int ALLOCATOR_ALIGNMENT_16 = 16;
   * - random hint address for mmap
   * - mmap_threshold for using mmap less or more
   */
-template <bool clear_memory_, bool mmap_populate, bool use_mmap>
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 class Allocator {
 public:
     void sys_memory_check(size_t size) const;
@@ -104,6 +230,7 @@ public:
         // consume memory in tracker before alloc, similar to early declaration.
         consume_memory(size);
         void* buf;
+        size_t record_size = size;
 
         if (use_mmap && size >= doris::config::mmap_threshold) {
             if (alignment > MMAP_MIN_ALIGNMENT)
@@ -117,37 +244,50 @@ public:
                 release_memory(size);
                 throw_bad_alloc(fmt::format("Allocator: Cannot mmap {}.", size));
             }
+            if constexpr (MemoryAllocator::need_record_actual_size()) {
+                record_size = MemoryAllocator::allocated_size(buf);
+            }
 
             /// No need for zero-fill, because mmap guarantees it.
         } else {
             if (alignment <= MALLOC_MIN_ALIGNMENT) {
                 if constexpr (clear_memory)
-                    buf = ::calloc(size, 1);
+                    buf = MemoryAllocator::calloc(size, 1);
                 else
-                    buf = ::malloc(size);
+                    buf = MemoryAllocator::malloc(size);
 
                 if (nullptr == buf) {
                     release_memory(size);
                     throw_bad_alloc(fmt::format("Allocator: Cannot malloc {}.", size));
                 }
+                if constexpr (MemoryAllocator::need_record_actual_size()) {
+                    record_size = MemoryAllocator::allocated_size(buf);
+                }
 #ifndef NDEBUG
-                add_address_sanitizers(buf, size);
+                add_address_sanitizers(buf, record_size);
 #endif
             } else {
                 buf = nullptr;
-                int res = posix_memalign(&buf, alignment, size);
+                int res = MemoryAllocator::posix_memalign(&buf, alignment, size);
 
                 if (0 != res) {
                     release_memory(size);
                     throw_bad_alloc(
                             fmt::format("Cannot allocate memory (posix_memalign) {}.", size));
                 }
-#ifndef NDEBUG
-                add_address_sanitizers(buf, size);
-#endif
 
                 if constexpr (clear_memory) memset(buf, 0, size);
+
+                if constexpr (MemoryAllocator::need_record_actual_size()) {
+                    record_size = MemoryAllocator::allocated_size(buf);
+                }
+#ifndef NDEBUG
+                add_address_sanitizers(buf, record_size);
+#endif
             }
+        }
+        if constexpr (MemoryAllocator::need_record_actual_size()) {
+            consume_memory(record_size - size);
         }
         return buf;
     }
@@ -162,10 +302,12 @@ public:
 #ifndef NDEBUG
             remove_address_sanitizers(buf, size);
 #endif
-            ::free(buf);
+            MemoryAllocator::free(buf);
         }
         release_memory(size);
     }
+
+    void release_unused() { MemoryAllocator::release_unused(); }
 
     /** Enlarge memory range.
       * Data from old range is moved to the beginning of new range.
@@ -187,7 +329,7 @@ public:
             remove_address_sanitizers(buf, old_size);
 #endif
             /// Resize malloc'd memory region with no special alignment requirement.
-            void* new_buf = ::realloc(buf, new_size);
+            void* new_buf = MemoryAllocator::realloc(buf, new_size);
             if (nullptr == new_buf) {
                 release_memory(new_size - old_size);
                 throw_bad_alloc(fmt::format("Allocator: Cannot realloc from {} to {}.", old_size,
@@ -195,7 +337,8 @@ public:
             }
 #ifndef NDEBUG
             add_address_sanitizers(
-                    new_buf, new_size); // usually, buf addr = new_buf addr, asan maybe not equal.
+                    new_buf,
+                    new_size); // usually, buf addr = new_buf addr, asan maybe not equal.
 #endif
 
             buf = new_buf;

--- a/be/src/vec/common/allocator_fwd.h
+++ b/be/src/vec/common/allocator_fwd.h
@@ -24,7 +24,9 @@
 #pragma once
 
 #include <cstddef>
-template <bool clear_memory_, bool mmap_populate = false, bool use_mmap = false>
+class DefaultMemoryAllocator;
+template <bool clear_memory_, bool mmap_populate = false, bool use_mmap = false,
+          typename MemoryAllocator = DefaultMemoryAllocator>
 class Allocator;
 
 template <typename Base, size_t N = 64, size_t Alignment = 1>

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 /// `Allocator_` implements several interfaces of `std::allocator`
 /// which `phmap::flat_hash_map` will use.
 template <typename T>
-class Allocator_ : private Allocator<true, false, false> {
+class Allocator_ : private Allocator<true, false, false, DefaultMemoryAllocator> {
 public:
     using value_type = T;
     using pointer = T*;

--- a/be/src/vec/exec/format/orc/orc_memory_pool.h
+++ b/be/src/vec/exec/format/orc/orc_memory_pool.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "orc/MemoryPool.hh"
+#include "vec/common/allocator.h"
+
+#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
+using ORC_MEMORY_ALLOCATOR = RecordSizeMemoryAllocator;
+#else
+using ORC_MEMORY_ALLOCATOR = ORCMemoryAllocator;
+#endif
+
+namespace doris::vectorized {
+
+class ORCMemoryPool : public orc::MemoryPool {
+public:
+    char* malloc(uint64_t size) override {
+        char* p = reinterpret_cast<char*>(_allocator.alloc(size));
+        return p;
+    }
+
+    void free(char* p) override {
+        if (p == nullptr) {
+            return;
+        }
+        size_t size = ORC_MEMORY_ALLOCATOR::allocated_size(p);
+        _allocator.free(p, size);
+    }
+
+    ORCMemoryPool() = default;
+    ~ORCMemoryPool() override = default;
+
+private:
+    Allocator<false, false, false, ORC_MEMORY_ALLOCATOR> _allocator;
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -71,6 +71,7 @@
 #include "vec/data_types/data_type_map.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_struct.h"
+#include "vec/exec/format/orc/orc_memory_pool.h"
 #include "vec/exec/format/table/transactional_hive_common.h"
 #include "vec/exprs/vbloom_predicate.h"
 #include "vec/exprs/vdirect_in_predicate.h"
@@ -252,6 +253,7 @@ Status OrcReader::_create_file_reader() {
     // create orc reader
     try {
         orc::ReaderOptions options;
+        options.setMemoryPool(*ExecEnv::GetInstance()->orc_memory_pool());
         _reader = orc::createReader(
                 std::unique_ptr<ORCFileInputStream>(_file_input_stream.release()), options);
     } catch (std::exception& e) {

--- a/be/src/vec/exec/format/parquet/arrow_memory_pool.cpp
+++ b/be/src/vec/exec/format/parquet/arrow_memory_pool.cpp
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/format/parquet/arrow_memory_pool.h"
+
+#include "glog/logging.h"
+
+namespace doris::vectorized {
+
+// A static piece of memory for 0-size allocations, so as to return
+// an aligned non-null pointer.  Note the correct value for DebugAllocator
+// checks is hardcoded.
+alignas(kDefaultBufferAlignment) int64_t zero_size_area[1] = {kDebugXorSuffix};
+
+arrow::Status ArrowAllocator::allocate_aligned(int64_t size, int64_t alignment, uint8_t** out) {
+    if (size == 0) {
+        *out = kZeroSizeArea;
+        return arrow::Status::OK();
+    }
+    *out = reinterpret_cast<uint8_t*>(_allocator.alloc(size, alignment));
+    if (*out == nullptr) {
+        return arrow::Status::OutOfMemory("malloc of size ", size, " failed");
+    }
+    return arrow::Status::OK();
+}
+
+arrow::Status ArrowAllocator::reallocate_aligned(int64_t old_size, int64_t new_size,
+                                                 int64_t alignment, uint8_t** ptr) {
+    uint8_t* previous_ptr = *ptr;
+    if (previous_ptr == kZeroSizeArea) {
+        DCHECK_EQ(old_size, 0);
+        return allocate_aligned(new_size, alignment, ptr);
+    }
+    if (new_size == 0) {
+        deallocate_aligned(previous_ptr, old_size, alignment);
+        *ptr = kZeroSizeArea;
+        return arrow::Status::OK();
+    }
+    *ptr = reinterpret_cast<uint8_t*>(_allocator.realloc(*ptr, static_cast<size_t>(old_size),
+                                                         static_cast<size_t>(new_size), alignment));
+    if (*ptr == nullptr) {
+        *ptr = previous_ptr;
+        return arrow::Status::OutOfMemory("realloc of size ", new_size, " failed");
+    }
+    return arrow::Status::OK();
+}
+
+void ArrowAllocator::deallocate_aligned(uint8_t* ptr, int64_t size, int64_t alignment) {
+    if (ptr == kZeroSizeArea) {
+        DCHECK_EQ(size, 0);
+    } else {
+        _allocator.free(ptr, static_cast<size_t>(size));
+    }
+}
+
+void ArrowAllocator::release_unused() {
+    _allocator.release_unused();
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/arrow_memory_pool.h
+++ b/be/src/vec/exec/format/parquet/arrow_memory_pool.h
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
+
+namespace doris::vectorized {
+
+constexpr int64_t kDefaultBufferAlignment = 64;
+static constexpr int64_t kDebugXorSuffix = -0x181fe80e0b464188LL;
+#ifndef NDEBUG
+static constexpr uint8_t kAllocPoison = 0xBC;
+static constexpr uint8_t kReallocPoison = 0xBD;
+static constexpr uint8_t kDeallocPoison = 0xBE;
+#endif
+
+// A static piece of memory for 0-size allocations, so as to return
+// an aligned non-null pointer.  Note the correct value for DebugAllocator
+// checks is hardcoded.
+extern int64_t zero_size_area[1];
+static uint8_t* const kZeroSizeArea = reinterpret_cast<uint8_t*>(&zero_size_area);
+
+using ARROW_MEMORY_ALLOCATOR = DefaultMemoryAllocator;
+
+class ArrowAllocator {
+public:
+    arrow::Status allocate_aligned(int64_t size, int64_t alignment, uint8_t** out);
+    arrow::Status reallocate_aligned(int64_t old_size, int64_t new_size, int64_t alignment,
+                                     uint8_t** ptr);
+    void deallocate_aligned(uint8_t* ptr, int64_t size, int64_t alignment);
+    void release_unused();
+
+private:
+    Allocator<false, false, false, ARROW_MEMORY_ALLOCATOR> _allocator;
+};
+
+///////////////////////////////////////////////////////////////////////
+// Helper tracking memory statistics
+
+/// \brief Memory pool statistics
+///
+/// 64-byte aligned so that all atomic values are on the same cache line.
+class alignas(64) ArrowMemoryPoolStats {
+private:
+    // All atomics are updated according to Acquire-Release ordering.
+    // https://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering
+    //
+    // max_memory_, total_allocated_bytes_, and num_allocs_ only go up (they are
+    // monotonically increasing) which can allow some optimizations.
+    std::atomic<int64_t> max_memory_ {0};
+    std::atomic<int64_t> bytes_allocated_ {0};
+    std::atomic<int64_t> total_allocated_bytes_ {0};
+    std::atomic<int64_t> num_allocs_ {0};
+
+public:
+    int64_t max_memory() const { return max_memory_.load(std::memory_order_acquire); }
+
+    int64_t bytes_allocated() const { return bytes_allocated_.load(std::memory_order_acquire); }
+
+    int64_t total_bytes_allocated() const {
+        return total_allocated_bytes_.load(std::memory_order_acquire);
+    }
+
+    int64_t num_allocations() const { return num_allocs_.load(std::memory_order_acquire); }
+
+    inline void did_allocate_bytes(int64_t size) {
+        // Issue the load before everything else. max_memory_ is monotonically increasing,
+        // so we can use a relaxed load before the read-modify-write.
+        auto max_memory = max_memory_.load(std::memory_order_relaxed);
+        const auto old_bytes_allocated =
+                bytes_allocated_.fetch_add(size, std::memory_order_acq_rel);
+        // Issue store operations on values that we don't depend on to proceed
+        // with execution. When done, max_memory and old_bytes_allocated have
+        // a higher chance of being available on CPU registers. This also has the
+        // nice side-effect of putting 3 atomic stores close to each other in the
+        // instruction stream.
+        total_allocated_bytes_.fetch_add(size, std::memory_order_acq_rel);
+        num_allocs_.fetch_add(1, std::memory_order_acq_rel);
+
+        // If other threads are updating max_memory_ concurrently we leave the loop without
+        // updating knowing that it already reached a value even higher than ours.
+        const auto allocated = old_bytes_allocated + size;
+        while (max_memory < allocated &&
+               !max_memory_.compare_exchange_weak(
+                       /*expected=*/max_memory, /*desired=*/allocated, std::memory_order_acq_rel)) {
+        }
+    }
+
+    inline void did_reallocate_bytes(int64_t old_size, int64_t new_size) {
+        if (new_size > old_size) {
+            did_allocate_bytes(new_size - old_size);
+        } else {
+            did_free_bytes(old_size - new_size);
+        }
+    }
+
+    inline void did_free_bytes(int64_t size) {
+        bytes_allocated_.fetch_sub(size, std::memory_order_acq_rel);
+    }
+};
+
+template <typename Allocator = ArrowAllocator>
+class ArrowMemoryPool : public arrow::MemoryPool {
+public:
+    ~ArrowMemoryPool() override = default;
+
+    arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
+        if (size < 0) {
+            return arrow::Status::Invalid("negative malloc size");
+        }
+        if (static_cast<uint64_t>(size) >= std::numeric_limits<size_t>::max()) {
+            return arrow::Status::OutOfMemory("malloc size overflows size_t");
+        }
+        RETURN_NOT_OK(_allocator.allocate_aligned(size, alignment, out));
+#ifndef NDEBUG
+        // Poison data
+        if (size > 0) {
+            DCHECK_NE(*out, nullptr);
+            (*out)[0] = kAllocPoison;
+            (*out)[size - 1] = kAllocPoison;
+        }
+#endif
+
+        _stats.did_allocate_bytes(size);
+        return arrow::Status::OK();
+    }
+
+    arrow::Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
+                             uint8_t** ptr) override {
+        if (new_size < 0) {
+            return arrow::Status::Invalid("negative realloc size");
+        }
+        if (static_cast<uint64_t>(new_size) >= std::numeric_limits<size_t>::max()) {
+            return arrow::Status::OutOfMemory("realloc overflows size_t");
+        }
+        RETURN_NOT_OK(_allocator.reallocate_aligned(old_size, new_size, alignment, ptr));
+#ifndef NDEBUG
+        // Poison data
+        if (new_size > old_size) {
+            DCHECK_NE(*ptr, nullptr);
+            (*ptr)[old_size] = kReallocPoison;
+            (*ptr)[new_size - 1] = kReallocPoison;
+        }
+#endif
+
+        _stats.did_reallocate_bytes(old_size, new_size);
+        return arrow::Status::OK();
+    }
+
+    void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
+#ifndef NDEBUG
+        // Poison data
+        if (size > 0) {
+            DCHECK_NE(buffer, nullptr);
+            buffer[0] = kDeallocPoison;
+            buffer[size - 1] = kDeallocPoison;
+        }
+#endif
+        _allocator.deallocate_aligned(buffer, size, alignment);
+
+        _stats.did_free_bytes(size);
+    }
+
+    void ReleaseUnused() override { _allocator.release_unused(); }
+
+    int64_t bytes_allocated() const override { return _stats.bytes_allocated(); }
+
+    int64_t max_memory() const override { return _stats.max_memory(); }
+
+    int64_t total_bytes_allocated() const override { return _stats.total_bytes_allocated(); }
+
+    int64_t num_allocations() const override { return _stats.num_allocations(); }
+
+    std::string backend_name() const override { return "ArrowMemoryPool"; }
+
+protected:
+    ArrowMemoryPoolStats _stats;
+    Allocator _allocator;
+};
+
+} // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

[Feature] (multi-catalog) Add memory tracker for orc reader/writer and arrow parquet writer。

## Future work

- Since the parquet reader is written by ourself and does not use the arrow third-party library, some memory usage needs to be added to the memory track.
- Added read and write operator-level memory tracker to the profile.
