### PR TITLE
[Pick 2.1](regression-test) fix wrong variable name in test_index_compaction_with_multi_index_segments 

### DIFF
--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_with_multi_index_segments.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_with_multi_index_segments.groovy
@@ -144,7 +144,7 @@ suite("test_index_compaction_with_multi_index_segments", "nonConcurrent") {
         * 4. insert 10 rows, again
         * 5. full compaction
         */
-        table_name = "test_index_compaction_with_multi_index_segments_dups"
+        tableName = "test_index_compaction_with_multi_index_segments_dups"
         sql """ DROP TABLE IF EXISTS ${tableName}; """
         sql """
             CREATE TABLE ${tableName} (
@@ -263,7 +263,7 @@ suite("test_index_compaction_with_multi_index_segments", "nonConcurrent") {
         * 4. insert 10 rows, again
         * 5. full compaction
         */
-        table_name = "test_index_compaction_with_multi_index_segments_unique"
+        tableName = "test_index_compaction_with_multi_index_segments_unique"
         sql """ DROP TABLE IF EXISTS ${tableName}; """
         sql """
             CREATE TABLE ${tableName} (


### PR DESCRIPTION

Fix wrong variable name for case in
test_index_compaction_with_multi_index_segments

pick from #38182

