### PR TITLE
[chore](explain) Add algorithm item to VSORT explainition and modify dump_data of Block

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -255,14 +255,20 @@ public:
 
     bool empty() const { return rows() == 0; }
 
-    /** Updates SipHash of the Block, using update method of columns.
+    /** 
+      * Updates SipHash of the Block, using update method of columns.
       * Returns hash for block, that could be used to differentiate blocks
       *  with same structure, but different data.
       */
     void update_hash(SipHash& hash) const;
 
-    /** Get block data in string. */
-    std::string dump_data(size_t begin = 0, size_t row_limit = 100) const;
+    /** 
+     *  Get block data in string. 
+     *  If code is in default_implementation_for_nulls or something likely, type and column's nullity could
+     *   temporarily be not same. set allow_null_mismatch to true to dump it correctly.
+    */
+    std::string dump_data(size_t begin = 0, size_t row_limit = 100,
+                          bool allow_null_mismatch = false) const;
 
     static std::string dump_column(ColumnPtr col, DataTypePtr type) {
         ColumnWithTypeAndName type_name {col, type, ""};

--- a/be/src/vec/functions/function.cpp
+++ b/be/src/vec/functions/function.cpp
@@ -216,7 +216,8 @@ Status PreparedFunctionImpl::default_implementation_for_nulls(
         }
         RETURN_IF_ERROR(execute_without_low_cardinality_columns(context, block, new_args, result,
                                                                 block.rows(), dry_run));
-        // after run with nested, wrap them in null.
+        // After run with nested, wrap them in null. Before this, block.get_by_position(result).type
+        // is not compatible with get_by_position(result).column
         block.get_by_position(result).column = wrap_in_nullable(
                 block.get_by_position(result).column, block, args, result, input_rows_count);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -198,6 +198,19 @@ public class SortNode extends PlanNode {
         if (useTwoPhaseReadOpt) {
             output.append(detailPrefix + "OPT TWO PHASE\n");
         }
+
+        output.append(detailPrefix + "algorithm: ");
+        boolean isFixedLength = info.getOrderingExprs().stream().allMatch(e -> !e.getType().isStringType()
+                && !e.getType().isCollectionType());
+        if (limit > 0 && limit + offset < 1024 && (useTwoPhaseReadOpt || hasRuntimePredicate
+                || isFixedLength)) {
+            output.append("heap sort\n");
+        } else if (limit > 0 && !isFixedLength && limit + offset < 256) {
+            output.append("topn sort\n");
+        } else {
+            output.append("full sort\n");
+        }
+
         output.append(detailPrefix).append("offset: ").append(offset).append("\n");
         return output.toString();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1.  add algorithm record in `VSORT`'s explain string:

before:
```sql
|   1:VSORT(101)                 |
|   |  order by: xxx             |
|   |  offset: 0                 |
|   |  distribute expr lists:    |
|   |  tuple ids: 2              |
```
after:
```sql
|   1:VSORT(101)                 |
|   |  order by: xxx             |
|   |  algorithm: full sort      |
|   |  offset: 0                 |
|   |  distribute expr lists:    |
|   |  tuple ids: 2              |
```
2. add a new parameter to make `Block::dump_data()` could work when the nullity of the type of data is different from that of column. it's useful when in some function call under `default_implementation_for_nulls()`

