### PR TITLE
[enhancement](cloud) unify scanner thread pool as LOCAL in cloud mode

### DIFF
--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -499,6 +499,10 @@ Status NewOlapScanner::_init_return_columns() {
 }
 
 doris::TabletStorageType NewOlapScanner::get_storage_type() {
+    if (config::is_cloud_mode()) {
+        // we don't have cold storage in cloud mode, all storage is treated as local
+        return doris::TabletStorageType::STORAGE_TYPE_LOCAL;
+    }
     int local_reader = 0;
     for (const auto& reader : _tablet_reader_params.rs_splits) {
         local_reader += reader.rs_reader->rowset()->is_local();


### PR DESCRIPTION
Current scanner is spread in both Scan & RScan thread pool. Unify them to get better performance (+10% in TPCH1T & SSB1T bench).

Before, two thread pools are both working:
![image](https://github.com/user-attachments/assets/11583705-574d-4b8c-b043-e4b72f2c5d17)

After, only local pool is working
![image](https://github.com/user-attachments/assets/c9ff5927-8726-438a-9a40-9edd2c3d0070)
