### PR TITLE
[opt](Nereids) add where Null rule to create empty relation as where false (#38135)

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateFilterTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.LogicalPlanBuilder;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
@@ -38,6 +39,17 @@ class EliminateFilterTest implements MemoPatternMatchSupported {
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), filterFalse)
+                .applyTopDown(new EliminateFilter())
+                .matches(logicalEmptyRelation());
+    }
+
+    @Test
+    void testEliminateFilterNull() {
+        LogicalPlan filterNull = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
+                .filter(NullLiteral.INSTANCE)
+                .build();
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), filterNull)
                 .applyTopDown(new EliminateFilter())
                 .matches(logicalEmptyRelation());
     }

--- a/regression-test/data/empty_relation/eliminate_empty.out
+++ b/regression-test/data/empty_relation/eliminate_empty.out
@@ -70,6 +70,81 @@ PhysicalResultSink
 
 -- !except_empty_data --
 
+-- !null_join --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !null_explain_union_empty_data --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----hashAgg[LOCAL]
+------PhysicalProject
+--------PhysicalOlapScan[nation]
+
+-- !null_union_empty_data --
+1
+
+-- !null_explain_union_empty_empty --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !null_union_empty_empty --
+
+-- !null_union_emtpy_onerow --
+10
+
+-- !null_explain_intersect_data_empty --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !null_explain_intersect_empty_data --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !null_explain_except_data_empty --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----PhysicalProject
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------PhysicalOlapScan[nation]
+
+-- !null_explain_except_data_empty_data --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalProject
+----------PhysicalOlapScan[nation]
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalProject
+----------filter(( not (n_nationkey = 1)))
+------------PhysicalOlapScan[nation]
+
+-- !null_except_data_empty_data --
+1
+
+-- !null_explain_except_empty_data --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !null_intersect_data_empty --
+
+-- !null_intersect_empty_data --
+
+-- !null_except_data_empty --
+1
+
+-- !null_except_empty_data --
+
+-- !prune_partition1 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !prune_partition2 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
 -- !join_with_empty_child --
 2	8	e	v	3
 4	7		at	2

--- a/regression-test/data/empty_relation/eliminate_empty.out
+++ b/regression-test/data/empty_relation/eliminate_empty.out
@@ -76,7 +76,7 @@ PhysicalResultSink
 
 -- !null_explain_union_empty_data --
 PhysicalResultSink
---PhysicalDistribute[DistributionSpecGather]
+--PhysicalDistribute
 ----hashAgg[LOCAL]
 ------PhysicalProject
 --------PhysicalOlapScan[nation]
@@ -103,7 +103,7 @@ PhysicalResultSink
 
 -- !null_explain_except_data_empty --
 PhysicalResultSink
---PhysicalDistribute[DistributionSpecGather]
+--PhysicalDistribute
 ----PhysicalProject
 ------hashAgg[LOCAL]
 --------PhysicalProject
@@ -111,12 +111,12 @@ PhysicalResultSink
 
 -- !null_explain_except_data_empty_data --
 PhysicalResultSink
---PhysicalDistribute[DistributionSpecGather]
+--PhysicalDistribute
 ----PhysicalExcept
-------PhysicalDistribute[DistributionSpecHash]
+------PhysicalDistribute
 --------PhysicalProject
 ----------PhysicalOlapScan[nation]
-------PhysicalDistribute[DistributionSpecHash]
+------PhysicalDistribute
 --------PhysicalProject
 ----------filter(( not (n_nationkey = 1)))
 ------------PhysicalOlapScan[nation]
@@ -139,11 +139,25 @@ PhysicalResultSink
 
 -- !prune_partition1 --
 PhysicalResultSink
---PhysicalEmptyRelation
+--PhysicalDistribute
+----PhysicalProject
+------hashAgg[GLOBAL]
+--------PhysicalDistribute
+----------hashAgg[LOCAL]
+------------PhysicalProject
+--------------filter((eliminate_partition_prune.k1 = 100))
+----------------PhysicalOlapScan[eliminate_partition_prune]
 
 -- !prune_partition2 --
 PhysicalResultSink
---PhysicalEmptyRelation
+--PhysicalDistribute
+----PhysicalProject
+------hashAgg[GLOBAL]
+--------PhysicalDistribute
+----------hashAgg[LOCAL]
+------------PhysicalProject
+--------------filter((eliminate_partition_prune.k1 = 100))
+----------------PhysicalOlapScan[eliminate_partition_prune]
 
 -- !join_with_empty_child --
 2	8	e	v	3

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_multi_range_partition.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_multi_range_partition.groovy
@@ -169,12 +169,12 @@ suite("test_multi_range_partition") {
 
     explain {
         sql "select * from pt where k1=7 and k2 in (null);"
-        contains "partitions=0/3"
+        contains "VEMPTYSET"
     }
 
     explain {
         sql "select * from pt where k1=7 and k2 not in (null);"
-        contains "partitions=0/3"
+        contains "VEMPTYSET"
     }
     
     explain {
@@ -189,13 +189,13 @@ suite("test_multi_range_partition") {
 
     explain {
         sql "select * from pt where k2 in (null);"
-        contains "partitions=0/3"
+        contains "VEMPTYSET"
     }
 
     // p1/p2/p3 NOT pruned
     explain {
         sql "select * from pt where k2 not in (null)"
-        contains "partitions=0/3"
+        contains "VEMPTYSET"
     }
 
     explain {

--- a/regression-test/suites/nereids_syntax_p0/test_simplify_comparison.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_simplify_comparison.groovy
@@ -89,15 +89,6 @@ suite("test_simplify_comparison") {
     }
 
     explain {
-        sql "verbose select * from simple_test_table_t where a = cast(1.1 as double) and b = cast(1.1 as double) and c = cast(1.1 as double) and d = cast(1.1 as double);"
-        contains "a[#0] IS NULL"
-        contains "b[#1] IS NULL"
-        contains "c[#2] IS NULL"
-        contains "d[#3] IS NULL"
-        contains "AND NULL"
-    }
-
-    explain {
         sql "verbose select * from simple_test_table_t where e = cast(1.1 as double);"
         contains "CAST(e[#4] AS double) = 1.1"
     }
@@ -202,15 +193,6 @@ suite("test_simplify_comparison") {
     explain {
         sql "verbose select * from simple_test_table_t where e <= 1.0;"
         contains "CAST"
-    }
-
-    explain {
-        sql "verbose select * from simple_test_table_t where a = 1.1 and b = 1.1 and c = 1.1 and d = 1.1;"
-        contains "a[#0] IS NULL"
-        contains "b[#1] IS NULL"
-        contains "c[#2] IS NULL"
-        contains "d[#3] IS NULL"
-        contains "AND NULL"
     }
 
     explain {


### PR DESCRIPTION
cherry-pick: #38135 

explain shape plan select * from table2 where Null; explain shape plan select * from table2 where false; in this case, null literal can be regard as same as false literal

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

