### PR TITLE
[opt](info) processlist schema table support show all fe

### DIFF
--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -69,6 +69,7 @@ struct SchemaScannerCommonParam {
     int32_t port;                                      // frontend thrift port
     int64_t thread_id;
     const std::string* catalog = nullptr;
+    std::set<TNetworkAddress> fe_addr_list;
 };
 
 // scanner parameter from frontend

--- a/be/src/exec/schema_scanner/schema_processlist_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_processlist_scanner.cpp
@@ -56,9 +56,14 @@ Status SchemaProcessListScanner::start(RuntimeState* state) {
     TShowProcessListRequest request;
     request.__set_show_full_sql(true);
 
-    RETURN_IF_ERROR(SchemaHelper::show_process_list(*(_param->common_param->ip),
-                                                    _param->common_param->port, request,
-                                                    &_process_list_result));
+    for (const auto& fe_addr : _param->common_param->fe_addr_list) {
+        TShowProcessListResult tmp_ret;
+        RETURN_IF_ERROR(
+                SchemaHelper::show_process_list(fe_addr.hostname, fe_addr.port, request, &tmp_ret));
+        _process_list_result.process_list.insert(_process_list_result.process_list.end(),
+                                                 tmp_ret.process_list.begin(),
+                                                 tmp_ret.process_list.end());
+    }
 
     return Status::OK();
 }

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -120,6 +120,17 @@ Status SchemaScanOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
         _common_scanner_param->catalog =
                 state->obj_pool()->add(new std::string(tnode.schema_scan_node.catalog));
     }
+
+    if (tnode.schema_scan_node.__isset.fe_addr_list) {
+        for (const auto& fe_addr : tnode.schema_scan_node.fe_addr_list) {
+            _common_scanner_param->fe_addr_list.insert(fe_addr);
+        }
+    } else if (tnode.schema_scan_node.__isset.ip && tnode.schema_scan_node.__isset.port) {
+        TNetworkAddress fe_addr;
+        fe_addr.hostname = tnode.schema_scan_node.ip;
+        fe_addr.port = tnode.schema_scan_node.port;
+        _common_scanner_param->fe_addr_list.insert(fe_addr);
+    }
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -508,7 +508,7 @@ public class SchemaTable extends Table {
                                     .column("INFO", ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH))
                                     .column("FE",
                                             ScalarType.createVarchar(64))
-                                    .column("CLOUD_CLUSTER", ScalarType.createVarchar(64)).build()))
+                                    .column("CLOUD_CLUSTER", ScalarType.createVarchar(64)).build(), true))
             .put("workload_policy",
                     new SchemaTable(SystemIdGenerator.getNextId(), "workload_policy", TableType.SCHEMA,
                             builder().column("ID", ScalarType.createType(PrimitiveType.BIGINT))
@@ -542,8 +542,15 @@ public class SchemaTable extends Table {
             )
             .build();
 
+    private boolean fetchAllFe = false;
+
     protected SchemaTable(long id, String name, TableType type, List<Column> baseSchema) {
         super(id, name, type, baseSchema);
+    }
+
+    protected SchemaTable(long id, String name, TableType type, List<Column> baseSchema, boolean fetchAllFe) {
+        this(id, name, type, baseSchema);
+        this.fetchAllFe = fetchAllFe;
     }
 
     @Override
@@ -557,6 +564,14 @@ public class SchemaTable extends Table {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public static boolean isShouldFetchAllFe(String schemaTableName) {
+        Table table = TABLE_MAP.get(schemaTableName);
+        if (table != null && table instanceof SchemaTable) {
+            return ((SchemaTable) table).fetchAllFe;
+        }
+        return false;
     }
 
     /**

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -698,6 +698,7 @@ struct TSchemaScanNode {
   12: optional bool show_hidden_cloumns = false
   // 13: optional list<TSchemaTableStructure> table_structure // deprecated
   14: optional string catalog
+  15: optional list<Types.TNetworkAddress> fe_addr_list
 }
 
 struct TMetaScanNode {


### PR DESCRIPTION
## Proposed changes
query schema table processlist support show all fe

```
mysql [information_schema]>select * from processlist;
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+---------------------------+------------+---------------+
| CURRENT_CONNECTED | ID   | USER | HOST             | LOGIN_TIME          | CATALOG  | DB                 | COMMAND | TIME | STATE | QUERY_ID                          | INFO                      | FE         | CLOUD_CLUSTER |
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+---------------------------+------------+---------------+
| No                | 0    | root | ip1:15070 | 2024-08-01 16:38:40 | internal |                    | Sleep   |  349 | EOF   | 566a4d49ff244ad1-a70a065f3b3351ae | show frontends            | ip1 | NULL          |
| No                | 1    | root | ip1:19718 | 2024-08-01 16:44:58 | internal | information_schema | Query   |    0 | OK    | f19c4b24094441bd-a6b68c07938ed1f2 | select * from processlist | ip1 | NULL          |
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+---------------------------+------------+---------------+
2 rows in set (0.05 sec)

mysql [information_schema]>set show_all_fe_connection = true;
Query OK, 0 rows affected (0.00 sec)

mysql [information_schema]>select * from processlist;
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+----------------------------------+------------+---------------+
| CURRENT_CONNECTED | ID   | USER | HOST             | LOGIN_TIME          | CATALOG  | DB                 | COMMAND | TIME | STATE | QUERY_ID                          | INFO                             | FE         | CLOUD_CLUSTER |
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+----------------------------------+------------+---------------+
| No                | 0    | root | ip1:15070 | 2024-08-01 16:38:40 | internal |                    | Sleep   |  360 | EOF   | 566a4d49ff244ad1-a70a065f3b3351ae | show frontends                   | ip1 | NULL          |
| No                | 1    | root | ip1:19718 | 2024-08-01 16:44:58 | internal | information_schema | Query   |    0 | OK    | 82560d98af964c69-b9c61bc0b5cf564a | select * from processlist        | ip1 | NULL          |
| No                | 0    | root | ip2:54660 | 2024-08-01 16:45:18 | internal |                    | Sleep   |   68 | EOF   | a555a28a1b094f69-ad25198d5b54f166 | select @@version_comment limit 1 | ip2 | NULL          |
+-------------------+------+------+------------------+---------------------+----------+--------------------+---------+------+-------+-----------------------------------+----------------------------------+------------+---------------+
3 rows in set (0.02 sec)
```
