### PR TITLE
[opt](mv) fix bug in fetching mv row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -182,10 +182,6 @@ public interface TableIf {
 
     BaseAnalysisTask createAnalysisTask(AnalysisInfo info);
 
-    // For empty table, nereids require getting 1 as row count. This is a wrap function for nereids to call getRowCount.
-    default long getRowCountForNereids() {
-        return Math.max(getRowCount(), 1);
-    }
 
     DatabaseIf getDatabase();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
@@ -30,6 +30,6 @@ public interface CatalogRelation extends Relation {
 
     // For empty table, nereids require getting 1 as row count. This is a wrap function for nereids to call getRowCount.
     default long getRowCountForNereids() {
-        return Math.max(getTable().fetchRowCount(), 1);
+        return Math.max(getTable().getRowCount(), 1);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
@@ -27,4 +27,9 @@ public interface CatalogRelation extends Relation {
     TableIf getTable();
 
     DatabaseIf getDatabase() throws AnalysisException;
+
+    // For empty table, nereids require getting 1 as row count. This is a wrap function for nereids to call getRowCount.
+    default long getRowCountForNereids() {
+        return Math.max(getTable().fetchRowCount(), 1);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -575,4 +575,9 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
         }
         return replaceMap;
     }
+
+    @Override
+    public long getRowCountForNereids() {
+        return Math.max(getTable().getRowCountForIndex(selectedIndexId), 1);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1812,4 +1812,8 @@ public class OlapScanNode extends ScanNode {
     public int numScanBackends() {
         return scanBackendIds.size();
     }
+
+    public long getRowCountForNereids() {
+        return Math.max(getOlapTable().getRowCountForIndex(selectedIndexId), 1);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapScanStatsDerive.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapScanStatsDerive.java
@@ -59,7 +59,7 @@ public class OlapScanStatsDerive extends BaseStatsDerive {
 
         Map<Id, ColumnStatistic> columnStatisticMap = new HashMap<>();
         Table table = scanNode.getOlapTable();
-        double rowCount = table.getRowCountForNereids();
+        double rowCount = scanNode.getRowCountForNereids();
         for (Map.Entry<Id, String> entry : slotIdToTableIdAndColumnName.entrySet()) {
             String colName = entry.getValue();
             // TODO. Get index id for materialized view.


### PR DESCRIPTION
## Proposed changes
StatsCalculator.computeOlapScan() could handle async mv correctly. But the approach to fetch row count of sync mv is different. In order to get sync mv row count, we should pass selectedIndex to the fetchRowCount() function.

Issue Number: close #xxx

<!--Describe your changes.-->

