### PR TITLE
[fix](statistics)Remove old partition stats in the next analyze after insert overwrite.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -1058,11 +1058,14 @@ public class StatisticsUtil {
         if (!StatisticsUtil.enablePartitionAnalyze() || !table.isPartitionedTable()) {
             return false;
         }
-        Collection<Partition> partitions = table.getPartitions();
+        if (tableStatsStatus.partitionChanged != null && tableStatsStatus.partitionChanged.get()) {
+            return true;
+        }
         ConcurrentMap<Long, Long> partitionUpdateRows = columnStatsMeta.partitionUpdateRows;
         if (partitionUpdateRows == null) {
             return true;
         }
+        Collection<Partition> partitions = table.getPartitions();
         // New partition added or old partition deleted.
         if (partitions.size() != partitionUpdateRows.size()) {
             return true;


### PR DESCRIPTION
Remove old partition stats in the next analyze after insert overwrite. Because insert overwrite will use new partitions to replace old ones, which means all partitions are new and the old partition stats should be removed.