### PR TITLE
[fix](func)fix array_with_const with larger than max_array_size

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -41,15 +41,6 @@ class SipHash;
 
 namespace doris::vectorized {
 
-namespace ErrorCodes {
-extern const int NOT_IMPLEMENTED;
-extern const int BAD_ARGUMENTS;
-extern const int PARAMETER_OUT_OF_BOUND;
-extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
-extern const int LOGICAL_ERROR;
-extern const int TOO_LARGE_ARRAY_SIZE;
-} // namespace ErrorCodes
-
 ColumnArray::ColumnArray(MutableColumnPtr&& nested_column, MutableColumnPtr&& offsets_column)
         : data(std::move(nested_column)), offsets(std::move(offsets_column)) {
     const auto* offsets_concrete = typeid_cast<const ColumnOffsets*>(offsets.get());

--- a/be/src/vec/functions/array/function_array_with_constant.cpp
+++ b/be/src/vec/functions/array/function_array_with_constant.cpp
@@ -91,9 +91,9 @@ public:
         array_sizes.reserve(input_rows_count);
         for (size_t i = 0; i < input_rows_count; ++i) {
             auto array_size = num->get_int(i);
-            if (UNLIKELY(array_size < 0)) {
-                return Status::RuntimeError("Array size can not be negative in function:" +
-                                            get_name());
+            if (UNLIKELY(array_size < 0) || UNLIKELY(array_size > max_array_size_as_field)) {
+                return Status::RuntimeError("Array size should in range(0, {}) in function: {}",
+                                            max_array_size_as_field, get_name());
             }
             offset += array_size;
             offsets.push_back(offset);

--- a/regression-test/suites/datatype_p0/nested_types/query/array_functions/test_array_functions_array_with_const.groovy
+++ b/regression-test/suites/datatype_p0/nested_types/query/array_functions/test_array_functions_array_with_const.groovy
@@ -16,6 +16,7 @@
 // under the License.
 
 suite("test_array_functions_array_with_const", "p0") {
+    sql "set enable_nereids_planner=false;"
     //array_with_constant
     qt_old_sql "SELECT 'array_with_constant';"
     order_qt_old_sql "SELECT array_with_constant(3, number) FROM numbers limit 10;"
@@ -31,7 +32,16 @@ suite("test_array_functions_array_with_const", "p0") {
                 SELECT array_with_constant(-231.37104, -138); 
                 """
     } catch (Exception ex) {
-        assertTrue(ex.getMessage().contains("Array size can not be negative in function:array_with_constant"))
+        assertTrue(ex.getMessage().contains("Array size should in range(0, 1000000) in function"))
+    }
+
+    // -- {server for large array}
+    try {
+        sql """
+                SELECT array_with_constant(1000001, 1);
+                """
+    } catch (Exception ex) {
+        assertTrue(ex.getMessage().contains("Array size should in range(0, 1000000) in function"))
     }
 
 
@@ -53,7 +63,15 @@ suite("test_array_functions_array_with_const", "p0") {
                 SELECT array_with_constant(-231.37104, -138); 
                 """
     } catch (Exception ex) {
-        assertTrue(ex.getMessage().contains("Array size can not be negative in function:array_with_constant"))
+        assertTrue(ex.getMessage().contains("Array size should in range(0, 1000000) in function"))
     }
 
+    // -- {server for large array}
+    try {
+        sql """
+                SELECT array_with_constant(1000001, 1);
+                """
+    } catch (Exception ex) {
+        assertTrue(ex.getMessage().contains("Array size should in range(0, 1000000) in function"))
+    }
 }


### PR DESCRIPTION
## Proposed changes
when we use func array_with_const with large size there has not limit so, we will make be core like this
<img width="1512" alt="截屏2024-07-08 20 41 43" src="https://github.com/apache/doris/assets/18551114/01986f1f-5b25-48cb-89bb-c66e89b5c1d8">


Issue Number: close #xxx

<!--Describe your changes.-->

