### PR TITLE
[fix](multicatalog) fix metacache is null issue when show_dbs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -294,6 +294,7 @@ public abstract class ExternalCatalog
         if (properties.getOrDefault(ExternalCatalog.USE_META_CACHE, "true").equals("false")) {
             LOG.warn("force to set use_meta_cache to true for catalog: {} when creating", name);
             getCatalogProperty().addProperty(ExternalCatalog.USE_META_CACHE, "true");
+            useMetaCache = Optional.of(true);
         }
     }
 


### PR DESCRIPTION
Brought by: #38244

how to reproduce:
create a hms catalog named hive with property use_meta_cache = false, after that restart fe, and run sql `switch hive; show databases;`, will get error：
```sql
ERROR 1105 (HY000): NullPointerException, msg: java.lang.NullPointerException: Cannot invoke "org.apache.doris.datasource.metacache.MetaCache.listNames()" because "this.metaCache" is null
```

reason, property use_meta_cache of newly created hms catalog after pr #38244 was force convert to true, but field  `useMetaCache` of class ExternalCatalog is not converted at the same time.
