### PR TITLE
[config](trash) change trash_file_expire_time_sec to 0

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -319,7 +319,7 @@ DEFINE_mInt32(garbage_sweep_batch_size, "100");
 DEFINE_mInt32(snapshot_expire_time_sec, "172800");
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
-DEFINE_mInt32(trash_file_expire_time_sec, "86400");
+DEFINE_mInt32(trash_file_expire_time_sec, "0");
 // minimum file descriptor number
 // modify them upon necessity
 DEFINE_Int32(min_file_descriptor_number, "60000");


### PR DESCRIPTION
long time ago, doris may lost data due to program bug:
1) during migrate or clone,  may cause new replica lost data;
2) a tablet may delete all its replicas.

But all these bugs had been solved. Now trash is useless.  There's hardly no user use trash to restore data for prod env.  Even a user can use a http to restore data from trash,  it still cann't use immedidately  because  fe not contains its meta.

On the other hand,  trash has cause other problems:
1) make unbalance because not deleleted the trash data;
2) be chose disks not RR because the disks may suddently delete a lot trash data when disk's usage over 80%;
3) had more disk load.

Considering all this, we make trash_file_expire_time_sec change to 0.  If user really want to keep trash,  they need to set trash_file_expire_time_sec > 0 manually.

