### PR TITLE
[chore](routine-load) increase routine load job default max batch size and rows (#36632)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -108,8 +108,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     public static final double DEFAULT_MAX_FILTER_RATIO = 1.0;
 
     public static final long DEFAULT_MAX_INTERVAL_SECOND = 10;
-    public static final long DEFAULT_MAX_BATCH_ROWS = 200000;
-    public static final long DEFAULT_MAX_BATCH_SIZE = 100 * 1024 * 1024; // 100MB
+    public static final long DEFAULT_MAX_BATCH_ROWS = 20000000;
+    public static final long DEFAULT_MAX_BATCH_SIZE = 1024 * 1024 * 1024; // 1GB
     public static final long DEFAULT_EXEC_MEM_LIMIT = 2 * 1024 * 1024 * 1024L;
     public static final boolean DEFAULT_STRICT_MODE = false; // default is false
     public static final int DEFAULT_SEND_BATCH_PARALLELISM = 1;

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
@@ -341,7 +341,6 @@ public class RoutineLoadJobTest {
                 11, "localhost:9092", "test_topic", UserIdentity.ADMIN);
         Deencapsulation.setField(routineLoadJob, "maxErrorNum", 10);
         Deencapsulation.setField(routineLoadJob, "maxBatchRows", 10);
-        Deencapsulation.setField(routineLoadJob, "maxBatchRows", 10);
         String showCreateInfo = routineLoadJob.getShowCreateInfo();
         String expect = "CREATE ROUTINE LOAD test_load ON 11\n"
                 + "WITH APPEND\n"
@@ -352,7 +351,7 @@ public class RoutineLoadJobTest {
                 + "\"max_filter_ratio\" = \"1.0\",\n"
                 + "\"max_batch_interval\" = \"10\",\n"
                 + "\"max_batch_rows\" = \"10\",\n"
-                + "\"max_batch_size\" = \"104857600\",\n"
+                + "\"max_batch_size\" = \"1073741824\",\n"
                 + "\"format\" = \"csv\",\n"
                 + "\"strip_outer_array\" = \"false\",\n"
                 + "\"num_as_string\" = \"false\",\n"


### PR DESCRIPTION
pick #36632

Most users only care about the size of **max_batch_interval**, but in order to achieve an interval effect, they have to configure **max_batch_rows** and **max_batch_size** according to the characteristics of the data. By adjusting these two default values, users do not need to worry about configuration in most scenarios.

