### PR TITLE
[branch-2.1][improvement](jdbc catalog) Added support for Oracle Raw type 

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/OracleJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/OracleJdbcExecutor.java
@@ -27,6 +27,10 @@ import org.apache.log4j.Logger;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -34,6 +38,7 @@ import java.time.LocalDateTime;
 
 public class OracleJdbcExecutor extends BaseJdbcExecutor {
     private static final Logger LOG = Logger.getLogger(OracleJdbcExecutor.class);
+    private final CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder();
 
     public OracleJdbcExecutor(byte[] thriftParams) throws Exception {
         super(thriftParams);
@@ -117,6 +122,8 @@ public class OracleJdbcExecutor extends BaseJdbcExecutor {
                             LOG.error("Failed to get string from clob", e);
                             return null;
                         }
+                    } else if (input instanceof byte[]) {
+                        return convertByteArrayToString((byte[]) input);
                     } else {
                         return input.toString();
                     }
@@ -124,5 +131,32 @@ public class OracleJdbcExecutor extends BaseJdbcExecutor {
             default:
                 return null;
         }
+    }
+
+    private String convertByteArrayToString(byte[] bytes) {
+        if (isValidUtf8(bytes)) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        } else {
+            // Convert byte[] to hexadecimal string with "0x" prefix
+            return "0x" + bytesToHex(bytes);
+        }
+    }
+
+    private boolean isValidUtf8(byte[] bytes) {
+        utf8Decoder.reset();
+        try {
+            utf8Decoder.decode(ByteBuffer.wrap(bytes));
+            return true;
+        } catch (CharacterCodingException e) {
+            return false;
+        }
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
     }
 }

--- a/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
@@ -136,30 +136,9 @@ mysql
 -- !date7 --
 3	\N	2019-11-12T20:33:57.999	\N	\N	\N	\N	\N
 
--- !filter4_old_plan --
-1	alice	20	99.5
-3	jerry	23	88.0
-4	andy	21	93.0
-
--- !filter5_old_plan --
-1	alice	20	99.5
-2	bob	21	90.5
-3	jerry	23	88.0
-4	andy	21	93.0
-
--- !filter6_old_plan --
-1	alice	20	99.5
-4	andy	21	93.0
-
--- !filter7_old_plan --
-3	jerry	23	88.0
-
--- !filter8_old_plan --
-4	andy	21	93.0
-
--- !filter9_old_plan --
-3	jerry	23	88.0
-4	andy	21	93.0
+-- !raw --
+1	0xFFFF	0xAAAA
+2	beijing	shanghai
 
 -- !test_insert1 --
 doris1	18

--- a/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
@@ -141,9 +141,7 @@ suite("test_oracle_jdbc_catalog", "p0,external,oracle,external_docker,external_d
             contains """SELECT "ID", "NAME", "AGE", "SCORE" FROM "DORIS_TEST"."STUDENT" WHERE ((nvl("SCORE", 0.0) < 95.0))"""
         }
 
-        // The result of TEST_RAW will change
-        // So instead of qt, we're using sql here.
-        sql  """ select * from TEST_RAW order by ID; """
+        order_qt_raw  """ select * from TEST_RAW order by ID; """
 
         // test insert
         String uuid1 = UUID.randomUUID().toString();


### PR DESCRIPTION
pick (#37078)
In previous versions, we adopted the strategy of reading the object address for Oracle's raw type, which would lead to unstable and meaningless results. Here I changed it to read hexadecimal or UTF8

