### PR TITLE
[fix](cloud) add lock when get visible version from cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -104,7 +104,12 @@ public class CloudPartition extends Partition {
 
     @Override
     public long getVisibleVersion(Boolean fromCache) {
-        return super.getVisibleVersion();
+        lock.lock();
+        try {
+            return super.getVisibleVersion();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

introduced by https://github.com/apache/doris/pull/34615

When get visible version from cache, the visible version may be updated by load, so it is necessary to add lock when get visible version.

