### PR TITLE
[fix]fix be core when migration tablet to other disk (#37712)

### DIFF
--- a/be/src/http/action/tablet_migration_action.cpp
+++ b/be/src/http/action/tablet_migration_action.cpp
@@ -74,7 +74,8 @@ void TabletMigrationAction::handle(HttpRequest* req) {
                         }
                         _migration_tasks[current_task] = "submitted";
                     }
-                    auto st = _migration_thread_pool->submit_func([&, dest_disk, current_task]() {
+                    auto st = _migration_thread_pool->submit_func([&, tablet, dest_store,
+                                                                   current_task]() {
                         {
                             std::unique_lock<std::mutex> lock(_migration_status_mutex);
                             _migration_tasks[current_task] = "running";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/01f67160-3ebe-41a1-ac79-a7173d14605c) The asynchronous task reference captures a local variable
Issue Number: close #36809

