### PR TITLE
[chore](fe) Returns dropped tables in GetMeta request

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -458,7 +458,6 @@ Status SnapshotLoader::remote_http_download(
     }
 
     // Step 3: Validate remote tablet snapshot paths && remote files map
-    // TODO(Drogon): Add md5sum check
     // key is remote snapshot paths, value is filelist
     // get all these use http download action
     // http://172.16.0.14:6781/api/_tablet/_download?token=e804dd27-86da-4072-af58-70724075d2a4&file=/home/ubuntu/doris_master/output/be/storage/snapshot/20230410102306.9.180//2774718/217609978/2774718.hdr

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -380,6 +380,20 @@ public class BinlogManager {
         }
     }
 
+    // get the dropped tables of the db.
+    public List<Long> getDroppedTables(long dbId) {
+        lock.readLock().lock();
+        try {
+            DBBinlog dbBinlog = dbBinlogMap.get(dbId);
+            if (dbBinlog == null) {
+                return Lists.newArrayList();
+            }
+            return dbBinlog.getDroppedTables();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     public List<BinlogTombstone> gc() {
         LOG.info("begin gc binlog");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DropTableRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DropTableRecord.java
@@ -58,6 +58,10 @@ public class DropTableRecord {
         return GsonUtils.GSON.toJson(this);
     }
 
+    public static DropTableRecord fromJson(String json) {
+        return GsonUtils.GSON.fromJson(json, DropTableRecord.class);
+    }
+
     @Override
     public String toString() {
         return toJson();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6307,6 +6307,7 @@ public class Env {
         if (Config.enable_feature_binlog) {
             BinlogManager binlogManager = Env.getCurrentEnv().getBinlogManager();
             dbMeta.setDroppedPartitions(binlogManager.getDroppedPartitions(db.getId()));
+            dbMeta.setDroppedTables(binlogManager.getDroppedTables(db.getId()));
         }
 
         result.setDbMeta(dbMeta);

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1457,6 +1457,7 @@ struct TGetMetaDBMeta {
     2: optional string name
     3: optional list<TGetMetaTableMeta> tables
     4: optional list<i64> dropped_partitions
+    5: optional list<i64> dropped_tables
 }
 
 struct TGetMetaResult {


### PR DESCRIPTION
The CCR syncer needs to know the distribution of tables, partitions, indexes, and replicas when synchronizing binlogs. If a table is deleted before the binlog synchronization is complete, the CCR syncer cannot continue synchronizing. This PR will record the deleted tables and include them in the get meta response, allowing the CCR syncer to filter out the binlogs that belong to these tables.

The CCR syncer part PR is selectdb/ccr-syncer#123.


