### PR TITLE
[fix](auth)fix fe can not restart when replay create row policy log for 2.0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
@@ -147,7 +147,10 @@ public class RowPolicy extends Policy {
             CreatePolicyStmt stmt = (CreatePolicyStmt) SqlParserUtils.getFirstStmt(parser);
             wherePredicate = stmt.getWherePredicate();
         } catch (Exception e) {
-            throw new IOException("table policy parse originStmt error", e);
+            String errorMsg = String.format("table policy parse originStmt error, originStmt: %s.",
+                    originStmt);
+            // Only print logs to avoid cluster failure to start
+            LOG.warn(errorMsg, e);
         }
     }
 


### PR DESCRIPTION
The fixed issue is the same as https://github.com/apache/doris/pull/37342

There are significant differences in metadata, so instead of directly picking, errors are ignored to achieve the effect of not affecting FE startup
