### PR TITLE
[bug](expr)fix operator do_projections should use local_state intermediate_projections

### DIFF
--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -261,7 +261,7 @@ Status OperatorXBase::do_projections(RuntimeState* state, vectorized::Block* ori
     vectorized::Block input_block = *origin_block;
 
     std::vector<int> result_column_ids;
-    for (const auto& projections : _intermediate_projections) {
+    for (const auto& projections : local_state->_intermediate_projections) {
         result_column_ids.resize(projections.size());
         for (int i = 0; i < projections.size(); i++) {
             RETURN_IF_ERROR(projections[i]->execute(&input_block, &result_column_ids[i]));

--- a/regression-test/data/javaudf_p0/test_javaudf_string.out
+++ b/regression-test/data/javaudf_p0/test_javaudf_string.out
@@ -10,6 +10,17 @@
 8	8	abcdefg8	poiuytre8abcdefg
 9	9	abcdefg9	poiuytre9abcdefg
 
+-- !select_default_2 --
+1	1	abcdefg1	poiuytre1abcdefg
+2	2	abcdefg2	poiuytre2abcdefg
+3	3	abcdefg3	poiuytre3abcdefg
+4	4	abcdefg4	poiuytre4abcdefg
+5	5	abcdefg5	poiuytre5abcdefg
+6	6	abcdefg6	poiuytre6abcdefg
+7	7	abcdefg7	poiuytre7abcdefg
+8	8	abcdefg8	poiuytre8abcdefg
+9	9	abcdefg9	poiuytre9abcdefg
+
 -- !select --
 ab***fg1
 ab***fg2
@@ -42,4 +53,15 @@ ab*def	ab**efg
 ab*def	ab**efg
 ab*def	ab**efg
 ab*def	ab**efg
+
+-- !select_4 --
+ab***fg1	ab***fg1
+ab***fg2	ab***fg2
+ab***fg3	ab***fg3
+ab***fg4	ab***fg4
+ab***fg5	ab***fg5
+ab***fg6	ab***fg6
+ab***fg7	ab***fg7
+ab***fg8	ab***fg8
+ab***fg9	ab***fg9
 

--- a/regression-test/suites/javaudf_p0/test_javaudf_string.groovy
+++ b/regression-test/suites/javaudf_p0/test_javaudf_string.groovy
@@ -29,6 +29,7 @@ suite("test_javaudf_string") {
     log.info("Jar path: ${jarPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """ DROP TABLE IF EXISTS test_javaudf_string_2 """
         sql """
         CREATE TABLE IF NOT EXISTS ${tableName} (
             `user_id`     INT         NOT NULL COMMENT "用户id",
@@ -51,7 +52,10 @@ suite("test_javaudf_string") {
         sql """ INSERT INTO ${tableName} VALUES
              ${sb.toString()}
             """
+        sql """ create table test_javaudf_string_2 like test_javaudf_string """
+        sql """ insert into test_javaudf_string_2 select * from test_javaudf_string; """
         qt_select_default """ SELECT * FROM ${tableName} t ORDER BY user_id; """
+        qt_select_default_2 """ SELECT * FROM test_javaudf_string_2 t ORDER BY user_id; """
 
         File path = new File(jarPath)
         if (!path.exists()) {
@@ -68,9 +72,23 @@ suite("test_javaudf_string") {
         qt_select """ SELECT java_udf_string_test(string_col, 2, 3)  result FROM ${tableName} ORDER BY result; """
         qt_select """ SELECT java_udf_string_test('abcdef', 2, 3), java_udf_string_test('abcdefg', 2, 3) result FROM ${tableName} ORDER BY result; """
 
-        
+        qt_select_4 """ 
+            SELECT
+                COALESCE(
+                    java_udf_string_test(test_javaudf_string.varchar_col, 2, 3),
+                    'not1'
+                ),
+                COALESCE(
+                    java_udf_string_test(test_javaudf_string.varchar_col, 2, 3),
+                    'not2'
+                )
+            FROM
+                test_javaudf_string
+                JOIN test_javaudf_string_2 ON test_javaudf_string.user_id = test_javaudf_string_2.user_id order by 1,2;
+        """
     } finally {
         try_sql("DROP FUNCTION IF EXISTS java_udf_string_test(string, int, int);")
         try_sql("DROP TABLE IF EXISTS ${tableName}")
+        try_sql("DROP TABLE IF EXISTS test_javaudf_string_2")
     }
 }


### PR DESCRIPTION
should use local_state->_intermediate_projections, this is clone from parent intermediate_projections.
So it can run independently between different instance operators without affecting each other。
It needs to run in some extreme multi-threaded environments, so it's not easy to add test cases.