### PR TITLE
[Fix](group commit) Fix group commit forward required param fault

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -403,6 +403,9 @@ public class LoadAction extends RestBaseController {
             ctx.setEnv(Env.getCurrentEnv());
             ctx.setThreadLocalInfo();
             ctx.setRemoteIP(request.getRemoteAddr());
+            // We set this variable to fulfill required field 'user' in
+            // TMasterOpRequest(FrontendService.thrift)
+            ctx.setQualifiedUser(Auth.ADMIN_USER);
             ctx.setThreadLocalInfo();
 
             try {


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

The error message is:

2024-07-23 17:30:09.300 INFO [suite-thread-1] (StreamLoadAction.groovy:201) - Stream load elapsed 2050 ms, is http stream: true,  response: nulljava.lang.IllegalStateException: Expect frontend stream load response code is 307, but meet 200
body: {"status":"FAILED","msg":"errCode = 2, detailMessage = Required field 'user' was not present! Struct: TMasterOpRequest(user:null, db:, sql:, clientNodeHost:172.20.48.85, clientNodePort:9010, groupCommitInfo:TGroupCommitInfo(getGroupCommitLoadBeId:true, groupCommitLoadTableId:10321, isCloud:false))"}

The forward param `TMasterOpRequest`(FrontendService.thrift) has a required field `user`, which get from ConnectContext. So we set admin_user to ConnectContext to solve this problem.