### PR TITLE
[feat](FE) add rest api to get last profile (#38268)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -290,6 +290,10 @@ public class ProfileManager {
         }
     }
 
+    public String getLastQueryId() {
+        return queryIdDeque.getLast();
+    }
+
     public String getProfileBrief(String queryID) {
         readLock.lock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ProfileAction.java
@@ -69,7 +69,7 @@ public class ProfileAction extends RestBaseController {
 
         String queryId = request.getParameter("query_id");
         if (Strings.isNullOrEmpty(queryId)) {
-            return "Missing query_id";
+            queryId = ProfileManager.getInstance().getLastQueryId();
         }
 
         String queryProfileStr = ProfileManager.getInstance().getProfile(queryId);


### PR DESCRIPTION
## Proposed changes
pick from #38268

if you want to get the profile of the query just executed, it not neccessary to find the query_id now.
this is useful to get profiles in shell script, for example, we want to get all profiles of tpcds queries (103 query profile) in a shell script.

before:
curl
http://root:@127.0.0.1:8030/api/profile/text?query_id=990cc3b19e464e03-a3af05a997eb4091
> profile
after:
curl http://root:@127.0.0.1:8030/api/profile/text > profilex

Issue Number: close #xxx

<!--Describe your changes.-->

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

