### PR TITLE
[fix](nereids) derive column stats for 'expr and A is not null'

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -110,6 +110,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         Expression leftExpr = predicate.child(0);
         Expression rightExpr = predicate.child(1);
         Statistics leftStats = leftExpr.accept(this, context);
+        leftStats = leftStats.normalizeByRatio(context.statistics.getRowCount());
         Statistics andStats = rightExpr.accept(this,
                 new EstimationContext(leftStats));
         if (predicate instanceof And) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -225,4 +225,22 @@ public class Statistics {
     public int getWidthInJoinCluster() {
         return widthInJoinCluster;
     }
+
+    public Statistics normalizeByRatio(double originRowCount) {
+        if (rowCount >= originRowCount || rowCount <= 0) {
+            return this;
+        }
+        StatisticsBuilder builder = new StatisticsBuilder(this);
+        double ratio = rowCount / originRowCount;
+        for (Entry<Expression, ColumnStatistic> entry : expressionToColumnStats.entrySet()) {
+            ColumnStatistic colStats = entry.getValue();
+            if (colStats.numNulls != 0 || colStats.ndv > rowCount) {
+                ColumnStatisticBuilder colStatsBuilder = new ColumnStatisticBuilder(colStats);
+                colStatsBuilder.setNumNulls(colStats.numNulls * ratio);
+                colStatsBuilder.setNdv(Math.min(rowCount - colStatsBuilder.getNumNulls(), colStats.ndv));
+                builder.putColumnStatistics(entry.getKey(), colStatsBuilder.build());
+            }
+        }
+        return builder.build();
+    }
 }

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query64.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query64.out
@@ -11,59 +11,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status)))
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=()
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF15 ss_addr_sk->[ca_address_sk]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF15
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF13 ss_item_sk->[sr_item_sk];RF14 ss_ticket_number->[sr_ticket_number]
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF13 RF14
-------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF12 ss_cdemo_sk->[cd_demo_sk]
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF12
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk]
-------------------------------------------PhysicalProject
---------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
-----------------------------------------------PhysicalProject
-------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=()
---------------------------------------------------PhysicalProject
-----------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=()
-------------------------------------------------------PhysicalProject
---------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF6 cs_item_sk->[ss_item_sk]
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7 RF11
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------filter((sale > (2 * refund)))
-------------------------------------------------------------------hashAgg[GLOBAL]
---------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------------------------------------------------hashAgg[LOCAL]
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF11
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF11
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------filter(d_year IN (2001, 2002))
---------------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[household_demographics]
---------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[income_band]
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[store]
-------------------------------------------PhysicalProject
---------------------------------------------filter((item.i_current_price <= 33.00) and (item.i_current_price >= 24.00) and i_color IN ('blanched', 'brown', 'burlywood', 'chocolate', 'drab', 'medium'))
-----------------------------------------------PhysicalOlapScan[item]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[promotion]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF17 ss_customer_sk->[c_customer_sk]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=()
 ----------------------------PhysicalProject
@@ -71,7 +19,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_hdemo_sk = hd2.hd_demo_sk)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[customer]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF17
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
@@ -82,6 +30,58 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF11 ss_item_sk->[sr_item_sk];RF12 ss_ticket_number->[sr_ticket_number]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_returns] apply RFs: RF11 RF12
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF10 ss_cdemo_sk->[cd_demo_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF10
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF9 ss_addr_sk->[ca_address_sk]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF9
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF8 i_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk]
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=()
+------------------------------------------PhysicalProject
+--------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=()
+--------------------------------------------------PhysicalProject
+----------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=()
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[ss_item_sk]
+--------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF8
+--------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
+----------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF8
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------------------------PhysicalProject
+----------------------------------------------------PhysicalOlapScan[income_band]
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[promotion]
+--------------------------------------PhysicalProject
+----------------------------------------filter((item.i_current_price <= 33.00) and (item.i_current_price >= 24.00) and i_color IN ('blanched', 'brown', 'burlywood', 'chocolate', 'drab', 'medium'))
+------------------------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query64.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query64.out
@@ -11,77 +11,77 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF18 d_date_sk->[c_first_sales_date_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF17 c_customer_sk->[ss_customer_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF17 ss_customer_sk->[c_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF16 p_promo_sk->[ss_promo_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF16 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF15 ss_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF15 cd_demo_sk->[c_current_cdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF15
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF13 ss_item_sk->[sr_item_sk];RF14 ss_ticket_number->[sr_ticket_number]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_hdemo_sk = hd2.hd_demo_sk)) otherCondition=() build RFs:RF14 hd_demo_sk->[c_current_hdemo_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF13 RF14
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF14 RF15 RF16 RF17 RF18 RF19
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF12 ss_cdemo_sk->[cd_demo_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=() build RFs:RF13 ib_income_band_sk->[hd_income_band_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF12
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk]
-------------------------------------------PhysicalProject
---------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF10 s_store_sk->[ss_store_sk]
-----------------------------------------------PhysicalProject
-------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=() build RFs:RF9 ib_income_band_sk->[hd_income_band_sk]
---------------------------------------------------PhysicalProject
-----------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=() build RFs:RF8 hd_demo_sk->[ss_hdemo_sk]
-------------------------------------------------------PhysicalProject
---------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF6 cs_item_sk->[ss_item_sk]
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7 RF8 RF10 RF11 RF16 RF17
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------filter((sale > (2 * refund)))
-------------------------------------------------------------------hashAgg[GLOBAL]
---------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------------------------------------------------hashAgg[LOCAL]
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF4 cr_item_sk->[cs_item_sk];RF5 cr_order_number->[cs_order_number]
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF5 RF11
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF11
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------filter(d_year IN (2001, 2002))
---------------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF9
---------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[income_band]
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[store]
-------------------------------------------PhysicalProject
---------------------------------------------filter((item.i_current_price <= 33.00) and (item.i_current_price >= 24.00) and i_color IN ('blanched', 'brown', 'burlywood', 'chocolate', 'drab', 'medium'))
-----------------------------------------------PhysicalOlapScan[item]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[promotion]
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[c_current_cdemo_sk]
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_hdemo_sk = hd2.hd_demo_sk)) otherCondition=() build RFs:RF1 hd_demo_sk->[c_current_hdemo_sk]
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[customer] apply RFs: RF1 RF2 RF3 RF18 RF19
-------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=() build RFs:RF0 ib_income_band_sk->[hd_income_band_sk]
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF0
+------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF13
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[income_band]
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF11 ss_item_sk->[sr_item_sk];RF12 ss_ticket_number->[sr_ticket_number]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_returns] apply RFs: RF11 RF12
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF10 ss_cdemo_sk->[cd_demo_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF10
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF9 ss_addr_sk->[ca_address_sk]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF9
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF8 i_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk]
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF7 p_promo_sk->[ss_promo_sk]
+------------------------------------------PhysicalProject
+--------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=() build RFs:RF5 ib_income_band_sk->[hd_income_band_sk]
+--------------------------------------------------PhysicalProject
+----------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[ss_hdemo_sk]
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[ss_item_sk]
+--------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4 RF6 RF7 RF8
+--------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
+----------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF8
+----------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF8
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF5
+--------------------------------------------------PhysicalProject
+----------------------------------------------------PhysicalOlapScan[income_band]
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[promotion]
+--------------------------------------PhysicalProject
+----------------------------------------filter((item.i_current_price <= 33.00) and (item.i_current_price >= 24.00) and i_color IN ('blanched', 'brown', 'burlywood', 'chocolate', 'drab', 'medium'))
+------------------------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject


### PR DESCRIPTION
## Proposed changes
the algorithm for computing stats for "expr1 and expr2" predicate is as following:
1. compute output stats of expr1 based on input stats. the result stats is denoted by leftStats
2. compute stats of expr2 based on leftStats
after step1, leftStats should be normalized to avoid abnormal cases, such as ndv > rowCount or numNulls > rowCount

Issue Number: close #xxx

<!--Describe your changes.-->

