### PR TITLE
[fix](colocate) fix colocate join while multi tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -325,12 +325,9 @@ public class JoinUtils {
 
             SlotReference leftSlot = (SlotReference) leftChild;
             SlotReference rightSlot = (SlotReference) rightChild;
-            Integer leftIndex = null;
-            Integer rightIndex = null;
-            if (leftSlot.getTable().isPresent() && leftSlot.getTable().get().getId() == leftHashSpec.getTableId()) {
-                leftIndex = leftHashSpec.getExprIdToEquivalenceSet().get(leftSlot.getExprId());
-                rightIndex = rightHashSpec.getExprIdToEquivalenceSet().get(rightSlot.getExprId());
-            } else {
+            Integer leftIndex = leftHashSpec.getExprIdToEquivalenceSet().get(leftSlot.getExprId());
+            Integer rightIndex = rightHashSpec.getExprIdToEquivalenceSet().get(rightSlot.getExprId());
+            if (leftIndex == null) {
                 leftIndex = rightHashSpec.getExprIdToEquivalenceSet().get(leftSlot.getExprId());
                 rightIndex = leftHashSpec.getExprIdToEquivalenceSet().get(rightSlot.getExprId());
             }


### PR DESCRIPTION
after https://github.com/apache/doris/pull/37361, in multi-tables cases, we should no depend on `SlotReference.getTable()`