### PR TITLE
[branch-2.0](timezone) make TimeUtils formatter use correct time_zone (#37465)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -648,7 +648,7 @@ public class Analyzer {
         Calendar currentDate = Calendar.getInstance();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(currentDate.toInstant(),
                 currentDate.getTimeZone().toZoneId());
-        String nowStr = localDateTime.format(TimeUtils.DATETIME_NS_FORMAT);
+        String nowStr = localDateTime.format(TimeUtils.getDatetimeNsFormatWithTimeZone());
         queryGlobals.setNowString(nowStr);
         queryGlobals.setNanoSeconds(LocalDateTime.now().getNano());
         return queryGlobals;

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -452,7 +452,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 throw new DdlException("read backup meta failed", e);
             }
             String backupTimestamp = TimeUtils.longToTimeString(
-                    jobInfo.getBackupTime(), TimeUtils.DATETIME_FORMAT_WITH_HYPHEN);
+                    jobInfo.getBackupTime(), TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
             restoreJob = new RestoreJob(stmt.getLabel(), backupTimestamp,
                     db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicaAlloc(),
                     stmt.getTimeoutMs(), metaVersion, stmt.reserveReplica(),

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -673,7 +673,8 @@ public class BackupJob extends AbstractJob {
     }
 
     private void saveMetaInfo() {
-        String createTimeStr = TimeUtils.longToTimeString(createTime, TimeUtils.DATETIME_FORMAT_WITH_HYPHEN);
+        String createTimeStr = TimeUtils.longToTimeString(createTime,
+                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
         // local job dir: backup/repo__repo_id/label__createtime/
         // Add repo_id to isolate jobs from different repos.
         localJobDirPath = Paths.get(BackupHandler.BACKUP_ROOT_DIR.toString(),

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -141,7 +141,7 @@ public class Repository implements Writable {
             return PREFIX_JOB_INFO;
         } else {
             return PREFIX_JOB_INFO
-                    + TimeUtils.longToTimeString(createTime, TimeUtils.DATETIME_FORMAT_WITH_HYPHEN);
+                    + TimeUtils.longToTimeString(createTime, TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -400,9 +400,9 @@ public class DynamicPartitionUtil {
 
     private static DateTimeFormatter getDateTimeFormatter(String timeUnit) {
         if (timeUnit.equalsIgnoreCase(TimeUnit.HOUR.toString())) {
-            return TimeUtils.DATETIME_FORMAT;
+            return TimeUtils.getDatetimeFormatWithTimeZone();
         } else {
-            return TimeUtils.DATE_FORMAT;
+            return TimeUtils.getDateFormatWithTimeZone();
         }
     }
 
@@ -806,9 +806,9 @@ public class DynamicPartitionUtil {
 
     private static LocalDateTime getDateTimeByTimeUnit(String time, String timeUnit) {
         if (timeUnit.equalsIgnoreCase(TimeUnit.HOUR.toString())) {
-            return LocalDateTime.parse(time, TimeUtils.DATETIME_FORMAT);
+            return LocalDateTime.parse(time, TimeUtils.getDatetimeFormatWithTimeZone());
         } else {
-            return LocalDate.from(TimeUtils.DATE_FORMAT.parse(time)).atStartOfDay();
+            return LocalDate.from(TimeUtils.getDateFormatWithTimeZone().parse(time)).atStartOfDay();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -29,7 +29,6 @@ import org.apache.doris.qe.VariableMgr;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,6 +46,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,13 +55,7 @@ import java.util.regex.Pattern;
 public class TimeUtils {
     public static final String UTC_TIME_ZONE = "Europe/London"; // This is just a Country to represent UTC offset +00:00
     public static final String DEFAULT_TIME_ZONE = "Asia/Shanghai";
-    public static final ZoneId TIME_ZONE;
     public static final ImmutableMap<String, String> timeZoneAliasMap;
-    // NOTICE: Date formats are not synchronized.
-    // it must be used as synchronized externally.
-    public static final DateTimeFormatter DATE_FORMAT;
-    public static final DateTimeFormatter DATETIME_FORMAT;
-    public static final DateTimeFormatter TIME_FORMAT;
     public static final Pattern DATETIME_FORMAT_REG =
             Pattern.compile("^((\\d{2}(([02468][048])|([13579][26]))[\\-\\/\\s]?((((0?[13578])|(1[02]))[\\-\\/\\s]?"
                     + "((0?[1-9])|([1-2][0-9])|(3[01])))|(((0?[469])|(11))[\\-\\/\\s]?"
@@ -70,25 +64,49 @@ public class TimeUtils {
                     + "[\\-\\/\\s]?((0?[1-9])|([1-2][0-9])|(3[01])))|(((0?[469])|(11))[\\-\\/\\s]?"
                     + "((0?[1-9])|([1-2][0-9])|(30)))|(0?2[\\-\\/\\s]?((0?[1-9])|(1[0-9])|(2[0-8]))))))"
                     + "(\\s(((0?[0-9])|([1][0-9])|([2][0-3]))\\:([0-5]?[0-9])((\\s)|(\\:([0-5]?[0-9])))))?$");
-    public static final DateTimeFormatter DATETIME_MS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-            .withZone(ZoneId.systemDefault());
-    public static final DateTimeFormatter DATETIME_NS_FORMAT = DateTimeFormatter.ofPattern(
-                    "yyyy-MM-dd HH:mm:ss.SSSSSSSSS")
-            .withZone(ZoneId.systemDefault());
-    public static final DateTimeFormatter DATETIME_FORMAT_WITH_HYPHEN = DateTimeFormatter.ofPattern(
-                    "yyyy-MM-dd-HH-mm-ss")
-            .withZone(ZoneId.systemDefault());
+
+    // these formatters must be visited by getter to make sure they have right
+    // timezone.
+    // NOTICE: Date formats are not synchronized.
+    // it must be used as synchronized externally.
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH");
+    private static final DateTimeFormatter DATETIME_MS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final DateTimeFormatter DATETIME_NS_FORMAT = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
+    private static final DateTimeFormatter DATETIME_FORMAT_WITH_HYPHEN = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd-HH-mm-ss");
+
+    public static DateTimeFormatter getDateFormatWithTimeZone() {
+        return DATE_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getDatetimeFormatWithTimeZone() {
+        return DATETIME_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getTimeFormatWithTimeZone() {
+        return TIME_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getDatetimeMsFormatWithTimeZone() {
+        return DATETIME_MS_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getDatetimeNsFormatWithTimeZone() {
+        return DATETIME_NS_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getDatetimeFormatWithHyphenWithTimeZone() {
+        return DATETIME_FORMAT_WITH_HYPHEN.withZone(getDorisZoneId());
+    }
+
     private static final Logger LOG = LogManager.getLogger(TimeUtils.class);
     private static final Pattern TIMEZONE_OFFSET_FORMAT_REG = Pattern.compile("^[+-]?\\d{1,2}:\\d{2}$");
-    public static Date MIN_DATE = null;
-    public static Date MAX_DATE = null;
-    public static Date MIN_DATETIME = null;
-    public static Date MAX_DATETIME = null;
 
     static {
-        TIME_ZONE = ZoneId.of("UTC+8");
-
-        Map<String, String> timeZoneMap = Maps.newHashMap();
+        Map<String, String> timeZoneMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         timeZoneMap.putAll(ZoneId.SHORT_IDS);
 
         // set CST to +08:00 instead of America/Chicago
@@ -98,32 +116,6 @@ public class TimeUtils {
         timeZoneMap.put("GMT", UTC_TIME_ZONE);
 
         timeZoneAliasMap = ImmutableMap.copyOf(timeZoneMap);
-
-        DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        DATE_FORMAT.withZone(TIME_ZONE);
-
-        DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        DATETIME_FORMAT.withZone(TIME_ZONE);
-
-        TIME_FORMAT = DateTimeFormatter.ofPattern("HH");
-        TIME_FORMAT.withZone(TIME_ZONE);
-
-        try {
-
-            MIN_DATE = Date.from(
-                    LocalDate.parse("0001-01-01", DATE_FORMAT).atStartOfDay().atZone(TIME_ZONE).toInstant());
-            MAX_DATE = Date.from(
-                    LocalDate.parse("9999-12-31", DATE_FORMAT).atStartOfDay().atZone(TIME_ZONE).toInstant());
-
-            MIN_DATETIME = Date.from(
-                    LocalDateTime.parse("0001-01-01 00:00:00", DATETIME_FORMAT).atZone(TIME_ZONE).toInstant());
-            MAX_DATETIME = Date.from(
-                    LocalDateTime.parse("9999-12-31 23:59:59", DATETIME_FORMAT).atZone(TIME_ZONE).toInstant());
-
-        } catch (DateTimeParseException e) {
-            LOG.error("invalid date format", e);
-            System.exit(-1);
-        }
     }
 
     public static long getStartTimeMs() {
@@ -135,7 +127,7 @@ public class TimeUtils {
     }
 
     public static String getCurrentFormatTime() {
-        return LocalDateTime.now().format(DATETIME_FORMAT);
+        return LocalDateTime.now().format(getDatetimeFormatWithTimeZone());
     }
 
     public static TimeZone getTimeZone() {
@@ -148,9 +140,13 @@ public class TimeUtils {
         return TimeZone.getTimeZone(ZoneId.of(timezone, timeZoneAliasMap));
     }
 
+    public static ZoneId getDorisZoneId() {
+        return getTimeZone().toZoneId();
+    }
+
     // return the time zone of current system
     public static TimeZone getSystemTimeZone() {
-        return TimeZone.getTimeZone(ZoneId.of(ZoneId.systemDefault().getId(), timeZoneAliasMap));
+        return TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID(), timeZoneAliasMap));
     }
 
     // get time zone of given zone name, or return system time zone if name is null.
@@ -165,7 +161,7 @@ public class TimeUtils {
         if (timeStamp <= 0L) {
             return FeConstants.null_string;
         }
-        return dateFormat.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timeStamp), ZoneId.systemDefault()));
+        return dateFormat.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timeStamp), getDorisZoneId()));
     }
 
     public static String longToTimeStringWithFormat(long timeStamp, DateTimeFormatter datetimeFormatTimeZone) {
@@ -174,12 +170,12 @@ public class TimeUtils {
         return longToTimeString(timeStamp, datetimeFormatTimeZone);
     }
 
-    public static String longToTimeString(long timeStamp) {
-        return longToTimeStringWithFormat(timeStamp, DATETIME_FORMAT);
+    public static String longToTimeString(Long timeStamp) {
+        return longToTimeStringWithFormat(timeStamp, getDatetimeFormatWithTimeZone());
     }
 
-    public static String longToTimeStringWithms(long timeStamp) {
-        return longToTimeStringWithFormat(timeStamp, DATETIME_MS_FORMAT);
+    public static String longToTimeStringWithms(Long timeStamp) {
+        return longToTimeStringWithFormat(timeStamp, getDatetimeMsFormatWithTimeZone());
     }
 
     public static Date getHourAsDate(String hour) {
@@ -189,7 +185,8 @@ public class TimeUtils {
         }
         try {
             return Date.from(
-                    LocalTime.parse(fullHour, TIME_FORMAT).atDate(LocalDate.now()).atZone(TIME_ZONE).toInstant());
+                    LocalTime.parse(fullHour, getTimeFormatWithTimeZone()).atDate(LocalDate.now())
+                            .atZone(getDorisZoneId()).toInstant());
         } catch (DateTimeParseException e) {
             LOG.warn("invalid time format: {}", fullHour);
             return null;
@@ -206,13 +203,15 @@ public class TimeUtils {
         if (type == PrimitiveType.DATE) {
             ParsePosition pos = new ParsePosition(0);
             date = Date.from(
-                    LocalDate.from(DATE_FORMAT.parse(dateStr, pos)).atStartOfDay().atZone(TIME_ZONE).toInstant());
+                    LocalDate.from(getDateFormatWithTimeZone().parse(dateStr, pos)).atStartOfDay()
+                            .atZone(getDorisZoneId()).toInstant());
             if (pos.getIndex() != dateStr.length() || date == null) {
                 throw new AnalysisException("Invalid date string: " + dateStr);
             }
         } else if (type == PrimitiveType.DATETIME) {
             try {
-                date = Date.from(LocalDateTime.parse(dateStr, DATETIME_FORMAT).atZone(TIME_ZONE).toInstant());
+                date = Date.from(LocalDateTime.parse(dateStr, getDatetimeFormatWithTimeZone())
+                        .atZone(getDorisZoneId()).toInstant());
             } catch (DateTimeParseException e) {
                 throw new AnalysisException("Invalid date string: " + dateStr);
             }
@@ -229,9 +228,11 @@ public class TimeUtils {
 
     public static String format(Date date, PrimitiveType type) {
         if (type == PrimitiveType.DATE) {
-            return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).format(DATE_FORMAT);
+            return LocalDateTime.ofInstant(date.toInstant(), getDorisZoneId())
+                    .format(getDateFormatWithTimeZone());
         } else if (type == PrimitiveType.DATETIME) {
-            return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).format(DATETIME_FORMAT);
+            return LocalDateTime.ofInstant(date.toInstant(), getDorisZoneId())
+                    .format(getDatetimeFormatWithTimeZone());
         } else {
             return "INVALID";
         }
@@ -244,7 +245,8 @@ public class TimeUtils {
     public static long timeStringToLong(String timeStr) {
         Date d;
         try {
-            d = Date.from(LocalDateTime.parse(timeStr, DATETIME_FORMAT).atZone(TIME_ZONE).toInstant());
+            d = Date.from(LocalDateTime.parse(timeStr, getDatetimeFormatWithTimeZone())
+                    .atZone(getDorisZoneId()).toInstant());
         } catch (DateTimeParseException e) {
             return -1;
         }
@@ -252,7 +254,7 @@ public class TimeUtils {
     }
 
     public static long timeStringToLong(String timeStr, TimeZone timeZone) {
-        DateTimeFormatter dateFormatTimeZone = DATETIME_FORMAT;
+        DateTimeFormatter dateFormatTimeZone = getDatetimeFormatWithTimeZone();
         dateFormatTimeZone.withZone(timeZone.toZoneId());
         LocalDateTime d;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/IcebergTableCreationRecordMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/IcebergTableCreationRecordMgr.java
@@ -132,7 +132,7 @@ public class IcebergTableCreationRecordMgr extends MasterDaemon {
     @Override
     protected void runAfterCatalogReady() {
         PropertySchema.DateProperty prop =
-                new PropertySchema.DateProperty("key", TimeUtils.DATETIME_FORMAT);
+                new PropertySchema.DateProperty("key", TimeUtils.getDatetimeFormatWithTimeZone());
         // list iceberg tables in dbs
         // When listing table is done, remove database from icebergDbs.
         for (Iterator<Map.Entry<Long, Database>> it = icebergDbs.entrySet().iterator(); it.hasNext(); it.remove()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
@@ -249,9 +249,9 @@ public class StreamLoadRecordMgr extends MasterDaemon {
                 for (Map.Entry<String, TStreamLoadRecord> entry : streamLoadRecordBatch.entrySet()) {
                     TStreamLoadRecord streamLoadItem = entry.getValue();
                     String startTime = TimeUtils.longToTimeString(streamLoadItem.getStartTime(),
-                            TimeUtils.DATETIME_MS_FORMAT);
+                            TimeUtils.getDatetimeMsFormatWithTimeZone());
                     String finishTime = TimeUtils.longToTimeString(streamLoadItem.getFinishTime(),
-                            TimeUtils.DATETIME_MS_FORMAT);
+                            TimeUtils.getDatetimeMsFormatWithTimeZone());
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("receive stream load record info from backend: {}."
                                         + " label: {}, db: {}, tbl: {}, user: {}, user_ip: {},"

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/canal/CanalUtils.java
@@ -69,7 +69,7 @@ public class CanalUtils {
         String startPosition = buildPositionForDump(entries.get(0));
         String endPosition = buildPositionForDump(entries.get(entries.size() - 1));
         logger.info(context_format, dataEvents.getId(), entries.size(), dataEvents.getMemSize(),
-                TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()), startPosition, endPosition);
+                TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()), startPosition, endPosition);
     }
 
     public static void printSummary(Message message, int size, long memsize) {
@@ -80,7 +80,7 @@ public class CanalUtils {
         String startPosition = buildPositionForDump(message.getEntries().get(0));
         String endPosition = buildPositionForDump(message.getEntries().get(message.getEntries().size() - 1));
         logger.info(context_format, message.getId(), size, memsize,
-                TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()), startPosition, endPosition);
+                TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()), startPosition, endPosition);
     }
 
     public static String buildPositionForDump(CanalEntry.Entry entry) {
@@ -94,7 +94,7 @@ public class CanalUtils {
                 .append(":")
                 .append(header.getExecuteTime())
                 .append("(")
-                .append(TimeUtils.DATETIME_FORMAT.format(date))
+                .append(TimeUtils.getDatetimeFormatWithTimeZone().format(date))
                 .append(")");
         if (StringUtils.isNotEmpty(entry.getHeader().getGtid())) {
             sb.append(" gtid(").append(entry.getHeader().getGtid())
@@ -120,8 +120,8 @@ public class CanalUtils {
         logger.info(row_format, header.getLogfileName(),
                 String.valueOf(header.getLogfileOffset()), header.getSchemaName(),
                 header.getTableName(), eventType,
-                String.valueOf(header.getExecuteTime()), TimeUtils.DATETIME_FORMAT.format(date),
-                header.getGtid(), String.valueOf(delayTime));
+                String.valueOf(header.getExecuteTime()), TimeUtils.getDatetimeFormatWithTimeZone().format(date),
+                        header.getGtid(), String.valueOf(delayTime));
         if (eventType == CanalEntry.EventType.QUERY || rowChange.getIsDdl()) {
             logger.info(" sql ----> " + rowChange.getSql() + SEP);
             return;
@@ -197,8 +197,9 @@ public class CanalUtils {
         // print transaction begin info, thread ID, time consumption
         logger.info(transaction_format, entry.getHeader().getLogfileName(),
                 String.valueOf(entry.getHeader().getLogfileOffset()),
-                String.valueOf(entry.getHeader().getExecuteTime()), TimeUtils.DATETIME_FORMAT.format(date),
-                entry.getHeader().getGtid(), String.valueOf(delayTime));
+                String.valueOf(entry.getHeader().getExecuteTime()),
+                TimeUtils.getDatetimeFormatWithTimeZone().format(date),
+                        entry.getHeader().getGtid(), String.valueOf(delayTime));
         logger.info(" BEGIN ----> Thread id: {}", begin.getThreadId());
         printXAInfo(begin.getPropsList());
     }
@@ -219,8 +220,9 @@ public class CanalUtils {
         printXAInfo(end.getPropsList());
         logger.info(transaction_format, entry.getHeader().getLogfileName(),
                 String.valueOf(entry.getHeader().getLogfileOffset()),
-                String.valueOf(entry.getHeader().getExecuteTime()), TimeUtils.DATETIME_FORMAT.format(date),
-                entry.getHeader().getGtid(), String.valueOf(delayTime));
+                String.valueOf(entry.getHeader().getExecuteTime()),
+                TimeUtils.getDatetimeFormatWithTimeZone().format(date),
+                        entry.getHeader().getGtid(), String.valueOf(delayTime));
     }
 
     public static boolean isDML(CanalEntry.EventType eventType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobFactory.java
@@ -106,8 +106,9 @@ public class MTMVJobFactory {
         MVRefreshIntervalTriggerInfo info = materializedView.getRefreshInfo().getTriggerInfo().getIntervalTrigger();
         long startTime;
         try {
-            LocalDateTime dateTime = LocalDateTime.parse(info.getStartTime(), TimeUtils.DATETIME_FORMAT);
-            startTime = dateTime.toEpochSecond(TimeUtils.TIME_ZONE.getRules().getOffset(dateTime));
+            LocalDateTime dateTime = LocalDateTime.parse(info.getStartTime(),
+                    TimeUtils.getDatetimeFormatWithTimeZone());
+            startTime = dateTime.toEpochSecond(TimeUtils.getDorisZoneId().getRules().getOffset(dateTime));
         } catch (DateTimeParseException e) {
             throw new RuntimeException(e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -164,7 +164,7 @@ public class FoldConstantRuleOnBE extends AbstractExpressionRewriteRule {
             TNetworkAddress brpcAddress = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
             TQueryGlobals queryGlobals = new TQueryGlobals();
-            queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+            queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
             queryGlobals.setTimestampMs(System.currentTimeMillis());
             queryGlobals.setTimeZone(TimeUtils.DEFAULT_TIME_ZONE);
             if (context.getSessionVariable().getTimeZone().equals("CST")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -316,7 +316,7 @@ public class StreamLoadPlanner {
 
         params.setQueryOptions(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();
-        queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+        queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
         queryGlobals.setTimestampMs(System.currentTimeMillis());
         queryGlobals.setTimeZone(taskInfo.getTimezone());
         queryGlobals.setLoadZeroTolerance(taskInfo.getMaxFilterRatio() <= 0.0);
@@ -536,7 +536,7 @@ public class StreamLoadPlanner {
 
         pipParams.setQueryOptions(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();
-        queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+        queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
         queryGlobals.setTimestampMs(System.currentTimeMillis());
         queryGlobals.setTimeZone(taskInfo.getTimezone());
         queryGlobals.setLoadZeroTolerance(taskInfo.getMaxFilterRatio() <= 0.0);

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -162,8 +162,9 @@ public class StoragePolicy extends Policy {
         }
         if (hasCooldownDatetime) {
             try {
-                this.cooldownTimestampMs = LocalDateTime.parse(props.get(COOLDOWN_DATETIME), TimeUtils.DATETIME_FORMAT)
-                        .atZone(TimeUtils.TIME_ZONE).toInstant().toEpochMilli();
+                this.cooldownTimestampMs = LocalDateTime
+                        .parse(props.get(COOLDOWN_DATETIME), TimeUtils.getDatetimeFormatWithTimeZone())
+                        .atZone(TimeUtils.getDorisZoneId()).toInstant().toEpochMilli();
             } catch (DateTimeParseException e) {
                 throw new AnalysisException(String.format("cooldown_datetime format error: %s",
                         props.get(COOLDOWN_DATETIME)), e);
@@ -327,7 +328,8 @@ public class StoragePolicy extends Policy {
             } else {
                 try {
                     cooldownTimestampMs = LocalDateTime.parse(properties.get(COOLDOWN_DATETIME),
-                            TimeUtils.DATETIME_FORMAT).atZone(TimeUtils.TIME_ZONE).toInstant().toEpochMilli();
+                            TimeUtils.getDatetimeFormatWithTimeZone()).atZone(TimeUtils.getDorisZoneId()).toInstant()
+                            .toEpochMilli();
                 } catch (DateTimeParseException e) {
                     throw new RuntimeException(e);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -309,7 +309,7 @@ public class Coordinator implements CoordInterface {
 
         setFromUserProperty(context);
 
-        this.queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+        this.queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
         this.queryGlobals.setTimestampMs(System.currentTimeMillis());
         this.queryGlobals.setNanoSeconds(LocalDateTime.now().getNano());
         this.queryGlobals.setLoadZeroTolerance(false);
@@ -337,7 +337,7 @@ public class Coordinator implements CoordInterface {
         this.fragments = fragments;
         this.scanNodes = scanNodes;
         this.queryOptions = new TQueryOptions();
-        this.queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+        this.queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
         this.queryGlobals.setTimestampMs(System.currentTimeMillis());
         this.queryGlobals.setTimeZone(timezone);
         this.queryGlobals.setLoadZeroTolerance(loadZeroTolerance);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2748,7 +2748,7 @@ public class ShowExecutor {
                 row.add(analysisInfo.jobType.toString());
                 row.add(analysisInfo.analysisType.toString());
                 row.add(analysisInfo.message);
-                row.add(TimeUtils.DATETIME_FORMAT.format(
+                row.add(TimeUtils.getDatetimeFormatWithTimeZone().format(
                         LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.lastExecTimeInMs),
                         ZoneId.systemDefault())));
                 row.add(analysisInfo.state.toString());
@@ -3026,7 +3026,7 @@ public class ShowExecutor {
                 row.add("N/A");
             }
             row.add(analysisInfo.message);
-            row.add(TimeUtils.DATETIME_FORMAT.format(
+            row.add(TimeUtils.getDatetimeFormatWithTimeZone().format(
                     LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.lastExecTimeInMs),
                             ZoneId.systemDefault())));
             row.add(String.valueOf(analysisInfo.timeCostInMs));

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -370,7 +370,7 @@ public class FoldConstantsRule implements ExprRewriteRule {
             brpcAddress = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
             TQueryGlobals queryGlobals = new TQueryGlobals();
-            queryGlobals.setNowString(TimeUtils.DATETIME_FORMAT.format(LocalDateTime.now()));
+            queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
             queryGlobals.setTimestampMs(System.currentTimeMillis());
             queryGlobals.setNanoSeconds(LocalDateTime.now().getNano());
             queryGlobals.setTimeZone(TimeUtils.DEFAULT_TIME_ZONE);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminCancelRebalanceDiskStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminCancelRebalanceDiskStmtTest.java
@@ -43,9 +43,9 @@ public class AdminCancelRebalanceDiskStmtTest {
 
     @Before()
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
 
         List<Long> beIds = Lists.newArrayList(10001L, 10002L, 10003L, 10004L);
         beIds.forEach(id -> Env.getCurrentSystemInfo().addBackend(RebalancerTestUtil.createBackend(id, 2048, 0)));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminRebalanceDiskStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminRebalanceDiskStmtTest.java
@@ -43,9 +43,9 @@ public class AdminRebalanceDiskStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
 
         List<Long> beIds = Lists.newArrayList(10001L, 10002L, 10003L, 10004L);
         beIds.forEach(id -> Env.getCurrentSystemInfo().addBackend(RebalancerTestUtil.createBackend(id, 2048, 0)));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogNameStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogNameStmtTest.java
@@ -39,9 +39,9 @@ public class AlterCatalogNameStmtTest {
 
     @Before
     public void setUp() throws DdlException {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "%");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogPropsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterCatalogPropsStmtTest.java
@@ -42,9 +42,9 @@ public class AlterCatalogPropsStmtTest {
 
     @Before
     public void setUp() throws DdlException {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "%");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
@@ -45,9 +45,9 @@ public class AlterSqlBlockRuleStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/BackupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/BackupTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
@@ -41,6 +42,8 @@ public class BackupTest {
 
     @Before
     public void setUp() {
+        MockedAuth.mockedConnectContext(ctx, "root", "192.188.3.1");
+
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         env = AccessTestUtil.fetchAdminCatalog();
         new MockUp<Env>() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateCatalogStmtTest.java
@@ -43,9 +43,9 @@ public class CreateCatalogStmtTest {
 
     @Before()
     public void setUp() throws DdlException {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "%");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
@@ -41,9 +41,9 @@ public class CreateDbStmtTest {
 
     @Before()
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateRoutineLoadStmtTest.java
@@ -189,6 +189,9 @@ public class CreateRoutineLoadStmtTest {
                 result = sessionVariable;
                 sessionVariable.getSendBatchParallelism();
                 result = 1;
+
+                sessionVariable.getTimeZone();
+                result = "Asia/Hong_Kong";
             }
         };
 
@@ -254,6 +257,9 @@ public class CreateRoutineLoadStmtTest {
                 result = sessionVariable;
                 sessionVariable.getSendBatchParallelism();
                 result = 1;
+
+                sessionVariable.getTimeZone();
+                result = "Asia/Hong_Kong";
             }
         };
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
@@ -45,9 +45,9 @@ public class CreateSqlBlockRuleStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -77,6 +77,8 @@ public class CreateTableStmtTest {
      **/
     @Before
     public void setUp() {
+        MockedAuth.mockedAccess(accessManager);
+        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
         // analyzer
         analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         // table name
@@ -98,9 +100,6 @@ public class CreateTableStmtTest {
         invalidColsName.add("col1");
         invalidColsName.add("col2");
         invalidColsName.add("col2");
-
-        MockedAuth.mockedAccess(accessManager);
-        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DeleteStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DeleteStmtTest.java
@@ -45,9 +45,9 @@ public class DeleteStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropCatalogStmtTest.java
@@ -40,9 +40,9 @@ public class DropCatalogStmtTest {
 
     @Before
     public void setUp() throws DdlException {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "%");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropDbStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropDbStmtTest.java
@@ -38,9 +38,9 @@ public class DropDbStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
@@ -46,6 +46,9 @@ public class DropTableStmtTest {
 
     @Before
     public void setUp() {
+        MockedAuth.mockedAccess(accessManager);
+        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+
         tbl = new TableName(internalCtl, "db1", "table1");
         noDbTbl = new TableName(internalCtl, "", "table1");
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
@@ -65,9 +68,6 @@ public class DropTableStmtTest {
                 result = "testCluster";
             }
         };
-
-        MockedAuth.mockedAccess(accessManager);
-        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropUserStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropUserStmtTest.java
@@ -38,9 +38,9 @@ public class DropUserStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/GrantStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/GrantStmtTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.VariableMgr;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -47,6 +48,13 @@ public class GrantStmtTest {
 
     @Before
     public void setUp() {
+        new Expectations() {
+            {
+                ctx.getSessionVariable();
+                minTimes = 0;
+                result = VariableMgr.newSessionVariable();
+            }
+        };
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         Auth auth = new Auth();
         AccessControllerManager accessManager = new AccessControllerManager(auth);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/LoadStmtTest.java
@@ -30,6 +30,7 @@ import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.task.LoadTaskInfo;
 
 import com.google.common.collect.Lists;
@@ -57,9 +58,6 @@ public class LoadStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
-        dataDescriptions = Lists.newArrayList();
-        dataDescriptions.add(desc);
         new Expectations() {
             {
                 ConnectContext.get();
@@ -70,11 +68,19 @@ public class LoadStmtTest {
                 minTimes = 0;
                 result = "default_cluster:user";
 
+                ctx.getSessionVariable();
+                minTimes = 0;
+                result = VariableMgr.newSessionVariable();
+
                 desc.toSql();
                 minTimes = 0;
                 result = "XXX";
             }
         };
+
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        dataDescriptions = Lists.newArrayList();
+        dataDescriptions.add(desc);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetOperationStmtTest.java
@@ -39,9 +39,9 @@ public class SetOperationStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetPassVarTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetPassVarTest.java
@@ -38,9 +38,9 @@ public class SetPassVarTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         UserIdentity currentUser = new UserIdentity("root", "192.168.1.1");
         currentUser.setIsAnalyzed();
         ctx.setCurrentUserIdentity(currentUser);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetStmtTest.java
@@ -41,9 +41,9 @@ public class SetStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetUserPropertyStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetUserPropertyStmtTest.java
@@ -41,9 +41,9 @@ public class SetUserPropertyStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVarTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVarTest.java
@@ -38,9 +38,9 @@ public class SetVarTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataTypesStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataTypesStmtTest.java
@@ -35,8 +35,8 @@ public class ShowDataTypesStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDbIdStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDbIdStmtTest.java
@@ -38,9 +38,9 @@ public class ShowDbIdStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowEncryptKeysStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowEncryptKeysStmtTest.java
@@ -48,10 +48,10 @@ public class ShowEncryptKeysStmtTest {
 
     @Before
     public void setUp() {
-        fakeEnv = new FakeEnv();
-        env = AccessTestUtil.fetchAdminCatalog();
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.188.3.1");
+        fakeEnv = new FakeEnv();
+        env = AccessTestUtil.fetchAdminCatalog();
         FakeEnv.setEnv(env);
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFunctionsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFunctionsStmtTest.java
@@ -49,10 +49,10 @@ public class ShowFunctionsStmtTest {
 
     @Before
     public void setUp() {
-        fakeEnv = new FakeEnv();
-        env = AccessTestUtil.fetchAdminCatalog();
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.188.3.1");
+        fakeEnv = new FakeEnv();
+        env = AccessTestUtil.fetchAdminCatalog();
         FakeEnv.setEnv(env);
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
@@ -41,9 +41,9 @@ public class ShowIndexStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowPartitionIdStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowPartitionIdStmtTest.java
@@ -38,9 +38,9 @@ public class ShowPartitionIdStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableCreationStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableCreationStmtTest.java
@@ -37,9 +37,9 @@ public class ShowTableCreationStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableIdStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableIdStmtTest.java
@@ -38,9 +38,9 @@ public class ShowTableIdStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowTableStmtTest.java
@@ -38,9 +38,9 @@ public class ShowTableStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowUserPropertyStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowUserPropertyStmtTest.java
@@ -41,9 +41,9 @@ public class ShowUserPropertyStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/UseStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/UseStmtTest.java
@@ -38,9 +38,9 @@ public class UseStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -59,11 +59,6 @@ public class TimeUtilsTest {
         Assert.assertNotNull(TimeUtils.getCurrentFormatTime());
         Assert.assertNotNull(TimeUtils.getStartTimeMs());
         Assert.assertTrue(TimeUtils.getElapsedTimeMs(0L) > 0);
-
-        Assert.assertEquals(-62135625600000L, TimeUtils.MIN_DATE.getTime());
-        Assert.assertEquals(253402185600000L, TimeUtils.MAX_DATE.getTime());
-        Assert.assertEquals(-62135625600000L, TimeUtils.MIN_DATETIME.getTime());
-        Assert.assertEquals(253402271999000L, TimeUtils.MAX_DATETIME.getTime());
     }
 
     @Test
@@ -148,7 +143,7 @@ public class TimeUtilsTest {
 
     @Test
     public void testDateTrans() throws AnalysisException {
-        Assert.assertEquals(FeConstants.null_string, TimeUtils.longToTimeString(-2));
+        Assert.assertEquals(FeConstants.null_string, TimeUtils.longToTimeString((long) -2));
 
         long timestamp = 1426125600000L;
         Assert.assertEquals("2015-03-12 10:00:00", TimeUtils.longToTimeString(timestamp));

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -40,6 +40,7 @@ import org.apache.doris.load.RoutineLoadDesc;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.kafka.KafkaConfiguration;
 import org.apache.doris.load.routineload.kafka.KafkaDataSourceProperties;
+import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TResourceInfo;
@@ -92,6 +93,8 @@ public class KafkaRoutineLoadJobTest {
 
     @Before
     public void init() {
+        MockedAuth.mockedConnectContext(connectContext, "root", "192.168.1.1");
+
         List<String> partitionNameList = Lists.newArrayList();
         partitionNameList.add("p1");
         partitionNames = new PartitionNames(false, partitionNameList);

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
@@ -20,6 +20,7 @@ package org.apache.doris.mysql.privilege;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.VariableMgr;
 
 import mockit.Expectations;
 
@@ -73,6 +74,10 @@ public class MockedAuth {
                 UserIdentity userIdentity = new UserIdentity(user, ip);
                 userIdentity.setIsAnalyzed();
                 result = userIdentity;
+
+                ctx.getSessionVariable();
+                minTimes = 0;
+                result = VariableMgr.newSessionVariable();
             }
         };
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.jobs.cascades;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.properties.LogicalProperties;
@@ -60,6 +61,8 @@ public class DeriveStatsJobTest {
 
     @Test
     public void testExecute() throws Exception {
+        MockedAuth.mockedConnectContext(context, "root", "192.168.1.1");
+
         LogicalOlapScan olapScan = constructOlapSCan();
         LogicalAggregate agg = constructAgg(olapScan);
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(agg);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -42,6 +42,8 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.PlanConstructor;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.Statistics;
@@ -49,6 +51,7 @@ import org.apache.doris.statistics.Statistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -61,7 +64,6 @@ import java.util.Map;
 import java.util.Optional;
 
 public class StatsCalculatorTest {
-
     private Group newGroup() {
         GroupExpression groupExpression = new GroupExpression(new FakePlan());
         Group group = new Group(null, groupExpression, null);
@@ -250,6 +252,20 @@ public class StatsCalculatorTest {
 
     @Test
     public void testOlapScan(@Mocked ConnectContext context) {
+        ConnectContext connectContext = ConnectContext.get();
+        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        new Expectations() {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = connectContext;
+
+                connectContext.getSessionVariable();
+                minTimes = 0;
+                result = sessionVariable;
+            }
+        };
+
         long tableId1 = 0;
         List<String> qualifier = ImmutableList.of("test", "t");
         SlotReference slot1 = new SlotReference(new ExprId(0),

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
@@ -38,6 +38,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.thrift.TPartitionType;
 
 import com.google.common.collect.ImmutableList;
@@ -60,6 +61,13 @@ public class RuntimeFilterGeneratorTest {
 
     @Before
     public void setUp() throws UserException {
+        new Expectations() {
+            {
+                ConnectContext.get().getSessionVariable();
+                minTimes = 0;
+                result = VariableMgr.newSessionVariable();
+            }
+        };
         Env env = Deencapsulation.newInstance(Env.class);
         analyzer = new Analyzer(env, connectContext);
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -85,9 +85,20 @@ public class StmtExecutorTest {
         ctx = new ConnectContext();
 
         SessionVariable sessionVariable = new SessionVariable();
+        new Expectations(ctx) {
+            {
+                ctx.getSessionVariable();
+                minTimes = 0;
+                result = sessionVariable;
+
+                ConnectContext.get().getSessionVariable();
+                minTimes = 0;
+                result = sessionVariable;
+            }
+        };
+
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         Env env = AccessTestUtil.fetchAdminCatalog();
-
         new Expectations(channel) {
             {
                 channel.sendOnePacket((ByteBuffer) any);
@@ -152,10 +163,6 @@ public class StmtExecutorTest {
                 ctx.getDatabase();
                 minTimes = 0;
                 result = "testCluster:testDb";
-
-                ctx.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
 
                 ctx.setStmtId(anyLong);
                 minTimes = 0;


### PR DESCRIPTION
All timestamp/datetime parsing in Doris is controlled by the session variable `time_zone`.
Apply it also to interface of `TimeUtils` in FE.

pick https://github.com/apache/doris/pull/37465

