### PR TITLE
[fix](recycler) Fix recycler compilation issue with libhdfs3

### DIFF
--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -18,7 +18,11 @@
 #include "recycler/hdfs_accessor.h"
 
 #include <gen_cpp/cloud.pb.h>
-#include <hadoop_hdfs/hdfs.h>
+#ifdef USE_HADOOP_HDFS
+#include <hadoop_hdfs/hdfs.h> // IWYU pragma: export
+#else
+#include <hdfs/hdfs.h> // IWYU pragma: export
+#endif
 
 #include <string_view>
 

--- a/cloud/src/recycler/hdfs_accessor.h
+++ b/cloud/src/recycler/hdfs_accessor.h
@@ -29,7 +29,11 @@ namespace doris::cloud {
 
 class HdfsVaultInfo;
 
+#ifdef USE_HADOOP_HDFS
 using HdfsSPtr = std::shared_ptr<struct hdfs_internal>;
+#else
+using HdfsSPtr = std::shared_ptr<struct HdfsFileSystemInternalWrapper>;
+#endif
 
 class HdfsAccessor final : public StorageVaultAccessor {
 public:


### PR DESCRIPTION
This PR fix compilation error for cloud recycler when the USE_LIBHDFS3 flag is enabled. 