### PR TITLE
[fix](multicatalog) fix hadoop authenticator not inited for existing hms catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -138,6 +138,11 @@ public class HMSExternalCatalog extends ExternalCatalog {
 
     @Override
     protected void initLocalObjectsImpl() {
+        if (authenticator == null) {
+            AuthenticationConfig config = AuthenticationConfig.getKerberosConfig(getConfiguration());
+            authenticator = HadoopAuthenticator.getHadoopAuthenticator(config);
+        }
+
         HiveConf hiveConf = null;
         JdbcClientConfig jdbcClientConfig = null;
         String hiveMetastoreType = catalogProperty.getOrDefault(HMSProperties.HIVE_METASTORE_TYPE, "");


### PR DESCRIPTION
authenticator for hms type catalog has been refactored to be initted only on creating，but existing catalog are not initted. 

Issue:
```sql
switch hive;
show databases;
ERROR 1105 (HY000): HMSClientException, msg: java.lang.NullPointerException: Cannot invoke "org.apache.doris.common.security.authentication.HadoopAuthenticator.doAs(java.security.PrivilegedExceptionAction)" because "this.hadoopAuthenticator" is null
```
