### PR TITLE
[profile](exchange) add more log/profile in network

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -262,7 +262,7 @@ private:
     inline bool _is_receiver_eof(InstanceLoId id);
     inline void _turn_off_channel(InstanceLoId id, bool cleanup = false);
     void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time);
-    int64_t get_sum_rpc_time();
+    std::pair<int64_t, int64_t> get_sum_rpc_time();
 
     std::atomic<int> _total_queue_size = 0;
     std::shared_ptr<Dependency> _queue_dependency = nullptr;

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -65,6 +65,7 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
             ADD_TIMER(_profile, "SplitBlockDistributeByChannelTime");
     _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);
     _rows_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "RowsProduced", TUnit::UNIT, 1);
+    _init_brpc_stub_timer = ADD_TIMER(_profile, "InitBrpcStubTime");
     _overall_throughput = _profile->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
             std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_sent_counter,
@@ -96,9 +97,12 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
     }
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
 
-    // Make sure brpc stub is ready before execution.
-    for (int i = 0; i < channels.size(); ++i) {
-        RETURN_IF_ERROR(channels[i]->init_stub(state));
+    {
+        SCOPED_TIMER(_init_brpc_stub_timer);
+        // Make sure brpc stub is ready before execution.
+        for (auto& channel : channels) {
+            RETURN_IF_ERROR(channel->init_stub(state));
+        }
     }
     return Status::OK();
 }
@@ -111,9 +115,9 @@ Status ExchangeSinkLocalState::open(RuntimeState* state) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
 
     int local_size = 0;
-    for (int i = 0; i < channels.size(); ++i) {
-        RETURN_IF_ERROR(channels[i]->open(state));
-        if (channels[i]->is_local()) {
+    for (auto& channel : channels) {
+        RETURN_IF_ERROR(channel->open(state));
+        if (channel->is_local()) {
             local_size++;
         }
     }

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -138,6 +138,7 @@ private:
     RuntimeProfile::Counter* _split_block_distribute_by_channel_timer = nullptr;
     RuntimeProfile::Counter* _blocks_sent_counter = nullptr;
     RuntimeProfile::Counter* _rows_sent_counter = nullptr;
+    RuntimeProfile::Counter* _init_brpc_stub_timer = nullptr;
     // Throughput per total time spent in sender
     RuntimeProfile::Counter* _overall_throughput = nullptr;
     // Used to counter send bytes under local data exchange

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -129,6 +129,7 @@ std::shared_ptr<pipeline::Dependency> PipChannel::get_local_channel_dependency()
 
 Status PipChannel::send_remote_block(PBlock* block, bool eos, Status exec_status) {
     COUNTER_UPDATE(Channel<pipeline::ExchangeSinkLocalState>::_parent->blocks_sent_counter(), 1);
+    SCOPED_TIMER(_parent->brpc_send_timer());
     std::unique_ptr<PBlock> pblock_ptr;
     pblock_ptr.reset(block);
 


### PR DESCRIPTION
## Proposed changes
1. Added `InitBrpcStubTime` because we often encounter slow queries due to tight brpc resources.
2. Renamed a few profile names, for example, `RpcMaxTime`, which actually represents the maximum total time spent on RPC for a specific instance.
3. The cost of `hostname_to_ip` will not occur on IPv4, so this has been updated.

<!--Describe your changes.-->

