### PR TITLE
[fix](spill) fix spill data usage counter is not update correctly

### DIFF
--- a/be/src/vec/spill/spill_stream.cpp
+++ b/be/src/vec/spill/spill_stream.cpp
@@ -68,11 +68,14 @@ void SpillStream::gc() {
             LOG_EVERY_T(WARNING, 1) << fmt::format("failed to gc spill data, dir {}, error: {}",
                                                    query_gc_dir, status.to_string());
         }
-        // decrease spill data usage anyway, since in ~QueryContext() spill data of the query will be
-        // clean up as a last resort
-        data_dir_->update_spill_data_usage(-total_written_bytes_);
-        total_written_bytes_ = 0;
     }
+    // If QueryContext is destructed earlier than PipelineFragmentContext,
+    // spill_dir_ will be already moved to spill_gc directory.
+
+    // decrease spill data usage anyway, since in ~QueryContext() spill data of the query will be
+    // clean up as a last resort
+    data_dir_->update_spill_data_usage(-total_written_bytes_);
+    total_written_bytes_ = 0;
 }
 
 Status SpillStream::prepare() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If QueryContext is destructed earlier than PipelineFragmentContext, spill_dir_ will be already moved to spill_gc directory, which result int spill data disk usage is not decreased.
