### PR TITLE
[Improvement](rpc) set grpc channel's keepAliveTime and remove proxy on InterruptedExcep…

### DIFF
--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -75,6 +75,7 @@ Status BRpcService::start(int port, int num_threads) {
     if (num_threads != -1) {
         options.num_threads = num_threads;
     }
+    options.idle_timeout_sec = 10;
 
     if (config::enable_https) {
         auto sslOptions = options.mutable_ssl_options();

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -75,7 +75,6 @@ Status BRpcService::start(int port, int num_threads) {
     if (num_threads != -1) {
         options.num_threads = num_threads;
     }
-    options.idle_timeout_sec = 10;
 
     if (config::enable_https) {
         auto sslOptions = options.mutable_ssl_options();

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1467,7 +1467,7 @@ public class Config extends ConfigBase {
 
     /**
      * sets the time without read activity before sending a keepalive ping
-	 * the smaller the value, the sooner the channel is unavailable, but it will increase network io
+     * the smaller the value, the sooner the channel is unavailable, but it will increase network io
      */
     @ConfField
     public static int grpc_keep_alive_second = 10;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1470,7 +1470,7 @@ public class Config extends ConfigBase {
      * the smaller the value, the sooner the channel is unavailable, but it will increase network io
      */
     @ConfField(description = { "设置grpc连接发送 keepalive ping 之前没有数据传输的时间。",
-                    "The time without grpc read activity before sending a keepalive ping" })
+            "The time without grpc read activity before sending a keepalive ping" })
     public static int grpc_keep_alive_second = 10;
 
     /**

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1469,7 +1469,8 @@ public class Config extends ConfigBase {
      * sets the time without read activity before sending a keepalive ping
      * the smaller the value, the sooner the channel is unavailable, but it will increase network io
      */
-    @ConfField
+    @ConfField(description = { "设置grpc连接发送 keepalive ping 之前没有数据传输的时间。",
+                    "The time without grpc read activity before sending a keepalive ping" })
     public static int grpc_keep_alive_second = 10;
 
     /**

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1467,6 +1467,7 @@ public class Config extends ConfigBase {
 
     /**
      * sets the time without read activity before sending a keepalive ping
+	 * the smaller the value, the sooner the channel is unavailable, but it will increase network io
      */
     @ConfField
     public static int grpc_keep_alive_second = 10;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1466,6 +1466,12 @@ public class Config extends ConfigBase {
     public static int grpc_threadmgr_threads_nums = 4096;
 
     /**
+     * sets the time without read activity before sending a keepalive ping
+     */
+    @ConfField
+    public static int grpc_keep_alive_second = 10;
+
+    /**
      * Used to set minimal number of replication per tablet.
      */
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -950,6 +950,7 @@ public class Coordinator implements CoordInterface {
             } catch (InterruptedException e) {
                 exception = e;
                 code = TStatusCode.INTERNAL_ERROR;
+                triple.getMiddle().removeProxy(triple.getLeft().brpcAddr);
             } catch (TimeoutException e) {
                 exception = e;
                 errMsg = String.format(
@@ -957,6 +958,7 @@ public class Coordinator implements CoordInterface {
                                             operation, queryOptions.getExecutionTimeout(), timeoutMs / 1000);
                 LOG.warn("Query {} {}", DebugUtil.printId(queryId), errMsg);
                 code = TStatusCode.TIMEOUT;
+                triple.getMiddle().removeProxy(triple.getLeft().brpcAddr);
             }
 
             if (code != TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -60,7 +60,7 @@ public class BackendServiceClient {
 
     // Is the underlying channel in a normal state? (That means the RPC call will not fail immediately)
     public boolean isNormalState() {
-        ConnectivityState state = channel.getState(false);
+        ConnectivityState state = channel.getState(true);
         return state == ConnectivityState.CONNECTING
                 || state == ConnectivityState.IDLE
                 || state == ConnectivityState.READY;
@@ -191,7 +191,7 @@ public class BackendServiceClient {
 
 
     public void shutdown() {
-        ConnectivityState state = channel.getState(false);
+        ConnectivityState state = channel.getState(true);
         LOG.warn("shut down backend service client: {}, channel state: {}", address, state);
         if (!channel.isShutdown()) {
             channel.shutdown();

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -47,6 +47,7 @@ public class BackendServiceClient {
         this.address = address;
         channel = NettyChannelBuilder.forAddress(address.getHostname(), address.getPort())
                 .executor(executor)
+                .keepAliveTime(5, TimeUnit.SECONDS)
                 .flowControlWindow(Config.grpc_max_message_size_bytes)
                 .keepAliveWithoutCalls(true)
                 .maxInboundMessageSize(Config.grpc_max_message_size_bytes).enableRetry().maxRetryAttempts(MAX_RETRY_NUM)

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -46,8 +46,7 @@ public class BackendServiceClient {
     public BackendServiceClient(TNetworkAddress address, Executor executor) {
         this.address = address;
         channel = NettyChannelBuilder.forAddress(address.getHostname(), address.getPort())
-                .executor(executor)
-                .keepAliveTime(5, TimeUnit.SECONDS)
+                .executor(executor).keepAliveTime(Config.grpc_keep_alive_second, TimeUnit.SECONDS)
                 .flowControlWindow(Config.grpc_max_message_size_bytes)
                 .keepAliveWithoutCalls(true)
                 .maxInboundMessageSize(Config.grpc_max_message_size_bytes).enableRetry().maxRetryAttempts(MAX_RETRY_NUM)
@@ -60,7 +59,7 @@ public class BackendServiceClient {
 
     // Is the underlying channel in a normal state? (That means the RPC call will not fail immediately)
     public boolean isNormalState() {
-        ConnectivityState state = channel.getState(true);
+        ConnectivityState state = channel.getState(false);
         return state == ConnectivityState.CONNECTING
                 || state == ConnectivityState.IDLE
                 || state == ConnectivityState.READY;
@@ -191,7 +190,7 @@ public class BackendServiceClient {
 
 
     public void shutdown() {
-        ConnectivityState state = channel.getState(true);
+        ConnectivityState state = channel.getState(false);
         LOG.warn("shut down backend service client: {}, channel state: {}", address, state);
         if (!channel.isShutdown()) {
             channel.shutdown();


### PR DESCRIPTION
## Proposed changes
1. set grpc channel's keepAliveTime
2. remove proxy on InterruptedException/TimeoutException to avoid channel unavailable