### PR TITLE
[opt](nereids) print ignored runtime filter in shape/physical plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.physical;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.planner.RuntimeFilterId;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TMinMaxRuntimeFilterType;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
@@ -153,8 +154,14 @@ public class RuntimeFilter {
 
     @Override
     public String toString() {
+        String ignore = "";
+        if (ConnectContext.get() != null
+                && ConnectContext.get().getSessionVariable()
+                .getIgnoredRuntimeFilterIds().contains(id.asInt())) {
+            ignore="(ignore)";
+        }
         StringBuilder sb = new StringBuilder();
-        sb.append("RF").append(id.asInt())
+        sb.append(ignore).append("RF").append(id.asInt())
                 .append("[").append(getSrcExpr()).append("->").append(targetExpressions)
                 .append("(ndv/size = ").append(buildSideNdv).append("/")
                 .append(org.apache.doris.planner.RuntimeFilter.expectRuntimeFilterSize(buildSideNdv))
@@ -167,8 +174,14 @@ public class RuntimeFilter {
      * @return brief version of toString()
      */
     public String shapeInfo() {
+        String ignore = "";
+        if (ConnectContext.get() != null
+                && ConnectContext.get().getSessionVariable()
+                .getIgnoredRuntimeFilterIds().contains(id.asInt())) {
+            ignore="(ignore)";
+        }
         StringBuilder sb = new StringBuilder();
-        sb.append("RF").append(id.asInt())
+        sb.append(ignore).append("RF").append(id.asInt())
                 .append(" ").append(getSrcExpr().toSql()).append("->[").append(
                         targetExpressions.stream().map(expr -> expr.toSql())
                                 .sorted().collect(Collectors.joining(",")))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
@@ -158,7 +158,7 @@ public class RuntimeFilter {
         if (ConnectContext.get() != null
                 && ConnectContext.get().getSessionVariable()
                 .getIgnoredRuntimeFilterIds().contains(id.asInt())) {
-            ignore="(ignore)";
+            ignore = "(ignored)";
         }
         StringBuilder sb = new StringBuilder();
         sb.append(ignore).append("RF").append(id.asInt())
@@ -178,7 +178,7 @@ public class RuntimeFilter {
         if (ConnectContext.get() != null
                 && ConnectContext.get().getSessionVariable()
                 .getIgnoredRuntimeFilterIds().contains(id.asInt())) {
-            ignore="(ignore)";
+            ignore = "(ignored)";
         }
         StringBuilder sb = new StringBuilder();
         sb.append(ignore).append("RF").append(id.asInt())


### PR DESCRIPTION
## Proposed changes
shape plan and physical plan should display the "ignore" tag of ignored runtime filters, like 
`hashJoin[INNER_JOIN bucketShuffle] ... build RFs:RF0 r_regionkey->[n_nationkey];(ignore)RF1 r_regionkey->[n_nationkey] `

Issue Number: close #xxx

<!--Describe your changes.-->

