### PR TITLE
[Improvement](profile) add catalog info in profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -44,6 +44,7 @@ public class SummaryProfile {
     public static final String TOTAL_TIME = "Total";
     public static final String TASK_STATE = "Task State";
     public static final String USER = "User";
+    public static final String DEFAULT_CATALOG = "Default Catalog";
     public static final String DEFAULT_DB = "Default Db";
     public static final String SQL_STATEMENT = "Sql Statement";
     public static final String IS_CACHED = "Is Cached";
@@ -107,7 +108,7 @@ public class SummaryProfile {
     // a column, so that should not
     // add many columns here. Add to ExecutionSummary list.
     public static final ImmutableList<String> SUMMARY_CAPTIONS = ImmutableList.of(PROFILE_ID, TASK_TYPE,
-            START_TIME, END_TIME, TOTAL_TIME, TASK_STATE, USER, DEFAULT_DB, SQL_STATEMENT);
+            START_TIME, END_TIME, TOTAL_TIME, TASK_STATE, USER, DEFAULT_CATALOG, DEFAULT_DB, SQL_STATEMENT);
     public static final ImmutableList<String> SUMMARY_KEYS = new ImmutableList.Builder<String>()
             .addAll(SUMMARY_CAPTIONS)
             .add(PHYSICAL_PLAN)
@@ -590,6 +591,11 @@ public class SummaryProfile {
 
         public SummaryBuilder user(String val) {
             map.put(USER, val);
+            return this;
+        }
+
+        public SummaryBuilder defaultCatalog(String val) {
+            map.put(DEFAULT_CATALOG, val);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -42,6 +42,7 @@ import org.apache.doris.common.util.LogKey;
 import org.apache.doris.common.util.MetaLockUtils;
 import org.apache.doris.common.util.ProfileManager.ProfileType;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.constants.S3Properties;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
@@ -400,6 +401,7 @@ public class BrokerLoadJob extends BulkLoadJob {
         }
         builder.taskState(isFinished ? "FINISHED" : "RUNNING");
         builder.user(getUserInfo() != null ? getUserInfo().getQualifiedUser() : "N/A");
+        builder.defaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
         builder.defaultDb(getDefaultDb());
         builder.sqlStatement(getOriginStmt().originStmt);
         return builder.build();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -389,6 +389,7 @@ public class StmtExecutor {
         builder.taskState(!isFinished && context.getState().getStateType().equals(MysqlStateType.OK) ? "RUNNING"
                 : context.getState().toString());
         builder.user(context.getQualifiedUser());
+        builder.defaultCatalog(context.getCurrentCatalog().getName());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());
         builder.sqlStatement(originStmt.originStmt);

--- a/regression-test/suites/query_profile/test_profile.groovy
+++ b/regression-test/suites/query_profile/test_profile.groovy
@@ -51,5 +51,31 @@ suite('test_profile') {
     def notExistingProfileString = getProfile("-100")
     logger.info("notExistingProfileString:{}", notExistingProfileString)
     def json2 = new JsonSlurper().parseText(notExistingProfileString)
-    assertEquals("ID -100 does not exist", json2.data)
+    assertEquals("Profile -100 not found", json2.data)
+
+    sql """
+        CREATE TABLE if not exists `test_profile` (
+          `id` INT,
+          `name` varchar(32)
+        )ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 10
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+
+    sql "set enable_profile=true"
+    def simpleSql = "select count(*) from test_profile"
+    sql "${simpleSql}"
+    def isRecorded = false
+    def wholeString = getProfileList()
+    List profileData = new JsonSlurper().parseText(wholeString).data.rows
+    for (final def profileItem in profileData) {
+        if (profileItem["Sql Statement"].toString() == simpleSql) {
+            isRecorded = true
+            assertEquals("internal", profileItem["Default Catalog"].toString())
+        }
+    }
+    assertTrue(isRecorded)
 }

--- a/regression-test/suites/query_profile/test_profile.groovy
+++ b/regression-test/suites/query_profile/test_profile.groovy
@@ -78,4 +78,7 @@ suite('test_profile') {
         }
     }
     assertTrue(isRecorded)
+
+    sql """ SET enable_profile = false """
+    sql """ DROP TABLE IF EXISTS test_profile """
 }


### PR DESCRIPTION
add catalog in load/query profile
<img width="1319" alt="image" src="https://github.com/user-attachments/assets/60207735-8547-4c08-9ab0-58de33df4353">


        "column_names": [
            "Profile ID",
            "Task Type",
            "Start Time",
            "End Time",
            "Total",
            "Task State",
            "User",
            "Default Catalog",
            "Default Db",
            "Sql Statement"
        ],
        "rows": [
            {
                "Task Type": "QUERY",
                "User": "root",
                "Default Catalog": "internal",
                "Total": "14ms",
                "__hrefPaths": [
                    "/query_profile/727f38676ca442bb-b33a77ea8dca569d"
                ],
                "Default Db": "regression_test_query_profile",
                "Profile ID": "727f38676ca442bb-b33a77ea8dca569d",
                "Task State": "EOF",
                "Sql Statement": "select count(*) from test_profile",
                "Start Time": "2024-07-24 03:19:39",
                "End Time": "2024-07-24 03:19:39"
            },

