### PR TITLE
[enhancement](nereids)optimized aggregate node's error msg

### DIFF
--- a/regression-test/suites/nereids_p0/aggregate/agg_error_msg.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/agg_error_msg.groovy
@@ -52,4 +52,14 @@ suite("agg_error_msg") {
         sql """SELECT * from table_20_undef_partitions2_keys3_properties4_distributed_by58 group by 1;"""
         exception "col_int_undef_signed, col_int_undef_signed2 not in aggregate's output";
     }
+
+    test {
+        sql """SELECT *, pk from table_20_undef_partitions2_keys3_properties4_distributed_by58 group by 1;"""
+        exception "col_int_undef_signed, col_int_undef_signed2 not in aggregate's output";
+    }
+
+    test {
+        sql """SELECT *, * from table_20_undef_partitions2_keys3_properties4_distributed_by58 group by 1;"""
+        exception "col_int_undef_signed, col_int_undef_signed2 not in aggregate's output";
+    }
 }

--- a/regression-test/suites/nereids_p0/aggregate/agg_error_msg.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/agg_error_msg.groovy
@@ -47,4 +47,9 @@ suite("agg_error_msg") {
         sql """SELECT col_int_undef_signed2   col_alias1, col_int_undef_signed  *  (SELECT  MAX (col_int_undef_signed) FROM table_20_undef_partitions2_keys3_properties4_distributed_by58 where table_20_undef_partitions2_keys3_properties4_distributed_by53.pk = pk)  AS col_alias2 FROM table_20_undef_partitions2_keys3_properties4_distributed_by53  GROUP BY  GROUPING SETS ((col_int_undef_signed2),())  ;"""
         exception "pk, col_int_undef_signed not in aggregate's output";
     }
+
+    test {
+        sql """SELECT * from table_20_undef_partitions2_keys3_properties4_distributed_by58 group by 1;"""
+        exception "col_int_undef_signed, col_int_undef_signed2 not in aggregate's output";
+    }
 }


### PR DESCRIPTION
## Proposed changes

```
create table t1
(
    c1 bigint, 
    c2 bigint
)
DISTRIBUTED BY HASH(c1) BUCKETS 3
PROPERTIES ("replication_num" = "1");
```

sql
`select * from t1 group by 1;`

the error msg before:
ERROR 1105 (HY000): errCode = 2, detailMessage = Invalid call to toSlot on unbound object
after:
ERROR 1105 (HY000): errCode = 2, detailMessage = c2 not in aggregate's output



Issue Number: close #xxx

<!--Describe your changes.-->

