### PR TITLE
[opt](cast) use fmt in cast float to string 

### DIFF
--- a/be/src/vec/data_types/data_type_number.cpp
+++ b/be/src/vec/data_types/data_type_number.cpp
@@ -47,10 +47,6 @@ void DataTypeNumber<T>::push_number(ColumnString::Chars& chars, const T& num) co
     if constexpr (std::is_same<T, UInt128>::value) {
         std::string hex = int128_to_string(num);
         chars.insert(hex.begin(), hex.end());
-    } else if constexpr (std::is_same_v<T, float>) {
-        char buf[MAX_FLOAT_STR_LENGTH + 2];
-        int len = FloatToBuffer(num, MAX_FLOAT_STR_LENGTH + 2, buf);
-        chars.insert(buf, buf + len);
     } else if constexpr (std::is_same_v<Int128, T> || std::numeric_limits<T>::is_iec559) {
         fmt::memory_buffer buffer;
         fmt::format_to(buffer, "{}", num);

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -54,12 +54,6 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
         std::string hex =
                 int128_to_string(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
         ostr.write(hex.data(), hex.size());
-    } else if constexpr (std::is_same_v<T, float>) {
-        // fmt::format_to maybe get inaccurate results at float type, so we use gutil implement.
-        char buf[MAX_FLOAT_STR_LENGTH + 2];
-        int len = FloatToBuffer(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num),
-                                MAX_FLOAT_STR_LENGTH + 2, buf);
-        ostr.write(buf, len);
     } else if constexpr (std::is_integral<T>::value || std::numeric_limits<T>::is_iec559) {
         ostr.write_number(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
     }


### PR DESCRIPTION
## Proposed changes

before
```
mysql [test10]>select cast(f64 as string) from nums;
+--------------+
| ReturnedRows |
+--------------+
| 20000000     |
+--------------+
1 row in set (0.48 sec)

mysql [test10]>select cast(f32 as string) from nums;
+--------------+
| ReturnedRows |
+--------------+
| 20000000     |
+--------------+
1 row in set (0.98 sec)

```

now
```
mysql [test10]>select cast(f64 as string) from nums;
+--------------+
| ReturnedRows |
+--------------+
| 20000000     |
+--------------+
1 row in set (0.42 sec)

mysql [test10]>select cast(f32 as string) from nums;
+--------------+
| ReturnedRows |
+--------------+
| 20000000     |
+--------------+
1 row in set (0.43 sec)
```

<!--Describe your changes.-->

