### PR TITLE
Fix broker storage path parameter not being deleted in the be conf file

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1527,6 +1527,13 @@ Status StorageEngine::_persist_broken_paths() {
         LOG(INFO) << "persist broken_storae_path " << config_value << st;
         return st;
     }
+    else
+    {
+        //reset broken_storage_path to ;
+        auto st = config::set_config("broken_storage_path", ";", true);
+        LOG(INFO) << "reset broken_storae_path: " <<st;
+        return st;
+    }
 
     return Status::OK();
 }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -437,8 +437,16 @@ int main(int argc, char** argv) {
                 LOG(WARNING) << "ignore broken disk, path = " << it->path;
                 it = paths.erase(it);
             } else {
-                LOG(ERROR) << "a broken disk is found " << it->path;
-                exit(-1);
+                LOG(ERROR) << "a broken disk is found, check it " << it->path;
+                // if broken path can be read and write（IO ok）,remove the broken path at BE start.
+                if (doris::check_datapath_rw(it->path)) {
+                    LOG(INFO) << " broken path=" << it->path << " is IO Ok. remove it on broken path.";
+                    broken_paths.erase(it->path);
+                    continue;
+                } else {
+                    LOG(ERROR) << " broken path=" << it->path << " is IO Error,can't start.";
+                    exit(-1);
+                }
             }
         } else if (!doris::check_datapath_rw(it->path)) {
             if (doris::config::ignore_broken_disk) {


### PR DESCRIPTION
## Proposed changes
### There are two questions here:
#### 1. As long as the parameter broken_storage_path has a value, doris_be process cannot be started.

#### 2. When the corresponding disk path is read and write, Doris will not update the broken_storage_path parameter，
and also doris_be process can't  be start。

## Does not support the scenario of unplugging and reinserting the disk.

## Issue Number: close #xxx
No

<!--Describe your changes.-->
## 1. Modified the logic of the health_check function. Every time, all path paths are detected

## 2. Modify the logic of the remove'brooken_path function。
```
a:  As long as the disk path corresponding to the path is recovered to Readable and writable,
will update the parameter broken_storage_path,
The original code cannot delete the last path. Even if the disk IO corresponding to the path is normal.

b:  When all path IO is are normal, broken_storage_path is set to;
```

