### PR TITLE
[fix](readconsistency) avoid table not exist error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -769,7 +769,8 @@ public class StmtExecutor {
             // Query following createting table would throw table not exist error.
             // For example.
             // t1: client issues create table to master fe
-            // t2: client issues query sql to observer fe, the query would fail due to not exist table in plan phase.
+            // t2: client issues query sql to observer fe, the query would fail due to not exist table in
+            //     plan phase.
             // t3: observer fe receive editlog creating the table from the master fe
             syncJournalIfNeeded();
             planner = new NereidsPlanner(statementContext);
@@ -970,7 +971,8 @@ public class StmtExecutor {
                 // Query following createting table would throw table not exist error.
                 // For example.
                 // t1: client issues create table to master fe
-                // t2: client issues query sql to observer fe, the query would fail due to not exist table in plan phase.
+                // t2: client issues query sql to observer fe, the query would fail due to not exist table
+                //     in plan phase.
                 // t3: observer fe receive editlog creating the table from the master fe
                 syncJournalIfNeeded();
                 analyzer = new Analyzer(context.getEnv(), context);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -725,6 +725,12 @@ public class StmtExecutor {
                     return;
                 }
             }
+            
+            // Query following createting table would throw table not exist error.
+            // For example.
+            // t1: client issues create table to master fe
+            // t2: client issues query sql to observer fe, the query would fail due to not exist table in plan phase.
+            // t3: observer fe receive editlog creating the table from the master fe
             syncJournalIfNeeded();
             try {
                 ((Command) logicalPlan).run(context, this);
@@ -760,6 +766,11 @@ public class StmtExecutor {
         } else {
             context.getState().setIsQuery(true);
             // create plan
+            // Query following createting table would throw table not exist error.
+            // For example.
+            // t1: client issues create table to master fe
+            // t2: client issues query sql to observer fe, the query would fail due to not exist table in plan phase.
+            // t3: observer fe receive editlog creating the table from the master fe
             syncJournalIfNeeded();
             planner = new NereidsPlanner(statementContext);
             if (context.getSessionVariable().isEnableMaterializedViewRewrite()) {
@@ -956,6 +967,11 @@ public class StmtExecutor {
                     }
                 }
             } else {
+                // Query following createting table would throw table not exist error.
+                // For example.
+                // t1: client issues create table to master fe
+                // t2: client issues query sql to observer fe, the query would fail due to not exist table in plan phase.
+                // t3: observer fe receive editlog creating the table from the master fe
                 syncJournalIfNeeded();
                 analyzer = new Analyzer(context.getEnv(), context);
                 parsedStmt.analyze(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -725,7 +725,7 @@ public class StmtExecutor {
                     return;
                 }
             }
-            
+
             // Query following createting table would throw table not exist error.
             // For example.
             // t1: client issues create table to master fe

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -725,6 +725,7 @@ public class StmtExecutor {
                     return;
                 }
             }
+            syncJournalIfNeeded();
             try {
                 ((Command) logicalPlan).run(context, this);
             } catch (MustFallbackException e) {
@@ -759,6 +760,7 @@ public class StmtExecutor {
         } else {
             context.getState().setIsQuery(true);
             // create plan
+            syncJournalIfNeeded();
             planner = new NereidsPlanner(statementContext);
             if (context.getSessionVariable().isEnableMaterializedViewRewrite()) {
                 planner.addHook(InitMaterializationContextHook.INSTANCE);
@@ -805,7 +807,6 @@ public class StmtExecutor {
 
     private void handleQueryWithRetry(TUniqueId queryId) throws Exception {
         // queue query here
-        syncJournalIfNeeded();
         int retryTime = Config.max_query_retry_time;
         for (int i = 0; i <= retryTime; i++) {
             try {
@@ -955,6 +956,7 @@ public class StmtExecutor {
                     }
                 }
             } else {
+                syncJournalIfNeeded();
                 analyzer = new Analyzer(context.getEnv(), context);
                 parsedStmt.analyze(analyzer);
                 parsedStmt.checkPriv();


### PR DESCRIPTION
Query following createting table would throw table not exist error.

For example.
t1: client issue create table to master fe
t2: client issue query sql to observer fe, the query would fail due to not exist table in plan phase.
t3: observer fe receive editlog creating the table from the master fe

After the pr:
query at t2 would wait until latest edit log is received from master fe in the observer fe.
