### PR TITLE
[fix](shuffle) Fix local exchange dependency blocking

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -484,7 +484,7 @@ void VDataStreamRecvr::close() {
     }
     _is_closed = true;
     for (auto& it : _sender_to_local_channel_dependency) {
-        it->set_ready();
+        it->set_always_ready();
     }
     for (int i = 0; i < _sender_queues.size(); ++i) {
         _sender_queues[i]->close();


### PR DESCRIPTION
## Proposed changes

If receiver is closed now, local exchange channel dependency is still blocked which is not correct.

<!--Describe your changes.-->

