### PR TITLE
[enhance](mtmv)refresh hms table before run mtmv task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -168,13 +168,12 @@ public class MTMVTask extends AbstractTask {
                             super.getTaskId(), taskSessionContext);
                 }
             }
-            refreshHmsTable();
             // Every time a task is run, the relation is regenerated because baseTables and baseViews may change,
             // such as deleting a table and creating a view with the same name
             this.relation = MTMVPlanUtil.generateMTMVRelation(mtmv, ctx);
             // Now, the MTMV first ensures consistency with the data in the cache.
             // To be completely consistent with hive, you need to manually refresh the cache
-            // refreshHmsTable();
+            refreshHmsTable();
             if (mtmv.getMvPartitionInfo().getPartitionType() != MTMVPartitionType.SELF_MANAGE) {
                 MTMVPartitionUtil.alignMvPartition(mtmv);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -171,6 +171,7 @@ public class MTMVTask extends AbstractTask {
             // Every time a task is run, the relation is regenerated because baseTables and baseViews may change,
             // such as deleting a table and creating a view with the same name
             this.relation = MTMVPlanUtil.generateMTMVRelation(mtmv, ctx);
+            refreshHmsTable();
             // Now, the MTMV first ensures consistency with the data in the cache.
             // To be completely consistent with hive, you need to manually refresh the cache
             // refreshHmsTable();
@@ -282,7 +283,7 @@ public class MTMVTask extends AbstractTask {
     }
 
     /**
-     * // Before obtaining information from hmsTable, refresh to ensure that the data is up-to-date
+     * Before obtaining information from hmsTable, refresh to ensure that the data is up-to-date
      *
      * @throws AnalysisException
      * @throws DdlException

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -168,10 +168,10 @@ public class MTMVTask extends AbstractTask {
                             super.getTaskId(), taskSessionContext);
                 }
             }
+            refreshHmsTable();
             // Every time a task is run, the relation is regenerated because baseTables and baseViews may change,
             // such as deleting a table and creating a view with the same name
             this.relation = MTMVPlanUtil.generateMTMVRelation(mtmv, ctx);
-            refreshHmsTable();
             // Now, the MTMV first ensures consistency with the data in the cache.
             // To be completely consistent with hive, you need to manually refresh the cache
             // refreshHmsTable();

--- a/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
@@ -160,6 +160,10 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
                                 """
         logger.info("hive sql: " + recover_column_str)
         hive_docker """ ${recover_column_str} """
+        // schema change need refresh catalog
+        sql """
+                REFRESH catalog ${catalog_name}
+            """
             sql """
                 REFRESH MATERIALIZED VIEW ${mvName} complete
             """

--- a/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
@@ -105,9 +105,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
         logger.info("hive sql: " + insert_str)
         hive_docker """ ${insert_str} """
         sql """
-                REFRESH catalog ${catalog_name}
-            """
-        sql """
             REFRESH MATERIALIZED VIEW ${mvName} auto
         """
         waitingMTMVTaskFinished(jobName)
@@ -120,9 +117,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
                                     """
         logger.info("hive sql: " + add_partition2021_str)
         hive_docker """ ${add_partition2021_str} """
-        sql """
-                REFRESH catalog ${catalog_name}
-            """
         sql """
             REFRESH MATERIALIZED VIEW ${mvName} auto
         """
@@ -139,9 +133,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
                                         """
         logger.info("hive sql: " + drop_partition2021_str)
         hive_docker """ ${drop_partition2021_str} """
-        sql """
-                REFRESH catalog ${catalog_name}
-            """
             sql """
                 REFRESH MATERIALIZED VIEW ${mvName} auto
             """
@@ -157,9 +148,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
                                     """
         logger.info("hive sql: " + rename_column_str)
         hive_docker """ ${rename_column_str} """
-        sql """
-                REFRESH catalog ${catalog_name}
-            """
             sql """
                 REFRESH MATERIALIZED VIEW ${mvName} complete
             """
@@ -172,9 +160,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
                                 """
         logger.info("hive sql: " + recover_column_str)
         hive_docker """ ${recover_column_str} """
-        sql """
-                REFRESH catalog ${catalog_name}
-            """
             sql """
                 REFRESH MATERIALIZED VIEW ${mvName} complete
             """


### PR DESCRIPTION
There are some caches in the HMS catalog, which can result in the inability to maintain consistency with Hive side data even after a successful refresh of the materialized view.
In this PR, the cache of relevant HMS tables will be cleared before refreshing the materialized view to solve this problem
