### PR TITLE
[fix](nereids)mv selection should only consider visible indexes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -144,13 +144,12 @@ public class InitMaterializationContextHook implements PlannerHook {
         for (Column column : olapTable.getFullSchema()) {
             keyCount += column.isKey() ? 1 : 0;
         }
-        for (Map.Entry<String, Long> entry : olapTable.getIndexNameToId().entrySet()) {
-            long indexId = entry.getValue();
+        for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getVisibleIndexIdToMeta().entrySet()) {
+            long indexId = entry.getKey();
             try {
-                // when doing schema change, a shadow index would be created and put together with mv indexes
-                // we must roll out these unexpected shadow indexes here
-                if (indexId != baseIndexId && !olapTable.isShadowIndex(indexId)) {
-                    MaterializedIndexMeta meta = olapTable.getIndexMetaByIndexId(entry.getValue());
+                if (indexId != baseIndexId) {
+                    MaterializedIndexMeta meta = entry.getValue();
+                    String indexName = olapTable.getIndexNameById(indexId);
                     String createMvSql;
                     if (meta.getDefineStmt() != null) {
                         // get the original create mv sql
@@ -159,11 +158,11 @@ public class InitMaterializationContextHook implements PlannerHook {
                         // it's rollup, need assemble create mv sql manually
                         if (olapTable.getKeysType() == KeysType.AGG_KEYS) {
                             createMvSql = assembleCreateMvSqlForAggTable(olapTable.getQualifiedName(),
-                                    entry.getKey(), meta.getSchema(false), keyCount);
+                                    indexName, meta.getSchema(false), keyCount);
                         } else {
                             createMvSql =
                                     assembleCreateMvSqlForDupOrUniqueTable(olapTable.getQualifiedName(),
-                                            entry.getKey(), meta.getSchema(false));
+                                            indexName, meta.getSchema(false));
                         }
                     }
                     if (createMvSql != null) {
@@ -176,10 +175,10 @@ public class InitMaterializationContextHook implements PlannerHook {
                         MTMVCache mtmvCache = MaterializedViewUtils.createMTMVCache(querySql.get(),
                                 cascadesContext.getConnectContext());
                         contexts.add(new SyncMaterializationContext(mtmvCache.getLogicalPlan(),
-                                mtmvCache.getOriginalPlan(), olapTable, meta.getIndexId(), entry.getKey(),
+                                mtmvCache.getOriginalPlan(), olapTable, meta.getIndexId(), indexName,
                                 cascadesContext, mtmvCache.getStatistics()));
                     } else {
-                        LOG.warn(String.format("can't assemble create mv sql for index ", entry.getKey()));
+                        LOG.warn(String.format("can't assemble create mv sql for index ", indexName));
                     }
                 }
             } catch (Exception exception) {

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/distinctQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/distinctQuery.groovy
@@ -42,6 +42,7 @@ suite ("distinctQuery") {
     createMV("create materialized view distinctQuery_mv2 as select empid, deptno, count(salary) from distinctQuery group by empid, deptno;")
 
     sql """insert into distinctQuery values("2020-01-01",1,"a",1,1,1);"""
+    sql """insert into distinctQuery values("2020-01-01",2,"a",1,1,1);"""
 
     sql "analyze table distinctQuery with sync;"
     sql """set enable_stats=false;"""


### PR DESCRIPTION
the indexes in olap table are not always visible. Sometimes, schema change will introduce invisible index into olap table. And we should only use getVisibleIndexIdToMeta() to get visible indexes as candidates for mv selection.

<!--Describe your changes.-->

