### PR TITLE
[fix](compile) replace shared_ptr::unique() with std::shared_ptr::use_count() == 1

### DIFF
--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -289,7 +289,7 @@ private:
         /// Pointer to file block is always hold by the cache itself.
         /// Apart from pointer in cache, it can be hold by cache users, when they call
         /// getorSet(), but cache users always hold it via FileBlocksHolder.
-        bool releasable() const { return file_block.unique(); }
+        bool releasable() const { return file_block.use_count() == 1; }
 
         size_t size() const { return file_block->_block_range.size(); }
 


### PR DESCRIPTION
## Proposed changes

`std::shared_ptr::unique` is supported until cpp20. It was disabled by default since llvm-18. [see](https://releases.llvm.org/18.1.0/projects/libcxx/docs/ReleaseNotes/18.html#id4).

Therefore, replace it with std::shared_ptr::use_count() == 1 for better compability. (Or we should work with _LIBCPP_ENABLE_CXX20_REMOVED_SHARED_PTR_UNIQUE which is ungraceful.)