### PR TITLE
[fix](mv) Fix  not hit mv problem when table has float type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
@@ -97,6 +97,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
 /**
  * Select materialized index, i.e., both for rollup and materialized view when aggregate is present.
  * TODO: optimize queries with aggregate not on top of scan directly, e.g., aggregate -> join -> scan


### PR DESCRIPTION

```
CREATE DATABASE test_db;
use test_db;
CREATE TABLE test_db.table_1 (
  k0 BOOLEAN NOT NULL, 
  k1 TINYINT NOT NULL, 
  k2 SMALLINT NOT NULL, 
  k3 INT NOT NULL, 
  k4 BIGINT NOT NULL, 
  k5 LARGEINT NOT NULL, 
  k6 DECIMALV3(9, 3) NOT NULL, 
  k7 CHAR(5) NOT NULL, 
  k8 DATE NOT NULL, 
  k9 DATETIME NOT NULL, 
  k10 VARCHAR(20) NOT NULL, 
  k11 DOUBLE NOT NULL, 
  k12 FLOAT NOT NULL
) PARTITION BY RANGE(k1) (
  PARTITION p1 
  VALUES 
    LESS THAN ("-10"), 
    PARTITION p2 
  VALUES 
    LESS THAN ("0"), 
    PARTITION p3 
  VALUES 
    LESS THAN ("10"), 
    PARTITION p4 
  VALUES 
    LESS THAN ("20")
) DISTRIBUTED BY HASH(k4, k5) BUCKETS 1;


CREATE MATERIALIZED VIEW table_1_mv AS SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from test_db.table_1 group by k0

set experimental_enable_nereids_planner=true;
insert into table_1 values(1,2,3,4,5,6,7,"8","2020-10-01","2020-10-10","10",12,13);

EXPLAIN SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from test_db.table_1 group by k0
```
result is wrong 
![image](https://github.com/apache/doris/assets/11487604/bd54bb6d-9425-4d51-ba6d-012f99fcb3bc)

after this pr fix problem

![image](https://github.com/apache/doris/assets/11487604/0c7f420a-cd98-4485-b5c2-ee5e541d0a36)
