### PR TITLE
[fix](dynamic partition) fix create dynamic partition with overlap not throw exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -299,7 +299,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                 LOG.warn("Error in gen addPartitionKeyRange. db: {}, table: {}, partition idx: {}",
                         db.getFullName(), olapTable.getName(), idx, e);
                 if (executeFirstTime) {
-                    throw new DdlException(e.getMessage());
+                    throw new DdlException("maybe dynamic_partition.start is too small, error: "
+                            + e.getMessage());
                 }
                 continue;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -475,7 +475,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                     + ", maybe it's too small, can use alter table sql to increase it. ";
             LOG.warn("Error in gen reservePartitionKeyRange. db: {}, table: {}. {}",
                     db.getFullName(), olapTable.getName(), hint, e);
-            recordDropPartitionFailedMsg(db.getFullName(), olapTable.getName(), hint + e.getMessage(),
+            recordDropPartitionFailedMsg(db.getFullName(), olapTable.getName(), hint + ", error: " + e.getMessage(),
                     olapTable.getId());
             return dropPartitionClauses;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -253,7 +253,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private ArrayList<AddPartitionClause> getAddPartitionClause(Database db, OlapTable olapTable,
-            Column partitionColumn, String partitionFormat, boolean executeFirstTime) {
+            Column partitionColumn, String partitionFormat, boolean executeFirstTime) throws DdlException {
         ArrayList<AddPartitionClause> addPartitionClauses = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
@@ -298,6 +298,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                 // IllegalArgumentException: lb is greater than ub
                 LOG.warn("Error in gen addPartitionKeyRange. db: {}, table: {}, partition idx: {}",
                         db.getFullName(), olapTable.getName(), idx, e);
+                if (executeFirstTime) {
+                    throw new DdlException(e.getMessage());
+                }
                 continue;
             }
             for (PartitionItem partitionItem : rangePartitionInfo.getIdToItem(false).values()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -253,7 +253,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private ArrayList<AddPartitionClause> getAddPartitionClause(Database db, OlapTable olapTable,
-            Column partitionColumn, String partitionFormat, boolean executeFirstTime) throws DdlException {
+            Column partitionColumn, String partitionFormat, boolean executeFirstTime) {
         ArrayList<AddPartitionClause> addPartitionClauses = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
@@ -298,9 +298,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                 // IllegalArgumentException: lb is greater than ub
                 LOG.warn("Error in gen addPartitionKeyRange. db: {}, table: {}, partition idx: {}",
                         db.getFullName(), olapTable.getName(), idx, e);
-                recordCreatePartitionFailedMsg(db.getFullName(), olapTable.getName(),
-                        e.getMessage(), olapTable.getId());
-                throw new DdlException(e.getMessage());
+                continue;
             }
             for (PartitionItem partitionItem : rangePartitionInfo.getIdToItem(false).values()) {
                 // only support single column partition now
@@ -319,7 +317,6 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                                 addPartitionKeyRange, db.getFullName(), olapTable.getName(), idx, e);
                         recordCreatePartitionFailedMsg(db.getFullName(), olapTable.getName(),
                                 e.getMessage(), olapTable.getId());
-                        throw new DdlException(e.getMessage());
                     }
                     break;
                 }

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_failed.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_failed.groovy
@@ -63,7 +63,7 @@ suite('test_dynamic_partition_failed', 'nonConcurrent') {
                 "dynamic_partition.time_unit" = "YEAR",
                 "dynamic_partition.prefix" = "p",
                 "dynamic_partition.buckets" = "1",
-                "dynamic_partition.start" = "-20",
+                "dynamic_partition.start" = "-10",
                 "dynamic_partition.create_history_partition" = "true"
               )'''
 

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_failed.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_failed.groovy
@@ -26,6 +26,7 @@ suite('test_dynamic_partition_failed', 'nonConcurrent') {
               PROPERTIES
               (
                 "replication_num" = "1",
+                "dynamic_partition.replication_num" = "1",
                 "dynamic_partition.enable" = "true",
                 "dynamic_partition.end" = "3",
                 "dynamic_partition.time_unit" = "day",
@@ -46,6 +47,26 @@ suite('test_dynamic_partition_failed', 'nonConcurrent') {
 
         setFeConfig('max_dynamic_partition_num', Integer.MAX_VALUE)
 
+        sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_ok2 FORCE'
+        sql '''CREATE TABLE test_dynamic_partition_failed_ok2
+              ( `k1` date NULL )
+              PARTITION BY RANGE(k1) (
+                 PARTITION `phistory` VALUES less than ('2020-01-01')
+              )
+              DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+              PROPERTIES
+              (
+                "replication_num" = "1",
+                "dynamic_partition.replication_num" = "1",
+                "dynamic_partition.enable" = "true",
+                "dynamic_partition.end" = "3",
+                "dynamic_partition.time_unit" = "YEAR",
+                "dynamic_partition.prefix" = "p",
+                "dynamic_partition.buckets" = "1",
+                "dynamic_partition.start" = "-20",
+                "dynamic_partition.create_history_partition" = "true"
+              )'''
+
         sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_2'
         test {
             sql '''CREATE TABLE test_dynamic_partition_failed_2
@@ -55,6 +76,7 @@ suite('test_dynamic_partition_failed', 'nonConcurrent') {
                   PROPERTIES
                   (
                     "replication_num" = "1",
+                    "dynamic_partition.replication_num" = "1",
                     "dynamic_partition.enable" = "true",
                     "dynamic_partition.end" = "3",
                     "dynamic_partition.time_unit" = "day",
@@ -102,6 +124,7 @@ suite('test_dynamic_partition_failed', 'nonConcurrent') {
     } finally {
         setFeConfig('max_dynamic_partition_num', old_max_dynamic_partition_num)
         sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_ok1 FORCE'
+        sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_ok2 FORCE'
         sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_2'
         sql 'DROP TABLE IF EXISTS test_dynamic_partition_failed_3'
     }


### PR DESCRIPTION
PR #35778  will throw exception if dynamic partition overlap with others.  Don't throw exception due to considering no behaviour change.  Just ignore create this partition.

SQL:
```
PARTITION BY RANGE(`dt`)(
PARTITION `phistory` VALUES less than ('2024-01-01')
)
DISTRIBUTED BY HASH(`user_id`, `room_id`) BUCKETS 3
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"dynamic_partition.enable" = "true",
"dynamic_partition.time_unit" = "DAY",
"dynamic_partition.end" = "10",
"dynamic_partition.prefix" = "p",
"dynamic_partition.create_history_partition" = "true",
"dynamic_partition.history_partition_num" = "250"
); 
```

error:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = errCode = 2, detailMessage = Range [types: [DATEV2]; keys: [0000-01-01]; ..types: [DATEV2]; keys: [2024-01-01]; ) is intersected with range: [types: [DATEV2]; keys: [2023-12-29]; ..types: [DATEV2]; keys: [2023-12-30]; ) 
```


