### PR TITLE
[Bug](udf) forbid varchar type and convert to use string type in java-udf

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JavaUdfDataType.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JavaUdfDataType.java
@@ -43,8 +43,6 @@ public class JavaUdfDataType {
     public static final JavaUdfDataType BIGINT = new JavaUdfDataType("BIGINT", TPrimitiveType.BIGINT, 8);
     public static final JavaUdfDataType FLOAT = new JavaUdfDataType("FLOAT", TPrimitiveType.FLOAT, 4);
     public static final JavaUdfDataType DOUBLE = new JavaUdfDataType("DOUBLE", TPrimitiveType.DOUBLE, 8);
-    public static final JavaUdfDataType CHAR = new JavaUdfDataType("CHAR", TPrimitiveType.CHAR, 0);
-    public static final JavaUdfDataType VARCHAR = new JavaUdfDataType("VARCHAR", TPrimitiveType.VARCHAR, 0);
     public static final JavaUdfDataType STRING = new JavaUdfDataType("STRING", TPrimitiveType.STRING, 0);
     public static final JavaUdfDataType DATE = new JavaUdfDataType("DATE", TPrimitiveType.DATE, 8);
     public static final JavaUdfDataType DATETIME = new JavaUdfDataType("DATETIME", TPrimitiveType.DATETIME, 8);
@@ -72,8 +70,6 @@ public class JavaUdfDataType {
         JavaUdfDataTypeSet.add(BIGINT);
         JavaUdfDataTypeSet.add(FLOAT);
         JavaUdfDataTypeSet.add(DOUBLE);
-        JavaUdfDataTypeSet.add(CHAR);
-        JavaUdfDataTypeSet.add(VARCHAR);
         JavaUdfDataTypeSet.add(STRING);
         JavaUdfDataTypeSet.add(DATE);
         JavaUdfDataTypeSet.add(DATETIME);
@@ -142,7 +138,9 @@ public class JavaUdfDataType {
         } else if (c == double.class || c == Double.class) {
             return Sets.newHashSet(JavaUdfDataType.DOUBLE);
         } else if (c == char.class || c == Character.class) {
-            return Sets.newHashSet(JavaUdfDataType.CHAR);
+            // some users case have create UDF use varchar as parameter not
+            // string type, but evaluate is String Class, so set TPrimitiveType is STRING
+            return Sets.newHashSet(JavaUdfDataType.STRING);
         } else if (c == String.class) {
             return Sets.newHashSet(JavaUdfDataType.STRING);
         } else if (Type.DATE_SUPPORTED_JAVA_TYPE.contains(c)) {
@@ -170,6 +168,10 @@ public class JavaUdfDataType {
             if (javaType.getPrimitiveType() == t.getPrimitiveType().toThrift()) {
                 return true;
             }
+        }
+        if (t.getPrimitiveType().toThrift() == TPrimitiveType.VARCHAR
+                || t.getPrimitiveType().toThrift() == TPrimitiveType.CHAR) {
+            return true;
         }
         return false;
     }

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -322,8 +322,6 @@ public abstract class Type {
                     .put(PrimitiveType.DOUBLE, Sets.newHashSet(Double.class, double.class))
                     .put(PrimitiveType.BIGINT, Sets.newHashSet(Long.class, long.class))
                     .put(PrimitiveType.IPV4, Sets.newHashSet(Integer.class, int.class))
-                    .put(PrimitiveType.CHAR, Sets.newHashSet(String.class))
-                    .put(PrimitiveType.VARCHAR, Sets.newHashSet(String.class))
                     .put(PrimitiveType.STRING, Sets.newHashSet(String.class))
                     .put(PrimitiveType.DATE, DATE_SUPPORTED_JAVA_TYPE)
                     .put(PrimitiveType.DATEV2, DATE_SUPPORTED_JAVA_TYPE)

--- a/regression-test/suites/javaudf_p0/test_javaudf_string.groovy
+++ b/regression-test/suites/javaudf_p0/test_javaudf_string.groovy
@@ -86,6 +86,22 @@ suite("test_javaudf_string") {
                 test_javaudf_string
                 JOIN test_javaudf_string_2 ON test_javaudf_string.user_id = test_javaudf_string_2.user_id order by 1,2;
         """
+        test {
+            sql """ CREATE FUNCTION java_udf_string_test(varchar, int, int) RETURNS string PROPERTIES (
+                "file"="file://${jarPath}",
+                "symbol"="org.apache.doris.udf.StringTest",
+                "type"="JAVA_UDF"
+            ); """
+            exception "does not support type"
+        }
+        test {
+            sql """ CREATE FUNCTION java_udf_string_test(string, int, int) RETURNS varchar PROPERTIES (
+                "file"="file://${jarPath}",
+                "symbol"="org.apache.doris.udf.StringTest",
+                "type"="JAVA_UDF"
+            ); """
+            exception "does not support type"
+        }
     } finally {
         try_sql("DROP FUNCTION IF EXISTS java_udf_string_test(string, int, int);")
         try_sql("DROP TABLE IF EXISTS ${tableName}")


### PR DESCRIPTION
## Proposed changes
Two point have change:
1.  forbid create udf function use varchar type, could use string type.2. 
2. in order to the compatibly of old version, convert varchar to string type to execute udf function.

<!--Describe your changes.-->

