### PR TITLE
[opt](file cache) write segment data asynchronous and merge small cache files

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1016,6 +1016,7 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
 DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
+DEFINE_Int64(file_cache_hdfs_block_size, "4096");    // 4KB
 
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1065,6 +1065,7 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
 DECLARE_Int64(file_cache_each_block_size);
+DECLARE_Int64(file_cache_hdfs_block_size);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
 DECLARE_Int32(file_cache_enter_disk_resource_limit_mode_percent);

--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -50,6 +50,18 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         json["released_elements"] = released;
         *json_metrics = json.ToString();
         return Status::OK();
+    } else if (operation == "merge") {
+        std::pair<size_t, size_t> origin_to_merge(0, 0);
+        if (req->param("base_path") != "") {
+            origin_to_merge = io::FileCacheFactory::instance()->try_merge(req->param("base_path"));
+        } else {
+            origin_to_merge = io::FileCacheFactory::instance()->try_merge();
+        }
+        EasyJson json;
+        json["origin_small_elements"] = origin_to_merge.first;
+        json["output_merged_elements"] = origin_to_merge.second;
+        *json_metrics = json.ToString();
+        return Status::OK();
     }
     return Status::InternalError("invalid operation: {}", operation);
 }

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -44,6 +44,8 @@ class BlockFileCache {
     friend struct FileBlocksHolder;
 
 public:
+    static constexpr size_t MAX_MERGED_SIZE = 16 * 1024 * 1024; // 16MB
+
     static std::string cache_type_to_string(FileCacheType type);
     static FileCacheType string_to_cache_type(const std::string& str);
     // hash the file_name to uint128
@@ -71,6 +73,20 @@ public:
     // try to release all releasable block
     // it maybe hang the io/system
     size_t try_release();
+
+    /// Merge continuous small segment files into a larger one
+    /// Return the number of origin segment files and the merged files
+    std::pair<size_t, size_t> try_merge();
+
+    Status async_merge(const UInt128Wrapper& key);
+
+    /// Find the continuous segment files for a remote file
+    /// Return the offsets of the continuous files.
+    std::vector<std::vector<size_t>> find_continuous_cells(const FileBlocksByOffset& segments);
+
+    std::pair<size_t, size_t> merge_continuous_cells(
+            const std::unordered_map<UInt128Wrapper, std::vector<std::vector<size_t>>, KeyHash>&
+                    merged_files);
 
     [[nodiscard]] const std::string& get_base_path() const { return _cache_base_path; }
 

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -61,6 +61,24 @@ size_t FileCacheFactory::try_release(const std::string& base_path) {
     return 0;
 }
 
+std::pair<size_t, size_t> FileCacheFactory::try_merge() {
+    std::pair<size_t, size_t> origin_to_merge(0, 0);
+    for (auto& cache : _caches) {
+        auto res = cache->try_merge();
+        origin_to_merge.first += res.first;
+        origin_to_merge.second += res.second;
+    }
+    return origin_to_merge;
+}
+
+std::pair<size_t, size_t> FileCacheFactory::try_merge(const std::string& base_path) {
+    auto iter = _path_to_cache.find(base_path);
+    if (iter != _path_to_cache.end()) {
+        return iter->second->try_merge();
+    }
+    return {0, 0};
+}
+
 Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
                                            FileCacheSettings file_cache_settings) {
     const auto& fs = global_local_filesystem();

--- a/be/src/io/cache/block_file_cache_factory.h
+++ b/be/src/io/cache/block_file_cache_factory.h
@@ -46,6 +46,12 @@ public:
 
     size_t try_release(const std::string& base_path);
 
+    /// Merge continuous small segment files into a larger one
+    /// Return the number of origin segment files and the merged files
+    std::pair<size_t, size_t> try_merge();
+
+    std::pair<size_t, size_t> try_merge(const std::string& base_path);
+
     const std::string& get_cache_path() {
         size_t cur_index = _next_index.fetch_add(1);
         return _caches[cur_index % _caches.size()]->get_base_path();

--- a/be/src/io/cache/cached_remote_file_reader.h
+++ b/be/src/io/cache/cached_remote_file_reader.h
@@ -61,6 +61,8 @@ protected:
 private:
     void _insert_file_reader(FileBlockSPtr file_block);
     bool _is_doris_table;
+    bool _is_remote_oss;
+    size_t _num_write_blocks = 0;
     FileReaderSPtr _remote_file_reader;
     UInt128Wrapper _cache_hash;
     BlockFileCache* _cache;

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -83,6 +83,7 @@ struct FileCacheKey {
     UInt128Wrapper hash;
     size_t offset;
     KeyMeta meta;
+    bool is_merged_file {false};
 };
 
 struct FileCacheSettings {

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -71,6 +71,7 @@ public:
 
     [[nodiscard]] static std::string get_path_in_local_cache(const std::string& dir, size_t offset,
                                                              FileCacheType type,
+                                                             bool is_merged_file = false,
                                                              bool is_tmp = false);
 
     [[nodiscard]] std::string get_path_in_local_cache(const UInt128Wrapper&,

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -192,6 +192,7 @@ public:
         return _buffered_reader_prefetch_thread_pool.get();
     }
     ThreadPool* send_table_stats_thread_pool() { return _send_table_stats_thread_pool.get(); }
+    ThreadPool* file_cache_thread_pool() { return _file_cache_thread_pool.get(); }
     ThreadPool* s3_file_upload_thread_pool() { return _s3_file_upload_thread_pool.get(); }
     ThreadPool* send_report_thread_pool() { return _send_report_thread_pool.get(); }
     ThreadPool* join_node_thread_pool() { return _join_node_thread_pool.get(); }
@@ -362,6 +363,8 @@ private:
     std::unique_ptr<ThreadPool> _buffered_reader_prefetch_thread_pool;
     // Threadpool used to send TableStats to FE
     std::unique_ptr<ThreadPool> _send_table_stats_thread_pool;
+    // Threadpool used for file cache
+    std::unique_ptr<ThreadPool> _file_cache_thread_pool;
     // Threadpool used to upload local file to s3
     std::unique_ptr<ThreadPool> _s3_file_upload_thread_pool;
     // Pool used by fragment manager to send profile or status to FE coordinator


### PR DESCRIPTION
## Proposed changes

### Three Optimizations
1. **Default Value Change**: Rename `file_cache_max_file_segment_size` as `file_cache_each_block_size`, and rename `file_cache_min_file_segment_size` as `file_cache_hdfs_block_size`(keep the same as master branch). Changed the default value of `file_cache_hdfs_block_size` from 1MB to 4KB to reduce read amplification. This adjustment aims to enhance read performance by minimizing the unnecessary reading of extra data. While this modification reduces the amount of data read per segment, it also results in the creation of a larger number of small files, which could have implications for file management and performance.
2. **Asynchronous Write**: Introduced an asynchronous write interface async_write in the FileBlock class. This enhancement allows data to be read without having to wait for the completion of writing to the cache file. By decoupling read operations from write operations, this feature significantly improves read efficiency and reduces latency, ensuring that read operations are not blocked by write operations.
3. **Background Merging Process**: Implemented a daemon process that runs when `CachedRemoteFileReader::close()` to check and merge small files. This process is designed to mitigate the potential negative effects introduced by the first optimization, specifically the accumulation of small files. By merging small files into larger ones, this daemon process helps maintain system performance and prevents degradation caused by excessive small file handling.

### Effects
Before Opt.
![image](https://github.com/apache/doris/assets/19337507/a88dd687-f63e-4f2d-b536-42861efc77f1)
After Opt.
![image](https://github.com/apache/doris/assets/19337507/7e5df9d6-f9ee-455f-adb7-4d420d60a045)

### Restful API
```shell
# release all cached files
curl http://${be}:${webserver_port}/api/file_cache?op=release
# merge small cached files
curl http://${be}:${webserver_port}/api/file_cache?op=merge
```

### Test
After extensive stability testing, with scripts running continuously for over 2 hours, no concurrency issues or query errors were detected. When no deletion or merging operations were performed, the total execution time for the test SQL was 7.42 seconds. Under conditions of frequent deletion and merging of cache files, the total execution time for the test SQL was 8.73 seconds. Overall, performance remained consistent with minimal fluctuation.