### PR TITLE
[enhance](tags)Support authentication of tags used by users when creating tables and partitions

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2341,6 +2341,12 @@ public class Config extends ConfigBase {
                     + "dynamic partitions. This config is recommended to be used only in the test environment"})
     public static String force_olap_table_replication_allocation = "";
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "用于强制检查用户在建表或创建分区时对指定标签是否有权限，如果该参数为false，则允许用户在任意tag下建表或创建分区",
+        "Used to forcibly check the user has permission for a specified tag when creating a table or partition. "
+            + "If this parameter is false, it allows the user to create a table or partition under any tags"})
+    public static boolean check_resource_tag_when_creating_table = false;
+
     @ConfField
     public static int auto_analyze_simultaneously_running_task_num = 1;
 


### PR DESCRIPTION
## Proposed changes

When users create tables or partitions, FE will not verify whether they have the corresponding tag BE permission. Resource tags can only be used for queries and loads. This PR adds a configuration that, if enabled, only allows users to create tables or partitions under BE with tag permission

Issue Number: close #xxx

<!--Describe your changes.-->

