### PR TITLE
[fix](fe) fix several blocking bugs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -2447,7 +2447,6 @@ public class FunctionCallExpr extends Expr {
         int result = super.hashCode();
         result = 31 * result + Objects.hashCode(opcode);
         result = 31 * result + Objects.hashCode(fnName);
-        result = 31 * result + Objects.hashCode(fnParams);
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -600,6 +600,11 @@ public abstract class ExternalCatalog
             // Should not return null.
             // Because replyInitCatalog can only be called when `use_meta_cache` is false.
             // And if `use_meta_cache` is false, getDbForReplay() will not return null
+            if (!db.isPresent()) {
+                LOG.warn("met invalid db id {} in replayInitCatalog, catalog: {}, ignore it to skip bug.",
+                        log.getRefreshDbIds().get(i), name);
+                continue;
+            }
             Preconditions.checkNotNull(db.get());
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -64,11 +64,20 @@ public class MasterCatalogExecutor {
         boolean isReturnToPool = false;
         try {
             TInitExternalCtlMetaResult result = client.initExternalCtlMeta(request);
-            Env.getCurrentEnv().getJournalObservable().waitOn(result.maxJournalId, waitTimeoutMs);
             if (!result.getStatus().equalsIgnoreCase(STATUS_OK)) {
                 throw new UserException(result.getStatus());
+            }else {
+                // DO NOT wait on journal replayed, this may cause deadlock.
+                // 1. hold table read lock
+                // 2. wait on journal replayed
+                // 3. previous journal (eg, txn journal) replayed need to hold table write lock
+                // 4. deadlock
+                // But no waiting on journal replayed may cause some request on non-master FE failed for some time.
+                // There is no good solution for this.
+                // In feature version, this whole process is refactored, so we temporarily remove this waiting.
+                // Env.getCurrentEnv().getJournalObservable().waitOn(result.maxJournalId, timeoutMs);
+                isReturnToPool = true;
             }
-            isReturnToPool = true;
         } catch (Exception e) {
             LOG.warn("Failed to finish forward init operation, please try again. ", e);
             throw e;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -66,7 +66,7 @@ public class MasterCatalogExecutor {
             TInitExternalCtlMetaResult result = client.initExternalCtlMeta(request);
             if (!result.getStatus().equalsIgnoreCase(STATUS_OK)) {
                 throw new UserException(result.getStatus());
-            }else {
+            } else {
                 // DO NOT wait on journal replayed, this may cause deadlock.
                 // 1. hold table read lock
                 // 2. wait on journal replayed


### PR DESCRIPTION
1. Redundant hashCode of FunctionCallExpr.java
    This line is redundant, and will cause the amount of hashcode calculation to grow exponentially. 

2. A potential deadlock of external catalog
    The following case may causing this deadlock:
    - high frequency load.
    - querying external table join inner table on non-master FE. 
    - refresh external catalog frequently.

3. A workaround to avoid FE restart failure because db does not found
    introduced from #33610 and fixed in #36530.
    This PR is to make previous metadata restart successfully.