### PR TITLE
(stream load) Add special code for transaction exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
@@ -38,6 +38,11 @@ public enum InternalErrorCode {
     CANNOT_RESUME_ERR(105),
     TIMEOUT_TOO_MUCH(106),
 
+    TXN_NOT_EXIST(151),
+    TXN_ALREADY_ABORT(152),
+    TXN_ALREADY_COMMITTED(153),
+    TXN_ALREADY_VISIBLE(154),
+
     // for external catalog
     GET_REMOTE_DATA_ERROR(202),
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1767,11 +1767,11 @@ public class DatabaseTransactionMgr {
             throws UserException {
         TransactionState transactionState = unprotectedGetTransactionState(transactionId);
         if (transactionState == null) {
-            throw new TransactionNotFoundException("transaction [" + transactionId + "] not found.");
+            throw new UserException(InternalErrorCode.TXN_NOT_EXIST, "transaction [" + transactionId + "] not found.");
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
-            throw new TransactionNotFoundException("transaction [" + transactionId + "] is already aborted, "
-                    + "abort reason: " + transactionState.getReason());
+            throw new UserException(InternalErrorCode.TXN_ALREADY_ABORT, "transaction [" + transactionId
+                    + "] is already aborted, " + "abort reason: " + transactionState.getReason());
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED
                 || transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -37,6 +37,7 @@ import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
+import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
@@ -678,15 +679,16 @@ public class DatabaseTransactionMgr {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("transaction not found: {}", transactionId);
             }
-            throw new TransactionCommitFailedException("transaction [" + transactionId + "] not found.");
+            throw new TransactionCommitFailedException(InternalErrorCode.TXN_NOT_EXIST,
+                    "transaction [" + transactionId + "] not found.");
         }
 
         if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("transaction is already aborted: {}", transactionId);
             }
-            throw new TransactionCommitFailedException("transaction [" + transactionId
-                    + "] is already aborted. abort reason: " + transactionState.getReason());
+            throw new TransactionCommitFailedException(InternalErrorCode.TXN_ALREADY_ABORT, "transaction ["
+                    + transactionId + "] is already aborted. abort reason: " + transactionState.getReason());
         }
 
         if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
@@ -694,8 +696,8 @@ public class DatabaseTransactionMgr {
                 LOG.debug("transaction is already visible: {}", transactionId);
             }
             if (is2PC) {
-                throw new TransactionCommitFailedException("transaction [" + transactionId
-                        + "] is already visible, not pre-committed.");
+                throw new TransactionCommitFailedException(InternalErrorCode.TXN_ALREADY_VISIBLE, "transaction ["
+                        + transactionId + "] is already visible, not pre-committed.");
             }
             return;
         }
@@ -704,8 +706,8 @@ public class DatabaseTransactionMgr {
                 LOG.debug("transaction is already committed: {}", transactionId);
             }
             if (is2PC) {
-                throw new TransactionCommitFailedException("transaction [" + transactionId
-                        + "] is already committed, not pre-committed.");
+                throw new TransactionCommitFailedException(InternalErrorCode.TXN_ALREADY_COMMITTED, "transaction ["
+                        + transactionId + "] is already committed, not pre-committed.");
             }
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionCommitFailedException.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionCommitFailedException.java
@@ -18,12 +18,18 @@
 package org.apache.doris.transaction;
 
 
+import org.apache.doris.common.InternalErrorCode;
+
 public class TransactionCommitFailedException extends TransactionException {
 
     private static final long serialVersionUID = -2528170792631761535L;
 
     public TransactionCommitFailedException(String msg) {
         super(msg);
+    }
+
+    public TransactionCommitFailedException(InternalErrorCode errCode, String msg) {
+        super(errCode, msg);
     }
 
     public TransactionCommitFailedException(String msg, Throwable e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionException.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionException.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.UserException;
 
 public class TransactionException extends UserException {
@@ -25,6 +26,10 @@ public class TransactionException extends UserException {
 
     public TransactionException(String msg) {
         super(msg);
+    }
+
+    public TransactionException(InternalErrorCode errCode, String msg) {
+        super(errCode, msg);
     }
 
     public TransactionException(String msg, Throwable e) {


### PR DESCRIPTION
## Proposed changes

## Proposed changes

Problem:

The return status is indistinguishable for _stream_load_2pc when we use it to _abort_ or _commit_ the transaction pre-commited before; When we abort a transaction that is aborted or committed，the return  status is same as **ANALYSIS_ERROR**。
1. committed transaction
```
{ "status": "ANALYSIS_ERROR", "msg": "TStatus: errCode = 2, detailMessage = transaction [1] is already aborted. abort reason: User Abort" }
```
2. aborted transation
```
{ "status": "ANALYSIS_ERROR", "msg": "TStatus: errCode = 2, detailMessage =  transaction [1] is already visible, not pre-committed." }
```
But the repeat commit is a normal operation in FlinkDorisConnector and SparkDorisConnector，when the task restore from one checkpoint；In this scene it need to differentiate the result from _msg_ string。

Improve:
Add special status for the result that not affect the logic of the process；FlinkDorisConnector can check the result with status for normal result。


