### PR TITLE
[opt](join)  merge each input block into the build block

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -111,7 +111,8 @@ class HashJoinBuildSinkOperatorX final
         : public JoinBuildSinkOperatorX<HashJoinBuildSinkLocalState> {
 public:
     HashJoinBuildSinkOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                               const DescriptorTbl& descs, bool use_global_rf);
+                               const DescriptorTbl& descs, bool use_global_rf,
+                               bool is_spill = false);
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TDataSink",
                                      JoinBuildSinkOperatorX<HashJoinBuildSinkLocalState>::_name);
@@ -173,6 +174,8 @@ private:
     const std::vector<TExpr> _partition_exprs;
 
     const bool _need_local_merge;
+
+    const bool _is_spill;
 };
 
 template <class HashTableContext>

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1233,7 +1233,7 @@ Status PipelineFragmentContext::_create_operator(ObjectPool* pool, const TPlanNo
             auto inner_probe_operator =
                     std::make_shared<HashJoinProbeOperatorX>(pool, tnode_, 0, descs);
             auto inner_sink_operator = std::make_shared<HashJoinBuildSinkOperatorX>(
-                    pool, 0, tnode_, descs, _need_local_merge);
+                    pool, 0, tnode_, descs, _need_local_merge, true);
 
             RETURN_IF_ERROR(inner_probe_operator->init(tnode_, _runtime_state.get()));
             RETURN_IF_ERROR(inner_sink_operator->init(tnode_, _runtime_state.get()));


### PR DESCRIPTION
## Proposed changes

In non-spill
the past approach was to accumulate blocks and only merge them into one build block when get eos. 
This caused the build sink side of the pipeline to be fast before get eos, resulting waiting for upstream data. 
```
                     HASH_JOIN_SINK_OPERATOR  (id=4  ,  nereids_id=342):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  17s635ms,  max  17s635ms,  min  17s635ms
                            -  InitTime:  avg  0ns,  max  0ns,  min  0ns
                            -  InputRows:  sum  10.0M  (10000000),  avg  10.0M  (10000000),  max  10.0M  (10000000),  min  10.0M  (10000000)
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  BuildBlocks:  sum  10.29  GB,  avg  10.29  GB,  max  10.29  GB,  min  10.29  GB
                                -  BuildKeyArena:  sum  10.37  GB,  avg  10.37  GB,  max  10.37  GB,  min  10.37  GB
                                -  HashTable:  sum  102.15  MB,  avg  102.15  MB,  max  102.15  MB,  min  102.15  MB
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  7.802us,  max  7.802us,  min  7.802us
                            -  WaitForDependency[HASH_JOIN_SINK_OPERATOR_DEPENDENCY]Time:  avg  0ns,  max  0ns,  min  0ns
                          EXCHANGE_OPERATOR  (id=1):
                                -  BlocksProduced:  sum  2.499K  (2499),  avg  2.499K  (2499),  max  2.499K  (2499),  min  2.499K  (2499)
                                -  CloseTime:  avg  7.900us,  max  7.900us,  min  7.900us
                                -  ExecTime:  avg  3.7ms,  max  3.7ms,  min  3.7ms
                                -  InitTime:  avg  7.253us,  max  7.253us,  min  7.253us
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  16.04  MB,  avg  16.04  MB,  max  16.04  MB,  min  16.04  MB
                                -  OpenTime:  avg  675ns,  max  675ns,  min  675ns
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  10.0M  (10000000),  avg  10.0M  (10000000),  max  10.0M  (10000000),  min  10.0M  (10000000)
                                -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                    -  WaitForData0:  avg  5s838ms,  max  5s838ms,  min  5s838ms
```
Therefore, the approach has been changed to merge each input block into the build block immediately.

In spills, it is necessary to avoid merging blocks multiple times.

<!--Describe your changes.-->

