### PR TITLE
[Enhancement](audit log) Add print audit log sesssion variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -153,7 +153,9 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
+        if (ctx.getSessionVariable().isEnableAuditLog()) {
+            auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
+        }
     }
 
     private void handleExecute(PrepareCommand prepareCommand, long stmtId, PreparedStatementContext prepCtx) {
@@ -205,15 +207,19 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             executor = new StmtExecutor(ctx, stmt);
             ctx.setExecutor(executor);
             executor.execute();
-            stmtStr = executeStmt.toSql();
-        } catch (Throwable e)  {
+            if (ctx.getSessionVariable().isEnableAuditLog()) {
+                stmtStr = executeStmt.toSql();
+            }
+        } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe doris bug.
             LOG.warn("Process one query failed because unknown reason: ", e);
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
+        if (ctx.getSessionVariable().isEnableAuditLog()) {
+            auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
+        }
     }
 
     // process COM_EXECUTE, parse binary row data

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -140,7 +140,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             //Printing audit logs can severely impact performance.
             //Therefore, we have introduced a session variable to control whether to print audit logs.
             //It is recommended to turn off audit logs only during group commit load via JDBC.
-            if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
+            if (ctx.getSessionVariable().isEnablePreparedStmtAuditLog()) {
                 PrepareStmtContext preparedStmtContext = ConnectContext.get().getPreparedStmt(String.valueOf(stmtId));
                 if (preparedStmtContext != null) {
                     stmtStr = executeStmt.toSql();
@@ -153,7 +153,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
+        if (ctx.getSessionVariable().isEnablePreparedStmtAuditLog()) {
             auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
         }
     }
@@ -207,7 +207,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             executor = new StmtExecutor(ctx, stmt);
             ctx.setExecutor(executor);
             executor.execute();
-            if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
+            if (ctx.getSessionVariable().isEnablePreparedStmtAuditLog()) {
                 stmtStr = executeStmt.toSql();
             }
         } catch (Throwable e) {
@@ -217,7 +217,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
+        if (ctx.getSessionVariable().isEnablePreparedStmtAuditLog()) {
             auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -140,7 +140,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             //Printing audit logs can severely impact performance.
             //Therefore, we have introduced a session variable to control whether to print audit logs.
             //It is recommended to turn off audit logs only during group commit load via JDBC.
-            if (ctx.getSessionVariable().isEnableAuditLog()) {
+            if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
                 PrepareStmtContext preparedStmtContext = ConnectContext.get().getPreparedStmt(String.valueOf(stmtId));
                 if (preparedStmtContext != null) {
                     stmtStr = executeStmt.toSql();
@@ -153,7 +153,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        if (ctx.getSessionVariable().isEnableAuditLog()) {
+        if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
             auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
         }
     }
@@ -207,7 +207,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             executor = new StmtExecutor(ctx, stmt);
             ctx.setExecutor(executor);
             executor.execute();
-            if (ctx.getSessionVariable().isEnableAuditLog()) {
+            if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
                 stmtStr = executeStmt.toSql();
             }
         } catch (Throwable e) {
@@ -217,7 +217,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
                     e.getClass().getSimpleName() + ", msg: " + e.getMessage());
         }
-        if (ctx.getSessionVariable().isEnableAuditLog()) {
+        if (ctx.getSessionVariable().isEnableExecStmtAuditLog()) {
             auditAfterExec(stmtStr, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -476,7 +476,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String GROUP_COMMIT = "group_commit";
 
-    public static final String ENABLE_AUDIT_LOG = "enable_audit_log";
+    public static final String ENABLE_EXEC_STMT_AUDIT_LOG = "enable_exec_stmt_audit_log";
 
     public static final String PARALLEL_SYNC_ANALYZE_TASK_NUM = "parallel_sync_analyze_task_num";
 
@@ -1682,7 +1682,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = GROUP_COMMIT, needForward = true)
     public String groupCommit = "off_mode";
 
-    @VariableMgr.VarAttr(name = ENABLE_AUDIT_LOG, needForward = true)
+    @VariableMgr.VarAttr(name = ENABLE_EXEC_STMT_AUDIT_LOG, needForward = true)
     public boolean enableExecStmtAuditLog = true;
 
     @VariableMgr.VarAttr(name = INVERTED_INDEX_CONJUNCTION_OPT_THRESHOLD,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1683,7 +1683,7 @@ public class SessionVariable implements Serializable, Writable {
     public String groupCommit = "off_mode";
 
     @VariableMgr.VarAttr(name = ENABLE_AUDIT_LOG, needForward = true)
-    public boolean enableAuditLog = true;
+    public boolean enableExecStmtAuditLog = true;
 
     @VariableMgr.VarAttr(name = INVERTED_INDEX_CONJUNCTION_OPT_THRESHOLD,
             description = {"在match_all中求取多个倒排索引的交集时,如果最大的倒排索引中的总数是最小倒排索引中的总数的整数倍,"
@@ -4138,8 +4138,8 @@ public class SessionVariable implements Serializable, Writable {
         return groupCommit;
     }
 
-    public boolean isEnableAuditLog() {
-        return enableAuditLog;
+    public boolean isEnableExecStmtAuditLog() {
+        return enableExecStmtAuditLog;
     }
 
     public boolean isEnableMaterializedViewRewrite() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -476,7 +476,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String GROUP_COMMIT = "group_commit";
 
-    public static final String ENABLE_EXEC_STMT_AUDIT_LOG = "enable_exec_stmt_audit_log";
+    public static final String ENABLE_PREPARED_STMT_AUDIT_LOG = "enable_prepared_stmt_audit_log";
 
     public static final String PARALLEL_SYNC_ANALYZE_TASK_NUM = "parallel_sync_analyze_task_num";
 
@@ -1682,8 +1682,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = GROUP_COMMIT, needForward = true)
     public String groupCommit = "off_mode";
 
-    @VariableMgr.VarAttr(name = ENABLE_EXEC_STMT_AUDIT_LOG, needForward = true)
-    public boolean enableExecStmtAuditLog = true;
+    @VariableMgr.VarAttr(name = ENABLE_PREPARED_STMT_AUDIT_LOG, needForward = true)
+    public boolean enablePreparedStmtAuditLog = true;
 
     @VariableMgr.VarAttr(name = INVERTED_INDEX_CONJUNCTION_OPT_THRESHOLD,
             description = {"在match_all中求取多个倒排索引的交集时,如果最大的倒排索引中的总数是最小倒排索引中的总数的整数倍,"
@@ -4138,8 +4138,8 @@ public class SessionVariable implements Serializable, Writable {
         return groupCommit;
     }
 
-    public boolean isEnableExecStmtAuditLog() {
-        return enableExecStmtAuditLog;
+    public boolean isEnablePreparedStmtAuditLog() {
+        return enablePreparedStmtAuditLog;
     }
 
     public boolean isEnableMaterializedViewRewrite() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -473,7 +473,10 @@ public class SessionVariable implements Serializable, Writable {
     public static final String EXTERNAL_TABLE_ANALYZE_PART_NUM = "external_table_analyze_part_num";
 
     public static final String ENABLE_STRONG_CONSISTENCY = "enable_strong_consistency_read";
+
     public static final String GROUP_COMMIT = "group_commit";
+
+    public static final String ENABLE_AUDIT_LOG = "enable_audit_log";
 
     public static final String PARALLEL_SYNC_ANALYZE_TASK_NUM = "parallel_sync_analyze_task_num";
 
@@ -1678,6 +1681,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = GROUP_COMMIT, needForward = true)
     public String groupCommit = "off_mode";
+
+    @VariableMgr.VarAttr(name = ENABLE_AUDIT_LOG, needForward = true)
+    public boolean enableAuditLog = true;
 
     @VariableMgr.VarAttr(name = INVERTED_INDEX_CONJUNCTION_OPT_THRESHOLD,
             description = {"在match_all中求取多个倒排索引的交集时,如果最大的倒排索引中的总数是最小倒排索引中的总数的整数倍,"
@@ -4130,6 +4136,10 @@ public class SessionVariable implements Serializable, Writable {
             return "sync_mode";
         }
         return groupCommit;
+    }
+
+    public boolean isEnableAuditLog() {
+        return enableAuditLog;
     }
 
     public boolean isEnableMaterializedViewRewrite() {


### PR DESCRIPTION
## Proposed changes

For the `insert into` statements during group commit load via JDBC. Printing audit logs can severely impact performance. Therefore, we have introduced a session variable to control whether to print audit logs. It is recommended to turn off audit logs only during group commit load via JDBC.

`enable_prepared_stmt_audit_log=false`

<!--Describe your changes.-->

