### PR TITLE
[Fix](test)Fix the job's erroneous test case for asynchronous tests of periodic tasks.

### DIFF
--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -187,7 +187,7 @@ suite("test_base_insert_job") {
     Awaitility.await("create-job-test").atMost(60, SECONDS).until({
         def job = sql """ select SucceedTaskCount from jobs("type"="insert") where name='${jobName}'"""
         println job
-        job.size() == 1 && '1' == job.get(0).get(0)
+        job.size() == 1 && '1' <= job.get(0).get(0)
     })
 
     sql """


### PR DESCRIPTION
…

Since there might be delays in execution, taskCount should be set to >=1.

## Proposed changes

Issue Number: close #xxx

#38263

