### PR TITLE
[enhancement](cloud) support TTL file cache evict through LRU

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1016,6 +1016,9 @@ DEFINE_mInt32(file_cache_exit_disk_resource_limit_mode_percent, "80");
 DEFINE_mBool(enable_read_cache_file_directly, "false");
 DEFINE_mBool(file_cache_enable_evict_from_other_queue_by_size, "false");
 DEFINE_mInt64(file_cache_ttl_valid_check_interval_second, "0"); // zero for not checking
+// If true, evict the ttl cache using LRU when full.
+// Otherwise, only expiration can evict ttl and new data won't add to cache when full.
+DEFINE_Bool(enable_ttl_cache_evict_using_lru, "true");
 
 DEFINE_mInt32(index_cache_entry_stay_time_after_lookup_s, "1800");
 DEFINE_mInt32(inverted_index_cache_stale_sweep_time_sec, "600");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1064,6 +1064,9 @@ DECLARE_Int32(file_cache_exit_disk_resource_limit_mode_percent);
 DECLARE_mBool(enable_read_cache_file_directly);
 DECLARE_Bool(file_cache_enable_evict_from_other_queue_by_size);
 DECLARE_mInt64(file_cache_ttl_valid_check_interval_second);
+// If true, evict the ttl cache using LRU when full.
+// Otherwise, only expiration can evict ttl and new data won't add to cache when full.
+DECLARE_Bool(enable_ttl_cache_evict_using_lru);
 
 // inverted index searcher cache
 // cache entry stay time after lookup

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -766,8 +766,8 @@ void BlockFileCache::remove_file_blocks(std::vector<FileBlockCell*>& to_evict,
     std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_if);
 }
 
-void BlockFileCache::remove_file_blocks_and_clean_time_maps(std::vector<FileBlockCell*>& to_evict,
-                                        std::lock_guard<std::mutex>& cache_lock) {
+void BlockFileCache::remove_file_blocks_and_clean_time_maps(
+        std::vector<FileBlockCell*>& to_evict, std::lock_guard<std::mutex>& cache_lock) {
     auto remove_file_block_and_clean_time_maps_if = [&](FileBlockCell* cell) {
         FileBlockSPtr file_block = cell->file_block;
         if (file_block) {
@@ -780,8 +780,7 @@ void BlockFileCache::remove_file_blocks_and_clean_time_maps(std::vector<FileBloc
                     auto _time_to_key_iter = _time_to_key.equal_range(iter->second);
                     while (_time_to_key_iter.first != _time_to_key_iter.second) {
                         if (_time_to_key_iter.first->second == hash) {
-                            _time_to_key_iter.first =
-                                    _time_to_key.erase(_time_to_key_iter.first);
+                            _time_to_key_iter.first = _time_to_key.erase(_time_to_key_iter.first);
                             break;
                         }
                         _time_to_key_iter.first++;
@@ -794,10 +793,10 @@ void BlockFileCache::remove_file_blocks_and_clean_time_maps(std::vector<FileBloc
     std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_and_clean_time_maps_if);
 }
 
-void BlockFileCache::find_evict_candidates(LRUQueue &queue, size_t size, size_t cur_cache_size,
-                                           size_t &removed_size,
-                                           std::vector<FileBlockCell*> &to_evict,
-                                           std::lock_guard<std::mutex> &cache_lock) {
+void BlockFileCache::find_evict_candidates(LRUQueue& queue, size_t size, size_t cur_cache_size,
+                                           size_t& removed_size,
+                                           std::vector<FileBlockCell*>& to_evict,
+                                           std::lock_guard<std::mutex>& cache_lock) {
     for (const auto& [entry_key, entry_offset, entry_size] : queue) {
         if (!is_overflow(removed_size, size, cur_cache_size)) {
             break;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -387,12 +387,11 @@ private:
     void remove_file_blocks(std::vector<FileBlockCell*>&, std::lock_guard<std::mutex>&);
 
     void remove_file_blocks_and_clean_time_maps(std::vector<FileBlockCell*>&,
-            std::lock_guard<std::mutex>&);
+                                                std::lock_guard<std::mutex>&);
 
-    void find_evict_candidates(LRUQueue &queue, size_t size, size_t cur_cache_size,
-                               size_t &removed_size,
-                               std::vector<FileBlockCell*> &to_evict,
-                               std::lock_guard<std::mutex> &cache_lock);
+    void find_evict_candidates(LRUQueue& queue, size_t size, size_t cur_cache_size,
+                               size_t& removed_size, std::vector<FileBlockCell*>& to_evict,
+                               std::lock_guard<std::mutex>& cache_lock);
     // info
     std::string _cache_base_path;
     size_t _capacity = 0;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -428,7 +428,8 @@ private:
     size_t _num_removed_blocks = 0;
     std::shared_ptr<bvar::Status<size_t>> _cur_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_size_metrics;
-    std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_lru_queue_size_metrics;
+    std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_lru_queue_cache_size_metrics;
+    std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_lru_queue_element_count_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_normal_queue_element_count_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_normal_queue_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_index_queue_element_count_metrics;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -384,6 +384,15 @@ private:
 
     bool is_overflow(size_t removed_size, size_t need_size, size_t cur_cache_size) const;
 
+    void remove_file_blocks(std::vector<FileBlockCell*>&, std::lock_guard<std::mutex>&);
+
+    void remove_file_blocks_and_clean_time_maps(std::vector<FileBlockCell*>&,
+            std::lock_guard<std::mutex>&);
+
+    void find_evict_candidates(LRUQueue &queue, size_t size, size_t cur_cache_size,
+                               size_t &removed_size,
+                               std::vector<FileBlockCell*> &to_evict,
+                               std::lock_guard<std::mutex> &cache_lock);
     // info
     std::string _cache_base_path;
     size_t _capacity = 0;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -341,6 +341,8 @@ private:
 
     bool try_reserve_for_ttl(size_t size, std::lock_guard<std::mutex>& cache_lock);
 
+    bool try_reserve_for_ttl_without_lru(size_t size, std::lock_guard<std::mutex>& cache_lock);
+
     FileBlocks split_range_into_cells(const UInt128Wrapper& hash, const CacheContext& context,
                                       size_t offset, size_t size, FileBlock::State state,
                                       std::lock_guard<std::mutex>& cache_lock);
@@ -418,6 +420,7 @@ private:
     LRUQueue _index_queue;
     LRUQueue _normal_queue;
     LRUQueue _disposable_queue;
+    LRUQueue _ttl_queue;
 
     // metrics
     size_t _num_read_blocks = 0;
@@ -425,6 +428,7 @@ private:
     size_t _num_removed_blocks = 0;
     std::shared_ptr<bvar::Status<size_t>> _cur_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_size_metrics;
+    std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_lru_queue_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_normal_queue_element_count_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_normal_queue_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_index_queue_element_count_metrics;

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -43,7 +43,8 @@
 namespace doris::io {
 
 bvar::Adder<uint64_t> s3_read_counter("cached_remote_reader_s3_read");
-bvar::LatencyRecorder g_skip_cache_counter("cached_remote_reader_skip_cache_count");
+bvar::LatencyRecorder g_skip_cache_num("cached_remote_reader_skip_cache_num");
+bvar::Adder<uint64_t> g_skip_cache_sum("cached_remote_reader_skip_cache_sum");
 
 CachedRemoteFileReader::CachedRemoteFileReader(FileReaderSPtr remote_file_reader,
                                                const FileReaderOptions& opts)
@@ -326,7 +327,8 @@ void CachedRemoteFileReader::_update_state(const ReadStatistics& read_stats,
     statis->bytes_write_into_cache += read_stats.bytes_write_into_file_cache;
     statis->write_cache_io_timer += read_stats.local_write_timer;
 
-    g_skip_cache_counter << read_stats.skip_cache;
+    g_skip_cache_num << read_stats.skip_cache;
+    g_skip_cache_sum << read_stats.skip_cache;
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -43,6 +43,7 @@
 namespace doris::io {
 
 bvar::Adder<uint64_t> s3_read_counter("cached_remote_reader_s3_read");
+bvar::LatencyRecorder g_skip_cache_counter("cached_remote_reader_skip_cache_count");
 
 CachedRemoteFileReader::CachedRemoteFileReader(FileReaderSPtr remote_file_reader,
                                                const FileReaderOptions& opts)
@@ -324,6 +325,8 @@ void CachedRemoteFileReader::_update_state(const ReadStatistics& read_stats,
     statis->num_skip_cache_io_total += read_stats.skip_cache;
     statis->bytes_write_into_cache += read_stats.bytes_write_into_file_cache;
     statis->write_cache_io_timer += read_stats.local_write_timer;
+
+    g_skip_cache_counter << read_stats.skip_cache;
 }
 
 } // namespace doris::io

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -121,6 +121,7 @@ class BlockFileCacheTest : public testing::Test {
 public:
     static void SetUpTestSuite() {
         config::file_cache_enter_disk_resource_limit_mode_percent = 99;
+        config::enable_ttl_cache_evict_using_lru = false;
         bool exists {false};
         ASSERT_TRUE(global_local_filesystem()->exists(caches_dir, &exists).ok());
         if (!exists) {
@@ -4091,6 +4092,136 @@ TEST_F(BlockFileCacheTest, recyle_unvalid_ttl_async) {
             std::chrono::seconds(config::file_cache_ttl_valid_check_interval_second + 2));
     config::file_cache_ttl_valid_check_interval_second = 0;
     EXPECT_EQ(cache._cur_cache_size, 5);
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, ttl_reserve_wo_evict_using_lru) {
+    config::file_cache_ttl_valid_check_interval_second = 4;
+    config::enable_ttl_cache_evict_using_lru = false;
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.index_queue_size = 30;
+    settings.index_queue_elements = 5;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    context.query_id = query_id;
+    auto key = io::BlockFileCache::hash("key1");
+    io::BlockFileCache cache(cache_base_path, settings);
+    context.cache_type = io::FileCacheType::TTL;
+    context.expiration_time = UnixSeconds() + 3600;
+
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    for (int64_t offset = 0; offset < (60 * config::max_ttl_cache_ratio / 100 - 5); offset += 5) {
+        auto holder = cache.get_or_set(key, offset, 5, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(segments[0]);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+    context.cache_type = io::FileCacheType::TTL;
+    context.expiration_time = UnixSeconds() + 3600;
+    for (int64_t offset = 60; offset < 70; offset += 5) {
+        auto holder = cache.get_or_set(key, offset, 5, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::SKIP_CACHE);
+    }
+
+    EXPECT_EQ(cache._cur_cache_size, 50);
+    EXPECT_EQ(cache._ttl_queue.cache_size, 0);
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, ttl_reserve_with_evict_using_lru) {
+    config::file_cache_ttl_valid_check_interval_second = 4;
+    config::enable_ttl_cache_evict_using_lru = true;
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.index_queue_size = 30;
+    settings.index_queue_elements = 5;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    context.query_id = query_id;
+    auto key = io::BlockFileCache::hash("key1");
+    io::BlockFileCache cache(cache_base_path, settings);
+    context.cache_type = io::FileCacheType::TTL;
+    context.expiration_time = UnixSeconds() + 3600;
+
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    for (int64_t offset = 0; offset < (60 * config::max_ttl_cache_ratio / 100); offset += 5) {
+        auto holder = cache.get_or_set(key, offset, 5, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(segments[0]);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+    context.cache_type = io::FileCacheType::TTL;
+    context.expiration_time = UnixSeconds() + 3600;
+    for (int64_t offset = 60; offset < 70; offset += 5) {
+        auto holder = cache.get_or_set(key, offset, 5, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(segments[0]);
+        assert_range(1, segments[0], io::FileBlock::Range(offset, offset + 4),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+
+    EXPECT_EQ(cache._cur_cache_size, 60);
+    EXPECT_EQ(cache._ttl_queue.cache_size, 60);
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
     }

--- a/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
+++ b/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.codehaus.groovy.runtime.IOGroovyMethods
+
+// Note: in order to trigger TTL full (thus LRU eviction),
+// we need smaller file cache for TTL (<20G). To achive this goal:
+//  - set smaller total_size in be conf and/or
+//  - set smaller max_ttl_cache_ratio in this test
+
+suite("test_ttl_lru_evict") {
+    // sql """ use @regression_cluster_name1 """
+    sql """ use @compute_cluster """
+    def ttlProperties = """ PROPERTIES("file_cache_ttl_seconds"="180") """
+    String[][] backends = sql """ show backends """
+    String backendId;
+    def backendIdToBackendIP = [:]
+    def backendIdToBackendHttpPort = [:]
+    def backendIdToBackendBrpcPort = [:]
+    for (String[] backend in backends) {
+        // if (backend[9].equals("true") && backend[19].contains("regression_cluster_name1")) {
+        if (backend[9].equals("true") && backend[19].contains("compute_cluster")) {
+            backendIdToBackendIP.put(backend[0], backend[1])
+            backendIdToBackendHttpPort.put(backend[0], backend[4])
+            backendIdToBackendBrpcPort.put(backend[0], backend[5])
+        }
+    }
+    assertEquals(backendIdToBackendIP.size(), 1)
+
+    backendId = backendIdToBackendIP.keySet()[0]
+    def url = backendIdToBackendIP.get(backendId) + ":" + backendIdToBackendHttpPort.get(backendId) + """/api/clear_file_cache"""
+    logger.info(url)
+    def clearFileCache = { check_func ->
+        httpTest {
+            endpoint ""
+            uri url
+            op "post"
+            body "{\"sync\"=\"true\"}"
+            check check_func
+        }
+    }
+
+    def tables = [customer_ttl: 15000000]
+    def s3BucketName = getS3BucketName()
+    def s3WithProperties = """WITH S3 (
+        |"AWS_ACCESS_KEY" = "${getS3AK()}",
+        |"AWS_SECRET_KEY" = "${getS3SK()}",
+        |"AWS_ENDPOINT" = "${getS3Endpoint()}",
+        |"AWS_REGION" = "${getS3Region()}",
+        |"provider" = "${getS3Provider()}")
+        |PROPERTIES(
+        |"exec_mem_limit" = "8589934592",
+        |"load_parallelism" = "3")""".stripMargin()
+
+
+    sql new File("""${context.file.parent}/../ddl/customer_ttl_delete.sql""").text
+    def load_customer_once =  { String table ->
+        def uniqueID = Math.abs(UUID.randomUUID().hashCode()).toString()
+        sql (new File("""${context.file.parent}/../ddl/${table}.sql""").text + ttlProperties)
+        def loadLabel = table + "_" + uniqueID
+        // load data from cos
+        def loadSql = new File("""${context.file.parent}/../ddl/${table}_load.sql""").text.replaceAll("\\\$\\{s3BucketName\\}", s3BucketName)
+        loadSql = loadSql.replaceAll("\\\$\\{loadLabel\\}", loadLabel) + s3WithProperties
+        sql loadSql
+
+        // check load state
+        while (true) {
+            def stateResult = sql "show load where Label = '${loadLabel}'"
+            def loadState = stateResult[stateResult.size() - 1][2].toString()
+            if ("CANCELLED".equalsIgnoreCase(loadState)) {
+                throw new IllegalStateException("load ${loadLabel} failed.")
+            } else if ("FINISHED".equalsIgnoreCase(loadState)) {
+                break
+            }
+            sleep(5000)
+        }
+    }
+
+    def getMetricsMethod = { check_func ->
+        httpTest {
+            endpoint backendIdToBackendIP.get(backendId) + ":" + backendIdToBackendBrpcPort.get(backendId)
+            uri "/brpc_metrics"
+            op "get"
+            check check_func
+        }
+    }
+
+    clearFileCache.call() {
+        respCode, body -> {}
+    }
+
+    // load for MANY times to this dup table to make cache full enough to evict
+    // It will takes huge amount of time, so it should be p1/p2 level case.
+    // But someone told me it is the right place. Never mind just do it!
+    for (int i = 0; i < 50; i++) {
+        load_customer_once("customer_ttl")
+    }
+    sleep(30000) // 30s
+    getMetricsMethod.call() {
+        respCode, body ->
+            assertEquals("${respCode}".toString(), "200")
+            String out = "${body}".toString()
+            def strs = out.split('\n')
+            Boolean flag1 = false;
+            long ttl_cache_size = 0;
+            for (String line in strs) {
+                if (flag1) break;
+                if (line.contains("ttl_cache_size")) {
+                    if (line.startsWith("#")) {
+                        continue
+                    }
+                    def i = line.indexOf(' ')
+                    ttl_cache_size = line.substring(i).toLong()
+                    flag1 = true
+                }
+            }
+            assertTrue(flag1)
+            assertTrue(ttl_cache_size > 1073741824)
+    }
+    sleep(180000)
+    getMetricsMethod.call() {
+        respCode, body ->
+            assertEquals("${respCode}".toString(), "200")
+            String out = "${body}".toString()
+            def strs = out.split('\n')
+            Boolean flag1 = false;
+            for (String line in strs) {
+                if (flag1) break;
+                if (line.contains("ttl_cache_size")) {
+                    if (line.startsWith("#")) {
+                        continue
+                    }
+                    def i = line.indexOf(' ')
+                    assertEquals(line.substring(i).toLong(), 0)
+                    flag1 = true
+                }
+            }
+            assertTrue(flag1)
+    }
+}

--- a/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
+++ b/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
@@ -280,7 +280,7 @@ suite("test_ttl_lru_evict") {
             load_customer_once("customer_ttl")
         }
         // then we do query and hopefully, we should not run into too many SKIP_CACHE
-        sql """ select count(*) from customer_ttl """
+        sql """ select count(*) from customer_ttl where C_ADDRESS like '%ea%' and C_NAME like '%a%' and C_COMMENT like '%b%' """
 
         long skip_cache_count_end = 0
         getMetricsMethod.call() {

--- a/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
+++ b/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
@@ -16,6 +16,21 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.client.RedirectStrategy;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+
 
 // Note: in order to trigger TTL full (thus LRU eviction),
 // we need smaller file cache for TTL (<20G). To achive this goal:
@@ -54,101 +69,272 @@ suite("test_ttl_lru_evict") {
         }
     }
 
-    def tables = [customer_ttl: 15000000]
-    def s3BucketName = getS3BucketName()
-    def s3WithProperties = """WITH S3 (
-        |"AWS_ACCESS_KEY" = "${getS3AK()}",
-        |"AWS_SECRET_KEY" = "${getS3SK()}",
-        |"AWS_ENDPOINT" = "${getS3Endpoint()}",
-        |"AWS_REGION" = "${getS3Region()}",
-        |"provider" = "${getS3Provider()}")
-        |PROPERTIES(
-        |"exec_mem_limit" = "8589934592",
-        |"load_parallelism" = "3")""".stripMargin()
+    def curl = { String method, String uri /* param */->
+        if (method != "GET" && method != "POST")
+        {
+            throw new Exception(String.format("invalid curl method: %s", method))
+        }
+        if (uri.isBlank())
+        {
+            throw new Exception("invalid curl url, blank")
+        }
 
+        Integer timeout = 10; // 10 seconds;
+        Integer maxRetries = 10; // Maximum number of retries
+        Integer retryCount = 0; // Current retry count
+        Integer sleepTime = 5000; // Sleep time in milliseconds
 
-    sql new File("""${context.file.parent}/../ddl/customer_ttl_delete.sql""").text
-    def load_customer_once =  { String table ->
-        def uniqueID = Math.abs(UUID.randomUUID().hashCode()).toString()
-        sql (new File("""${context.file.parent}/../ddl/${table}.sql""").text + ttlProperties)
-        def loadLabel = table + "_" + uniqueID
-        // load data from cos
-        def loadSql = new File("""${context.file.parent}/../ddl/${table}_load.sql""").text.replaceAll("\\\$\\{s3BucketName\\}", s3BucketName)
-        loadSql = loadSql.replaceAll("\\\$\\{loadLabel\\}", loadLabel) + s3WithProperties
-        sql loadSql
+        String cmd = String.format("curl --max-time %d -X %s %s", timeout, method, uri).toString()
+        logger.info("curl cmd: " + cmd)
+        def process
+        int code
+        String err
+        String out
 
-        // check load state
-        while (true) {
-            def stateResult = sql "show load where Label = '${loadLabel}'"
-            def loadState = stateResult[stateResult.size() - 1][2].toString()
-            if ("CANCELLED".equalsIgnoreCase(loadState)) {
-                throw new IllegalStateException("load ${loadLabel} failed.")
-            } else if ("FINISHED".equalsIgnoreCase(loadState)) {
+        while (retryCount < maxRetries) {
+            process = cmd.execute()
+            code = process.waitFor()
+            err = IOGroovyMethods.getText(new BufferedReader(new InputStreamReader(process.getErrorStream())))
+            out = process.getText()
+
+            // If the command was successful, break the loop
+            if (code == 0) {
                 break
             }
-            sleep(5000)
+
+            // If the command was not successful, increment the retry count, sleep for a while and try again
+            retryCount++
+            sleep(sleepTime)
+        }
+
+        // If the command was not successful after maxRetries attempts, log the failure and return the result
+        if (code != 0) {
+            logger.error("Command curl failed after " + maxRetries + " attempts. code: "  + code + ", err: " + err)
+        }
+
+        return [code, out, err]
+    }
+
+    def show_be_config = { String ip, String port /*param */ ->
+        return curl("GET", String.format("http://%s:%s/api/show_config", ip, port))
+    }
+
+    def get_be_param = { paramName ->
+        // assuming paramName on all BEs have save value
+        def (code, out, err) = show_be_config(backendIdToBackendIP.get(backendId), backendIdToBackendHttpPort.get(backendId))
+        assertEquals(code, 0)
+        def configList = parseJson(out.trim())
+        assert configList instanceof List
+        for (Object ele in (List) configList) {
+            assert ele instanceof List<String>
+            if (((List<String>) ele)[0] == paramName) {
+                return ((List<String>) ele)[2]
+            }
         }
     }
 
-    def getMetricsMethod = { check_func ->
-        httpTest {
-            endpoint backendIdToBackendIP.get(backendId) + ":" + backendIdToBackendBrpcPort.get(backendId)
-            uri "/brpc_metrics"
-            op "get"
-            check check_func
+    def set_be_param = { paramName, paramValue ->
+        // for eache BE node, set paramName=paramValue
+        for (String id in backendIdToBackendIP.keySet()) {
+            def beIp = backendIdToBackendIP.get(id)
+            def bePort = backendIdToBackendHttpPort.get(id)
+            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", beIp, bePort, paramName, paramValue))
+            assertTrue(out.contains("OK"))
         }
     }
 
-    clearFileCache.call() {
-        respCode, body -> {}
-    }
+    long org_max_ttl_cache_ratio = Long.parseLong(get_be_param.call("max_ttl_cache_ratio"))
 
-    // load for MANY times to this dup table to make cache full enough to evict
-    // It will takes huge amount of time, so it should be p1/p2 level case.
-    // But someone told me it is the right place. Never mind just do it!
-    for (int i = 0; i < 50; i++) {
-        load_customer_once("customer_ttl")
-    }
-    sleep(30000) // 30s
-    getMetricsMethod.call() {
-        respCode, body ->
-            assertEquals("${respCode}".toString(), "200")
-            String out = "${body}".toString()
-            def strs = out.split('\n')
-            Boolean flag1 = false;
-            long ttl_cache_size = 0;
-            for (String line in strs) {
-                if (flag1) break;
-                if (line.contains("ttl_cache_size")) {
-                    if (line.startsWith("#")) {
-                        continue
-                    }
-                    def i = line.indexOf(' ')
-                    ttl_cache_size = line.substring(i).toLong()
-                    flag1 = true
+    try {
+        set_be_param.call("max_ttl_cache_ratio", "2")
+
+        def tables = [customer_ttl: 15000000]
+        def s3BucketName = getS3BucketName()
+        def s3WithProperties = """WITH S3 (
+            |"AWS_ACCESS_KEY" = "${getS3AK()}",
+            |"AWS_SECRET_KEY" = "${getS3SK()}",
+            |"AWS_ENDPOINT" = "${getS3Endpoint()}",
+            |"AWS_REGION" = "${getS3Region()}",
+            |"provider" = "${getS3Provider()}")
+            |PROPERTIES(
+            |"exec_mem_limit" = "8589934592",
+            |"load_parallelism" = "3")""".stripMargin()
+
+
+        sql new File("""${context.file.parent}/../ddl/customer_ttl_delete.sql""").text
+        def load_customer_once =  { String table ->
+            def uniqueID = Math.abs(UUID.randomUUID().hashCode()).toString()
+            sql (new File("""${context.file.parent}/../ddl/${table}.sql""").text + ttlProperties)
+            def loadLabel = table + "_" + uniqueID
+            // load data from cos
+            def loadSql = new File("""${context.file.parent}/../ddl/${table}_load.sql""").text.replaceAll("\\\$\\{s3BucketName\\}", s3BucketName)
+            loadSql = loadSql.replaceAll("\\\$\\{loadLabel\\}", loadLabel) + s3WithProperties
+            sql loadSql
+
+            // check load state
+            while (true) {
+                def stateResult = sql "show load where Label = '${loadLabel}'"
+                def loadState = stateResult[stateResult.size() - 1][2].toString()
+                if ("CANCELLED".equalsIgnoreCase(loadState)) {
+                    throw new IllegalStateException("load ${loadLabel} failed.")
+                } else if ("FINISHED".equalsIgnoreCase(loadState)) {
+                    break
                 }
+                sleep(5000)
             }
-            assertTrue(flag1)
-            assertTrue(ttl_cache_size > 1073741824)
-    }
-    sleep(180000)
-    getMetricsMethod.call() {
-        respCode, body ->
-            assertEquals("${respCode}".toString(), "200")
-            String out = "${body}".toString()
-            def strs = out.split('\n')
-            Boolean flag1 = false;
-            for (String line in strs) {
-                if (flag1) break;
-                if (line.contains("ttl_cache_size")) {
-                    if (line.startsWith("#")) {
-                        continue
+        }
+
+        def getMetricsMethod = { check_func ->
+            httpTest {
+                endpoint backendIdToBackendIP.get(backendId) + ":" + backendIdToBackendBrpcPort.get(backendId)
+                uri "/brpc_metrics"
+                op "get"
+                check check_func
+            }
+        }
+
+        clearFileCache.call() {
+            respCode, body -> {}
+        }
+
+        long ttl_cache_evict_size_begin = 0;
+        getMetricsMethod.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                String out = "${body}".toString()
+                def strs = out.split('\n')
+                Boolean flag1 = false;
+                for (String line in strs) {
+                    if (flag1) break;
+                    if (line.contains("ttl_cache_evict_size")) {
+                        if (line.startsWith("#")) {
+                            continue
+                        }
+                        def i = line.indexOf(' ')
+                        ttl_cache_evict_size_begin = line.substring(i).toLong()
+                        flag1 = true
                     }
-                    def i = line.indexOf(' ')
-                    assertEquals(line.substring(i).toLong(), 0)
-                    flag1 = true
                 }
-            }
-            assertTrue(flag1)
+                assertTrue(flag1)
+        }
+
+        // load for MANY times to this dup table to make cache full enough to evict
+        // It will takes huge amount of time, so it should be p1/p2 level case.
+        // But someone told me it is the right place. Never mind just do it!
+        for (int i = 0; i < 10; i++) {
+            load_customer_once("customer_ttl")
+        }
+        sleep(10000) // 10s
+        // first, we test whether ttl evict actively
+        long ttl_cache_evict_size_end = 0;
+        getMetricsMethod.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                String out = "${body}".toString()
+                def strs = out.split('\n')
+                Boolean flag1 = false;
+                for (String line in strs) {
+                    if (flag1) break;
+                    if (line.contains("ttl_cache_evict_size")) {
+                        if (line.startsWith("#")) {
+                            continue
+                        }
+                        def i = line.indexOf(' ')
+                        ttl_cache_evict_size_end = line.substring(i).toLong()
+                        flag1 = true
+                    }
+                }
+                assertTrue(flag1)
+        }
+        // Note: this only applies when the case is run
+        // sequentially, coz we don't know what other cases are
+        // doing with TTL cache
+        logger.info("ttl evict diff:" + (ttl_cache_evict_size_end - ttl_cache_evict_size_begin).toString())
+        assertTrue((ttl_cache_evict_size_end - ttl_cache_evict_size_begin) > 1073741824)
+
+        // then we test skip_cache count when doing query when ttl cache is full
+        // we expect it to be rare
+        long skip_cache_count_begin = 0
+        getMetricsMethod.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                String out = "${body}".toString()
+                def strs = out.split('\n')
+                Boolean flag1 = false;
+                for (String line in strs) {
+                    if (flag1) break;
+                    if (line.contains("cached_remote_reader_skip_cache_sum")) {
+                        if (line.startsWith("#")) {
+                            continue
+                        }
+                        def i = line.indexOf(' ')
+                        skip_cache_count_begin = line.substring(i).toLong()
+                        flag1 = true
+                    }
+                }
+                assertTrue(flag1)
+        }
+
+        // another wave of load to flush the current TTL away
+        for (int i = 0; i < 10; i++) {
+            load_customer_once("customer_ttl")
+        }
+        // then we do query and hopefully, we should not run into too many SKIP_CACHE
+        sql """ select count(*) from customer_ttl """
+
+        long skip_cache_count_end = 0
+        getMetricsMethod.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                String out = "${body}".toString()
+                def strs = out.split('\n')
+                Boolean flag1 = false;
+                for (String line in strs) {
+                    if (flag1) break;
+                    if (line.contains("cached_remote_reader_skip_cache_sum")) {
+                        if (line.startsWith("#")) {
+                            continue
+                        }
+                        def i = line.indexOf(' ')
+                        skip_cache_count_end = line.substring(i).toLong()
+                        flag1 = true
+                    }
+                }
+                assertTrue(flag1)
+        }
+        // Note: this only applies when the case is run
+        // sequentially, coz we don't know what other cases are
+        // doing with TTL cache
+        logger.info("skip cache diff:" + (skip_cache_count_end - skip_cache_count_begin).toString())
+        assertTrue((skip_cache_count_end - skip_cache_count_begin) < 1000000)
+
+        // finally, we test whether LRU queue clean itself up when all ttl
+        // cache evict after expiration
+        sleep(200000)
+        getMetricsMethod.call() {
+            respCode, body ->
+                assertEquals("${respCode}".toString(), "200")
+                String out = "${body}".toString()
+                def strs = out.split('\n')
+                Boolean flag1 = false;
+                for (String line in strs) {
+                    if (flag1) break;
+                    if (line.contains("ttl_cache_lru_queue_size")) {
+                        if (line.startsWith("#")) {
+                            continue
+                        }
+                        def i = line.indexOf(' ')
+                        // all ttl will expire, so the ttl LRU queue set to 0
+                        // Note: this only applies when the case is run
+                        // sequentially, coz we don't know what other cases are
+                        // doing with TTL cache
+                        assertEquals(line.substring(i).toLong(), 0)
+                        flag1 = true
+                    }
+                }
+                assertTrue(flag1)
+        }
+    } finally {
+        set_be_param.call("max_ttl_cache_ratio", org_max_ttl_cache_ratio.toString())
     }
 }


### PR DESCRIPTION
# Motivation and Basic Ideas
Originally, the TTL file cache only evicts when it expires. If TTL data fills the cache, new TTL data won't fit in the cache and thus switch to SKIP_CACHE mode, which is a performance killer that overruns the S3 downloader with tons of small IOs.

This commit enables evicting the TTL cache actively through LRU beside the original TTL expiration.

# Performance tests
We can set up a scenario where the TTL cache is full by using a small file cache space (e.g. 5GB). We use table comsumer_ttl in the regression test attached with the PR and load data several times (e.g. 20GB) to populate the TTL cache.

With this setting, we execute query `select count(*) from customer_ttl where C_ADDRESS like '%ea%' and C_NAME like '%a%' and C_COMMENT like '%b%'` separately while enable_ttl_cache_evict_using_lru = true/false in the be conf. The results shows that the performance is increased by 43x during the tests:


| ttl_cache_evict_using_lru feature | enabled | disabled (baseline) |
| --------------------------------- | ------- | ------------------- |
| query execution time              | 8.5s    | 342s                |

Note that the result heavily depends on the ratio of cache size and the amount of data that the query incurs, along with S3 server performance, etc, so the result is only here for reference.

Such improvement is achieved by the active eviction of the TTL cache , which effectively reduces the possibility of SKIP_CACHE. During the tests:

| ttl_cache_evict_using_lru feature | enabled | disabled (baseline) |
| --------------------------------- | ------- | ------------------- |
| SKIP_CACHE occurence              | 0   | 257.1K               |