### PR TITLE
[fix](regression test) fix test_report_version_missing due to set force_olap_table_replication_num

### DIFF
--- a/regression-test/suites/control_p0/test_report_version_missing.groovy
+++ b/regression-test/suites/control_p0/test_report_version_missing.groovy
@@ -19,7 +19,14 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
 suite('test_report_version_missing', "nonConcurrent") {
+    if (isCloudMode()) {
+        return
+    }
     def tableName = "test_set_replica_status_table_in_docker"
+    try {
+    setFeConfig('disable_tablet_scheduler', true)
+    Thread.sleep(1000)
+
     sql "DROP TABLE IF EXISTS ${tableName}"
     sql """
         CREATE TABLE ${tableName} (
@@ -45,7 +52,7 @@ suite('test_report_version_missing', "nonConcurrent") {
         tabletId = res.TabletId
         break
     }
-    try {
+
         GetDebugPoint().enableDebugPointForAllBEs("Tablet.build_tablet_report_info.version_miss", [tablet_id:"${tabletId}",version_miss:true])
         boolean succ = false
 
@@ -68,6 +75,8 @@ suite('test_report_version_missing', "nonConcurrent") {
         assertTrue(succ)
         
     } finally {
+        setFeConfig('disable_tablet_scheduler', false)
         GetDebugPoint().disableDebugPointForAllBEs("Tablet.build_tablet_report_info.version_miss")
+        sql "DROP TABLE IF EXISTS ${tableName}"
     }
 }

--- a/regression-test/suites/control_p0/test_report_version_missing.groovy
+++ b/regression-test/suites/control_p0/test_report_version_missing.groovy
@@ -25,7 +25,7 @@ suite('test_report_version_missing', "nonConcurrent") {
     def tableName = "test_set_replica_status_table_in_docker"
     try {
     setFeConfig('disable_tablet_scheduler', true)
-    Thread.sleep(1000)
+    Thread.sleep(2000)
 
     sql "DROP TABLE IF EXISTS ${tableName}"
     sql """


### PR DESCRIPTION
error:

```
Exception in control_p0/test_report_version_missing.groovy(line 68):

succ = true
break
}
}
if (succ)

{ break }
Thread.sleep(60000)
}
assertTrue(succ)
^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^

} finally

{ GetDebugPoint().disableDebugPointForAllBEs("Tablet.build_tablet_report_info.version_miss") }
}

Exception:
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:40)
at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:35)
at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:179)
at sun.reflect.GeneratedMethodAccessor55.invoke(Unknown Source)
```

logs:
```
2024-07-22 03:20:55,050 INFO (tablet checker|201) Add tablet to pending queue, tablet id: 807781, status: VERSION_INCOMPLETE, state: PENDING, type: REPAIR, priority: HIGH, tablet size: 0, visible version: -1, committed version: -1
2024-07-22 03:20:55,061 INFO (tablet checker|201) finished to check tablets. unhealth/total/added/in_sched/not_ready: 1/87388/1/0/0, cost: 87 ms
2024-07-22 03:20:55,464 INFO (tablet scheduler|201) balance or tablet scheduler is disabled. skip selecting tablets for balance
2024-07-22 03:20:55,464 INFO (tablet scheduler|201) create clone task to repair replica, tabletId=807781, replica=[replicaId=807783, BackendId=10008, version=2, dataSize=346, rowCount=10, lastFailedVersion=3, lastSuccessVersion=2, lastFailedTimestamp=1721589639451, schemaHash=1701605109, state=NORMAL, isBad=false], visible version 2, tablet status VERSION_INCOMPLETE
2024-07-22 03:20:55,464 INFO (tablet scheduler|201) add clone task to agent task queue: tablet id: 807781, replica id: 807783, schema hash: 1701605109, storageMedium: HDD, visible version: 2, src backend: 172.20.48.72, src path hash: -597904549178930561, dest backend id: 10008, dest backend: 172.20.48.71, dest path hash: -5391737830213585625
```


