### PR TITLE
[fix](profile) Task state of query profile is not set correctly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -386,8 +386,11 @@ public class StmtExecutor {
             builder.endTime(TimeUtils.longToTimeString(currentTimestamp));
             builder.totalTime(DebugUtil.getPrettyStringMs(currentTimestamp - context.getStartTime()));
         }
-        builder.taskState(!isFinished && context.getState().getStateType().equals(MysqlStateType.OK) ? "RUNNING"
-                : context.getState().toString());
+        String taskState = "RUNNING";
+        if (isFinished) {
+            taskState = coord.queryStatus.getErrorCode().name();
+        }
+        builder.taskState(taskState);
         builder.user(context.getQualifiedUser());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -388,7 +388,11 @@ public class StmtExecutor {
         }
         String taskState = "RUNNING";
         if (isFinished) {
-            taskState = coord.queryStatus.getErrorCode().name();
+            if (coord != null) {
+                taskState = coord.queryStatus.getErrorCode().name();
+            } else {
+                taskState = context.getState().toString();
+            }
         }
         builder.taskState(taskState);
         builder.user(context.getQualifiedUser());


### PR DESCRIPTION
Task state in connection context will only be updated after profile is updated. So task state of profile should be set to query state of coordinator.