### PR TITLE
[fix](SSL) Correctly close SSL connections

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -314,7 +314,7 @@ public class MysqlChannel implements BytesChannel {
             // before read, set limit to make read only one packet
             result.limit(result.position() + packetLen);
             readLen = readAll(result, false);
-            if (isSslMode && remainingBuffer.position() == 0) {
+            if (isSslMode && remainingBuffer.position() == 0 && result.hasRemaining()) {
                 byte[] header = result.array();
                 int packetId = header[3] & 0xFF;
                 if (packetId != sequenceId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -332,6 +332,11 @@ public class MysqlConnectProcessor extends ConnectProcessor {
                 LOG.warn("Null packet received from network. remote: {}", channel.getRemoteHostPortString());
                 throw new IOException("Error happened when receiving packet.");
             }
+            if (!packetBuf.hasRemaining()) {
+                LOG.info("No more data to be read. Close connection. remote={}", channel.getRemoteHostPortString());
+                ctx.setKilled();
+                return;
+            }
         } catch (AsynchronousCloseException e) {
             // when this happened, timeout checker close this channel
             // killed flag in ctx has been already set, just return


### PR DESCRIPTION
## Proposed changes

Issue Number: close #38590 

If SSL connection closed, a specified packet will sent to indicate the closing of connection. The SSL engine will be shut down and output an empty unwrapped result.

Therefore, handle this case correctly to avoid buffer overflow by breaking the reading flow and do the cleanup stuff initiatively.
