### PR TITLE
[fix](nereids) optimize cost model to make join order good for runtime filter when stats is not available

### DIFF
--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query10.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query10.out
@@ -12,9 +12,9 @@ PhysicalResultSink
 ------------------filter((ifnull($c$1, FALSE) OR ifnull($c$2, FALSE)))
 --------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer] apply RFs: RF4
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF5
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 ------------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-----------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalOlapScan[customer_demographics]
+------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------PhysicalProject
+----------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+------------------------------PhysicalOlapScan[customer_address]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query17.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query17.out
@@ -9,36 +9,36 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_quarter_name = '2001Q1'))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------------filter((d1.d_quarter_name = '2001Q1'))
 ------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store]
+--------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------PhysicalOlapScan[date_dim]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[item]
+----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query18.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query18.out
@@ -10,33 +10,33 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cs_bill_customer_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
+----------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[cs_bill_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF4
+--------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF5
 ------------------------------------------PhysicalProject
---------------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
-----------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
+----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 --------------------------------------PhysicalProject
-----------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
-------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
 --------------------------------filter(ca_state IN ('GA', 'IN', 'ME', 'NC', 'OK', 'WA', 'WY'))
 ----------------------------------PhysicalOlapScan[customer_address]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 1998))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 1998))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query19.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query19.out
@@ -11,25 +11,25 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5))))
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer]
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_manager_id = 2))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
+------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
+--------------------------filter((item.i_manager_id = 2))
+----------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query22.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query22.out
@@ -10,14 +10,14 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[inv_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[inv_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[inventory] apply RFs: RF0
+----------------------------PhysicalOlapScan[inventory] apply RFs: RF1
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query23.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query23.out
@@ -8,16 +8,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ----------------------PhysicalProject
-------------------------filter(d_year IN (2000, 2001, 2002, 2003))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[item]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------filter(d_year IN (2000, 2001, 2002, 2003))
+----------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#2 )
 ----PhysicalCteProducer ( cteId=CTEId#2 )
 ------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query24.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query24.out
@@ -7,28 +7,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk) and (store.s_zip = customer_address.ca_zip)) otherCondition=(( not (c_birth_country = upper(ca_country))))
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_zip->[ca_zip];RF6 s_store_sk->[ss_store_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF6
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter((store.s_market_id = 8))
---------------------------------PhysicalOlapScan[store]
+------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[item]
+--------------------------PhysicalOlapScan[customer] apply RFs: RF4
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[customer]
+----------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((store.s_market_id = 8))
+--------------------PhysicalOlapScan[store]
 --PhysicalResultSink
 ----PhysicalQuickSort[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query25.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query25.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+----------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query26.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query26.out
@@ -10,21 +10,21 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[cs_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF3
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF3
 ------------------------------PhysicalProject
 --------------------------------filter((customer_demographics.cd_education_status = 'Unknown') and (customer_demographics.cd_gender = 'M') and (customer_demographics.cd_marital_status = 'S'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query27.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query27.out
@@ -10,24 +10,24 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3
 ----------------------------------PhysicalProject
 ------------------------------------filter((customer_demographics.cd_education_status = 'Secondary') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'D'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
-----------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
-------------------------------PhysicalOlapScan[store]
+----------------------------filter((date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
+--------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query29.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query29.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter(d_year IN (1999, 2000, 2001))
+----------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter(d_year IN (1999, 2000, 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query30.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query30.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[wr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[web_returns] apply RFs: RF0
+----------------------PhysicalOlapScan[web_returns] apply RFs: RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query31.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query31.out
@@ -6,32 +6,32 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[LOCAL]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+--------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ------------------PhysicalProject
---------------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
-----------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalOlapScan[customer_address]
 --------------PhysicalProject
-----------------PhysicalOlapScan[customer_address]
+----------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
+------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#1 )
 ----PhysicalCteProducer ( cteId=CTEId#1 )
 ------hashAgg[GLOBAL]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ws_sold_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------PhysicalOlapScan[web_sales] apply RFs: RF3
 --------------------PhysicalProject
-----------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
+--------------------PhysicalOlapScan[date_dim]
 ----PhysicalResultSink
 ------PhysicalQuickSort[MERGE_SORT]
 --------PhysicalDistribute[DistributionSpecGather]
@@ -42,10 +42,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL)))
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -53,6 +50,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 )

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query33.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query33.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query36.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query36.out
@@ -17,16 +17,16 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
 ----------------------------------------PhysicalProject
-------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[item]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((d1.d_year = 2002))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
 ----------------------------------filter(s_state IN ('AL', 'GA', 'MI', 'MO', 'OH', 'SC', 'SD', 'TN'))
 ------------------------------------PhysicalOlapScan[store]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query47.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=()
 --------------------PhysicalProject
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query56.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query56.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query60.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query60.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query61.out
@@ -12,26 +12,26 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF8 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF7 p_promo_sk->[ss_promo_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 p_promo_sk->[ss_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_store_sk->[ss_store_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF7 RF8 RF10
 --------------------------------------PhysicalProject
-----------------------------------------filter((store.s_gmt_offset = -7.00))
-------------------------------------------PhysicalOlapScan[store]
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF9
 ----------------------------------PhysicalProject
-------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
---------------------------------------PhysicalOlapScan[promotion]
+------------------------------------filter((store.s_gmt_offset = -7.00))
+--------------------------------------PhysicalOlapScan[store]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
+----------------------------------PhysicalOlapScan[promotion]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF9
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]
@@ -46,21 +46,21 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk]
+--------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------PhysicalProject
-------------------------------------filter((store.s_gmt_offset = -7.00))
---------------------------------------PhysicalOlapScan[store]
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((store.s_gmt_offset = -7.00))
+----------------------------------PhysicalOlapScan[store]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query64.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query64.out
@@ -29,37 +29,37 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=()
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
+--------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
+----------------------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF4 RF5 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF19
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF4 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF5 RF19
 ------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------filter((sale > (2 * refund)))
-----------------------------------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF19
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
+--------------------------------------------------------------------------PhysicalOlapScan[customer]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------filter(d_year IN (2001, 2002))
-------------------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF19
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[customer]
+--------------------------------------------------------------PhysicalOlapScan[store]
 --------------------------------------------------------PhysicalProject
 ----------------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query69.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query69.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 --------------------------------PhysicalProject
@@ -24,7 +24,7 @@ PhysicalResultSink
 --------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF4
+----------------------------------PhysicalOlapScan[customer] apply RFs: RF5
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 ----------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query7.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query7.out
@@ -10,21 +10,21 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[ss_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF3
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3
 ------------------------------PhysicalProject
 --------------------------------filter((customer_demographics.cd_education_status = 'College') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'W'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query72.out
@@ -8,13 +8,13 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2)))
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk) and (d1.d_week_seq = d2.d_week_seq)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF7 d_week_seq->[d_week_seq];RF8 d_date_sk->[cs_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF6 hd_demo_sk->[cs_bill_hdemo_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[cs_bill_hdemo_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,13 +23,13 @@ PhysicalResultSink
 ----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=()
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity))
-----------------------------------------------PhysicalOlapScan[inventory]
+----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF4
 ----------------------------------------------PhysicalProject
 ------------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 --------------------------------------------------PhysicalProject
 ----------------------------------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF6 RF8
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[promotion]
 --------------------------------------------------PhysicalProject
@@ -42,13 +42,13 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_marital_status = 'W'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
-----------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 --------------------------PhysicalProject
-----------------------------filter((d1.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[date_dim]
+------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
+--------------------------PhysicalOlapScan[household_demographics]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[date_dim]
+--------------------filter((d1.d_year = 2002))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query75.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query75.out
@@ -11,55 +11,55 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------PhysicalUnion
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[catalog_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[web_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query80.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query80.out
@@ -48,20 +48,20 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 ------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF6 RF7
+--------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[catalog_returns]
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
-------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------PhysicalOlapScan[catalog_page]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_page]
+------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
+--------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalProject
 --------------------------------------filter((item.i_current_price > 50.00))
 ----------------------------------------PhysicalOlapScan[item]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query81.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query81.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF0
+----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query84.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query84.out
@@ -13,16 +13,16 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[c_current_hdemo_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=()
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer] apply RFs: RF0 RF2
+------------------------------PhysicalOlapScan[customer] apply RFs: RF1 RF2
 ----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_city = 'Oakwood'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter((customer_address.ca_city = 'Oakwood'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query85.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query85.out
@@ -15,25 +15,25 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=((((ca_state IN ('DE', 'FL', 'TX') AND ((web_sales.ws_net_profit >= 100.00) AND (web_sales.ws_net_profit <= 200.00))) OR (ca_state IN ('ID', 'IN', 'ND') AND ((web_sales.ws_net_profit >= 150.00) AND (web_sales.ws_net_profit <= 300.00)))) OR (ca_state IN ('IL', 'MT', 'OH') AND ((web_sales.ws_net_profit >= 50.00) AND (web_sales.ws_net_profit <= 250.00))))) build RFs:RF7 ca_address_sk->[wr_refunded_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status) and (cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk) and (cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF4 cd_marital_status->[cd_marital_status];RF5 cd_education_status->[cd_education_status];RF6 cd_demo_sk->[wr_refunded_cdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF3 cd_demo_sk->[wr_refunded_cdemo_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[wr_returning_cdemo_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF0 ws_item_sk->[wr_item_sk];RF1 ws_order_number->[wr_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF7
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF6 RF7
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((web_sales.ws_net_profit <= 300.00) and (web_sales.ws_net_profit >= 50.00) and (web_sales.ws_sales_price <= 200.00) and (web_sales.ws_sales_price >= 50.00))
 ------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF8
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[web_page]
 ------------------------------------PhysicalProject
---------------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
-----------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
+------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query86.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query86.out
@@ -15,14 +15,14 @@ PhysicalResultSink
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalRepeat
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[item]
+----------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
+------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query91.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query91.out
@@ -15,9 +15,9 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[cr_returning_customer_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cr_returning_customer_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_call_center_sk = call_center.cc_call_center_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
@@ -25,10 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[call_center]
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
+----------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
+------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query10.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query10.out
@@ -12,9 +12,9 @@ PhysicalResultSink
 ------------------filter((ifnull($c$1, FALSE) OR ifnull($c$2, FALSE)))
 --------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-----------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalOlapScan[customer_demographics]
+------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------PhysicalProject
+----------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+------------------------------PhysicalOlapScan[customer_address]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query17.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query17.out
@@ -9,36 +9,36 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_quarter_name = '2001Q1'))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------------filter((d1.d_quarter_name = '2001Q1'))
 ------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store]
+--------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------PhysicalOlapScan[date_dim]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[item]
+----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query18.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query18.out
@@ -10,33 +10,33 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[cs_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[cs_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[c_current_cdemo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cs_bill_customer_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF1 cd_demo_sk->[c_current_cdemo_sk]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
+----------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[cs_bill_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF4 RF5
+--------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF4 RF5
 ------------------------------------------PhysicalProject
---------------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
-----------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
+----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF1 RF3
 --------------------------------------PhysicalProject
-----------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
-------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2 RF3
+----------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
 --------------------------------filter(ca_state IN ('GA', 'IN', 'ME', 'NC', 'OK', 'WA', 'WY'))
 ----------------------------------PhysicalOlapScan[customer_address]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 1998))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 1998))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query19.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query19.out
@@ -11,25 +11,25 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3 RF4
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_manager_id = 2))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
+--------------------------filter((item.i_manager_id = 2))
+----------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query22.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query22.out
@@ -10,14 +10,14 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[inv_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[inv_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[inv_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[inv_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query23.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query23.out
@@ -8,16 +8,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ss_item_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 ----------------------PhysicalProject
-------------------------filter(d_year IN (2000, 2001, 2002, 2003))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[item]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------filter(d_year IN (2000, 2001, 2002, 2003))
+----------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#2 )
 ----PhysicalCteProducer ( cteId=CTEId#2 )
 ------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query24.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query24.out
@@ -7,28 +7,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk) and (store.s_zip = customer_address.ca_zip)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF5 ca_address_sk->[c_current_addr_sk];RF6 ca_zip->[s_zip]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_zip->[ca_zip];RF6 s_store_sk->[ss_store_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_ticket_number->[ss_ticket_number];RF1 sr_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF6
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF2
 ----------------------------PhysicalProject
-------------------------------filter((store.s_market_id = 8))
---------------------------------PhysicalOlapScan[store] apply RFs: RF6
+------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[item]
+--------------------------PhysicalOlapScan[customer] apply RFs: RF4
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[customer] apply RFs: RF5
+----------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((store.s_market_id = 8))
+--------------------PhysicalOlapScan[store]
 --PhysicalResultSink
 ----PhysicalQuickSort[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query25.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query25.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+----------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query26.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query26.out
@@ -10,9 +10,9 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[cs_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[cs_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
 ------------------------------PhysicalProject
@@ -21,10 +21,10 @@ PhysicalResultSink
 --------------------------------filter((customer_demographics.cd_education_status = 'Unknown') and (customer_demographics.cd_gender = 'M') and (customer_demographics.cd_marital_status = 'S'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query27.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query27.out
@@ -10,11 +10,11 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,11 +23,11 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_education_status = 'Secondary') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'D'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
-----------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
-------------------------------PhysicalOlapScan[store]
+----------------------------filter((date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
+--------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query29.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query29.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter(d_year IN (1999, 2000, 2001))
+----------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter(d_year IN (1999, 2000, 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query30.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query30.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[wr_returning_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[wr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[wr_returning_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query31.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query31.out
@@ -6,32 +6,32 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[LOCAL]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[ss_addr_sk]
 ------------------PhysicalProject
 --------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 ------------------PhysicalProject
---------------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
-----------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalOlapScan[customer_address]
 --------------PhysicalProject
-----------------PhysicalOlapScan[customer_address]
+----------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
+------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#1 )
 ----PhysicalCteProducer ( cteId=CTEId#1 )
 ------hashAgg[GLOBAL]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[ws_bill_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ws_sold_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ws_bill_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
 --------------------PhysicalProject
-----------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
+--------------------PhysicalOlapScan[date_dim]
 ----PhysicalResultSink
 ------PhysicalQuickSort[MERGE_SORT]
 --------PhysicalDistribute[DistributionSpecGather]
@@ -42,10 +42,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL)))
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -53,6 +50,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 )

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query33.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query33.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query36.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query36.out
@@ -17,16 +17,16 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
 ----------------------------------------PhysicalProject
-------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[item]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((d1.d_year = 2002))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
 ----------------------------------filter(s_state IN ('AL', 'GA', 'MI', 'MO', 'OH', 'SC', 'SD', 'TN'))
 ------------------------------------PhysicalOlapScan[store]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query47.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=()
 --------------------PhysicalProject
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query56.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query56.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query60.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query60.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query61.out
@@ -12,26 +12,26 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF8 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF7 p_promo_sk->[ss_promo_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 p_promo_sk->[ss_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_store_sk->[ss_store_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF7 RF8 RF10
 --------------------------------------PhysicalProject
-----------------------------------------filter((store.s_gmt_offset = -7.00))
-------------------------------------------PhysicalOlapScan[store]
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF9
 ----------------------------------PhysicalProject
-------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
---------------------------------------PhysicalOlapScan[promotion]
+------------------------------------filter((store.s_gmt_offset = -7.00))
+--------------------------------------PhysicalOlapScan[store]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
+----------------------------------PhysicalOlapScan[promotion]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF9
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]
@@ -46,21 +46,21 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk]
+--------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------PhysicalProject
-------------------------------------filter((store.s_gmt_offset = -7.00))
---------------------------------------PhysicalOlapScan[store]
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((store.s_gmt_offset = -7.00))
+----------------------------------PhysicalOlapScan[store]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query64.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query64.out
@@ -29,37 +29,37 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[c_first_sales_date_sk]
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->[ss_customer_sk]
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF7 s_store_sk->[ss_store_sk]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
+--------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
+----------------------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
 ------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF2 sr_item_sk->[ss_item_sk];RF3 sr_ticket_number->[ss_ticket_number]
 ----------------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4 RF5 RF6 RF7 RF10 RF12 RF13 RF15 RF19
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF4 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF5 RF19
 ------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------filter((sale > (2 * refund)))
-----------------------------------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF19
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
+--------------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF8 RF9 RF11 RF14 RF16
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------filter(d_year IN (2001, 2002))
-------------------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF19
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF8 RF9 RF11 RF14 RF16
+--------------------------------------------------------------PhysicalOlapScan[store]
 --------------------------------------------------------PhysicalProject
 ----------------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query69.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query69.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 --------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query7.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query7.out
@@ -10,9 +10,9 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[ss_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ------------------------------PhysicalProject
@@ -21,10 +21,10 @@ PhysicalResultSink
 --------------------------------filter((customer_demographics.cd_education_status = 'College') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'W'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query72.out
@@ -8,13 +8,13 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF8 d_date_sk->[cs_ship_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk) and (d1.d_week_seq = d2.d_week_seq)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF7 d_week_seq->[d_week_seq];RF8 d_date_sk->[cs_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq];RF7 d_date_sk->[inv_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF6 hd_demo_sk->[cs_bill_hdemo_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_ship_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[cs_bill_hdemo_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,13 +23,13 @@ PhysicalResultSink
 ----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=() build RFs:RF1 w_warehouse_sk->[inv_warehouse_sk]
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)) build RFs:RF0 cs_item_sk->[inv_item_sk]
-----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1 RF2 RF7
+----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------------------PhysicalProject
 ------------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 --------------------------------------------------PhysicalProject
 ----------------------------------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3 RF4 RF5 RF8
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3 RF5 RF6 RF8
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[promotion]
 --------------------------------------------------PhysicalProject
@@ -42,13 +42,13 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_marital_status = 'W'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
-----------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 --------------------------PhysicalProject
-----------------------------filter((d1.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim] apply RFs: RF6
+----------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[date_dim]
+------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
+--------------------------PhysicalOlapScan[household_demographics]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[date_dim]
+--------------------filter((d1.d_year = 2002))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query75.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query75.out
@@ -11,55 +11,55 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------PhysicalUnion
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[catalog_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[web_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query80.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query80.out
@@ -48,9 +48,9 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF5 cp_catalog_page_sk->[cs_catalog_page_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF4 cp_catalog_page_sk->[cs_catalog_page_sk]
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 ------------------------------------------------PhysicalProject
@@ -58,10 +58,10 @@ PhysicalResultSink
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[catalog_returns]
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
-------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------PhysicalOlapScan[catalog_page]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_page]
+------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
+--------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalProject
 --------------------------------------filter((item.i_current_price > 50.00))
 ----------------------------------------PhysicalOlapScan[item]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query81.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query81.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[cr_returning_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[cr_returning_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF0 RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query84.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query84.out
@@ -13,16 +13,16 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[c_current_hdemo_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 cd_demo_sk->[c_current_cdemo_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer] apply RFs: RF0 RF1 RF2
 ----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_city = 'Oakwood'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter((customer_address.ca_city = 'Oakwood'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query85.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query85.out
@@ -15,25 +15,25 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=((((ca_state IN ('DE', 'FL', 'TX') AND ((web_sales.ws_net_profit >= 100.00) AND (web_sales.ws_net_profit <= 200.00))) OR (ca_state IN ('ID', 'IN', 'ND') AND ((web_sales.ws_net_profit >= 150.00) AND (web_sales.ws_net_profit <= 300.00)))) OR (ca_state IN ('IL', 'MT', 'OH') AND ((web_sales.ws_net_profit >= 50.00) AND (web_sales.ws_net_profit <= 250.00))))) build RFs:RF7 ca_address_sk->[wr_refunded_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status) and (cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[wr_returning_cdemo_sk];RF5 cd_marital_status->[cd_marital_status];RF6 cd_education_status->[cd_education_status]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk) and (cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF4 cd_marital_status->[cd_marital_status];RF5 cd_education_status->[cd_education_status];RF6 cd_demo_sk->[wr_refunded_cdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF3 cd_demo_sk->[wr_refunded_cdemo_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[wr_returning_cdemo_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF2 wp_web_page_sk->[ws_web_page_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF0 ws_item_sk->[wr_item_sk];RF1 ws_order_number->[wr_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF4 RF7 RF9
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF6 RF7 RF9
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((web_sales.ws_net_profit <= 300.00) and (web_sales.ws_net_profit >= 50.00) and (web_sales.ws_sales_price <= 200.00) and (web_sales.ws_sales_price >= 50.00))
 ------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF8
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[web_page]
 ------------------------------------PhysicalProject
---------------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
-----------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5 RF6
+--------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
+------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query86.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query86.out
@@ -15,14 +15,14 @@ PhysicalResultSink
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalRepeat
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ws_item_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[item]
+----------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
+------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query91.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query91.out
@@ -15,9 +15,9 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[cr_returning_customer_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cr_returning_customer_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_call_center_sk = call_center.cc_call_center_sk)) otherCondition=() build RFs:RF0 cc_call_center_sk->[cr_call_center_sk]
 ----------------------------------------PhysicalProject
@@ -25,10 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[call_center]
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
+----------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
+------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query10.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query10.out
@@ -12,9 +12,9 @@ PhysicalResultSink
 ------------------filter((ifnull($c$1, FALSE) OR ifnull($c$2, FALSE)))
 --------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer] apply RFs: RF4
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF5
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 ------------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-----------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalOlapScan[customer_demographics]
+------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------PhysicalProject
+----------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+------------------------------PhysicalOlapScan[customer_address]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query17.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query17.out
@@ -9,36 +9,36 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_quarter_name = '2001Q1'))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------------filter((d1.d_quarter_name = '2001Q1'))
 ------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store]
+--------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------PhysicalOlapScan[date_dim]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[item]
+----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query18.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query18.out
@@ -10,33 +10,33 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cs_bill_customer_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
+----------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[cs_bill_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF4
+--------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF5
 ------------------------------------------PhysicalProject
---------------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
-----------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
+----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 --------------------------------------PhysicalProject
-----------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
-------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
 --------------------------------filter(ca_state IN ('GA', 'IN', 'ME', 'NC', 'OK', 'WA', 'WY'))
 ----------------------------------PhysicalOlapScan[customer_address]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 1998))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 1998))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query19.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query19.out
@@ -11,25 +11,25 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5))))
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer]
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_manager_id = 2))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
+------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
+--------------------------filter((item.i_manager_id = 2))
+----------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query22.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query22.out
@@ -10,14 +10,14 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[inv_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[inv_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[inventory] apply RFs: RF0
+----------------------------PhysicalOlapScan[inventory] apply RFs: RF1
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query23.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query23.out
@@ -8,16 +8,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ----------------------PhysicalProject
-------------------------filter(d_year IN (2000, 2001, 2002, 2003))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[item]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------filter(d_year IN (2000, 2001, 2002, 2003))
+----------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#2 )
 ----PhysicalCteProducer ( cteId=CTEId#2 )
 ------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query24.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query24.out
@@ -7,28 +7,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk) and (store.s_zip = customer_address.ca_zip)) otherCondition=(( not (c_birth_country = upper(ca_country))))
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_zip->[ca_zip];RF6 s_store_sk->[ss_store_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF6
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter((store.s_market_id = 8))
---------------------------------PhysicalOlapScan[store]
+------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[item]
+--------------------------PhysicalOlapScan[customer] apply RFs: RF4
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[customer]
+----------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((store.s_market_id = 8))
+--------------------PhysicalOlapScan[store]
 --PhysicalResultSink
 ----PhysicalQuickSort[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query25.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query25.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+----------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query26.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query26.out
@@ -10,21 +10,21 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[cs_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF3
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF3
 ------------------------------PhysicalProject
 --------------------------------filter((customer_demographics.cd_education_status = 'Unknown') and (customer_demographics.cd_gender = 'M') and (customer_demographics.cd_marital_status = 'S'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query27.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query27.out
@@ -10,24 +10,24 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
+------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3
 ----------------------------------PhysicalProject
 ------------------------------------filter((customer_demographics.cd_education_status = 'Secondary') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'D'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
-----------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
-------------------------------PhysicalOlapScan[store]
+----------------------------filter((date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
+--------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query29.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query29.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4 RF6
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter(d_year IN (1999, 2000, 2001))
+----------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter(d_year IN (1999, 2000, 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query30.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query30.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[wr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[web_returns] apply RFs: RF0
+----------------------PhysicalOlapScan[web_returns] apply RFs: RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query31.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query31.out
@@ -6,32 +6,32 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[LOCAL]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+--------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ------------------PhysicalProject
---------------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
-----------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalOlapScan[customer_address]
 --------------PhysicalProject
-----------------PhysicalOlapScan[customer_address]
+----------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
+------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#1 )
 ----PhysicalCteProducer ( cteId=CTEId#1 )
 ------hashAgg[GLOBAL]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ws_sold_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------PhysicalOlapScan[web_sales] apply RFs: RF3
 --------------------PhysicalProject
-----------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
+--------------------PhysicalOlapScan[date_dim]
 ----PhysicalResultSink
 ------PhysicalQuickSort[MERGE_SORT]
 --------PhysicalDistribute[DistributionSpecGather]
@@ -42,10 +42,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL)))
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -53,6 +50,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 )

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query33.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query33.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query36.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query36.out
@@ -17,16 +17,16 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
 ----------------------------------------PhysicalProject
-------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[item]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((d1.d_year = 2002))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
 ----------------------------------filter(s_state IN ('AL', 'GA', 'MI', 'MO', 'OH', 'SC', 'SD', 'TN'))
 ------------------------------------PhysicalOlapScan[store]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query47.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=()
 --------------------PhysicalProject
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query56.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query56.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query60.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query60.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query61.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query61.out
@@ -12,26 +12,26 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF8 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF7 p_promo_sk->[ss_promo_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 p_promo_sk->[ss_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_store_sk->[ss_store_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF7 RF8 RF10
 --------------------------------------PhysicalProject
-----------------------------------------filter((store.s_gmt_offset = -7.00))
-------------------------------------------PhysicalOlapScan[store]
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF9
 ----------------------------------PhysicalProject
-------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
---------------------------------------PhysicalOlapScan[promotion]
+------------------------------------filter((store.s_gmt_offset = -7.00))
+--------------------------------------PhysicalOlapScan[store]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
+----------------------------------PhysicalOlapScan[promotion]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF9
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]
@@ -46,21 +46,21 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk]
+--------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------PhysicalProject
-------------------------------------filter((store.s_gmt_offset = -7.00))
---------------------------------------PhysicalOlapScan[store]
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((store.s_gmt_offset = -7.00))
+----------------------------------PhysicalOlapScan[store]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query64.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query64.out
@@ -29,37 +29,37 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=()
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=()
+--------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
+----------------------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF4 RF5 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF19
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF4 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF5 RF19
 ------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------filter((sale > (2 * refund)))
-----------------------------------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF19
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
+--------------------------------------------------------------------------PhysicalOlapScan[customer]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------filter(d_year IN (2001, 2002))
-------------------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF19
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[customer]
+--------------------------------------------------------------PhysicalOlapScan[store]
 --------------------------------------------------------PhysicalProject
 ----------------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query69.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query69.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 --------------------------------PhysicalProject
@@ -24,7 +24,7 @@ PhysicalResultSink
 --------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF4
+----------------------------------PhysicalOlapScan[customer] apply RFs: RF5
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 ----------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query7.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query7.out
@@ -10,21 +10,21 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[ss_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF3
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3
 ------------------------------PhysicalProject
 --------------------------------filter((customer_demographics.cd_education_status = 'College') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'W'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query72.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query72.out
@@ -8,13 +8,13 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2)))
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk) and (d1.d_week_seq = d2.d_week_seq)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF7 d_week_seq->[d_week_seq];RF8 d_date_sk->[cs_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=()
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF6 hd_demo_sk->[cs_bill_hdemo_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[cs_bill_hdemo_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,13 +23,13 @@ PhysicalResultSink
 ----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=()
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity))
-----------------------------------------------PhysicalOlapScan[inventory]
+----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF4
 ----------------------------------------------PhysicalProject
 ------------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 --------------------------------------------------PhysicalProject
 ----------------------------------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4 RF5
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF6 RF8
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[promotion]
 --------------------------------------------------PhysicalProject
@@ -42,13 +42,13 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_marital_status = 'W'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
-----------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 --------------------------PhysicalProject
-----------------------------filter((d1.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[date_dim]
+------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
+--------------------------PhysicalOlapScan[household_demographics]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[date_dim]
+--------------------filter((d1.d_year = 2002))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query75.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query75.out
@@ -11,55 +11,55 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------PhysicalUnion
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[catalog_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[web_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query80.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query80.out
@@ -48,20 +48,20 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=()
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 ------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF6 RF7
+--------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[catalog_returns]
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
-------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------PhysicalOlapScan[catalog_page]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_page]
+------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
+--------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalProject
 --------------------------------------filter((item.i_current_price > 50.00))
 ----------------------------------------PhysicalOlapScan[item]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query81.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query81.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF0
+----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query84.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query84.out
@@ -13,16 +13,16 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[c_current_hdemo_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=()
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer] apply RFs: RF0 RF2
+------------------------------PhysicalOlapScan[customer] apply RFs: RF1 RF2
 ----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_city = 'Oakwood'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter((customer_address.ca_city = 'Oakwood'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query85.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query85.out
@@ -15,25 +15,25 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=((((ca_state IN ('DE', 'FL', 'TX') AND ((web_sales.ws_net_profit >= 100.00) AND (web_sales.ws_net_profit <= 200.00))) OR (ca_state IN ('ID', 'IN', 'ND') AND ((web_sales.ws_net_profit >= 150.00) AND (web_sales.ws_net_profit <= 300.00)))) OR (ca_state IN ('IL', 'MT', 'OH') AND ((web_sales.ws_net_profit >= 50.00) AND (web_sales.ws_net_profit <= 250.00))))) build RFs:RF7 ca_address_sk->[wr_refunded_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status) and (cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk) and (cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF4 cd_marital_status->[cd_marital_status];RF5 cd_education_status->[cd_education_status];RF6 cd_demo_sk->[wr_refunded_cdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF3 cd_demo_sk->[wr_refunded_cdemo_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[wr_returning_cdemo_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF0 ws_item_sk->[wr_item_sk];RF1 ws_order_number->[wr_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF7
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF6 RF7
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((web_sales.ws_net_profit <= 300.00) and (web_sales.ws_net_profit >= 50.00) and (web_sales.ws_sales_price <= 200.00) and (web_sales.ws_sales_price >= 50.00))
 ------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF8
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[web_page]
 ------------------------------------PhysicalProject
---------------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
-----------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
+------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query86.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query86.out
@@ -15,14 +15,14 @@ PhysicalResultSink
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalRepeat
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=()
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=()
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[item]
+----------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
+------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query91.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/noStatsRfPrune/query91.out
@@ -15,9 +15,9 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[cr_returning_customer_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cr_returning_customer_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_call_center_sk = call_center.cc_call_center_sk)) otherCondition=()
 ----------------------------------------PhysicalProject
@@ -25,10 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[call_center]
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
+----------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
+------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query10.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query10.out
@@ -12,9 +12,9 @@ PhysicalResultSink
 ------------------filter((ifnull($c$1, FALSE) OR ifnull($c$2, FALSE)))
 --------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-----------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalOlapScan[customer_demographics]
+------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------PhysicalProject
+----------------------------filter(ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+------------------------------PhysicalOlapScan[customer_address]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 --------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query17.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query17.out
@@ -9,36 +9,36 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+----------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+----------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_quarter_name = '2001Q1'))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------------filter((d1.d_quarter_name = '2001Q1'))
 ------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store]
+--------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+----------------------------PhysicalOlapScan[date_dim]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[item]
+----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query18.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query18.out
@@ -10,33 +10,33 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[cs_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[cs_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[c_current_cdemo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cs_bill_customer_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF1 cd_demo_sk->[c_current_cdemo_sk]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
+----------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[cs_bill_customer_sk]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF4 RF5
+--------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF2 RF4 RF5
 ------------------------------------------PhysicalProject
---------------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
-----------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
+----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF1 RF3
 --------------------------------------PhysicalProject
-----------------------------------------filter(c_birth_month IN (1, 10, 2, 4, 7, 8))
-------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2 RF3
+----------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------filter((cd1.cd_education_status = 'Advanced Degree') and (cd1.cd_gender = 'F'))
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
 --------------------------------filter(ca_state IN ('GA', 'IN', 'ME', 'NC', 'OK', 'WA', 'WY'))
 ----------------------------------PhysicalOlapScan[customer_address]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 1998))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 1998))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query19.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query19.out
@@ -11,25 +11,25 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF2 RF3 RF4
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_manager_id = 2))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1999))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
+--------------------------filter((item.i_manager_id = 2))
+----------------------------PhysicalOlapScan[item]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query22.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query22.out
@@ -10,14 +10,14 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[inv_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[inv_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[inv_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[inv_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_month_seq <= 1199) and (date_dim.d_month_seq >= 1188))
+--------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query23.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query23.out
@@ -8,16 +8,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ss_item_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 ----------------------PhysicalProject
-------------------------filter(d_year IN (2000, 2001, 2002, 2003))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[item]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------filter(d_year IN (2000, 2001, 2002, 2003))
+----------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#2 )
 ----PhysicalCteProducer ( cteId=CTEId#2 )
 ------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query24.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query24.out
@@ -7,28 +7,28 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk) and (store.s_zip = customer_address.ca_zip)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF5 ca_address_sk->[c_current_addr_sk];RF6 ca_zip->[s_zip]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_zip->[ca_zip];RF6 s_store_sk->[ss_store_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_ticket_number->[ss_ticket_number];RF1 sr_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF6
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF2
 ----------------------------PhysicalProject
-------------------------------filter((store.s_market_id = 8))
---------------------------------PhysicalOlapScan[store] apply RFs: RF6
+------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[item]
+--------------------------PhysicalOlapScan[customer] apply RFs: RF4
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[customer] apply RFs: RF5
+----------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((store.s_market_id = 8))
+--------------------PhysicalOlapScan[store]
 --PhysicalResultSink
 ----PhysicalQuickSort[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query25.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query25.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 2000))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+----------------------------filter((d2.d_moy <= 10) and (d2.d_moy >= 4) and (d2.d_year = 2000))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter((d3.d_moy <= 10) and (d3.d_moy >= 4) and (d3.d_year = 2000))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query26.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query26.out
@@ -10,9 +10,9 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[cs_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[cs_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
 ------------------------------PhysicalProject
@@ -21,10 +21,10 @@ PhysicalResultSink
 --------------------------------filter((customer_demographics.cd_education_status = 'Unknown') and (customer_demographics.cd_gender = 'M') and (customer_demographics.cd_marital_status = 'S'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query27.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query27.out
@@ -10,11 +10,11 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,11 +23,11 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_education_status = 'Secondary') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'D'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
-----------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
-------------------------------PhysicalOlapScan[store]
+----------------------------filter((date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter(s_state IN ('AL', 'LA', 'MI', 'MO', 'SC', 'TN'))
+--------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query29.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query29.out
@@ -8,36 +8,36 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF9 i_item_sk->[sr_item_sk,ss_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF9 s_store_sk->[ss_store_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF8 s_store_sk->[ss_store_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[sr_returned_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk) and (store_returns.sr_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF3 cs_bill_customer_sk->[sr_customer_sk,ss_customer_sk];RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF0 sr_customer_sk->[ss_customer_sk];RF1 sr_item_sk->[ss_item_sk];RF2 sr_ticket_number->[ss_ticket_number]
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF8 RF9
+--------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4 RF5 RF6 RF9
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF6 RF9
+--------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF3 RF4 RF5 RF7
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF7
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF8
 ----------------------------------PhysicalProject
-------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[item]
 ------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
+--------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
 ----------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------filter(d_year IN (1999, 2000, 2001))
+----------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+------------------------filter(d_year IN (1999, 2000, 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query30.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query30.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[wr_returning_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[wr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[wr_returning_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query31.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query31.out
@@ -6,32 +6,32 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[LOCAL]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[ss_addr_sk]
 ------------------PhysicalProject
 --------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 ------------------PhysicalProject
---------------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
-----------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalOlapScan[customer_address]
 --------------PhysicalProject
-----------------PhysicalOlapScan[customer_address]
+----------------filter((ss.d_year = 2000) and d_qoy IN (1, 2, 3))
+------------------PhysicalOlapScan[date_dim]
 --PhysicalCteAnchor ( cteId=CTEId#1 )
 ----PhysicalCteProducer ( cteId=CTEId#1 )
 ------hashAgg[GLOBAL]
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[ws_bill_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ws_sold_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ws_bill_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3
 --------------------PhysicalProject
-----------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((ws.d_year = 2000) and d_qoy IN (1, 2, 3))
+--------------------PhysicalOlapScan[date_dim]
 ----PhysicalResultSink
 ------PhysicalQuickSort[MERGE_SORT]
 --------PhysicalDistribute[DistributionSpecGather]
@@ -42,10 +42,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL)))
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=()
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=()
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -53,6 +50,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 )

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query33.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query33.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF0 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF4 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Home'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_manufact_id = item.i_manufact_id)) otherCondition=() build RFs:RF8 i_manufact_id->[i_manufact_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 2002))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query36.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query36.out
@@ -17,16 +17,16 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ss_item_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
 ----------------------------------------PhysicalProject
-------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[item]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((d1.d_year = 2002))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
 ----------------------------------filter(s_state IN ('AL', 'GA', 'MI', 'MO', 'OH', 'SC', 'SD', 'TN'))
 ------------------------------------PhysicalOlapScan[store]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query47.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=()
 --------------------PhysicalProject
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query56.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query56.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('cyan', 'green', 'powder'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 2) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query60.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query60.out
@@ -13,71 +13,71 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[ss_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF0
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF0 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[cs_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 ca_address_sk->[cs_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[cs_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5 RF6 RF7
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF4
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF4 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF4
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[ws_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF10 ca_address_sk->[ws_bill_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[ws_bill_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------------PhysicalOlapScan[customer_address]
-----------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF8
-------------------------------PhysicalProject
---------------------------------filter((item.i_category = 'Children'))
-----------------------------------PhysicalOlapScan[item]
+--------------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=() build RFs:RF8 i_item_id->[i_item_id]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item] apply RFs: RF8
+----------------------------------PhysicalProject
+------------------------------------filter((item.i_category = 'Children'))
+--------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query61.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query61.out
@@ -12,26 +12,26 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF8 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF7 p_promo_sk->[ss_promo_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF6 p_promo_sk->[ss_promo_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF5 s_store_sk->[ss_store_sk]
+------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->[ss_customer_sk]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6 RF7 RF8 RF10
 --------------------------------------PhysicalProject
-----------------------------------------filter((store.s_gmt_offset = -7.00))
-------------------------------------------PhysicalOlapScan[store]
+----------------------------------------PhysicalOlapScan[customer] apply RFs: RF9
 ----------------------------------PhysicalProject
-------------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
---------------------------------------PhysicalOlapScan[promotion]
+------------------------------------filter((store.s_gmt_offset = -7.00))
+--------------------------------------PhysicalOlapScan[store]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((((promotion.p_channel_dmail = 'Y') OR (promotion.p_channel_email = 'Y')) OR (promotion.p_channel_tv = 'Y')))
+----------------------------------PhysicalOlapScan[promotion]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF9
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]
@@ -46,21 +46,21 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk]
+--------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF0 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------PhysicalProject
-------------------------------------filter((store.s_gmt_offset = -7.00))
---------------------------------------PhysicalOlapScan[store]
+------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------filter((store.s_gmt_offset = -7.00))
+----------------------------------PhysicalOlapScan[store]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 1999))
+------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query64.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query64.out
@@ -29,37 +29,37 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[c_first_sales_date_sk]
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->[ss_customer_sk]
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF7 s_store_sk->[ss_store_sk]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
+--------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
+------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[sr_item_sk,ss_item_sk]
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF4 cs_item_sk->[sr_item_sk,ss_item_sk]
+----------------------------------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
 ------------------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF2 sr_item_sk->[ss_item_sk];RF3 sr_ticket_number->[ss_ticket_number]
 ----------------------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4 RF5 RF6 RF7 RF10 RF12 RF13 RF15 RF19
 ----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF4 RF19
+------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF5 RF19
 ------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------filter((sale > (2 * refund)))
-----------------------------------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF19
---------------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
+--------------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF8 RF9 RF11 RF14 RF16
 --------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------filter(d_year IN (2001, 2002))
-------------------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------------------------filter((sale > (2 * refund)))
+------------------------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF19
+----------------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF19
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[store]
+------------------------------------------------------------------filter(d_year IN (2001, 2002))
+--------------------------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF8 RF9 RF11 RF14 RF16
+--------------------------------------------------------------PhysicalOlapScan[store]
 --------------------------------------------------------PhysicalProject
 ----------------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query69.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query69.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->[c_current_cdemo_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 --------------------------------PhysicalProject
@@ -33,10 +33,10 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter(ca_state IN ('MI', 'TX', 'VA'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query7.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query7.out
@@ -10,9 +10,9 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF3 p_promo_sk->[ss_promo_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ss_item_sk]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[ss_cdemo_sk]
 ------------------------------PhysicalProject
@@ -21,10 +21,10 @@ PhysicalResultSink
 --------------------------------filter((customer_demographics.cd_education_status = 'College') and (customer_demographics.cd_gender = 'F') and (customer_demographics.cd_marital_status = 'W'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalProject
-----------------------------filter((date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[item]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[item]
+------------------------filter((date_dim.d_year = 2001))
+--------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
 --------------------filter(((promotion.p_channel_email = 'N') OR (promotion.p_channel_event = 'N')))
 ----------------------PhysicalOlapScan[promotion]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query72.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query72.out
@@ -8,13 +8,13 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF8 d_date_sk->[cs_ship_date_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk) and (d1.d_week_seq = d2.d_week_seq)) otherCondition=((d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))) build RFs:RF7 d_week_seq->[d_week_seq];RF8 d_date_sk->[cs_sold_date_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq];RF7 d_date_sk->[inv_date_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF6 hd_demo_sk->[cs_bill_hdemo_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_ship_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[cs_bill_hdemo_sk]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
 ----------------------------------PhysicalProject
@@ -23,13 +23,13 @@ PhysicalResultSink
 ----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=() build RFs:RF1 w_warehouse_sk->[inv_warehouse_sk]
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)) build RFs:RF0 cs_item_sk->[inv_item_sk]
-----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1 RF2 RF7
+----------------------------------------------PhysicalOlapScan[inventory] apply RFs: RF0 RF1 RF2 RF4
 ----------------------------------------------PhysicalProject
 ------------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 --------------------------------------------------PhysicalProject
 ----------------------------------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3 RF4 RF5 RF8
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3 RF5 RF6 RF8
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[promotion]
 --------------------------------------------------PhysicalProject
@@ -42,13 +42,13 @@ PhysicalResultSink
 ------------------------------------filter((customer_demographics.cd_marital_status = 'W'))
 --------------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------------PhysicalProject
---------------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
-----------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 --------------------------PhysicalProject
-----------------------------filter((d1.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim] apply RFs: RF6
+----------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[date_dim]
+------------------------filter((household_demographics.hd_buy_potential = '501-1000'))
+--------------------------PhysicalOlapScan[household_demographics]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[date_dim]
+--------------------filter((d1.d_year = 2002))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query75.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query75.out
@@ -11,55 +11,55 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------PhysicalUnion
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[catalog_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[store_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute[DistributionSpecExecutionAny]
 --------------------PhysicalProject
-----------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=()
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalOlapScan[web_returns]
 ----------------------------PhysicalProject
-------------------------------filter(d_year IN (1998, 1999))
---------------------------------PhysicalOlapScan[date_dim]
+------------------------------filter((item.i_category = 'Home'))
+--------------------------------PhysicalOlapScan[item]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_returns]
+--------------------------filter(d_year IN (1998, 1999))
+----------------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query80.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query80.out
@@ -48,9 +48,9 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF6 i_item_sk->[cs_item_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF5 cp_catalog_page_sk->[cs_catalog_page_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_sold_date_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk]
+------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF4 cp_catalog_page_sk->[cs_catalog_page_sk]
 --------------------------------------------PhysicalProject
 ----------------------------------------------hashJoin[LEFT_OUTER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=()
 ------------------------------------------------PhysicalProject
@@ -58,10 +58,10 @@ PhysicalResultSink
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[catalog_returns]
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
-------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------PhysicalOlapScan[catalog_page]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_page]
+------------------------------------------filter((date_dim.d_date <= '1998-09-27') and (date_dim.d_date >= '1998-08-28'))
+--------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalProject
 --------------------------------------filter((item.i_current_price > 50.00))
 ----------------------------------------PhysicalOlapScan[item]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query81.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query81.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[cr_returning_addr_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cr_returned_date_sk]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[cr_returning_addr_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[catalog_returns] apply RFs: RF0 RF1
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------filter((date_dim.d_year = 2002))
+--------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query84.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query84.out
@@ -13,16 +13,16 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[c_current_hdemo_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 cd_demo_sk->[c_current_cdemo_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer] apply RFs: RF0 RF1 RF2
 ----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_city = 'Oakwood'))
---------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter((customer_address.ca_city = 'Oakwood'))
+----------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query85.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query85.out
@@ -15,25 +15,25 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=((((ca_state IN ('DE', 'FL', 'TX') AND ((web_sales.ws_net_profit >= 100.00) AND (web_sales.ws_net_profit <= 200.00))) OR (ca_state IN ('ID', 'IN', 'ND') AND ((web_sales.ws_net_profit >= 150.00) AND (web_sales.ws_net_profit <= 300.00)))) OR (ca_state IN ('IL', 'MT', 'OH') AND ((web_sales.ws_net_profit >= 50.00) AND (web_sales.ws_net_profit <= 250.00))))) build RFs:RF7 ca_address_sk->[wr_refunded_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status) and (cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->[wr_returning_cdemo_sk];RF5 cd_marital_status->[cd_marital_status];RF6 cd_education_status->[cd_education_status]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk) and (cd1.cd_education_status = cd2.cd_education_status) and (cd1.cd_marital_status = cd2.cd_marital_status)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF4 cd_marital_status->[cd_marital_status];RF5 cd_education_status->[cd_education_status];RF6 cd_demo_sk->[wr_refunded_cdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd1.cd_demo_sk = web_returns.wr_refunded_cdemo_sk)) otherCondition=((((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) AND ((web_sales.ws_sales_price >= 100.00) AND (web_sales.ws_sales_price <= 150.00))) OR (((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary')) AND ((web_sales.ws_sales_price >= 50.00) AND (web_sales.ws_sales_price <= 100.00)))) OR (((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree')) AND ((web_sales.ws_sales_price >= 150.00) AND (web_sales.ws_sales_price <= 200.00))))) build RFs:RF3 cd_demo_sk->[wr_refunded_cdemo_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((cd2.cd_demo_sk = web_returns.wr_returning_cdemo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[wr_returning_cdemo_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF2 wp_web_page_sk->[ws_web_page_sk]
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF0 ws_item_sk->[wr_item_sk];RF1 ws_order_number->[wr_order_number]
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF4 RF7 RF9
+----------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1 RF3 RF6 RF7 RF9
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((web_sales.ws_net_profit <= 300.00) and (web_sales.ws_net_profit >= 50.00) and (web_sales.ws_sales_price <= 200.00) and (web_sales.ws_sales_price >= 50.00))
 ------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF8
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[web_page]
 ------------------------------------PhysicalProject
---------------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
-----------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5 RF6
+--------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------filter(((((cd1.cd_marital_status = 'M') AND (cd1.cd_education_status = '4 yr Degree')) OR ((cd1.cd_marital_status = 'S') AND (cd1.cd_education_status = 'Secondary'))) OR ((cd1.cd_marital_status = 'W') AND (cd1.cd_education_status = 'Advanced Degree'))))
+------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query86.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query86.out
@@ -15,14 +15,14 @@ PhysicalResultSink
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalRepeat
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[ws_item_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = web_sales.ws_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[ws_item_sk]
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 ------------------------------------PhysicalProject
---------------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[item]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[item]
+----------------------------------filter((d1.d_month_seq <= 1235) and (d1.d_month_seq >= 1224))
+------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query91.out
+++ b/regression-test/data/new_shapes_p0/tpcds_sf100/no_stats_shape/query91.out
@@ -15,9 +15,9 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[cr_returning_customer_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cr_returned_date_sk]
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_returning_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[cr_returning_customer_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_call_center_sk = call_center.cc_call_center_sk)) otherCondition=() build RFs:RF0 cc_call_center_sk->[cr_call_center_sk]
 ----------------------------------------PhysicalProject
@@ -25,10 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[call_center]
 ------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
-----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer] apply RFs: RF3 RF4 RF5
+----------------------------------filter((date_dim.d_moy = 11) and (date_dim.d_year = 2001))
+------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/new_shapes_p0/tpch_sf1000/nostats_rf_prune/q9.out
+++ b/regression-test/data/new_shapes_p0/tpch_sf1000/nostats_rf_prune/q9.out
@@ -10,20 +10,20 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN colocated] hashCondition=((partsupp.ps_partkey = lineitem.l_partkey) and (partsupp.ps_suppkey = lineitem.l_suppkey)) otherCondition=()
+--------------------hashJoin[INNER_JOIN colocated] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=() build RFs:RF4 p_partkey->[l_partkey,ps_partkey]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=() build RFs:RF2 p_partkey->[l_partkey]
+------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((partsupp.ps_partkey = lineitem.l_partkey) and (partsupp.ps_suppkey = lineitem.l_suppkey)) otherCondition=()
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN colocated] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[lineitem] apply RFs: RF2
+--------------------------------PhysicalOlapScan[lineitem] apply RFs: RF4
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[orders]
 --------------------------PhysicalProject
-----------------------------filter((p_name like '%green%'))
-------------------------------PhysicalOlapScan[part]
+----------------------------PhysicalOlapScan[partsupp] apply RFs: RF4
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[partsupp]
+------------------------filter((p_name like '%green%'))
+--------------------------PhysicalOlapScan[part]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_nationkey = nation.n_nationkey)) otherCondition=()
 ----------------------PhysicalProject

--- a/regression-test/data/new_shapes_p0/tpch_sf1000/shape_no_stats/q9.out
+++ b/regression-test/data/new_shapes_p0/tpch_sf1000/shape_no_stats/q9.out
@@ -10,9 +10,9 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF5 s_suppkey->[l_suppkey,ps_suppkey]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN colocated] hashCondition=((partsupp.ps_partkey = lineitem.l_partkey) and (partsupp.ps_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF3 ps_suppkey->[l_suppkey];RF4 ps_partkey->[l_partkey,p_partkey]
+--------------------hashJoin[INNER_JOIN colocated] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=() build RFs:RF4 p_partkey->[l_partkey,ps_partkey]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((part.p_partkey = lineitem.l_partkey)) otherCondition=() build RFs:RF2 p_partkey->[l_partkey]
+------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((partsupp.ps_partkey = lineitem.l_partkey) and (partsupp.ps_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF2 ps_suppkey->[l_suppkey];RF3 ps_partkey->[l_partkey]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN colocated] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=() build RFs:RF1 o_orderkey->[l_orderkey]
 ------------------------------PhysicalProject
@@ -20,10 +20,10 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[orders]
 --------------------------PhysicalProject
-----------------------------filter((p_name like '%green%'))
-------------------------------PhysicalOlapScan[part] apply RFs: RF4
+----------------------------PhysicalOlapScan[partsupp] apply RFs: RF4 RF5
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[partsupp] apply RFs: RF5
+------------------------filter((p_name like '%green%'))
+--------------------------PhysicalOlapScan[part]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_nationkey = nation.n_nationkey)) otherCondition=() build RFs:RF0 n_nationkey->[s_nationkey]
 ----------------------PhysicalProject


### PR DESCRIPTION
## Proposed changes
we prefer join order: A-B-filter(C) to A-filter(C)-B, since filter(C) may generate effective RF to B, and RF(C->B) makes RF(B->A) more effective.
Issue Number: close #xxx

<!--Describe your changes.-->

