### PR TITLE
[Enhancement](External)change the keep alive unit from minute to second, to make the scan fa…

### DIFF
--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -131,8 +131,8 @@ void ExternalScanContextMgr::gc_expired_context() {
                     ++iter; // advance one entry
                     continue;
                 }
-                // free context if context is idle for context->keep_alive_min
-                if (current_time - context->last_access_time > context->keep_alive_min * 60) {
+                // free context if context is idle for context->keep_alive_sec
+                if (current_time - context->last_access_time > context->keep_alive_sec) {
                     LOG(INFO) << "gc expired scan context: context id [ " << context->context_id
                               << " ]";
                     expired_contexts.push_back(context);

--- a/be/src/runtime/external_scan_context_mgr.h
+++ b/be/src/runtime/external_scan_context_mgr.h
@@ -44,7 +44,7 @@ public:
     time_t last_access_time;
     std::mutex _local_lock;
     std::string context_id;
-    short keep_alive_min;
+    short keep_alive_sec;
     ScanContext(std::string id) : context_id(std::move(id)) {}
 };
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -815,8 +815,7 @@ void BaseBackendService::open_scanner(TScanOpenResult& result_, const TScanOpenP
     p_context->last_access_time = time(nullptr);
     if (params.__isset.keep_alive_min) {
         p_context->keep_alive_sec = params.keep_alive_min * 60;
-    }
-    else if (params.__isset.keep_alive_sec) {
+    } else if (params.__isset.keep_alive_sec) {
         p_context->keep_alive_sec = params.keep_alive_sec;
     } else {
         p_context->keep_alive_sec = 5 * 60;

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -814,9 +814,12 @@ void BaseBackendService::open_scanner(TScanOpenResult& result_, const TScanOpenP
     p_context->offset = 0;
     p_context->last_access_time = time(nullptr);
     if (params.__isset.keep_alive_min) {
-        p_context->keep_alive_min = params.keep_alive_min;
+        p_context->keep_alive_sec = params.keep_alive_min * 60;
+    }
+    else if (params.__isset.keep_alive_sec) {
+        p_context->keep_alive_sec = params.keep_alive_sec;
     } else {
-        p_context->keep_alive_min = 5;
+        p_context->keep_alive_sec = 5 * 60;
     }
 
     Status exec_st;

--- a/gensrc/thrift/DorisExternalService.thrift
+++ b/gensrc/thrift/DorisExternalService.thrift
@@ -59,6 +59,9 @@ struct TScanOpenParams {
   
   // memory limit for a single query
   13: optional i64 mem_limit
+
+  // max keep alive time sec
+  14: optional i16 keep_alive_sec
 }
 
 struct TScanColumnDesc {


### PR DESCRIPTION
## Proposed changes

the Scenes：
when we use spark connector to read a table in Doris,  and  the table is huge,  the read will take a lot times and resource(cup/memory),   when we try to cancel the spark job, the scan in be still work from a long time about "5 minutes".
 
we want to fail fast. so change the keep alive unit from minutes to second.


<!--Describe your changes.-->

