### PR TITLE
[mac](compile) fix compile error on mac

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -142,7 +142,7 @@ Status LoadBlockQueue::get_block(RuntimeState* runtime_state, vectorized::Block*
                           << ", runtime_state=" << runtime_state;
             }
         }
-        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000L)));
+        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000LL)));
     }
     if (runtime_state->is_cancelled()) {
         auto st = Status::Cancelled<false>(runtime_state->cancel_reason());

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -142,7 +142,8 @@ Status LoadBlockQueue::get_block(RuntimeState* runtime_state, vectorized::Block*
                           << ", runtime_state=" << runtime_state;
             }
         }
-        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, 10000LL)));
+        _get_cond.wait_for(l, std::chrono::milliseconds(
+                                      std::min(left_milliseconds, static_cast<int64_t>(10000))));
     }
     if (runtime_state->is_cancelled()) {
         auto st = Status::Cancelled<false>(runtime_state->cancel_reason());


### PR DESCRIPTION
compile `branch-2.1` failed on mac:

```
FAILED: src/runtime/CMakeFiles/Runtime.dir/group_commit_mgr.cpp.o
/opt/homebrew/opt/llvm@16/bin/clang++ -DBOOST_STACKTRACE_USE_NOOP -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DUSE_LIBCPP -DUSE_LIBHDFS3 -I/Users/zhuxiaoli/Codes/doris-2.1/be/src/apache-orc/c++/include -I/Users/zhuxiaoli/Codes/doris-2.1/be/cmake-build-debug/src/apache-orc/c++/include -I/Users/zhuxiaoli/Codes/doris-2.1/be/cmake-build-debug/src/clucene/src/shared -I/Users/zhuxiaoli/Codes/doris-2.1/be/src/clucene/src/core -I/Users/zhuxiaoli/Codes/doris-2.1/be/src/clucene/src/shared -I/Users/zhuxiaoli/Codes/doris-2.1/be/src/clucene/src/contribs-lib -I/Users/zhuxiaoli/Codes/doris-2.1/be/src -I/Users/zhuxiaoli/Codes/doris-2.1/be/test -I/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home/include/darwin -isystem /Users/zhuxiaoli/Codes/doris-2.1/be/../gensrc/build -isystem /Users/zhuxiaoli/Codes/doris-2.1/be/../thirdparty/installed/include -isystem /Users/zhuxiaoli/Codes/doris-2.1/be/../thirdparty/installed/gperftools/include -Og  -g -std=gnu++20 -arch arm64 -fcolor-diagnostics   -D OS_MACOSX -g -Wall -Wextra -Werror -pthread -fstrict-aliasing -fno-omit-frame-pointer -Wnon-virtual-dtor -Wno-unused-parameter -Wno-sign-compare -fcolor-diagnostics -Wpedantic -Wshadow-field -Wunused -Wunused-command-line-argument -Wunused-exception-parameter -Wunused-volatile-lvalue -Wunused-template -Wunused-member-function -Wunused-macros -Wconversion -Wno-vla-extension -Wno-gnu-statement-expression -Wno-implicit-float-conversion -Wno-implicit-int-conversion -Wno-sign-conversion -Wno-shorten-64-to-32 -stdlib=libc++ -D__STDC_FORMAT_MACROS -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -DBRPC_ENABLE_CPU_PROFILER -DS2_USE_GFLAGS -DS2_USE_GLOG -march=armv8-a+crc -DDORIS_WITH_MYSQL -DUSE_JEMALLOC -Winvalid-pch -Xarch_arm64 -include/Users/zhuxiaoli/Codes/doris-2.1/be/cmake-build-debug/CMakeFiles/pch.dir/cmake_pch_arm64.hxx -MD -MT src/runtime/CMakeFiles/Runtime.dir/group_commit_mgr.cpp.o -MF src/runtime/CMakeFiles/Runtime.dir/group_commit_mgr.cpp.o.d -o src/runtime/CMakeFiles/Runtime.dir/group_commit_mgr.cpp.o -c /Users/zhuxiaoli/Codes/doris-2.1/be/src/runtime/group_commit_mgr.cpp
/Users/zhuxiaoli/Codes/doris-2.1/be/src/runtime/group_commit_mgr.cpp:145:57: error: no matching function for call to 'min'
        _get_cond.wait_for(l, std::chrono::milliseconds(std::min(left_milliseconds, (size_t)10000L)));
                                                        ^~~~~~~~ 
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:40:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('int64_t' (aka 'long long') vs. 'size_t' (aka 'unsigned long'))
min(const _Tp& __a, const _Tp& __b)
^ 
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/min.h:51:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'int64_t' (aka 'long long')
min(initializer_list<_Tp> __t, _Compare __comp)
```