### PR TITLE
[fix](pipeline) Fix blocked tasks if query is canceled before opening

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -120,6 +120,9 @@ Status PipelineTask::prepare(const TPipelineInstanceParams& local_params, const 
         std::unique_lock<std::mutex> lc(_dependency_lock);
         filter_dependencies.swap(_filter_dependencies);
     }
+    if (query_context()->is_cancelled()) {
+        clear_blocking_state();
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

If query is canceled before opening, pipeline tasks will be always blocked until timeout

<!--Describe your changes.-->

