### PR TITLE
[Fix](group commit) Fix group commit wal back pressure case

### DIFF
--- a/regression-test/suites/load_p0/stream_load/test_group_commit_and_wal_back_pressure.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_group_commit_and_wal_back_pressure.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_group_commit_and_wal_back_pressure", "p2") {
+suite("test_group_commit_and_wal_back_pressure") {
 
     def tableName = "test_group_commit_and_wal_back_pressure"
     sql """ DROP TABLE IF EXISTS ${tableName}1 """
@@ -122,6 +122,9 @@ suite("test_group_commit_and_wal_back_pressure", "p2") {
     for (Thread th in t3) {
         th.join()
     }
+
+    // wait for group commit
+    Thread.sleep(10000)
 
     sql "sync"
 


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Problem: The group commit WAL back pressure case failed.

Reason: Previously, the group commit was restructured from **regular load** to **pipeline architecture load**, which improved the concurrency and speed of load. Consequently, the loads in the test case were completed much faster. The default batching time for a group commit is 10 seconds. Therefore, if all loads are finished in less than this time(10 seconds), the group commit data is not yet committed to the disk and visible, resulting in no data being returned by the final select statement.

Solution: To resolve the issue, wait for one batching period (10 seconds) after completing all imports before executing the query.

Plus, due to the faster speed of load, we move this case from p2 to p0.


