### PR TITLE
[pipeline](fix) Set upstream operators always runnable once source op…

### DIFF
--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -459,6 +459,11 @@ Status PipelineXLocalState<SharedStateArg>::close(RuntimeState* state) {
         _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
     }
     _closed = true;
+    // Some kinds of source operators has a 1-1 relationship with a sink operator (such as AnalyticOperator).
+    // We must ensure AnalyticSinkOperator will not be blocked if AnalyticSourceOperator already closed.
+    if (_shared_state && _shared_state->sink_deps.size() == 1) {
+        _shared_state->sink_deps.front()->set_always_ready();
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
…erator closed (#37297)

Some kinds of source operators has a 1-1 relationship with a sink operator (such as AnalyticOperator). We must ensure AnalyticSinkOperator will not be blocked if AnalyticSourceOperator already closed.

pick #37297

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

