### PR TITLE
[fix](regression test) fix unstable test_alter_colocate_group

### DIFF
--- a/regression-test/suites/alter_p2/test_alter_colocate_group.groovy
+++ b/regression-test/suites/alter_p2/test_alter_colocate_group.groovy
@@ -158,11 +158,11 @@ suite ("test_alter_colocate_group") {
 
     for (int i = 1; i <= 3; i++) {
         def groupName = "regression_test_alter_p2.group_${i}"
-        checkGroupsReplicaAlloc(groupName, 1)
+        checkGroupsReplicaAlloc(groupName, replication_num)
 
         def tableName = "tbl${i}"
         def hasDynamicPart = i == 3
-        checkTableReplicaAlloc(tableName, hasDynamicPart, 1)
+        checkTableReplicaAlloc(tableName, hasDynamicPart, replication_num)
 
         test {
             sql """


### PR DESCRIPTION
FIX:

```
Exception in alter_p2/test_alter_colocate_group.groovy(line 130):

def checkGroupsReplicaAlloc = { groupName, replicaNum ->
// groupName -> replicaAlloc
def allocMap = [:]
def groups = sql """ show proc "/colocation_group" """
for (def group : groups)

{ allocMap[group[1]] = group[4] }
assertEquals("tag.location.default: ${replicaNum}".toString(), allocMap[groupName])
^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^
}

def checkTableReplicaAlloc = { tableName, hasDynamicPart, replicaNum ->
def result = sql """ show create table ${tableName} """
def createTbl = result[0][1].toString()
assertTrue(createTbl.indexOf("\"replication_allocation\" = \"tag.location.default: ${replicaNum}\"") > 0)
if (hasDynamicPart) {
assertTrue(createTbl.indexOf(
"\"dynamic_partition.replication_allocation\" = \"tag.location.default: ${replicaNum}\"") > 0)
}

Exception:
org.opentest4j.AssertionFailedError: expected: <tag.location.default: 1> but was: <tag.location.default: 3>
```
