### PR TITLE
[fix](external) Fix case-insensitive table name mapping retrieval rules

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -92,7 +92,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
     // table family group map
     private final Map<Long, Table> idToTable;
     private ConcurrentMap<String, Table> nameToTable;
-    // table name lower cast -> table name
+    // table name lower case -> table name
     private final Map<String, String> lowerCaseToTableName;
 
     // user define function

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Base class of external database.
@@ -83,6 +84,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     protected Map<String, Long> tableNameToId = Maps.newConcurrentMap();
     @SerializedName(value = "idToTbl")
     protected Map<Long, T> idToTbl = Maps.newConcurrentMap();
+    // table name lower case -> table name
+    private Map<String, String> lowerCaseToTableName = Maps.newConcurrentMap();
     @SerializedName(value = "lastUpdateTime")
     protected long lastUpdateTime;
     protected final InitDatabaseLog.Type dbLogType;
@@ -239,7 +242,14 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         } else if (name.equals(MysqlDb.DATABASE_NAME)) {
             tableNames = ExternalMysqlDatabase.listTableNames();
         } else {
-            tableNames = extCatalog.listTableNames(null, name);
+            tableNames = extCatalog.listTableNames(null, name).stream().map(tableName -> {
+                lowerCaseToTableName.put(tableName.toLowerCase(), tableName);
+                if (Env.isStoredTableNamesLowerCase()) {
+                    return tableName.toLowerCase();
+                } else {
+                    return tableName;
+                }
+            }).collect(Collectors.toList());
         }
         return tableNames;
     }
@@ -325,6 +335,12 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     @Override
     public boolean isTableExist(String tableName) {
+        if (Env.isTableNamesCaseInsensitive()) {
+            tableName = lowerCaseToTableName.get(tableName.toLowerCase());
+            if (tableName == null) {
+                return false;
+            }
+        }
         return extCatalog.tableExist(ConnectContext.get().getSessionContext(), name, tableName);
     }
 
@@ -375,6 +391,15 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public T getTableNullable(String tableName) {
         makeSureInitialized();
+        if (Env.isStoredTableNamesLowerCase()) {
+            tableName = tableName.toLowerCase();
+        }
+        if (Env.isTableNamesCaseInsensitive()) {
+            tableName = lowerCaseToTableName.get(tableName.toLowerCase());
+            if (tableName == null) {
+                return null;
+            }
+        }
         if (extCatalog.getUseMetaCache().get()) {
             // must use full qualified name to generate id.
             // otherwise, if 2 databases have the same table name, the id will be the same.
@@ -419,6 +444,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public void gsonPostProcess() throws IOException {
         tableNameToId = Maps.newConcurrentMap();
+        lowerCaseToTableName = Maps.newConcurrentMap();
         Map<Long, T> tmpIdToTbl = Maps.newConcurrentMap();
         for (Object obj : idToTbl.values()) {
             if (obj instanceof LinkedTreeMap) {
@@ -443,6 +469,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                 Preconditions.checkState(obj instanceof ExternalTable);
                 tmpIdToTbl.put(((ExternalTable) obj).getId(), (T) obj);
                 tableNameToId.put(((ExternalTable) obj).getName(), ((ExternalTable) obj).getId());
+                lowerCaseToTableName.put(((ExternalTable) obj).getName().toLowerCase(),
+                        ((ExternalTable) obj).getName());
             }
         }
         idToTbl = tmpIdToTbl;
@@ -452,6 +480,9 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public void unregisterTable(String tableName) {
         makeSureInitialized();
+        if (Env.isStoredTableNamesLowerCase()) {
+            tableName = tableName.toLowerCase();
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("create table [{}]", tableName);
         }
@@ -459,6 +490,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         if (extCatalog.getUseMetaCache().get()) {
             if (isInitialized()) {
                 metaCache.invalidate(tableName, Util.genIdByName(getQualifiedName(tableName)));
+                lowerCaseToTableName.remove(tableName.toLowerCase());
             }
         } else {
             Long tableId = tableNameToId.remove(tableName);
@@ -467,6 +499,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                 return;
             }
             idToTbl.remove(tableId);
+            lowerCaseToTableName.remove(tableName.toLowerCase());
         }
         setLastUpdateTime(System.currentTimeMillis());
         Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(
@@ -490,11 +523,13 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         if (extCatalog.getUseMetaCache().get()) {
             if (isInitialized()) {
                 metaCache.updateCache(tableName, (T) tableIf, Util.genIdByName(getQualifiedName(tableName)));
+                lowerCaseToTableName.put(tableName.toLowerCase(), tableName);
             }
         } else {
             if (!tableNameToId.containsKey(tableName)) {
                 tableNameToId.put(tableName, tableId);
                 idToTbl.put(tableId, buildTableForInit(tableName, tableId, extCatalog));
+                lowerCaseToTableName.put(tableName.toLowerCase(), tableName);
             }
         }
         setLastUpdateTime(System.currentTimeMillis());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameComparedLowercaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameComparedLowercaseTest.java
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.lowercase;
+
+import org.apache.doris.analysis.CreateCatalogStmt;
+import org.apache.doris.analysis.DropCatalogStmt;
+import org.apache.doris.analysis.SwitchStmt;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ExternalTableNameComparedLowercaseTest extends TestWithFeService {
+    private static Env env;
+    private ConnectContext rootCtx;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        rootCtx = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        // 1. create test catalog
+        CreateCatalogStmt testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt("create catalog test1 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.lowercase.ExternalTableNameComparedLowercaseTest$ExternalTableNameComparedLowercaseProvider\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+    }
+
+    @Override
+    protected void beforeCluster() {
+        Config.lower_case_table_names = 2;
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Override
+    protected void runAfterAll() throws Exception {
+        super.runAfterAll();
+        rootCtx.setThreadLocalInfo();
+        DropCatalogStmt stmt = (DropCatalogStmt) parseAndAnalyzeStmt("drop catalog test1");
+        env.getCatalogMgr().dropCatalog(stmt);
+    }
+
+
+    @Test
+    public void testGlobalVariable() {
+        Assertions.assertEquals(2, GlobalVariable.lowerCaseTableNames);
+    }
+
+    @Test
+    public void testTableNameLowerCase() {
+        Set<String> tableNames = env.getCatalogMgr().getCatalog("test1").getDbNullable("db1").getTableNamesWithLock();
+        Assertions.assertEquals(2, tableNames.size());
+        Assertions.assertTrue(tableNames.contains("TABLE1"));
+        Assertions.assertTrue(tableNames.contains("TABLE2"));
+    }
+
+    private void switchTest() throws Exception {
+        SwitchStmt switchTest = (SwitchStmt) parseAndAnalyzeStmt("switch test1;");
+        Env.getCurrentEnv().changeCatalog(connectContext, switchTest.getCatalogName());
+    }
+
+    public static class ExternalTableNameComparedLowercaseProvider implements TestExternalCatalog.TestCatalogProvider {
+        public static final Map<String, Map<String, List<Column>>> MOCKED_META;
+
+        static {
+            MOCKED_META = Maps.newHashMap();
+            Map<String, List<Column>> tblSchemaMap1 = Maps.newHashMap();
+            // db1
+            tblSchemaMap1.put("TABLE1", Lists.newArrayList(
+                    new Column("siteid", PrimitiveType.INT),
+                    new Column("citycode", PrimitiveType.SMALLINT),
+                    new Column("username", PrimitiveType.VARCHAR),
+                    new Column("pv", PrimitiveType.BIGINT)));
+            tblSchemaMap1.put("TABLE2", Lists.newArrayList(
+                    new Column("k1", PrimitiveType.INT),
+                    new Column("k2", PrimitiveType.VARCHAR),
+                    new Column("k3", PrimitiveType.VARCHAR),
+                    new Column("k4", PrimitiveType.INT),
+                    new Column("k5", PrimitiveType.LARGEINT)));
+            MOCKED_META.put("db1", tblSchemaMap1);
+        }
+
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return MOCKED_META;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameStoredLowercaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameStoredLowercaseTest.java
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.lowercase;
+
+import org.apache.doris.analysis.CreateCatalogStmt;
+import org.apache.doris.analysis.DropCatalogStmt;
+import org.apache.doris.analysis.SwitchStmt;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ExternalTableNameStoredLowercaseTest extends TestWithFeService {
+    private static Env env;
+    private ConnectContext rootCtx;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        rootCtx = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        // 1. create test catalog
+        CreateCatalogStmt testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt("create catalog test1 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.lowercase.ExternalTableNameStoredLowercaseTest$ExternalTableNameStoredLowercaseProvider\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+    }
+
+    @Override
+    protected void beforeCluster() {
+        Config.lower_case_table_names = 1;
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Override
+    protected void runAfterAll() throws Exception {
+        super.runAfterAll();
+        rootCtx.setThreadLocalInfo();
+        DropCatalogStmt stmt = (DropCatalogStmt) parseAndAnalyzeStmt("drop catalog test1");
+        env.getCatalogMgr().dropCatalog(stmt);
+    }
+
+
+    @Test
+    public void testGlobalVariable() {
+        Assertions.assertEquals(1, GlobalVariable.lowerCaseTableNames);
+    }
+
+    @Test
+    public void testTableNameLowerCase() {
+        Set<String> tableNames = env.getCatalogMgr().getCatalog("test1").getDbNullable("db1").getTableNamesWithLock();
+        Assertions.assertEquals(3, tableNames.size());
+        Assertions.assertTrue(tableNames.contains("table1"));
+        Assertions.assertTrue(tableNames.contains("table2"));
+        Assertions.assertTrue(tableNames.contains("table3"));
+        Assertions.assertFalse(tableNames.contains("TABLE1"));
+    }
+
+    private void switchTest() throws Exception {
+        SwitchStmt switchTest = (SwitchStmt) parseAndAnalyzeStmt("switch test1;");
+        Env.getCurrentEnv().changeCatalog(connectContext, switchTest.getCatalogName());
+    }
+
+    public static class ExternalTableNameStoredLowercaseProvider implements TestExternalCatalog.TestCatalogProvider {
+        public static final Map<String, Map<String, List<Column>>> MOCKED_META;
+
+        static {
+            MOCKED_META = Maps.newHashMap();
+            Map<String, List<Column>> tblSchemaMap1 = Maps.newHashMap();
+            // db1
+            tblSchemaMap1.put("table1", Lists.newArrayList(
+                    new Column("siteid", PrimitiveType.INT),
+                    new Column("citycode", PrimitiveType.SMALLINT),
+                    new Column("username", PrimitiveType.VARCHAR),
+                    new Column("pv", PrimitiveType.BIGINT)));
+            tblSchemaMap1.put("table2", Lists.newArrayList(
+                    new Column("k1", PrimitiveType.INT),
+                    new Column("k2", PrimitiveType.VARCHAR),
+                    new Column("k3", PrimitiveType.VARCHAR),
+                    new Column("k4", PrimitiveType.INT),
+                    new Column("k5", PrimitiveType.LARGEINT)));
+            tblSchemaMap1.put("TABLE3", Lists.newArrayList(
+                    new Column("k1", PrimitiveType.INT),
+                    new Column("k2", PrimitiveType.VARCHAR),
+                    new Column("k3", PrimitiveType.VARCHAR),
+                    new Column("k4", PrimitiveType.INT),
+                    new Column("k5", PrimitiveType.LARGEINT)));
+            MOCKED_META.put("db1", tblSchemaMap1);
+        }
+
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return MOCKED_META;
+        }
+    }
+}


### PR DESCRIPTION
# Catalog DDL
```
Doris > CREATE CATALOG `oracle` PROPERTIES (
    -> "user" = "doris_test",
    -> "type" = "jdbc",
    -> "password" = "xxx",
    -> "jdbc_url" = "jdbc:oracle:thin:@xxx:1521:XE",
    -> "driver_url" = "ojdbc8-19.3.0.0.jar",
    -> "driver_class" = "oracle.jdbc.driver.OracleDriver"
    -> ); 
Query OK, 0 rows affected (2.16 sec)
```

# FE Conf lower_case_table_names = 1

```
Doris > show variables like '%lower_case%';
+------------------------+-------+---------------+---------+
| Variable_name          | Value | Default_Value | Changed |
+------------------------+-------+---------------+---------+
| lower_case_table_names | 1     | 0             | 1       |
+------------------------+-------+---------------+---------+
1 row in set (0.00 sec)

Doris > show tables from oracle.DORIS_TEST;
+----------------------+
| Tables_in_DORIS_TEST |
+----------------------+
| aa/d                 |
| aaad                 |
| lower_test           |
| student              |
| student2             |
| student3             |
| test_all_types       |
| test_char            |
| test_clob            |
| test_date            |
| test_insert          |
| test_int             |
| test_num             |
| test_number          |
| test_number2         |
| test_number3         |
| test_number4         |
| test_raw             |
| test_timestamp       |
+----------------------+
19 rows in set (0.01 sec)

```

## Before:

```
Doris > select * from oracle.DORIS_TEST.test_int limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (1.03 sec)

Doris > select * from oracle.DORIS_TEST.TEST_INT limit 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Table [TEST_INT] does not exist in database [DORIS_TEST].

```
## After:

```
Doris > select * from oracle.DORIS_TEST.test_int limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (0.20 sec)

Doris > select * from oracle.DORIS_TEST.TEST_INT limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (0.20 sec)
```


# FE Conf lower_case_table_names = 2

```
Doris > show variables like '%lower_case%';
+------------------------+-------+---------------+---------+
| Variable_name          | Value | Default_Value | Changed |
+------------------------+-------+---------------+---------+
| lower_case_table_names | 2     | 0             | 1       |
+------------------------+-------+---------------+---------+
1 row in set (0.01 sec)

Doris > show tables from oracle.DORIS_TEST;
+----------------------+
| Tables_in_DORIS_TEST |
+----------------------+
| AA/D                 |
| AAAD                 |
| LOWER_TEST           |
| STUDENT              |
| TEST_ALL_TYPES       |
| TEST_CHAR            |
| TEST_CLOB            |
| TEST_DATE            |
| TEST_INSERT          |
| TEST_INT             |
| TEST_NUM             |
| TEST_NUMBER          |
| TEST_NUMBER2         |
| TEST_NUMBER3         |
| TEST_NUMBER4         |
| TEST_RAW             |
| TEST_TIMESTAMP       |
| student2             |
| student3             |
+----------------------+
19 rows in set (1.05 sec)
```

## Before:

```
Doris > select * from oracle.DORIS_TEST.test_int limit 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Table [test_int] does not exist in database [DORIS_TEST].
Doris > select * from oracle.DORIS_TEST.TEST_INT limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (1.07 sec)
```

## After:

```
Doris > select * from oracle.DORIS_TEST.test_int limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (0.21 sec)

Doris > select * from oracle.DORIS_TEST.TEST_INT limit 1;
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| ID   | TINYINT_VALUE1 | SMALLINT_VALUE1 | INT_VALUE1 | BIGINT_VALUE1      | TINYINT_VALUE2 | SMALLINT_VALUE2 | INT_VALUE2 | BIGINT_VALUE2       |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
| 1    |             99 |            9999 |  999999999 | 999999999999999999 |            999 |           99999 | 9999999999 | 9999999999999999999 |
+------+----------------+-----------------+------------+--------------------+----------------+-----------------+------------+---------------------+
1 row in set (0.20 sec)
```