### PR TITLE
[cherry-pick](branch-2.0) pick "[Fix](schema change) Fix schema change fault when add complex type column (#31824)"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -80,7 +80,11 @@ public class AddColumnClause extends AlterTableClause {
                     && columnDef.getAggregateType() == null) {
                 columnDef.setIsKey(true);
             }
+            if (table instanceof OlapTable) {
+                columnDef.setKeysType(((OlapTable) table).getKeysType());
+            }
         }
+
         columnDef.analyze(true);
         if (colPos != null) {
             colPos.analyze();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -22,6 +22,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
@@ -178,6 +179,8 @@ public class ColumnDef {
     private boolean isKey;
     private boolean isAllowNull;
     private boolean isAutoInc;
+    private long autoIncInitValue;
+    private KeysType keysType;
     private DefaultValue defaultValue;
     private String comment;
     private boolean visible;
@@ -290,6 +293,10 @@ public class ColumnDef {
         this.isKey = isKey;
     }
 
+    public void setKeysType(KeysType keysType) {
+        this.keysType = keysType;
+    }
+
     public TypeDef getTypeDef() {
         return typeDef;
     }
@@ -326,8 +333,10 @@ public class ColumnDef {
             if (isKey) {
                 throw new AnalysisException("Key column can not set complex type:" + name);
             }
-            if (aggregateType == null) {
-                throw new AnalysisException("complex type have to use aggregate function: " + name);
+            if (keysType == null || keysType == KeysType.AGG_KEYS) {
+                if (aggregateType == null) {
+                    throw new AnalysisException("complex type have to use aggregate function: " + name);
+                }
             }
             isAllowNull = false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -75,7 +75,11 @@ public class ModifyColumnClause extends AlterTableClause {
                     && columnDef.getAggregateType() == null) {
                 columnDef.setIsKey(true);
             }
+            if (table instanceof OlapTable) {
+                columnDef.setKeysType(((OlapTable) table).getKeysType());
+            }
         }
+
         columnDef.analyze(true);
         if (colPos != null) {
             colPos.analyze();

--- a/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_duplicate.groovy
@@ -203,6 +203,13 @@ suite("test_schema_change_duplicate", "p0") {
     'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', 10086) """
 
     sql """ alter table ${tableName3} drop column v14 """
+    
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
 
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {

--- a/regression-test/suites/schema_change_p0/test_schema_change_unique.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_unique.groovy
@@ -204,6 +204,14 @@ suite("test_schema_change_unique", "p0") {
 
     sql """ alter table ${tableName3} drop column v14 """
 
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
+
+
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {
         assertEquals(2, row[1]);

--- a/regression-test/suites/schema_change_p0/test_schema_change_unique_mow.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_unique_mow.groovy
@@ -205,6 +205,13 @@ suite("test_schema_change_unique_mow", "p0") {
 
     sql """ alter table ${tableName3} drop column v14 """
 
+    sql """ alter table ${tableName3} add column v14 bitmap after k13 """
+
+    sql """ insert into ${tableName3} values (10002, 2, 3, 4, 5, 6.6, 1.7, 8.8,
+    'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00', to_bitmap(243)) """
+
+    sql """ alter table ${tableName3} drop column v14 """
+
     List<List<Object>> result  = sql """ select * from ${tableName3} """
     for (row : result) {
         assertEquals(2, row[1]);


### PR DESCRIPTION
Problem: An error is encountered when executing a schema change on a unique table to add a column with a complex type, such as bitmap, as documented in https://github.com/apache/doris/issues/31365

Reason: The error arises because the schema change logic erroneously applies an aggregation check for new columns across all table types, demanding an explicit aggregation type declaration. However, unique and duplicate tables inherently assume default aggregation types for newly added columns, leading to this misstep.

Solution: The schema change process for introducing new columns needs to distinguish between table types accurately. For unique and duplicate tables, it should automatically assign the appropriate aggregation type, which, for the purpose of smooth integration with subsequent processes, should be set to NONE.

pick #31824

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

