### PR TITLE
[fix](query cancel) Fix query is cancelled when it comes from follower FE

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -904,13 +904,14 @@ void FragmentMgr::cancel_worker() {
                             bool fe_host_is_standing = std::any_of(
                                     running_fes.begin(), running_fes.end(),
                                     [&q_ctx](const auto& fe) {
-                                        return fe.first.hostname == q_ctx->coord_addr.hostname;
+                                        return fe.first.hostname == q_ctx->coord_addr.hostname &&
+                                               fe.first.port == 0;
                                     });
                             if (fe_host_is_standing) {
                                 LOG_WARNING(
                                         "Coordinator {}:{} is not found, but its host is still "
-                                        "running, "
-                                        "not going to cancel it.",
+                                        "running with an unstable brpc port, not going to cancel "
+                                        "it.",
                                         q_ctx->coord_addr.hostname, q_ctx->coord_addr.port,
                                         print_id(q_ctx->query_id()));
                                 continue;


### PR DESCRIPTION
In some rear cases, the rpc port of follower FE is not updated in time, the value of rpc port of this follower in heartbeat will be 0, but actually it is still running. Query from the follower FE will be cancelled by be until rpc port is updated correctly on BE. 

This pr fixes the problem on BE by detecting above situation, and avoid cancel query in this situation.