### PR TITLE
[Fix](Variant) ensure variant column finalized before reading the root column

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -1601,6 +1601,9 @@ Status VariantRootColumnIterator::next_batch(size_t* n, vectorized::MutableColum
     if (obj.is_null_root()) {
         obj.create_root();
     }
+    if (!obj.is_finalized()) {
+        obj.finalize();
+    }
     auto root_column = obj.get_root();
     RETURN_IF_ERROR(_inner_iter->next_batch(n, root_column, has_null));
     obj.incr_num_rows(*n);
@@ -1633,6 +1636,9 @@ Status VariantRootColumnIterator::read_by_rowids(const rowid_t* rowids, const si
                     : assert_cast<vectorized::ColumnObject&>(*dst);
     if (obj.is_null_root()) {
         obj.create_root();
+    }
+    if (!obj.is_finalized()) {
+        obj.finalize();
     }
     auto root_column = obj.get_root();
     RETURN_IF_ERROR(_inner_iter->read_by_rowids(rowids, count, root_column));


### PR DESCRIPTION
…t column

Eg. segment 1 has no variant columns and fill the dst with default value, which the variant columns's root is type nothing with n rows(not finalized), then reading segment2 with the none finalized variant column will lead to nullptr in `obj.get_root();`

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

