### PR TITLE
[improvement](regression)Use createMV to create materialized view.

### DIFF
--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -127,12 +127,9 @@ suite("test_analyze_mv") {
             "replication_num" = "1"
         )
     """
-    sql """create materialized view mv1 as select key1 from mvTestDup;"""
-    wait_mv_finish("test_analyze_mv", "mvTestDup")
-    sql """create materialized view mv2 as select key2 from mvTestDup;"""
-    wait_mv_finish("test_analyze_mv", "mvTestDup")
-    sql """create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestDup group by key1, key2;"""
-    wait_mv_finish("test_analyze_mv", "mvTestDup")
+    createMV("create materialized view mv1 as select key1 from mvTestDup;")
+    createMV("create materialized view mv2 as select key2 from mvTestDup;")
+    createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestDup group by key1, key2;")
     sql """insert into mvTestDup values (1, 2, 3, 4, 5), (1, 2, 3, 4, 5), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
 
     sql """analyze table mvTestDup with sync;"""
@@ -237,12 +234,9 @@ suite("test_analyze_mv") {
         );
     """
 
-    sql """create materialized view mv1 as select key2 from mvTestAgg;"""
-    wait_mv_finish("test_analyze_mv", "mvTestAgg")
-    sql """create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestAgg group by key1, key2;"""
-    wait_mv_finish("test_analyze_mv", "mvTestAgg")
-    sql """create materialized view mv6 as select key1, sum(value1) from mvTestAgg group by key1;"""
-    wait_mv_finish("test_analyze_mv", "mvTestAgg")
+    createMV("create materialized view mv1 as select key2 from mvTestAgg;")
+    createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestAgg group by key1, key2;")
+    createMV("create materialized view mv6 as select key1, sum(value1) from mvTestAgg group by key1;")
     sql """alter table mvTestAgg ADD ROLLUP rollup1(key1, value1)"""
     wait_mv_finish("test_analyze_mv", "mvTestAgg")
     sql """insert into mvTestAgg values (1, 2, 3, 4, 5), (1, 2, 3, 4, 5), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
@@ -379,10 +373,8 @@ suite("test_analyze_mv") {
         );
     """
 
-    sql """create materialized view mv1 as select key1 from mvTestUni;"""
-    wait_mv_finish("test_analyze_mv", "mvTestUni")
-    sql """create materialized view mv6 as select key2, value2, value3 from mvTestUni;"""
-    wait_mv_finish("test_analyze_mv", "mvTestUni")
+    createMV("create materialized view mv1 as select key1 from mvTestUni;")
+    createMV("create materialized view mv6 as select key2, value2, value3 from mvTestUni;")
     sql """insert into mvTestUni values (1, 2, 3, 4, 5), (1, 2, 3, 7, 8), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
 
     sql """analyze table mvTestUni with sync;"""

--- a/regression-test/suites/statistics/test_partition_stats.groovy
+++ b/regression-test/suites/statistics/test_partition_stats.groovy
@@ -904,10 +904,8 @@ suite("test_partition_stats") {
     PROPERTIES (
         "replication_allocation" = "tag.location.default: 1"
     )"""
-    sql """create materialized view mv1 as select id, colint from part8;"""
-    wait_mv_finish("test_partition_stats", "part8")
-    sql """create materialized view mv2 as select colsmallint, sum(colbigint) from part8 group by colsmallint;"""
-    wait_mv_finish("test_partition_stats", "part8")
+    createMV("create materialized view mv1 as select id, colint from part8;")
+    createMV("create materialized view mv2 as select colsmallint, sum(colbigint) from part8 group by colsmallint;")
     sql """alter table part8 ADD ROLLUP rollup1(coltinyint, collargeint)"""
     wait_mv_finish("test_partition_stats", "part8")
 

--- a/regression-test/suites/statistics/test_select_mv.groovy
+++ b/regression-test/suites/statistics/test_select_mv.groovy
@@ -67,9 +67,7 @@ suite("test_select_mv") {
         );
     """
 
-    sql """
-        create materialized view dup1 as select key2, sum(value) from test_dup group by key2; 
-    """
+    createMV("create materialized view dup1 as select key2, sum(value) from test_dup group by key2;")
 
     sql """CREATE TABLE test_agg (
             key1 int NOT NULL,
@@ -83,10 +81,7 @@ suite("test_select_mv") {
         );
     """
 
-    sql """
-        create materialized view agg1 as select key2, sum(value) from test_agg group by key2; 
-    """
-    wait_mv_finish("test_select_mv")
+    createMV("create materialized view agg1 as select key2, sum(value) from test_agg group by key2;")
 
     sql """insert into test_dup values (1, 1, 1), (2, 2, 2)"""
     sql """insert into test_dup values (1, 1, 1), (2, 2, 2)"""


### PR DESCRIPTION
Sometimes, the regression case of create mv will fail because table is not NORMAL. Do not allow doing ALTER.
This pr use createMV method to create mv, it include the waiting time of doing mv jobs.