### PR TITLE
[improve](load) reduce memory reserved in memtable limiter

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -118,6 +118,8 @@ DEFINE_mInt32(double_resize_threshold, "23");
 
 DEFINE_Int64(max_sys_mem_available_low_water_mark_bytes, "6871947673");
 
+DEFINE_Int64(memtable_limiter_reserved_memory_bytes, "838860800");
+
 // The size of the memory that gc wants to release each time, as a percentage of the mem limit.
 DEFINE_mString(process_minor_gc_size, "10%");
 DEFINE_mString(process_full_gc_size, "20%");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -165,6 +165,9 @@ DECLARE_mInt32(double_resize_threshold);
 // Turn down max. will use as much memory as possible.
 DECLARE_Int64(max_sys_mem_available_low_water_mark_bytes);
 
+// reserve a small amount of memory so we do not trigger MinorGC
+DECLARE_Int64(memtable_limiter_reserved_memory_bytes);
+
 // The size of the memory that gc wants to release each time, as a percentage of the mem limit.
 DECLARE_mString(process_minor_gc_size);
 DECLARE_mString(process_full_gc_size);

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -78,19 +78,17 @@ void MemTableMemoryLimiter::register_writer(std::weak_ptr<MemTableWriter> writer
 }
 
 int64_t MemTableMemoryLimiter::_avail_mem_lack() {
-    // reserve a small amount of memory so we do not trigger MinorGC
-    auto reserved_mem = doris::MemInfo::sys_mem_available_low_water_mark();
     auto avail_mem_lack = doris::MemInfo::sys_mem_available_warning_water_mark() -
                           doris::GlobalMemoryArbitrator::sys_mem_available();
-    return avail_mem_lack + reserved_mem;
+    // reserve a small amount of memory so we do not trigger MinorGC
+    return avail_mem_lack + config::memtable_limiter_reserved_memory_bytes;
 }
 
 int64_t MemTableMemoryLimiter::_proc_mem_extra() {
-    // reserve a small amount of memory so we do not trigger MinorGC
-    auto reserved_mem = doris::MemInfo::sys_mem_available_low_water_mark();
     auto proc_mem_extra =
             GlobalMemoryArbitrator::process_memory_usage() - MemInfo::soft_mem_limit();
-    return proc_mem_extra + reserved_mem;
+    // reserve a small amount of memory so we do not trigger MinorGC
+    return proc_mem_extra + config::memtable_limiter_reserved_memory_bytes;
 }
 
 bool MemTableMemoryLimiter::_soft_limit_reached() {

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -51,8 +51,8 @@ public:
     int64_t mem_usage() const { return _mem_usage; }
 
 private:
-    static int64_t _avail_mem_lack();
-    static int64_t _proc_mem_extra();
+    static inline bool _sys_avail_mem_less_than_warning_water_mark();
+    static inline bool _process_used_mem_more_than_soft_mem_limit();
 
     bool _soft_limit_reached();
     bool _hard_limit_reached();


### PR DESCRIPTION
## Proposed changes

#37174 increased max sys_mem_available_low_water_mark from 1.6G to 6.4G, causing memtable memory limiter reserving too much memory.

This PR adds a BE config `memtable_limiter_reserved_memory_bytes`, defaults to 800MB, which defines bytes reserved in memtable memory limiter.

