### PR TITLE
[opt](regression) ./run-regression.sh -d parameter accept "regression-test/suites/" as prefix

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -253,6 +253,17 @@ class Config {
         this.cloudVersion = cloudVersion
     }
 
+    static String removeDirectoryPrefix(String str) {
+        def prefixes = ["./regression-test/suites/", "regression-test/suites/"]
+
+        def prefix = prefixes.find { str.startsWith(it) }
+        if (prefix) {
+            return str.substring(prefix.length())
+        }
+
+        return str
+    }
+
     static Config fromCommandLine(CommandLine cmd) {
         String confFilePath = cmd.getOptionValue(confFileOpt, "")
         File confFile = new File(confFilePath)
@@ -295,7 +306,9 @@ class Config {
                 .toSet()
         config.directories = cmd.getOptionValue(directoriesOpt, config.testDirectories)
                 .split(",")
-                .collect({d -> d.trim()})
+                .collect({d -> 
+                    d.trim()
+                    removeDirectoryPrefix(d)})
                 .findAll({d -> d != null && d.length() > 0})
                 .toSet()
         config.excludeSuiteWildcard = cmd.getOptionValue(excludeSuiteOpt, config.excludeSuites)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -279,6 +279,7 @@ class RegressionTest {
     static Recorder runScripts(Config config) {
         def recorder = new Recorder()
         def directoryFilter = config.getDirectoryFilter()
+        log.info("run scripts in directories: " + config.directories)
         if (!config.withOutLoadData) {
             log.info('Start to run load scripts')
             runScripts(config, recorder, directoryFilter,

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -48,17 +48,18 @@ Usage: $0 <shell_options> <framework_options>
      -times                            rum tests {times} times
 
   Eg.
-    $0                                 build regression test framework and run all suite which in default group
-    $0 --run test_select               run a suite which named as test_select
-    $0 --compile                       only compile regression framework
-    $0 --run -s test_select            run a suite which named as test_select
-    $0 --run test_select -genOut       generate output file for test_select if not exist
-    $0 --run -g default                run all suite in the group which named as default
-    $0 --run -d demo,correctness/tmp   run all suite in the directories which named as demo and correctness/tmp
-    $0 --clean                         clean output of regression test framework
-    $0 --clean --run test_select       clean output and build regression test framework and run a suite which named as test_select
-    $0 --run -h                        print framework options
-    $0 --teamcity --run test_select    print teamcity service messages and build regression test framework and run test_select
+    $0                                        build regression test framework and run all suite which in default group
+    $0 --run test_select                      run a suite which named as test_select
+    $0 --compile                              only compile regression framework
+    $0 --run -s test_select                   run a suite which named as test_select
+    $0 --run test_select -genOut              generate output file for test_select if not exist
+    $0 --run -g default                       run all suite in the group which named as default
+    $0 --run -d demo,correctness/tmp          run all suite in the directories which named as demo and correctness/tmp
+    $0 --run -d regression-test/suites/demo   specify the suite directories path from repo root
+    $0 --clean                                clean output of regression test framework
+    $0 --clean --run test_select              clean output and build regression test framework and run a suite which named as test_select
+    $0 --run -h                               print framework options
+    $0 --teamcity --run test_select           print teamcity service messages and build regression test framework and run test_select
 
 Log path: \${DORIS_HOME}/output/regression-test/log
 Default config file: \${DORIS_HOME}/regression-test/conf/regression-conf.groovy


### PR DESCRIPTION
## Proposed changes

./run-regression.sh accept -d parameter with "./regression-test/suites/" or “regression-test/suites/" prefix
for example:
./run-regression-test.sh --run -d regression-test/suites/nereids_tpch_shape_sf1000_p0/shape -s q1
with the prefix, we could use command completion (supported by shell) to indicate with directory to run 

Issue Number: close #xxx

<!--Describe your changes.-->

