### PR TITLE
[bugfix](external)Modify the default value of `pushdowncount`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -98,6 +98,9 @@ public abstract class FileScanNode extends ExternalScanNode {
     }
 
     public long getPushDownCount() {
+        // 1. Do not use `0`: If the number of entries in the table is 0,
+        //                    it is unclear whether optimization has been performed.
+        // 2. Do not use `null` or `-`: This makes it easier for the program to parse the `explain` data.
         return -1;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -98,7 +98,7 @@ public abstract class FileScanNode extends ExternalScanNode {
     }
 
     public long getPushDownCount() {
-        return 0;
+        return -1;
     }
 
     @Override

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
@@ -40,7 +40,6 @@ suite("test_iceberg_optimize_count", "p0,external,doris,external_docker,external
             );"""
 
         sql """ switch ${catalog_name} """
-        sql """ create database if not exists ${catalog_name} """
         sql """ use format_v2 """
 
         sqlstr1 = """ select count(*) from sample_cow_orc; """


### PR DESCRIPTION
## Proposed changes

  1. Do not use `0`: If the number of entries in the table is 0,  it is unclear whether optimization has been performed.
  2. Do not use `null` or `-`: This makes it easier for the program to parse the `explain` data.

