### PR TITLE
[opt](memory) Add memory metrics to bvar

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -228,6 +228,7 @@ void Daemon::memory_maintenance_thread() {
             DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
         }
 #endif
+        MemInfo::refresh_memory_bvar();
 
         // Update and print memory stat when the memory changes by 256M.
         if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -39,12 +39,33 @@
 #include "common/config.h"
 #include "common/status.h"
 #include "gutil/strings/split.h"
+#include "runtime/memory/global_memory_arbitrator.h"
 #include "util/cgroup_util.h"
 #include "util/parse_util.h"
 #include "util/pretty_printer.h"
 #include "util/string_parser.hpp"
 
 namespace doris {
+
+static bvar::Adder<int64_t> memory_process_vm_rss_bytes("memory_process_vm_rss_bytes");
+static bvar::Adder<int64_t> memory_process_vm_rss_peak_bytes("memory_process_vm_rss_peak_bytes");
+static bvar::Adder<int64_t> memory_process_vm_virtual_bytes("memory_process_vm_virtual_bytes");
+static bvar::Adder<int64_t> memory_process_vm_virtual_peak_bytes(
+        "memory_process_vm_virtual_peak_bytes");
+static bvar::Adder<int64_t> memory_jemalloc_cache_bytes("memory_jemalloc_cache_bytes");
+static bvar::Adder<int64_t> memory_jemalloc_dirty_pages_bytes("memory_jemalloc_dirty_pages_bytes");
+static bvar::Adder<int64_t> memory_jemalloc_metadata_bytes("memory_jemalloc_metadata_bytes");
+static bvar::Adder<int64_t> memory_jemalloc_virtual_bytes("memory_jemalloc_virtual_bytes");
+static bvar::Adder<int64_t> memory_cgroup_usage_bytes("memory_cgroup_usage_bytes");
+static bvar::Adder<int64_t> memory_sys_available_bytes("memory_sys_available_bytes");
+static bvar::Adder<int64_t> memory_arbitrator_sys_available_bytes(
+        "memory_arbitrator_sys_available_bytes");
+static bvar::Adder<int64_t> memory_arbitrator_process_usage_bytes(
+        "memory_arbitrator_process_usage_bytes");
+static bvar::Adder<int64_t> memory_arbitrator_reserve_memory_bytes(
+        "memory_arbitrator_reserve_memory_bytes");
+static bvar::Adder<int64_t> memory_arbitrator_refresh_interval_growth_bytes(
+        "memory_arbitrator_refresh_interval_growth_bytes");
 
 bool MemInfo::_s_initialized = false;
 std::atomic<int64_t> MemInfo::_s_physical_mem = std::numeric_limits<int64_t>::max();
@@ -114,6 +135,42 @@ void MemInfo::refresh_allocator_mem() {
                                          get_tc_metrics("tcmalloc.pageheap_unmapped_bytes"),
                                  std::memory_order_relaxed);
 #endif
+}
+
+void MemInfo::refresh_memory_bvar() {
+    memory_process_vm_rss_bytes << PerfCounters::get_vm_rss() -
+                                           memory_process_vm_rss_bytes.get_value();
+    memory_process_vm_rss_peak_bytes
+            << PerfCounters::get_vm_hwm() - memory_process_vm_rss_peak_bytes.get_value();
+    memory_process_vm_virtual_bytes
+            << PerfCounters::get_vm_size() - memory_process_vm_virtual_bytes.get_value();
+    memory_process_vm_virtual_peak_bytes
+            << PerfCounters::get_vm_peak() - memory_process_vm_virtual_peak_bytes.get_value();
+
+    memory_jemalloc_cache_bytes << MemInfo::allocator_cache_mem() -
+                                           memory_jemalloc_cache_bytes.get_value();
+    memory_jemalloc_dirty_pages_bytes
+            << MemInfo::je_dirty_pages_mem() - memory_jemalloc_dirty_pages_bytes.get_value();
+    memory_jemalloc_metadata_bytes
+            << MemInfo::allocator_metadata_mem() - memory_jemalloc_metadata_bytes.get_value();
+    memory_jemalloc_virtual_bytes << MemInfo::allocator_virtual_mem() -
+                                             memory_jemalloc_virtual_bytes.get_value();
+
+    memory_cgroup_usage_bytes << _s_cgroup_mem_usage - memory_cgroup_usage_bytes.get_value();
+    memory_sys_available_bytes << _s_sys_mem_available - memory_sys_available_bytes.get_value();
+
+    memory_arbitrator_sys_available_bytes
+            << GlobalMemoryArbitrator::sys_mem_available() -
+                       memory_arbitrator_sys_available_bytes.get_value();
+    memory_arbitrator_process_usage_bytes
+            << GlobalMemoryArbitrator::process_memory_usage() -
+                       memory_arbitrator_process_usage_bytes.get_value();
+    memory_arbitrator_reserve_memory_bytes
+            << GlobalMemoryArbitrator::process_reserved_memory() -
+                       memory_arbitrator_reserve_memory_bytes.get_value();
+    memory_arbitrator_refresh_interval_growth_bytes
+            << GlobalMemoryArbitrator::refresh_interval_memory_growth -
+                       memory_arbitrator_refresh_interval_growth_bytes.get_value();
 }
 
 #ifndef __APPLE__

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -47,11 +47,6 @@
 
 namespace doris {
 
-static bvar::Adder<int64_t> memory_process_vm_rss_bytes("memory_process_vm_rss_bytes");
-static bvar::Adder<int64_t> memory_process_vm_rss_peak_bytes("memory_process_vm_rss_peak_bytes");
-static bvar::Adder<int64_t> memory_process_vm_virtual_bytes("memory_process_vm_virtual_bytes");
-static bvar::Adder<int64_t> memory_process_vm_virtual_peak_bytes(
-        "memory_process_vm_virtual_peak_bytes");
 static bvar::Adder<int64_t> memory_jemalloc_cache_bytes("memory_jemalloc_cache_bytes");
 static bvar::Adder<int64_t> memory_jemalloc_dirty_pages_bytes("memory_jemalloc_dirty_pages_bytes");
 static bvar::Adder<int64_t> memory_jemalloc_metadata_bytes("memory_jemalloc_metadata_bytes");
@@ -138,15 +133,6 @@ void MemInfo::refresh_allocator_mem() {
 }
 
 void MemInfo::refresh_memory_bvar() {
-    memory_process_vm_rss_bytes << PerfCounters::get_vm_rss() -
-                                           memory_process_vm_rss_bytes.get_value();
-    memory_process_vm_rss_peak_bytes
-            << PerfCounters::get_vm_hwm() - memory_process_vm_rss_peak_bytes.get_value();
-    memory_process_vm_virtual_bytes
-            << PerfCounters::get_vm_size() - memory_process_vm_virtual_bytes.get_value();
-    memory_process_vm_virtual_peak_bytes
-            << PerfCounters::get_vm_peak() - memory_process_vm_virtual_peak_bytes.get_value();
-
     memory_jemalloc_cache_bytes << MemInfo::allocator_cache_mem() -
                                            memory_jemalloc_cache_bytes.get_value();
     memory_jemalloc_dirty_pages_bytes

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -75,6 +75,8 @@ public:
 
     static void refresh_proc_meminfo();
 
+    static void refresh_memory_bvar();
+
     static inline int64_t sys_mem_available_low_water_mark() {
         return _s_sys_mem_available_low_water_mark;
     }


### PR DESCRIPTION
1. Bvar add Process Memory Status, Memory Tracker, Arbitrator Memory Status, Jemalloc Status, etc.
2. Memory Tracker(label=`sum_of_all_trackers`) add reserved memory.