### PR TITLE
[fix](jni_connector) fix that be core when jni_connector open fails

### DIFF
--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -87,8 +87,8 @@ Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
     RETURN_IF_ERROR(_init_jni_scanner(env, batch_size));
     // Call org.apache.doris.common.jni.JniScanner#open
     env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_open);
-    _scanner_opened = true;
     RETURN_ERROR_IF_EXC(env);
+    _scanner_opened = true;
     return Status::OK();
 }
 

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -87,8 +87,8 @@ Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
     RETURN_IF_ERROR(_init_jni_scanner(env, batch_size));
     // Call org.apache.doris.common.jni.JniScanner#open
     env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_open);
-    RETURN_ERROR_IF_EXC(env);
     _scanner_opened = true;
+    RETURN_ERROR_IF_EXC(env);
     return Status::OK();
 }
 
@@ -154,6 +154,13 @@ Status JniConnector::get_table_schema(std::string& table_schema_str) {
 
 std::map<std::string, std::string> JniConnector::get_statistics(JNIEnv* env) {
     jobject metrics = env->CallObjectMethod(_jni_scanner_obj, _jni_scanner_get_statistics);
+    jthrowable exc = (env)->ExceptionOccurred();
+    if (exc != nullptr) {
+        LOG(WARNING) << "get_statistics has error: "
+                     << JniUtil::GetJniExceptionMsg(env).to_string();
+        env->DeleteLocalRef(metrics);
+        return std::map<std::string, std::string> {};
+    }
     std::map<std::string, std::string> result = JniUtil::convert_to_cpp_map(env, metrics);
     env->DeleteLocalRef(metrics);
     return result;
@@ -163,7 +170,7 @@ Status JniConnector::close() {
     if (!_closed) {
         JNIEnv* env = nullptr;
         RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
-        if (_scanner_opened) {
+        if (_scanner_opened && _jni_scanner_obj != nullptr) {
             // _fill_block may be failed and returned, we should release table in close.
             // org.apache.doris.common.jni.JniScanner#releaseTable is idempotent
             env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);

--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
@@ -132,6 +132,7 @@ public class TrinoConnectorJniScanner extends JniScanner {
         catalogNameString = params.get("catalog_name");
         super.batchSize = batchSize;
         super.fields = params.get("required_fields").split(",");
+        appendDataTimeNs = new long[fields.length];
 
         connectorSplitString = params.get("trino_connector_split");
         connectorTableHandleString = params.get("trino_connector_table_handle");


### PR DESCRIPTION
## Proposed changes

Here are two problems:
1. `appendDataTimeNs` will be `NULL` if TrinoConnector open fails before call to `parseRequiredTypes`
2. It does not catch exception in method `get_statistics()` and this exception is not caught until `close()` method. Therefore, it will cause BE core dump in `JniConnector::close()` at `LOG(FATAL)`


<!--Describe your changes.-->

