### PR TITLE
[improvement](nereids)Set index initial row count to -1.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -90,7 +90,6 @@ public class ShowDataStmt extends ShowStmt {
                     .addColumn(new Column("ReplicaCount", ScalarType.createVarchar(20)))
                     .addColumn(new Column("RowCount", ScalarType.createVarchar(20)))
                     .addColumn(new Column("RemoteSize", ScalarType.createVarchar(30)))
-                    .addColumn(new Column("StatsRowCount", ScalarType.createVarchar(20)))
                     .build();
 
     public static final ImmutableList<String> SHOW_TABLE_DATA_META_DATA_ORIGIN =
@@ -289,12 +288,11 @@ public class ShowDataStmt extends ShowStmt {
                     long indexReplicaCount = 0;
                     long indexRowCount = 0;
                     long indexRemoteSize = 0;
-                    long indexStatsRowCount = olapTable.getRowCountForIndex(indexId);
                     for (Partition partition : olapTable.getAllPartitions()) {
                         MaterializedIndex mIndex = partition.getIndex(indexId);
                         indexSize += mIndex.getDataSize(false);
                         indexReplicaCount += mIndex.getReplicaCount();
-                        indexRowCount += mIndex.getRowCount();
+                        indexRowCount += mIndex.getRowCount() == -1 ? 0 : mIndex.getRowCount();
                         indexRemoteSize += mIndex.getRemoteDataSize();
                     }
 
@@ -302,7 +300,7 @@ public class ShowDataStmt extends ShowStmt {
                     // .add("TableName").add("IndexName").add("Size").add("ReplicaCount").add("RowCount")
                     //      .add("RemoteSize")
                     List<Object> row = Arrays.asList(tableName, indexName, indexSize, indexReplicaCount,
-                             indexRowCount, indexRemoteSize, indexStatsRowCount);
+                             indexRowCount, indexRemoteSize);
                     totalRowsObject.add(row);
 
                     totalSize += indexSize;
@@ -335,11 +333,11 @@ public class ShowDataStmt extends ShowStmt {
                     if (index == 0) {
                         result = Arrays.asList(tableName.getTbl(), String.valueOf(row.get(1)),
                                 readableSize, String.valueOf(row.get(3)),
-                                String.valueOf(row.get(4)), remoteReadableSize, String.valueOf(row.get(6)));
+                                String.valueOf(row.get(4)), remoteReadableSize);
                     } else {
                         result = Arrays.asList("", String.valueOf(row.get(1)),
                                 readableSize, String.valueOf(row.get(3)),
-                                String.valueOf(row.get(4)), remoteReadableSize, String.valueOf(row.get(6)));
+                                String.valueOf(row.get(4)), remoteReadableSize);
                     }
                     totalRows.add(result);
                 }
@@ -351,7 +349,7 @@ public class ShowDataStmt extends ShowStmt {
                 String remoteReadableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalRemoteSizePair.first) + " "
                         + totalRemoteSizePair.second;
                 List<String> row = Arrays.asList("", "Total", readableSize, String.valueOf(totalReplicaCount), "",
-                         remoteReadableSize, "");
+                         remoteReadableSize);
                 totalRows.add(row);
             } finally {
                 olapTable.readUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CloudTabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CloudTabletStatMgr.java
@@ -159,7 +159,6 @@ public class CloudTabletStatMgr extends MasterDaemon {
                 if (!table.writeLockIfExist()) {
                     continue;
                 }
-                Map<Long, Long> indexesRowCount = new HashMap<>();
                 try {
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
@@ -201,13 +200,12 @@ public class CloudTabletStatMgr extends MasterDaemon {
                                 tableSegmentCount += tabletSegmentCount;
                             } // end for tablets
                             index.setRowCount(indexRowCount);
-                            indexesRowCount.put(index.getId(), indexRowCount);
                         } // end for indices
                     } // end for partitions
 
                     olapTable.setStatistics(new OlapTable.Statistics(db.getName(),
                             table.getName(), tableDataSize, tableTotalReplicaDataSize, 0L,
-                            tableReplicaCount, tableRowCount, tableRowsetCount, tableSegmentCount, indexesRowCount));
+                            tableReplicaCount, tableRowCount, tableRowsetCount, tableSegmentCount));
                     LOG.debug("finished to set row num for table: {} in database: {}",
                              table.getName(), db.getFullName());
                 } finally {
@@ -216,7 +214,7 @@ public class CloudTabletStatMgr extends MasterDaemon {
 
                 newCloudTableStatsMap.put(Pair.of(dbId, table.getId()), new OlapTable.Statistics(db.getName(),
                         table.getName(), tableDataSize, tableTotalReplicaDataSize, 0L,
-                        tableReplicaCount, tableRowCount, tableRowsetCount, tableSegmentCount, indexesRowCount));
+                        tableReplicaCount, tableRowCount, tableRowsetCount, tableSegmentCount));
             }
         }
         this.cloudTableStatsMap = newCloudTableStatsMap;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
@@ -90,7 +90,7 @@ public class MaterializedIndex extends MetaObject implements GsonPostProcessable
         this.idToTablets = new HashMap<>();
         this.tablets = new ArrayList<>();
 
-        this.rowCount = 0;
+        this.rowCount = -1;
 
         this.rollupIndexId = -1L;
         this.rollupFinishedVersion = -1L;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
@@ -124,7 +123,6 @@ public class TabletStatMgr extends MasterDaemon {
                 if (!table.tryWriteLockIfExist(3000, TimeUnit.MILLISECONDS)) {
                     continue;
                 }
-                Map<Long, Long> indexesRowCount = new HashMap<>();
                 try {
                     for (Partition partition : olapTable.getAllPartitions()) {
                         long version = partition.getVisibleVersion();
@@ -161,13 +159,12 @@ public class TabletStatMgr extends MasterDaemon {
                                 indexRowCount += tabletRowCount;
                             } // end for tablets
                             index.setRowCount(indexRowCount);
-                            indexesRowCount.put(index.getId(), indexRowCount);
                         } // end for indices
                     } // end for partitions
 
                     olapTable.setStatistics(new OlapTable.Statistics(db.getName(), table.getName(),
                             tableDataSize, tableTotalReplicaDataSize,
-                            tableRemoteDataSize, tableReplicaCount, tableRowCount, 0L, 0L, indexesRowCount));
+                            tableRemoteDataSize, tableReplicaCount, tableRowCount, 0L, 0L));
 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("finished to set row num for table: {} in database: {}",

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
@@ -156,7 +156,7 @@ public class ShowDataStmtTest {
         Assert.assertEquals(
                 "SHOW DATA FROM `testDb`.`test_tbl` ORDER BY `ReplicaCount` DESC, `Size` DESC",
                 stmt.toString());
-        Assert.assertEquals(7, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(6, stmt.getMetaData().getColumnCount());
         Assert.assertEquals(true, stmt.hasTable());
 
         stmt = new ShowDataStmt(null, Arrays.asList(orderByElementOne, orderByElementTwo), null);

--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -127,10 +127,6 @@ suite("test_analyze_mv") {
             "replication_num" = "1"
         )
     """
-    def rowCounts = sql """show data from mvTestDup"""
-    logger.info("row count: " + rowCounts)
-    assertEquals("0", rowCounts[0][4])
-    assertEquals("-1", rowCounts[0][6])
     createMV("create materialized view mv1 as select key1 from mvTestDup;")
     createMV("create materialized view mv2 as select key2 from mvTestDup;")
     createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestDup group by key1, key2;")
@@ -237,6 +233,7 @@ suite("test_analyze_mv") {
             "replication_num" = "1"
         );
     """
+
     createMV("create materialized view mv1 as select key2 from mvTestAgg;")
     createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestAgg group by key1, key2;")
     createMV("create materialized view mv6 as select key1, sum(value1) from mvTestAgg group by key1;")
@@ -428,10 +425,6 @@ suite("test_analyze_mv") {
         logger.info(e.getMessage());
         return;
     }
-    wait_row_count_reported("test_analyze_mv", "mvTestDup", 0, 6, "6")
-    wait_row_count_reported("test_analyze_mv", "mvTestDup", 1, 6, "6")
-    wait_row_count_reported("test_analyze_mv", "mvTestDup", 2, 6, "4")
-    wait_row_count_reported("test_analyze_mv", "mvTestDup", 3, 6, "6")
     sql """analyze table mvTestDup with sample rows 4000000"""
     wait_analyze_finish("mvTestDup")
     result_sample = sql """SHOW ANALYZE mvTestDup;"""


### PR DESCRIPTION
Set index initial row count to -1. So when a new table created, we can tell the row count of a index is reported at least once or not. When a new table's row count of a index is never reported, the row count of that index would be -1 instead of 0.