### PR TITLE
[fix](test) Modify SQLServer image to custom hub

### DIFF
--- a/docker/thirdparties/docker-compose/sqlserver/sqlserver.yaml.tpl
+++ b/docker/thirdparties/docker-compose/sqlserver/sqlserver.yaml.tpl
@@ -18,7 +18,7 @@
 version: '3'
 services:
   doris--sqlserver_2022:
-    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    image: "doristhirdpartydocker/mssql-server:2022-latest"
     container_name: "doris--sqlserver_2022"
     ports:
       - ${DOCKER_SQLSERVER_EXTERNAL_PORT}:1433


### PR DESCRIPTION
Since the latest sqlserver image changes the sqlcmd path, it cannot run, but the image tag has not been changed, so we pick a fixed version of the image to the custom hub and use it

