### PR TITLE
[pipeline](fix) Set upstream operators always runnable once source operator closed

### DIFF
--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -498,6 +498,9 @@ Status PipelineXLocalState<SharedStateArg>::close(RuntimeState* state) {
         _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
     }
     _closed = true;
+    if (_shared_state && _shared_state->sink_deps.size() == 1) {
+        _shared_state->sink_deps.front()->set_always_ready();
+    }
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -498,6 +498,8 @@ Status PipelineXLocalState<SharedStateArg>::close(RuntimeState* state) {
         _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
     }
     _closed = true;
+    // Some kinds of source operators has a 1-1 relationship with a sink operator (such as AnalyticOperator).
+    // We must ensure AnalyticSinkOperator will not be blocked if AnalyticSourceOperator already closed.
     if (_shared_state && _shared_state->sink_deps.size() == 1) {
         _shared_state->sink_deps.front()->set_always_ready();
     }


### PR DESCRIPTION
## Proposed changes

Some kinds of source operators has a 1-1 relationship with a sink operator (such as AnalyticOperator). We must ensure AnalyticSinkOperator will not be blocked if AnalyticSourceOperator already closed.

<!--Describe your changes.-->

