### PR TITLE
[pipeline](fix) Fix blocking task which is not triggered by 2nd RPC (…

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_task.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.h
@@ -139,6 +139,7 @@ public:
     int task_id() const { return _index; };
 
     void clear_blocking_state() {
+        _state->get_query_ctx()->get_execution_dependency()->set_always_ready();
         // We use a lock to assure all dependencies are not deconstructed here.
         std::unique_lock<std::mutex> lc(_dependency_lock);
         if (!_finished) {


### PR DESCRIPTION
…#38568)

Once a query is cancelled due to any reason, BE may not receive 2nd RPC from FE. If so, we must ensure the execution dependency is ready so tasks will not be blocked.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

