### PR TITLE
[fix](Nereids) adjust min/max stats for cast function if types are comparable (#28166)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Objects;
 
-public class DecimalLiteral extends LiteralExpr {
+public class DecimalLiteral extends NumericLiteralExpr {
     private static final Logger LOG = LogManager.getLogger(DecimalLiteral.class);
     private BigDecimal value;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -35,7 +35,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.NumberFormat;
 
-public class FloatLiteral extends LiteralExpr {
+public class FloatLiteral extends NumericLiteralExpr {
     private double value;
 
     public FloatLiteral() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
@@ -38,7 +38,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class IntLiteral extends LiteralExpr {
+public class IntLiteral extends NumericLiteralExpr {
     private static final Logger LOG = LogManager.getLogger(IntLiteral.class);
 
     public static final long TINY_INT_MIN = Byte.MIN_VALUE; // -2^7 ~ 2^7 - 1

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
@@ -38,7 +38,7 @@ import java.nio.ByteOrder;
 import java.util.Objects;
 
 // large int for the num that native types can not
-public class LargeIntLiteral extends LiteralExpr {
+public class LargeIntLiteral extends NumericLiteralExpr {
     private static final Logger LOG = LogManager.getLogger(LargeIntLiteral.class);
 
     // -2^127

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NumericLiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NumericLiteralExpr.java
@@ -14,29 +14,18 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+// This file is copied from
+// https://github.com/apache/impala/blob/branch-2.9.0/fe/src/main/java/org/apache/impala/LiteralExpr.java
+// and modified by Doris
 
-package org.apache.doris.nereids.trees.expressions.literal;
+package org.apache.doris.analysis;
 
-import org.apache.doris.nereids.types.DataType;
-
-/** IntegralLiteral */
-public abstract class IntegerLikeLiteral extends NumericLiteral {
-    /**
-     * Constructor for Literal.
-     *
-     * @param dataType logical data type in Nereids
-     */
-    public IntegerLikeLiteral(DataType dataType) {
-        super(dataType);
+public abstract class NumericLiteralExpr extends LiteralExpr {
+    public NumericLiteralExpr() {
+        super();
     }
 
-    public int getIntValue() {
-        return getNumber().intValue();
+    public NumericLiteralExpr(NumericLiteralExpr other) {
+        super(other);
     }
-
-    public long getLongValue() {
-        return getNumber().longValue();
-    }
-
-    public abstract Number getNumber();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -18,11 +18,7 @@
 package org.apache.doris.nereids.stats;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
-import org.apache.doris.analysis.DecimalLiteral;
-import org.apache.doris.analysis.FloatLiteral;
-import org.apache.doris.analysis.IntLiteral;
-import org.apache.doris.analysis.LargeIntLiteral;
-import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.NumericLiteralExpr;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Add;
@@ -224,7 +220,7 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
             }
         }
         // cast numeric to numeric
-        if (isNumericLiteralExpr(colStats.minExpr) && isNumericLiteralExpr(colStats.maxExpr)) {
+        if (colStats.minExpr instanceof NumericLiteralExpr && colStats.maxExpr instanceof NumericLiteralExpr) {
             if (targetType.isNumericType()) {
                 return colStats;
             }
@@ -235,11 +231,6 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         builder.setMinExpr(null).setMinValue(Double.NEGATIVE_INFINITY)
                 .setMaxExpr(null).setMaxValue(Double.POSITIVE_INFINITY);
         return builder.build();
-    }
-
-    private boolean isNumericLiteralExpr(LiteralExpr literal) {
-        return literal instanceof DecimalLiteral || literal instanceof FloatLiteral
-                || literal instanceof IntLiteral || literal instanceof LargeIntLiteral;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 /**
  * decimal type literal
  */
-public class DecimalLiteral extends Literal {
+public class DecimalLiteral extends FractionalLiteral {
 
     private final BigDecimal value;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 /**
  * Literal for DecimalV3 Type
  */
-public class DecimalV3Literal extends Literal {
+public class DecimalV3Literal extends FractionalLiteral {
 
     private final BigDecimal value;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
@@ -28,7 +28,7 @@ import java.text.NumberFormat;
 /**
  * Double literal
  */
-public class DoubleLiteral extends Literal {
+public class DoubleLiteral extends FractionalLiteral {
 
     private final double value;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
@@ -27,7 +27,7 @@ import java.text.NumberFormat;
 /**
  * float type literal
  */
-public class FloatLiteral extends Literal {
+public class FloatLiteral extends FractionalLiteral {
 
     private final float value;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FractionalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FractionalLiteral.java
@@ -19,24 +19,16 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.nereids.types.DataType;
 
-/** IntegralLiteral */
-public abstract class IntegerLikeLiteral extends NumericLiteral {
+/**
+ * float/double/decimal
+ */
+public abstract class FractionalLiteral extends NumericLiteral {
     /**
-     * Constructor for Literal.
+     * Constructor for FractionalLiteral.
      *
      * @param dataType logical data type in Nereids
      */
-    public IntegerLikeLiteral(DataType dataType) {
+    public FractionalLiteral(DataType dataType) {
         super(dataType);
     }
-
-    public int getIntValue() {
-        return getNumber().intValue();
-    }
-
-    public long getLongValue() {
-        return getNumber().longValue();
-    }
-
-    public abstract Number getNumber();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
@@ -19,24 +19,16 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.nereids.types.DataType;
 
-/** IntegralLiteral */
-public abstract class IntegerLikeLiteral extends NumericLiteral {
+/**
+ * numeric literal
+ */
+public abstract class NumericLiteral extends Literal {
     /**
-     * Constructor for Literal.
+     * Constructor for NumericLiteral.
      *
      * @param dataType logical data type in Nereids
      */
-    public IntegerLikeLiteral(DataType dataType) {
+    public NumericLiteral(DataType dataType) {
         super(dataType);
     }
-
-    public int getIntValue() {
-        return getNumber().intValue();
-    }
-
-    public long getLongValue() {
-        return getNumber().longValue();
-    }
-
-    public abstract Number getNumber();
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -30,8 +30,6 @@ import org.apache.doris.nereids.trees.expressions.Subtract;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
-import org.apache.doris.nereids.types.DateType;
-import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.types.DateType;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -30,6 +30,8 @@ import org.apache.doris.nereids.trees.expressions.Subtract;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
+import org.apache.doris.nereids.types.DateType;
+import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.types.DateType;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -842,7 +842,9 @@ class FilterEstimationTest {
                 .setNdv(100)
                 .setAvgSizeByte(4)
                 .setNumNulls(0)
+                .setMaxExpr(new IntLiteral(100))
                 .setMaxValue(100)
+                .setMinExpr(new IntLiteral(0))
                 .setMinValue(0)
                 .setMaxExpr(new IntLiteral(100))
                 .setMinExpr(new IntLiteral(0))
@@ -856,7 +858,7 @@ class FilterEstimationTest {
         stats.addColumnStats(a, builder.build());
         FilterEstimation filterEstimation = new FilterEstimation();
         Statistics result = filterEstimation.estimate(and, stats);
-        Assertions.assertEquals(result.getRowCount(), 10, 0.01);
+        Assertions.assertEquals(10, result.getRowCount(), 0.01);
         ColumnStatistic colStats = result.findColumnStatistics(a);
         Assertions.assertTrue(colStats != null);
         Assertions.assertEquals(10, colStats.ndv, 0.1);


### PR DESCRIPTION
pick from #28166

estimate column stats for "cast(col, XXXType)"

-----cast-est------
query4 41169 40335 40267 40267
query58 463 361 401 361
Total cold run time: 41632 ms
Total hot run time: 40628 ms

----master------
query4 40624 40180 40299 40180
query58 487 389 420 389
Total cold run time: 41111 ms
Total hot run time: 40569 ms

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

