### PR TITLE
[feature](Recycler) Retry object storage request when meeting 429 http error code

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -196,4 +196,6 @@ CONF_Validator(s3_client_http_scheme, [](const std::string& config) -> bool {
     return config == "http" || config == "https";
 });
 
+CONF_mInt64(max_s3_client_retry, 10);
+
 } // namespace doris::cloud::config

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -196,6 +196,7 @@ CONF_Validator(s3_client_http_scheme, [](const std::string& config) -> bool {
     return config == "http" || config == "https";
 });
 
+// Max retry times for object storage request
 CONF_mInt64(max_s3_client_retry, 10);
 
 } // namespace doris::cloud::config

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -197,6 +197,6 @@ CONF_Validator(s3_client_http_scheme, [](const std::string& config) -> bool {
 });
 
 // Max retry times for object storage request
-CONF_mInt64(max_s3_client_retry, 10);
+CONF_mInt64(max_s3_client_retry, "10");
 
 } // namespace doris::cloud::config


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

When encountering 429 http code, the client sdk would not do retry by default. This pr makes the client retry `max_s3_client_retry` times.