### PR TITLE
[improvement](drop tablet) reduce shard lock wait time

### DIFF
--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -194,8 +194,8 @@ private:
 
     bool _check_tablet_id_exist_unlocked(TTabletId tablet_id);
 
-    Status _drop_tablet_unlocked(TTabletId tablet_id, TReplicaId replica_id, bool keep_files,
-                                 bool is_drop_table_or_partition);
+    Status _drop_tablet(TTabletId tablet_id, TReplicaId replica_id, bool keep_files,
+                        bool is_drop_table_or_partition, bool had_held_shard_lock);
 
     TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id);
     TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id, bool include_deleted,


### PR DESCRIPTION
drop tablet's code:

```
    lock_guard(tablet_manager.shard.lock);

    delete tablet from tablet map

     {
            lock_guard(tablet.meta_lock)
            ...
     }

     ...
```

Sometimes,  tablet meta lock may held by other threads for a long time,    it will cause shard.lock also wait for a long time.

For creating tablet thread, it also need to acquire the shard.lock,  so creating tablet thread will also wait for a long time, then creating partition will be timeout.

Fix:   shard.lock   don't wait the time of the tablet meta lock.