### PR TITLE
[chore](query) print query id when killed by timeout checker (#36868)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -760,8 +760,8 @@ public class ConnectContext {
             //to ms
             long timeout = getExecTimeout() * 1000L;
             if (delta > timeout) {
-                LOG.warn("kill {} timeout, remote: {}, query timeout: {}",
-                        timeoutTag, getMysqlChannel().getRemoteHostPortString(), timeout);
+                LOG.warn("kill {} timeout, remote: {}, query timeout: {}, query id: {}",
+                        timeoutTag, getMysqlChannel().getRemoteHostPortString(), timeout, queryId);
                 killFlag = true;
             }
         }


### PR DESCRIPTION
pick #36868

```
2024-06-26 14:58:30,917 WARN (connect-scheduler-check-timer-0|92) [ConnectContext.checkTimeout():776] kill query timeout, remote: XXXX:XX, query timeout: 900000
```
It is hard to know which query is killed when timeout, so it is necessary to print query id.

