### PR TITLE
[enhance](S3) Use allocator for s3 buffer's allocation

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1052,10 +1052,6 @@ DEFINE_mInt32(tablet_path_check_batch_size, "1000");
 DEFINE_mInt64(row_column_page_size, "4096");
 // it must be larger than or equal to 5MB
 DEFINE_mInt32(s3_write_buffer_size, "5242880");
-// the size of the whole s3 buffer pool, which indicates the s3 file writer
-// can at most buffer 50MB data. And the num of multi part upload task is
-// s3_write_buffer_whole_size / s3_write_buffer_size
-DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 DEFINE_mInt64(file_cache_max_file_reader_cache_size, "1000000");
 
 //disable shrink memory by default
@@ -1146,8 +1142,6 @@ DEFINE_Int32(download_binlog_rate_limit_kbs, "0");
 DEFINE_mInt32(buffered_reader_read_timeout_ms, "20000");
 
 DEFINE_Bool(enable_snapshot_action, "false");
-
-DEFINE_mInt32(s3_writer_buffer_allocation_timeout_second, "60");
 
 DEFINE_mBool(enable_column_type_check, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1082,10 +1082,6 @@ DECLARE_mInt32(tablet_path_check_batch_size);
 DECLARE_mInt64(row_column_page_size);
 // it must be larger than or equal to 5MB
 DECLARE_mInt32(s3_write_buffer_size);
-// the size of the whole s3 buffer pool, which indicates the s3 file writer
-// can at most buffer 50MB data. And the num of multi part upload task is
-// s3_write_buffer_whole_size / s3_write_buffer_size
-DECLARE_mInt32(s3_write_buffer_whole_size);
 // the max number of cached file handle for block segemnt
 DECLARE_mInt64(file_cache_max_file_reader_cache_size);
 //enable shrink memory
@@ -1196,9 +1192,6 @@ DECLARE_mInt32(buffered_reader_read_timeout_ms);
 
 // whether to enable /api/snapshot api
 DECLARE_Bool(enable_snapshot_action);
-
-// The timeout config for S3 write buffer allocation
-DECLARE_mInt32(s3_writer_buffer_allocation_timeout_second);
 
 DECLARE_mBool(enable_column_type_check);
 

--- a/be/src/io/fs/benchmark/fs_benchmark_tool.cpp
+++ b/be/src/io/fs/benchmark/fs_benchmark_tool.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
             .set_max_threads(num_cores)
             .build(&buffered_reader_prefetch_thread_pool);
     doris::io::S3FileBufferPool* s3_buffer_pool = doris::io::S3FileBufferPool::GetInstance();
-    s3_buffer_pool->init(524288000, 5242880, buffered_reader_prefetch_thread_pool.get());
+    s3_buffer_pool->init(buffered_reader_prefetch_thread_pool.get());
 
     try {
         doris::io::MultiBenchmark multi_bm(FLAGS_fs_type, FLAGS_operation, std::stoi(FLAGS_threads),

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -202,7 +202,7 @@ Status S3FileWriter::close() {
 
         if (_bytes_appended == 0 && _create_empty_file) {
             // No data written, but need to create an empty file
-            _pending_buf = S3FileBufferPool::GetInstance()->allocate();
+            RETURN_IF_ERROR(S3FileBufferPool::GetInstance()->allocate(&_pending_buf));
             // if there is no upload id, we need to create a new one
             _pending_buf->set_upload_remote_callback(
                     [this, buf = _pending_buf]() { _put_object(*buf); });
@@ -238,7 +238,7 @@ Status S3FileWriter::appendv(const Slice* data, size_t data_cnt) {
                 return _st;
             }
             if (!_pending_buf) {
-                _pending_buf = S3FileBufferPool::GetInstance()->allocate();
+                RETURN_IF_ERROR(S3FileBufferPool::GetInstance()->allocate(&_pending_buf));
                 // capture part num by value along with the value of the shared ptr
                 _pending_buf->set_upload_remote_callback(
                         [part_num = _cur_part_num, this, cur_buf = _pending_buf]() {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -468,9 +468,7 @@ int main(int argc, char** argv) {
 
     // init s3 write buffer pool
     doris::io::S3FileBufferPool* s3_buffer_pool = doris::io::S3FileBufferPool::GetInstance();
-    s3_buffer_pool->init(doris::config::s3_write_buffer_whole_size,
-                         doris::config::s3_write_buffer_size,
-                         exec_env->buffered_reader_prefetch_thread_pool());
+    s3_buffer_pool->init(exec_env->buffered_reader_prefetch_thread_pool());
 
     // init and open storage engine
     doris::EngineOptions options;


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Remove the static buffer pool for S3 upload. Use the dynamic allocator to control the memory usage for S3 upload which is more adaptive and easy to use. Remove all the useless config plus.