### PR TITLE
[Pick 2.1](inverted index) skip index compaction for inverted index V2

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -783,7 +783,9 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
     if (config::inverted_index_compaction_enable &&
         (((_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
            _tablet->enable_unique_key_merge_on_write()) ||
-          _tablet->keys_type() == KeysType::DUP_KEYS))) {
+          _tablet->keys_type() == KeysType::DUP_KEYS)) &&
+        _cur_tablet_schema->get_inverted_index_storage_format() ==
+                InvertedIndexStorageFormatPB::V1) {
         for (const auto& index : _cur_tablet_schema->indexes()) {
             if (index.index_type() == IndexType::INVERTED) {
                 auto col_unique_id = index.col_unique_ids()[0];

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -70,6 +70,7 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "test_spark_load," +
     "test_broker_load_func," +
     "test_stream_stub_fault_injection," +
+    "test_index_compaction_failure_injection," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -70,7 +70,6 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "test_spark_load," +
     "test_broker_load_func," +
     "test_stream_stub_fault_injection," +
-    "test_index_compaction_failure_injection," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed


### PR DESCRIPTION

Enabling index compaction in the inverted index V2 format currently causes unexpected errors, especially in the case of tables with hybrid indexes, such as BKD index and Fulltext index together.

backport #38209 
