### PR TITLE
[pipeline](fix) Fix blocking task which is not triggered by 2nd RPC

### DIFF
--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -136,6 +136,7 @@ public:
     bool is_finalized() const { return _finalized; }
 
     void clear_blocking_state() {
+        _state->get_query_ctx()->get_execution_dependency()->set_always_ready();
         // We use a lock to assure all dependencies are not deconstructed here.
         std::unique_lock<std::mutex> lc(_dependency_lock);
         if (!_finalized) {


### PR DESCRIPTION
## Proposed changes

Once a query is cancelled due to any reason, BE may not receive 2nd RPC from FE. If so, we must ensure the execution dependency is ready so tasks will not be blocked.

<!--Describe your changes.-->

