### PR TITLE
[Bug](agg) fix collect_set function core dump without arena pool

### DIFF
--- a/be/src/pipeline/exec/analytic_source_operator.cpp
+++ b/be/src/pipeline/exec/analytic_source_operator.cpp
@@ -279,8 +279,6 @@ void AnalyticLocalState::_destroy_agg_status() {
     }
 }
 
-//now is execute for lead/lag row_number/rank/dense_rank/ntile functions
-//sum min max count avg first_value last_value functions
 void AnalyticLocalState::_execute_for_win_func(int64_t partition_start, int64_t partition_end,
                                                int64_t frame_start, int64_t frame_end) {
     for (size_t i = 0; i < _agg_functions_size; ++i) {
@@ -292,7 +290,7 @@ void AnalyticLocalState::_execute_for_win_func(int64_t partition_start, int64_t 
                 partition_start, partition_end, frame_start, frame_end,
                 _fn_place_ptr +
                         _parent->cast<AnalyticSourceOperatorX>()._offsets_of_aggregate_states[i],
-                agg_columns.data(), nullptr);
+                agg_columns.data(), _agg_arena_pool.get());
 
         // If the end is not greater than the start, the current window should be empty.
         _current_window_empty =

--- a/regression-test/data/nereids_function_p0/agg_function/group_unique_array.out
+++ b/regression-test/data/nereids_function_p0/agg_function/group_unique_array.out
@@ -8,3 +8,12 @@
 3	["2023-01-02"]	["hello"]
 4	["2023-01-02", "2023-01-03"]	["sql"]
 
+-- !3 --
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+["doris", "world", "hello", "sql"]
+

--- a/regression-test/suites/nereids_function_p0/agg_function/group_unique_array.groovy
+++ b/regression-test/suites/nereids_function_p0/agg_function/group_unique_array.groovy
@@ -48,4 +48,7 @@ suite("group_unique_array") {
     qt_2 """
     select k1,collect_set(k2),collect_set(k3,1) from test_group_unique_array_table group by k1 order by k1;
     """
+    qt_3 """
+    select collect_set(k3) over() from test_group_unique_array_table;
+    """
 }


### PR DESCRIPTION
## Proposed changes
before the add_range_single_place pass nullptr as arena object,
but collect_set function need save data in arena, so will core dump without arena pool.

<!--Describe your changes.-->

