### PR TITLE
[Fix](Group commit) Fix group commit forward fault

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1034,7 +1034,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setPacket("".getBytes());
             return result;
         }
-        if (params.getGroupCommitInfo().isGetGroupCommitLoadBeId()) {
+        if (params.getGroupCommitInfo() != null && params.getGroupCommitInfo().isGetGroupCommitLoadBeId()) {
             final TGroupCommitInfo info = params.getGroupCommitInfo();
             final TMasterOpResult result = new TMasterOpResult();
             try {
@@ -1047,7 +1047,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setPacket("".getBytes());
             return result;
         }
-        if (params.getGroupCommitInfo().isUpdateLoadData()) {
+        if (params.getGroupCommitInfo() != null && params.getGroupCommitInfo().isUpdateLoadData()) {
             final TGroupCommitInfo info = params.getGroupCommitInfo();
             final TMasterOpResult result = new TMasterOpResult();
             Env.getCurrentEnv().getGroupCommitManager()


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

When client connect to observer and do group commit, observer will forward to master. The forward parameter `GroupCommitInfo` maybe null, which leads to an exception.

