### PR TITLE
[fix](debug_point) Add reached_limit_early debug point

### DIFF
--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -152,7 +152,6 @@ public:
     // If use projection, we should clear `_origin_block`.
     void clear_origin_block();
 
-    [[nodiscard]] bool reached_limit() const;
     void reached_limit(vectorized::Block* block, bool* eos);
     RuntimeProfile* profile() { return _runtime_profile.get(); }
 


### PR DESCRIPTION
## Proposed changes

This debug point has a parameter named `op_name` used to specify the operator's name.

And remove the unused function `reached_limit()`

