### PR TITLE
[fix](fe) Fix the default value of ReplacePartitionClause.isStrictRange

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplacePartitionClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ReplacePartitionClause.java
@@ -66,6 +66,15 @@ public class ReplacePartitionClause extends AlterTableClause {
         this.needTableStable = false;
         this.forceDropOldPartition = isForce;
         this.properties = properties;
+
+        // ATTN: During ReplacePartitionClause.analyze(), the default value of isStrictRange is true.
+        // However, ReplacePartitionClause instances constructed by internal code do not call analyze(),
+        // so their isStrictRange value is incorrect (e.g., INSERT INTO ... OVERWRITE).
+        //
+        // Considering this, we should handle the relevant properties when constructing.
+        this.isStrictRange = getBoolProperty(properties, PropertyAnalyzer.PROPERTIES_STRICT_RANGE, true);
+        this.useTempPartitionName = getBoolProperty(
+                properties, PropertyAnalyzer.PROPERTIES_USE_TEMP_PARTITION_NAME, false);
     }
 
     public List<String> getPartitionNames() {
@@ -140,5 +149,13 @@ public class ReplacePartitionClause extends AlterTableClause {
     @Override
     public String toString() {
         return toSql();
+    }
+
+    public static boolean getBoolProperty(Map<String, String> properties, String propKey, boolean defaultVal) {
+        if (properties != null && properties.containsKey(propKey)) {
+            String val = properties.get(propKey);
+            return Boolean.parseBoolean(val);
+        }
+        return defaultVal;
     }
 }


### PR DESCRIPTION
During ReplacePartitionClause.analyze(), the default value of isStrictRange is true. However, ReplacePartitionClause instances constructed by internal code do not call analyze(), so their isStrictRange value is incorrect (e.g., INSERT INTO ... OVERWRITE).

This PR handle the relevant properties when constructing ReplacePartitionClause.


