### PR TITLE
[feat](fe) Add `ignore_bdbje_log_checksum_read` for BDBEnvironment (#31247)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2378,6 +2378,15 @@ public class Config extends ConfigBase {
     })
     public static int label_num_threshold = 2000;
 
+    /* https://forums.oracle.com/ords/apexds/post/je-log-checksumexception-2812
+      when meeting disk damage or other reason described in the oracle forums
+      and fe cannot start due to `com.sleepycat.je.log.ChecksumException`, we
+      add a param `ignore_bdbje_log_checksum_read` to ignore the exception, but
+      there is no guarantee of correctness for bdbje kv data
+    */
+    @ConfField
+    public static boolean ignore_bdbje_log_checksum_read = false;
+
     @ConfField(description = {
             "是否开启 Proxy Protocol 支持",
             "Whether to enable proxy protocol"

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -140,6 +140,11 @@ public class BDBEnvironment {
         environmentConfig.setConfigParam(EnvironmentConfig.RESERVED_DISK,
                 String.valueOf(Config.bdbje_reserved_disk_bytes));
 
+        if (Config.ignore_bdbje_log_checksum_read) {
+            environmentConfig.setConfigParam(EnvironmentConfig.LOG_CHECKSUM_READ, "false");
+            LOG.warn("set EnvironmentConfig.LOG_CHECKSUM_READ false");
+        }
+
         if (BDBJE_LOG_LEVEL.contains(Config.bdbje_file_logging_level)) {
             java.util.logging.Logger parent = java.util.logging.Logger.getLogger("com.sleepycat.je");
             parent.setLevel(Level.parse(Config.bdbje_file_logging_level));


### PR DESCRIPTION
* https://forums.oracle.com/ords/apexds/post/je-log-checksumexception-2812

* When meeting disk damage or other reason described in the oracle forums and fe cannot start due to `com.sleepycat.je.log.ChecksumException`, we add a param `ignore_bdbje_log_checksum_read` to ignore the exception, but there is no guarantee of correctness for bdbje kv data

## Proposed changes

pick #31247

Issue Number: close #xxx

<!--Describe your changes.-->

