### PR TITLE
[improvement](mow) Add more log on getDeleteBitmapUpdateLock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -714,6 +714,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         }
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
+        int totalRetryTime = 0;
         for (Map.Entry<Long, Set<Long>> entry : tableToParttions.entrySet()) {
             GetDeleteBitmapUpdateLockRequest.Builder builder = GetDeleteBitmapUpdateLockRequest.newBuilder();
             builder.setTableId(entry.getKey())
@@ -790,10 +791,13 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                     cumulativePoints.put(tabletId, respCumulativePoints.get(i));
                 }
             }
+            totalRetryTime += retryTime;
         }
         stopWatch.stop();
-        LOG.info("get delete bitmap lock successfully. txns: {}. time cost: {} ms.",
-                 transactionId, stopWatch.getTime());
+        LOG.info(
+                "get delete bitmap lock successfully. txns: {}. totalRetryTime: {}. "
+                        + "partitionSize: {}. time cost: {} ms.",
+                transactionId, totalRetryTime, tableToParttions.size(), stopWatch.getTime());
     }
 
     private void sendCalcDeleteBitmaptask(long dbId, long transactionId,

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -794,10 +794,12 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             totalRetryTime += retryTime;
         }
         stopWatch.stop();
-        LOG.info(
-                "get delete bitmap lock successfully. txns: {}. totalRetryTime: {}. "
-                        + "partitionSize: {}. time cost: {} ms.",
-                transactionId, totalRetryTime, tableToParttions.size(), stopWatch.getTime());
+        if (totalRetryTime > 0 || stopWatch.getTime() > 20) {
+            LOG.info(
+                    "get delete bitmap lock successfully. txns: {}. totalRetryTime: {}. "
+                            + "partitionSize: {}. time cost: {} ms.",
+                    transactionId, totalRetryTime, tableToParttions.size(), stopWatch.getTime());
+        }
     }
 
     private void sendCalcDeleteBitmaptask(long dbId, long transactionId,


### PR DESCRIPTION
getDeleteBitmapUpdateLock may cost too much time, here is an example:
2024-07-08 16:58:43,050 INFO (thrift-server-pool-1|183) [CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock():521] get delete bitmap lock successfully. txns: 27787309217006594. time cost: 10500 ms.
So need to add more log to find out why it cost so much time.
