### PR TITLE
 [fix](cloud) Fix insert_group_commit_into in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2394,7 +2394,7 @@ public class StmtExecutor {
                     if (response.hasErrorUrl()) {
                         errMsg += ", error url: " + response.getErrorUrl();
                     }
-                    throw new DdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
+                    ErrorReport.reportDdlException(errMsg.replaceAll("%", "%%"), ErrorCode.ERR_FAILED_WHEN_INSERT);
                 }
                 label = response.getLabel();
                 txnStatus = TransactionStatus.PREPARE;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2394,7 +2394,7 @@ public class StmtExecutor {
                     if (response.hasErrorUrl()) {
                         errMsg += ", error url: " + response.getErrorUrl();
                     }
-                    ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
+                    throw new DdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
                 }
                 label = response.getLabel();
                 txnStatus = TransactionStatus.PREPARE;


### PR DESCRIPTION
The insert_group_commit_into is failed because:
```
2024-07-29 13:26:53,212 WARN (mysql-nio-pool-37|242) execute Exception. stmt[117782, b23c0447050d40a8-82c73eb0ba031977]
java.util.UnknownFormatConversionException: Conversion = 'F'
        at java.util.Formatter$FormatSpecifier.conversion(Formatter.java:2855) ~[?:?]
        at java.util.Formatter$FormatSpecifier.<init>(Formatter.java:2891) ~[?:?]
        at java.util.Formatter.parse(Formatter.java:2747) ~[?:?]
        at java.util.Formatter.format(Formatter.java:2671) ~[?:?]
        at java.util.Formatter.format(Formatter.java:2625) ~[?:?]
        at java.lang.String.format(String.java:4145) ~[?:?]
        at org.apache.doris.common.ErrorReport.reportCommon(ErrorReport.java:30) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.ErrorReport.reportDdlException(ErrorReport.java:68) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleInsertStmt(StmtExecutor.java:2397) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:1043) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:646) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:567) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:557) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:385) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:237) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:260) ~[doris-fe.jar:1.2-SNAPSHOT]
```

Because the cloud error url may contain `%`