### PR TITLE
[Feature](rpc) support set brpc_idle_timeout_sec and enable thrift socket keep alive

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -67,6 +67,9 @@ DEFINE_mString(public_access_ip, "");
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores
 DEFINE_Int32(brpc_num_threads, "256");
+// the time of brpc server keep idle connection, the default value is set to -1,
+// which means never close idle connection
+DEFINE_Int32(brpc_idle_timeout_sec, "-1");
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -69,7 +69,7 @@ DEFINE_mString(public_access_ip, "");
 DEFINE_Int32(brpc_num_threads, "256");
 // the time of brpc server keep idle connection, the default value is set to -1,
 // which means never close idle connection
-DEFINE_Int32(brpc_idle_timeout_sec, "-1");
+DEFINE_Int32(brpc_idle_timeout_sec, "1");
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -67,9 +67,9 @@ DEFINE_mString(public_access_ip, "");
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores
 DEFINE_Int32(brpc_num_threads, "256");
-// the time of brpc server keep idle connection, the default value is set to -1,
-// which means never close idle connection
-DEFINE_Int32(brpc_idle_timeout_sec, "1");
+// the time of brpc server keep idle connection, setting this value too small may cause rpc between backends to fail,
+// the default value is set to -1, which means never close idle connection.
+DEFINE_Int32(brpc_idle_timeout_sec, "-1");
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -108,6 +108,7 @@ DECLARE_mString(public_access_ip);
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores
 DECLARE_Int32(brpc_num_threads);
+DECLARE_Int32(brpc_idle_timeout_sec);
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -75,6 +75,7 @@ Status BRpcService::start(int port, int num_threads) {
     if (num_threads != -1) {
         options.num_threads = num_threads;
     }
+    options.idle_timeout_sec = config::brpc_idle_timeout_sec;
 
     if (config::enable_https) {
         auto sslOptions = options.mutable_ssl_options();

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -377,6 +377,7 @@ Status ThriftServer::start() {
         server_socket = new apache::thrift::transport::TServerSocket(
                 BackendOptions::get_service_bind_address_without_bracket(), _port);
         fe_server_transport.reset(server_socket);
+        server_socket->setKeepAlive(true);
 
         if (transport_factory == nullptr) {
             transport_factory.reset(new apache::thrift::transport::TBufferedTransportFactory());


### PR DESCRIPTION
## Proposed changes
In some special circumstances (such as network instability), the brpc server will always retain many tcp connections.