### PR TITLE
[chore](backup) Fix the db name of the restored view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -402,7 +402,7 @@ public class BackupJob extends AbstractJob {
             }
         }
 
-        backupMeta = new BackupMeta(copiedTables, copiedResources);
+        backupMeta = new BackupMeta(db.getName(), copiedTables, copiedResources);
 
         // send tasks
         for (AgentTask task : batchTask.getAllTasks()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupMeta.java
@@ -39,6 +39,8 @@ import java.util.Map;
 
 public class BackupMeta implements Writable {
 
+    @SerializedName(value = "db")
+    private String dbName;
     // tbl name -> tbl
     @SerializedName(value = "tblNameMap")
     private Map<String, Table> tblNameMap = Maps.newHashMap();
@@ -52,7 +54,9 @@ public class BackupMeta implements Writable {
     private BackupMeta() {
     }
 
-    public BackupMeta(List<Table> tables, List<Resource> resources) {
+    public BackupMeta(String dbName, List<Table> tables, List<Resource> resources) {
+        this.dbName = dbName;
+
         for (Table table : tables) {
             tblNameMap.put(table.getName(), table);
             tblIdMap.put(table.getId(), table);
@@ -60,6 +64,10 @@ public class BackupMeta implements Writable {
         for (Resource resource : resources) {
             resourceNameMap.put(resource.getName(), resource);
         }
+    }
+
+    public String getDbName() {
+        return dbName;
     }
 
     public Map<String, Table> getTables() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -738,7 +738,8 @@ public class RestoreJob extends AbstractJob {
                         return;
                     }
                 } else {
-                    remoteView.resetIdsForRestore(env);
+                    String srcDbName = backupMeta.getDbName();
+                    remoteView.resetIdsForRestore(env, srcDbName, db.getFullName());
                     restoredTbls.add(remoteView);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -222,6 +222,11 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         return fullQualifiedName;
     }
 
+    public String getName() {
+        String[] strs = fullQualifiedName.split(":");
+        return strs.length == 2 ? strs[1] : strs[0];
+    }
+
     public void setNameWithLock(String newName) {
         writeLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -240,8 +240,13 @@ public class View extends Table {
         return copied;
     }
 
-    public void resetIdsForRestore(Env env) {
+    public void resetIdsForRestore(Env env, String srcDbName, String dbName) {
         id = env.getNextId();
+
+        // the source db name is not setted in old BackupMeta, keep compatible with the old one.
+        if (srcDbName != null) {
+            inlineViewDef = inlineViewDef.replaceAll(srcDbName, dbName);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -212,7 +212,7 @@ public class BackupHandlerTest {
                 List<Table> tbls = Lists.newArrayList();
                 tbls.add(tbl);
                 List<Resource> resources = Lists.newArrayList();
-                BackupMeta backupMeta = new BackupMeta(tbls, resources);
+                BackupMeta backupMeta = new BackupMeta(null, tbls, resources);
                 Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
                 for (Partition part : tbl.getPartitions()) {
                     for (MaterializedIndex idx : part.getMaterializedIndices(IndexExtState.VISIBLE)) {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -252,7 +252,7 @@ public class RestoreJobTest {
         List<Table> tbls = Lists.newArrayList();
         List<Resource> resources = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
-        backupMeta = new BackupMeta(tbls, resources);
+        backupMeta = new BackupMeta(null, tbls, resources);
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick #37412

Previously, during restore, the database name in the CREATE VIEW statement was not modified, causing the restored view to be unviewable with the SHOW VIEW command. This PR retains the original cluster's database name in the BackupMeta and manually replaces it with the new cluster's database name in the CREATE VIEW statement during restore.

