### PR TITLE
[opt](regression-test) Increase the size of webserver_num_workers

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -30,3 +30,4 @@ file_cache_path = [{"path":"/data/doris_cloud/file_cache","total_size":104857600
 tmp_file_dirs = [{"path":"/data/doris_cloud/tmp","max_cache_bytes":104857600,"max_upload_bytes":104857600}]
 thrift_rpc_timeout_ms = 360000
 save_load_error_log_to_s3 = true
+webserver_num_workers = 128

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -66,4 +66,5 @@ enable_jvm_monitor = true
 
 enable_be_proc_monitor = true
 be_proc_monitor_interval_ms = 30000
+webserver_num_workers = 128
 


### PR DESCRIPTION
Having multiple concurrent stream loads in #37569, may result in insufficient web server threads, affecting the speed of other stream load cases.

