### PR TITLE
[refine](time type) remove and deprecated  datatypetimev1 

### DIFF
--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -97,8 +97,6 @@ FieldType TabletColumn::get_field_type_by_type(PrimitiveType primitiveType) {
         return FieldType::OLAP_FIELD_TYPE_HLL;
     case PrimitiveType::TYPE_DECIMALV2:
         return FieldType::OLAP_FIELD_TYPE_UNKNOWN; // Not implemented
-    case PrimitiveType::TYPE_TIME:
-        return FieldType::OLAP_FIELD_TYPE_UNKNOWN;
     case PrimitiveType::TYPE_OBJECT:
         return FieldType::OLAP_FIELD_TYPE_OBJECT;
     case PrimitiveType::TYPE_STRING:

--- a/be/src/runtime/define_primitive_type.h
+++ b/be/src/runtime/define_primitive_type.h
@@ -49,7 +49,8 @@ enum PrimitiveType : PrimitiveNative {
     TYPE_HLL,       /* 19 */
     TYPE_DECIMALV2, /* 20 */
 
-    TYPE_TIME,            /* 21 */
+    TYPE_TIME [[deprecated]], /*TYPE_TIMEV2*/
+
     TYPE_OBJECT,          /* 22 */
     TYPE_STRING,          /* 23 */
     TYPE_QUANTILE_STATE,  /* 24 */

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -65,10 +65,10 @@
 namespace doris {
 
 static std::unordered_set<PrimitiveType> PRIMITIVE_TYPE_SET {
-        TYPE_BOOLEAN,  TYPE_TINYINT,  TYPE_SMALLINT, TYPE_INT,        TYPE_BIGINT,
-        TYPE_LARGEINT, TYPE_FLOAT,    TYPE_TIME,     TYPE_DOUBLE,     TYPE_TIMEV2,
-        TYPE_CHAR,     TYPE_VARCHAR,  TYPE_STRING,   TYPE_HLL,        TYPE_OBJECT,
-        TYPE_DATE,     TYPE_DATETIME, TYPE_DATEV2,   TYPE_DATETIMEV2, TYPE_DECIMALV2};
+        TYPE_BOOLEAN,  TYPE_TINYINT, TYPE_SMALLINT,   TYPE_INT,      TYPE_BIGINT,
+        TYPE_LARGEINT, TYPE_FLOAT,   TYPE_DOUBLE,     TYPE_TIMEV2,   TYPE_CHAR,
+        TYPE_VARCHAR,  TYPE_STRING,  TYPE_HLL,        TYPE_OBJECT,   TYPE_DATE,
+        TYPE_DATETIME, TYPE_DATEV2,  TYPE_DATETIMEV2, TYPE_DECIMALV2};
 
 Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& params,
                                                  PConstantExprResult* response) {
@@ -225,7 +225,6 @@ Status FoldConstantExecutor::_get_result(void* src, size_t size, const TypeDescr
         result = fmt::format(FMT_COMPILE("{}"), val);
         break;
     }
-    case TYPE_TIME:
     case TYPE_DOUBLE: {
         double val = *reinterpret_cast<double*>(src);
         result = fmt::format(FMT_COMPILE("{}"), val);

--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -99,7 +99,7 @@ PrimitiveType thrift_to_type(TPrimitiveType::type ttype) {
         return TYPE_TIMEV2;
 
     case TPrimitiveType::TIME:
-        return TYPE_TIME;
+        return TYPE_TIMEV2;
 
     case TPrimitiveType::VARCHAR:
         return TYPE_VARCHAR;
@@ -207,9 +207,6 @@ TPrimitiveType::type to_thrift(PrimitiveType ptype) {
 
     case TYPE_DATETIME:
         return TPrimitiveType::DATETIME;
-
-    case TYPE_TIME:
-        return TPrimitiveType::TIME;
 
     case TYPE_DATEV2:
         return TPrimitiveType::DATEV2;
@@ -323,9 +320,6 @@ std::string type_to_string(PrimitiveType t) {
 
     case TYPE_DATETIME:
         return "DATETIME";
-
-    case TYPE_TIME:
-        return "TIME";
 
     case TYPE_DATEV2:
         return "DATEV2";

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -162,12 +162,6 @@ struct PrimitiveTypeTraits<TYPE_FLOAT> {
     using ColumnType = vectorized::ColumnFloat32;
 };
 template <>
-struct PrimitiveTypeTraits<TYPE_TIME> {
-    using CppType = double;
-    using StorageFieldType = CppType;
-    using ColumnType = vectorized::ColumnFloat64;
-};
-template <>
 struct PrimitiveTypeTraits<TYPE_TIMEV2> {
     using CppType = double;
     using StorageFieldType = CppType;

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -46,11 +46,13 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx)
             DCHECK(scalar_type.__isset.len);
             len = scalar_type.len;
         } else if (type == TYPE_DECIMALV2 || type == TYPE_DECIMAL32 || type == TYPE_DECIMAL64 ||
-                   type == TYPE_DECIMAL128I || type == TYPE_DECIMAL256 || type == TYPE_DATETIMEV2 ||
-                   type == TYPE_TIMEV2) {
+                   type == TYPE_DECIMAL128I || type == TYPE_DECIMAL256 || type == TYPE_DATETIMEV2) {
             DCHECK(scalar_type.__isset.precision);
             DCHECK(scalar_type.__isset.scale);
             precision = scalar_type.precision;
+            scale = scalar_type.scale;
+        } else if (type == TYPE_TIMEV2) {
+            DCHECK(scalar_type.__isset.scale);
             scale = scalar_type.scale;
         } else if (type == TYPE_STRING) {
             if (scalar_type.__isset.len) {

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -52,8 +52,11 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx)
             precision = scalar_type.precision;
             scale = scalar_type.scale;
         } else if (type == TYPE_TIMEV2) {
-            DCHECK(scalar_type.__isset.scale);
-            scale = scalar_type.scale;
+            if (scalar_type.__isset.scale) {
+                scale = scalar_type.scale;
+            } else {
+                scale = 0;
+            }
         } else if (type == TYPE_STRING) {
             if (scalar_type.__isset.len) {
                 len = scalar_type.len;

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -69,7 +69,7 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_DOUBLE:
         *result = arrow::float64();
         break;
-    case TYPE_TIME:
+    case TYPE_TIMEV2:
         *result = arrow::float64();
         break;
     case TYPE_IPV4:

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -155,7 +155,6 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
     case TYPE_DATETIME:
         nested = std::make_shared<vectorized::DataTypeDateTime>();
         break;
-    case TYPE_TIME:
     case TYPE_TIMEV2:
         nested = std::make_shared<vectorized::DataTypeTimeV2>(col_desc.scale);
         break;

--- a/be/src/vec/data_types/data_type_time.cpp
+++ b/be/src/vec/data_types/data_type_time.cpp
@@ -40,43 +40,9 @@ class IColumn;
 
 namespace doris::vectorized {
 
-bool DataTypeTime::equals(const IDataType& rhs) const {
-    return typeid(rhs) == typeid(*this);
-}
-
-size_t DataTypeTime::number_length() const {
-    //59:59:59
-    return 8;
-}
-void DataTypeTime::push_number(ColumnString::Chars& chars, const Float64& num) const {
-    auto time_str = time_to_buffer_from_double(num);
-    chars.insert(time_str.begin(), time_str.end());
-}
-
-std::string DataTypeTime::to_string(const IColumn& column, size_t row_num) const {
-    auto result = check_column_const_set_readability(column, row_num);
-    ColumnPtr ptr = result.first;
-    row_num = result.second;
-
-    auto value = assert_cast<const ColumnFloat64&>(*ptr).get_element(row_num);
-    return time_to_buffer_from_double(value);
-}
-
-std::string DataTypeTime::to_string(double value) const {
-    return time_to_buffer_from_double(value);
-}
-void DataTypeTime::to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const {
-    std::string value = to_string(column, row_num);
-    ostr.write(value.data(), value.size());
-}
-
 void DataTypeTimeV2::to_pb_column_meta(PColumnMeta* col_meta) const {
     IDataType::to_pb_column_meta(col_meta);
     col_meta->mutable_decimal_param()->set_scale(_scale);
-}
-
-MutableColumnPtr DataTypeTime::create_column() const {
-    return DataTypeNumberBase<Float64>::create_column();
 }
 
 bool DataTypeTimeV2::equals(const IDataType& rhs) const {

--- a/be/src/vec/data_types/data_type_time.h
+++ b/be/src/vec/data_types/data_type_time.h
@@ -23,16 +23,13 @@
 #include <gen_cpp/Types_types.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 
 #include "runtime/define_primitive_type.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_number_base.h"
 #include "vec/data_types/serde/data_type_serde.h"
 #include "vec/data_types/serde/data_type_time_serde.h"
@@ -45,38 +42,6 @@ class IColumn;
 } // namespace doris
 
 namespace doris::vectorized {
-
-class DataTypeTime final : public DataTypeNumberBase<Float64> {
-public:
-    DataTypeTime() = default;
-
-    bool equals(const IDataType& rhs) const override;
-
-    std::string to_string(const IColumn& column, size_t row_num) const override;
-    std::string to_string(double int_val) const;
-    TypeDescriptor get_type_as_type_descriptor() const override {
-        return TypeDescriptor(TYPE_TIME);
-    }
-
-    doris::FieldType get_storage_field_type() const override {
-        return doris::FieldType::OLAP_FIELD_TYPE_TIMEV2;
-    }
-
-    void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
-    void to_string_batch(const IColumn& column, ColumnString& column_to) const final {
-        DataTypeNumberBase<Float64>::template to_string_batch_impl<DataTypeTime>(column, column_to);
-    }
-
-    size_t number_length() const;
-    void push_number(ColumnString::Chars& chars, const Float64& num) const;
-    MutableColumnPtr create_column() const override;
-
-    DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
-        return std::make_shared<DataTypeTimeSerDe>(nesting_level);
-    };
-    TypeIndex get_type_id() const override { return TypeIndex::Time; }
-    const char* get_family_name() const override { return "time"; }
-};
 
 class DataTypeTimeV2 final : public DataTypeNumberBase<Float64> {
 public:

--- a/be/src/vec/exec/format/parquet/schema_desc.cpp
+++ b/be/src/vec/exec/format/parquet/schema_desc.cpp
@@ -326,7 +326,7 @@ TypeDescriptor FieldDescriptor::convert_to_doris_type(tparquet::LogicalType logi
             }
         }
     } else if (logicalType.__isset.TIME) {
-        type = TypeDescriptor(TYPE_TIME);
+        type = TypeDescriptor(TYPE_TIMEV2);
     } else if (logicalType.__isset.TIMESTAMP) {
         type = TypeDescriptor(TYPE_DATETIMEV2);
         const auto& time_unit = logicalType.TIMESTAMP.unit;

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -463,8 +463,6 @@ std::string JniConnector::get_jni_type(const DataTypePtr& data_type) {
     case TYPE_DATEV2:
         return "datev2";
     case TYPE_DATETIME:
-        [[fallthrough]];
-    case TYPE_TIME:
         return "datetimev1";
     case TYPE_DATETIMEV2:
         [[fallthrough]];
@@ -547,8 +545,6 @@ std::string JniConnector::get_jni_type(const TypeDescriptor& desc) {
     case TYPE_DATEV2:
         return "datev2";
     case TYPE_DATETIME:
-        [[fallthrough]];
-    case TYPE_TIME:
         return "datetimev1";
     case TYPE_DATETIMEV2:
         [[fallthrough]];

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -366,7 +366,7 @@ Status create_texpr_literal_node(const void* data, TExprNode* node, int precisio
         large_int_literal.__set_value(LargeIntValue::to_string(*origin_value));
         (*node).__set_large_int_literal(large_int_literal);
         (*node).__set_type(create_type_desc(PrimitiveType::TYPE_LARGEINT));
-    } else if constexpr ((T == TYPE_DATE) || (T == TYPE_DATETIME) || (T == TYPE_TIME)) {
+    } else if constexpr ((T == TYPE_DATE) || (T == TYPE_DATETIME) || (T == TYPE_TIMEV2)) {
         const auto* origin_value = reinterpret_cast<const VecDateTimeValue*>(data);
         TDateLiteral date_literal;
         char convert_buffer[30];
@@ -379,7 +379,7 @@ Status create_texpr_literal_node(const void* data, TExprNode* node, int precisio
         } else if (origin_value->type() == TimeType::TIME_DATETIME) {
             (*node).__set_type(create_type_desc(PrimitiveType::TYPE_DATETIME));
         } else if (origin_value->type() == TimeType::TIME_TIME) {
-            (*node).__set_type(create_type_desc(PrimitiveType::TYPE_TIME));
+            (*node).__set_type(create_type_desc(PrimitiveType::TYPE_TIMEV2));
         }
     } else if constexpr (T == TYPE_DATEV2) {
         const auto* origin_value = reinterpret_cast<const DateV2Value<DateV2ValueType>*>(data);

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -2260,8 +2260,7 @@ private:
 
             if constexpr (!(IsDataTypeDecimalOrNumber<ToDataType> || IsTimeType<ToDataType> ||
                             IsTimeV2Type<ToDataType> ||
-                            std::is_same_v<ToDataType, DataTypeTimeV2> ||
-                            std::is_same_v<ToDataType, DataTypeTime>)) {
+                            std::is_same_v<ToDataType, DataTypeTimeV2>)) {
                 return false;
             }
             return call_on_index_and_data_type<
@@ -2270,8 +2269,7 @@ private:
                 using FromDataType = typename Types2::LeftType;
                 if constexpr (!(IsDataTypeDecimalOrNumber<FromDataType> ||
                                 IsTimeType<FromDataType> || IsTimeV2Type<FromDataType> ||
-                                std::is_same_v<FromDataType, DataTypeTimeV2> ||
-                                std::is_same_v<FromDataType, DataTypeTime>)) {
+                                std::is_same_v<FromDataType, DataTypeTimeV2>)) {
                     return false;
                 }
                 if constexpr (IsDataTypeDecimal<FromDataType> || IsDataTypeDecimal<ToDataType>) {
@@ -2422,7 +2420,6 @@ private:
                           std::is_same_v<ToDataType, DataTypeDateV2> ||
                           std::is_same_v<ToDataType, DataTypeDateTimeV2> ||
                           std::is_same_v<ToDataType, DataTypeTimeV2> ||
-                          std::is_same_v<ToDataType, DataTypeTime> ||
                           std::is_same_v<ToDataType, DataTypeIPv4> ||
                           std::is_same_v<ToDataType, DataTypeIPv6>) {
                 ret = create_wrapper(from_type, check_and_get_data_type<ToDataType>(to_type.get()),

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -57,11 +57,11 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/data_types/data_type_time.h"
 #include "vec/functions/simple_function_factory.h"
 namespace doris::vectorized {
 
 class DataTypeJsonb;
-class DataTypeTime;
 class TableFunction;
 template <typename T>
 class DataTypeDecimal;
@@ -264,7 +264,7 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
     } else if constexpr (std::is_same_v<ReturnType, DataTypeInt32>) {
         fn_ctx_return.type = doris::PrimitiveType::TYPE_INT;
     } else if constexpr (std::is_same_v<ReturnType, DataTypeFloat64> ||
-                         std::is_same_v<ReturnType, DataTypeTime>) {
+                         std::is_same_v<ReturnType, DataTypeTimeV2>) {
         fn_ctx_return.type = doris::PrimitiveType::TYPE_DOUBLE;
     } else if constexpr (std::is_same_v<ReturnType, DateTime>) {
         fn_ctx_return.type = doris::PrimitiveType::TYPE_DATETIME;
@@ -341,7 +341,7 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
                             << " at row " << i;
                 } else if constexpr (std::is_same_v<ReturnType, DataTypeFloat32> ||
                                      std::is_same_v<ReturnType, DataTypeFloat64> ||
-                                     std::is_same_v<ReturnType, DataTypeTime>) {
+                                     std::is_same_v<ReturnType, DataTypeTimeV2>) {
                     const auto& column_data = field.get<DataTypeFloat64::FieldType>();
                     EXPECT_DOUBLE_EQ(expect_data, column_data) << " at row " << i;
                 } else {


### PR DESCRIPTION
## Proposed changes

"The time type cannot be used to create tables, and there is no existing data. timev2 can completely replace timev1."

<!--Describe your changes.-->

