### PR TITLE
[fix](routine-load) fix show routine load job result is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRoutineLoadStmt.java
@@ -125,12 +125,9 @@ public class ShowRoutineLoadStmt extends ShowStmt {
     }
 
     private void checkLabelName(Analyzer analyzer) throws AnalysisException {
-        String dbName = labelName == null ? null : labelName.getDbName();
-        if (Strings.isNullOrEmpty(dbName)) {
-            dbFullName = analyzer.getContext().getDatabase();
-            if (Strings.isNullOrEmpty(dbFullName)) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
-            }
+        dbFullName = analyzer.getContext().getDatabase();
+        if (Strings.isNullOrEmpty(dbFullName)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
         }
         name = labelName == null ? null : labelName.getLabelName();
     }

--- a/regression-test/suites/load_p0/routine_load/test_show_routine_load.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_show_routine_load.groovy
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_routine_load","p0") {
+    String kafka_port = context.config.otherConfigs.get("kafka_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    def kafka_broker = "${externalEnvIp}:${kafka_port}"
+
+    try {
+        sql """
+            CREATE ROUTINE LOAD testShow
+            COLUMNS TERMINATED BY "|"
+            PROPERTIES
+            (
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "multi_table_load_invalid_table",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+
+        sql """
+            CREATE ROUTINE LOAD testShow1
+            COLUMNS TERMINATED BY "|"
+            PROPERTIES
+            (
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "multi_table_load_invalid_table",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        String db = context.config.getDbNameByFile(context.file)
+        log.info("reason of state changed: ${db}".toString())
+
+        def res = sql "show routine load for ${db}.testShow"
+        log.info("reason of state changed: ${res.size()}".toString())
+        assertTrue(res.size() == 1)
+
+        res = sql "show routine load for testShow"
+        log.info("reason of state changed: ${res.size()}".toString())
+        assertTrue(res.size() == 1)
+
+        res = sql "show all routine load"
+        log.info("reason of state changed: ${res.size()}".toString())
+        assertTrue(res.size() > 1)
+
+        res = sql "SHOW ROUTINE LOAD LIKE \"%testShow%\""
+        log.info("reason of state changed: ${res.size()}".toString())
+        assertTrue(res.size() == 2)
+    } finally {
+        sql "stop routine load for testShow"
+        sql "stop routine load for testShow1"
+    }
+}


### PR DESCRIPTION
Use the sql to query routine load records:
```
show routine load for db.job1\G
```
return all routine load job in the db:
```
10 rows in set (0.02 sec)
```


why the bug happen is there is no correct assignment when analyze the sql:
```
if (Strings.isNullOrEmpty(dbName)) {
            dbFullName = analyzer.getContext().getDatabase();
            if (Strings.isNullOrEmpty(dbFullName)) {
                ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
            }
}
```
dbFullName will always null if dbName is not null or empty.

The bug is introduce by: https://github.com/apache/doris/pull/27861


