### PR TITLE
[fix](sleep) sleep with character const make be crash

### DIFF
--- a/be/src/vec/functions/function_utility.cpp
+++ b/be/src/vec/functions/function_utility.cpp
@@ -62,7 +62,7 @@ public:
     size_t get_number_of_arguments() const override { return 1; }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        if (arguments[0].get()->is_nullable()) {
+        if (arguments[0]->is_nullable()) {
             return make_nullable(std::make_shared<DataTypeUInt8>());
         }
         return std::make_shared<DataTypeUInt8>();
@@ -74,19 +74,12 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
-        ColumnPtr& argument_column = block.get_by_position(arguments[0]).column;
+        const auto& argument_column =
+                block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
 
         auto res_column = ColumnUInt8::create();
 
-        if (is_column_const(*argument_column)) {
-            Int64 seconds = argument_column->get_int(0);
-            for (int i = 0; i < input_rows_count; i++) {
-                std::this_thread::sleep_for(std::chrono::seconds(seconds));
-                res_column->insert(1);
-            }
-
-            block.replace_by_position(result, std::move(res_column));
-        } else if (auto* nullable_column = check_and_get_column<ColumnNullable>(*argument_column)) {
+        if (auto* nullable_column = check_and_get_column<ColumnNullable>(*argument_column)) {
             auto null_map_column = ColumnUInt8::create();
 
             auto nested_column = nullable_column->get_nested_column_ptr();

--- a/be/src/vec/functions/function_utility.cpp
+++ b/be/src/vec/functions/function_utility.cpp
@@ -70,6 +70,8 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return false; }
 
+    // Sleep function should not be executed during open stage, this will makes fragment prepare
+    // waiting too long, so we do not use default impl.
     bool use_default_implementation_for_constants() const override { return false; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,

--- a/regression-test/suites/nereids_p0/system/test_query_sys.groovy
+++ b/regression-test/suites/nereids_p0/system/test_query_sys.groovy
@@ -36,6 +36,7 @@ suite("test_query_sys", "query,p0") {
     sql "select pi();"
     sql "select e();"
     sql "select sleep(2);"
+    sql "select sleep('1.1');"
 
     // INFORMATION_SCHEMA
     sql "SELECT table_name FROM INFORMATION_SCHEMA.TABLES where table_schema=\"nereids_test_query_db\" and TABLE_TYPE = \"BASE TABLE\" order by table_name"


### PR DESCRIPTION
## Proposed changes

Issue Number: close https://github.com/apache/doris/issues/37327

Come from: #31689

<!--Describe your changes.-->

After fix be will not crash any more.

```
mysql> select cast('1.1' as int);
+--------------------+
| cast('1.1' as INT) |
+--------------------+
|               NULL |
+--------------------+
1 row in set (0.04 sec)

mysql> select sleep('1.1');
+---------------------------+
| sleep(cast('1.1' as INT)) |
+---------------------------+
|                      NULL |
+---------------------------+
1 row in set (0.02 sec)

```
