### PR TITLE
[fix](fe) Fix `removeDroppedMember` use incorrect `nodeName`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
@@ -259,11 +259,11 @@ public class BDBHA implements HAProtocol {
             LOG.debug("node:{}", replicationNode.toString());
             if (removedFrontends.contains(replicationNode.getName())) {
                 try {
-                    replicationGroupAdmin.removeMember(nodeName);
+                    replicationGroupAdmin.removeMember(replicationNode.getName());
                 } catch (MemberNotFoundException e) {
-                    LOG.warn("the electable node is not found {}", nodeName);
+                    LOG.warn("the electable node is not found {}", replicationNode.getName());
                 } catch (Exception e) {
-                    LOG.error("remove electable node {} meeting unknown exception:", nodeName, e);
+                    LOG.error("remove electable node {} meeting unknown exception:", replicationNode.getName(), e);
                     System.exit(-1);
                 }
             }


### PR DESCRIPTION
```
com.sleepycat.je.rep.MasterStateException: (JE 18.3.12) Cannot remove an active master
    at com.sleepycat.je.rep.util.ReplicationGroupAdmin.checkMember(ReplicationGroupAdmin.java:591)
    at com.sleepycat.je.rep.util.ReplicationGroupAdmin.removeMember(ReplicationGroupAdmin.java:315)
    at org.apache.doris.ha.BDBHA.removeDroppedMember(BDBHA.java:262)
    at org.apache.doris.catalog.Env.removeDroppedFrontends(Env.java:3077)
    at org.apache.doris.catalog.Env.transferToMaster(Env.java:1520)
    at org.apache.doris.catalog.Env.access$1300(Env.java:338)
    at org.apache.doris.catalog.Env$5.runOneCycle(Env.java:2792)
    at org.apache.doris.common.util.Daemon.run(Daemon.java:116)
```

* the bug is introduced by https://github.com/apache/doris/pull/35203

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

