### PR TITLE
[fix](cloud-schema-change) Write schema change jobs to a deserialized pb buffer rather than a new one

### DIFF
--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -297,6 +297,11 @@ void start_schema_change_job(MetaServiceCode& code, std::string& msg, std::strin
         code = cast_as<ErrCategory::READ>(err);
         return;
     }
+    if (!job_pb.ParseFromString(job_val)) {
+        code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+        msg = "pb deserialization failed";
+        return;
+    }
     job_pb.mutable_idx()->CopyFrom(request->job().idx());
     // FE can ensure that a tablet does not have more than one schema_change job at the same time,
     // so we can directly preempt previous schema_change job.


### PR DESCRIPTION
## Proposed changes

Currently, when starting a schema change job, job info will be persists in an new created protobuf struct rather than the original stored one, which will lead to compation job losing and result in `failed to lease compaction job`.

Therefore, write the newly created schema job info into the deserialized proto buffer of the original job info to fix the job info lose.

