### PR TITLE
[enhance](S3) Don't use aws's multithread utility in S3 FS to suite newer C++ compiler

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -938,7 +938,8 @@ DEFINE_mInt32(cold_data_compaction_interval_sec, "1800");
 
 DEFINE_String(tmp_file_dir, "tmp");
 
-DEFINE_Int32(s3_transfer_executor_pool_size, "2");
+DEFINE_Int32(min_s3_file_system_thread_num, "16");
+DEFINE_Int32(max_s3_file_system_thread_num, "64");
 
 DEFINE_Bool(enable_time_lut, "true");
 DEFINE_mBool(enable_simdjson_reader, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -995,7 +995,8 @@ DECLARE_mInt32(confirm_unused_remote_files_interval_sec);
 DECLARE_Int32(cold_data_compaction_thread_num);
 DECLARE_mInt32(cold_data_compaction_interval_sec);
 
-DECLARE_Int32(s3_transfer_executor_pool_size);
+DECLARE_Int32(min_s3_file_system_thread_num);
+DECLARE_Int32(max_s3_file_system_thread_num);
 
 DECLARE_Bool(enable_time_lut);
 DECLARE_mBool(enable_simdjson_reader);

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -18,9 +18,8 @@
 #include "io/fs/s3_file_system.h"
 
 #include <fmt/format.h>
-#include <stddef.h>
 
-#include <algorithm>
+#include <cstddef>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
 // IWYU pragma: no_include <bits/chrono.h>
@@ -32,7 +31,6 @@
 #include <fstream> // IWYU pragma: keep
 #include <future>
 #include <memory>
-#include <sstream>
 
 #include "common/config.h"
 #include "common/logging.h"
@@ -46,7 +44,7 @@
 #include "io/fs/s3_file_reader.h"
 #include "io/fs/s3_file_writer.h"
 #include "io/fs/s3_obj_storage_client.h"
-#include "util/bvar_helper.h"
+#include "runtime/exec_env.h"
 #include "util/s3_uri.h"
 #include "util/s3_util.h"
 
@@ -67,13 +65,6 @@ Result<std::string> get_key(const Path& full_path) {
     S3URI uri(full_path.native());
     RETURN_IF_ERROR_RESULT(uri.parse());
     return uri.get_key();
-}
-
-// TODO(plat1ko): AwsTransferManager will be deprecated
-std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor>& default_executor() {
-    static auto executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
-            "default", config::s3_transfer_executor_pool_size);
-    return executor;
 }
 
 } // namespace
@@ -383,13 +374,19 @@ Status S3FileSystem::batch_upload_impl(const std::vector<Path>& local_files,
         return Status::OK();
     };
 
+    Status s = Status::OK();
     std::vector<std::future<Status>> futures;
     for (int i = 0; i < local_files.size(); ++i) {
         auto task = std::make_shared<std::packaged_task<Status(size_t idx)>>(upload_task);
         futures.emplace_back(task->get_future());
-        default_executor()->Submit([t = std::move(task), idx = i]() mutable { (*t)(idx); });
+        auto st = ExecEnv::GetInstance()->s3_file_system_thread_pool()->submit_func(
+                [t = std::move(task), idx = i]() mutable { (*t)(idx); });
+        // We shouldn't return immediately since the previous submitted tasks might still be running in the thread pool
+        if (!st.ok()) {
+            s = st;
+            break;
+        }
     }
-    Status s = Status::OK();
     for (auto&& f : futures) {
         auto cur_s = f.get();
         if (!cur_s.ok()) {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -204,6 +204,7 @@ public:
     ThreadPool* join_node_thread_pool() { return _join_node_thread_pool.get(); }
     ThreadPool* lazy_release_obj_pool() { return _lazy_release_obj_pool.get(); }
     ThreadPool* non_block_close_thread_pool();
+    ThreadPool* s3_file_system_thread_pool() { return _s3_file_system_thread_pool.get(); }
 
     Status init_pipeline_task_scheduler();
     void init_file_cache_factory();
@@ -381,6 +382,7 @@ private:
     // Pool to use a new thread to release object
     std::unique_ptr<ThreadPool> _lazy_release_obj_pool;
     std::unique_ptr<ThreadPool> _non_block_close_thread_pool;
+    std::unique_ptr<ThreadPool> _s3_file_system_thread_pool;
 
     FragmentMgr* _fragment_mgr = nullptr;
     pipeline::TaskScheduler* _without_group_task_scheduler = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -265,6 +265,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_min_threads(config::min_nonblock_close_thread_num)
                               .set_max_threads(config::max_nonblock_close_thread_num)
                               .build(&_non_block_close_thread_pool));
+    static_cast<void>(ThreadPoolBuilder("S3FileSystemThreadPool")
+                              .set_min_threads(config::min_s3_file_system_thread_num)
+                              .set_max_threads(config::max_s3_file_system_thread_num)
+                              .build(&_s3_file_system_thread_pool));
 
     // NOTE: runtime query statistics mgr could be visited by query and daemon thread
     // so it should be created before all query begin and deleted after all query and daemon thread stoppped
@@ -675,6 +679,7 @@ void ExecEnv::destroy() {
     SAFE_SHUTDOWN(_join_node_thread_pool);
     SAFE_SHUTDOWN(_lazy_release_obj_pool);
     SAFE_SHUTDOWN(_non_block_close_thread_pool);
+    SAFE_SHUTDOWN(_s3_file_system_thread_pool);
     SAFE_SHUTDOWN(_send_report_thread_pool);
     SAFE_SHUTDOWN(_send_batch_thread_pool);
 
@@ -720,6 +725,7 @@ void ExecEnv::destroy() {
     _join_node_thread_pool.reset(nullptr);
     _lazy_release_obj_pool.reset(nullptr);
     _non_block_close_thread_pool.reset(nullptr);
+    _s3_file_system_thread_pool.reset(nullptr);
     _send_report_thread_pool.reset(nullptr);
     _send_table_stats_thread_pool.reset(nullptr);
     _buffered_reader_prefetch_thread_pool.reset(nullptr);


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

When compiling BE using clang version 18.1, it will fail at `default_executor()->Submit([t = std::move(task), idx = i]() mutable { (*t)(idx); });`;

```
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:552:2: error: 'result_of<(lambda at /mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:36) &()>' is deprecated: use 'std::invoke_result' instead [-Werror,-Wdeprecated-declarations]
  552 |         using _Res_type_impl
      |         ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:556:2: note: in instantiation of template type alias '_Res_type_impl' requested here
  556 |         using _Res_type = _Res_type_impl<_Functor, _CallArgs, _Bound_args...>;
      |         ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:586:28: note: in instantiation of template type alias '_Res_type' requested here
  586 |                typename _Result = _Res_type<tuple<_Args...>>>
      |                                   ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:881:5: note: in instantiation of template class 'std::_Bind<(lambda at /mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:36) ()>' requested here
  881 |     bind(_Func&& __f, _BoundArgs&&... __args)
      |     ^
/mnt/disk1/yuejing/projects/doris/thirdparty/installed/include/aws/core/utils/threading/Executor.h:41:58: note: in instantiation of function template specialization 'std::bind<(lambda at /mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:36)>' requested here
   41 |                     std::function<void()> callable{ std::bind(std::forward<Fn>(fn), std::forward<Args>(args)...) };
      |                                                          ^
/mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:29: note: in instantiation of function template specialization 'Aws::Utils::Threading::Executor::Submit<(lambda at /mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:36)>' requested here
  390 |         default_executor()->Submit([t = std::move(task), idx = i]() mutable { (*t)(idx); });
      |                             ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/type_traits:2590:9: note: 'result_of<(lambda at /mnt/disk1/yuejing/projects/doris/be/src/io/fs/s3_file_system.cpp:390:36) &()>' has been explicitly marked deprecated here
 2590 |     { } _GLIBCXX17_DEPRECATED_SUGGEST("std::invoke_result");
      |         ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13/bits/c++config.h:122:45: note: expanded from macro '_GLIBCXX17_DEPRECATED_SUGGEST'
  122 | # define _GLIBCXX17_DEPRECATED_SUGGEST(ALT) _GLIBCXX_DEPRECATED_SUGGEST(ALT)
      |                                             ^
/mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13/bits/c++config.h:98:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
   98 |   __attribute__ ((__deprecated__ ("use '" ALT "' instead")))
      |                   ^
1 error generated.
```