### PR TITLE
[opt](Nereids): disable PRUNE_EMPTY_PARTITION rule in SqlTestBase.java

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/JoinOrderJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/JoinOrderJobTest.java
@@ -149,6 +149,7 @@ public class JoinOrderJobTest extends SqlTestBase {
     @Disabled
     @Test
     void test64CliqueJoin() {
+        connectContext.getSessionVariable().joinReorderTimeLimit = 10000000;
         HyperGraphBuilder hyperGraphBuilder = new HyperGraphBuilder(Sets.newHashSet(JoinType.INNER_JOIN));
         Plan plan = hyperGraphBuilder
                 .randomBuildPlanWith(64, 64 * 63 / 2);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
@@ -97,6 +97,7 @@ public abstract class SqlTestBase extends TestWithFeService implements MemoPatte
     @Override
     protected void runBeforeEach() throws Exception {
         StatementScopeIdGenerator.clear();
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
     }
 
     protected LogicalCompatibilityContext constructContext(Plan p1, Plan p2, CascadesContext context) {


### PR DESCRIPTION
## Proposed changes

disable PRUNE_EMPTY_PARTITION rule in SqlTestBase to avoid convert plan to empty relation

