### PR TITLE
[fix](cloud) provide a conf to enable/disable streamload commit on be (#37848)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -537,6 +537,8 @@ DEFINE_mInt32(stream_load_record_batch_size, "50");
 DEFINE_Int32(stream_load_record_expire_time_secs, "28800");
 // time interval to clean expired stream load records
 DEFINE_mInt64(clean_stream_load_record_interval_secs, "1800");
+// enable stream load commit txn on BE directly, bypassing FE. Only for cloud.
+DEFINE_mBool(enable_stream_load_commit_txn_on_be, "false");
 // The buffer size to store stream table function schema info
 DEFINE_Int64(stream_tvf_buffer_size, "1048576"); // 1MB
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -586,6 +586,8 @@ DECLARE_mInt32(stream_load_record_batch_size);
 DECLARE_Int32(stream_load_record_expire_time_secs);
 // time interval to clean expired stream load records
 DECLARE_mInt64(clean_stream_load_record_interval_secs);
+// enable stream load commit txn on BE directly, bypassing FE. Only for cloud.
+DECLARE_mBool(enable_stream_load_commit_txn_on_be);
 // The buffer size to store stream table function schema info
 DECLARE_Int64(stream_tvf_buffer_size);
 


### PR DESCRIPTION
Add BE config `enable_stream_load_commit_txn_on_be` default false

When to enable commit on be?
Bypassing FE during commit is good for load performance, especially when doing frequent streamloading.

When to disable commit on be?
The current implementation of the bypass will mess up the statistics, thus the query plan optimizer. So disable it when you encountering any troubles. Such problem will be fixed in future work.