### PR TITLE
[fix](Nereids): Enhance LogicalJoin input validation when push down agg

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
@@ -155,4 +155,14 @@ class PushDownAggThroughJoinOnPkFkTest extends TestWithFeService implements Memo
                 .matches(logicalJoin(logicalAggregate(), any()))
                 .printlnTree();
     }
+
+    @Test
+    void testMissSlot() {
+        String sql = "select count(pri.name) from pri inner join foreign_not_null on pri.name = foreign_not_null.name";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalAggregate(logicalProject(logicalJoin())))
+                .printlnTree();
+    }
 }


### PR DESCRIPTION
intro by #36035

This PR refines the LogicalJoin class by introducing robust input validation. Key improvements:

* Implement precise checks for join input validity
* Ensure consistency between input slots and output sets
* Gracefully handle various join scenarios (left/right)

These enhancements bolster query integrity and optimize join operations.

