### PR TITLE
[fix](load data) decommission replica don't load data when it misses versions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -242,7 +242,9 @@ public class Tablet extends MetaObject {
 
             ReplicaState state = replica.getState();
             if (state.canLoad()
-                    || (state == ReplicaState.DECOMMISSION && replica.getPostWatermarkTxnId() < 0)) {
+                    || (state == ReplicaState.DECOMMISSION
+                            && replica.getPostWatermarkTxnId() < 0
+                            && replica.getLastFailedVersion() > 0)) {
                 map.put(backendId, replica.getPathHash());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -244,7 +244,7 @@ public class Tablet extends MetaObject {
             if (state.canLoad()
                     || (state == ReplicaState.DECOMMISSION
                             && replica.getPostWatermarkTxnId() < 0
-                            && replica.getLastFailedVersion() > 0)) {
+                            && replica.getLastFailedVersion() < 0)) {
                 map.put(backendId, replica.getPathHash());
             }
         }


### PR DESCRIPTION
BUG:  when a decommission replica misses versions (last failed version > 0),   it will cause a bug:
1. It cann't do compaction due to it has miss versions;
2. It cann't  cloning the missing rowsets because it's decommissioned.

So if it continue to load data, its rowset will increase  util it cause error -235(TOO MANY VERSION).

Fix:  don't write data to the decommission replica if it miss rowsets.


