### PR TITLE
[Fix](load) Fix uninitiated load_type (not a valid value for type) of StreamLoadContext when operate_txn_2pc

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -123,7 +123,7 @@ public:
 public:
     static const int default_txn_id = -1;
     // load type, eg: ROUTINE LOAD/MANUAL LOAD
-    TLoadType::type load_type;
+    TLoadType::type load_type = TLoadType::type::MANUL_LOAD;
     // load data source: eg: KAFKA/RAW
     TLoadSourceType::type load_src_type;
 


### PR DESCRIPTION
/root/doris/be/src/runtime/stream_load/stream_load_executor.cpp:384:14: runtime error: load of value 3200171710, which is not a valid value for type 'TLoadType::type'
    #0 0x55be4e2cf808 in doris::StreamLoadExecutor::collect_load_stat(doris::StreamLoadContext*, doris::TTxnCommitAttachment*) /root/doris/be/src/runtime/stream_load/stream_load_executor.cpp:384:14
    #1 0x55be4e2d2666 in doris::StreamLoadExecutor::rollback_txn(doris::StreamLoadContext*) /root/doris/be/src/runtime/stream_load/stream_load_executor.cpp:364:9
    #2 0x55be80413748 in doris::CloudStreamLoadExecutor::operate_txn_2pc(doris::StreamLoadContext*) /root/doris/be/src/cloud/cloud_stream_load_executor.cpp:80:33
    #3 0x55be50cad893 in doris::StreamLoad2PCAction::handle(doris::HttpRequest*) /root/doris/be/src/http/action/stream_load_2pc.cpp:85:49

