### PR TITLE
[fix](profile) Fix profile eject 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -180,11 +180,11 @@ public class ProfileManager {
             if (queryIdToExecutionProfiles.size() > 2 * Config.max_query_profile_num) {
                 List<ExecutionProfile> finishOrExpireExecutionProfiles = Lists.newArrayList();
                 for (ExecutionProfile tmpProfile : queryIdToExecutionProfiles.values()) {
-                    boolean query_finished_long_enough = tmpProfile.getQueryFinishTime() > 0
+                    boolean queryFinishedLongEnough = tmpProfile.getQueryFinishTime() > 0
                             && System.currentTimeMillis() - tmpProfile.getQueryFinishTime()
                             > Config.profile_async_collect_expire_time_secs * 1000;
 
-                    if (query_finished_long_enough) {
+                    if (queryFinishedLongEnough) {
                         finishOrExpireExecutionProfiles.add(tmpProfile);
                     }
                 }
@@ -232,9 +232,9 @@ public class ProfileManager {
                             this.queryIdToExecutionProfiles.remove(executionProfile.getQueryId());
                             LOG.warn("Remove expired profile {}, queryIdDeque size {}, profile count {},"
                                     + " execution profile count {} max_query_profile_num {}",
-                                    profileElementRemoved.profile.getSummaryProfile().getProfileId(), queryIdDeque.size(),
-                                    queryIdToProfileMap.size(), queryIdToExecutionProfiles.size(),
-                                    Config.max_query_profile_num);
+                                    profileElementRemoved.profile.getSummaryProfile().getProfileId(),
+                                    queryIdDeque.size(), queryIdToProfileMap.size(),
+                                    queryIdToExecutionProfiles.size(), Config.max_query_profile_num);
                         }
                     }
                     queryIdDeque.removeFirst();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -228,14 +228,17 @@ public class ProfileManager {
                     ProfileElement profileElementRemoved = queryIdToProfileMap.remove(queryIdDeque.getFirst());
                     // If the Profile object is removed from manager, then related execution profile is also useless.
                     if (profileElementRemoved != null) {
+                        StringBuilder sb = new StringBuilder();
                         for (ExecutionProfile executionProfile : profileElementRemoved.profile.getExecutionProfiles()) {
+                            sb.append(executionProfile.getQueryId()).append(",");
                             this.queryIdToExecutionProfiles.remove(executionProfile.getQueryId());
-                            LOG.warn("Remove expired profile {}, queryIdDeque size {}, profile count {},"
+                        }
+                        LOG.warn("Remove expired profile {}, execution profiles {},"
+                                    + " queryIdDeque size {}, profile count {},"
                                     + " execution profile count {} max_query_profile_num {}",
                                     profileElementRemoved.profile.getSummaryProfile().getProfileId(),
-                                    queryIdDeque.size(), queryIdToProfileMap.size(),
+                                    sb.toString(), queryIdDeque.size(), queryIdToProfileMap.size(),
                                     queryIdToExecutionProfiles.size(), Config.max_query_profile_num);
-                        }
                     }
                     queryIdDeque.removeFirst();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -173,22 +173,27 @@ public class ProfileManager {
                 LOG.debug("Add execution profile {} to profile manager",
                         DebugUtil.printId(executionProfile.getQueryId()));
             }
-            // Check if there are some query profiles that not finish collecting, should
-            // remove them to release memory.
+            // This branch has two purposes:
+            // 1. discard profile collecting if its collection not finished in 5 seconds after query finished.
+            // 2. prevent execution profile from leakage. If we have too many execution profiles in memory,
+            // we will remove execution profiles of query that has finished in 5 seconds ago.
             if (queryIdToExecutionProfiles.size() > 2 * Config.max_query_profile_num) {
                 List<ExecutionProfile> finishOrExpireExecutionProfiles = Lists.newArrayList();
                 for (ExecutionProfile tmpProfile : queryIdToExecutionProfiles.values()) {
-                    if (System.currentTimeMillis() - tmpProfile.getQueryFinishTime()
-                            > Config.profile_async_collect_expire_time_secs * 1000) {
+                    boolean query_finished_long_enough = tmpProfile.getQueryFinishTime() > 0
+                            && System.currentTimeMillis() - tmpProfile.getQueryFinishTime()
+                            > Config.profile_async_collect_expire_time_secs * 1000;
+
+                    if (query_finished_long_enough) {
                         finishOrExpireExecutionProfiles.add(tmpProfile);
                     }
                 }
+                StringBuilder stringBuilder = new StringBuilder();
                 for (ExecutionProfile tmp : finishOrExpireExecutionProfiles) {
+                    stringBuilder.append(DebugUtil.printId(tmp.getQueryId())).append(",");
                     queryIdToExecutionProfiles.remove(tmp.getQueryId());
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Remove expired execution profile {}", DebugUtil.printId(tmp.getQueryId()));
-                    }
                 }
+                LOG.warn("Remove expired execution profiles {}", stringBuilder.toString());
             }
         } finally {
             writeLock.unlock();
@@ -225,6 +230,11 @@ public class ProfileManager {
                     if (profileElementRemoved != null) {
                         for (ExecutionProfile executionProfile : profileElementRemoved.profile.getExecutionProfiles()) {
                             this.queryIdToExecutionProfiles.remove(executionProfile.getQueryId());
+                            LOG.warn("Remove expired profile {}, queryIdDeque size {}, profile count {},"
+                                    + " execution profile count {} max_query_profile_num {}",
+                                    profileElementRemoved.profile.getSummaryProfile().getProfileId(), queryIdDeque.size(),
+                                    queryIdToProfileMap.size(), queryIdToExecutionProfiles.size(),
+                                    Config.max_query_profile_num);
                         }
                     }
                     queryIdDeque.removeFirst();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -122,10 +122,11 @@ public final class QeProcessorImpl implements QeProcessor {
         if (result != null) {
             throw new UserException("queryId " + queryId + " already exists");
         }
-
         // Should add the execution profile to profile manager, BE will report the profile to FE and FE
         // will update it in ProfileManager
-        ProfileManager.getInstance().addExecutionProfile(info.getCoord().getExecutionProfile());
+        if (info.coord.getQueryOptions().enable_profile) {
+            ProfileManager.getInstance().addExecutionProfile(info.getCoord().getExecutionProfile());
+        }
     }
 
     @Override


### PR DESCRIPTION
1. We should only eject execution profiles after query has finished for a long enough time.
2. Only add execution to profile manager if enable_profile is true