### PR TITLE
[fix](test) fix case of test_stream_load_error_url for cloud

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -29,3 +29,4 @@ enable_file_cache = true
 file_cache_path = [{"path":"/data/doris_cloud/file_cache","total_size":104857600,"query_limit":104857600}]
 tmp_file_dirs = [{"path":"/data/doris_cloud/tmp","max_cache_bytes":104857600,"max_upload_bytes":104857600}]
 thrift_rpc_timeout_ms = 360000
+save_load_error_log_to_s3 = true

--- a/regression-test/pipeline/cloud_p1/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p1/conf/be_custom.conf
@@ -28,3 +28,4 @@ meta_service_use_load_balancer = false
 enable_file_cache = true
 file_cache_path = [{"path":"/data/doris_cloud/file_cache","total_size":104857600,"query_limit":104857600}]
 tmp_file_dirs = [{"path":"/data/doris_cloud/tmp","max_cache_bytes":104857600,"max_upload_bytes":104857600}]
+save_load_error_log_to_s3 = true


### PR DESCRIPTION
## Proposed changes

`save_load_error_log_to_s3` should be set to true for cloud case, which will save load error log to s3.

<!--Describe your changes.-->

