### PR TITLE
[fix](publish) Catch exception in genPublishTask to make one failed txn does not block the other txns

### DIFF
--- a/regression-test/data/insert_p0/txn_insert_inject_case.out
+++ b/regression-test/data/insert_p0/txn_insert_inject_case.out
@@ -7,3 +7,17 @@
 2	3.3	xyz	[1]	[1, 0]
 2	3.3	xyz	[1]	[1, 0]
 
+-- !select2 --
+
+-- !select3 --
+\N	\N	\N	[null]	[null, 0]
+1	2.2	abc	[]	[]
+101	2.2	abc	[]	[]
+2	3.3	xyz	[1]	[1, 0]
+
+-- !select4 --
+\N	\N	\N	[null]	[null, 0]
+102	2.2	abc	[]	[]
+3	2.2	abc	[]	[]
+4	3.3	xyz	[1]	[1, 0]
+


### PR DESCRIPTION
## Proposed changes

If any exception(such as NullPointerException) is thrown in `genPublishTask` when publish, the publish for all txns will fail.
This pr catch the exception to make the failed txn does not block other txns.
