### PR TITLE
[improvement](statistics)Analyze table if it hasn't been analyzed for longer than 1 day.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2730,6 +2730,13 @@ public class Config extends ConfigBase {
             "SHould abort txn by checking conflick txn in schema change"})
     public static boolean enable_abort_txn_by_checking_conflict_txn = true;
 
+    @ConfField(mutable = true, description = {
+            "内表自动收集时间间隔，当某一列上次收集时间距离当前时间大于该值，则会触发一次新的收集，0表示不会触发。",
+            "Columns that have not been collected within the specified interval will trigger automatic analyze. "
+                + "0 means not trigger."
+    })
+    public static long auto_analyze_interval_seconds = 0;
+
     //==========================================================================
     //                    begin of cloud config
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -224,6 +224,7 @@ public class StatisticsUtil {
         sessionVariable.enablePushDownMinMaxOnUnique = true;
         sessionVariable.enablePushDownStringMinMax = true;
         sessionVariable.enableUniqueKeyPartialUpdate = false;
+        sessionVariable.enableMaterializedViewRewrite = false;
         connectContext.setEnv(Env.getCurrentEnv());
         connectContext.setDatabase(FeConstants.INTERNAL_DB_NAME);
         connectContext.setQualifiedUser(UserIdentity.ROOT.getQualifiedUser());
@@ -1001,6 +1002,12 @@ public class StatisticsUtil {
         ColStatsMeta columnStatsMeta = tableStatsStatus.findColumnStatsMeta(column.first, column.second);
         // Column never been analyzed, need analyze.
         if (columnStatsMeta == null) {
+            return true;
+        }
+        // Column hasn't been analyzed for longer than config interval.
+        if (Config.auto_analyze_interval_seconds > 0
+                && System.currentTimeMillis() - columnStatsMeta.updatedTime
+                        > Config.auto_analyze_interval_seconds * 1000) {
             return true;
         }
         // Partition table partition stats never been collected.


### PR DESCRIPTION
Need to reanalyze a table when it hasn't been analyzed for longer than 1 day. 
Set enableMaterializedViewRewrite to false for statistics session.