### PR TITLE
[Improvement](expr) fold child when const expr not folded

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -255,7 +255,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
         // This kind of function is often used to change the attributes of columns.
         // Folding will make it impossible to construct columns such as nullable(1).
-        if (expr instanceof Nullable || expr instanceof NonNullable ) {
+        if (expr instanceof Nullable || expr instanceof NonNullable) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -56,7 +56,6 @@ import org.apache.doris.nereids.trees.expressions.literal.LargeIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.MapLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.NumericLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StructLiteral;

--- a/regression-test/data/nereids_p0/expression/fold_constant/fold_constant_by_be.out
+++ b/regression-test/data/nereids_p0/expression/fold_constant/fold_constant_by_be.out
@@ -2,3 +2,21 @@
 -- !sql_1 --
 80000
 
+-- !sql --
+PLAN FRAGMENT 0
+  OUTPUT EXPRS:
+    sleep(100)[#0]
+  PARTITION: UNPARTITIONED
+
+  HAS_COLO_PLAN_NODE: false
+
+  VRESULT SINK
+     MYSQL_PROTOCAL
+
+  0:VUNION(32)
+     constant exprs: 
+         sleep(100)
+
+-- !sql --
+true
+

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -45,4 +45,8 @@ suite("fold_constant_by_be") {
     def res2 = sql " select /*+SET_VAR(enable_fold_constant_by_be=false)*/ ST_CIRCLE(121.510651, 31.234391, 1918.0); "
     log.info("result: {}, {}", res1, res2)
     assertEquals(res1[0][0], res2[0][0])
+
+    qt_sql "explain select sleep(sign(1)*100);"
+    sql 'set query_timeout=12;'
+    qt_sql "select sleep(sign(1)*10);"
 }

--- a/regression-test/suites/query_p0/aggregate/select_random_distributed_tbl.groovy
+++ b/regression-test/suites/query_p0/aggregate/select_random_distributed_tbl.groovy
@@ -41,8 +41,9 @@ suite("select_random_distributed_tbl") {
     "replication_allocation" = "tag.location.default: 1"
     );
     """
-    
+    sql 'set enable_fold_constant_by_be=true'
     sql """ insert into ${tableName} values(1,"a",1,1,1,avg_state(1),hll_hash(1),bitmap_hash(1),to_quantile_state(1, 2048)) """
+    sql 'set enable_fold_constant_by_be=false'
     sql """ insert into ${tableName} values(1,"a",2,2,2,avg_state(2),hll_hash(2),bitmap_hash(2),to_quantile_state(2, 2048)) """
     sql """ insert into ${tableName} values(1,"a",3,3,3,avg_state(3),hll_hash(3),bitmap_hash(3),to_quantile_state(3, 2048)) """
     sql """ insert into ${tableName} values(2,"b",4,4,4,avg_state(4),hll_hash(4),bitmap_hash(4),to_quantile_state(4, 2048)) """


### PR DESCRIPTION
## Proposed changes
1. fold child when const expr not folded
2. do not fold function `sleep`
3. move all exceptional expression into shouldSkipFold

before
```sql
mysql [test]>explain select sleep(sign(1)*100);
+-----------------------------------------------+
| Explain String(Nereids Planner)               |
+-----------------------------------------------+
| PLAN FRAGMENT 0                               |
|   OUTPUT EXPRS:                               |
|     sleep(cast((sign(1.0) * 100) as INT))[#0] |
|   PARTITION: UNPARTITIONED                    |
|                                               |
|   HAS_COLO_PLAN_NODE: false                   |
|                                               |
|   VRESULT SINK                                |
|      MYSQL_PROTOCAL                           |
|                                               |
|   0:VUNION(32)                                |
|      constant exprs:                          |
|          sleep(CAST((sign(1) * 100) AS int))  |
+-----------------------------------------------+
13 rows in set (15.02 sec)

mysql [test]>select sleep(sign(1)*100);
+-----------------------------------------------------+
| sleep(cast((sign(cast(1 as DOUBLE)) * 100) as INT)) |
+-----------------------------------------------------+
|                                                   1 |
+-----------------------------------------------------+
1 row in set (1 min 55.34 sec)
```

after
```sql
mysql [test]>explain select sleep(sign(1)*100);
+---------------------------------+
| Explain String(Nereids Planner) |
+---------------------------------+
| PLAN FRAGMENT 0                 |
|   OUTPUT EXPRS:                 |
|     sleep(100)[#0]              |
|   PARTITION: UNPARTITIONED      |
|                                 |
|   HAS_COLO_PLAN_NODE: false     |
|                                 |
|   VRESULT SINK                  |
|      MYSQL_PROTOCAL             |
|                                 |
|   0:VUNION(32)                  |
|      constant exprs:            |
|          sleep(100)             |
+---------------------------------+
13 rows in set (0.23 sec)

mysql [test]> select sleep(sign(1)*100);
+-----------------------------------------------------+
| sleep(cast((sign(cast(1 as DOUBLE)) * 100) as INT)) |
+-----------------------------------------------------+
|                                                   1 |
+-----------------------------------------------------+
1 row in set (1 min 40.37 sec)

```