### PR TITLE
[opt](Nereids) support no-key hint parameter (#37720)

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -464,6 +464,7 @@ hintStatement
 
 hintAssignment
     : key=identifierOrText (EQ (constantValue=constant | identifierValue=identifier))?
+    | constant
     ;
     
 updateAssignment

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3101,24 +3101,28 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                 case "set_var":
                     Map<String, Optional<String>> parameters = Maps.newLinkedHashMap();
                     for (HintAssignmentContext kv : hintStatement.parameters) {
-                        String parameterName = visitIdentifierOrText(kv.key);
-                        Optional<String> value = Optional.empty();
-                        if (kv.constantValue != null) {
-                            Literal literal = (Literal) visit(kv.constantValue);
-                            value = Optional.ofNullable(literal.toLegacyLiteral().getStringValue());
-                        } else if (kv.identifierValue != null) {
-                            // maybe we should throw exception when the identifierValue is quoted identifier
-                            value = Optional.ofNullable(kv.identifierValue.getText());
+                        if (kv.key != null) {
+                            String parameterName = visitIdentifierOrText(kv.key);
+                            Optional<String> value = Optional.empty();
+                            if (kv.constantValue != null) {
+                                Literal literal = (Literal) visit(kv.constantValue);
+                                value = Optional.ofNullable(literal.toLegacyLiteral().getStringValue());
+                            } else if (kv.identifierValue != null) {
+                                // maybe we should throw exception when the identifierValue is quoted identifier
+                                value = Optional.ofNullable(kv.identifierValue.getText());
+                            }
+                            parameters.put(parameterName, value);
                         }
-                        parameters.put(parameterName, value);
                     }
                     hints.put(hintName, new SelectHintSetVar(hintName, parameters));
                     break;
                 case "leading":
                     List<String> leadingParameters = new ArrayList<String>();
                     for (HintAssignmentContext kv : hintStatement.parameters) {
-                        String parameterName = visitIdentifierOrText(kv.key);
-                        leadingParameters.add(parameterName);
+                        if (kv.key != null) {
+                            String parameterName = visitIdentifierOrText(kv.key);
+                            leadingParameters.add(parameterName);
+                        }
                     }
                     hints.put(hintName, new SelectHintLeading(hintName, leadingParameters));
                     break;

--- a/regression-test/suites/nereids_syntax_p0/hint.groovy
+++ b/regression-test/suites/nereids_syntax_p0/hint.groovy
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("hint") {
+    sql """select /*+ func(k=v) */ 1"""
+    sql """select /*+ func('k'=v) */ 1"""
+    sql """select /*+ func("k"=v) */ 1"""
+    sql """select /*+ func(k) */ 1"""
+    sql """select /*+ func('k') */ 1"""
+    sql """select /*+ func("k") */ 1"""
+    sql """select /*+ func(1) */ 1"""
+}
+


### PR DESCRIPTION
pick from master #37720

support hint use parameter without key, like:

```sql
SELECT /*+ query_timeout(3000) */ * FROM t;
```
