### PR TITLE
[fix](nereids) fix outerjoin assoc rule bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
@@ -56,7 +56,6 @@ public class OuterJoinAssocProject extends OneExplorationRuleFactory {
     // Pair<bottomJoin, topJoin>
     // newBottomJoin Type = topJoin Type, newTopJoin Type = bottomJoin Type
     public static Set<Pair<JoinType, JoinType>> VALID_TYPE_PAIR_SET = ImmutableSet.of(
-            Pair.of(JoinType.LEFT_OUTER_JOIN, JoinType.INNER_JOIN),
             Pair.of(JoinType.INNER_JOIN, JoinType.LEFT_OUTER_JOIN),
             Pair.of(JoinType.LEFT_OUTER_JOIN, JoinType.LEFT_OUTER_JOIN));
 


### PR DESCRIPTION
## Proposed changes

Fix outer join assoc rule bug, which unexpectly doing the join reorder for the (t1 left outer t2) inner t3 => t1 left outer (t2 inner join t3) transformation, and leading the wrong result.

