### PR TITLE
[fix](group commit) Fix prepare stmt setNull return too many filtered rows error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -47,6 +47,7 @@ import org.apache.doris.analysis.NativeInsertStmt;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.PartitionNames;
+import org.apache.doris.analysis.PlaceHolderExpr;
 import org.apache.doris.analysis.PrepareStmt;
 import org.apache.doris.analysis.PrepareStmt.PreparedType;
 import org.apache.doris.analysis.Queriable;
@@ -350,6 +351,9 @@ public class StmtExecutor {
         }
         InternalService.PDataRow.Builder row = InternalService.PDataRow.newBuilder();
         for (Expr expr : cols) {
+            if (expr instanceof PlaceHolderExpr) {
+                expr = ((PlaceHolderExpr) expr).getLiteral();
+            }
             if (!expr.isLiteralOrCastExpr()) {
                 throw new UserException(
                         "do not support non-literal expr in transactional insert operation: " + expr.toSql());

--- a/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
@@ -148,8 +148,6 @@ suite("insert_group_commit_with_prepare_stmt") {
             );
             """
 
-            sql """ set enable_insert_strict = false; """
-
             // 1. insert into
             def insert_stmt = prepareStatement """ INSERT INTO ${table} VALUES(?, ?, ?) """
             assertEquals(com.mysql.cj.jdbc.ServerPreparedStatement, insert_stmt.class)
@@ -211,8 +209,6 @@ suite("insert_group_commit_with_prepare_stmt") {
                 "replication_num" = "1"
             );
             """
-
-            sql """ set enable_insert_strict = false; """
 
             // 1. insert into
             def insert_stmt = prepareStatement """ INSERT INTO ${table} VALUES(?, ?, ?) """


### PR DESCRIPTION
When use prepare statement and setNull to do group commit:
```
stmt.setString(3, "WAGERNO");
stmt.setNull(4, Types.INTEGER);
```
we may get `too many rows filtered` rows.