### PR TITLE
[improvement](cloud) Accelerate cloud rebalance by batch editlog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowReplicaDistributionStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowReplicaDistributionStmt.java
@@ -82,6 +82,10 @@ public class ShowReplicaDistributionStmt extends ShowStmt {
 
     @Override
     public RedirectStatus getRedirectStatus() {
-        return RedirectStatus.FORWARD_NO_SYNC;
+        if (ConnectContext.get().getSessionVariable().getForwardToMaster()) {
+            return RedirectStatus.FORWARD_NO_SYNC;
+        } else {
+            return RedirectStatus.NO_FORWARD;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -25,6 +25,7 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 
@@ -221,7 +222,10 @@ public class CloudReplica extends Replica {
                 return backendId;
             }
         }
-
+        if (DebugPointUtil.isEnable("CloudReplica.getBackendIdImpl.clusterToBackends")) {
+            LOG.info("Debug Point enable CloudReplica.getBackendIdImpl.clusterToBackends");
+            return -1;
+        }
         return hashReplicaToBe(clusterId, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -991,6 +991,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
     }
 
     private List<UpdateCloudReplicaInfo> batchUpdateCloudReplicaInfoEditlogs(List<UpdateCloudReplicaInfo> infos) {
+        long start = System.currentTimeMillis();
         List<UpdateCloudReplicaInfo> rets = new ArrayList<>();
         // clusterId, infos
         Map<String, List<UpdateCloudReplicaInfo>> clusterIdToInfos = infos.stream()
@@ -1039,6 +1040,10 @@ public class CloudTabletRebalancer extends MasterDaemon {
                 newInfo.setTabletId(-1);
                 rets.add(newInfo);
             });
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("batchUpdateCloudReplicaInfoEditlogs old size {}, cur size {} cost {} ms",
+                    infos.size(), rets.size(), System.currentTimeMillis() - start);
         }
         return rets;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -1036,6 +1036,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
                 newInfo.setTableId(tableId);
                 newInfo.setPartitionId(partitionId);
                 newInfo.setIndexId(indexId);
+                newInfo.setClusterId(clusterId);
                 // APPR: in unprotectUpdateCloudReplica, use batch must set tabletId = -1
                 newInfo.setTabletId(-1);
                 rets.add(newInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -939,7 +939,12 @@ public class CloudInternalCatalog extends InternalCatalog {
                 List<Long> tabletIds = info.getTabletIds();
                 for (int i = 0; i < tabletIds.size(); ++i) {
                     Tablet tablet = materializedIndex.getTablet(tabletIds.get(i));
-                    Replica replica = tablet.getReplicas().get(0);
+                    Replica replica;
+                    if (info.getReplicaIds().isEmpty()) {
+                        replica = tablet.getReplicas().get(0);
+                    } else {
+                        replica = tablet.getReplicaById(info.getReplicaIds().get(i));
+                    }
                     Preconditions.checkNotNull(replica, info);
 
                     String clusterId = info.getClusterId();

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/persist/UpdateCloudReplicaInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/persist/UpdateCloudReplicaInfo.java
@@ -59,7 +59,7 @@ public class UpdateCloudReplicaInfo implements Writable {
     @SerializedName(value = "beIds")
     private List<Long> beIds = new ArrayList<Long>();
 
-    @SerializedName(value = "rids", alternate = {"replicaIds"})
+    @SerializedName(value = "rids")
     private List<Long> replicaIds = new ArrayList<>();
 
     public UpdateCloudReplicaInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/persist/UpdateCloudReplicaInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/persist/UpdateCloudReplicaInfo.java
@@ -17,11 +17,14 @@
 
 package org.apache.doris.cloud.persist;
 
+
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -29,6 +32,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
+@Setter
 public class UpdateCloudReplicaInfo implements Writable {
     @SerializedName(value = "dbId")
     private long dbId;
@@ -53,6 +58,9 @@ public class UpdateCloudReplicaInfo implements Writable {
 
     @SerializedName(value = "beIds")
     private List<Long> beIds = new ArrayList<Long>();
+
+    @SerializedName(value = "rids", alternate = {"replicaIds"})
+    private List<Long> replicaIds = new ArrayList<>();
 
     public UpdateCloudReplicaInfo() {
     }
@@ -97,46 +105,6 @@ public class UpdateCloudReplicaInfo implements Writable {
         return GsonUtils.GSON.fromJson(json, UpdateCloudReplicaInfo.class);
     }
 
-    public long getDbId() {
-        return dbId;
-    }
-
-    public long getTableId() {
-        return tableId;
-    }
-
-    public long getPartitionId() {
-        return partitionId;
-    }
-
-    public long getIndexId() {
-        return indexId;
-    }
-
-    public long getTabletId() {
-        return tabletId;
-    }
-
-    public long getReplicaId() {
-        return replicaId;
-    }
-
-    public String getClusterId() {
-        return clusterId;
-    }
-
-    public long getBeId() {
-        return beId;
-    }
-
-    public List<Long> getBeIds() {
-        return beIds;
-    }
-
-    public List<Long> getTabletIds() {
-        return tabletIds;
-    }
-
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("database id: ").append(dbId);
@@ -157,6 +125,11 @@ public class UpdateCloudReplicaInfo implements Writable {
 
                 sb.append(" tablet id list: ");
                 for (long id : tabletIds) {
+                    sb.append(" ").append(id);
+                }
+
+                sb.append(" replica id list: ");
+                for (long id : replicaIds) {
                     sb.append(" ").append(id);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalBatch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalBatch.java
@@ -60,8 +60,8 @@ public class JournalBatch {
         entity.setData(data);
 
         DataOutputBuffer buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
-        size += buffer.size();
         entity.write(buffer);
+        size += buffer.size();
 
         entities.add(new Entity(op, buffer));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalBatch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalBatch.java
@@ -21,6 +21,8 @@ import org.apache.doris.common.io.DataOutputBuffer;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.OperationType;
 
+import lombok.Getter;
+
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -28,6 +30,9 @@ public class JournalBatch {
     private static final int OUTPUT_BUFFER_INIT_SIZE = 128;
 
     private ArrayList<Entity> entities;
+
+    @Getter
+    private long size = 0;
 
     public JournalBatch() {
         entities = new ArrayList<>();
@@ -55,6 +60,7 @@ public class JournalBatch {
         entity.setData(data);
 
         DataOutputBuffer buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
+        size += buffer.size();
         entity.write(buffer);
 
         entities.add(new Entity(op, buffer));

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1595,7 +1595,11 @@ public class EditLog {
     }
 
     public void logUpdateCloudReplicas(List<UpdateCloudReplicaInfo> infos) throws IOException {
+        long start = System.currentTimeMillis();
         logEdit(OperationType.OP_UPDATE_CLOUD_REPLICA, infos);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("log update {} cloud replicas. cost: {} ms", infos.size(), (System.currentTimeMillis() - start));
+        }
     }
 
     public void logExportUpdateState(long jobId, ExportJobState newState) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -104,7 +104,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -1267,21 +1266,17 @@ public class EditLog {
     }
 
     private synchronized <T extends Writable> void logEdit(short op, List<T> entries) throws IOException {
-        List<JournalBatch> batches = new ArrayList<>();
         JournalBatch batch = new JournalBatch(35);
         for (T entry : entries) {
             // the number of batch entities to less than 32 and the batch data size to less than 640KB
             if (batch.getJournalEntities().size() >= 32 || batch.getSize() >= 640 * 1024) {
-                batches.add(batch);
+                journal.write(batch);
                 batch = new JournalBatch(35);
             }
             batch.addJournal(op, entry);
         }
         if (!batch.getJournalEntities().isEmpty()) {
-            batches.add(batch);
-        }
-        for (JournalBatch b : batches) {
-            journal.write(b);
+            journal.write(batch);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1271,7 +1271,7 @@ public class EditLog {
         JournalBatch batch = new JournalBatch(35);
         for (T entry : entries) {
             // the number of batch entities to less than 32 and the batch data size to less than 640KB
-            if (batch.getJournalEntities().size() > 32 || batch.getSize() > 640 * 1024) {
+            if (batch.getJournalEntities().size() >= 32 || batch.getSize() >= 640 * 1024) {
                 batches.add(batch);
                 batch = new JournalBatch(35);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1277,6 +1277,9 @@ public class EditLog {
             }
             batch.addJournal(op, entry);
         }
+        if (!batch.getJournalEntities().isEmpty()) {
+            batches.add(batch);
+        }
         for (JournalBatch b : batches) {
             journal.write(b);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1594,10 +1594,6 @@ public class EditLog {
         logEdit(OperationType.OP_EXPORT_CREATE, job);
     }
 
-    public void logUpdateCloudReplica(UpdateCloudReplicaInfo info) {
-        logEdit(OperationType.OP_UPDATE_CLOUD_REPLICA, info);
-    }
-
     public void logUpdateCloudReplicas(List<UpdateCloudReplicaInfo> infos) throws IOException {
         logEdit(OperationType.OP_UPDATE_CLOUD_REPLICA, infos);
     }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -17,6 +17,8 @@
 
 package org.apache.doris.regression.suite
 
+import org.awaitility.Awaitility
+import static java.util.concurrent.TimeUnit.SECONDS
 import groovy.json.JsonOutput
 import com.google.common.collect.Maps
 import com.google.common.util.concurrent.Futures
@@ -257,6 +259,15 @@ class Suite implements GroovyInterceptable {
     public <T> T connect(String user = context.config.jdbcUser, String password = context.config.jdbcPassword,
                          String url = context.config.jdbcUrl, Closure<T> actionSupplier) {
         return context.connect(user, password, url, actionSupplier)
+    }
+
+    public void dockerAwaitUntil(int atMostSeconds, int intervalSecond = 1, Closure actionSupplier) {
+        def connInfo = context.threadLocalConn.get()
+        Awaitility.await().atMost(atMostSeconds, SECONDS).pollInterval(intervalSecond, SECONDS).until(
+            {
+                connect(connInfo.username, connInfo.password, connInfo.conn.getMetaData().getURL(), actionSupplier)
+            }
+        )
     }
 
     public void docker(ClusterOptions options = new ClusterOptions(), Closure actionSupplier) throws Exception {

--- a/regression-test/suites/cloud_p0/multi_cluster/test_rebalance.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_rebalance.groovy
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+import org.awaitility.Awaitility;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+suite('test_rebalance_in_cloud', 'multi_cluster') {
+    if (!isCloudMode()) {
+        return;
+    }
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'enable_cloud_warm_up_for_rebalance=false',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.setFeNum(3)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.connectToFollower = true
+
+    docker(options) {
+        sql """
+            CREATE TABLE table100 (
+            class INT,
+            id INT,
+            score INT SUM
+            )
+            AGGREGATE KEY(class, id)
+            DISTRIBUTED BY HASH(class) BUCKETS 48
+        """
+
+        sql """
+            CREATE TABLE table_p2 ( k1 int(11) NOT NULL, k2 varchar(20) NOT NULL, k3 int sum NOT NULL )
+            AGGREGATE KEY(k1, k2)
+            PARTITION BY RANGE(k1) (
+            PARTITION p1992 VALUES [("-2147483648"), ("19930101")),
+            PARTITION p1993 VALUES [("19930101"), ("19940101")),
+            PARTITION p1994 VALUES [("19940101"), ("19950101")),
+            PARTITION p1995 VALUES [("19950101"), ("19960101")),
+            PARTITION p1996 VALUES [("19960101"), ("19970101")),
+            PARTITION p1997 VALUES [("19970101"), ("19980101")),
+            PARTITION p1998 VALUES [("19980101"), ("19990101")))
+            DISTRIBUTED BY HASH(k1) BUCKETS 3
+        """
+
+        setFeConfig('cloud_balance_tablet_percent_per_run', 0.5)
+        setFeConfig('cloud_pre_heating_time_limit_sec', 1)
+        sql """set forward_to_master=false"""
+        
+        // add a be
+        cluster.addBackend(1, null)
+        
+        dockerAwaitUntil(30) {
+            def bes = sql """show backends"""
+            log.info("bes: {}", bes)
+            bes.size() == 2
+        }
+        
+
+        dockerAwaitUntil(5) {
+            def ret = sql """ADMIN SHOW REPLICA DISTRIBUTION FROM table100"""
+            log.info("replica distribution table100: {}", ret)
+            ret.size() == 2
+        }
+
+        def result = sql """ADMIN SHOW REPLICA DISTRIBUTION FROM table100; """
+        assertEquals(2, result.size());
+
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 25 && Integer.valueOf((String) row[1]) >= 23)
+        }
+
+        dockerAwaitUntil(5) {
+            def ret = sql """ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1992)"""
+            log.info("replica distribution table_p2: {}", ret)
+            ret.size() == 2
+        }
+
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1992) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1993) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1994) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1995) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1996) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+
+        result = sql """ ADMIN SHOW REPLICA DISTRIBUTION FROM table_p2 PARTITION(p1997) """
+        assertEquals(2, result.size());
+        for (def row : result) {
+            log.info("replica distribution: ${row} ".toString())
+            assertTrue(Integer.valueOf((String) row[1]) <= 2 && Integer.valueOf((String) row[1]) >= 1)
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

1. use `JournalBatch` to batch editlogs
2. same partition, different tablets use one editlog

env：
in docker cloud mode, 3fe 3be. 
3be expansion to 4be, trigger cloud rebalance
table, 1860 partitions, 48 buckets, every rebalance loop min balance 12 and close pre cache

result:
```
before improvement
2024-07-16 16:51:01,371 INFO (cloud tablet rebalancer|77) [CloudTabletRebalancer.runAfterCatalogReady():228] 
finished to rebalancer. cost: 58471 ms


after imprevement
2024-07-16 17:10:20,699 INFO (cloud tablet rebalancer|77) [CloudTabletRebalancer.runAfterCatalogReady():235]
finished to rebalancer. cost: 28687 ms
```
