### PR TITLE
[branch-2.1][fix](compatibility) Enhance SSL and Long Flag Handling in MySQL Handshake 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
@@ -80,7 +80,7 @@ public class MysqlCapability {
     private static final int SSL_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()
             | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LOCAL_FILES.getFlagBit()
-            | Flag.CLIENT_SSL.getFlagBit();
+            | Flag.CLIENT_LONG_FLAG.getFlagBit() | Flag.CLIENT_SSL.getFlagBit();
 
     public static final MysqlCapability DEFAULT_CAPABILITY = new MysqlCapability(DEFAULT_FLAGS);
     public static final MysqlCapability SSL_CAPABILITY = new MysqlCapability(SSL_FLAGS);


### PR DESCRIPTION
pick(#38086)
Issue Number: close #38065

This PR introduces a fix to the SSL and CLIENT_LONG_FLAG handling in the MySQL handshake process. It ensures that the flags are correctly set according to the protocol requirements and resolves the issues related to decimal data fetching when SSL is enabled.
