### PR TITLE
[bugfix](paimon)adding dependencies for `clang`

### DIFF
--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -207,6 +207,11 @@ under the License.
             <artifactId>paimon-oss</artifactId>
             <version>${paimon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Proposed changes

When paimon uses the `hms` type catalog and reads data in jni mode, it needs to use the `org.apache.commons.lang.StringUtils` class. 
(This problem is not tested in the pipeline environment because the pipeline environment automatically generates the `java-udf-case-jar-with-dependencies.jar` for testing, which contains the `lang` package.)

