### PR TITLE
[Bug](http-api) fix core dump on /api/reset_rpc_channel coz exec_env not initialized

### DIFF
--- a/be/src/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/http/action/reset_rpc_channel_action.cpp
@@ -34,7 +34,7 @@
 namespace doris {
 ResetRPCChannelAction::ResetRPCChannelAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
                                              TPrivilegeType::type type)
-        : HttpHandlerWithAuth(exec_env, hier, type) {}
+        : HttpHandlerWithAuth(exec_env, hier, type), _exec_env(exec_env) {}
 void ResetRPCChannelAction::handle(HttpRequest* req) {
     std::string endpoints = req->param("endpoints");
     if (iequal(endpoints, "all")) {

--- a/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
+++ b/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
@@ -16,6 +16,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import static org.apache.doris.regression.ConfigOptions.*
+
 suite('reset_rpc_channel') {
-    curl("POST",config.feSourceThriftAddress+"/api/reset_rpc_channel/all")
+    curl("POST",config.beHttpAddress+"/api/reset_rpc_channel/all")
 }

--- a/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
+++ b/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
@@ -17,5 +17,11 @@
 // under the License.
 
 suite('reset_rpc_channel') {
-    curl("POST",context.config.beHttpAddress+"/api/reset_rpc_channel/all")
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+    for (int i=0;i<backendId_to_backendIP.size();i++){
+        def beHttpAddress =backendId_to_backendIP.entrySet()[i].getValue()+":"+backendId_to_backendHttpPort.entrySet()[i].getValue()
+        curl("POST",beHttpAddress+"/api/reset_rpc_channel/all")
+    }
 }

--- a/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
+++ b/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
@@ -16,8 +16,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import static org.apache.doris.regression.ConfigOptions.*
-
 suite('reset_rpc_channel') {
-    curl("POST",config.beHttpAddress+"/api/reset_rpc_channel/all")
+    curl("POST",context.config.beHttpAddress+"/api/reset_rpc_channel/all")
 }

--- a/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
+++ b/regression-test/suites/http_p0/reset_rpc_channel/reset_rpc_channel.groovy
@@ -1,0 +1,21 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('reset_rpc_channel') {
+    curl("POST",config.feSourceThriftAddress+"/api/reset_rpc_channel/all")
+}


### PR DESCRIPTION
## Proposed changes
fix core dump on /api/reset_rpc_channel coz exec_env not initialized
```cpp
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1722235709 (unix time) try "date -d @1722235709" if you are using GNU date ***
*** Current BE git commitID: 60eea39cd6 ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 3829988 (TID 3835435 OR 0x7f9a7242e700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/common/signal_handler.h:421
 1# 0x00007FA57984DB50 in /lib64/libc.so.6
 2# doris::ExecEnv::brpc_internal_client_cache() const at /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/exec_env.h:212
 3# doris::ResetRPCChannelAction::handle(doris::HttpRequest*) at /mnt/disk1/xiaolei/incubator-doris/be/src/http/action/reset_rpc_channel_action.cpp:41
 4# doris::on_request(evhttp_request*, void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/http/ev_http_server.cpp:69
 5# 0x0000558B9818EBD7 in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 6# bufferevent_run_readcb_ in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 7# 0x0000558B98190C9B in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 8# 0x0000558B9817801A in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 9# 0x0000558B9817867F in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
10# 0x0000558B9817AE30 in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
11# doris::EvHttpServer::start()::$_0::operator()() const at /mnt/disk1/xiaolei/incubator-doris/be/src/http/ev_http_server.cpp:139
12# void std::__invoke_impl<void, doris::EvHttpServer::start()::$_0&>(std::__invoke_other, doris::EvHttpServer::start()::$_0&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
13# std::enable_if<is_invocable_r_v<void, doris::EvHttpServer::start()::$_0&>, void>::type std::__invoke_r<void, doris::EvHttpServer::start()::$_0&>(doris::EvHttpServer::start()::$_0&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:117
14# std::_Function_handler<void (), doris::EvHttpServer::start()::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
15# std::function<void ()>::operator()() const at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
16# doris::FunctionRunnable::run() at /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:48
17# doris::ThreadPool::dispatch_thread() at /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:543
18# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74
19# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96
20# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:506
21# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:591
22# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
23# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:117
24# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
25# std::function<void ()>::operator()() const at /mnt/disk1/xiaolei/ldb_17/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
26# doris::Thread::supervise_thread(void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:498
27# asan_thread_start(void*) in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
28# start_thread in /lib64/libpthread.so.0
29# __clone in /lib64/libc.so.6

```