### PR TITLE
[Improvement](runtime-filter) use shared ptr to instead object pool to store runtime filters

### DIFF
--- a/be/src/exprs/create_predicate_function.h
+++ b/be/src/exprs/create_predicate_function.h
@@ -34,7 +34,9 @@ public:
     using BasePtr = MinMaxFuncBase*;
     template <PrimitiveType type, size_t N>
     static BasePtr get_function() {
-        return new MinMaxNumFunc<typename PrimitiveTypeTraits<type>::CppType>();
+        using CppType = typename PrimitiveTypeTraits<type>::CppType;
+        return new MinMaxNumFunc<
+                std::conditional_t<std::is_same_v<CppType, StringRef>, std::string, CppType>>();
     }
 };
 

--- a/be/src/exprs/minmax_predicate.h
+++ b/be/src/exprs/minmax_predicate.h
@@ -82,7 +82,6 @@ public:
                 }
             }
         }
-        store_string_ref();
     }
 
     void update_batch(const vectorized::ColumnPtr& column, size_t start) {
@@ -143,7 +142,6 @@ public:
             if constexpr (NeedMax) {
                 _max = std::max(_max, other_minmax->_max);
             }
-            store_string_ref();
         } else {
             auto* other_minmax = static_cast<MinMaxNumFunc<T>*>(minmax_func);
             if constexpr (NeedMin) {
@@ -172,28 +170,9 @@ public:
         return Status::OK();
     }
 
-    void store_string_ref() {
-        if constexpr (std::is_same_v<T, StringRef>) {
-            if constexpr (NeedMin) {
-                if (_min.data != _stored_min.data()) {
-                    _stored_min = _min.to_string();
-                    _min = StringRef(_stored_min);
-                }
-            }
-            if constexpr (NeedMax) {
-                if (_max.data != _stored_max.data()) {
-                    _stored_max = _max.to_string();
-                    _max = StringRef(_stored_max);
-                }
-            }
-        }
-    }
-
 protected:
     T _max = type_limit<T>::min();
     T _min = type_limit<T>::max();
-    std::string _stored_min;
-    std::string _stored_max;
 };
 
 template <class T>

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -48,7 +48,6 @@ class IOBufAsZeroCopyInputStream;
 }
 
 namespace doris {
-class ObjectPool;
 class RuntimePredicateWrapper;
 class PPublishFilterRequest;
 class PPublishFilterRequestV2;
@@ -157,17 +156,15 @@ protected:
 
 struct UpdateRuntimeFilterParams {
     UpdateRuntimeFilterParams(const PPublishFilterRequest* req,
-                              butil::IOBufAsZeroCopyInputStream* data_stream, ObjectPool* obj_pool)
-            : request(req), data(data_stream), pool(obj_pool) {}
+                              butil::IOBufAsZeroCopyInputStream* data_stream)
+            : request(req), data(data_stream) {}
     const PPublishFilterRequest* request = nullptr;
     butil::IOBufAsZeroCopyInputStream* data = nullptr;
-    ObjectPool* pool = nullptr;
 };
 
 struct UpdateRuntimeFilterParamsV2 {
     const PPublishFilterRequestV2* request;
     butil::IOBufAsZeroCopyInputStream* data;
-    ObjectPool* pool = nullptr;
     PrimitiveType column_type = INVALID_TYPE;
 };
 
@@ -192,10 +189,9 @@ enum RuntimeFilterState {
 /// that can be pushed down to node based on the results of the right table.
 class IRuntimeFilter {
 public:
-    IRuntimeFilter(RuntimeFilterParamsContext* state, ObjectPool* pool,
-                   const TRuntimeFilterDesc* desc, bool need_local_merge = false)
+    IRuntimeFilter(RuntimeFilterParamsContext* state, const TRuntimeFilterDesc* desc,
+                   bool need_local_merge = false)
             : _state(state),
-              _pool(pool),
               _filter_id(desc->filter_id),
               _is_broadcast_join(true),
               _has_remote_target(false),
@@ -215,9 +211,9 @@ public:
 
     ~IRuntimeFilter() = default;
 
-    static Status create(RuntimeFilterParamsContext* state, ObjectPool* pool,
-                         const TRuntimeFilterDesc* desc, const TQueryOptions* query_options,
-                         const RuntimeFilterRole role, int node_id, IRuntimeFilter** res,
+    static Status create(RuntimeFilterParamsContext* state, const TRuntimeFilterDesc* desc,
+                         const TQueryOptions* query_options, const RuntimeFilterRole role,
+                         int node_id, std::shared_ptr<IRuntimeFilter>* res,
                          bool build_bf_exactly = false, bool need_local_merge = false);
 
     SharedRuntimeFilterContext& get_shared_context_ref();
@@ -281,17 +277,17 @@ public:
 
     Status merge_from(const RuntimePredicateWrapper* wrapper);
 
-    static Status create_wrapper(const MergeRuntimeFilterParams* param, ObjectPool* pool,
+    static Status create_wrapper(const MergeRuntimeFilterParams* param,
                                  std::unique_ptr<RuntimePredicateWrapper>* wrapper);
-    static Status create_wrapper(const UpdateRuntimeFilterParams* param, ObjectPool* pool,
+    static Status create_wrapper(const UpdateRuntimeFilterParams* param,
                                  std::unique_ptr<RuntimePredicateWrapper>* wrapper);
 
     static Status create_wrapper(const UpdateRuntimeFilterParamsV2* param,
-                                 RuntimePredicateWrapper** wrapper);
+                                 std::shared_ptr<RuntimePredicateWrapper>* wrapper);
     Status change_to_bloom_filter();
     Status init_bloom_filter(const size_t build_bf_cardinality);
     Status update_filter(const UpdateRuntimeFilterParams* param);
-    void update_filter(RuntimePredicateWrapper* filter_wrapper, int64_t merge_time,
+    void update_filter(std::shared_ptr<RuntimePredicateWrapper> filter_wrapper, int64_t merge_time,
                        int64_t start_apply);
 
     void set_ignored();
@@ -381,7 +377,7 @@ protected:
     Status serialize_impl(T* request, void** data, int* len);
 
     template <class T>
-    static Status _create_wrapper(const T* param, ObjectPool* pool,
+    static Status _create_wrapper(const T* param,
                                   std::unique_ptr<RuntimePredicateWrapper>* wrapper);
 
     void _set_push_down(bool push_down) { _is_push_down = push_down; }
@@ -395,10 +391,8 @@ protected:
     }
 
     RuntimeFilterParamsContext* _state = nullptr;
-    ObjectPool* _pool = nullptr;
     // _wrapper is a runtime filter function wrapper
-    // _wrapper should alloc from _pool
-    RuntimePredicateWrapper* _wrapper = nullptr;
+    std::shared_ptr<RuntimePredicateWrapper> _wrapper;
     // runtime filter id
     int _filter_id;
     // Specific types BoardCast or Shuffle

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -34,10 +34,10 @@ class VRuntimeFilterSlots {
 public:
     VRuntimeFilterSlots(
             const std::vector<std::shared_ptr<vectorized::VExprContext>>& build_expr_ctxs,
-            const std::vector<IRuntimeFilter*>& runtime_filters)
+            const std::vector<std::shared_ptr<IRuntimeFilter>>& runtime_filters)
             : _build_expr_context(build_expr_ctxs), _runtime_filters(runtime_filters) {
-        for (auto* runtime_filter : _runtime_filters) {
-            _runtime_filters_map[runtime_filter->expr_order()].push_back(runtime_filter);
+        for (auto runtime_filter : _runtime_filters) {
+            _runtime_filters_map[runtime_filter->expr_order()].push_back(runtime_filter.get());
         }
     }
 
@@ -46,14 +46,14 @@ public:
         if (_runtime_filters.empty()) {
             return Status::OK();
         }
-        for (auto* runtime_filter : _runtime_filters) {
+        for (auto runtime_filter : _runtime_filters) {
             if (runtime_filter->need_sync_filter_size()) {
                 runtime_filter->set_dependency(dependency);
             }
         }
 
         // send_filter_size may call dependency->sub(), so we call set_dependency firstly for all rf to avoid dependency set_ready repeatedly
-        for (auto* runtime_filter : _runtime_filters) {
+        for (auto runtime_filter : _runtime_filters) {
             if (runtime_filter->need_sync_filter_size()) {
                 RETURN_IF_ERROR(runtime_filter->send_filter_size(state, hash_table_size));
             }
@@ -70,7 +70,7 @@ public:
     Status ignore_filters(RuntimeState* state) {
         // process ignore duplicate IN_FILTER
         std::unordered_set<int> has_in_filter;
-        for (auto* filter : _runtime_filters) {
+        for (auto filter : _runtime_filters) {
             if (filter->get_ignored()) {
                 continue;
             }
@@ -85,7 +85,7 @@ public:
         }
 
         // process ignore filter when it has IN_FILTER on same expr, and init bloom filter size
-        for (auto* filter : _runtime_filters) {
+        for (auto filter : _runtime_filters) {
             if (filter->get_ignored()) {
                 continue;
             }
@@ -100,12 +100,13 @@ public:
 
     Status init_filters(RuntimeState* state, uint64_t local_hash_table_size) {
         // process IN_OR_BLOOM_FILTER's real type
-        for (auto* filter : _runtime_filters) {
+        for (auto filter : _runtime_filters) {
             if (filter->get_ignored()) {
                 continue;
             }
             if (filter->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
-                get_real_size(filter, local_hash_table_size) > state->runtime_filter_max_in_num()) {
+                get_real_size(filter.get(), local_hash_table_size) >
+                        state->runtime_filter_max_in_num()) {
                 RETURN_IF_ERROR(filter->change_to_bloom_filter());
             }
 
@@ -114,8 +115,8 @@ public:
                     return Status::InternalError("sync filter size meet error, filter: {}",
                                                  filter->debug_string());
                 }
-                RETURN_IF_ERROR(
-                        filter->init_bloom_filter(get_real_size(filter, local_hash_table_size)));
+                RETURN_IF_ERROR(filter->init_bloom_filter(
+                        get_real_size(filter.get(), local_hash_table_size)));
             }
         }
         return Status::OK();
@@ -175,7 +176,7 @@ public:
 
 private:
     const std::vector<std::shared_ptr<vectorized::VExprContext>>& _build_expr_context;
-    std::vector<IRuntimeFilter*> _runtime_filters;
+    std::vector<std::shared_ptr<IRuntimeFilter>> _runtime_filters;
     // prob_contition index -> [IRuntimeFilter]
     std::map<int, std::list<IRuntimeFilter*>> _runtime_filters_map;
 };

--- a/be/src/pipeline/common/runtime_filter_consumer.h
+++ b/be/src/pipeline/common/runtime_filter_consumer.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "exprs/runtime_filter.h"
 #include "pipeline/dependency.h"
 
@@ -55,10 +57,10 @@ protected:
 
     // For runtime filters
     struct RuntimeFilterContext {
-        RuntimeFilterContext(IRuntimeFilter* rf) : runtime_filter(rf) {}
+        RuntimeFilterContext(std::shared_ptr<IRuntimeFilter> rf) : runtime_filter(std::move(rf)) {}
         // set to true if this runtime filter is already applied to vconjunct_ctx_ptr
         bool apply_mark = false;
-        IRuntimeFilter* runtime_filter = nullptr;
+        std::shared_ptr<IRuntimeFilter> runtime_filter;
         pipeline::RuntimeFilterDependency* runtime_filter_dependency = nullptr;
     };
 

--- a/be/src/pipeline/exec/datagen_operator.cpp
+++ b/be/src/pipeline/exec/datagen_operator.cpp
@@ -86,7 +86,7 @@ Status DataGenLocalState::init(RuntimeState* state, LocalStateInfo& info) {
 
     // TODO: use runtime filter to filte result block, maybe this node need derive from vscan_node.
     for (const auto& filter_desc : p._runtime_filter_descs) {
-        IRuntimeFilter* runtime_filter = nullptr;
+        std::shared_ptr<IRuntimeFilter> runtime_filter;
         RETURN_IF_ERROR(state->register_consumer_runtime_filter(
                 filter_desc, p.ignore_data_distribution(), p.node_id(), &runtime_filter));
         runtime_filter->init_profile(_runtime_profile.get());

--- a/be/src/pipeline/exec/join_build_sink_operator.h
+++ b/be/src/pipeline/exec/join_build_sink_operator.h
@@ -28,7 +28,9 @@ class JoinBuildSinkLocalState : public PipelineXSinkLocalState<SharedStateType> 
 public:
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
 
-    const std::vector<IRuntimeFilter*>& runtime_filters() const { return _runtime_filters; }
+    const std::vector<std::shared_ptr<IRuntimeFilter>>& runtime_filters() const {
+        return _runtime_filters;
+    }
 
 protected:
     JoinBuildSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state)
@@ -41,7 +43,7 @@ protected:
     RuntimeProfile::Counter* _publish_runtime_filter_timer = nullptr;
     RuntimeProfile::Counter* _runtime_filter_compute_timer = nullptr;
     RuntimeProfile::Counter* _runtime_filter_init_timer = nullptr;
-    std::vector<IRuntimeFilter*> _runtime_filters;
+    std::vector<std::shared_ptr<IRuntimeFilter>> _runtime_filters;
 };
 
 template <typename LocalStateType>

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1054,7 +1054,6 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
     QueryThreadContext query_thread_context;
 
     RuntimeFilterMgr* runtime_filter_mgr = nullptr;
-    ObjectPool* pool = nullptr;
 
     const auto& fragment_instance_ids = request->fragment_instance_ids();
     {
@@ -1071,7 +1070,6 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
 
                 DCHECK(pip_context != nullptr);
                 runtime_filter_mgr = pip_context->get_query_ctx()->runtime_filter_mgr();
-                pool = &pip_context->get_query_ctx()->obj_pool;
                 query_thread_context = {pip_context->get_query_ctx()->query_id(),
                                         pip_context->get_query_ctx()->query_mem_tracker};
             } else {
@@ -1088,13 +1086,13 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
 
     SCOPED_ATTACH_TASK(query_thread_context);
     // 1. get the target filters
-    std::vector<IRuntimeFilter*> filters;
+    std::vector<std::shared_ptr<IRuntimeFilter>> filters;
     RETURN_IF_ERROR(runtime_filter_mgr->get_consume_filters(request->filter_id(), filters));
 
     // 2. create the filter wrapper to replace or ignore the target filters
     if (!filters.empty()) {
-        UpdateRuntimeFilterParamsV2 params {request, attach_data, pool, filters[0]->column_type()};
-        RuntimePredicateWrapper* filter_wrapper = nullptr;
+        UpdateRuntimeFilterParamsV2 params {request, attach_data, filters[0]->column_type()};
+        std::shared_ptr<RuntimePredicateWrapper> filter_wrapper;
         RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(&params, &filter_wrapper));
 
         std::ranges::for_each(filters, [&](auto& filter) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -539,10 +539,9 @@ RuntimeFilterMgr* RuntimeState::global_runtime_filter_mgr() {
     return _query_ctx->runtime_filter_mgr();
 }
 
-Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
-                                                      bool need_local_merge,
-                                                      doris::IRuntimeFilter** producer_filter,
-                                                      bool build_bf_exactly) {
+Status RuntimeState::register_producer_runtime_filter(
+        const TRuntimeFilterDesc& desc, bool need_local_merge,
+        std::shared_ptr<IRuntimeFilter>* producer_filter, bool build_bf_exactly) {
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_local_merge_producer_filter(
                 desc, query_options(), producer_filter, build_bf_exactly);
@@ -552,9 +551,9 @@ Status RuntimeState::register_producer_runtime_filter(const doris::TRuntimeFilte
     }
 }
 
-Status RuntimeState::register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
-                                                      bool need_local_merge, int node_id,
-                                                      doris::IRuntimeFilter** consumer_filter) {
+Status RuntimeState::register_consumer_runtime_filter(
+        const doris::TRuntimeFilterDesc& desc, bool need_local_merge, int node_id,
+        std::shared_ptr<IRuntimeFilter>* consumer_filter) {
     if (desc.has_remote_targets || need_local_merge) {
         return global_runtime_filter_mgr()->register_consumer_filter(desc, query_options(), node_id,
                                                                      consumer_filter, false, true);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -572,12 +572,12 @@ public:
 
     Status register_producer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                             bool need_local_merge,
-                                            doris::IRuntimeFilter** producer_filter,
+                                            std::shared_ptr<IRuntimeFilter>* producer_filter,
                                             bool build_bf_exactly);
 
     Status register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
                                             bool need_local_merge, int node_id,
-                                            doris::IRuntimeFilter** producer_filter);
+                                            std::shared_ptr<IRuntimeFilter>* producer_filter);
     bool is_nereids() const;
 
     bool enable_join_spill() const {

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -48,8 +48,10 @@ private:
     // std::unique_ptr<IRuntimeFilter> _runtime_filter;
 };
 
-IRuntimeFilter* create_runtime_filter(TRuntimeFilterType::type type, TQueryOptions* options,
-                                      RuntimeState* _runtime_stat, ObjectPool* _obj_pool) {
+std::shared_ptr<IRuntimeFilter> create_runtime_filter(TRuntimeFilterType::type type,
+                                                      TQueryOptions* options,
+                                                      RuntimeState* _runtime_stat,
+                                                      ObjectPool* _obj_pool) {
     TRuntimeFilterDesc desc;
     desc.__set_filter_id(0);
     desc.__set_expr_order(0);
@@ -96,10 +98,10 @@ IRuntimeFilter* create_runtime_filter(TRuntimeFilterType::type type, TQueryOptio
         desc.__set_planId_to_target_expr(planid_to_target_expr);
     }
 
-    IRuntimeFilter* runtime_filter = nullptr;
-    Status status = IRuntimeFilter::create(RuntimeFilterParamsContext::create(_runtime_stat),
-                                           _obj_pool, &desc, options, RuntimeFilterRole::PRODUCER,
-                                           -1, &runtime_filter);
+    std::shared_ptr<IRuntimeFilter> runtime_filter;
+    Status status =
+            IRuntimeFilter::create(RuntimeFilterParamsContext::create(_runtime_stat), &desc,
+                                   options, RuntimeFilterRole::PRODUCER, -1, &runtime_filter);
 
     EXPECT_TRUE(status.ok()) << status.to_string();
 


### PR DESCRIPTION
## Proposed changes
use shared ptr to instead object pool to store runtime filters