### PR TITLE
[bugfix](wg) should not remove token directly, there maybe concurrency problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueryQueue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueryQueue.java
@@ -165,13 +165,4 @@ public class QueryQueue {
         }
     }
 
-    public void removeToken(QueueToken queueToken) {
-        queueLock.lock();
-        try {
-            priorityTokenQueue.remove(queueToken);
-        } finally {
-            queueLock.unlock();
-        }
-    }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueueToken.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/QueueToken.java
@@ -76,13 +76,13 @@ public class QueueToken implements Comparable<QueueToken> {
         try {
             future.get(waitTimeout, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
-            queue.removeToken(this);
+            queue.releaseAndNotify(this);
             throw new UserException("query queue timeout, timeout: " + waitTimeout + " ms ");
         } catch (CancellationException e) {
-            queue.removeToken(this);
+            queue.releaseAndNotify(this);
             throw new UserException("query is cancelled");
         } catch (Throwable t) {
-            queue.removeToken(this);
+            queue.releaseAndNotify(this);
             String errMsg = String.format("error happens when query {} queue", queryId);
             LOG.error(errMsg, t);
             throw new RuntimeException(errMsg, t);


### PR DESCRIPTION
remove token api will not check token state is ready to run. If the token is set to ready to run before call remove token, then the currentRunningQueryNum is not decrement. 

imported by PR https://github.com/apache/doris/pull/35929/files
