### PR TITLE
[fix](nereids) bug: after is-null stats derive, other column stats are dropped (#37809)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -625,17 +625,24 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 Statistics isNullStats = computeGeneratedIsNullStats((LogicalJoin) plan, filter);
                 if (isNullStats != null) {
                     // overwrite the stats corrected as above before passing to filter estimation
-                    stats = isNullStats;
                     Set<Expression> newConjuncts = filter.getConjuncts().stream()
                             .filter(e -> !(e instanceof IsNull))
                             .collect(Collectors.toSet());
                     if (newConjuncts.isEmpty()) {
-                        return stats;
+                        return isNullStats;
                     } else {
                         // overwrite the filter by removing is null and remain the others
                         filter = ((LogicalFilter<?>) filter).withConjunctsAndProps(newConjuncts,
                                 ((LogicalFilter<?>) filter).getGroupExpression(),
                                 Optional.of(((LogicalFilter<?>) filter).getLogicalProperties()), plan);
+                        // add update is-null related column stats for other predicate derive
+                        StatisticsBuilder builder = new StatisticsBuilder(stats);
+                        for (Expression expr : isNullStats.columnStatistics().keySet()) {
+                            builder.putColumnStatistics(expr, isNullStats.findColumnStatistics(expr));
+                        }
+                        builder.setRowCount(isNullStats.getRowCount());
+                        stats = builder.build();
+                        stats.enforceValid();
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes
pick from #37809 
Issue Number: close #xxx

<!--Describe your changes.-->

