### PR TITLE
[opt](merge-on-write) Skip considering rowsets produced by compaction from commited txns' rowsets in publish phase

### DIFF
--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -181,6 +181,9 @@ public:
     static void add_sentinel_mark_to_delete_bitmap(DeleteBitmap* delete_bitmap,
                                                    const RowsetIdUnorderedSet& rowsetids);
 
+    static void add_skip_mark_to_delete_bitmap(DeleteBitmap* delete_bitmap,
+                                               std::vector<RowsetSharedPtr> rowsets);
+
     Status check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
                                            int64_t txn_id, const RowsetIdUnorderedSet& rowset_ids,
                                            std::vector<RowsetSharedPtr>* rowsets = nullptr);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -991,6 +991,10 @@ Status CompactionMixin::modify_rowsets() {
                     _tablet->add_sentinel_mark_to_delete_bitmap(&txn_output_delete_bitmap,
                                                                 rowsetids);
                 }
+
+                _tablet->add_skip_mark_to_delete_bitmap(&txn_output_delete_bitmap,
+                                                        {_output_rowset});
+
                 it.delete_bitmap->merge(txn_output_delete_bitmap);
                 // Step3: write back updated delete bitmap and tablet info.
                 it.rowset_ids.insert(_output_rowset->rowset_id());

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -376,12 +376,14 @@ public:
     constexpr static inline uint32_t INVALID_SEGMENT_ID = std::numeric_limits<uint32_t>::max() - 1;
     constexpr static inline uint32_t ROWSET_SENTINEL_MARK =
             std::numeric_limits<uint32_t>::max() - 1;
+    constexpr static inline uint32_t ROWSET_SKIP_MARK = std::numeric_limits<uint32_t>::max() - 2;
 
     // When a delete bitmap is merged into tablet's delete bitmap, the version of entries in the delete bitmap
     // will be replaced to the correspoding correct version. So before we finally merge a delete bitmap into
     // tablet's delete bitmap we can use arbitary version number in BitmapKey. Here we define some version numbers
     // for specific usage during this periods to avoid conflicts
     constexpr static inline uint64_t TEMP_VERSION_COMMON = 0;
+    constexpr static inline uint64_t INVALID_VERSION = std::numeric_limits<uint64_t>::max();
 
     /**
      * 


### PR DESCRIPTION
## Proposed changes

https://github.com/apache/doris/pull/20907 let compaction calculates the delete bitmap of the output rowset from committed txns' rowsets to reduce the calculation pressure of publish phase. But this output rowset will be considered as new rowset in the publish phase and will be calculated again in the publish phase. This PR let the publish phase calculation skip considering these rowsets.
