### PR TITLE
[Improvement](scan) use loop to instead recursion on Level1Iterator::_normal_next 

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -857,18 +857,18 @@ Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
 Status VCollectIterator::Level1Iterator::_normal_next(Block* block) {
     SCOPED_RAW_TIMER(&_reader->_stats.collect_iterator_normal_next_timer);
     auto res = _cur_child->next(block);
+
+    while (res.is<END_OF_FILE>() && !_children.empty()) {
+        _cur_child = std::move(*(_children.begin()));
+        _children.pop_front();
+        res = _cur_child->next(block);
+    }
+
     if (LIKELY(res.ok())) {
         return Status::OK();
     } else if (res.is<END_OF_FILE>()) {
-        // current child has been read, to read next
-        if (!_children.empty()) {
-            _cur_child = std::move(*(_children.begin()));
-            _children.pop_front();
-            return _normal_next(block);
-        } else {
-            _cur_child.reset();
-            return Status::Error<END_OF_FILE>("");
-        }
+        _cur_child.reset();
+        return Status::Error<END_OF_FILE>("");
     } else {
         _cur_child.reset();
         LOG(WARNING) << "failed to get next from child, res=" << res;


### PR DESCRIPTION
## Proposed changes
use loop to instead recursion on Level1Iterator::_normal_next