### PR TITLE
[opt](multicast) opt MultiCastDataStreamer when source close

### DIFF
--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -67,6 +67,8 @@ Status MultiCastDataStreamSourceLocalState::close(RuntimeState* state) {
 
     SCOPED_TIMER(_close_timer);
     SCOPED_TIMER(exec_time_counter());
+    auto& p = _parent->cast<Parent>();
+    _shared_state->multi_cast_data_streamer->close_sender(p._consumer_id);
     int64_t rf_time = 0;
     for (auto& dep : _filter_dependencies) {
         rf_time += dep->watcher_elapse_time();

--- a/be/src/pipeline/exec/multi_cast_data_streamer.h
+++ b/be/src/pipeline/exec/multi_cast_data_streamer.h
@@ -64,6 +64,8 @@ public:
         _block_reading(sender_idx);
     }
 
+    void close_sender(int sender_idx);
+
 private:
     void _set_ready_for_read(int sender_idx);
     void _block_reading(int sender_idx);
@@ -79,7 +81,8 @@ private:
     std::condition_variable _cv;
     std::mutex _mutex;
     bool _eos = false;
-    int _cast_sender_count = 0;
+    const int _cast_sender_count;
+    int _close_sender_count = 0;
     int64_t _cumulative_mem_size = 0;
 
     RuntimeProfile::Counter* _process_rows = nullptr;


### PR DESCRIPTION
## Proposed changes
When the source is closed, we reduce the initial value of the use count to avoid unnecessary copies.

<!--Describe your changes.-->

