### PR TITLE
[chore](query) print query id when killed by timeout checker

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -959,8 +959,8 @@ public class ConnectContext {
             // to ms
             long timeout = getExecTimeout() * 1000L;
             if (delta > timeout) {
-                LOG.warn("kill {} timeout, remote: {}, query timeout: {}",
-                        timeoutTag, getRemoteHostPortString(), timeout);
+                LOG.warn("kill {} timeout, remote: {}, query timeout: {}, query id: {}",
+                        timeoutTag, getRemoteHostPortString(), timeout, queryId);
                 killFlag = true;
             }
         }


### PR DESCRIPTION
## Proposed changes

pick #36868

```
2024-06-26 14:58:30,917 WARN (connect-scheduler-check-timer-0|92) [ConnectContext.checkTimeout():776] kill query timeout, remote: XXXX:XX, query timeout: 900000
```
It is hard to know which query is killed when timeout, so it is necessary to print query id.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

