### PR TITLE
[feature](Recycler) Parallelize s3 delete operations and recycle_tablet 

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -62,6 +62,8 @@ CONF_Strings(recycle_whitelist, ""); // Comma seprated list
 CONF_Strings(recycle_blacklist, ""); // Comma seprated list
 CONF_mInt32(instance_recycler_worker_pool_size, "1");
 CONF_Bool(enable_checker, "false");
+// The parallelism for parallel recycle operation
+CONF_Int32(recycle_pool_parallelism, "10");
 // Currently only used for recycler test
 CONF_Bool(enable_inverted_check, "false");
 // interval for scanning instances to do checks and inspections

--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -209,7 +209,8 @@ std::unique_ptr<ObjectListIterator> AzureObjClient::list_objects(ObjectStoragePa
 // You can find out the num in https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch?tabs=microsoft-entra-id
 // > Each batch request supports a maximum of 256 subrequests.
 ObjectStorageResponse AzureObjClient::delete_objects(const std::string& bucket,
-                                                     std::vector<std::string> keys) {
+                                                     std::vector<std::string> keys,
+                                                     ObjClientOptions option) {
     if (keys.empty()) {
         return {0};
     }
@@ -275,8 +276,9 @@ ObjectStorageResponse AzureObjClient::delete_object(ObjectStoragePathRef path) {
 }
 
 ObjectStorageResponse AzureObjClient::delete_objects_recursively(ObjectStoragePathRef path,
+                                                                 ObjClientOptions option,
                                                                  int64_t expiration_time) {
-    return delete_objects_recursively_(path, expiration_time, BlobBatchMaxOperations);
+    return delete_objects_recursively_(path, option, expiration_time, BlobBatchMaxOperations);
 }
 
 ObjectStorageResponse AzureObjClient::get_life_cycle(const std::string& bucket,

--- a/cloud/src/recycler/azure_obj_client.h
+++ b/cloud/src/recycler/azure_obj_client.h
@@ -38,12 +38,13 @@ public:
 
     std::unique_ptr<ObjectListIterator> list_objects(ObjectStoragePathRef path) override;
 
-    ObjectStorageResponse delete_objects(const std::string& bucket,
-                                         std::vector<std::string> keys) override;
+    ObjectStorageResponse delete_objects(const std::string& bucket, std::vector<std::string> keys,
+                                         ObjClientOptions option) override;
 
     ObjectStorageResponse delete_object(ObjectStoragePathRef path) override;
 
     ObjectStorageResponse delete_objects_recursively(ObjectStoragePathRef path,
+                                                     ObjClientOptions option,
                                                      int64_t expiration_time = 0) override;
 
     ObjectStorageResponse get_life_cycle(const std::string& bucket,

--- a/cloud/src/recycler/obj_storage_client.cpp
+++ b/cloud/src/recycler/obj_storage_client.cpp
@@ -18,10 +18,13 @@
 #include "recycler/obj_storage_client.h"
 
 #include "cpp/sync_point.h"
+#include "recycler/sync_executor.h"
+#include "recycler/util.h"
 
 namespace doris::cloud {
 
 ObjectStorageResponse ObjStorageClient::delete_objects_recursively_(ObjectStoragePathRef path,
+                                                                    const ObjClientOptions& option,
                                                                     int64_t expired_time,
                                                                     size_t batch_size) {
     TEST_SYNC_POINT_CALLBACK("ObjStorageClient::delete_objects_recursively_", &batch_size);
@@ -29,6 +32,10 @@ ObjectStorageResponse ObjStorageClient::delete_objects_recursively_(ObjectStorag
 
     ObjectStorageResponse ret;
     std::vector<std::string> keys;
+    SyncExecutor<int> concurrent_delete_executor(
+            option.executor,
+            fmt::format("delete objects under bucket {}, path {}", path.bucket, path.key),
+            [](const int& ret) { return ret != 0; });
 
     for (auto obj = list_iter->next(); obj.has_value(); obj = list_iter->next()) {
         if (expired_time > 0 && obj->mtime_s > expired_time) {
@@ -39,20 +46,31 @@ ObjectStorageResponse ObjStorageClient::delete_objects_recursively_(ObjectStorag
         if (keys.size() < batch_size) {
             continue;
         }
-
-        ret = delete_objects(path.bucket, std::move(keys));
-        if (ret.ret != 0) {
-            return ret;
-        }
+        concurrent_delete_executor.add([this, &path, k = std::move(keys), option]() mutable {
+            return delete_objects(path.bucket, std::move(k), option).ret;
+        });
     }
 
     if (!list_iter->is_valid()) {
+        bool finished;
+        concurrent_delete_executor.when_all(&finished);
         return {-1};
     }
 
     if (!keys.empty()) {
-        return delete_objects(path.bucket, std::move(keys));
+        concurrent_delete_executor.add([this, &path, k = std::move(keys), option]() mutable {
+            return delete_objects(path.bucket, std::move(k), option).ret;
+        });
     }
+    bool finished = true;
+    std::vector<int> rets = concurrent_delete_executor.when_all(&finished);
+    for (int r : rets) {
+        if (r != 0) {
+            ret = -1;
+        }
+    }
+
+    ret = finished ? ret : -1;
 
     return ret;
 }

--- a/cloud/src/recycler/obj_storage_client.h
+++ b/cloud/src/recycler/obj_storage_client.h
@@ -51,6 +51,12 @@ public:
     virtual std::optional<ObjectMeta> next() = 0;
 };
 
+class SimpleThreadPool;
+struct ObjClientOptions {
+    bool prefetch {true};
+    std::shared_ptr<SimpleThreadPool> executor;
+};
+
 class ObjStorageClient {
 public:
     ObjStorageClient() = default;
@@ -71,7 +77,8 @@ public:
 
     // According to the bucket and prefix specified by the user, it performs batch deletion based on the object names in the object array.
     virtual ObjectStorageResponse delete_objects(const std::string& bucket,
-                                                 std::vector<std::string> keys) = 0;
+                                                 std::vector<std::string> keys,
+                                                 ObjClientOptions option) = 0;
 
     // Delete the file named key in the object storage bucket.
     virtual ObjectStorageResponse delete_object(ObjectStoragePathRef path) = 0;
@@ -79,6 +86,7 @@ public:
     // According to the prefix, recursively delete all objects under the prefix.
     // If `expiration_time` > 0, only delete objects with mtime earlier than `expiration_time`.
     virtual ObjectStorageResponse delete_objects_recursively(ObjectStoragePathRef path,
+                                                             ObjClientOptions option,
                                                              int64_t expiration_time = 0) = 0;
 
     // Get the objects' expiration time on the bucket
@@ -91,6 +99,7 @@ public:
 
 protected:
     ObjectStorageResponse delete_objects_recursively_(ObjectStoragePathRef path,
+                                                      const ObjClientOptions& option,
                                                       int64_t expiration_time, size_t batch_size);
 };
 

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -40,6 +40,24 @@ class TxnKv;
 class InstanceRecycler;
 class StorageVaultAccessor;
 class Checker;
+class SimpleThreadPool;
+struct RecyclerThreadPoolGroup {
+    RecyclerThreadPoolGroup() = default;
+    RecyclerThreadPoolGroup(std::shared_ptr<SimpleThreadPool> s3_producer_pool,
+                            std::shared_ptr<SimpleThreadPool> recycle_tablet_pool,
+                            std::shared_ptr<SimpleThreadPool> group_recycle_function_pool)
+            : s3_producer_pool(std::move(s3_producer_pool)),
+              recycle_tablet_pool(std::move(recycle_tablet_pool)),
+              group_recycle_function_pool(std::move(group_recycle_function_pool)) {}
+    ~RecyclerThreadPoolGroup() = default;
+    RecyclerThreadPoolGroup(const RecyclerThreadPoolGroup&) = default;
+    RecyclerThreadPoolGroup& operator=(RecyclerThreadPoolGroup& other) = default;
+    RecyclerThreadPoolGroup& operator=(RecyclerThreadPoolGroup&& other) = default;
+    RecyclerThreadPoolGroup(RecyclerThreadPoolGroup&&) = default;
+    std::shared_ptr<SimpleThreadPool> s3_producer_pool;
+    std::shared_ptr<SimpleThreadPool> recycle_tablet_pool;
+    std::shared_ptr<SimpleThreadPool> group_recycle_function_pool;
+};
 
 class Recycler {
 public:
@@ -83,11 +101,13 @@ private:
 
     WhiteBlackList instance_filter_;
     std::unique_ptr<Checker> checker_;
+    RecyclerThreadPoolGroup _thread_pool_group;
 };
 
 class InstanceRecycler {
 public:
-    explicit InstanceRecycler(std::shared_ptr<TxnKv> txn_kv, const InstanceInfoPB& instance);
+    explicit InstanceRecycler(std::shared_ptr<TxnKv> txn_kv, const InstanceInfoPB& instance,
+                              RecyclerThreadPoolGroup thread_pool_group);
     ~InstanceRecycler();
 
     // returns 0 for success otherwise error
@@ -217,6 +237,7 @@ private:
     std::mutex recycle_tasks_mutex;
     // <task_name, start_time>>
     std::map<std::string, int64_t> running_recycle_tasks;
+    RecyclerThreadPoolGroup _thread_pool_group;
 };
 
 } // namespace doris::cloud

--- a/cloud/src/recycler/recycler_service.cpp
+++ b/cloud/src/recycler/recycler_service.cpp
@@ -151,7 +151,8 @@ void RecyclerServiceImpl::check_instance(const std::string& instance_id, MetaSer
 }
 
 void recycle_copy_jobs(const std::shared_ptr<TxnKv>& txn_kv, const std::string& instance_id,
-                       MetaServiceCode& code, std::string& msg) {
+                       MetaServiceCode& code, std::string& msg,
+                       RecyclerThreadPoolGroup thread_pool_group) {
     std::unique_ptr<Transaction> txn;
     TxnErrorCode err = txn_kv->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
@@ -188,13 +189,13 @@ void recycle_copy_jobs(const std::shared_ptr<TxnKv>& txn_kv, const std::string& 
             return;
         }
     }
-    auto recycler = std::make_unique<InstanceRecycler>(txn_kv, instance);
+
+    auto recycler = std::make_unique<InstanceRecycler>(txn_kv, instance, thread_pool_group);
     if (recycler->init() != 0) {
         LOG(WARNING) << "failed to init InstanceRecycler recycle_copy_jobs on instance "
                      << instance_id;
         return;
     }
-
     std::thread worker([recycler = std::move(recycler), instance_id] {
         LOG(INFO) << "manually trigger recycle_copy_jobs on instance " << instance_id;
         recycler->recycle_copy_jobs();
@@ -332,7 +333,7 @@ void RecyclerServiceImpl::http(::google::protobuf::RpcController* controller,
             status_code = 400;
             return;
         }
-        recycle_copy_jobs(txn_kv_, *instance_id, code, msg);
+        recycle_copy_jobs(txn_kv_, *instance_id, code, msg, recycler_->_thread_pool_group);
         response_body = msg;
         return;
     }

--- a/cloud/src/recycler/s3_accessor.h
+++ b/cloud/src/recycler/s3_accessor.h
@@ -34,6 +34,7 @@ class S3RateLimiterHolder;
 enum class S3RateLimitType;
 namespace cloud {
 class ObjectStoreInfoPB;
+class SimpleThreadPool;
 
 struct AccessorRateLimiter {
 public:

--- a/cloud/src/recycler/s3_obj_client.cpp
+++ b/cloud/src/recycler/s3_obj_client.cpp
@@ -192,7 +192,8 @@ std::unique_ptr<ObjectListIterator> S3ObjClient::list_objects(ObjectStoragePathR
 }
 
 ObjectStorageResponse S3ObjClient::delete_objects(const std::string& bucket,
-                                                  std::vector<std::string> keys) {
+                                                  std::vector<std::string> keys,
+                                                  ObjClientOptions option) {
     if (keys.empty()) {
         return {0};
     }
@@ -281,8 +282,9 @@ ObjectStorageResponse S3ObjClient::delete_object(ObjectStoragePathRef path) {
 }
 
 ObjectStorageResponse S3ObjClient::delete_objects_recursively(ObjectStoragePathRef path,
+                                                              ObjClientOptions option,
                                                               int64_t expiration_time) {
-    return delete_objects_recursively_(path, expiration_time, MaxDeleteBatch);
+    return delete_objects_recursively_(path, option, expiration_time, MaxDeleteBatch);
 }
 
 ObjectStorageResponse S3ObjClient::get_life_cycle(const std::string& bucket,

--- a/cloud/src/recycler/s3_obj_client.h
+++ b/cloud/src/recycler/s3_obj_client.h
@@ -39,12 +39,13 @@ public:
 
     std::unique_ptr<ObjectListIterator> list_objects(ObjectStoragePathRef path) override;
 
-    ObjectStorageResponse delete_objects(const std::string& bucket,
-                                         std::vector<std::string> keys) override;
+    ObjectStorageResponse delete_objects(const std::string& bucket, std::vector<std::string> keys,
+                                         ObjClientOptions option) override;
 
     ObjectStorageResponse delete_object(ObjectStoragePathRef path) override;
 
     ObjectStorageResponse delete_objects_recursively(ObjectStoragePathRef path,
+                                                     ObjClientOptions option,
                                                      int64_t expiration_time = 0) override;
 
     ObjectStorageResponse get_life_cycle(const std::string& bucket,

--- a/cloud/src/recycler/sync_executor.h
+++ b/cloud/src/recycler/sync_executor.h
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <bthread/countdown_event.h>
+#include <fmt/core.h>
+#include <gen_cpp/cloud.pb.h>
+#include <glog/logging.h>
+
+#include <future>
+#include <iostream>
+#include <string>
+
+#include "common/logging.h"
+#include "common/simple_thread_pool.h"
+
+namespace doris::cloud {
+
+template <typename T>
+class SyncExecutor {
+public:
+    SyncExecutor(
+            std::shared_ptr<SimpleThreadPool> pool, std::string name_tag,
+            std::function<bool(const T&)> cancel = [](const T& /**/) { return false; })
+            : _pool(std::move(pool)), _cancel(std::move(cancel)), _name_tag(std::move(name_tag)) {}
+    auto add(std::function<T()> callback) -> SyncExecutor<T>& {
+        auto task = std::make_unique<Task>(std::move(callback), _cancel, _count);
+        _count.add_count();
+        // The actual task logic would be wrapped by one promise and passed to the threadpool.
+        // The result would be returned by the future once the task is finished.
+        // Or the task would be invalid if the whole task is cancelled.
+        int r = _pool->submit([this, t = task.get()]() { (*t)(_stop_token); });
+        CHECK(r == 0);
+        _res.emplace_back(std::move(task));
+        return *this;
+    }
+    std::vector<T> when_all(bool* finished) {
+        timespec current_time;
+        auto current_time_second = time(nullptr);
+        current_time.tv_sec = current_time_second + 300;
+        current_time.tv_nsec = 0;
+        auto msg = fmt::format("{} has already taken 5 min", _name_tag);
+        while (0 != _count.timed_wait(current_time)) {
+            current_time.tv_sec += 300;
+            LOG(WARNING) << msg;
+        }
+        *finished = !_stop_token;
+        std::vector<T> res;
+        res.reserve(_res.size());
+        for (auto& task : _res) {
+            if (!task->valid()) {
+                *finished = false;
+                return res;
+            }
+            res.emplace_back((*task).get());
+        }
+        return res;
+    }
+    void reset() {
+        _res.clear();
+        _stop_token = false;
+    }
+
+private:
+    class Task {
+    public:
+        Task(std::function<T()> callback, std::function<bool(const T&)> cancel,
+             bthread::CountdownEvent& count)
+                : _callback(std::move(callback)),
+                  _cancel(std::move(cancel)),
+                  _count(count),
+                  _fut(_pro.get_future()) {}
+        void operator()(std::atomic_bool& stop_token) {
+            std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01,
+                                                                  [&](int*) { _count.signal(); });
+            if (stop_token) {
+                _valid = false;
+                return;
+            }
+            T t = _callback();
+            // We'll return this task result to user even if this task return error
+            // So we don't set _valid to false here
+            if (_cancel(t)) {
+                stop_token = true;
+            }
+            _pro.set_value(std::move(t));
+        }
+        bool valid() { return _valid; }
+        T get() { return _fut.get(); }
+
+    private:
+        // It's guarantted that the valid function can only be called inside SyncExecutor's `when_all()` function
+        // and only be called when the _count.timed_wait function returned. So there would be no data race for
+        // _valid then it doesn't need to be one atomic bool.
+        bool _valid = true;
+        std::function<T()> _callback;
+        std::function<bool(const T&)> _cancel;
+        std::promise<T> _pro;
+        bthread::CountdownEvent& _count;
+        std::future<T> _fut;
+    };
+    std::vector<std::unique_ptr<Task>> _res;
+    // use CountdownEvent to do periodically log using CountdownEvent::time_wait()
+    bthread::CountdownEvent _count {0};
+    std::atomic_bool _stop_token {false};
+    std::shared_ptr<SimpleThreadPool> _pool;
+    std::function<bool(const T&)> _cancel;
+    std::string _name_tag;
+};
+} // namespace doris::cloud

--- a/cloud/src/recycler/util.h
+++ b/cloud/src/recycler/util.h
@@ -19,6 +19,7 @@
 
 #include <fmt/core.h>
 #include <gen_cpp/cloud.pb.h>
+#include <glog/logging.h>
 
 #include <string>
 

--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -50,9 +50,9 @@ add_executable(s3_accessor_test s3_accessor_test.cpp)
 
 add_executable(hdfs_accessor_test hdfs_accessor_test.cpp)
 
-add_executable(util_test util_test.cpp)
-
 add_executable(stopwatch_test stopwatch_test.cpp)
+
+add_executable(util_test util_test.cpp)
 
 add_executable(network_util_test network_util_test.cpp)
 
@@ -85,9 +85,9 @@ target_link_libraries(s3_accessor_test ${TEST_LINK_LIBS})
 
 target_link_libraries(hdfs_accessor_test ${TEST_LINK_LIBS})
 
-target_link_libraries(util_test ${TEST_LINK_LIBS})
-
 target_link_libraries(stopwatch_test ${TEST_LINK_LIBS})
+
+target_link_libraries(util_test ${TEST_LINK_LIBS})
 
 target_link_libraries(network_util_test ${TEST_LINK_LIBS})
 

--- a/cloud/test/util_test.cpp
+++ b/cloud/test/util_test.cpp
@@ -15,17 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "recycler/util.h"
+
+#include <chrono>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <tuple>
 #include <vector>
 
 #include "common/config.h"
+#include "common/logging.h"
+#include "common/simple_thread_pool.h"
 #include "common/string_util.h"
-#include "glog/logging.h"
 #include "gtest/gtest.h"
+#include "recycler/recycler.h"
+#include "recycler/sync_executor.h"
+
+using namespace doris::cloud;
 
 int main(int argc, char** argv) {
-    doris::cloud::config::init(nullptr, true);
+    const auto* conf_file = "doris_cloud.conf";
+    if (!config::init(conf_file, true)) {
+        std::cerr << "failed to init config file, conf=" << conf_file << std::endl;
+        return -1;
+    }
+    if (!::init_glog("util")) {
+        std::cerr << "failed to init glog" << std::endl;
+        return -1;
+    }
+
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
@@ -88,4 +107,131 @@ TEST(StringUtilTest, test_string_strip) {
     }
 
     // clang-format on
+}
+
+template <typename... Func>
+auto task_wrapper(Func... funcs) -> std::function<int()> {
+    return [funcs...]() {
+        return [](std::initializer_list<int> numbers) {
+            int i = 0;
+            for (int num : numbers) {
+                if (num != 0) {
+                    i = num;
+                }
+            }
+            return i;
+        }({funcs()...});
+    };
+}
+
+TEST(UtilTest, stage_wrapper) {
+    std::function<int()> func1 = []() { return 0; };
+    std::function<int()> func2 = []() { return -1; };
+    std::function<int()> func3 = []() { return 0; };
+    auto f = task_wrapper(func1, func2, func3);
+    ASSERT_EQ(-1, f());
+
+    f = task_wrapper(func1, func3);
+    ASSERT_EQ(0, f());
+}
+
+TEST(UtilTest, delay) {
+    auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
+    s3_producer_pool->start();
+    // test normal execute
+    {
+        SyncExecutor<int> sync_executor(s3_producer_pool, "normal test",
+                                        [](int k) { return k == -1; });
+        auto f1 = []() { return -1; };
+        auto f2 = []() {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            return 1;
+        };
+        sync_executor.add(f2);
+        sync_executor.add(f2);
+        sync_executor.add(f1);
+        bool finished = true;
+        std::vector<int> res = sync_executor.when_all(&finished);
+        ASSERT_EQ(finished, false);
+        ASSERT_EQ(3, res.size());
+    }
+    // test normal execute
+    {
+        SyncExecutor<std::string_view> sync_executor(
+                s3_producer_pool, "normal test",
+                [](const std::string_view k) { return k.empty(); });
+        auto f1 = []() { return ""; };
+        auto f2 = []() {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            return "fake";
+        };
+        sync_executor.add(f2);
+        sync_executor.add(f2);
+        sync_executor.add(f1);
+        bool finished = true;
+        auto res = sync_executor.when_all(&finished);
+        ASSERT_EQ(finished, false);
+        ASSERT_EQ(3, res.size());
+    }
+}
+
+TEST(UtilTest, normal) {
+    auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
+    s3_producer_pool->start();
+    // test normal execute
+    {
+        SyncExecutor<int> sync_executor(s3_producer_pool, "normal test",
+                                        [](int k) { return k == -1; });
+        auto f1 = []() { return 1; };
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        bool finished = true;
+        std::vector<int> res = sync_executor.when_all(&finished);
+        ASSERT_EQ(3, res.size());
+        ASSERT_EQ(finished, true);
+        std::for_each(res.begin(), res.end(), [](auto&& n) { ASSERT_EQ(1, n); });
+    }
+    // test when error happen
+    {
+        SyncExecutor<int> sync_executor(s3_producer_pool, "normal test",
+                                        [](int k) { return k == -1; });
+        auto f1 = []() { return 1; };
+        sync_executor._stop_token = true;
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        bool finished = true;
+        std::vector<int> res = sync_executor.when_all(&finished);
+        ASSERT_EQ(finished, false);
+        ASSERT_EQ(0, res.size());
+    }
+    {
+        SyncExecutor<int> sync_executor(s3_producer_pool, "normal test",
+                                        [](int k) { return k == -1; });
+        auto f1 = []() { return 1; };
+        auto cancel = []() { return -1; };
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        sync_executor.add(cancel);
+        bool finished = true;
+        std::vector<int> res = sync_executor.when_all(&finished);
+        ASSERT_EQ(finished, false);
+    }
+    // test string_view
+    {
+        SyncExecutor<std::string_view> sync_executor(
+                s3_producer_pool, "normal test",
+                [](const std::string_view k) { return k.empty(); });
+        std::string s = "Hello World";
+        auto f1 = [&s]() { return std::string_view(s); };
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        sync_executor.add(f1);
+        bool finished = true;
+        std::vector<std::string_view> res = sync_executor.when_all(&finished);
+        ASSERT_EQ(3, res.size());
+        std::for_each(res.begin(), res.end(), [&s](auto&& n) { ASSERT_EQ(s, n); });
+    }
 }


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Previously the procedure of recycler instance is single-threaded, which is not full sufficiently parallel.  And there exists many network IO operation. So this pr tries to spilt recycle tasks into different stage which can be parallel. And make the delete operations parallel.

