### PR TITLE
[COMPILE](macos) do not patch bitshuffle on macos

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.cpp
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.cpp
@@ -72,7 +72,7 @@ __attribute__((constructor)) void SelectBitshuffleFunctions() {
         g_bshuf_compress_lz4 = bshuf_compress_lz4;
         g_bshuf_decompress_lz4 = bshuf_decompress_lz4;
     }
-#elif defined(__ARM_NEON) && defined(__aarch64__)
+#elif defined(__ARM_NEON) && defined(__aarch64__) && !defined(__APPLE__)
     g_bshuf_compress_lz4_bound = bshuf_compress_lz4_bound_neon;
     g_bshuf_compress_lz4 = bshuf_compress_lz4_neon;
     g_bshuf_decompress_lz4 = bshuf_decompress_lz4_neon;

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1126,6 +1126,7 @@ build_bitshuffle() {
     check_if_source_exist "${BITSHUFFLE_SOURCE}"
     local ld="${DORIS_BIN_UTILS}/ld"
     local ar="${DORIS_BIN_UTILS}/ar"
+    MACHINE_OS=$(uname -s)
 
     if [[ ! -f "${ld}" ]]; then ld="$(command -v ld)"; fi
     if [[ ! -f "${ar}" ]]; then ar="$(command -v ar)"; fi
@@ -1153,7 +1154,7 @@ build_bitshuffle() {
         if [[ "${arch}" == "avx512" ]]; then
             arch_flag="-mavx512bw -mavx512f"
         fi
-        if [[ "${arch}" == "neon" ]]; then
+        if [[ "${MACHINE_OS}" != "Darwin" ]] && [[ "${arch}" == "neon" ]]; then
             arch_flag="-march=armv8-a+crc"
         fi
         tmp_obj="bitshuffle_${arch}_tmp.o"
@@ -1165,7 +1166,7 @@ build_bitshuffle() {
         # Merge the object files together to produce a combined .o file.
         "${ld}" -r -o "${tmp_obj}" bitshuffle_core.o bitshuffle.o iochain.o
         # For the AVX2 symbols, suffix them.
-        if [[ "${arch}" == "avx2" ]] || [[ "${arch}" == "avx512" ]] || [[ "${arch}" == "neon" ]]; then
+        if [[ "${MACHINE_OS}" != "Darwin" ]] && { [[ "${arch}" == "avx2" ]] || [[ "${arch}" == "avx512" ]] || [[ "${arch}" == "neon" ]]; }; then
             local nm="${DORIS_BIN_UTILS}/nm"
             local objcopy="${DORIS_BIN_UTILS}/objcopy"
 

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -503,16 +503,22 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " KRB5 " ]]; then
 fi
 
 # patch bitshuffle
-if [[ " ${TP_ARCHIVES[*]} " =~ " BITSHUFFLE " ]]; then
-    if [[ "${BITSHUFFLE_SOURCE}" = "bitshuffle-0.5.1" ]]; then
-        cd "${TP_SOURCE_DIR}/${BITSHUFFLE_SOURCE}"
-        if [[ ! -f "${PATCHED_MARK}" ]]; then
-            patch -p1 <"${TP_PATCH_DIR}/bitshuffle-0.5.1.patch"
-            touch "${PATCHED_MARK}"
+MACHINE_OS=$(uname -s)
+
+if [[ "${MACHINE_OS}" == "Darwin" ]]; then
+    echo "MacOS. Skipping BITSHUFFLE patching."
+else
+    if [[ " ${TP_ARCHIVES[*]} " =~ " BITSHUFFLE " ]]; then
+        if [[ "${BITSHUFFLE_SOURCE}" = "bitshuffle-0.5.1" ]]; then
+            cd "${TP_SOURCE_DIR}/${BITSHUFFLE_SOURCE}"
+            if [[ ! -f "${PATCHED_MARK}" ]]; then
+                patch -p1 <"${TP_PATCH_DIR}/bitshuffle-0.5.1.patch"
+                touch "${PATCHED_MARK}"
+            fi
+            cd -
         fi
-        cd -
+        echo "Finished patching ${BITSHUFFLE_SOURCE}"
     fi
-    echo "Finished patching ${BITSHUFFLE_SOURCE}"
 fi
 
 # vim: ts=4 sw=4 ts=4 tw=100:


### PR DESCRIPTION
## Proposed changes

This PR(https://github.com/apache/doris/pull/38378) introduces a patch, but the patch cannot be applied on macOS.

error info
```
mryange/doris/thirdparty/installed/lib/liblz4.a  /Users/mryange/doris/thirdparty/installed/lib/libzstd.a  bin/libclucene-core-static.a  bin/libclucene-shared-static.a && :
ld: warning: directory not found for option '-F/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/System/Library/Frameworks'
```

Temporary solution:

Revert this PR(https://github.com/apache/doris/pull/38378)
```
cd thirdparty 
rm -rf src/bitshuffle-0.5.1
rm installed/lib64/libbitshuffle.a
./build-thirdparty.sh bitshuffle
```
Note, if you encounter this error ("download-thirdparty.sh: line 59: ${GIVEN_LIB,,}: bad substitution"), you can upgrade your bash version or manually modify the script.


OR

Either pick the current PR, 
```
cd thirdparty 
rm -rf src/bitshuffle-0.5.1
rm installed/lib64/libbitshuffle.a
./build-thirdparty.sh bitshuffle
```

If executed correctly, you will get:
```
===== Patching thirdparty archives...
MacOS. Skipping BITSHUFFLE patching.
```


OR
wait for the latest precompiled third-party library



<!--Describe your changes.-->

