### PR TITLE
[fix](regression) fix prepare_insert when execute prepare stmt in observer fe

### DIFF
--- a/regression-test/suites/insert_p0/prepare_insert.groovy
+++ b/regression-test/suites/insert_p0/prepare_insert.groovy
@@ -144,7 +144,7 @@ suite("prepare_insert") {
     // insert with null
     result1 = connect(user = user, password = password, url = url) {
         def stmt = prepareStatement "insert into ${tableName} values(?, ?, ?)"
-        assertEquals(com.mysql.cj.jdbc.ServerPreparedStatement, stmt.class)
+        check {assertEquals(com.mysql.cj.jdbc.ServerPreparedStatement, stmt.class)}
         stmt.setNull(1, java.sql.Types.INTEGER)
         stmt.setNull(2, java.sql.Types.VARCHAR)
         stmt.setNull(3, java.sql.Types.INTEGER)


### PR DESCRIPTION
observer fe will forward insert statements to master fe, and forward does not support prepare protocol