### PR TITLE
[fix](deps) fix NoSuchMethodError: newInstanceFromKeytab when using kerberos

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -888,5 +888,4 @@ if [[ -n "${DORIS_POST_BUILD_HOOK}" ]]; then
     eval "${DORIS_POST_BUILD_HOOK}"
 fi
 
-cp start_fe.sh output/fe/bin/start_fe.sh
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -742,6 +742,8 @@ if [[ "${BUILD_SPARK_DPP}" -eq 1 ]]; then
 fi
 
 if [[ "${OUTPUT_BE_BINARY}" -eq 1 ]]; then
+    # need remove old version hadoop jars if $DORIS_OUTPUT use multiple times, otherwise will cause jar conflict 
+    rm -rf "${DORIS_OUTPUT}/be/lib/hadoop_hdfs"
     install -d "${DORIS_OUTPUT}/be/bin" \
         "${DORIS_OUTPUT}/be/conf" \
         "${DORIS_OUTPUT}/be/lib" \
@@ -886,4 +888,5 @@ if [[ -n "${DORIS_POST_BUILD_HOOK}" ]]; then
     eval "${DORIS_POST_BUILD_HOOK}"
 fi
 
+cp start_fe.sh output/fe/bin/start_fe.sh
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -874,6 +874,7 @@ fi
 
 if [[ ${BUILD_CLOUD} -eq 1 ]]; then
     rm -rf "${DORIS_HOME}/output/ms"
+    rm -rf "${DORIS_HOME}/cloud/output/lib/hadoop_hdfs"
     if [[ -d "${DORIS_THIRDPARTY}/installed/lib/hadoop_hdfs/" ]]; then
         cp -r -p "${DORIS_THIRDPARTY}/installed/lib/hadoop_hdfs/" "${DORIS_HOME}/cloud/output/lib"
     fi

--- a/build.sh
+++ b/build.sh
@@ -742,7 +742,7 @@ if [[ "${BUILD_SPARK_DPP}" -eq 1 ]]; then
 fi
 
 if [[ "${OUTPUT_BE_BINARY}" -eq 1 ]]; then
-    # need remove old version hadoop jars if $DORIS_OUTPUT use multiple times, otherwise will cause jar conflict 
+    # need remove old version hadoop jars if $DORIS_OUTPUT been used multiple times, otherwise will cause jar conflict
     rm -rf "${DORIS_OUTPUT}/be/lib/hadoop_hdfs"
     install -d "${DORIS_OUTPUT}/be/bin" \
         "${DORIS_OUTPUT}/be/conf" \

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1673,6 +1673,8 @@ build_hadoop_libs() {
     echo "THIRDPARTY_INSTALLED=${TP_INSTALL_DIR}" >env.sh
     ./build.sh
 
+    rm -rf "${TP_INSTALL_DIR}/include/hadoop_hdfs/"
+    rm -rf "${TP_INSTALL_DIR}/lib/hadoop_hdfs/"
     mkdir -p "${TP_INSTALL_DIR}/include/hadoop_hdfs/"
     mkdir -p "${TP_INSTALL_DIR}/lib/hadoop_hdfs/"
     cp -r ./hadoop-dist/target/hadoop-libhdfs-3.3.6/* "${TP_INSTALL_DIR}/lib/hadoop_hdfs/"


### PR DESCRIPTION
Issue:
when connect to a kerberosied hive catalog, doris throw error:
```sql
task_scheduler.cpp:276] Instance ab1535db6ff4d42-9b9ae0e5d0952451 pipeline task 1 failed, reason: failed to init reader for file hdfs://HDFS1012085/usr/hive/warehouse/region/000000_0, err: [IO_ERROR]faield to connect to hdfs hdfs://HDFS1012085: (255), Unknown error 255), reason: NoSuchMethodError: newInstanceFromKeytab
```

Reason:
be/lib has old hadoop jars, e.g. hadoop-common-3.3.4.jar etc, and they are conflict with new version hadoop jars.
what caused this? Doris is built on a directory which has been used for multiple times, and this directory contains legacy version hadoop jars. These legacy jars are downloaded by earlier version of doris, after that, doris upgrade hadoop jars to 3.3.6 by #29939, but these legacy jars are not cleaned, when build lastest doris, these legacy jars are copied to be/lib 

<img width="1451" alt="image" src="https://github.com/apache/doris/assets/28004179/0d007e68-7d73-4344-95da-1714d6048642">
