### PR TITLE
[fix](function) fix wrong result when convert_tz is out of bound

### DIFF
--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -18,19 +18,15 @@
 #pragma once
 
 #include <cctz/time_zone.h>
-#include <stddef.h>
-#include <stdint.h>
 
+#include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
 
 #include "common/status.h"
-#include "runtime/exec_env.h"
-#include "runtime/runtime_state.h"
 #include "udf/udf.h"
 #include "util/binary_cast.hpp"
 #include "util/datetype_cast.hpp"
@@ -54,7 +50,6 @@
 #include "vec/data_types/data_type_string.h"
 #include "vec/data_types/data_type_time_v2.h"
 #include "vec/functions/function.h"
-#include "vec/io/io_helper.h"
 #include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 
@@ -187,7 +182,6 @@ private:
             result_column->insert_default();
             return;
         }
-
         if (!TimezoneUtils::find_cctz_time_zone(to_tz_name, to_tz)) {
             result_null_map[index_now] = true;
             result_column->insert_default();
@@ -211,6 +205,12 @@ private:
             }
 
             ts_value2.from_unixtime(timestamp, to_tz);
+        }
+
+        if (!ts_value2.is_valid_date()) [[unlikely]] {
+            result_null_map[index_now] = true;
+            result_column->insert_default();
+            return;
         }
 
         result_column->insert(binary_cast<ReturnDateValueType, ReturnNativeType>(ts_value2));

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -203,26 +203,12 @@ TEST(VTimestampFunctionsTest, timediff_test) {
 }
 
 TEST(VTimestampFunctionsTest, convert_tz_test) {
-    GTEST_SKIP() << "Skip temporarily. need fix";
     std::string func_name = "convert_tz";
 
     TimezoneUtils::clear_timezone_caches();
+    TimezoneUtils::load_timezones_to_cache();
 
     InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::String, TypeIndex::String};
-
-    bool case_sensitive = true;
-    cctz::time_zone tz {};
-    if (TimezoneUtils::find_cctz_time_zone("Asia/SHANGHAI", tz)) {
-        case_sensitive = false;
-    }
-
-    if (case_sensitive) {
-        DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
-                              std::string {"america/Los_angeles"}},
-                             Null()}};
-        static_cast<void>(
-                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
-    }
 
     {
         DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
@@ -230,16 +216,13 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
                              str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"UTC"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")}};
-        if (case_sensitive) {
-            data_set.push_back(Row {{std::string {"2019-08-01 02:18:27"},
-                                     std::string {"Asia/Shanghai"}, std::string {"Utc"}},
-                                    Null()});
-            data_set.push_back(
-                    Row {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
-                          std::string {"america/Los_angeles"}},
-                         Null()});
-        }
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"0000-01-01 00:00:00"}, std::string {"+08:00"},
+                              std::string {"-02:00"}},
+                             Null()},
+                            {{std::string {"0000-01-01 00:00:00"}, std::string {"+08:00"},
+                              std::string {"+08:00"}},
+                             str_to_datetime_v2("0000-01-01 00:00:00", "%Y-%m-%d %H:%i:%s.%f")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
     }
@@ -257,7 +240,6 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
                               std::string {"america/Los_angeles"}},
                              str_to_datetime_v2("2019-07-31 11:18:27", "%Y-%m-%d %H:%i:%s.%f")}};
-        TimezoneUtils::load_timezones_to_cache();
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
     }

--- a/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_function.out
+++ b/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_function.out
@@ -38,6 +38,12 @@
 -- !sql --
 \N
 
+-- !lower_bound --
+\N
+
+-- !lower_bound --
+0000-01-01T00:00
+
 -- !sql_convert_tz_null --
 \N
 \N

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -54,6 +54,8 @@ suite("test_date_function") {
     qt_sql """ SELECT convert_tz('2022-2-29 13:21:03', '+08:00', 'America/London') result; """
     qt_sql """ SELECT convert_tz('2022-02-29 13:21:03', '+08:00', 'America/London') result; """
     qt_sql """ SELECT convert_tz('1900-00-00 13:21:03', '+08:00', 'America/London') result; """
+    qt_lower_bound """ select convert_tz('0000-01-01 00:00:00', '+08:00', '-02:00'); """
+    qt_lower_bound """ select convert_tz('0000-01-01 00:00:00', '+08:00', '+08:00'); """
 
     // bug fix
     sql """ insert into ${tableName} values 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
```sql
mysql> select CONVERT_TZ(cast('0000-01-01 00:00:00.00001'  as DATETIMEV1), cast('Asia/Shanghai' as VARCHAR(65533)), cast('America/Los_Angeles' as VARCHAR(65533)));
+---------------------------------------------------------------------------------------------------------------------------------------------------+
| convert_tz(cast('0000-01-01 00:00:00.00001' as DATETIME), cast('Asia/Shanghai' as VARCHAR(65533)), cast('America/Los_Angeles' as VARCHAR(65533))) |
+---------------------------------------------------------------------------------------------------------------------------------------------------+
| q535-12-31 08:01:19                                                                                                                               |
+---------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.12 sec)
```
now:
```sql
mysql> select CONVERT_TZ(cast('0000-01-01 00:00:00.00001'  as DATETIMEV1), cast('Asia/Shanghai' as VARCHAR(65533)), cast('America/Los_Angeles' as VARCHAR(65533)));
+---------------------------------------------------------------------------------------------------------------------------------------------------+
| convert_tz(cast('0000-01-01 00:00:00.00001' as DATETIME), cast('Asia/Shanghai' as VARCHAR(65533)), cast('America/Los_Angeles' as VARCHAR(65533))) |
+---------------------------------------------------------------------------------------------------------------------------------------------------+
| NULL                                                                                                                                              |
+---------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.09 sec)
```