### PR TITLE
[fix](core) fix closure use after release

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1918,11 +1918,6 @@ void PInternalServiceImpl::_response_pull_slave_rowset(const std::string& remote
 
     pull_rowset_callback->join();
     if (pull_rowset_callback->cntl_->Failed()) {
-        if (!ExecEnv::GetInstance()->brpc_internal_client_cache()->available(stub, remote_host,
-                                                                             brpc_port)) {
-            ExecEnv::GetInstance()->brpc_internal_client_cache()->erase(
-                    closure->cntl_->remote_side());
-        }
         LOG(WARNING) << "failed to response result of slave replica to master replica, error="
                      << berror(pull_rowset_callback->cntl_->ErrorCode())
                      << ", error_text=" << pull_rowset_callback->cntl_->ErrorText()


### PR DESCRIPTION
## Proposed changes

```
*** SIGSEGV address not mapped to object (@0x8) received by PID 3465895 (TID 3467451 OR 0x7f383371d700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:421
 1# 0x00007F3B62FFEB50 in /lib64/libc.so.6
 2# doris::PInternalServiceImpl::_response_pull_slave_rowset(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, long, long, long, bool) at /home/zcp/repo_center/doris_release/doris/be/src/service/internal_service.cpp:1922
 3# doris::PInternalServiceImpl::request_slave_tablet_pull_rowset(google::protobuf::RpcController*, doris::PTabletWriteSlaveRequest const*, doris::PTabletWriteSlaveResult*, google::protobuf::Closure*)::$_0::operator()() const at /home/zcp/repo_center/doris_release/doris/be/src/service/internal_service.cpp:1878
 4# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_release/doris/be/src/util/work_thread_pool.hpp:159
 5# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
 6# start_thread in /lib64/libpthread.so.0
 7# __clone in /lib64/libc.so.6 
```

<!--Describe your changes.-->

