### PR TITLE
[Enhancement](delete) Modify some p2 delete cases' property

### DIFF
--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
@@ -113,7 +113,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -145,7 +145,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
@@ -113,6 +113,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -144,6 +145,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
@@ -129,6 +129,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -161,6 +162,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
@@ -129,7 +129,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -162,7 +162,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
@@ -114,7 +114,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -146,7 +146,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
@@ -114,6 +114,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """
@@ -145,6 +146,7 @@ DUPLICATE KEY(`l_shipdate`, `l_orderkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "1"
 );
         """

--- a/regression-test/suites/insert_p2/txn_insert_concurrent_insert_ud.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_concurrent_insert_ud.groovy
@@ -52,7 +52,7 @@ suite("txn_insert_concurrent_insert_ud") {
             UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
-                "enable_light_delete" = "true",
+                "enable_mow_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/insert_p2/txn_insert_concurrent_insert_ud.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_concurrent_insert_ud.groovy
@@ -52,6 +52,7 @@ suite("txn_insert_concurrent_insert_ud") {
             UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
+                "enable_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/insert_p2/txn_insert_concurrent_insert_update.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_concurrent_insert_update.groovy
@@ -52,6 +52,7 @@ suite("txn_insert_concurrent_insert_update") {
             UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
+                "enable_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/insert_p2/txn_insert_concurrent_insert_update.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_concurrent_insert_update.groovy
@@ -52,7 +52,7 @@ suite("txn_insert_concurrent_insert_update") {
             UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
-                "enable_light_delete" = "true",
+                "enable_mow_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/insert_p2/txn_insert_with_schema_change.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_with_schema_change.groovy
@@ -54,7 +54,7 @@ suite("txn_insert_with_schema_change") {
             DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
-                "enable_light_delete" = "true",
+                "enable_mow_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/insert_p2/txn_insert_with_schema_change.groovy
+++ b/regression-test/suites/insert_p2/txn_insert_with_schema_change.groovy
@@ -54,6 +54,7 @@ suite("txn_insert_with_schema_change") {
             DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
             DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
             PROPERTIES (
+                "enable_light_delete" = "true",
                 "replication_num" = "1"
             )
         """

--- a/regression-test/suites/tpch_sf100_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/customer.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 DUPLICATE KEY(C_CUSTKEY, C_NAME)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/customer.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 DUPLICATE KEY(C_CUSTKEY, C_NAME)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/lineitem.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/lineitem.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/nation.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 DUPLICATE KEY(N_NATIONKEY, N_NAME)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/nation.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 DUPLICATE KEY(N_NATIONKEY, N_NAME)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/orders.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 DUPLICATE KEY(O_ORDERKEY, O_CUSTKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/orders.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 DUPLICATE KEY(O_ORDERKEY, O_CUSTKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/part.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 DUPLICATE KEY(P_PARTKEY, P_NAME)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/part.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 DUPLICATE KEY(P_PARTKEY, P_NAME)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/partsupp.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 DUPLICATE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/partsupp.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 DUPLICATE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/region.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 DUPLICATE KEY(R_REGIONKEY, R_NAME)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/region.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 DUPLICATE KEY(R_REGIONKEY, R_NAME)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf100_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/supplier.sql
@@ -10,5 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 DUPLICATE KEY(S_SUPPKEY, S_NAME)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 32
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf100_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_p2/ddl/supplier.sql
@@ -10,6 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 DUPLICATE KEY(S_SUPPKEY, S_NAME)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 32
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/customer.sql
@@ -12,7 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/customer.sql
@@ -12,6 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/customer_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/customer_sequence.sql
@@ -12,6 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/customer_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/customer_sequence.sql
@@ -12,7 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem.sql
@@ -20,6 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem.sql
@@ -20,7 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem_sequence.sql
@@ -20,7 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'DATE',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/lineitem_sequence.sql
@@ -20,6 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'DATE',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/nation.sql
@@ -8,7 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/nation.sql
@@ -8,6 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/nation_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/nation_sequence.sql
@@ -8,7 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 );

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/nation_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/nation_sequence.sql
@@ -8,6 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 );

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/orders.sql
@@ -13,5 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/orders.sql
@@ -13,6 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/orders_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/orders_sequence.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'bigint',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/orders_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/orders_sequence.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'bigint',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/part.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/part.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/part_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/part_sequence.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/part_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/part_sequence.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp.sql
@@ -9,7 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp.sql
@@ -9,6 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp_sequence.sql
@@ -9,6 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/partsupp_sequence.sql
@@ -9,7 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/region.sql
@@ -7,7 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/region.sql
@@ -7,6 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/region_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/region_sequence.sql
@@ -7,7 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/region_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/region_sequence.sql
@@ -7,6 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier.sql
@@ -11,6 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier.sql
@@ -11,5 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier_sequence.sql
@@ -11,6 +11,7 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier_sequence.sql
+++ b/regression-test/suites/tpch_sf100_unique_p2/ddl/supplier_sequence.sql
@@ -11,7 +11,7 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/customer.sql
@@ -12,7 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/customer.sql
@@ -12,6 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/lineitem.sql
@@ -20,6 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/lineitem.sql
@@ -20,7 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/nation.sql
@@ -8,7 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/nation.sql
@@ -8,6 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/orders.sql
@@ -13,5 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/orders.sql
@@ -13,6 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/part.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/part.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/partsupp.sql
@@ -9,7 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/partsupp.sql
@@ -9,6 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/region.sql
@@ -7,7 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/region.sql
@@ -7,6 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/supplier.sql
@@ -11,6 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/ddl/supplier.sql
@@ -11,5 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/customer.sql
@@ -12,7 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/customer.sql
@@ -12,6 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/customer_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/customer_sequence.sql
@@ -12,6 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/customer_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/customer_sequence.sql
@@ -12,7 +12,7 @@ UNIQUE KEY(`c_custkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem.sql
@@ -20,6 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem.sql
@@ -20,7 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem_sequence.sql
@@ -20,7 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'DATE',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/lineitem_sequence.sql
@@ -20,6 +20,7 @@ UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'DATE',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/nation.sql
@@ -8,7 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/nation.sql
@@ -8,6 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 );
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/nation_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/nation_sequence.sql
@@ -8,7 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 );

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/nation_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/nation_sequence.sql
@@ -8,6 +8,7 @@ UNIQUE KEY(`N_NATIONKEY`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 );

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/orders.sql
@@ -13,5 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/orders.sql
@@ -13,6 +13,6 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/orders_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/orders_sequence.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'bigint',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/orders_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/orders_sequence.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`o_orderkey`, `o_orderdate`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'bigint',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/part.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/part.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/part_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/part_sequence.sql
@@ -13,7 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/part_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/part_sequence.sql
@@ -13,6 +13,7 @@ UNIQUE KEY(`p_partkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp.sql
@@ -9,7 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp.sql
@@ -9,6 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp_sequence.sql
@@ -9,6 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/partsupp_sequence.sql
@@ -9,7 +9,7 @@ UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/region.sql
@@ -7,7 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/region.sql
@@ -7,6 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )
 

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/region_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/region_sequence.sql
@@ -7,7 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/region_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/region_sequence.sql
@@ -7,6 +7,7 @@ UNIQUE KEY(`r_regionkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier.sql
@@ -11,6 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier.sql
@@ -11,5 +11,6 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
+    "enable_light_delete" = "true",
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier_sequence.sql
@@ -11,6 +11,7 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
+    "enable_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier_sequence.sql
+++ b/regression-test/suites/tpch_sf10_unique_p2/ddl/supplier_sequence.sql
@@ -11,7 +11,7 @@ UNIQUE KEY(`s_suppkey`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
 PROPERTIES (
-    "enable_light_delete" = "true",
+    "enable_mow_light_delete" = "true",
     "function_column.sequence_type" = 'int',
     "replication_num" = "3"
 )

--- a/regression-test/suites/tpch_sf1_p2/ddl/create_table.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/create_table.sql
@@ -6,6 +6,6 @@ CREATE TABLE IF NOT EXISTS gavin_test (
 DUPLICATE KEY(id, name)
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf1_p2/ddl/create_table.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/create_table.sql
@@ -6,5 +6,6 @@ CREATE TABLE IF NOT EXISTS gavin_test (
 DUPLICATE KEY(id, name)
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf1_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/customer.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 DUPLICATE KEY(C_CUSTKEY, C_NAME)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/customer.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 DUPLICATE KEY(C_CUSTKEY, C_NAME)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/lineitem.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/lineitem.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/nation.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 DUPLICATE KEY(N_NATIONKEY, N_NAME)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/nation.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 DUPLICATE KEY(N_NATIONKEY, N_NAME)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/orders.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 DUPLICATE KEY(O_ORDERKEY, O_CUSTKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/orders.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 DUPLICATE KEY(O_ORDERKEY, O_CUSTKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/part.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 DUPLICATE KEY(P_PARTKEY, P_NAME)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/part.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 DUPLICATE KEY(P_PARTKEY, P_NAME)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/partsupp.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 DUPLICATE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/partsupp.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 DUPLICATE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/region.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 DUPLICATE KEY(R_REGIONKEY, R_NAME)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/region.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 DUPLICATE KEY(R_REGIONKEY, R_NAME)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/supplier.sql
@@ -10,5 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 DUPLICATE KEY(S_SUPPKEY, S_NAME)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 3
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf1_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf1_p2/ddl/supplier.sql
@@ -10,6 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 DUPLICATE KEY(S_SUPPKEY, S_NAME)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 3
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/customer.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 UNIQUE KEY(C_CUSTKEY)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/customer.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS customer (
 UNIQUE KEY(C_CUSTKEY)
 DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/lineitem.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/lineitem.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
 UNIQUE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
 DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/nation.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 UNIQUE KEY(N_NATIONKEY)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/nation.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS nation  (
 UNIQUE KEY(N_NATIONKEY)
 DISTRIBUTED BY HASH(N_NATIONKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/orders.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 UNIQUE KEY(O_ORDERKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/orders.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS orders  (
 UNIQUE KEY(O_ORDERKEY)
 DISTRIBUTED BY HASH(O_ORDERKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/part.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 UNIQUE KEY(P_PARTKEY)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/part.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS part (
 UNIQUE KEY(P_PARTKEY)
 DISTRIBUTED BY HASH(P_PARTKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/partsupp.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 UNIQUE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/partsupp.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
 UNIQUE KEY(PS_PARTKEY, PS_SUPPKEY)
 DISTRIBUTED BY HASH(PS_PARTKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/region.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 UNIQUE KEY(R_REGIONKEY)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/region.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS region (
 UNIQUE KEY(R_REGIONKEY)
 DISTRIBUTED BY HASH(R_REGIONKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )
 

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/supplier.sql
@@ -10,6 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 UNIQUE KEY(S_SUPPKEY)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 1
 PROPERTIES (
-  "enable_light_delete" = "true",
+  "enable_mow_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/tpch_sf1_unique_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf1_unique_p2/ddl/supplier.sql
@@ -10,5 +10,6 @@ CREATE TABLE IF NOT EXISTS supplier (
 UNIQUE KEY(S_SUPPKEY)
 DISTRIBUTED BY HASH(S_SUPPKEY) BUCKETS 1
 PROPERTIES (
+  "enable_light_delete" = "true",
   "replication_num" = "1"
 )

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_create.sql
@@ -12,7 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_region`, `c_phone`, `c_city`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_create.sql
@@ -12,6 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_region`, `c_phone`, `c_city`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
@@ -12,6 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_mktsegment`, `c_city`, `c_region`, `c_nation`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
@@ -12,7 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_mktsegment`, `c_city`, `c_region`, `c_nation`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_create.sql
@@ -21,6 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_sellingseason`, `d_holidayfl`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_create.sql
@@ -21,7 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_sellingseason`, `d_holidayfl`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
@@ -21,6 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_sellingseason`, `d_lastdayinweekfl`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
@@ -21,7 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_sellingseason`, `d_lastdayinweekfl`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
@@ -29,6 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
@@ -29,7 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
@@ -29,7 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
@@ -29,6 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_create.sql
@@ -13,7 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_color`, `p_name`, `p_category`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_create.sql
@@ -13,6 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_color`, `p_name`, `p_category`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
@@ -13,7 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_size`, `p_type`, `p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
@@ -13,6 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_size`, `p_type`, `p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
@@ -11,7 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_address`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
@@ -11,6 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_address`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
@@ -11,7 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_nation`, `s_region`, `s_city`, `s_name`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
@@ -11,6 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_nation`, `s_region`, `s_city`, `s_name`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_type" = 'int',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
@@ -12,6 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_region`, `c_address`, `c_city`, `c_name`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
@@ -12,7 +12,7 @@ UNIQUE KEY (`c_custkey`)
 CLUSTER BY (`c_region`, `c_address`, `c_city`, `c_name`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/date_create.sql
@@ -21,7 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_weeknuminyear`, `d_month`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/date_create.sql
@@ -21,6 +21,7 @@ UNIQUE KEY (`d_datekey`)
 CLUSTER BY (`d_weeknuminyear`, `d_month`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
@@ -29,6 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
@@ -29,7 +29,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/part_create.sql
@@ -13,6 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_color`, `p_container`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/part_create.sql
@@ -13,7 +13,7 @@ UNIQUE KEY (`p_partkey`)
 CLUSTER BY (`p_color`, `p_container`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
@@ -11,6 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_address`, `s_name`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
@@ -11,7 +11,7 @@ UNIQUE KEY (`s_suppkey`)
 CLUSTER BY (`s_address`, `s_name`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "disable_auto_compaction" = "true",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_create.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_create.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_col" = 'c_custkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/customer_sequence_create.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_col" = 'c_custkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_create.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_create.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_col" = 'd_datekey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/date_sequence_create.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_col" = 'd_datekey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
@@ -28,6 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_create.sql
@@ -28,7 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
@@ -28,7 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_col" = 'lo_orderkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/lineorder_sequence_create.sql
@@ -28,6 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_col" = 'lo_orderkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_create.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_create.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_col" = 'p_partkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/part_sequence_create.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_col" = 'p_partkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_create.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "function_column.sequence_col" = 's_suppkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_load_zstd/ddl/supplier_sequence_create.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "function_column.sequence_col" = 's_suppkey',
 "compression"="zstd",
 "replication_num" = "1",

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/customer_create.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `customer` (
 UNIQUE KEY (`c_custkey`)
 DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/date_create.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/date_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/date_create.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `date` (
 UNIQUE KEY (`d_datekey`)
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
@@ -28,6 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/lineorder_create.sql
@@ -28,7 +28,7 @@ PARTITION p1997 VALUES [("19970101"), ("19980101")),
 PARTITION p1998 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/part_create.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/part_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/part_create.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `part` (
 UNIQUE KEY (`p_partkey`)
 DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
+"enable_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/ddl/supplier_create.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS `supplier` (
 UNIQUE KEY (`s_suppkey`)
 DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 10
 PROPERTIES (
-"enable_light_delete" = "true",
+"enable_mow_light_delete" = "true",
 "compression"="zstd",
 "replication_num" = "1",
 "enable_unique_key_merge_on_write" = "true"


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

In #35917 and #37151, we changed MOW table default delete command from delete predicate to delete sign. It makes sure the correctness during partial update but leads to slowdowns. Actually, if there is no partial update, delete predicate will not lead to data fault. Delete data by delete predicate or delete sign can be controlled by a table property "enable_light_delete". If "enable_light_delete=true", we execute delete command by delete predicate. Otherwise, we execute delete command by delete sign.

In p2 cases, there are lots of cases with large data need to delete and do not perform partial column update operations. Therefore, in order to make it faster, we change some cases default create table clause.