### PR TITLE
[fix](cloud) Fix auth compatibility logic run errer mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -1123,7 +1123,7 @@ public class Role implements Writable, GsonPostProcessable {
                     privBitSet.set(Privilege.SHOW_VIEW_PRIV.getIdx());
                 }
             });
-        } else {
+        } else if (Config.isCloudMode()) {
             // cloud mode
             // For versions greater than VERSION_123, the cloud requires compatibility logic.
 


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: 11
	at com.google.common.base.Preconditions.checkState(Preconditions.java:512) ~[guava-32.1.2-jre.jar:?]
	at org.apache.doris.mysql.privilege.PrivBitSet.get(PrivBitSet.java:63) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.privilege.PrivBitSet.containsPrivs(PrivBitSet.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.privilege.Role.lambda$compatibilityErrEnum$4(Role.java:1150) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.LinkedHashMap$LinkedValues.forEach(LinkedHashMap.java:647) ~[?:?]
	at org.apache.doris.mysql.privilege.Role.compatibilityErrEnum(Role.java:1149) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.privilege.Role.gsonPostProcess(Role.java:1100) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

