### PR TITLE
[fix](mv) fix not hit mv when table has float type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
@@ -71,6 +71,11 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.FloatType;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.SmallIntType;
+import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.VarcharType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.Utils;
@@ -1495,7 +1500,14 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                 return result;
             }
             if (!sum.isDistinct()) {
-                Expression expr = castIfNeed(sum.child(), BigIntType.INSTANCE);
+                Expression expr = sum.child();
+                if (expr.getDataType().equals(TinyIntType.INSTANCE)
+                        || expr.getDataType().equals(SmallIntType.INSTANCE)
+                        || expr.getDataType().equals(IntegerType.INSTANCE)) {
+                    expr = castIfNeed(expr, BigIntType.INSTANCE);
+                } else if (expr.getDataType().equals(FloatType.INSTANCE)) {
+                    expr = castIfNeed(expr, DoubleType.INSTANCE);
+                }
                 String sumColumn = normalizeName(CreateMaterializedViewStmt.mvColumnBuilder(AggregateType.SUM,
                         CreateMaterializedViewStmt.mvColumnBuilder(expr.toSql())));
                 Column mvColumn = context.checkContext.getColumn(sumColumn);

--- a/regression-test/suites/demo_p0/explain_action.groovy
+++ b/regression-test/suites/demo_p0/explain_action.groovy
@@ -51,4 +51,66 @@ suite("explain_action") {
             assertTrue(exception != null)
         }
     }
+
+    def dbName = "regression_test_demo_p0"
+    def tbName = "tb_base"
+    def tbMvName = "${tbName}_mv"
+    sql """
+            set experimental_enable_nereids_planner=true;
+        """
+    sql """
+            drop database if exists ${dbName};
+        """
+    sql """
+            create database  ${dbName};
+        """
+    sql """ CREATE TABLE ${dbName}.${tbName} (
+                k0 BOOLEAN NOT NULL, 
+                k1 TINYINT NOT NULL, 
+                k2 SMALLINT NOT NULL, 
+                k3 INT NOT NULL, 
+                k4 BIGINT NOT NULL, 
+                k5 LARGEINT NOT NULL, 
+                k6 DECIMALV3(9, 3) NOT NULL, 
+                k7 CHAR(5) NOT NULL, 
+                k8 DATE NOT NULL, 
+                k9 DATETIME NOT NULL, 
+                k10 VARCHAR(20) NOT NULL, 
+                k11 DOUBLE NOT NULL, 
+                k12 FLOAT NOT NULL
+                ) PARTITION BY RANGE(k1) (
+                PARTITION p1 
+                VALUES 
+                    LESS THAN ("-10"), 
+                    PARTITION p2 
+                VALUES 
+                    LESS THAN ("0"), 
+                    PARTITION p3 
+                VALUES 
+                    LESS THAN ("10"), 
+                    PARTITION p4 
+                VALUES 
+                    LESS THAN ("20")
+                ) DISTRIBUTED BY HASH(k4, k5) BUCKETS 1;
+        """
+    sql """
+            CREATE MATERIALIZED VIEW ${tbMvName} AS SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from ${dbName}.${tbName} group by k0;
+        """
+    sql """
+            insert into ${dbName}.${tbName} values(1,2,3,4,5,6,7,"8","2020-10-01","2020-10-10","10",12,13);
+        """
+    def count = 10;
+    while (true) {
+        def result = sql "desc ${dbName}.${tbName} all;"
+        if (result.toString().containsIgnoreCase("${tbMvName}")) {
+            break;
+        } else {
+            sleep 1000
+            count++
+        }
+    }
+    explain {
+        sql("SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from ${dbName}.${tbName} group by k0;")
+        contains "${tbMvName}"
+    }
 }


### PR DESCRIPTION
```
CREATE DATABASE test_db;
use test_db;
CREATE TABLE test_db.table_1 (
  k0 BOOLEAN NOT NULL, 
  k1 TINYINT NOT NULL, 
  k2 SMALLINT NOT NULL, 
  k3 INT NOT NULL, 
  k4 BIGINT NOT NULL, 
  k5 LARGEINT NOT NULL, 
  k6 DECIMALV3(9, 3) NOT NULL, 
  k7 CHAR(5) NOT NULL, 
  k8 DATE NOT NULL, 
  k9 DATETIME NOT NULL, 
  k10 VARCHAR(20) NOT NULL, 
  k11 DOUBLE NOT NULL, 
  k12 FLOAT NOT NULL
) PARTITION BY RANGE(k1) (
  PARTITION p1 
  VALUES 
    LESS THAN ("-10"), 
    PARTITION p2 
  VALUES 
    LESS THAN ("0"), 
    PARTITION p3 
  VALUES 
    LESS THAN ("10"), 
    PARTITION p4 
  VALUES 
    LESS THAN ("20")
) DISTRIBUTED BY HASH(k4, k5) BUCKETS 1;


CREATE MATERIALIZED VIEW table_1_mv AS SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from test_db.table_1 group by k0

set experimental_enable_nereids_planner=true;
insert into table_1 values(1,2,3,4,5,6,7,"8","2020-10-01","2020-10-10","10",12,13);

EXPLAIN SELECT k0, max(k8), min(k11), sum(k12), count(k10), hll_union(hll_hash(k7)), bitmap_union(to_bitmap(k2)) from test_db.table_1 group by k0
```
# wrong result
```
 0:VOlapScanNode(141)                                                                                                                                                                                                                                                                                                                                                                                                |
|      TABLE: test_db.table_1(table_1), PREAGGREGATION: ON

```

# expected result
```
 0:VOlapScanNode(141)                                                                                                                                                                                                                                                                                                                                                                                                |
|      TABLE: test_db.table_1(table_1_mv), PREAGGREGATION: ON

```
