### PR TITLE
[feature](Vault) Support alter hdfs storage vault and alter vault's name

### DIFF
--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -646,7 +646,8 @@ TEST(MetaServiceTest, AlterHdfsStorageVaultTest) {
                   TxnErrorCode::TXN_OK);
         StorageVaultPB get_obj;
         get_obj.ParseFromString(val);
-        ASSERT_EQ(get_obj.hdfs_info().build_conf().user(), "hadoop") << get_obj.hdfs_info().build_conf().fs_name();
+        ASSERT_EQ(get_obj.hdfs_info().build_conf().user(), "hadoop")
+                << get_obj.hdfs_info().build_conf().fs_name();
     }
 
     {

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -531,6 +531,28 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
 
     {
         AlterObjStoreInfoRequest req;
+        constexpr char new_vault_name[] = "@!#vault_name";
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        StorageVaultPB vault;
+        vault.set_alter_name(new_vault_name);
+        ObjectStoreInfoPB obj;
+        obj_info.set_ak("new_ak");
+        vault.mutable_obj_info()->MergeFrom(obj);
+        vault.set_name(vault_name);
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_NE(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        ASSERT_TRUE(res.status().msg().find("invalid storage vault name") != std::string::npos)
+                << res.status().msg();
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
         constexpr char new_vault_name[] = "new_test_alter_s3_vault";
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
@@ -665,6 +687,26 @@ TEST(MetaServiceTest, AlterHdfsStorageVaultTest) {
         meta_service->alter_storage_vault(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
         ASSERT_NE(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
+        constexpr char new_vault_name[] = "Thi213***@fakeVault";
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_HDFS_VAULT);
+        StorageVaultPB vault;
+        vault.mutable_hdfs_info()->mutable_build_conf()->set_user("hadoop");
+        vault.set_name(vault_name);
+        vault.set_alter_name(new_vault_name);
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_NE(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        ASSERT_TRUE(res.status().msg().find("invalid storage vault name") != std::string::npos)
+                << res.status().msg();
     }
 
     {

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -459,8 +459,9 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
     obj_info.set_ak("ak");
     obj_info.set_sk("sk");
     StorageVaultPB vault;
+    constexpr char vault_name[] = "test_alter_s3_vault";
     vault.mutable_obj_info()->MergeFrom(obj_info);
-    vault.set_name("test_alter_s3_vault");
+    vault.set_name(vault_name);
     vault.set_id("2");
     InstanceInfoPB instance;
     instance.add_storage_vault_names(vault.name());
@@ -489,7 +490,7 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
         req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
         StorageVaultPB vault;
         vault.mutable_obj_info()->set_ak("new_ak");
-        vault.set_name("test_alter_s3_vault");
+        vault.set_name(vault_name);
         req.mutable_vault()->CopyFrom(vault);
 
         brpc::Controller cntl;
@@ -526,6 +527,172 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
         meta_service->alter_storage_vault(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
         ASSERT_NE(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
+        constexpr char new_vault_name[] = "new_test_alter_s3_vault";
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        StorageVaultPB vault;
+        vault.set_alter_name(new_vault_name);
+        ObjectStoreInfoPB obj;
+        obj_info.set_ak("new_ak");
+        vault.mutable_obj_info()->MergeFrom(obj);
+        vault.set_name(vault_name);
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        InstanceInfoPB instance;
+        get_test_instance(instance);
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({instance.instance_id(), "2"}), &val),
+                  TxnErrorCode::TXN_OK);
+        StorageVaultPB get_obj;
+        get_obj.ParseFromString(val);
+        ASSERT_EQ(get_obj.name(), new_vault_name) << get_obj.obj_info().ak();
+    }
+
+    SyncPoint::get_instance()->disable_processing();
+    SyncPoint::get_instance()->clear_all_call_backs();
+}
+
+TEST(MetaServiceTest, AlterHdfsStorageVaultTest) {
+    auto meta_service = get_meta_service();
+
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    sp->set_call_back("encrypt_ak_sk:get_encryption_key", [](auto&& args) {
+        auto* ret = try_any_cast<int*>(args[0]);
+        *ret = 0;
+        auto* key = try_any_cast<std::string*>(args[1]);
+        *key = "selectdbselectdbselectdbselectdb";
+        auto* key_id = try_any_cast<int64_t*>(args[2]);
+        *key_id = 1;
+    });
+    std::pair<std::string, std::string> pair;
+    sp->set_call_back("extract_object_storage_info:get_aksk_pair", [&](auto&& args) {
+        auto* ret = try_any_cast<std::pair<std::string, std::string>*>(args[0]);
+        pair = *ret;
+    });
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string key;
+    std::string val;
+    InstanceKeyInfo key_info {"test_instance"};
+    instance_key(key_info, &key);
+
+    HdfsBuildConf hdfs_build_conf;
+    hdfs_build_conf.set_fs_name("fs_name");
+    hdfs_build_conf.set_user("root");
+    HdfsVaultInfo hdfs_info;
+    hdfs_info.set_prefix("root_path");
+    hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
+    StorageVaultPB vault;
+    constexpr char vault_name[] = "test_alter_hdfs_vault";
+    vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
+    vault.set_name(vault_name);
+    vault.set_id("2");
+    InstanceInfoPB instance;
+    instance.add_storage_vault_names(vault.name());
+    instance.add_resource_ids(vault.id());
+    instance.set_instance_id("GetObjStoreInfoTestInstance");
+    val = instance.SerializeAsString();
+    txn->put(key, val);
+    txn->put(storage_vault_key({instance.instance_id(), "2"}), vault.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    txn = nullptr;
+
+    auto get_test_instance = [&](InstanceInfoPB& i) {
+        std::string key;
+        std::string val;
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        InstanceKeyInfo key_info {"test_instance"};
+        instance_key(key_info, &key);
+        ASSERT_EQ(txn->get(key, &val), TxnErrorCode::TXN_OK);
+        i.ParseFromString(val);
+    };
+
+    {
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_HDFS_VAULT);
+        StorageVaultPB vault;
+        vault.mutable_hdfs_info()->mutable_build_conf()->set_user("hadoop");
+        vault.set_name(vault_name);
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        InstanceInfoPB instance;
+        get_test_instance(instance);
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({instance.instance_id(), "2"}), &val),
+                  TxnErrorCode::TXN_OK);
+        StorageVaultPB get_obj;
+        get_obj.ParseFromString(val);
+        ASSERT_EQ(get_obj.hdfs_info().build_conf().user(), "hadoop") << get_obj.hdfs_info().build_conf().fs_name();
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_HDFS_VAULT);
+        StorageVaultPB vault;
+        auto* hdfs = vault.mutable_hdfs_info();
+        hdfs->set_prefix("fake_one");
+        vault.set_name("test_alter_hdfs_vault_non_exist");
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_NE(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
+        constexpr char new_vault_name[] = "new_test_alter_hdfs_vault";
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_HDFS_VAULT);
+        StorageVaultPB vault;
+        vault.mutable_hdfs_info()->mutable_build_conf()->set_user("hadoop");
+        vault.set_name(vault_name);
+        vault.set_alter_name(new_vault_name);
+        req.mutable_vault()->CopyFrom(vault);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        InstanceInfoPB instance;
+        get_test_instance(instance);
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({instance.instance_id(), "2"}), &val),
+                  TxnErrorCode::TXN_OK);
+        StorageVaultPB get_obj;
+        get_obj.ParseFromString(val);
+        ASSERT_EQ(get_obj.name(), new_vault_name) << get_obj.obj_info().ak();
     }
 
     SyncPoint::get_instance()->disable_processing();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -37,12 +37,19 @@ import java.util.Map;
 // PROPERTIES (key1 = value1, ...)
 public class CreateStorageVaultStmt extends DdlStmt {
     private static final String TYPE = "type";
+
+    private static final String PATH_VERSION = "path_version";
+
+    private static final String SHARD_NUM = "shard_num";
+
     private static final String SET_AS_DEFAULT = "set_as_default";
 
     private final boolean ifNotExists;
     private final String vaultName;
     private final Map<String, String> properties;
     private boolean setAsDefault;
+    private int pathVersion = 0;
+    private int numShard = 0;
     private StorageVault.StorageVaultType vaultType;
 
     public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
@@ -62,6 +69,14 @@ public class CreateStorageVaultStmt extends DdlStmt {
 
     public String getStorageVaultName() {
         return vaultName;
+    }
+
+    public int getNumShard() {
+        return numShard;
+    }
+
+    public int getPathVersion() {
+        return pathVersion;
     }
 
     public Map<String, String> getProperties() {
@@ -107,6 +122,16 @@ public class CreateStorageVaultStmt extends DdlStmt {
         String type = properties.get(TYPE);
         if (type == null) {
             throw new AnalysisException("Storage Vault type can't be null");
+        }
+        final String pathVersionString = properties.get(PATH_VERSION);
+        if (pathVersionString != null) {
+            this.pathVersion = Integer.parseInt(pathVersionString);
+            properties.remove(PATH_VERSION);
+        }
+        final String numShardString = properties.get(SHARD_NUM);
+        if (numShardString != null) {
+            this.numShard = Integer.parseInt(numShardString);
+            properties.remove(SHARD_NUM);
         }
         setAsDefault = Boolean.parseBoolean(properties.getOrDefault(SET_AS_DEFAULT, "false"));
         setStorageVaultType(StorageVault.StorageVaultType.fromString(type));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -27,6 +27,8 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,6 +57,11 @@ public class HdfsStorageVault extends StorageVault {
     public static String DSF_NAMESERVICES = "dfs.nameservices";
     public static final String HDFS_PREFIX = "hdfs:";
     public static final String HDFS_FILE_PREFIX = "hdfs://";
+
+    public static final HashSet<String> ALTER_CHECK_PROPERTIES = new HashSet<>(Arrays.asList(
+            VAULT_PATH_PREFIX,
+            HADOOP_FS_NAME
+    ));
 
     /**
      * Property keys used by Doris, and should not be put in HDFS client configs,
@@ -99,6 +106,8 @@ public class HdfsStorageVault extends StorageVault {
                 hdfsConfBuilder.setHdfsKerberosPrincipal(property.getValue());
             } else if (property.getKey().equalsIgnoreCase(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB)) {
                 hdfsConfBuilder.setHdfsKerberosKeytab(property.getValue());
+            } else if (property.getKey().equalsIgnoreCase(VAULT_NAME)) {
+                continue;
             } else {
                 if (!nonHdfsConfPropertyKeys.contains(property.getKey().toLowerCase())) {
                     Cloud.HdfsBuildConf.HdfsConfKVPair.Builder conf = Cloud.HdfsBuildConf.HdfsConfKVPair.newBuilder();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -58,7 +58,7 @@ public class HdfsStorageVault extends StorageVault {
     public static final String HDFS_PREFIX = "hdfs:";
     public static final String HDFS_FILE_PREFIX = "hdfs://";
 
-    public static final HashSet<String> ALTER_CHECK_PROPERTIES = new HashSet<>(Arrays.asList(
+    public static final HashSet<String> FORBID_CHECK_PROPERTIES = new HashSet<>(Arrays.asList(
             VAULT_PATH_PREFIX,
             HADOOP_FS_NAME
     ));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -58,7 +58,7 @@ public class S3StorageVault extends StorageVault {
 
     private static final String TYPE = "type";
 
-    public static final HashSet<String> ALTER_CHECK_PROPERTIES = new HashSet<>(Arrays.asList(
+    public static final HashSet<String> ALLOW_ALTER_PROPERTIES = new HashSet<>(Arrays.asList(
             TYPE,
             S3Properties.ACCESS_KEY,
             S3Properties.SECRET_KEY,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -61,7 +61,8 @@ public class S3StorageVault extends StorageVault {
     public static final HashSet<String> ALTER_CHECK_PROPERTIES = new HashSet<>(Arrays.asList(
             TYPE,
             S3Properties.ACCESS_KEY,
-            S3Properties.SECRET_KEY
+            S3Properties.SECRET_KEY,
+            VAULT_NAME
     ));
 
     @SerializedName(value = "properties")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -59,11 +59,14 @@ public abstract class StorageVault {
         }
     }
 
+    protected static final String VAULT_NAME = "VAULT_NAME";
     protected String name;
     protected StorageVaultType type;
     protected String id;
     private boolean ifNotExists;
     private boolean setAsDefault;
+    private int pathVersion = 0;
+    private int numShard = 0;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
@@ -105,6 +108,13 @@ public abstract class StorageVault {
         return this.setAsDefault;
     }
 
+    public int getPathVersion() {
+        return pathVersion;
+    }
+
+    public int getNumShard() {
+        return numShard;
+    }
 
     public String getId() {
         return this.id;
@@ -142,6 +152,8 @@ public abstract class StorageVault {
             default:
                 throw new DdlException("Unknown StorageVault type: " + type);
         }
+        vault.pathVersion = stmt.getPathVersion();
+        vault.numShard = stmt.getNumShard();
         return vault;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -47,17 +47,12 @@ import java.util.concurrent.Executors;
 
 public class StorageVaultMgr {
     private static final Logger LOG = LogManager.getLogger(StorageVaultMgr.class);
-
+    private static final ExecutorService ALTER_BE_SYNC_THREAD_POOL = Executors.newFixedThreadPool(1);
+    private final SystemInfoService systemInfoService;
     // <VaultName, VaultId>
     private Pair<String, String> defaultVaultInfo;
-
     private Map<String, String> vaultNameToVaultId = new HashMap<>();
-
     private MonitoredReentrantReadWriteLock rwLock = new MonitoredReentrantReadWriteLock();
-
-    private static final ExecutorService ALTER_BE_SYNC_THREAD_POOL = Executors.newFixedThreadPool(1);
-
-    private final SystemInfoService systemInfoService;
 
     public StorageVaultMgr(SystemInfoService systemInfoService) {
         this.systemInfoService = systemInfoService;
@@ -93,32 +88,85 @@ public class StorageVaultMgr {
         return vaultId;
     }
 
-    public void alterStorageVault(StorageVaultType type, Map<String, String> properties, String name) throws Exception {
-        if (type != StorageVaultType.S3) {
-            throw new DdlException("Only support alter s3 storage vault");
-        }
-        properties.keySet().stream()
-                .filter(key -> !S3StorageVault.ALTER_CHECK_PROPERTIES.contains(key))
-                .findAny()
-                .ifPresent(key -> {
-                    throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
-                });
-        Cloud.AlterObjStoreInfoRequest.Builder requestBuilder
-                = Cloud.AlterObjStoreInfoRequest.newBuilder();
-        requestBuilder.setOp(Cloud.AlterObjStoreInfoRequest.Operation.ALTER_S3_VAULT);
+    private Cloud.StorageVaultPB.Builder buildAlterS3VaultRequest(Map<String, String> properties, String name)
+            throws Exception {
         Cloud.ObjectStoreInfoPB.Builder objBuilder = S3Properties.getObjStoreInfoPB(properties);
         Cloud.StorageVaultPB.Builder alterObjVaultBuilder = Cloud.StorageVaultPB.newBuilder();
         alterObjVaultBuilder.setName(name);
         alterObjVaultBuilder.setObjInfo(objBuilder.build());
-        requestBuilder.setVault(alterObjVaultBuilder.build());
+        if (properties.containsKey(StorageVault.VAULT_NAME)) {
+            alterObjVaultBuilder.setAlterName(properties.get(StorageVault.VAULT_NAME));
+        }
+        return alterObjVaultBuilder;
+    }
+
+    private Cloud.StorageVaultPB.Builder buildAlterHdfsVaultRequest(Map<String, String> properties, String name)
+            throws Exception {
+        Cloud.HdfsVaultInfo hdfsInfos = HdfsStorageVault.generateHdfsParam(properties);
+        Cloud.StorageVaultPB.Builder alterHdfsInfoBuilder = Cloud.StorageVaultPB.newBuilder();
+        alterHdfsInfoBuilder.setName(name);
+        alterHdfsInfoBuilder.setHdfsInfo(hdfsInfos);
+        if (properties.containsKey(StorageVault.VAULT_NAME)) {
+            alterHdfsInfoBuilder.setAlterName(properties.get(StorageVault.VAULT_NAME));
+        }
+        return alterHdfsInfoBuilder;
+    }
+
+    private Cloud.StorageVaultPB.Builder buildAlterStorageVaultRequest(StorageVaultType type,
+            Map<String, String> properties, String name) throws Exception {
+        Cloud.StorageVaultPB.Builder builder;
+        if (type == StorageVaultType.S3) {
+            builder = buildAlterS3VaultRequest(properties, name);
+        } else if (type == StorageVaultType.HDFS) {
+            builder = buildAlterHdfsVaultRequest(properties, name);
+        } else {
+            throw new DdlException("Unknown storage vault type");
+        }
+        return builder;
+    }
+
+    private Cloud.StorageVaultPB.Builder buildAlterStorageVaultRequest(StorageVault vault) throws Exception {
+        Cloud.StorageVaultPB.Builder builder = buildAlterStorageVaultRequest(vault.getType(),
+                vault.getCopiedProperties(), vault.getName());
+        Cloud.StorageVaultPB.PathFormat.Builder pathBuilder = Cloud.StorageVaultPB.PathFormat.newBuilder();
+        pathBuilder.setShardNum(vault.getNumShard());
+        pathBuilder.setPathVersion(vault.getPathVersion());
+        builder.setPathFormat(pathBuilder);
+        return builder;
+    }
+
+    public void alterStorageVault(StorageVaultType type, Map<String, String> properties, String name) throws Exception {
+        if (type == StorageVaultType.UNKNOWN) {
+            throw new DdlException("Unknown storage vault type");
+        }
         try {
+            Cloud.AlterObjStoreInfoRequest.Builder request = Cloud.AlterObjStoreInfoRequest.newBuilder();
+            if (type == StorageVaultType.S3) {
+                properties.keySet().stream()
+                        .filter(key -> !S3StorageVault.ALTER_CHECK_PROPERTIES.contains(key))
+                        .findAny()
+                        .ifPresent(key -> {
+                            throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
+                        });
+                request.setOp(Operation.ALTER_S3_VAULT);
+            } else if (type == StorageVaultType.HDFS) {
+                properties.keySet().stream()
+                        .filter(HdfsStorageVault.ALTER_CHECK_PROPERTIES::contains)
+                        .findAny()
+                        .ifPresent(key -> {
+                            throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
+                        });
+                request.setOp(Operation.ALTER_HDFS_VAULT);
+            }
+            Cloud.StorageVaultPB.Builder vaultBuilder = buildAlterStorageVaultRequest(type, properties, name);
+            request.setVault(vaultBuilder);
             Cloud.AlterObjStoreInfoResponse response =
-                    MetaServiceProxy.getInstance().alterStorageVault(requestBuilder.build());
+                    MetaServiceProxy.getInstance().alterStorageVault(request.build());
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
                 LOG.warn("failed to alter storage vault response: {} ", response);
                 throw new DdlException(response.getStatus().getMsg());
             }
-            LOG.info("Succeed to alter s3 vault {}, id {}, origin default vault replaced {}",
+            LOG.info("Succeed to alter storage vault {}, id {}, origin default vault replaced {}",
                     name, response.getStorageVaultId(), response.getDefaultStorageVaultReplaced());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
@@ -193,12 +241,8 @@ public class StorageVaultMgr {
     }
 
     @VisibleForTesting
-    public void createHdfsVault(StorageVault vault) throws DdlException {
-        HdfsStorageVault hdfsStorageVault = (HdfsStorageVault) vault;
-        Cloud.HdfsVaultInfo hdfsInfos = HdfsStorageVault.generateHdfsParam(hdfsStorageVault.getCopiedProperties());
-        Cloud.StorageVaultPB.Builder alterHdfsInfoBuilder = Cloud.StorageVaultPB.newBuilder();
-        alterHdfsInfoBuilder.setName(hdfsStorageVault.getName());
-        alterHdfsInfoBuilder.setHdfsInfo(hdfsInfos);
+    public void createHdfsVault(StorageVault vault) throws Exception {
+        Cloud.StorageVaultPB.Builder alterHdfsInfoBuilder = buildAlterStorageVaultRequest(vault);
         Cloud.AlterObjStoreInfoRequest.Builder requestBuilder
                 = Cloud.AlterObjStoreInfoRequest.newBuilder();
         requestBuilder.setOp(Cloud.AlterObjStoreInfoRequest.Operation.ADD_HDFS_INFO);
@@ -208,21 +252,21 @@ public class StorageVaultMgr {
             Cloud.AlterObjStoreInfoResponse response =
                     MetaServiceProxy.getInstance().alterStorageVault(requestBuilder.build());
             if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
-                    && hdfsStorageVault.ifNotExists()) {
-                LOG.info("Hdfs vault {} already existed", hdfsStorageVault.getName());
+                    && vault.ifNotExists()) {
+                LOG.info("Hdfs vault {} already existed", vault.getName());
                 return;
             }
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
                 LOG.warn("failed to create hdfs storage vault, vault name {}, response: {} ",
-                        hdfsStorageVault.getName(), response);
+                        vault.getName(), response);
                 throw new DdlException(response.getStatus().getMsg());
             }
             rwLock.writeLock().lock();
-            vaultNameToVaultId.put(hdfsStorageVault.getName(), response.getStorageVaultId());
+            vaultNameToVaultId.put(vault.getName(), response.getStorageVaultId());
             rwLock.writeLock().unlock();
             LOG.info("Succeed to create hdfs vault {}, id {}, origin default vault replaced {}",
-                    hdfsStorageVault.getName(), response.getStorageVaultId(),
-                            response.getDefaultStorageVaultReplaced());
+                    vault.getName(), response.getStorageVaultId(),
+                    response.getDefaultStorageVaultReplaced());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());
@@ -248,23 +292,19 @@ public class StorageVaultMgr {
         });
     }
 
-    public void createS3Vault(StorageVault vault) throws DdlException {
-        S3StorageVault s3StorageVault = (S3StorageVault) vault;
+    public void createS3Vault(StorageVault vault) throws Exception {
+        Cloud.StorageVaultPB.Builder s3StorageVaultBuilder = buildAlterStorageVaultRequest(vault);
         Cloud.AlterObjStoreInfoRequest.Builder requestBuilder
                 = Cloud.AlterObjStoreInfoRequest.newBuilder();
         requestBuilder.setOp(Cloud.AlterObjStoreInfoRequest.Operation.ADD_S3_VAULT);
-        Cloud.ObjectStoreInfoPB.Builder objBuilder = S3Properties.getObjStoreInfoPB(vault.getCopiedProperties());
-        Cloud.StorageVaultPB.Builder alterObjVaultBuilder = Cloud.StorageVaultPB.newBuilder();
-        alterObjVaultBuilder.setName(s3StorageVault.getName());
-        alterObjVaultBuilder.setObjInfo(objBuilder.build());
-        requestBuilder.setVault(alterObjVaultBuilder.build());
+        requestBuilder.setVault(s3StorageVaultBuilder);
         requestBuilder.setSetAsDefaultStorageVault(vault.setAsDefault());
         try {
             Cloud.AlterObjStoreInfoResponse response =
                     MetaServiceProxy.getInstance().alterStorageVault(requestBuilder.build());
             if (response.getStatus().getCode() == Cloud.MetaServiceCode.ALREADY_EXISTED
-                    && s3StorageVault.ifNotExists()) {
-                LOG.info("S3 vault {} already existed", s3StorageVault.getName());
+                    && vault.ifNotExists()) {
+                LOG.info("S3 vault {} already existed", vault.getName());
                 return;
             }
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
@@ -272,10 +312,10 @@ public class StorageVaultMgr {
                 throw new DdlException(response.getStatus().getMsg());
             }
             rwLock.writeLock().lock();
-            vaultNameToVaultId.put(s3StorageVault.getName(), response.getStorageVaultId());
+            vaultNameToVaultId.put(vault.getName(), response.getStorageVaultId());
             rwLock.writeLock().unlock();
             LOG.info("Succeed to create s3 vault {}, id {}, origin default vault replaced {}",
-                    s3StorageVault.getName(), response.getStorageVaultId(), response.getDefaultStorageVaultReplaced());
+                    vault.getName(), response.getStorageVaultId(), response.getDefaultStorageVaultReplaced());
         } catch (RpcException e) {
             LOG.warn("failed to alter storage vault due to RpcException: {}", e);
             throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -143,7 +143,7 @@ public class StorageVaultMgr {
             Cloud.AlterObjStoreInfoRequest.Builder request = Cloud.AlterObjStoreInfoRequest.newBuilder();
             if (type == StorageVaultType.S3) {
                 properties.keySet().stream()
-                        .filter(key -> !S3StorageVault.ALTER_CHECK_PROPERTIES.contains(key))
+                        .filter(key -> !S3StorageVault.ALLOW_ALTER_PROPERTIES.contains(key))
                         .findAny()
                         .ifPresent(key -> {
                             throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
@@ -151,7 +151,7 @@ public class StorageVaultMgr {
                 request.setOp(Operation.ALTER_S3_VAULT);
             } else if (type == StorageVaultType.HDFS) {
                 properties.keySet().stream()
-                        .filter(HdfsStorageVault.ALTER_CHECK_PROPERTIES::contains)
+                        .filter(HdfsStorageVault.FORBID_CHECK_PROPERTIES::contains)
                         .findAny()
                         .ifPresent(key -> {
                             throw new IllegalArgumentException("Alter property " + key + " is not allowed.");

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -210,6 +210,8 @@ message StorageVaultPB {
     }
 
     optional PathFormat path_format = 5;
+    // Set this filed when the user tries to alter name to alter_name
+    optional string alter_name = 6;
 }
 
 message HdfsBuildConf {
@@ -853,6 +855,7 @@ message AlterObjStoreInfoRequest {
         ADD_S3_VAULT = 103;
         DROP_S3_VAULT = 104;
         ALTER_S3_VAULT = 105;
+        ALTER_HDFS_VAULT = 106;
 
         SET_DEFAULT_VAULT = 200;
         UNSET_DEFAULT_VAULT = 201;

--- a/regression-test/suites/vaults/alter/alter_hdfs.groovy
+++ b/regression-test/suites/vaults/alter/alter_hdfs.groovy
@@ -31,6 +31,23 @@ suite("alter_hdfs_vault", "nonConcurrent") {
         );
     """
 
+    sql """
+        CREATE TABLE IF NOT EXISTS alter_hdfs_vault_tbl (
+                C_CUSTKEY     INTEGER NOT NULL,
+                C_NAME        INTEGER NOT NULL
+                )
+                DUPLICATE KEY(C_CUSTKEY, C_NAME)
+                DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 1
+                PROPERTIES (
+                "replication_num" = "1",
+                "storage_vault_name" = "alter_hdfs_vault"
+                )
+    """
+
+    sql """
+        insert into alter_hdfs_vault_tbl values("1", "1");
+    """
+
     expectExceptionLike({
         sql """
             ALTER STORAGE VAULT alter_hdfs_vault
@@ -92,4 +109,11 @@ suite("alter_hdfs_vault", "nonConcurrent") {
         }
     }
     assertFalse(exist)
+
+    // failed to insert due to the wrong ak
+    expectExceptionLike({
+        sql """
+            insert into alter_hdfs_vault_tbl values("2", "2");
+        """
+    }, "")
 }

--- a/regression-test/suites/vaults/alter/alter_hdfs.groovy
+++ b/regression-test/suites/vaults/alter/alter_hdfs.groovy
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("alter_hdfs_vault", "nonConcurrent") {
+    if (!enableStoragevault()) {
+        logger.info("skip alter hdfs storgage vault case")
+        return
+    }
+
+    sql """
+        CREATE STORAGE VAULT IF NOT EXISTS alter_hdfs_vault
+        PROPERTIES (
+        "type"="HDFS",
+        "fs.defaultFS"="${getHmsHdfsFs()}",
+        "path_prefix" = "ssb_sf1_p2",
+        "hadoop.username" = "hadoop"
+        );
+    """
+
+    expectExceptionLike({
+        sql """
+            ALTER STORAGE VAULT alter_hdfs_vault
+            PROPERTIES (
+            "type"="hdfs",
+            "path_prefix" = "ssb_sf1_p3"
+            );
+        """
+    }, "Alter property")
+
+    expectExceptionLike({
+        sql """
+            ALTER STORAGE VAULT alter_hdfs_vault
+            PROPERTIES (
+            "type"="hdfs",
+            "fs.defaultFS" = "ssb_sf1_p3"
+            );
+        """
+    }, "Alter property")
+
+    def vault_name = "alter_hdfs_vault"
+    String properties;
+
+    def vaults_info = try_sql """
+        show storage vault
+    """
+
+    for (int i = 0; i < vaults_info.size(); i++) {
+        def name = vaults_info[i][0]
+        if (name.equals(vault_name)) {
+            properties = vaults_info[i][2]
+        }
+    }
+    
+    sql """
+        ALTER STORAGE VAULT alter_hdfs_vault
+        PROPERTIES (
+        "type"="hdfs",
+        "VAULT_NAME" = "alter_hdfs_vault_new_name",
+        "hadoop.username" = "hdfs"
+        );
+    """
+
+    def new_vault_name = "alter_hdfs_vault_new_name"
+
+    vaults_info = sql """
+        SHOW STORAGE VAULT;
+    """
+    boolean exist = false
+
+    for (int i = 0; i < vaults_info.size(); i++) {
+        def name = vaults_info[i][0]
+        logger.info("name is ${name}, info ${vaults_info[i]}")
+        if (name.equals(vault_name)) {
+            exist = true
+        }
+        if (name.equals(new_vault_name)) {
+            assertTrue(vaults_info[i][2].contains(""""hadoop.username" = "hdfs"""""))
+        }
+    }
+    assertFalse(exist)
+}

--- a/regression-test/suites/vaults/alter/alter_s3.groovy
+++ b/regression-test/suites/vaults/alter/alter_s3.groovy
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("alter_s3_vault", "nonConcurrent") {
+    if (!enableStoragevault()) {
+        logger.info("skip alter s3 storgage vault case")
+        return
+    }
+
+    sql """
+        CREATE STORAGE VAULT IF NOT EXISTS alter_s3_vault
+        PROPERTIES (
+        "type"="S3",
+        "s3.endpoint"="${getS3Endpoint()}",
+        "s3.region" = "${getS3Region()}",
+        "s3.access_key" = "${getS3AK()}",
+        "s3.secret_key" = "${getS3SK()}",
+        "s3.root.path" = "ssb_sf1_p2_s3",
+        "s3.bucket" = "${getS3BucketName()}",
+        "s3.external_endpoint" = "",
+        "provider" = "${getS3Provider()}"
+        );
+    """
+
+    expectExceptionLike({
+        sql """
+            ALTER STORAGE VAULT alter_s3_vault
+            PROPERTIES (
+            "type"="S3",
+            "s3.bucket" = "error_bucket"
+            );
+        """
+    }, "Alter property")
+    expectExceptionLike({
+        sql """
+            ALTER STORAGE VAULT alter_s3_vault
+            PROPERTIES (
+            "type"="S3",
+            "provider" = "${getS3Provider()}"
+            );
+        """
+    }, "Alter property")
+
+    def vault_name = "alter_s3_vault"
+    String properties;
+
+    def vaults_info = try_sql """
+        show storage vault
+    """
+
+    for (int i = 0; i < vaults_info.size(); i++) {
+        def name = vaults_info[i][0]
+        if (name.equals(vault_name)) {
+            properties = vaults_info[i][2]
+        }
+    }
+    
+    sql """
+        ALTER STORAGE VAULT alter_s3_vault
+        PROPERTIES (
+        "type"="S3",
+        "VAULT_NAME" = "alter_s3_vault",
+        "s3.access_key" = "new_ak"
+        );
+    """
+
+    def new_vault_name = "alter_s3_vault_new"
+
+    vaults_info = sql """
+        SHOW STORAGE VAULT;
+    """
+    boolean exist = false
+
+    for (int i = 0; i < vaults_info.size(); i++) {
+        def name = vaults_info[i][0]
+        logger.info("name is ${name}, info ${vaults_info[i]}")
+        if (name.equals(vault_name)) {
+            exist = true
+        }
+        if (name.equals(new_vault_name)) {
+            assertTrue(vaults_info[i][2].contains(""""s3.access_key" = "new_ak"""""))
+        }
+    }
+    assertFalse(exist)    
+}


### PR DESCRIPTION
Previously only s3 vault can be altered. This pr adds support of hdfs storage vault. And this pr also supports to alter vault's name.

usage example
```
ALTER STORAGE VAULT alter_s3_vault
PROPERTIES (
        "type"="S3",
        "s3.access_key" = "new_ak", -- change ak
        "s3.secrete_key" = "new_ak", -- change sk
);

ALTER STORAGE VAULT alter_hdfs_vault
PROPERTIES (
        "type"="hdfs",
        "VAULT_NAME" = "alter_hdfs_vault_new_name", -- change vault name
        "hadoop.username" = "hdfs" -- change user name
);
```