### PR TITLE
[fix](compaction) Fix data race when fetching base compaction score from cloud tablet

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <memory>
+#include <shared_mutex>
 #include <unordered_map>
 
 #include "cloud/cloud_meta_mgr.h"
@@ -463,6 +464,7 @@ int64_t CloudTablet::get_cloud_base_compaction_score() const {
     if (_tablet_meta->compaction_policy() == CUMULATIVE_TIME_SERIES_POLICY) {
         bool has_delete = false;
         int64_t point = cumulative_layer_point();
+        std::shared_lock<std::shared_mutex> rlock(_meta_lock);
         for (const auto& rs_meta : _tablet_meta->all_rs_metas()) {
             if (rs_meta->start_version() >= point) {
                 continue;


### PR DESCRIPTION
## Proposed changes

When calculating base compaction score on cloud tablet, data race may cause rowset meta become nullptr and cause a crash.

Therefore added a read lock as protection in this case.

