### PR TITLE
[chore](arm) use __crc32cw intrinsic to optimize Fast_CRC32

### DIFF
--- a/be/src/util/crc32c.cpp
+++ b/be/src/util/crc32c.cpp
@@ -19,6 +19,11 @@
 // https://github.com/facebook/rocksdb/blob/master/util/crc32c.cc
 
 // IWYU pragma: no_include <crc32intrin.h>
+
+#if defined(__aarch64__)
+#include <sse2neon.h>
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
## Proposed changes

include <sse2neon.h>
But this header file is already included in util/coding.h; it is only explicitly included here.
```C++
// Starting with the initial value in crc, accumulates a CRC32 value for
// unsigned 32-bit integer v.
// https://msdn.microsoft.com/en-us/library/bb531394(v=vs.100)
FORCE_INLINE uint32_t _mm_crc32_u32(uint32_t crc, uint32_t v)
{
#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
    __asm__ __volatile__("crc32cw %w[c], %w[c], %w[v]\n\t"
                         : [c] "+r"(crc)
                         : [v] "r"(v));
#elif (__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)
    crc = __crc32cw(crc, v);
#else
    crc = _mm_crc32_u16(crc, v & 0xffff);
    crc = _mm_crc32_u16(crc, (v >> 16) & 0xffff);
#endif
    return crc;
}
```

<!--Describe your changes.-->

