### PR TITLE
[fix](mtmv)Mtmv support force replica 2.1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
@@ -185,6 +185,7 @@ public class CreateMTMVInfo {
     }
 
     private void analyzeProperties() {
+        properties = PropertyAnalyzer.rewriteReplicaAllocationProperties(mvName.getCtl(), mvName.getDb(), properties);
         if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
             throw new AnalysisException("Not support dynamic partition properties on async materialized view");
         }


### PR DESCRIPTION
master do not have bug, because has call `PropertyAnalyzer.getInstance().rewriteOlapProperties`

2.1 not have this method ,should call `PropertyAnalyzer.rewriteReplicaAllocationProperties`
