### PR TITLE
[fix](case)fix s3 tvf case failed in pipeline of 2.1

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
@@ -202,6 +202,7 @@ suite("test_s3_tvf_with_resource", "p0") {
     // not have usage priv, can not select tvf with resource
     connect(user=user, password="${pwd}", url=url) {
         test {
+                sql """set enable_fallback_to_original_planner=false;"""
                 sql """
                     SELECT * FROM S3 (
                                         "uri" = "https://${bucket}.${s3_endpoint}/regression/tvf/test_hive_text.text",


### PR DESCRIPTION
default value `enable_fallback_to_original_planner` is true, resource priv check only support in nereids,so need set enable_fallback_to_original_planner=false;

