### PR TITLE
[fix](create table) create table fail not write drop table editlog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2979,7 +2979,8 @@ public class InternalCatalog implements CatalogIf<Database> {
             for (Long tabletId : tabletIdSet) {
                 Env.getCurrentInvertedIndex().deleteTablet(tabletId);
             }
-            // edit log write DropTableInfo will also remove colocate group
+            // edit log write DropTableInfo will result in deleting colocate group,
+            // but follow fe may need wait 30s (recycle bin mgr run every 30s).
             if (Env.getCurrentColocateIndex().isColocateTable(tableId)) {
                 Env.getCurrentColocateIndex().removeTable(tableId);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2937,9 +2937,6 @@ public class InternalCatalog implements CatalogIf<Database> {
                 ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
             }
 
-            // if table not exists, then db.createTableWithLock will write an editlog.
-            editlogCreateTable = !result.second;
-
             if (result.second) {
                 if (Env.getCurrentColocateIndex().isColocateTable(tableId)) {
                     // if this is a colocate table, its table id is already added to colocate group
@@ -2951,6 +2948,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                 }
                 LOG.info("duplicate create table[{};{}], skip next steps", tableName, tableId);
             } else {
+                // if table not exists, then db.createTableWithLock will write an editlog.
+                editlogCreateTable = true;
+
                 // we have added these index to memory, only need to persist here
                 if (Env.getCurrentColocateIndex().isColocateTable(tableId)) {
                     GroupId groupId = Env.getCurrentColocateIndex().getGroup(tableId);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2979,9 +2979,8 @@ public class InternalCatalog implements CatalogIf<Database> {
             for (Long tabletId : tabletIdSet) {
                 Env.getCurrentInvertedIndex().deleteTablet(tabletId);
             }
+            // edit log write DropTableInfo will also remove colocate group
             if (Env.getCurrentColocateIndex().isColocateTable(tableId)) {
-                // edit log write DropTableInfo will also remove colocate group
-                GroupId groupId = Env.getCurrentColocateIndex().getGroup(tableId);
                 Env.getCurrentColocateIndex().removeTable(tableId);
             }
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2980,9 +2980,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                 Env.getCurrentInvertedIndex().deleteTablet(tabletId);
             }
             if (Env.getCurrentColocateIndex().isColocateTable(tableId)) {
+                // edit log write DropTableInfo will also remove colocate group
                 GroupId groupId = Env.getCurrentColocateIndex().getGroup(tableId);
                 Env.getCurrentColocateIndex().removeTable(tableId);
-                // edit log write DropTableInfo will also remove colocate group
             }
             try {
                 dropTable(db, tableId, true, 0L);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ColocatePersistInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ColocatePersistInfo.java
@@ -62,10 +62,6 @@ public class ColocatePersistInfo implements Writable {
         return new ColocatePersistInfo(groupId, tableId, backendsPerBucketSeq, new ReplicaAllocation());
     }
 
-    public static ColocatePersistInfo createForRemoveTable(GroupId groupId, long tableId) {
-        return new ColocatePersistInfo(groupId, tableId, Maps.newHashMap(), new ReplicaAllocation());
-    }
-
     public static ColocatePersistInfo createForBackendsPerBucketSeq(GroupId groupId,
             Map<Tag, List<List<Long>>> backendsPerBucketSeq) {
         return new ColocatePersistInfo(groupId, -1L, backendsPerBucketSeq, new ReplicaAllocation());

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ColocatePersistInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ColocatePersistInfo.java
@@ -62,6 +62,10 @@ public class ColocatePersistInfo implements Writable {
         return new ColocatePersistInfo(groupId, tableId, backendsPerBucketSeq, new ReplicaAllocation());
     }
 
+    public static ColocatePersistInfo createForRemoveTable(GroupId groupId, long tableId) {
+        return new ColocatePersistInfo(groupId, tableId, Maps.newHashMap(), new ReplicaAllocation());
+    }
+
     public static ColocatePersistInfo createForBackendsPerBucketSeq(GroupId groupId,
             Map<Tag, List<List<Long>>> backendsPerBucketSeq) {
         return new ColocatePersistInfo(groupId, -1L, backendsPerBucketSeq, new ReplicaAllocation());

--- a/regression-test/suites/partition_p0/test_create_table_exception.groovy
+++ b/regression-test/suites/partition_p0/test_create_table_exception.groovy
@@ -129,7 +129,7 @@ suite("test_create_table_exception") {
             checkResult()
 
             cluster.restartFrontends(cluster.getMasterFe().index)
-            sleep 30_000
+            sleep 32_000
             reconnectFe()
             checkResult()
         } finally {

--- a/regression-test/suites/partition_p0/test_create_table_exception.groovy
+++ b/regression-test/suites/partition_p0/test_create_table_exception.groovy
@@ -128,12 +128,17 @@ suite("test_create_table_exception") {
             createTable(2)
             checkResult()
 
+            sleep 1000
             cluster.restartFrontends(cluster.getMasterFe().index)
             sleep 32_000
-            reconnectFe()
-            checkResult()
+            def newMasterFe = cluster.getMasterFe()
+            def newMasterFeUrl =  "jdbc:mysql://${newMasterFe.host}:${newMasterFe.queryPort}/?useLocalSessionState=false&allowLoadLocalInfile=false"
+            newMasterFeUrl = context.config.buildUrlWithDb(newMasterFeUrl, context.dbName)
+            connect('root', '', newMasterFeUrl) {
+                checkResult()
+            }
+
         } finally {
-            GetDebugPoint().disableDebugPointForAllFEs('FE.createOlapTable.exception')
         }
     }
 }

--- a/regression-test/suites/partition_p0/test_create_table_exception.groovy
+++ b/regression-test/suites/partition_p0/test_create_table_exception.groovy
@@ -116,11 +116,11 @@ suite("test_create_table_exception") {
 
             def checkResult = { ->
                 def tables = sql """show tables;"""
-                log.info(tables.toString())
+                log.info("tables=" + tables)
                 assertEquals(3, tables.size())
 
                 def groups = sql """ show proc "/colocation_group" """
-                log.info(groups)
+                log.info("groups=" + groups)
                 assertEquals(1, groups.size())
             }
 

--- a/regression-test/suites/partition_p0/test_create_table_exception.groovy
+++ b/regression-test/suites/partition_p0/test_create_table_exception.groovy
@@ -31,9 +31,9 @@ suite("test_create_table_exception") {
         def table3 = "dynamic_partition_table"
         try {
             GetDebugPoint().enableDebugPointForAllFEs('FE.createOlapTable.exception', null)
-            def createTable = { ->
+            def createTable = { tableIdx ->
                 try_sql """
-                    CREATE TABLE $table1 (
+                    CREATE TABLE ${table1}_${tableIdx} (
                         `k1` int(11) NULL,
                         `k2` int(11) NULL
                     )
@@ -41,12 +41,13 @@ suite("test_create_table_exception") {
                     COMMENT 'OLAP'
                     DISTRIBUTED BY HASH(`k1`) BUCKETS 10
                     PROPERTIES (
+                    "colocate_with" = "col_grp_${tableIdx}",
                     "replication_num"="3"
                     );
                 """
 
                 try_sql """
-                    CREATE TABLE IF NOT EXISTS $table2 (
+                    CREATE TABLE IF NOT EXISTS ${table2}_${tableIdx} (
                         lo_orderdate int(11) NOT NULL COMMENT "",
                         lo_orderkey bigint(20) NOT NULL COMMENT "",
                         lo_linenumber bigint(20) NOT NULL COMMENT "",
@@ -79,7 +80,7 @@ suite("test_create_table_exception") {
                 """
 
                 try_sql """
-                    CREATE TABLE $table3 (
+                    CREATE TABLE ${table3}_${tableIdx} (
                         time date,
                         key1 int,
                         key2 int,
@@ -109,19 +110,30 @@ suite("test_create_table_exception") {
                     );
                 """
             }
-            createTable()
+            createTable(1)
             def result = sql """show tables;"""
             assertEquals(result.size(), 0)
+
+            def checkResult = { ->
+                def tables = sql """show tables;"""
+                log.info(tables.toString())
+                assertEquals(3, tables.size())
+
+                def groups = sql """ show proc "/colocation_group" """
+                log.info(groups)
+                assertEquals(1, groups.size())
+            }
+
             GetDebugPoint().disableDebugPointForAllFEs('FE.createOlapTable.exception')
-            createTable()
-            result = sql """show tables;"""
-            log.info(result.toString())
-            assertEquals(result.size(), 3)
+            createTable(2)
+            checkResult()
+
+            cluster.restartFrontends(cluster.getMasterFe().index)
+            sleep 30_000
+            reconnectFe()
+            checkResult()
         } finally {
             GetDebugPoint().disableDebugPointForAllFEs('FE.createOlapTable.exception')
-            sql """drop table if exists ${table1}"""
-            sql """drop table if exists ${table2}"""
-            sql """drop table if exists ${table3}"""
         }
     }
 }


### PR DESCRIPTION
Fix:  for creating table,  if create dynamic partition throw exception (pr #35778),  then create table will fail,  then drop table,  but it forget to write an editlog.

