### PR TITLE
[fix](fe) Fix the sql of AddPartitionRecord

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
@@ -79,7 +79,7 @@ public class AddPartitionRecord {
         sb.append("` ");
 
         // See fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java:addPartition for details.
-        if (!this.range.equals(RangePartitionItem.DUMMY_ITEM)) {
+        if (!this.range.equals(RangePartitionItem.DUMMY_RANGE)) {
             // range
             sb.append("VALUES [");
             sb.append(range.lowerEndpoint().toSql());


### PR DESCRIPTION
The range field is accidentally compared to DUMMY_ITEM.

It was introduced by #35461.

The case is improved in selectdb/ccr_syncer#118.

Affected versions:
- 2.0.11 ~ 2.0.12
- 2.1.4
