### PR TITLE
[Fix](Variant) fix potential heap use after free when concurrently flush segments on one tablet

### DIFF
--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -712,7 +712,9 @@ Status VerticalSegmentWriter::_append_block_with_variant_subcolumns(RowsInBlock&
             continue;
         }
         if (_flush_schema == nullptr) {
-            _flush_schema = std::make_shared<TabletSchema>(*_tablet_schema);
+            _flush_schema = std::make_shared<TabletSchema>();
+            // deep copy
+            _flush_schema->copy_from(*_tablet_schema);
         }
         auto column_ref = data.block->get_by_position(i).column;
         const vectorized::ColumnObject& object_column = assert_cast<vectorized::ColumnObject&>(

--- a/regression-test/suites/variant_p0/compaction_sparse_column.groovy
+++ b/regression-test/suites/variant_p0/compaction_sparse_column.groovy
@@ -47,6 +47,7 @@ suite("test_compaction_sparse_column", "nonConcurrent") {
         }
 
         set_be_config.call("variant_ratio_of_defaults_as_sparse_column", "0.95")
+        set_be_config.call("write_buffer_size", "10240")
 
         sql """ DROP TABLE IF EXISTS ${tableName} """
         sql """
@@ -169,5 +170,7 @@ suite("test_compaction_sparse_column", "nonConcurrent") {
         qt_select_all """SELECT k, v['a'], v['b'], v['xxxx'], v['point'], v['ddddd'] from ${tableName} where (cast(v['point'] as int) = 1);"""
     } finally {
         // try_sql("DROP TABLE IF EXISTS ${tableName}")
+        set_be_config.call("write_buffer_size", "209715200")
+        set_be_config.call("variant_ratio_of_defaults_as_sparse_column", "1")
     }
 }


### PR DESCRIPTION

TabletSchema is shallow copied, should do deep copy for _flush_schema

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

