### PR TITLE
[fix](regression) fix mow flaky case for cloud

### DIFF
--- a/regression-test/suites/fault_injection_p0/cloud/test_cloud_mow_delete_bitmap_calc_timeout.groovy
+++ b/regression-test/suites/fault_injection_p0/cloud/test_cloud_mow_delete_bitmap_calc_timeout.groovy
@@ -36,6 +36,7 @@ suite("test_cloud_mow_delete_bitmap_calc_timeout","nonConcurrent") {
         """
 
     GetDebugPoint().clearDebugPointsForAllFEs()
+    GetDebugPoint().clearDebugPointsForAllBEs()
 
     try {
         sql "insert into ${tableName} values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3);"


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

the case `test_cloud_mow_delete_bitmap_calc_timeout` is flaky, it failed due to the following exception
```
Exception:
java.sql.SQLException: errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]failed to initialize storage reader. tablet=532938472811, res=[INTERNAL_ERROR]{} does not need to read data
```
but the exception is injected by other case, I suspect these cases don't clear the debug points for some unexpected reason.

to fix the flaky case, add a clear command at the first
