### PR TITLE
[improvement](statistics)Async drop stats while truncating table.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3264,8 +3264,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (target.partitions != null) {
             partitionNames = new PartitionNames(false, new ArrayList<>(target.partitions));
         }
-        analysisManager.invalidateLocalStats(target.catalogId, target.dbId, target.tableId,
-                target.columns, tableStats, partitionNames);
+        if (target.isTruncate) {
+            analysisManager.submitAsyncDropStatsTask(target.catalogId, target.dbId,
+                    target.tableId, tableStats, partitionNames);
+        } else {
+            analysisManager.invalidateLocalStats(target.catalogId, target.dbId, target.tableId,
+                    target.columns, tableStats, partitionNames);
+        }
         return new TStatus(TStatusCode.OK);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/InvalidateStatsTarget.java
@@ -38,11 +38,16 @@ public class InvalidateStatsTarget {
     @SerializedName("partitions")
     public final Set<String> partitions;
 
-    public InvalidateStatsTarget(long catalogId, long dbId, long tableId, Set<String> columns, Set<String> partitions) {
+    @SerializedName("it")
+    public final boolean isTruncate;
+
+    public InvalidateStatsTarget(long catalogId, long dbId, long tableId, Set<String> columns,
+                                 Set<String> partitions, boolean isTruncate) {
         this.catalogId = catalogId;
         this.dbId = dbId;
         this.tableId = tableId;
         this.columns = columns;
         this.partitions = partitions;
+        this.isTruncate = isTruncate;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/PartitionColumnStatistic.java
@@ -137,7 +137,7 @@ public class PartitionColumnStatistic {
                     / partitionStatisticBuilder.getCount());
             String min = row.get(9);
             String max = row.get(10);
-            if (!"NULL".equalsIgnoreCase(min)) {
+            if (min != null && !"NULL".equalsIgnoreCase(min)) {
                 try {
                     partitionStatisticBuilder.setMinValue(StatisticsUtil.convertToDouble(col.getType(), min));
                     partitionStatisticBuilder.setMinExpr(StatisticsUtil.readableValue(col.getType(), min));
@@ -148,7 +148,7 @@ public class PartitionColumnStatistic {
             } else {
                 partitionStatisticBuilder.setMinValue(Double.NEGATIVE_INFINITY);
             }
-            if (!"NULL".equalsIgnoreCase(max)) {
+            if (max != null && !"NULL".equalsIgnoreCase(max)) {
                 try {
                     partitionStatisticBuilder.setMaxValue(StatisticsUtil.convertToDouble(col.getType(), max));
                     partitionStatisticBuilder.setMaxExpr(StatisticsUtil.readableValue(col.getType(), max));


### PR DESCRIPTION
Drop stats for table with many partitions may slow, because to invalidate partition stats cache is time consuming. Truncate table operation do the drop stats synchronously, so the truncate table may be very slow for partition tables.
This pr is to improvement the performance of truncate table. Do the drop stats asynchronously.

Time consumed for truncate a table with 10000 partitions and 10 columns reduced to 2.5s from 10s.