### PR TITLE
[fix](cast) differences between FE and BE in parsing strings to integers.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -244,6 +244,14 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
         if (targetType instanceof IntegralType) {
             // do trailing zeros to avoid number parse error when cast to integral type
             BigDecimal bigDecimal = new BigDecimal(desc);
+            // Remove trailing zeros and check if there are no decimal places
+            BigDecimal stripped = bigDecimal.stripTrailingZeros();
+            // Here is to align with the BE code. The BE fails to parse "3.0" because it
+            // contains non-numeric characters.
+            if (stripped.scale() == 0 && desc.contains(".")) {
+                throw new AnalysisException(
+                        String.format("%s can't cast to %s", desc, targetType));
+            }
             if (bigDecimal.stripTrailingZeros().scale() <= 0) {
                 desc = bigDecimal.stripTrailingZeros().toPlainString();
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -324,7 +324,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 : new DateTimeLiteral(1991, 5, 3, 0, 0, 0);
         assertRewrite(e7, e8);
 
-        interval = "date '1991-05-01' + interval 10 / 2 + 1 day";
+        interval = "date '1991-05-01' + interval 5 + 1 day";
         e7 = process((TimestampArithmetic) PARSER.parseExpression(interval));
         e8 = Config.enable_date_conversion
                 ? new DateV2Literal(1991, 5, 7)

--- a/regression-test/data/datatype_p0/string/test_string_basic.out
+++ b/regression-test/data/datatype_p0/string/test_string_basic.out
@@ -98,3 +98,9 @@
 -- !test --
 a
 
+-- !cast_string_to_int --
+\N	\N	\N	0
+
+-- !cast_string_to_int --
+\N	\N	\N	0
+

--- a/regression-test/suites/datatype_p0/string/test_string_basic.groovy
+++ b/regression-test/suites/datatype_p0/string/test_string_basic.groovy
@@ -376,5 +376,12 @@ suite("test_string_basic") {
     }
     assertEquals(table_too_long, "fail")
     sql "drop table if exists varchar_table_too_long;"
+
+    //  calculations on the BE.
+    sql """ set debug_skip_fold_constant = true;"""
+    qt_cast_string_to_int""" select cast('3.123' as int),cast('3.000' as int) , cast('0000.0000' as int) , cast('0000' as int)"""
+    //  calculations on the FE.
+    sql """ set debug_skip_fold_constant = false;"""
+    qt_cast_string_to_int""" select cast('3.123' as int),cast('3.000' as int) , cast('0000.0000' as int) , cast('0000' as int)"""
 }
 


### PR DESCRIPTION
## Proposed changes


```
mysql [(none)]>select cast('3.000' as int);
+----------------------+
| cast('3.000' as INT) |
+----------------------+
|                    3 |
+----------------------+

mysql [(none)]>set debug_skip_fold_constant = true;
Query OK, 0 rows affected (0.01 sec)

mysql [(none)]>select cast('3.000' as int);
+----------------------+
| cast('3.000' as INT) |
+----------------------+
|                 NULL |
+----------------------+
```

<!--Describe your changes.-->

