### PR TITLE
[feature](compaction) Add an http action for visibility of compaction score on each tablet

### DIFF
--- a/be/src/http/action/compaction_score_action.cpp
+++ b/be/src/http/action/compaction_score_action.cpp
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#include "http/action/compaction_score_action.h"
+
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "common/status.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+#include "olap/olap_common.h"
+#include "olap/tablet_fwd.h"
+#include "olap/tablet_manager.h"
+
+namespace doris {
+
+constexpr std::string_view TABLET_ID = "tablet_id";
+constexpr std::string_view BASE_COMPACTION_SCORE = "base_compaction_score";
+constexpr std::string_view CUMULATIVE_COMPACTION_SCORE = "cumu_compaction_score";
+
+CompactionScoreAction::CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                             TPrivilegeType::type type,
+                                             StorageEngine& storage_engine)
+        : HttpHandlerWithAuth(exec_env, hier, type), _storage_engine(storage_engine) {}
+
+static rapidjson::Value jsonfy_tablet_compaction_score(
+        const TabletSharedPtr& tablet, rapidjson::MemoryPoolAllocator<>& allocator) {
+    rapidjson::Value node;
+    node.SetObject();
+
+    rapidjson::Value tablet_id_key;
+    tablet_id_key.SetString(TABLET_ID.data(), TABLET_ID.length(), allocator);
+    rapidjson::Value tablet_id_val;
+    auto tablet_id_str = std::to_string(tablet->tablet_id());
+    tablet_id_val.SetString(tablet_id_str.c_str(), tablet_id_str.length(), allocator);
+
+    auto add_compaction_score = [&tablet, &allocator, &node](std::string_view key_name,
+                                                             CompactionType type) {
+        rapidjson::Value score_key;
+        score_key.SetString(key_name.data(), key_name.size());
+
+        rapidjson::Value score_val;
+        auto score =
+                tablet->calc_compaction_score(type, tablet->get_cumulative_compaction_policy());
+        auto score_str = std::to_string(score);
+        score_val.SetString(score_str.c_str(), score_str.length(), allocator);
+        node.AddMember(score_key, score_val, allocator);
+    };
+
+    node.AddMember(tablet_id_key, tablet_id_val, allocator);
+    add_compaction_score(BASE_COMPACTION_SCORE, CompactionType::BASE_COMPACTION);
+    add_compaction_score(CUMULATIVE_COMPACTION_SCORE, CompactionType::CUMULATIVE_COMPACTION);
+    return node;
+}
+
+void CompactionScoreAction::handle(HttpRequest* req) {
+    std::string result;
+    if (auto st = _handle(req, &result); !st) {
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, st.to_json());
+    }
+    HttpChannel::send_reply(req, HttpStatus::OK, result);
+}
+
+Status CompactionScoreAction::_handle(HttpRequest* req, std::string* result) {
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HttpHeaders::JsonType.data());
+    auto tablet_id_param = req->param(TABLET_ID.data());
+    rapidjson::Document root;
+    if (tablet_id_param.empty()) {
+        // fetch comapction scores from all tablets
+        // [{tablet_id: xxx, base_compaction_score: xxx, cumu_compaction_score: xxx}, ...]
+        auto tablets = _storage_engine.tablet_manager()->get_all_tablet();
+        root.SetArray();
+        auto& allocator = root.GetAllocator();
+        for (const auto& tablet : tablets) {
+            root.PushBack(jsonfy_tablet_compaction_score(tablet, allocator), allocator);
+        }
+    } else {
+        // {tablet_id: xxx, base_compaction_score: xxx, cumu_compaction_score: xxx}
+        int64_t tablet_id;
+        try {
+            tablet_id = std::stoll(tablet_id_param);
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "convert failed:" << e.what();
+            return Status::InvalidArgument("invalid argument: tablet_id={}", tablet_id_param);
+        }
+        auto base_tablet = DORIS_TRY(_storage_engine.get_tablet(tablet_id));
+        auto tablet = std::static_pointer_cast<Tablet>(base_tablet);
+        root.SetObject();
+        auto val = jsonfy_tablet_compaction_score(tablet, root.GetAllocator());
+        root.Swap(val);
+    }
+    rapidjson::StringBuffer str_buf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(str_buf);
+    root.Accept(writer);
+    *result = str_buf.GetString();
+    return Status::OK();
+}
+
+} // namespace doris

--- a/be/src/http/action/compaction_score_action.cpp
+++ b/be/src/http/action/compaction_score_action.cpp
@@ -82,7 +82,6 @@ struct LocalCompactionScoreAccessor final : CompactionScoresAccessor {
     LocalCompactionScoreAccessor(TabletManager* tablet_mgr) : tablet_mgr(tablet_mgr) {}
 
     std::vector<CompactionScoreResult> get_all_tablet_compaction_scores() override {
-        DCHECK_NOTNULL(tablet_mgr);
         auto tablets = tablet_mgr->get_all_tablet();
         std::span<TabletSharedPtr> s = {tablets.begin(), tablets.end()};
         return calculate_compaction_scores(s);

--- a/be/src/http/action/compaction_score_action.cpp
+++ b/be/src/http/action/compaction_score_action.cpp
@@ -171,7 +171,7 @@ void CompactionScoreAction::handle(HttpRequest* req) {
             top_n = tmp_top_n;
         } catch (const std::exception& e) {
             LOG(WARNING) << "convert failed:" << e.what();
-            auto msg = std::format("invalid argument: top_n={}", top_n_param);
+            auto msg = fmt::format("invalid argument: top_n={}", top_n_param);
             HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, msg);
             return;
         }
@@ -189,7 +189,7 @@ void CompactionScoreAction::handle(HttpRequest* req) {
     } else if (sync_meta_param == "false") {
         sync_meta = false;
     } else if (!sync_meta_param.empty()) {
-        auto msg = std::format("invalid argument: sync_meta={}", sync_meta_param);
+        auto msg = fmt::format("invalid argument: sync_meta={}", sync_meta_param);
         HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, msg);
         return;
     }

--- a/be/src/http/action/compaction_score_action.h
+++ b/be/src/http/action/compaction_score_action.h
@@ -25,6 +25,7 @@
 #include "olap/storage_engine.h"
 namespace doris {
 
+// topn, sync
 class CompactionScoreAction : public HttpHandlerWithAuth {
 public:
     CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type,

--- a/be/src/http/action/compaction_score_action.h
+++ b/be/src/http/action/compaction_score_action.h
@@ -31,7 +31,20 @@
 #include "runtime/exec_env.h"
 namespace doris {
 
-struct CompactionScoresAccessor;
+struct CompactionScoreResult {
+    int64_t tablet_id;
+    size_t compaction_score;
+};
+
+inline bool operator>(const CompactionScoreResult& lhs, const CompactionScoreResult& rhs) {
+    return lhs.compaction_score > rhs.compaction_score;
+}
+
+struct CompactionScoresAccessor {
+    virtual ~CompactionScoresAccessor() = default;
+
+    virtual std::vector<CompactionScoreResult> get_all_tablet_compaction_scores() = 0;
+};
 
 // topn, sync
 class CompactionScoreAction : public HttpHandlerWithAuth {

--- a/be/src/http/action/compaction_score_action.h
+++ b/be/src/http/action/compaction_score_action.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+#include "http/http_handler_with_auth.h"
+#include "http/http_request.h"
+#include "olap/storage_engine.h"
+namespace doris {
+
+class CompactionScoreAction : public HttpHandlerWithAuth {
+public:
+    CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type,
+                          StorageEngine& storage_engine);
+
+    void handle(HttpRequest* req) override;
+
+private:
+    Status _handle(HttpRequest* req, std::string* result);
+
+    StorageEngine& _storage_engine;
+};
+
+} // namespace doris

--- a/be/src/http/action/compaction_score_action.h
+++ b/be/src/http/action/compaction_score_action.h
@@ -17,26 +17,37 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <cstddef>
+#include <memory>
 #include <string>
 
+#include "cloud/cloud_tablet_mgr.h"
 #include "common/status.h"
 #include "http/http_handler_with_auth.h"
 #include "http/http_request.h"
 #include "olap/storage_engine.h"
+#include "runtime/exec_env.h"
 namespace doris {
+
+struct CompactionScoresAccessor;
 
 // topn, sync
 class CompactionScoreAction : public HttpHandlerWithAuth {
 public:
-    CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type,
-                          StorageEngine& storage_engine);
+    explicit CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                   TPrivilegeType::type type, TabletManager* tablet_mgr);
+
+    explicit CompactionScoreAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                   TPrivilegeType::type type, CloudTabletMgr& tablet_mgr);
 
     void handle(HttpRequest* req) override;
 
 private:
-    Status _handle(HttpRequest* req, std::string* result);
+    Status _handle(size_t top_n, bool sync_meta, std::string* result);
 
-    StorageEngine& _storage_engine;
+    std::unique_ptr<CompactionScoresAccessor> _accessor;
 };
 
 } // namespace doris

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -29,6 +29,7 @@
 #include "olap/rowid_conversion.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_fwd.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/tablet_fwd.h"
 #include "olap/txn_manager.h"
@@ -180,6 +181,14 @@ Status BaseTablet::update_by_least_common_schema(const TabletSchemaSPtr& update_
     _max_version_schema = final_schema;
     VLOG_DEBUG << "dump updated tablet schema: " << final_schema->dump_structure();
     return Status::OK();
+}
+
+uint32_t BaseTablet::get_real_compaction_score() const {
+    const auto& rs_metas = _tablet_meta->all_rs_metas();
+    return std::accumulate(rs_metas.begin(), rs_metas.end(), 0,
+                           [](uint32_t score, const RowsetMetaSharedPtr& rs_meta) {
+                               return score + rs_meta->get_compaction_score();
+                           });
 }
 
 Status BaseTablet::capture_rs_readers_unlocked(const Versions& version_path,

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -105,6 +105,10 @@ public:
 
     virtual size_t tablet_footprint() = 0;
 
+    // this method just return the compaction sum on each rowset
+    // note(tsy): we should unify the compaction score calculation finally
+    uint32_t get_real_compaction_score() const;
+
     // MUST hold shared meta lock
     Status capture_rs_readers_unlocked(const Versions& version_path,
                                        std::vector<RowSetSplits>* rs_splits) const;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1023,6 +1023,9 @@ uint32_t Tablet::calc_cold_data_compaction_score() const {
 
 uint32_t Tablet::_calc_cumulative_compaction_score(
         std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
+    if (cumulative_compaction_policy == nullptr) [[unlikely]] {
+        return 0;
+    }
 #ifndef BE_TEST
     if (_cumulative_compaction_policy == nullptr ||
         _cumulative_compaction_policy->name() != cumulative_compaction_policy->name()) {

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -19,6 +19,7 @@
 
 #include <event2/bufferevent.h>
 #include <event2/http.h>
+#include <gen_cpp/FrontendService_types.h>
 
 #include <string>
 #include <vector>
@@ -37,6 +38,7 @@
 #include "http/action/checksum_action.h"
 #include "http/action/clear_cache_action.h"
 #include "http/action/compaction_action.h"
+#include "http/action/compaction_score_action.h"
 #include "http/action/config_action.h"
 #include "http/action/debug_point_action.h"
 #include "http/action/download_action.h"
@@ -381,6 +383,11 @@ void HttpService::register_local_handler(StorageEngine& engine) {
             new ShowNestedIndexFileAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/show_nested_index_file",
                                       show_nested_index_file_action);
+
+    CompactionScoreAction* compaction_score_action = _pool.add(
+            new CompactionScoreAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, engine));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction_score",
+                                      compaction_score_action);
 }
 
 void HttpService::register_cloud_handler(CloudStorageEngine& engine) {

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -384,8 +384,8 @@ void HttpService::register_local_handler(StorageEngine& engine) {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/show_nested_index_file",
                                       show_nested_index_file_action);
 
-    CompactionScoreAction* compaction_score_action = _pool.add(
-            new CompactionScoreAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, engine));
+    CompactionScoreAction* compaction_score_action = _pool.add(new CompactionScoreAction(
+            _env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, engine.tablet_manager()));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction_score",
                                       compaction_score_action);
 }
@@ -424,6 +424,10 @@ void HttpService::register_cloud_handler(CloudStorageEngine& engine) {
             new ShowNestedIndexFileAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/show_nested_index_file",
                                       show_nested_index_file_action);
+    CompactionScoreAction* compaction_score_action = _pool.add(new CompactionScoreAction(
+            _env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, engine.tablet_mgr()));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction_score",
+                                      compaction_score_action);
 }
 // NOLINTEND(readability-function-size)
 

--- a/regression-test/suites/compaction/test_compaction_score_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_score_action.groovy
@@ -39,14 +39,15 @@ suite("test_compaction_score_action") {
     for (int i=0;i<backendId_to_backendIP.size();i++){
         def beHttpAddress =backendId_to_backendIP.entrySet()[i].getValue()+":"+backendId_to_backendHttpPort.entrySet()[i].getValue()
         if (isCloudMode()) {
-            def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1&sync_meta=true")
+            def (code, text, err) = curl("GET",beHttpAddress+ "/api/compaction_score?top_n=1&sync_meta=true")
+            def score_str = parseJson(text).get(0).get("compaction_score")
+            def score = Integer.parseInt(score_str)
+            assertTrue(score >= 90)
         } else {
             def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1")
+            def score_str = parseJson(text).get(0).get("compaction_score")
+            def score = Integer.parseInt(score_str)
+            assertTrue(score >= 90)
         }
-        def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1")
-        def score_str = parseJson(text).get(0).get("compaction_score")
-        def score = Integer.parseInt(score_str)
-        assertTrue(score >= 90)
     }
-
 }

--- a/regression-test/suites/compaction/test_compaction_score_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_score_action.groovy
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_compaction_score_action") {
+    def tableName = "test_compaction_score_action";
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            id INT NOT NULL,
+            name STRING NOT NULL
+        ) DUPLICATE KEY (`id`)
+          PROPERTIES ("replication_num" = "1", "disable_auto_compaction" = "true");
+    """
+    for (i in 0..<30) {
+        sql """ INSERT INTO ${tableName} VALUES(1, "Vedal") """
+        sql """ INSERT INTO ${tableName} VALUES(2, "Neuro") """
+        sql """ INSERT INTO ${tableName} VALUES(3, "Evil") """
+    }
+
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+
+    for (int i=0;i<backendId_to_backendIP.size();i++){
+        def beHttpAddress =backendId_to_backendIP.entrySet()[i].getValue()+":"+backendId_to_backendHttpPort.entrySet()[i].getValue()
+        if (isCloudMode()) {
+            def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1&sync_meta=true")
+        } else {
+            def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1")
+        }
+        def (code, text, err) = curl("GET",beHttpAddress+"/api/compaction_score?top_n=1")
+        def score_str = parseJson(text).get(0).get("compaction_score")
+        def score = Integer.parseInt(score_str)
+        assertTrue(score >= 90)
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

As title.

Usage:
1. `curl http://be_ip:be_port/api/compaction_score?top_n=10`
Returns a json object contains compaction score for top n, n=top_n.
```
[
    {
        "compaction_score": "5",
        "tablet_id": "42595"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42587"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42593"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42597"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42589"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42599"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42601"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42591"
    },
    {
        "compaction_score": "5",
        "tablet_id": "42585"
    },
    {
        "compaction_score": "4",
        "tablet_id": "10034"
    }
]
```
If top_n is not specified, return all compaction score for all tablets.
If top_n is illegal, raise an error.
```
invalid argument: top_n=wrong
```

2. `curl http://be_ip:be_host/api/compaction_score?sync_meta=true`
`sync_meta` is only available on cloud mode, will sync meta from meta service. It can cooperate with top_n.
If add param `sync_meta` on non-cloud mode, will raise an error.
```
sync meta is only available for cloud mode
```

3. In the future, this endpoint may extend other utility, like fetching tablet compaction score by table id, etc.
