### PR TITLE
[Fix](Timezone)The time zone should not be fixed to UTC+8.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -86,8 +86,6 @@ public class TimeUtils {
     public static Date MAX_DATETIME = null;
 
     static {
-        TIME_ZONE = ZoneId.of("UTC+8");
-
         Map<String, String> timeZoneMap = Maps.newHashMap();
         timeZoneMap.putAll(ZoneId.SHORT_IDS);
 
@@ -98,7 +96,7 @@ public class TimeUtils {
         timeZoneMap.put("GMT", UTC_TIME_ZONE);
 
         timeZoneAliasMap = ImmutableMap.copyOf(timeZoneMap);
-
+        TIME_ZONE = getSystemTimeZone().toZoneId();
         DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         DATE_FORMAT.withZone(TIME_ZONE);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -59,11 +59,6 @@ public class TimeUtilsTest {
         Assert.assertNotNull(TimeUtils.getCurrentFormatTime());
         Assert.assertNotNull(TimeUtils.getStartTimeMs());
         Assert.assertTrue(TimeUtils.getElapsedTimeMs(0L) > 0);
-
-        Assert.assertEquals(-62135625600000L, TimeUtils.MIN_DATE.getTime());
-        Assert.assertEquals(253402185600000L, TimeUtils.MAX_DATE.getTime());
-        Assert.assertEquals(-62135625600000L, TimeUtils.MIN_DATETIME.getTime());
-        Assert.assertEquals(253402271999000L, TimeUtils.MAX_DATETIME.getTime());
     }
 
     @Test


### PR DESCRIPTION

## Proposed changes


It is generally more reasonable to use the system's default time zone rather than binding the default time zone to UTC+8. This approach ensures that the application will behave correctly in different environments and regions.

**For countries that observe DST, this might require extra attention.**

