### PR TITLE
[chore](dependencies)Remove Unnecessary Dependencies

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -93,6 +93,7 @@ under the License.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -359,6 +360,10 @@ under the License.
                     <artifactId>netty-all</artifactId>
                     <groupId>io.netty</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.alibaba.otter/canal.protocol -->
@@ -378,6 +383,10 @@ under the License.
                 <exclusion>
                     <artifactId>netty-all</artifactId>
                     <groupId>io.netty</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1202,6 +1202,8 @@ under the License.
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka-clients.version}</version>
+                <!--routine load test use kafka-clients-->
+                <scope>test</scope>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.github.oshi/oshi-core -->
             <dependency>


### PR DESCRIPTION
## Proposed changes
**devtools**: This dependency is only needed during local development, so we should set its scope to runtime.
**canal** :  The Spring dependency for Canal is primarily used for Pulsar's Bean replication. Since binlogload does not require any MQ dependencies, we can remove the corresponding Spring jar.  https://github.com/alibaba/canal/blob/master/client/src/main/java/com/alibaba/otter/canal/client/kafka/protocol/KafkaFlatMessage.java
**kafka** :Fe does not directly interact with Kafka; only UT uses Kafka libraries, so its dependency scope should be set to 'test'.


