### PR TITLE
[fix](agg) fix RowsProduced counter is not set

### DIFF
--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -460,6 +460,12 @@ void AggLocalState::do_agg_limit(vectorized::Block* block, bool* eos) {
         } else {
             reached_limit(block, eos);
         }
+    } else {
+        if (auto rows = block->rows()) {
+            _num_rows_returned += rows;
+            COUNTER_UPDATE(_blocks_returned_counter, 1);
+            COUNTER_SET(_rows_returned_counter, _num_rows_returned);
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes
`RowsProduced` and `BlocksProduced` counter of agg source is not right:

```
Pipeline  :  0(instance_num=4):
                      RESULT_SINK_OPERATOR  (id=0):
                            -  PlanInfo
                                  -  TABLE:  rqg_1333358549.table_10_undef_partitions2_keys3_properties4_distributed_by52(table_10_undef_partitions2_keys3_properties4_distributed_by52),  PREAGGREGATION:  ON
                                  -  partitions=1/1  (table_10_undef_partitions2_keys3_properties4_distributed_by52)
                                  -  tablets=10/10,  tabletList=39981436181982,39981436181984,39981436181986  ...
                                  -  cardinality=10,  avgRowSize=0.0,  numNodes=1
                                  -  pushAggOp=NONE
                            -  BlocksProduced:  sum  4,  avg  1,  max  1,  min  1
                            -  CloseTime:  avg  28.396us,  max  43.17us,  min  19.647us
                            -  ExecTime:  avg  514.688us,  max  694.677us,  min  353.811us
                            -  InitTime:  avg  52.136us,  max  55.309us,  min  46.966us
                            -  InputRows:  sum  0,  avg  0,  max  0,  min  0
                            -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                            -  OpenTime:  avg  212.328us,  max  249.375us,  min  170.678us
                            -  RowsProduced:  sum  8,  avg  2,  max  3,  min  0
                            -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                            -  WaitForDependency[RESULT_SINK_OPERATOR_DEPENDENCY]Time:  avg  0ns,  max  0ns,  min  0ns
                          AGGREGATION_OPERATOR  (id=10  ,  nereids_id=598):
                                -  PlanInfo
                                      -  output:  count(pk)[#31]
                                      -  group  by:  col_varchar_10__undef_signed
                                      -  sortByGroupKey:false
                                      -  cardinality=8
                                      -  projections:  field1,  col_varchar_10__undef_signed
                                      -  project  output  tuple  id:  11
                                -  BlocksProduced:  sum  0,  avg  0,  max  0,  min  0
                                -  CloseTime:  avg  5.617us,  max  6.543us,  min  5.247us
                                -  ExecTime:  avg  1.172ms,  max  1.609ms,  min  289.815us
                                -  InitTime:  avg  0ns,  max  0ns,  min  0ns
                                -  MemoryUsage:  sum  ,  avg  ,  max  ,  min  
                                    -  PeakMemoryUsage:  sum  0.00  ,  avg  0.00  ,  max  0.00  ,  min  0.00  
                                -  OpenTime:  avg  130.883us,  max  143.370us,  min  120.96us
                                -  ProjectionTime:  avg  420.824us,  max  636.882us,  min  763ns
                                -  RowsProduced:  sum  0,  avg  0,  max  0,  min  0
                                -  WaitForDependency[AGGREGATION_OPERATOR_DEPENDENCY]Time:  avg  72.547ms,  max  79.260ms,  min  65.118ms
```

