### PR TITLE
[Feat](job)scheduled job allows the time to be set in the past (#36732)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
@@ -96,7 +96,7 @@ public class JobExecutionConfiguration {
             return;
         }
         if (timerDefinition.getStartTimeMs() < System.currentTimeMillis()) {
-            throw new IllegalArgumentException("startTimeMs cannot be less than current time");
+            throw new IllegalArgumentException("startTimeMs must be greater than current time");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/TimerDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/TimerDefinition.java
@@ -39,9 +39,6 @@ public class TimerDefinition {
 
 
     public void checkParams(boolean immediate) {
-        if (null != startTimeMs && startTimeMs < System.currentTimeMillis()) {
-            throw new IllegalArgumentException("startTimeMs must be greater than current time");
-        }
         if (null != startTimeMs && immediate) {
             throw new IllegalArgumentException("startTimeMs must be null when immediate is true");
         }
@@ -52,7 +49,7 @@ public class TimerDefinition {
             startTimeMs = System.currentTimeMillis() + intervalUnit.getIntervalMs(interval);
         }
         if (null != endTimeMs && endTimeMs < startTimeMs) {
-            throw new IllegalArgumentException("end time cannot be less than start time");
+            throw new IllegalArgumentException("endTimeMs must be greater than the start time");
         }
 
         if (null != intervalUnit) {

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
@@ -65,6 +65,9 @@ public class JobExecutionConfigurationTest {
         delayTimes = configuration.getTriggerDelayTimes(
                 1001000L, 0L, 1000000L);
         Assertions.assertEquals(1, delayTimes.size());
+        timerDefinition.setStartTimeMs(2000L);
+        timerDefinition.setIntervalUnit(IntervalUnit.SECOND);
+        Assertions.assertArrayEquals(new Long[]{2L, 12L}, configuration.getTriggerDelayTimes(100000L, 100000L, 120000L).toArray());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

In some cases, users want to set the start time to a time in the past.

**For periodic scheduling tasks only, the start time of a one-time task must be set to the future or present time**
**If the start time is the past time, then the next execution time should be the start time + time interval.**

(cherry picked from commit fa6061070f6d4063b1966e99fc285e4e6b9c3750)



#36732

