### PR TITLE
[fix](compaction) fix mismatch between segment key and value column rows during compaction

### DIFF
--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -109,10 +109,10 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
                 num_rows_written = 0;
                 num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
             } else {
-                RETURN_IF_ERROR(
-                        _segment_writers[_cur_writer_idx]->append_block(block, start_offset, limit));
+                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, start_offset,
+                                                                                limit));
                 CHECK(_segment_writers[_cur_writer_idx]->num_rows_written() <=
-                       _segment_writers[_cur_writer_idx]->row_count());
+                      _segment_writers[_cur_writer_idx]->row_count());
             }
         }
     }

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -97,8 +97,8 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
             }
 
             int64_t to_write = num_rows_written + left >= num_rows_key_group
-                                         ? num_rows_key_group - num_rows_written
-                                         : left;
+                                       ? num_rows_key_group - num_rows_written
+                                       : left;
             RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, num_rows - left,
                                                                             to_write));
             left -= to_write;

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -83,13 +83,13 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
         RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, 0, num_rows));
     } else {
         // value columns
-        size_t left = num_rows;
+        int64_t left = num_rows;
         while (left > 0) {
             uint32_t num_rows_written = _segment_writers[_cur_writer_idx]->num_rows_written();
             VLOG_NOTICE << "num_rows_written: " << num_rows_written
                         << ", _cur_writer_idx: " << _cur_writer_idx;
             uint32_t num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
-            CHECK(num_rows_written <= num_rows_key_group);
+            CHECK_LE(num_rows_written, num_rows_key_group);
             // init if it's first value column write in current segment
             if (num_rows_written == 0) {
                 VLOG_NOTICE << "init first value column segment writer";
@@ -102,7 +102,7 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
             RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, num_rows - left,
                                                                             to_write));
             left -= to_write;
-            CHECK(left >= 0);
+            CHECK_GE(left, 0);
 
             if (left > 0) {
                 ++_cur_writer_idx;

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -82,9 +82,9 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
         }
         RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, 0, num_rows));
     } else {
+        // value columns
         size_t left = num_rows;
         while (left > 0) {
-            // value columns
             uint32_t num_rows_written = _segment_writers[_cur_writer_idx]->num_rows_written();
             VLOG_NOTICE << "num_rows_written: " << num_rows_written
                         << ", _cur_writer_idx: " << _cur_writer_idx;

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -82,38 +82,30 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
         }
         RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, 0, num_rows));
     } else {
-        size_t start_offset = 0;
-        size_t limit = num_rows;
-        while (limit > 0) {
+        size_t left = num_rows;
+        while (left > 0) {
             // value columns
             uint32_t num_rows_written = _segment_writers[_cur_writer_idx]->num_rows_written();
             VLOG_NOTICE << "num_rows_written: " << num_rows_written
                         << ", _cur_writer_idx: " << _cur_writer_idx;
             uint32_t num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
+            CHECK(num_rows_written <= num_rows_key_group);
             // init if it's first value column write in current segment
-            if (_cur_writer_idx == 0 && num_rows_written == 0) {
+            if (num_rows_written == 0) {
                 VLOG_NOTICE << "init first value column segment writer";
                 RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
             }
-            // when splitting segment, need to make rows align between key columns and value columns
-            if (num_rows_written + limit >= num_rows_key_group &&
-                _cur_writer_idx < _segment_writers.size() - 1) {
-                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(
-                        block, 0, num_rows_key_group - num_rows_written));
-                RETURN_IF_ERROR(_flush_columns(_segment_writers[_cur_writer_idx].get()));
-                start_offset += (num_rows_key_group - num_rows_written);
-                limit = num_rows - start_offset;
+
+            int64_t to_write = num_rows_written + left >= num_rows_key_group
+                                         ? num_rows_key_group - num_rows_written
+                                         : left;
+            RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, num_rows - left,
+                                                                            to_write));
+            left -= to_write;
+            CHECK(left >= 0);
+
+            if (left > 0) {
                 ++_cur_writer_idx;
-                // switch to next writer
-                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
-                num_rows_written = 0;
-                num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
-            } else {
-                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, start_offset,
-                                                                                limit));
-                CHECK(_segment_writers[_cur_writer_idx]->num_rows_written() <=
-                      _segment_writers[_cur_writer_idx]->row_count());
-                break;
             }
         }
     }

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -113,6 +113,7 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
                                                                                 limit));
                 CHECK(_segment_writers[_cur_writer_idx]->num_rows_written() <=
                       _segment_writers[_cur_writer_idx]->row_count());
+                break;
             }
         }
     }

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -82,37 +82,38 @@ Status VerticalBetaRowsetWriter<T>::add_columns(const vectorized::Block* block,
         }
         RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(block, 0, num_rows));
     } else {
-        // value columns
-        uint32_t num_rows_written = _segment_writers[_cur_writer_idx]->num_rows_written();
-        VLOG_NOTICE << "num_rows_written: " << num_rows_written
-                    << ", _cur_writer_idx: " << _cur_writer_idx;
-        uint32_t num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
-        // init if it's first value column write in current segment
-        if (_cur_writer_idx == 0 && num_rows_written == 0) {
-            VLOG_NOTICE << "init first value column segment writer";
-            RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
-        }
-        // when splitting segment, need to make rows align between key columns and value columns
         size_t start_offset = 0;
         size_t limit = num_rows;
-        if (num_rows_written + num_rows >= num_rows_key_group &&
-            _cur_writer_idx < _segment_writers.size() - 1) {
-            RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(
-                    block, 0, num_rows_key_group - num_rows_written));
-            RETURN_IF_ERROR(_flush_columns(_segment_writers[_cur_writer_idx].get()));
-            start_offset = num_rows_key_group - num_rows_written;
-            limit = num_rows - start_offset;
-            ++_cur_writer_idx;
-            // switch to next writer
-            RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
-            num_rows_written = 0;
-            num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
-        }
-        if (limit > 0) {
-            RETURN_IF_ERROR(
-                    _segment_writers[_cur_writer_idx]->append_block(block, start_offset, limit));
-            DCHECK(_segment_writers[_cur_writer_idx]->num_rows_written() <=
-                   _segment_writers[_cur_writer_idx]->row_count());
+        while (limit > 0) {
+            // value columns
+            uint32_t num_rows_written = _segment_writers[_cur_writer_idx]->num_rows_written();
+            VLOG_NOTICE << "num_rows_written: " << num_rows_written
+                        << ", _cur_writer_idx: " << _cur_writer_idx;
+            uint32_t num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
+            // init if it's first value column write in current segment
+            if (_cur_writer_idx == 0 && num_rows_written == 0) {
+                VLOG_NOTICE << "init first value column segment writer";
+                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
+            }
+            // when splitting segment, need to make rows align between key columns and value columns
+            if (num_rows_written + limit >= num_rows_key_group &&
+                _cur_writer_idx < _segment_writers.size() - 1) {
+                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(
+                        block, 0, num_rows_key_group - num_rows_written));
+                RETURN_IF_ERROR(_flush_columns(_segment_writers[_cur_writer_idx].get()));
+                start_offset += (num_rows_key_group - num_rows_written);
+                limit = num_rows - start_offset;
+                ++_cur_writer_idx;
+                // switch to next writer
+                RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
+                num_rows_written = 0;
+                num_rows_key_group = _segment_writers[_cur_writer_idx]->row_count();
+            } else {
+                RETURN_IF_ERROR(
+                        _segment_writers[_cur_writer_idx]->append_block(block, start_offset, limit));
+                CHECK(_segment_writers[_cur_writer_idx]->num_rows_written() <=
+                       _segment_writers[_cur_writer_idx]->row_count());
+            }
         }
     }
     if (is_key) {


### PR DESCRIPTION
When a block is splitted to 3 segments, old code just handles 2 and the last is overlowed.