### PR TITLE
[fix](move-memtable) multi replica tables should tolerate minority failures

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer_v2.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.cpp
@@ -83,9 +83,19 @@ Status BetaRowsetWriterV2::create_file_writer(uint32_t segment_id, io::FileWrite
 
 Status BetaRowsetWriterV2::add_segment(uint32_t segment_id, const SegmentStatistics& segstat,
                                        TabletSchemaSPtr flush_schema) {
+    bool ok = false;
     for (const auto& stream : _streams) {
-        RETURN_IF_ERROR(stream->add_segment(_context.partition_id, _context.index_id,
-                                            _context.tablet_id, segment_id, segstat, flush_schema));
+        auto st = stream->add_segment(_context.partition_id, _context.index_id, _context.tablet_id,
+                                      segment_id, segstat, flush_schema);
+        if (!st.ok()) {
+            LOG(WARNING) << "failed to add segment " << segment_id << " to stream "
+                         << stream->stream_id();
+        }
+        ok = ok || st.ok();
+    }
+    if (!ok) {
+        return Status::InternalError("failed to add segment {} of tablet {} to any replicas",
+                                     segment_id, _context.tablet_id);
     }
     return Status::OK();
 }

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -62,7 +62,7 @@ TabletStream::TabletStream(PUniqueId load_id, int64_t id, int64_t txn_id,
           _txn_id(txn_id),
           _load_stream_mgr(load_stream_mgr) {
     load_stream_mgr->create_tokens(_flush_tokens);
-    _failed_st = std::make_shared<Status>();
+    _status = Status::OK();
     _profile = profile->create_child(fmt::format("TabletStream {}", id), true, true);
     _append_data_timer = ADD_TIMER(_profile, "AppendDataTime");
     _add_segment_timer = ADD_TIMER(_profile, "AddSegmentTime");
@@ -71,7 +71,7 @@ TabletStream::TabletStream(PUniqueId load_id, int64_t id, int64_t txn_id,
 
 inline std::ostream& operator<<(std::ostream& ostr, const TabletStream& tablet_stream) {
     ostr << "load_id=" << tablet_stream._load_id << ", txn_id=" << tablet_stream._txn_id
-         << ", tablet_id=" << tablet_stream._id << ", status=" << *tablet_stream._failed_st;
+         << ", tablet_id=" << tablet_stream._id << ", status=" << tablet_stream._status;
     return ostr;
 }
 
@@ -89,17 +89,20 @@ Status TabletStream::init(std::shared_ptr<OlapTableSchemaParam> schema, int64_t 
     };
 
     _load_stream_writer = std::make_shared<LoadStreamWriter>(&req, _profile);
-    auto st = _load_stream_writer->init();
-    if (!st.ok()) {
-        _failed_st = std::make_shared<Status>(st);
+    DBUG_EXECUTE_IF("TabletStream.init.uninited_writer", {
+        _status = Status::Uninitialized("fault injection");
+        return _status;
+    });
+    _status = _load_stream_writer->init();
+    if (!_status.ok()) {
         LOG(INFO) << "failed to init rowset builder due to " << *this;
     }
-    return st;
+    return _status;
 }
 
 Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data) {
-    if (!_failed_st->ok()) {
-        return *_failed_st;
+    if (!_status.ok()) {
+        return _status;
     }
 
     // dispatch add_segment request
@@ -156,9 +159,9 @@ Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data
                         file_type, new_segid);
             }
         }
-        if (!st.ok() && _failed_st->ok()) {
-            _failed_st = std::make_shared<Status>(st);
-            LOG(INFO) << "write data failed " << *this;
+        if (!st.ok() && _status.ok()) {
+            _status = st;
+            LOG(WARNING) << "write data failed " << st << ", " << *this;
         }
     };
     auto& flush_token = _flush_tokens[new_segid % _flush_tokens.size()];
@@ -173,10 +176,11 @@ Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data
     timer.start();
     while (flush_token->num_tasks() >= load_stream_flush_token_max_tasks) {
         if (timer.elapsed_time() / 1000 / 1000 >= load_stream_max_wait_flush_token_time_ms) {
-            return Status::Error<true>(
+            _status = Status::Error<true>(
                     "wait flush token back pressure time is more than "
                     "load_stream_max_wait_flush_token_time {}",
                     load_stream_max_wait_flush_token_time_ms);
+            return _status;
         }
         bthread_usleep(2 * 1000); // 2ms
     }
@@ -184,10 +188,18 @@ Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data
     int64_t time_ms = timer.elapsed_time() / 1000 / 1000;
     g_load_stream_flush_wait_ms << time_ms;
     g_load_stream_flush_running_threads << 1;
-    return flush_token->submit_func(flush_func);
+    auto st = flush_token->submit_func(flush_func);
+    if (!st.ok()) {
+        _status = st;
+    }
+    return _status;
 }
 
 Status TabletStream::add_segment(const PStreamHeader& header, butil::IOBuf* data) {
+    if (!_status.ok()) {
+        return _status;
+    }
+
     SCOPED_TIMER(_add_segment_timer);
     DCHECK(header.has_segment_statistics());
     SegmentStatistics stat(header.segment_statistics());
@@ -204,15 +216,17 @@ Status TabletStream::add_segment(const PStreamHeader& header, butil::IOBuf* data
     {
         std::lock_guard lock_guard(_lock);
         if (!_segids_mapping.contains(src_id)) {
-            return Status::InternalError(
+            _status = Status::InternalError(
                     "add segment failed, no segment written by this src be yet, src_id={}, "
                     "segment_id={}",
                     src_id, segid);
+            return _status;
         }
         if (segid >= _segids_mapping[src_id]->size()) {
-            return Status::InternalError(
+            _status = Status::InternalError(
                     "add segment failed, segment is never written, src_id={}, segment_id={}",
                     src_id, segid);
+            return _status;
         }
         new_segid = _segids_mapping[src_id]->at(segid);
     }
@@ -221,16 +235,24 @@ Status TabletStream::add_segment(const PStreamHeader& header, butil::IOBuf* data
     auto add_segment_func = [this, new_segid, stat, flush_schema]() {
         signal::set_signal_task_id(_load_id);
         auto st = _load_stream_writer->add_segment(new_segid, stat, flush_schema);
-        if (!st.ok() && _failed_st->ok()) {
-            _failed_st = std::make_shared<Status>(st);
+        if (!st.ok() && _status.ok()) {
+            _status = st;
             LOG(INFO) << "add segment failed " << *this;
         }
     };
     auto& flush_token = _flush_tokens[new_segid % _flush_tokens.size()];
-    return flush_token->submit_func(add_segment_func);
+    auto st = flush_token->submit_func(add_segment_func);
+    if (!st.ok()) {
+        _status = st;
+    }
+    return _status;
 }
 
 Status TabletStream::close() {
+    if (!_status.ok()) {
+        return _status;
+    }
+
     SCOPED_TIMER(_close_wait_timer);
     bthread::Mutex mu;
     std::unique_lock<bthread::Mutex> lock(mu);
@@ -247,23 +269,24 @@ Status TabletStream::close() {
     if (ret) {
         cv.wait(lock);
     } else {
-        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+        _status = Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "there is not enough thread resource for close load");
+        return _status;
     }
 
-    if (!_failed_st->ok()) {
-        return *_failed_st;
-    }
     if (_next_segid.load() != _num_segments) {
-        return Status::Corruption(
+        _status = Status::Corruption(
                 "segment num mismatch in tablet {}, expected: {}, actual: {}, load_id: {}", _id,
                 _num_segments, _next_segid.load(), print_id(_load_id));
+        return _status;
     }
 
-    Status st = Status::OK();
-    auto close_func = [this, &mu, &cv, &st]() {
+    auto close_func = [this, &mu, &cv]() {
         signal::set_signal_task_id(_load_id);
-        st = _load_stream_writer->close();
+        auto st = _load_stream_writer->close();
+        if (!st.ok() && _status.ok()) {
+            _status = st;
+        }
         std::lock_guard<bthread::Mutex> lock(mu);
         cv.notify_one();
     };
@@ -271,10 +294,10 @@ Status TabletStream::close() {
     if (ret) {
         cv.wait(lock);
     } else {
-        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+        _status = Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "there is not enough thread resource for close load");
     }
-    return st;
+    return _status;
 }
 
 IndexStream::IndexStream(PUniqueId load_id, int64_t id, int64_t txn_id,
@@ -298,7 +321,7 @@ Status IndexStream::append_data(const PStreamHeader& header, butil::IOBuf* data)
         std::lock_guard lock_guard(_lock);
         auto it = _tablet_streams_map.find(tablet_id);
         if (it == _tablet_streams_map.end()) {
-            RETURN_IF_ERROR(_init_tablet_stream(tablet_stream, tablet_id, header.partition_id()));
+            _init_tablet_stream(tablet_stream, tablet_id, header.partition_id());
         } else {
             tablet_stream = it->second;
         }
@@ -307,17 +330,19 @@ Status IndexStream::append_data(const PStreamHeader& header, butil::IOBuf* data)
     return tablet_stream->append_data(header, data);
 }
 
-Status IndexStream::_init_tablet_stream(TabletStreamSharedPtr& tablet_stream, int64_t tablet_id,
-                                        int64_t partition_id) {
+void IndexStream::_init_tablet_stream(TabletStreamSharedPtr& tablet_stream, int64_t tablet_id,
+                                      int64_t partition_id) {
     tablet_stream = std::make_shared<TabletStream>(_load_id, tablet_id, _txn_id, _load_stream_mgr,
                                                    _profile);
     _tablet_streams_map[tablet_id] = tablet_stream;
-    RETURN_IF_ERROR(tablet_stream->init(_schema, _id, partition_id));
-    return Status::OK();
+    auto st = tablet_stream->init(_schema, _id, partition_id);
+    if (!st.ok()) {
+        LOG(WARNING) << "tablet stream init failed " << *tablet_stream;
+    }
 }
 
-Status IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
-                          std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
+void IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
+                        std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
     std::lock_guard lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
     // open all need commit tablets
@@ -328,8 +353,7 @@ Status IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
         TabletStreamSharedPtr tablet_stream;
         auto it = _tablet_streams_map.find(tablet.tablet_id());
         if (it == _tablet_streams_map.end()) {
-            RETURN_IF_ERROR(
-                    _init_tablet_stream(tablet_stream, tablet.tablet_id(), tablet.partition_id()));
+            _init_tablet_stream(tablet_stream, tablet.tablet_id(), tablet.partition_id());
             tablet_stream->add_num_segments(tablet.num_segments());
         } else {
             it->second->add_num_segments(tablet.num_segments());
@@ -345,7 +369,6 @@ Status IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
             failed_tablets->emplace_back(tablet_stream->id(), st);
         }
     }
-    return Status::OK();
 }
 
 // TODO: Profile is temporary disabled, because:
@@ -398,8 +421,8 @@ Status LoadStream::init(const POpenLoadStreamRequest* request) {
     return Status::OK();
 }
 
-Status LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-                         std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
+void LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
+                       std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
     std::lock_guard<bthread::Mutex> lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
 
@@ -417,16 +440,14 @@ Status LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_t
 
     if (_close_load_cnt < _total_streams) {
         // do not return commit info if there is remaining streams.
-        return Status::OK();
+        return;
     }
 
     for (auto& [_, index_stream] : _index_streams_map) {
-        RETURN_IF_ERROR(
-                index_stream->close(_tablets_to_commit, success_tablet_ids, failed_tablets));
+        index_stream->close(_tablets_to_commit, success_tablet_ids, failed_tablets);
     }
     LOG(INFO) << "close load " << *this << ", success_tablet_num=" << success_tablet_ids->size()
               << ", failed_tablet_num=" << failed_tablets->size();
-    return Status::OK();
 }
 
 void LoadStream::_report_result(StreamId stream, const Status& status,
@@ -612,8 +633,8 @@ void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* 
         std::vector<int64_t> success_tablet_ids;
         FailedTablets failed_tablets;
         std::vector<PTabletID> tablets_to_commit(hdr.tablets().begin(), hdr.tablets().end());
-        auto st = close(hdr.src_id(), tablets_to_commit, &success_tablet_ids, &failed_tablets);
-        _report_result(id, st, success_tablet_ids, failed_tablets, true);
+        close(hdr.src_id(), tablets_to_commit, &success_tablet_ids, &failed_tablets);
+        _report_result(id, Status::OK(), success_tablet_ids, failed_tablets, true);
         brpc::StreamClose(id);
     } break;
     case PStreamHeader::GET_SCHEMA: {

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -66,7 +66,7 @@ private:
     std::atomic<uint32_t> _next_segid;
     int64_t _num_segments = 0;
     bthread::Mutex _lock;
-    std::shared_ptr<Status> _failed_st;
+    Status _status;
     PUniqueId _load_id;
     int64_t _txn_id;
     RuntimeProfile* _profile = nullptr;
@@ -86,12 +86,12 @@ public:
 
     Status append_data(const PStreamHeader& header, butil::IOBuf* data);
 
-    Status close(const std::vector<PTabletID>& tablets_to_commit,
-                 std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
+    void close(const std::vector<PTabletID>& tablets_to_commit,
+               std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 
 private:
-    Status _init_tablet_stream(TabletStreamSharedPtr& tablet_stream, int64_t tablet_id,
-                               int64_t partition_id);
+    void _init_tablet_stream(TabletStreamSharedPtr& tablet_stream, int64_t tablet_id,
+                             int64_t partition_id);
 
 private:
     int64_t _id;
@@ -124,8 +124,8 @@ public:
         }
     }
 
-    Status close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-                 std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
+    void close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
+               std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 
     // callbacks called by brpc
     int on_received_messages(StreamId id, butil::IOBuf* const messages[], size_t size) override;

--- a/be/src/runtime/load_stream_writer.cpp
+++ b/be/src/runtime/load_stream_writer.cpp
@@ -140,7 +140,6 @@ Status LoadStreamWriter::close_writer(uint32_t segid, FileType file_type) {
             file_type == FileType::SEGMENT_FILE ? _segment_file_writers : _inverted_file_writers;
     {
         std::lock_guard lock_guard(_lock);
-        DBUG_EXECUTE_IF("LoadStreamWriter.close_writer.uninited_writer", { _is_init = false; });
         if (!_is_init) {
             return Status::Corruption("close_writer failed, LoadStreamWriter is not inited");
         }
@@ -183,7 +182,6 @@ Status LoadStreamWriter::add_segment(uint32_t segid, const SegmentStatistics& st
     size_t inverted_file_size = 0;
     {
         std::lock_guard lock_guard(_lock);
-        DBUG_EXECUTE_IF("LoadStreamWriter.add_segment.uninited_writer", { _is_init = false; });
         if (!_is_init) {
             return Status::Corruption("add_segment failed, LoadStreamWriter is not inited");
         }

--- a/be/src/vec/sink/load_stream_map_pool.cpp
+++ b/be/src/vec/sink/load_stream_map_pool.cpp
@@ -77,10 +77,14 @@ Status LoadStreamMap::for_each_st(std::function<Status(int64_t, const Streams&)>
         std::lock_guard<std::mutex> lock(_mutex);
         snapshot = _streams_for_node;
     }
+    Status status = Status::OK();
     for (auto& [dst_id, streams] : snapshot) {
-        RETURN_IF_ERROR(fn(dst_id, *streams));
+        auto st = fn(dst_id, *streams);
+        if (!st.ok() && status.ok()) {
+            status = st;
+        }
     }
-    return Status::OK();
+    return status;
 }
 
 void LoadStreamMap::save_tablets_to_commit(int64_t dst_id,
@@ -112,19 +116,26 @@ Status LoadStreamMap::close_load(bool incremental) {
             tablets_to_commit.push_back(tablet);
             tablets_to_commit.back().set_num_segments(_segments_for_tablet[tablet_id]);
         }
+        Status status = Status::OK();
         bool first = true;
         for (auto& stream : streams) {
             if (stream->is_incremental() != incremental) {
                 continue;
             }
             if (first) {
-                RETURN_IF_ERROR(stream->close_load(tablets_to_commit));
+                auto st = stream->close_load(tablets_to_commit);
+                if (!st.ok() && status.ok()) {
+                    status = st;
+                }
                 first = false;
             } else {
-                RETURN_IF_ERROR(stream->close_load({}));
+                auto st = stream->close_load({});
+                if (!st.ok() && status.ok()) {
+                    status = st;
+                }
             }
         }
-        return Status::OK();
+        return status;
     });
 }
 

--- a/be/src/vec/sink/load_stream_map_pool.cpp
+++ b/be/src/vec/sink/load_stream_map_pool.cpp
@@ -107,8 +107,8 @@ bool LoadStreamMap::release() {
     return false;
 }
 
-Status LoadStreamMap::close_load(bool incremental) {
-    return for_each_st([this, incremental](int64_t dst_id, const Streams& streams) -> Status {
+void LoadStreamMap::close_load(bool incremental) {
+    auto st = for_each_st([this, incremental](int64_t dst_id, const Streams& streams) -> Status {
         std::vector<PTabletID> tablets_to_commit;
         const auto& tablets = _tablets_to_commit[dst_id];
         tablets_to_commit.reserve(tablets.size());
@@ -137,6 +137,10 @@ Status LoadStreamMap::close_load(bool incremental) {
         }
         return status;
     });
+    if (!st.ok()) {
+        LOG(WARNING) << "close_load for " << (incremental ? "incremental" : "non-incremental")
+                     << " streams failed: " << st << ", load_id=" << _load_id;
+    }
 }
 
 LoadStreamMapPool::LoadStreamMapPool() = default;

--- a/be/src/vec/sink/load_stream_map_pool.h
+++ b/be/src/vec/sink/load_stream_map_pool.h
@@ -98,7 +98,7 @@ public:
 
     // send CLOSE_LOAD to all streams, return ERROR if any.
     // only call this method after release() returns true.
-    Status close_load(bool incremental);
+    void close_load(bool incremental);
 
 private:
     const UniqueId _load_id;

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -149,7 +149,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
                             int64_t idle_timeout_ms, bool enable_profile) {
     std::unique_lock<bthread::Mutex> lock(_open_mutex);
     if (_is_init.load()) {
-        return Status::OK();
+        return _init_st;
     }
     _dst_id = node_info.id;
     std::string host_port = get_host_port(node_info.host, node_info.brpc_port);
@@ -161,7 +161,8 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     brpc::Controller cntl;
     if (int ret = brpc::StreamCreate(&_stream_id, cntl, &opt)) {
         delete opt.handler;
-        return Status::Error<true>(ret, "Failed to create stream");
+        _init_st = Status::Error<true>(ret, "Failed to create stream");
+        return _init_st;
     }
     cntl.set_timeout_ms(config::open_load_stream_timeout_ms);
     POpenLoadStreamRequest request;
@@ -174,7 +175,8 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     } else if (total_streams > 0) {
         request.set_total_streams(total_streams);
     } else {
-        return Status::InternalError("total_streams should be greator than 0");
+        _init_st = Status::InternalError("total_streams should be greator than 0");
+        return _init_st;
     }
     request.set_idle_timeout_ms(idle_timeout_ms);
     schema.to_protobuf(request.mutable_schema());
@@ -195,8 +197,9 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     }
     if (cntl.Failed()) {
         brpc::StreamClose(_stream_id);
-        return Status::InternalError("Failed to connect to backend {}: {}", _dst_id,
-                                     cntl.ErrorText());
+        _init_st = Status::InternalError("Failed to connect to backend {}: {}", _dst_id,
+                                         cntl.ErrorText());
+        return _init_st;
     }
     LOG(INFO) << "open load stream to " << host_port << ", " << *this;
     _is_init.store(true);
@@ -207,6 +210,10 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
 Status LoadStreamStub::append_data(int64_t partition_id, int64_t index_id, int64_t tablet_id,
                                    int64_t segment_id, uint64_t offset, std::span<const Slice> data,
                                    bool segment_eos, FileType file_type) {
+    if (!_is_init.load()) {
+        add_failed_tablet(tablet_id, _init_st);
+        return _init_st;
+    }
     DBUG_EXECUTE_IF("LoadStreamStub.only_send_segment_0", {
         if (segment_id != 0) {
             return Status::OK();
@@ -230,6 +237,10 @@ Status LoadStreamStub::append_data(int64_t partition_id, int64_t index_id, int64
 Status LoadStreamStub::add_segment(int64_t partition_id, int64_t index_id, int64_t tablet_id,
                                    int64_t segment_id, const SegmentStatistics& segment_stat,
                                    TabletSchemaSPtr flush_schema) {
+    if (!_is_init.load()) {
+        add_failed_tablet(tablet_id, _init_st);
+        return _init_st;
+    }
     DBUG_EXECUTE_IF("LoadStreamStub.only_send_segment_0", {
         if (segment_id != 0) {
             return Status::OK();
@@ -252,6 +263,9 @@ Status LoadStreamStub::add_segment(int64_t partition_id, int64_t index_id, int64
 
 // CLOSE_LOAD
 Status LoadStreamStub::close_load(const std::vector<PTabletID>& tablets_to_commit) {
+    if (!_is_init.load()) {
+        return _init_st;
+    }
     PStreamHeader header;
     *header.mutable_load_id() = _load_id;
     header.set_src_id(_src_id);
@@ -259,11 +273,20 @@ Status LoadStreamStub::close_load(const std::vector<PTabletID>& tablets_to_commi
     for (const auto& tablet : tablets_to_commit) {
         *header.add_tablets() = tablet;
     }
-    return _encode_and_send(header);
+    _close_st = _encode_and_send(header);
+    if (!_close_st.ok()) {
+        LOG(WARNING) << "stream " << _stream_id << " close failed: " << _close_st;
+        return _close_st;
+    }
+    _is_closing.store(true);
+    return Status::OK();
 }
 
 // GET_SCHEMA
 Status LoadStreamStub::get_schema(const std::vector<PTabletID>& tablets) {
+    if (!_is_init.load()) {
+        return _init_st;
+    }
     PStreamHeader header;
     *header.mutable_load_id() = _load_id;
     header.set_src_id(_src_id);
@@ -284,6 +307,9 @@ Status LoadStreamStub::get_schema(const std::vector<PTabletID>& tablets) {
 
 Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, int64_t tablet_id,
                                        int64_t timeout_ms) {
+    if (!_is_init.load()) {
+        return _init_st;
+    }
     if (_tablet_schema_for_index->contains(index_id)) {
         return Status::OK();
     }
@@ -310,7 +336,10 @@ Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, i
 Status LoadStreamStub::close_wait(RuntimeState* state, int64_t timeout_ms) {
     DBUG_EXECUTE_IF("LoadStreamStub::close_wait.long_wait", DBUG_BLOCK);
     if (!_is_init.load()) {
-        return Status::InternalError("stream {} is not opened, {}", _stream_id, to_string());
+        return _init_st;
+    }
+    if (!_is_closing.load()) {
+        return _close_st;
     }
     if (_is_closed.load()) {
         return _check_cancel();
@@ -341,7 +370,7 @@ void LoadStreamStub::cancel(Status reason) {
     LOG(WARNING) << *this << " is cancelled because of " << reason;
     {
         std::lock_guard<bthread::Mutex> lock(_cancel_mutex);
-        _cancel_reason = reason;
+        _cancel_st = reason;
         _is_cancelled.store(true);
     }
     {

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -194,6 +194,8 @@ public:
 
     int64_t dst_id() const { return _dst_id; }
 
+    bool is_inited() const { return _is_init.load(); }
+
     bool is_incremental() const { return _is_incremental; }
 
     friend std::ostream& operator<<(std::ostream& ostr, const LoadStreamStub& stub);
@@ -237,7 +239,7 @@ protected:
     brpc::StreamId _stream_id;
     int64_t _src_id = -1; // source backend_id
     int64_t _dst_id = -1; // destination backend_id
-    Status _init_st;
+    Status _init_st = Status::InternalError<false>("Stream is not open");
     Status _close_st;
     Status _cancel_st;
 

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -223,11 +223,12 @@ private:
         }
         std::lock_guard<bthread::Mutex> lock(_cancel_mutex);
         return Status::Cancelled("load_id={}, reason: {}", print_id(_load_id),
-                                 _cancel_reason.to_string_no_stack());
+                                 _cancel_st.to_string_no_stack());
     }
 
 protected:
     std::atomic<bool> _is_init;
+    std::atomic<bool> _is_closing;
     std::atomic<bool> _is_closed;
     std::atomic<bool> _is_cancelled;
     std::atomic<bool> _is_eos;
@@ -236,7 +237,9 @@ protected:
     brpc::StreamId _stream_id;
     int64_t _src_id = -1; // source backend_id
     int64_t _dst_id = -1; // destination backend_id
-    Status _cancel_reason;
+    Status _init_st;
+    Status _close_st;
+    Status _cancel_st;
 
     bthread::Mutex _open_mutex;
     bthread::Mutex _close_mutex;

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -594,10 +594,7 @@ Status VTabletWriterV2::close(Status exec_status) {
 
         // send CLOSE_LOAD on all non-incremental streams if this is the last sink
         if (is_last_sink) {
-            auto st = _load_stream_map->close_load(false);
-            if (!st.ok()) {
-                LOG(WARNING) << "close_load failed: " << st;
-            }
+            _load_stream_map->close_load(false);
         }
 
         // close_wait on all non-incremental streams, even if this is not the last sink.
@@ -609,10 +606,7 @@ Status VTabletWriterV2::close(Status exec_status) {
         // this must happen after all non-incremental streams are closed,
         // so we can ensure all sinks are in close phase before closing incremental streams.
         if (is_last_sink) {
-            auto st = _load_stream_map->close_load(true);
-            if (!st.ok()) {
-                LOG(WARNING) << "close_load failed: " << st;
-            }
+            _load_stream_map->close_load(true);
         }
 
         // close_wait on all incremental streams, even if this is not the last sink.

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -149,7 +149,7 @@ private:
 
     Status _close_wait(bool incremental);
 
-    Status _cancel(Status status);
+    void _cancel(Status status);
 
     std::shared_ptr<MemTracker> _mem_tracker;
 

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -147,7 +147,7 @@ private:
 
     void _calc_tablets_to_commit();
 
-    Status _close_wait(bool incremental);
+    void _close_wait(bool incremental);
 
     void _cancel(Status status);
 

--- a/regression-test/suites/fault_injection_p0/test_load_stream_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_load_stream_fault_injection.groovy
@@ -143,8 +143,6 @@ suite("load_stream_fault_injection", "nonConcurrent") {
     load_with_injection("LocalFileSystem.create_file_impl.open_file_failed", "")
     // LoadStreamWriter append_data meet null file writer error
     load_with_injection("LoadStreamWriter.append_data.null_file_writer", "")
-    // LoadStreamWriter close_writer meet not inited error
-    load_with_injection("LoadStreamWriter.close_writer.uninited_writer", "")
     // LoadStreamWriter close_writer meet not bad segid error
     load_with_injection("LoadStreamWriter.close_writer.bad_segid", "")
     // LoadStreamWriter close_writer meet null file writer error
@@ -153,8 +151,8 @@ suite("load_stream_fault_injection", "nonConcurrent") {
     load_with_injection("LocalFileWriter.close.failed", "")
     // LoadStreamWriter close_writer meet bytes_appended and real file size not match error
     load_with_injection("FileWriter.close_writer.zero_bytes_appended", "")
-    // LoadStreamWriter add_segment meet not inited error
-    load_with_injection("LoadStreamWriter.add_segment.uninited_writer", "")
+    // LoadStreamWriter close_writer/add_segment meet not inited error
+    load_with_injection("TabletStream.init.uninited_writer", "")
     // LoadStreamWriter add_segment meet not bad segid error
     load_with_injection("LoadStreamWriter.add_segment.bad_segid", "")
     // LoadStreamWriter add_segment meet null file writer error

--- a/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
@@ -77,6 +77,7 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
 
         def load_with_injection = { injection, error_msg->
             try {
+                sql "truncate table test"
                 GetDebugPoint().enableDebugPointForAllBEs(injection)
                 sql "insert into test select * from baseall where k1 <= 3"
             } catch(Exception e) {
@@ -98,6 +99,8 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
         load_with_injection("LoadStreamStub.only_send_segment_0", "segment num mismatch")
         // test 1st stream to each backend failure
         load_with_injection("VTabletWriterV2._open_streams_to_backend.one_stream_open_failure", "success")
+        // test one backend open failure
+        load_with_injection("VTabletWriterV2._open_streams.skip_one_backend", "success")
         sql """ set enable_memtable_on_sink_node=false """
     }
 }

--- a/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
@@ -96,6 +96,8 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
         load_with_injection("StreamSinkFileWriter.appendv.write_segment_failed_all_replica", "failed to send segment data to any replicas")
         // test segment num check when LoadStreamStub missed tail segments
         load_with_injection("LoadStreamStub.only_send_segment_0", "segment num mismatch")
+        // test 1st stream to each backend failure
+        load_with_injection("VTabletWriterV2._open_streams_to_backend.one_stream_open_failure", "success")
         sql """ set enable_memtable_on_sink_node=false """
     }
 }


### PR DESCRIPTION
## Proposed changes

Load job for multi replica tables shouldn't fail immediately on any single replica errors.
Errors should be recorded and reported for individual replica of tablets, and checked on commit info. 