### PR TITLE
[fix](cloud) fix analyze compound predicate exception when show copy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCopyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCopyStmt.java
@@ -197,7 +197,7 @@ public class ShowCopyStmt extends ShowLoadStmt {
         }
     }
 
-    protected void analyzeCompoundPredicate(Expr expr, List<Expr> exprs) throws AnalysisException {
+    private void analyzeCompoundPredicate(Expr expr, List<Expr> exprs) throws AnalysisException {
         if (expr instanceof CompoundPredicate) {
             CompoundPredicate cp = (CompoundPredicate) expr;
             if (cp.getOp() != CompoundPredicate.Operator.AND) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadStmt.java
@@ -164,15 +164,7 @@ public class ShowLoadStmt extends ShowStmt {
         // analyze where clause if not null
         if (whereClause != null) {
             if (whereClause instanceof CompoundPredicate) {
-                CompoundPredicate cp = (CompoundPredicate) whereClause;
-                if (cp.getOp() != org.apache.doris.analysis.CompoundPredicate.Operator.AND) {
-                    throw new AnalysisException("Only allow compound predicate with operator AND");
-                }
-
-                // check whether left.columnName equals to right.columnName
-                checkPredicateName(cp.getChild(0), cp.getChild(1));
-                analyzeSubPredicate(cp.getChild(0));
-                analyzeSubPredicate(cp.getChild(1));
+                analyzeCompoundPredicate(whereClause);
             } else {
                 analyzeSubPredicate(whereClause);
             }


### PR DESCRIPTION
Bug report:
```
mysql> show copy where id='e66c0eb7372b4c80-8781ffff29e0fd85' and tablename ='test_delete_on' and files like 'test_delete_on.json' and state='finished'\G
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: class org.apache.doris.analysis.CompoundPredicate cannot be cast to class org.apache.doris.analysis.SlotRef (org.apache.doris.analysis.CompoundPredicate and org.apache.doris.analysis.SlotRef are in unnamed module of loader 'app')
```

