### PR TITLE
[Fix](Nereids) fix fold constant rule by be cause case when exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 
@@ -132,7 +133,7 @@ public class CaseWhen extends Expression {
         for (int i = 0; i < children.size(); i++) {
             if (children.get(i) instanceof WhenClause) {
                 whenClauseList.add((WhenClause) children.get(i));
-            } else if (children.size() - 1 == i) {
+            } else if ((children.size() - 1 == i || children.get(i) instanceof Literal) && defaultValue == null) {
                 defaultValue = children.get(i);
             } else {
                 throw new AnalysisException("The children format needs to be [WhenClause+, DefaultValue?]");

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -49,4 +49,9 @@ suite("fold_constant_by_be") {
     qt_sql "explain select sleep(sign(1)*100);"
     sql 'set query_timeout=12;'
     qt_sql "select sleep(sign(1)*10);"
+
+    def res3 = sql " select /*+SET_VAR(enable_fold_constant_by_be=true)*/ ( CASE NULLIF ( - 34, 20 ) WHEN - 56 THEN NULL WHEN - 104 THEN count(*) END ); "
+    def res4 = sql " select /*+SET_VAR(enable_fold_constant_by_be=false)*/ ( CASE NULLIF ( - 34, 20 ) WHEN - 56 THEN NULL WHEN - 104 THEN count(*) END ); "
+    log.info("result: {}, {}", res3, res4)
+    assertEquals(res3[0][0], res4[0][0])
 }


### PR DESCRIPTION
Problem:
when use be fold constant rule, whenclause in case when expression would be folded into constant, so fe would throw an exception cause of whenclause can not be constant
Solved:
When be fold constant rule fold whenclause success, fe would make this constant as first priority default value

