### PR TITLE
[Fix](Nereids) fix fe fold constant evaluate like function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -43,7 +43,6 @@ import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
-import org.apache.doris.nereids.trees.expressions.Like;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
@@ -401,11 +400,6 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
             // null or null
             return new NullLiteral(BooleanType.INSTANCE);
         }
-    }
-
-    @Override
-    public Expression visitLike(Like like, ExpressionRewriteContext context) {
-        return like;
     }
 
     @Override

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
@@ -19,6 +19,7 @@ suite("test_fold_constant_by_fe") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set enable_fold_nondeterministic_fn=true'
+    sql 'set enable_fold_constant_by_be=false'
 
     def results = sql 'select uuid(), uuid()'
     assertFalse(Objects.equals(results[0][0], results[0][1]))
@@ -154,4 +155,12 @@ suite("test_fold_constant_by_fe") {
         res = res.split('VUNION')[1]
         assertFalse(res.contains("unix"))
     }
+
+    // test null like string cause of fe need to fold constant like that to enable not null derive
+    res = sql """explain select null like '%123%'"""
+    assertFalse(res.contains("like"))
+    // now fe fold constant still can not deal with this case
+    res = sql """explain select "12" like '%123%'"""
+    assertTrue(res.contains("like"))
+
 }


### PR DESCRIPTION
Problem:
When evaluating like function using fe, it can not evaluating nullliteral correctly
Example:
Null like "%string%"   can not folded to null on fe
Reason:
Fe fold constant does not deal with like function
Solved:
Add fe fold constant of like function

