### PR TITLE
[Fix]Add audit log event queue size limit

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2899,6 +2899,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_cloud_running_txn_check = true;
 
+    //* audit_event_log_queue_size = qps * query_audit_log_timeout_ms
+    @ConfField(mutable = true)
+    public static int audit_event_log_queue_size = 250000;
+
     @ConfField(description = {"存算分离模式下streamload导入使用的转发策略, 可选值为public-private或者空",
             "streamload route policy in cloud mode, availale options are public-private and empty string"})
     public static String streamload_redirect_policy = "";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
@@ -70,12 +70,21 @@ public class AuditEventProcessor {
         }
     }
 
-    public void handleAuditEvent(AuditEvent auditEvent) {
+    public boolean handleAuditEvent(AuditEvent auditEvent) {
+        return handleAuditEvent(auditEvent, false);
+    }
+
+    public boolean handleAuditEvent(AuditEvent auditEvent, boolean ignoreQueueFullLog) {
+        boolean isAddSucc = true;
         try {
             eventQueue.add(auditEvent);
         } catch (Exception e) {
-            LOG.warn("encounter exception when handle audit event, ignore", e);
+            isAddSucc = false;
+            if (!ignoreQueueFullLog) {
+                LOG.warn("encounter exception when handle audit event {}, ignore", auditEvent.type, e);
+            }
         }
+        return isAddSucc;
     }
 
     public class Worker implements Runnable {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
@@ -71,20 +71,35 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
         Map<String, TQueryStatistics> queryStatisticsMap = getQueryStatisticsMap();
 
         // 2 log query audit
-        List<AuditEvent> auditEventList = getQueryNeedAudit();
-        for (AuditEvent auditEvent : auditEventList) {
-            TQueryStatistics queryStats = queryStatisticsMap.get(auditEvent.queryId);
-            if (queryStats != null) {
-                auditEvent.scanRows = queryStats.scan_rows;
-                auditEvent.scanBytes = queryStats.scan_bytes;
-                auditEvent.scanBytesFromLocalStorage = queryStats.scan_bytes_from_local_storage;
-                auditEvent.scanBytesFromRemoteStorage = queryStats.scan_bytes_from_remote_storage;
-                auditEvent.peakMemoryBytes = queryStats.max_peak_memory_bytes;
-                auditEvent.cpuTimeMs = queryStats.cpu_ms;
-                auditEvent.shuffleSendBytes = queryStats.shuffle_send_bytes;
-                auditEvent.shuffleSendRows = queryStats.shuffle_send_rows;
+        try {
+            List<AuditEvent> auditEventList = getQueryNeedAudit();
+            int missedLogCount = 0;
+            int succLogCount = 0;
+            for (AuditEvent auditEvent : auditEventList) {
+                TQueryStatistics queryStats = queryStatisticsMap.get(auditEvent.queryId);
+                if (queryStats != null) {
+                    auditEvent.scanRows = queryStats.scan_rows;
+                    auditEvent.scanBytes = queryStats.scan_bytes;
+                    auditEvent.scanBytesFromLocalStorage = queryStats.scan_bytes_from_local_storage;
+                    auditEvent.scanBytesFromRemoteStorage = queryStats.scan_bytes_from_remote_storage;
+                    auditEvent.peakMemoryBytes = queryStats.max_peak_memory_bytes;
+                    auditEvent.cpuTimeMs = queryStats.cpu_ms;
+                    auditEvent.shuffleSendBytes = queryStats.shuffle_send_bytes;
+                    auditEvent.shuffleSendRows = queryStats.shuffle_send_rows;
+                }
+                boolean ret = Env.getCurrentAuditEventProcessor().handleAuditEvent(auditEvent, true);
+                if (!ret) {
+                    missedLogCount++;
+                } else {
+                    succLogCount++;
+                }
             }
-            Env.getCurrentAuditEventProcessor().handleAuditEvent(auditEvent);
+            if (missedLogCount > 0) {
+                LOG.warn("discard audit event because of log queue is full, discard num : {}, succ num : {}",
+                        missedLogCount, succLogCount);
+            }
+        } catch (Throwable t) {
+            LOG.warn("exception happens when handleAuditEvent, ", t);
         }
 
         // 3 clear beToQueryStatsMap when be report timeout
@@ -94,6 +109,12 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
     public void submitFinishQueryToAudit(AuditEvent event) {
         queryAuditEventLogWriteLock();
         try {
+            if (queryAuditEventList.size() >= Config.audit_event_log_queue_size) {
+                LOG.warn("audit log event queue size {} is full, this may cause audit log missed."
+                                + "you can check whether qps is too high or reset audit_event_log_queue_size",
+                        queryAuditEventList.size());
+                return;
+            }
             event.pushToAuditLogQueueTime = System.currentTimeMillis();
             queryAuditEventList.add(event);
         } finally {


### PR DESCRIPTION
## Proposed changes
```

 num     #instances         #bytes  class name
----------------------------------------------
   1:     375686347    28162104360  [C
   2:      93198001    21621936232  org.apache.doris.plugin.audit.AuditEvent
   3:     375801573    12025650336  java.lang.String
   4:      61002811     2440112440  java.util.LinkedList$Node
```
We find in some cases  excessive audit log may be generatated, so add a queue limit for audit log queue in WorkloadRuntimeStatMgr.
