### PR TITLE
[enhance](mtmv)hive cache add partitionId to partitionName Map

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2919,16 +2919,6 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         return new MTMVVersionSnapshot(visibleVersion);
     }
 
-    @Override
-    public String getPartitionName(long partitionId) throws AnalysisException {
-        readLock();
-        try {
-            return getPartitionOrAnalysisException(partitionId).getName();
-        } finally {
-            readUnlock();
-        }
-    }
-
     private static Cloud.GetVersionResponse getVersionFromMeta(Cloud.GetVersionRequest req)
             throws RpcException {
         long startAt = System.nanoTime();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -759,11 +759,10 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
 
     @Override
     public String getPartitionName(long partitionId) throws AnalysisException {
-        Map<String, Long> partitionNameToIdMap = getHivePartitionValues().getPartitionNameToIdMap();
-        for (Entry<String, Long> entry : partitionNameToIdMap.entrySet()) {
-            if (entry.getValue().equals(partitionId)) {
-                return entry.getKey();
-            }
+        Map<Long, String> partitionIdToNameMap = getHivePartitionValues().getPartitionIdToNameMap();
+        String name = partitionIdToNameMap.get(partitionId);
+        if (name != null) {
+            return name;
         }
         throw new AnalysisException("can not find partition,  partitionId: " + partitionId);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -48,6 +48,7 @@ import org.apache.doris.thrift.THiveTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
+import com.google.common.collect.BiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -746,25 +747,11 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
                 getDbName(), getName(), getPartitionColumnTypes());
         Map<String, PartitionItem> res = Maps.newHashMap();
         Map<Long, PartitionItem> idToPartitionItem = hivePartitionValues.getIdToPartitionItem();
+        BiMap<Long, String> idToName = hivePartitionValues.getPartitionNameToIdMap().inverse();
         for (Entry<Long, PartitionItem> entry : idToPartitionItem.entrySet()) {
-            try {
-                res.put(getPartitionName(entry.getKey()), entry.getValue());
-            } catch (AnalysisException e) {
-                LOG.info("can not get partitionName by: " + entry.getKey());
-            }
-
+            res.put(idToName.get(entry.getKey()), entry.getValue());
         }
         return res;
-    }
-
-    @Override
-    public String getPartitionName(long partitionId) throws AnalysisException {
-        Map<Long, String> partitionIdToNameMap = getHivePartitionValues().getPartitionIdToNameMap();
-        String name = partitionIdToNameMap.get(partitionId);
-        if (name != null) {
-            return name;
-        }
-        throw new AnalysisException("can not find partition,  partitionId: " + partitionId);
     }
 
     private HiveMetaStoreCache.HivePartitionValues getHivePartitionValues() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -636,6 +636,7 @@ public class HiveMetaStoreCache {
         HivePartitionValues copy = partitionValues.copy();
         Map<Long, PartitionItem> idToPartitionItemBefore = copy.getIdToPartitionItem();
         Map<String, Long> partitionNameToIdMapBefore = copy.getPartitionNameToIdMap();
+        Map<Long, String> partitionIdToNameMapBefore = copy.getPartitionIdToNameMap();
         Map<Long, List<UniqueId>> idToUniqueIdsMap = copy.getIdToUniqueIdsMap();
         Map<Long, PartitionItem> idToPartitionItem = new HashMap<>();
         long idx = copy.getNextPartitionId();
@@ -649,6 +650,7 @@ public class HiveMetaStoreCache {
             idToPartitionItemBefore.put(partitionId, listPartitionItem);
             idToPartitionItem.put(partitionId, listPartitionItem);
             partitionNameToIdMapBefore.put(partitionName, partitionId);
+            partitionIdToNameMapBefore.put(partitionId, partitionName);
         }
         Map<Long, List<String>> partitionValuesMapBefore = copy.getPartitionValuesMap();
         Map<Long, List<String>> partitionValuesMap = ListPartitionPrunerV2.getPartitionValuesMap(idToPartitionItem);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -1087,6 +1087,7 @@ public class HiveMetaStoreCache {
     public static class HivePartitionValues {
         private long nextPartitionId;
         private Map<String, Long> partitionNameToIdMap;
+        private Map<Long, String> partitionIdToNameMap;
         private Map<Long, List<UniqueId>> idToUniqueIdsMap;
         private Map<Long, PartitionItem> idToPartitionItem;
         private Map<Long, List<String>> partitionValuesMap;
@@ -1115,6 +1116,7 @@ public class HiveMetaStoreCache {
             this.singleColumnRangeMap = singleColumnRangeMap;
             this.nextPartitionId = nextPartitionId;
             this.partitionNameToIdMap = partitionNameToIdMap;
+            this.partitionIdToNameMap = transferToIdName(partitionNameToIdMap);
             this.idToUniqueIdsMap = idToUniqueIdsMap;
             this.singleUidToColumnRangeMap = singleUidToColumnRangeMap;
             this.partitionValuesMap = partitionValuesMap;
@@ -1124,6 +1126,7 @@ public class HiveMetaStoreCache {
             HivePartitionValues copy = new HivePartitionValues();
             copy.setNextPartitionId(nextPartitionId);
             copy.setPartitionNameToIdMap(partitionNameToIdMap == null ? null : Maps.newHashMap(partitionNameToIdMap));
+            copy.setPartitionIdToNameMap(partitionIdToNameMap == null ? null : Maps.newHashMap(partitionIdToNameMap));
             copy.setIdToUniqueIdsMap(idToUniqueIdsMap == null ? null : Maps.newHashMap(idToUniqueIdsMap));
             copy.setIdToPartitionItem(idToPartitionItem == null ? null : Maps.newHashMap(idToPartitionItem));
             copy.setPartitionValuesMap(partitionValuesMap == null ? null : Maps.newHashMap(partitionValuesMap));
@@ -1137,6 +1140,14 @@ public class HiveMetaStoreCache {
                 copy.setSingleColumnRangeMap(copySingleColumnRangeMap);
             }
             return copy;
+        }
+
+        private Map<Long, String> transferToIdName(Map<String, Long> partitionNameToIdMap) {
+            if (partitionNameToIdMap == null) {
+                return null;
+            }
+            return partitionNameToIdMap.entrySet().stream()
+                    .collect(Collectors.toMap(entry -> entry.getValue(), entry -> entry.getKey()));
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
@@ -41,7 +41,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -164,14 +163,6 @@ public class MTMVPartitionUtil {
                     System.currentTimeMillis() - start, mvPartitionInfo);
         }
         return result.getDescs();
-    }
-
-    public static List<String> getPartitionNamesByIds(MTMV mtmv, Collection<Long> ids) throws AnalysisException {
-        List<String> res = Lists.newArrayList();
-        for (Long partitionId : ids) {
-            res.add(mtmv.getPartitionName(partitionId));
-        }
-        return res;
     }
 
     public static List<Long> getPartitionsIdsByNames(MTMV mtmv, List<String> partitions) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelatedTableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelatedTableIf.java
@@ -80,15 +80,6 @@ public interface MTMVRelatedTableIf extends TableIf {
     MTMVSnapshotIf getTableSnapshot() throws AnalysisException;
 
     /**
-     * getPartitionName
-     *
-     * @param partitionId
-     * @return partitionName
-     * @throws AnalysisException
-     */
-    String getPartitionName(long partitionId) throws AnalysisException;
-
-    /**
      * Does the current type of table allow timed triggering
      *
      * @return If return false,The method of comparing whether to synchronize will directly return true,

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -63,6 +63,8 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -477,7 +479,7 @@ public class CatalogMgrTest extends TestWithFeService {
                 partitionValueCacheKey.getTypes());
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
-        Assert.assertEquals(partitionValues.getPartitionIdToNameMap().size(), 4);
+        Assert.assertEquals(partitionValues.getPartitionNameToIdMap().inverse().size(), 4);
     }
 
     @Test
@@ -521,7 +523,7 @@ public class CatalogMgrTest extends TestWithFeService {
             HiveMetaStoreCache metaStoreCache) {
         // partition name format: nation=cn/city=beijing
         Map<Long, PartitionItem> idToPartitionItem = Maps.newHashMapWithExpectedSize(partitionNames.size());
-        Map<String, Long> partitionNameToIdMap = Maps.newHashMapWithExpectedSize(partitionNames.size());
+        BiMap<String, Long> partitionNameToIdMap = HashBiMap.create(partitionNames.size());
         Map<Long, List<UniqueId>> idToUniqueIdsMap = Maps.newHashMapWithExpectedSize(partitionNames.size());
         long idx = 0;
         for (String partitionName : partitionNames) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -477,6 +477,7 @@ public class CatalogMgrTest extends TestWithFeService {
                 partitionValueCacheKey.getTypes());
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
+        Assert.assertEquals(partitionValues.getPartitionIdToNameMap().size(), 4);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
@@ -99,10 +99,6 @@ public class MTMVPartitionUtilTest {
                 minTimes = 0;
                 result = baseSnapshotIf;
 
-                mtmv.getPartitionName(anyLong);
-                minTimes = 0;
-                result = "name1";
-
                 mtmv.getRefreshSnapshot();
                 minTimes = 0;
                 result = refreshSnapshot;
@@ -122,10 +118,6 @@ public class MTMVPartitionUtilTest {
                 baseOlapTable.getPartitionSnapshot(anyString);
                 minTimes = 0;
                 result = baseSnapshotIf;
-
-                baseOlapTable.getPartitionName(anyLong);
-                minTimes = 0;
-                result = "name1";
 
                 refreshSnapshot.equalsWithRelatedPartition(anyString, anyString, (MTMVSnapshotIf) any);
                 minTimes = 0;


### PR DESCRIPTION
MTMV need get partitionName  by partitionId

but now only have partitionName=>partitionId Map,when there are many partitions, obtaining the name from this map based on the ID can be slow,


