### PR TITLE
[feature](audit) add new FE config to skip audit for certain user

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2525,6 +2525,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int query_audit_log_timeout_ms = 5000;
 
+    @ConfField(description = {
+            "在这个列表中的用户的操作，不会被记录到审计日志中。多个用户之间用逗号分隔。",
+            "The operations of the users in this list will not be recorded in the audit log. "
+                    + "Multiple users are separated by commas."
+    })
+    public static String skip_audit_user_list = "";
+
     @ConfField(mutable = true)
     public static int be_report_query_statistics_timeout_ms = 60000;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
@@ -17,17 +17,21 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.plugin.AuditPlugin;
 import org.apache.doris.plugin.Plugin;
 import org.apache.doris.plugin.PluginInfo.PluginType;
 import org.apache.doris.plugin.PluginMgr;
 import org.apache.doris.plugin.audit.AuditEvent;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -49,14 +53,28 @@ public class AuditEventProcessor {
 
     private volatile boolean isStopped = false;
 
+    private Set<String> skipAuditUsers = Sets.newHashSet();
+
     public AuditEventProcessor(PluginMgr pluginMgr) {
         this.pluginMgr = pluginMgr;
     }
 
     public void start() {
+        initSkipAuditUsers();
         workerThread = new Thread(new Worker(), "AuditEventProcessor");
         workerThread.setDaemon(true);
         workerThread.start();
+    }
+
+    private void initSkipAuditUsers() {
+        if (Strings.isNullOrEmpty(Config.skip_audit_user_list)) {
+            return;
+        }
+        String[] users = Config.skip_audit_user_list.replaceAll(" ", "").split(",");
+        for (String user : users) {
+            skipAuditUsers.add(user);
+        }
+        LOG.info("skip audit users: {}", skipAuditUsers);
     }
 
     public void stop() {
@@ -75,6 +93,10 @@ public class AuditEventProcessor {
     }
 
     public boolean handleAuditEvent(AuditEvent auditEvent, boolean ignoreQueueFullLog) {
+        if (skipAuditUsers.contains(auditEvent.user)) {
+            // return true to ignore this event
+            return true;
+        }
         boolean isAddSucc = true;
         try {
             eventQueue.add(auditEvent);


### PR DESCRIPTION
Sometime we don't want to audit operation from certain user in audit log or audit table.
Add a new FE config `skip_audit_user_list`.
Default is empty, which means all operations will be recorded.
When you want to ignore some user's operation, you can set this config like:

```
skip_audit_user_list=user1
--or
skip_audit_user_list=user1,user2
```