### PR TITLE
[enhance](Recycler) Catch RequestFailedException for all azure request

### DIFF
--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -52,6 +52,11 @@ ObjectStorageResponse do_azure_client_call(Func f, std::string_view url, std::st
                 e.Message, static_cast<int>(e.StatusCode), e.RequestId, url, key);
         LOG_WARNING(msg);
         return {-1, std::move(msg)};
+    } catch (std::exception& e) {
+        auto msg = fmt::format("Azure request failed because {}, url: {}, key: {}", e.what(), url,
+                               key);
+        LOG_WARNING(msg);
+        return {-1, std::move(msg)};
     }
     return {};
 }

--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -45,7 +45,7 @@ template <typename Func>
 ObjectStorageResponse do_azure_client_call(Func f, std::string_view url, std::string_view key) {
     try {
         f();
-    } catch (Azure::Storage::StorageException& e) {
+    } catch (Azure::Core::RequestFailedException& e) {
         auto msg = fmt::format(
                 "Azure request failed because {}, http_code: {}, request_id: {}, url: {}, "
                 "key: {}",


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Previously we only catch storageException for azure's request. But it could also throw RequestFailedException which is the base class for storageException. So we directly catch RequestFailedException here.