### PR TITLE
Revert "[fix](routine-load) fix auto resume invalid when FE leader change (#37071)"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -242,16 +242,11 @@ public abstract class RoutineLoadJob
     @SerializedName("pg")
     protected RoutineLoadProgress progress;
 
-    @SerializedName("lrt")
     protected long latestResumeTimestamp; // the latest resume time
-    @SerializedName("art")
     protected long autoResumeCount;
     // some other msg which need to show to user;
-    @SerializedName("om")
     protected String otherMsg = "";
-    @SerializedName("pr")
     protected ErrorReason pauseReason;
-    @SerializedName("cr")
     protected ErrorReason cancelReason;
 
     @SerializedName("cts")


### PR DESCRIPTION
revert (#37071)

It will only call the `write` method to write the edit log when creating the routine load job, but will not use this method when change job state to pause, but use the logic:
```
Env.getCurrentEnv().getEditLog().logOpRoutineLoadJob(new RoutineLoadOperation(id, jobState));
```
Therefore, using the logic:
```
@SerializedName("pr")
protected ErrorReason pauseReason;
```
only persist pauseReason when create job, rather than pause job, which means `pauseReason` will not be persist when it is assigned due to pause, causing auto resume still invalid if FE leader change when job pause.

