### PR TITLE
[enhancement](tools) make benchmark scripts better use

### DIFF
--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -370,6 +370,7 @@ file_changed_performance() {
             [[ "${af}" == 'regression-test/pipeline/common/doris-utils.sh' ]] ||
             [[ "${af}" == 'regression-test/pipeline/common/oss-utils.sh' ]] ||
             [[ "${af}" == 'regression-test/pipeline/performance/'* ]] ||
+            [[ "${af}" == 'tools/clickbench-tools/run-clickbench-queries.sh' ]] ||
             [[ "${af}" == 'tools/tpch-tools/bin/run-tpch-queries.sh' ]] ||
             [[ "${af}" == 'tools/tpcds-tools/bin/run-tpcds-queries.sh' ]] ||
             [[ "${af}" == 'regression-test/pipeline/tpch/tpch-sf100/'* ]]; then

--- a/tools/clickbench-tools/load-clickbench-data.sh
+++ b/tools/clickbench-tools/load-clickbench-data.sh
@@ -169,3 +169,13 @@ check_doris_conf
 load
 end=$(date +%s)
 echo "load cost time: $((end - start)) seconds"
+
+run_sql() {
+  echo $@
+  mysql -h$FE_HOST -u$USER -P$FE_QUERY_PORT -D$DB -e "$@"
+}
+
+echo '============================================'
+echo "analyzing table hits"
+run_sql "analyze table hits with sync;"
+echo "analyzing table hits finished!"

--- a/tools/clickbench-tools/run-clickbench-queries.sh
+++ b/tools/clickbench-tools/run-clickbench-queries.sh
@@ -107,19 +107,12 @@ get_session_variable() {
   echo "${v/*Value: /}"
 }
 
-_parallel_fragment_exec_instance_num="$(get_session_variable parallel_fragment_exec_instance_num)"
 _exec_mem_limit="$(get_session_variable exec_mem_limit)"
-_query_timeout="$(get_session_variable query_timeout)"
-
 echo '============================================'
 echo "Optimize session variables"
-run_sql "set global parallel_fragment_exec_instance_num=16;"
 run_sql "set global exec_mem_limit=32G;"
-run_sql "set global query_timeout=900;"
 echo '============================================'
 run_sql "show variables"
-echo '============================================'
-run_sql "analyze table hits with sync;"
 
 TRIES=3
 QUERY_NUM=1
@@ -147,11 +140,9 @@ done
 
 cold_run_sum=$(awk -F ',' '{sum+=$2} END {print sum}' result.csv)
 best_hot_run_sum=$(awk -F ',' '{if($3<$4){sum+=$3}else{sum+=$4}} END {print sum}' result.csv)
-echo "Total cold run time: ${cold_run_sum} ms"
-echo "Total hot run time: ${best_hot_run_sum} ms"
+echo "Total cold run time: ${cold_run_sum} s"
+echo "Total hot run time: ${best_hot_run_sum} s"
 echo 'Finish ClickBench queries.'
 
 echo "Restore session variables"
-run_sql "set global parallel_fragment_exec_instance_num=${_parallel_fragment_exec_instance_num};"
 run_sql "set global exec_mem_limit=${_exec_mem_limit};"
-run_sql "set global query_timeout=${_query_timeout};"

--- a/tools/ssb-tools/bin/load-ssb-data.sh
+++ b/tools/ssb-tools/bin/load-ssb-data.sh
@@ -296,15 +296,15 @@ else
         -T "${SSB_DATA_DIR}"/part.tbl http://"${FE_HOST}":"${FE_HTTP_PORT}"/api/"${DB}"/part/_stream_load
 fi
 
-echo 'Loading data for table: date'
+echo 'Loading data for table: dates'
 if [[ -z ${TXN_ID} ]]; then
     curl --location-trusted -u "${USER}":"${PASSWORD}" \
-        -H "label:${TXN_ID}_date" -H "column_separator:|" \
+        -H "column_separator:|" \
         -H "columns:d_datekey,d_date,d_dayofweek,d_month,d_year,d_yearmonthnum,d_yearmonth,d_daynuminweek,d_daynuminmonth,d_daynuminyear,d_monthnuminyear,d_weeknuminyear,d_sellingseason,d_lastdayinweekfl,d_lastdayinmonthfl,d_holidayfl,d_weekdayfl,d_dummy" \
         -T "${SSB_DATA_DIR}"/date.tbl http://"${FE_HOST}":"${FE_HTTP_PORT}"/api/"${DB}"/dates/_stream_load
 else
     curl --location-trusted -u "${USER}":"${PASSWORD}" \
-        -H "column_separator:|" \
+        -H "label:${TXN_ID}_date" -H "column_separator:|" \
         -H "columns:d_datekey,d_date,d_dayofweek,d_month,d_year,d_yearmonthnum,d_yearmonth,d_daynuminweek,d_daynuminmonth,d_daynuminyear,d_monthnuminyear,d_weeknuminyear,d_sellingseason,d_lastdayinweekfl,d_lastdayinmonthfl,d_holidayfl,d_weekdayfl,d_dummy" \
         -T "${SSB_DATA_DIR}"/date.tbl http://"${FE_HOST}":"${FE_HTTP_PORT}"/api/"${DB}"/dates/_stream_load
 fi
@@ -376,21 +376,9 @@ wait
 date
 
 echo "==========Start to insert data into ssb flat table=========="
-echo "change some session variables before load, and then restore after load."
-origin_parallel=$(
-    set -e
-    run_sql 'select @@parallel_fragment_exec_instance_num;' | sed -n '3p'
-)
-# set parallel_fragment_exec_instance_num=1, loading maybe slow but stable.
-run_sql "set global insert_timeout=7200;"
-run_sql "set global parallel_fragment_exec_instance_num=1;"
-echo '============================================'
 date
 load_lineitem_flat
 date
-echo '============================================'
-echo "restore session variables"
-run_sql "set global parallel_fragment_exec_instance_num=${origin_parallel};"
 echo '============================================'
 
 end_time=$(date +%s)

--- a/tools/tpcds-tools/ddl/create-tpcds-tables-sf100.sql
+++ b/tools/tpcds-tools/ddl/create-tpcds-tables-sf100.sql
@@ -46,7 +46,7 @@ drop table if exists date_dim;
 CREATE TABLE IF NOT EXISTS date_dim (
     d_date_sk bigint not null,
     d_date_id char(16) not null,
-    d_date datev2,
+    d_date date,
     d_month_seq integer,
     d_week_seq integer,
     d_quarter_seq integer,
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS warehouse (
     w_state char(2),
     w_zip char(10),
     w_country varchar(20),
-    w_gmt_offset decimalv3(5,2)
+    w_gmt_offset decimal(5,2)
 )
 DUPLICATE KEY(w_warehouse_sk)
 DISTRIBUTED BY HASH(w_warehouse_sk) BUCKETS 1
@@ -121,21 +121,21 @@ CREATE TABLE IF NOT EXISTS catalog_sales (
     cs_warehouse_sk bigint,
     cs_promo_sk bigint,
     cs_quantity integer,
-    cs_wholesale_cost decimalv3(7,2),
-    cs_list_price decimalv3(7,2),
-    cs_sales_price decimalv3(7,2),
-    cs_ext_discount_amt decimalv3(7,2),
-    cs_ext_sales_price decimalv3(7,2),
-    cs_ext_wholesale_cost decimalv3(7,2),
-    cs_ext_list_price decimalv3(7,2),
-    cs_ext_tax decimalv3(7,2),
-    cs_coupon_amt decimalv3(7,2),
-    cs_ext_ship_cost decimalv3(7,2),
-    cs_net_paid decimalv3(7,2),
-    cs_net_paid_inc_tax decimalv3(7,2),
-    cs_net_paid_inc_ship decimalv3(7,2),
-    cs_net_paid_inc_ship_tax decimalv3(7,2),
-    cs_net_profit decimalv3(7,2)
+    cs_wholesale_cost decimal(7,2),
+    cs_list_price decimal(7,2),
+    cs_sales_price decimal(7,2),
+    cs_ext_discount_amt decimal(7,2),
+    cs_ext_sales_price decimal(7,2),
+    cs_ext_wholesale_cost decimal(7,2),
+    cs_ext_list_price decimal(7,2),
+    cs_ext_tax decimal(7,2),
+    cs_coupon_amt decimal(7,2),
+    cs_ext_ship_cost decimal(7,2),
+    cs_net_paid decimal(7,2),
+    cs_net_paid_inc_tax decimal(7,2),
+    cs_net_paid_inc_ship decimal(7,2),
+    cs_net_paid_inc_ship_tax decimal(7,2),
+    cs_net_profit decimal(7,2)
 )
 DUPLICATE KEY(cs_item_sk, cs_order_number)
 PARTITION BY RANGE(cs_sold_date_sk)
@@ -180,8 +180,8 @@ drop table if exists call_center;
 CREATE TABLE IF NOT EXISTS call_center (
   cc_call_center_sk bigint not null,
   cc_call_center_id char(16) not null,
-  cc_rec_start_date datev2,
-  cc_rec_end_date datev2,
+  cc_rec_start_date date,
+  cc_rec_end_date date,
   cc_closed_date_sk integer,
   cc_open_date_sk integer,
   cc_name varchar(50),
@@ -207,8 +207,8 @@ CREATE TABLE IF NOT EXISTS call_center (
   cc_state char(2),
   cc_zip char(10),
   cc_country varchar(20),
-  cc_gmt_offset decimalv3(5,2),
-  cc_tax_percentage decimalv3(5,2)
+  cc_gmt_offset decimal(5,2),
+  cc_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(cc_call_center_sk)
 DISTRIBUTED BY HASH(cc_call_center_sk) BUCKETS 1
@@ -247,15 +247,15 @@ CREATE TABLE IF NOT EXISTS catalog_returns (
   cr_warehouse_sk bigint,
   cr_reason_sk bigint,
   cr_return_quantity integer,
-  cr_return_amount decimalv3(7,2),
-  cr_return_tax decimalv3(7,2),
-  cr_return_amt_inc_tax decimalv3(7,2),
-  cr_fee decimalv3(7,2),
-  cr_return_ship_cost decimalv3(7,2),
-  cr_refunded_cash decimalv3(7,2),
-  cr_reversed_charge decimalv3(7,2),
-  cr_store_credit decimalv3(7,2),
-  cr_net_loss decimalv3(7,2)
+  cr_return_amount decimal(7,2),
+  cr_return_tax decimal(7,2),
+  cr_return_amt_inc_tax decimal(7,2),
+  cr_fee decimal(7,2),
+  cr_return_ship_cost decimal(7,2),
+  cr_refunded_cash decimal(7,2),
+  cr_reversed_charge decimal(7,2),
+  cr_store_credit decimal(7,2),
+  cr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(cr_item_sk, cr_order_number)
 DISTRIBUTED BY HASH(cr_item_sk, cr_order_number) BUCKETS 32
@@ -289,7 +289,7 @@ CREATE TABLE IF NOT EXISTS customer_address (
     ca_state char(2),
     ca_zip char(10),
     ca_country varchar(20),
-    ca_gmt_offset decimalv3(5,2),
+    ca_gmt_offset decimal(5,2),
     ca_location_type char(20)
 )
 DUPLICATE KEY(ca_address_sk)
@@ -329,11 +329,11 @@ drop table if exists item;
 CREATE TABLE IF NOT EXISTS item (
     i_item_sk bigint not null,
     i_item_id char(16) not null,
-    i_rec_start_date datev2,
-    i_rec_end_date datev2,
+    i_rec_start_date date,
+    i_rec_end_date date,
     i_item_desc varchar(200),
-    i_current_price decimalv3(7,2),
-    i_wholesale_cost decimalv3(7,2),
+    i_current_price decimal(7,2),
+    i_wholesale_cost decimal(7,2),
     i_brand_id integer,
     i_brand char(50),
     i_class_id integer,
@@ -372,15 +372,15 @@ CREATE TABLE IF NOT EXISTS web_returns (
     wr_web_page_sk bigint,
     wr_reason_sk bigint,
     wr_return_quantity integer,
-    wr_return_amt decimalv3(7,2),
-    wr_return_tax decimalv3(7,2),
-    wr_return_amt_inc_tax decimalv3(7,2),
-    wr_fee decimalv3(7,2),
-    wr_return_ship_cost decimalv3(7,2),
-    wr_refunded_cash decimalv3(7,2),
-    wr_reversed_charge decimalv3(7,2),
-    wr_account_credit decimalv3(7,2),
-    wr_net_loss decimalv3(7,2)
+    wr_return_amt decimal(7,2),
+    wr_return_tax decimal(7,2),
+    wr_return_amt_inc_tax decimal(7,2),
+    wr_fee decimal(7,2),
+    wr_return_ship_cost decimal(7,2),
+    wr_refunded_cash decimal(7,2),
+    wr_reversed_charge decimal(7,2),
+    wr_account_credit decimal(7,2),
+    wr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(wr_item_sk, wr_order_number)
 DISTRIBUTED BY HASH(wr_item_sk, wr_order_number) BUCKETS 32
@@ -392,8 +392,8 @@ drop table if exists web_site;
 CREATE TABLE IF NOT EXISTS web_site (
     web_site_sk bigint not null,
     web_site_id char(16) not null,
-    web_rec_start_date datev2,
-    web_rec_end_date datev2,
+    web_rec_start_date date,
+    web_rec_end_date date,
     web_name varchar(50),
     web_open_date_sk bigint,
     web_close_date_sk bigint,
@@ -414,8 +414,8 @@ CREATE TABLE IF NOT EXISTS web_site (
     web_state char(2),
     web_zip char(10),
     web_country varchar(20),
-    web_gmt_offset decimalv3(5,2),
-    web_tax_percentage decimalv3(5,2)
+    web_gmt_offset decimal(5,2),
+    web_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(web_site_sk)
 DISTRIBUTED BY HASH(web_site_sk) BUCKETS 1
@@ -429,7 +429,7 @@ CREATE TABLE IF NOT EXISTS promotion (
     p_start_date_sk bigint,
     p_end_date_sk bigint,
     p_item_sk bigint,
-    p_cost decimalv3(15,2),
+    p_cost decimal(15,2),
     p_response_targe integer,
     p_promo_name char(50),
     p_channel_dmail char(1),
@@ -470,21 +470,21 @@ CREATE TABLE IF NOT EXISTS web_sales (
     ws_warehouse_sk bigint,
     ws_promo_sk bigint,
     ws_quantity integer,
-    ws_wholesale_cost decimalv3(7,2),
-    ws_list_price decimalv3(7,2),
-    ws_sales_price decimalv3(7,2),
-    ws_ext_discount_amt decimalv3(7,2),
-    ws_ext_sales_price decimalv3(7,2),
-    ws_ext_wholesale_cost decimalv3(7,2),
-    ws_ext_list_price decimalv3(7,2),
-    ws_ext_tax decimalv3(7,2),
-    ws_coupon_amt decimalv3(7,2),
-    ws_ext_ship_cost decimalv3(7,2),
-    ws_net_paid decimalv3(7,2),
-    ws_net_paid_inc_tax decimalv3(7,2),
-    ws_net_paid_inc_ship decimalv3(7,2),
-    ws_net_paid_inc_ship_tax decimalv3(7,2),
-    ws_net_profit decimalv3(7,2)
+    ws_wholesale_cost decimal(7,2),
+    ws_list_price decimal(7,2),
+    ws_sales_price decimal(7,2),
+    ws_ext_discount_amt decimal(7,2),
+    ws_ext_sales_price decimal(7,2),
+    ws_ext_wholesale_cost decimal(7,2),
+    ws_ext_list_price decimal(7,2),
+    ws_ext_tax decimal(7,2),
+    ws_coupon_amt decimal(7,2),
+    ws_ext_ship_cost decimal(7,2),
+    ws_net_paid decimal(7,2),
+    ws_net_paid_inc_tax decimal(7,2),
+    ws_net_paid_inc_ship decimal(7,2),
+    ws_net_paid_inc_ship_tax decimal(7,2),
+    ws_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ws_item_sk, ws_order_number)
 PARTITION BY RANGE(ws_sold_date_sk)
@@ -529,8 +529,8 @@ drop table if exists store;
 CREATE TABLE IF NOT EXISTS store (
     s_store_sk bigint not null,
     s_store_id char(16) not null,
-    s_rec_start_date datev2,
-    s_rec_end_date datev2,
+    s_rec_start_date date,
+    s_rec_end_date date,
     s_closed_date_sk bigint,
     s_store_name varchar(50),
     s_number_employees integer,
@@ -554,8 +554,8 @@ CREATE TABLE IF NOT EXISTS store (
     s_state char(2),
     s_zip char(10),
     s_country varchar(20),
-    s_gmt_offset decimalv3(5,2),
-    s_tax_precentage decimalv3(5,2)
+    s_gmt_offset decimal(5,2),
+    s_tax_precentage decimal(5,2)
 )
 DUPLICATE KEY(s_store_sk)
 DISTRIBUTED BY HASH(s_store_sk) BUCKETS 1
@@ -584,8 +584,8 @@ drop table if exists web_page;
 CREATE TABLE IF NOT EXISTS web_page (
         wp_web_page_sk bigint not null,
         wp_web_page_id char(16) not null,
-        wp_rec_start_date datev2,
-        wp_rec_end_date datev2,
+        wp_rec_start_date date,
+        wp_rec_end_date date,
         wp_creation_date_sk bigint,
         wp_access_date_sk bigint,
         wp_autogen_flag char(1),
@@ -615,15 +615,15 @@ CREATE TABLE IF NOT EXISTS store_returns (
     sr_store_sk bigint,
     sr_reason_sk bigint,
     sr_return_quantity integer,
-    sr_return_amt decimalv3(7,2),
-    sr_return_tax decimalv3(7,2),
-    sr_return_amt_inc_tax decimalv3(7,2),
-    sr_fee decimalv3(7,2),
-    sr_return_ship_cost decimalv3(7,2),
-    sr_refunded_cash decimalv3(7,2),
-    sr_reversed_charge decimalv3(7,2),
-    sr_store_credit decimalv3(7,2),
-    sr_net_loss decimalv3(7,2)
+    sr_return_amt decimal(7,2),
+    sr_return_tax decimal(7,2),
+    sr_return_amt_inc_tax decimal(7,2),
+    sr_fee decimal(7,2),
+    sr_return_ship_cost decimal(7,2),
+    sr_refunded_cash decimal(7,2),
+    sr_reversed_charge decimal(7,2),
+    sr_store_credit decimal(7,2),
+    sr_net_loss decimal(7,2)
 )
 duplicate key(sr_item_sk, sr_ticket_number)
 distributed by hash (sr_item_sk, sr_ticket_number) buckets 32
@@ -644,18 +644,18 @@ CREATE TABLE IF NOT EXISTS store_sales (
     ss_store_sk bigint,
     ss_promo_sk bigint,
     ss_quantity integer,
-    ss_wholesale_cost decimalv3(7,2),
-    ss_list_price decimalv3(7,2),
-    ss_sales_price decimalv3(7,2),
-    ss_ext_discount_amt decimalv3(7,2),
-    ss_ext_sales_price decimalv3(7,2),
-    ss_ext_wholesale_cost decimalv3(7,2),
-    ss_ext_list_price decimalv3(7,2),
-    ss_ext_tax decimalv3(7,2),
-    ss_coupon_amt decimalv3(7,2),
-    ss_net_paid decimalv3(7,2),
-    ss_net_paid_inc_tax decimalv3(7,2),
-    ss_net_profit decimalv3(7,2)
+    ss_wholesale_cost decimal(7,2),
+    ss_list_price decimal(7,2),
+    ss_sales_price decimal(7,2),
+    ss_ext_discount_amt decimal(7,2),
+    ss_ext_sales_price decimal(7,2),
+    ss_ext_wholesale_cost decimal(7,2),
+    ss_ext_list_price decimal(7,2),
+    ss_ext_tax decimal(7,2),
+    ss_coupon_amt decimal(7,2),
+    ss_net_paid decimal(7,2),
+    ss_net_paid_inc_tax decimal(7,2),
+    ss_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ss_item_sk, ss_ticket_number)
 PARTITION BY RANGE(ss_sold_date_sk)
@@ -740,7 +740,7 @@ drop table if exists dbgen_version;
 CREATE TABLE IF NOT EXISTS dbgen_version
 (
     dv_version                varchar(16)                   ,
-    dv_create_date            datev2                        ,
+    dv_create_date            date                        ,
     dv_create_time            datetime                      ,
     dv_cmdline_args           varchar(200)                  
 )

--- a/tools/tpcds-tools/ddl/create-tpcds-tables-sf1000.sql
+++ b/tools/tpcds-tools/ddl/create-tpcds-tables-sf1000.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS warehouse (
     w_state char(2),
     w_zip char(10),
     w_country varchar(20),
-    w_gmt_offset decimalv3(5,2)
+    w_gmt_offset decimal(5,2)
 )
 DUPLICATE KEY(w_warehouse_sk)
 DISTRIBUTED BY HASH(w_warehouse_sk) BUCKETS 1
@@ -121,21 +121,21 @@ CREATE TABLE IF NOT EXISTS catalog_sales (
     cs_warehouse_sk bigint,
     cs_promo_sk bigint,
     cs_quantity integer,
-    cs_wholesale_cost decimalv3(7,2),
-    cs_list_price decimalv3(7,2),
-    cs_sales_price decimalv3(7,2),
-    cs_ext_discount_amt decimalv3(7,2),
-    cs_ext_sales_price decimalv3(7,2),
-    cs_ext_wholesale_cost decimalv3(7,2),
-    cs_ext_list_price decimalv3(7,2),
-    cs_ext_tax decimalv3(7,2),
-    cs_coupon_amt decimalv3(7,2),
-    cs_ext_ship_cost decimalv3(7,2),
-    cs_net_paid decimalv3(7,2),
-    cs_net_paid_inc_tax decimalv3(7,2),
-    cs_net_paid_inc_ship decimalv3(7,2),
-    cs_net_paid_inc_ship_tax decimalv3(7,2),
-    cs_net_profit decimalv3(7,2)
+    cs_wholesale_cost decimal(7,2),
+    cs_list_price decimal(7,2),
+    cs_sales_price decimal(7,2),
+    cs_ext_discount_amt decimal(7,2),
+    cs_ext_sales_price decimal(7,2),
+    cs_ext_wholesale_cost decimal(7,2),
+    cs_ext_list_price decimal(7,2),
+    cs_ext_tax decimal(7,2),
+    cs_coupon_amt decimal(7,2),
+    cs_ext_ship_cost decimal(7,2),
+    cs_net_paid decimal(7,2),
+    cs_net_paid_inc_tax decimal(7,2),
+    cs_net_paid_inc_ship decimal(7,2),
+    cs_net_paid_inc_ship_tax decimal(7,2),
+    cs_net_profit decimal(7,2)
 )
 DUPLICATE KEY(cs_item_sk, cs_order_number)
 PARTITION BY RANGE(cs_sold_date_sk)
@@ -249,8 +249,8 @@ CREATE TABLE IF NOT EXISTS call_center (
   cc_state char(2),
   cc_zip char(10),
   cc_country varchar(20),
-  cc_gmt_offset decimalv3(5,2),
-  cc_tax_percentage decimalv3(5,2)
+  cc_gmt_offset decimal(5,2),
+  cc_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(cc_call_center_sk)
 DISTRIBUTED BY HASH(cc_call_center_sk) BUCKETS 1
@@ -364,15 +364,15 @@ CREATE TABLE IF NOT EXISTS catalog_returns (
   cr_warehouse_sk bigint,
   cr_reason_sk bigint,
   cr_return_quantity integer,
-  cr_return_amount decimalv3(7,2),
-  cr_return_tax decimalv3(7,2),
-  cr_return_amt_inc_tax decimalv3(7,2),
-  cr_fee decimalv3(7,2),
-  cr_return_ship_cost decimalv3(7,2),
-  cr_refunded_cash decimalv3(7,2),
-  cr_reversed_charge decimalv3(7,2),
-  cr_store_credit decimalv3(7,2),
-  cr_net_loss decimalv3(7,2)
+  cr_return_amount decimal(7,2),
+  cr_return_tax decimal(7,2),
+  cr_return_amt_inc_tax decimal(7,2),
+  cr_fee decimal(7,2),
+  cr_return_ship_cost decimal(7,2),
+  cr_refunded_cash decimal(7,2),
+  cr_reversed_charge decimal(7,2),
+  cr_store_credit decimal(7,2),
+  cr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(cr_item_sk, cr_order_number)
 PARTITION BY RANGE(cr_returned_date_sk)
@@ -481,7 +481,7 @@ CREATE TABLE IF NOT EXISTS customer_address (
     ca_state char(2),
     ca_zip char(10),
     ca_country varchar(20),
-    ca_gmt_offset decimalv3(5,2),
+    ca_gmt_offset decimal(5,2),
     ca_location_type char(20)
 )
 DUPLICATE KEY(ca_address_sk)
@@ -524,8 +524,8 @@ CREATE TABLE IF NOT EXISTS item (
     i_rec_start_date datev2,
     i_rec_end_date datev2,
     i_item_desc varchar(200),
-    i_current_price decimalv3(7,2),
-    i_wholesale_cost decimalv3(7,2),
+    i_current_price decimal(7,2),
+    i_wholesale_cost decimal(7,2),
     i_brand_id integer,
     i_brand char(50),
     i_class_id integer,
@@ -564,15 +564,15 @@ CREATE TABLE IF NOT EXISTS web_returns (
     wr_web_page_sk bigint,
     wr_reason_sk bigint,
     wr_return_quantity integer,
-    wr_return_amt decimalv3(7,2),
-    wr_return_tax decimalv3(7,2),
-    wr_return_amt_inc_tax decimalv3(7,2),
-    wr_fee decimalv3(7,2),
-    wr_return_ship_cost decimalv3(7,2),
-    wr_refunded_cash decimalv3(7,2),
-    wr_reversed_charge decimalv3(7,2),
-    wr_account_credit decimalv3(7,2),
-    wr_net_loss decimalv3(7,2)
+    wr_return_amt decimal(7,2),
+    wr_return_tax decimal(7,2),
+    wr_return_amt_inc_tax decimal(7,2),
+    wr_fee decimal(7,2),
+    wr_return_ship_cost decimal(7,2),
+    wr_refunded_cash decimal(7,2),
+    wr_reversed_charge decimal(7,2),
+    wr_account_credit decimal(7,2),
+    wr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(wr_item_sk, wr_order_number)
 PARTITION BY RANGE(wr_returned_date_sk)
@@ -681,8 +681,8 @@ CREATE TABLE IF NOT EXISTS web_site (
     web_state char(2),
     web_zip char(10),
     web_country varchar(20),
-    web_gmt_offset decimalv3(5,2),
-    web_tax_percentage decimalv3(5,2)
+    web_gmt_offset decimal(5,2),
+    web_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(web_site_sk)
 DISTRIBUTED BY HASH(web_site_sk) BUCKETS 1
@@ -696,7 +696,7 @@ CREATE TABLE IF NOT EXISTS promotion (
     p_start_date_sk bigint,
     p_end_date_sk bigint,
     p_item_sk bigint,
-    p_cost decimalv3(15,2),
+    p_cost decimal(15,2),
     p_response_targe integer,
     p_promo_name char(50),
     p_channel_dmail char(1),
@@ -737,21 +737,21 @@ CREATE TABLE IF NOT EXISTS web_sales (
     ws_warehouse_sk bigint,
     ws_promo_sk bigint,
     ws_quantity integer,
-    ws_wholesale_cost decimalv3(7,2),
-    ws_list_price decimalv3(7,2),
-    ws_sales_price decimalv3(7,2),
-    ws_ext_discount_amt decimalv3(7,2),
-    ws_ext_sales_price decimalv3(7,2),
-    ws_ext_wholesale_cost decimalv3(7,2),
-    ws_ext_list_price decimalv3(7,2),
-    ws_ext_tax decimalv3(7,2),
-    ws_coupon_amt decimalv3(7,2),
-    ws_ext_ship_cost decimalv3(7,2),
-    ws_net_paid decimalv3(7,2),
-    ws_net_paid_inc_tax decimalv3(7,2),
-    ws_net_paid_inc_ship decimalv3(7,2),
-    ws_net_paid_inc_ship_tax decimalv3(7,2),
-    ws_net_profit decimalv3(7,2)
+    ws_wholesale_cost decimal(7,2),
+    ws_list_price decimal(7,2),
+    ws_sales_price decimal(7,2),
+    ws_ext_discount_amt decimal(7,2),
+    ws_ext_sales_price decimal(7,2),
+    ws_ext_wholesale_cost decimal(7,2),
+    ws_ext_list_price decimal(7,2),
+    ws_ext_tax decimal(7,2),
+    ws_coupon_amt decimal(7,2),
+    ws_ext_ship_cost decimal(7,2),
+    ws_net_paid decimal(7,2),
+    ws_net_paid_inc_tax decimal(7,2),
+    ws_net_paid_inc_ship decimal(7,2),
+    ws_net_paid_inc_ship_tax decimal(7,2),
+    ws_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ws_item_sk, ws_order_number)
 PARTITION BY RANGE(ws_sold_date_sk)
@@ -863,8 +863,8 @@ CREATE TABLE IF NOT EXISTS store (
     s_state char(2),
     s_zip char(10),
     s_country varchar(20),
-    s_gmt_offset decimalv3(5,2),
-    s_tax_precentage decimalv3(5,2)
+    s_gmt_offset decimal(5,2),
+    s_tax_precentage decimal(5,2)
 )
 DUPLICATE KEY(s_store_sk)
 DISTRIBUTED BY HASH(s_store_sk) BUCKETS 1
@@ -924,15 +924,15 @@ CREATE TABLE IF NOT EXISTS store_returns (
     sr_store_sk bigint,
     sr_reason_sk bigint,
     sr_return_quantity integer,
-    sr_return_amt decimalv3(7,2),
-    sr_return_tax decimalv3(7,2),
-    sr_return_amt_inc_tax decimalv3(7,2),
-    sr_fee decimalv3(7,2),
-    sr_return_ship_cost decimalv3(7,2),
-    sr_refunded_cash decimalv3(7,2),
-    sr_reversed_charge decimalv3(7,2),
-    sr_store_credit decimalv3(7,2),
-    sr_net_loss decimalv3(7,2)
+    sr_return_amt decimal(7,2),
+    sr_return_tax decimal(7,2),
+    sr_return_amt_inc_tax decimal(7,2),
+    sr_fee decimal(7,2),
+    sr_return_ship_cost decimal(7,2),
+    sr_refunded_cash decimal(7,2),
+    sr_reversed_charge decimal(7,2),
+    sr_store_credit decimal(7,2),
+    sr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(sr_item_sk, sr_ticket_number)
 PARTITION BY RANGE(sr_returned_date_sk)
@@ -1028,18 +1028,18 @@ CREATE TABLE IF NOT EXISTS store_sales (
     ss_store_sk bigint,
     ss_promo_sk bigint,
     ss_quantity integer,
-    ss_wholesale_cost decimalv3(7,2),
-    ss_list_price decimalv3(7,2),
-    ss_sales_price decimalv3(7,2),
-    ss_ext_discount_amt decimalv3(7,2),
-    ss_ext_sales_price decimalv3(7,2),
-    ss_ext_wholesale_cost decimalv3(7,2),
-    ss_ext_list_price decimalv3(7,2),
-    ss_ext_tax decimalv3(7,2),
-    ss_coupon_amt decimalv3(7,2),
-    ss_net_paid decimalv3(7,2),
-    ss_net_paid_inc_tax decimalv3(7,2),
-    ss_net_profit decimalv3(7,2)
+    ss_wholesale_cost decimal(7,2),
+    ss_list_price decimal(7,2),
+    ss_sales_price decimal(7,2),
+    ss_ext_discount_amt decimal(7,2),
+    ss_ext_sales_price decimal(7,2),
+    ss_ext_wholesale_cost decimal(7,2),
+    ss_ext_list_price decimal(7,2),
+    ss_ext_tax decimal(7,2),
+    ss_coupon_amt decimal(7,2),
+    ss_net_paid decimal(7,2),
+    ss_net_paid_inc_tax decimal(7,2),
+    ss_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ss_item_sk, ss_ticket_number)
 PARTITION BY RANGE(ss_sold_date_sk)

--- a/tools/tpcds-tools/ddl/create-tpcds-tables-sf10000.sql
+++ b/tools/tpcds-tools/ddl/create-tpcds-tables-sf10000.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS warehouse (
     w_state char(2),
     w_zip char(10),
     w_country varchar(20),
-    w_gmt_offset decimalv3(5,2)
+    w_gmt_offset decimal(5,2)
 )
 DUPLICATE KEY(w_warehouse_sk)
 DISTRIBUTED BY HASH(w_warehouse_sk) BUCKETS 1
@@ -121,21 +121,21 @@ CREATE TABLE IF NOT EXISTS catalog_sales (
     cs_warehouse_sk bigint,
     cs_promo_sk bigint,
     cs_quantity integer,
-    cs_wholesale_cost decimalv3(7,2),
-    cs_list_price decimalv3(7,2),
-    cs_sales_price decimalv3(7,2),
-    cs_ext_discount_amt decimalv3(7,2),
-    cs_ext_sales_price decimalv3(7,2),
-    cs_ext_wholesale_cost decimalv3(7,2),
-    cs_ext_list_price decimalv3(7,2),
-    cs_ext_tax decimalv3(7,2),
-    cs_coupon_amt decimalv3(7,2),
-    cs_ext_ship_cost decimalv3(7,2),
-    cs_net_paid decimalv3(7,2),
-    cs_net_paid_inc_tax decimalv3(7,2),
-    cs_net_paid_inc_ship decimalv3(7,2),
-    cs_net_paid_inc_ship_tax decimalv3(7,2),
-    cs_net_profit decimalv3(7,2)
+    cs_wholesale_cost decimal(7,2),
+    cs_list_price decimal(7,2),
+    cs_sales_price decimal(7,2),
+    cs_ext_discount_amt decimal(7,2),
+    cs_ext_sales_price decimal(7,2),
+    cs_ext_wholesale_cost decimal(7,2),
+    cs_ext_list_price decimal(7,2),
+    cs_ext_tax decimal(7,2),
+    cs_coupon_amt decimal(7,2),
+    cs_ext_ship_cost decimal(7,2),
+    cs_net_paid decimal(7,2),
+    cs_net_paid_inc_tax decimal(7,2),
+    cs_net_paid_inc_ship decimal(7,2),
+    cs_net_paid_inc_ship_tax decimal(7,2),
+    cs_net_profit decimal(7,2)
 )
 DUPLICATE KEY(cs_item_sk, cs_order_number)
 PARTITION BY RANGE(cs_sold_date_sk)
@@ -249,8 +249,8 @@ CREATE TABLE IF NOT EXISTS call_center (
   cc_state char(2),
   cc_zip char(10),
   cc_country varchar(20),
-  cc_gmt_offset decimalv3(5,2),
-  cc_tax_percentage decimalv3(5,2)
+  cc_gmt_offset decimal(5,2),
+  cc_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(cc_call_center_sk)
 DISTRIBUTED BY HASH(cc_call_center_sk) BUCKETS 1
@@ -364,15 +364,15 @@ CREATE TABLE IF NOT EXISTS catalog_returns (
   cr_warehouse_sk bigint,
   cr_reason_sk bigint,
   cr_return_quantity integer,
-  cr_return_amount decimalv3(7,2),
-  cr_return_tax decimalv3(7,2),
-  cr_return_amt_inc_tax decimalv3(7,2),
-  cr_fee decimalv3(7,2),
-  cr_return_ship_cost decimalv3(7,2),
-  cr_refunded_cash decimalv3(7,2),
-  cr_reversed_charge decimalv3(7,2),
-  cr_store_credit decimalv3(7,2),
-  cr_net_loss decimalv3(7,2)
+  cr_return_amount decimal(7,2),
+  cr_return_tax decimal(7,2),
+  cr_return_amt_inc_tax decimal(7,2),
+  cr_fee decimal(7,2),
+  cr_return_ship_cost decimal(7,2),
+  cr_refunded_cash decimal(7,2),
+  cr_reversed_charge decimal(7,2),
+  cr_store_credit decimal(7,2),
+  cr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(cr_item_sk, cr_order_number)
 PARTITION BY RANGE(cr_returned_date_sk)
@@ -481,7 +481,7 @@ CREATE TABLE IF NOT EXISTS customer_address (
     ca_state char(2),
     ca_zip char(10),
     ca_country varchar(20),
-    ca_gmt_offset decimalv3(5,2),
+    ca_gmt_offset decimal(5,2),
     ca_location_type char(20)
 )
 DUPLICATE KEY(ca_address_sk)
@@ -524,8 +524,8 @@ CREATE TABLE IF NOT EXISTS item (
     i_rec_start_date datev2,
     i_rec_end_date datev2,
     i_item_desc varchar(200),
-    i_current_price decimalv3(7,2),
-    i_wholesale_cost decimalv3(7,2),
+    i_current_price decimal(7,2),
+    i_wholesale_cost decimal(7,2),
     i_brand_id integer,
     i_brand char(50),
     i_class_id integer,
@@ -564,15 +564,15 @@ CREATE TABLE IF NOT EXISTS web_returns (
     wr_web_page_sk bigint,
     wr_reason_sk bigint,
     wr_return_quantity integer,
-    wr_return_amt decimalv3(7,2),
-    wr_return_tax decimalv3(7,2),
-    wr_return_amt_inc_tax decimalv3(7,2),
-    wr_fee decimalv3(7,2),
-    wr_return_ship_cost decimalv3(7,2),
-    wr_refunded_cash decimalv3(7,2),
-    wr_reversed_charge decimalv3(7,2),
-    wr_account_credit decimalv3(7,2),
-    wr_net_loss decimalv3(7,2)
+    wr_return_amt decimal(7,2),
+    wr_return_tax decimal(7,2),
+    wr_return_amt_inc_tax decimal(7,2),
+    wr_fee decimal(7,2),
+    wr_return_ship_cost decimal(7,2),
+    wr_refunded_cash decimal(7,2),
+    wr_reversed_charge decimal(7,2),
+    wr_account_credit decimal(7,2),
+    wr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(wr_item_sk, wr_order_number)
 PARTITION BY RANGE(wr_returned_date_sk)
@@ -681,8 +681,8 @@ CREATE TABLE IF NOT EXISTS web_site (
     web_state char(2),
     web_zip char(10),
     web_country varchar(20),
-    web_gmt_offset decimalv3(5,2),
-    web_tax_percentage decimalv3(5,2)
+    web_gmt_offset decimal(5,2),
+    web_tax_percentage decimal(5,2)
 )
 DUPLICATE KEY(web_site_sk)
 DISTRIBUTED BY HASH(web_site_sk) BUCKETS 1
@@ -696,7 +696,7 @@ CREATE TABLE IF NOT EXISTS promotion (
     p_start_date_sk bigint,
     p_end_date_sk bigint,
     p_item_sk bigint,
-    p_cost decimalv3(15,2),
+    p_cost decimal(15,2),
     p_response_targe integer,
     p_promo_name char(50),
     p_channel_dmail char(1),
@@ -737,21 +737,21 @@ CREATE TABLE IF NOT EXISTS web_sales (
     ws_warehouse_sk bigint,
     ws_promo_sk bigint,
     ws_quantity integer,
-    ws_wholesale_cost decimalv3(7,2),
-    ws_list_price decimalv3(7,2),
-    ws_sales_price decimalv3(7,2),
-    ws_ext_discount_amt decimalv3(7,2),
-    ws_ext_sales_price decimalv3(7,2),
-    ws_ext_wholesale_cost decimalv3(7,2),
-    ws_ext_list_price decimalv3(7,2),
-    ws_ext_tax decimalv3(7,2),
-    ws_coupon_amt decimalv3(7,2),
-    ws_ext_ship_cost decimalv3(7,2),
-    ws_net_paid decimalv3(7,2),
-    ws_net_paid_inc_tax decimalv3(7,2),
-    ws_net_paid_inc_ship decimalv3(7,2),
-    ws_net_paid_inc_ship_tax decimalv3(7,2),
-    ws_net_profit decimalv3(7,2)
+    ws_wholesale_cost decimal(7,2),
+    ws_list_price decimal(7,2),
+    ws_sales_price decimal(7,2),
+    ws_ext_discount_amt decimal(7,2),
+    ws_ext_sales_price decimal(7,2),
+    ws_ext_wholesale_cost decimal(7,2),
+    ws_ext_list_price decimal(7,2),
+    ws_ext_tax decimal(7,2),
+    ws_coupon_amt decimal(7,2),
+    ws_ext_ship_cost decimal(7,2),
+    ws_net_paid decimal(7,2),
+    ws_net_paid_inc_tax decimal(7,2),
+    ws_net_paid_inc_ship decimal(7,2),
+    ws_net_paid_inc_ship_tax decimal(7,2),
+    ws_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ws_item_sk, ws_order_number)
 PARTITION BY RANGE(ws_sold_date_sk)
@@ -863,8 +863,8 @@ CREATE TABLE IF NOT EXISTS store (
     s_state char(2),
     s_zip char(10),
     s_country varchar(20),
-    s_gmt_offset decimalv3(5,2),
-    s_tax_precentage decimalv3(5,2)
+    s_gmt_offset decimal(5,2),
+    s_tax_precentage decimal(5,2)
 )
 DUPLICATE KEY(s_store_sk)
 DISTRIBUTED BY HASH(s_store_sk) BUCKETS 1
@@ -924,15 +924,15 @@ CREATE TABLE IF NOT EXISTS store_returns (
     sr_store_sk bigint,
     sr_reason_sk bigint,
     sr_return_quantity integer,
-    sr_return_amt decimalv3(7,2),
-    sr_return_tax decimalv3(7,2),
-    sr_return_amt_inc_tax decimalv3(7,2),
-    sr_fee decimalv3(7,2),
-    sr_return_ship_cost decimalv3(7,2),
-    sr_refunded_cash decimalv3(7,2),
-    sr_reversed_charge decimalv3(7,2),
-    sr_store_credit decimalv3(7,2),
-    sr_net_loss decimalv3(7,2)
+    sr_return_amt decimal(7,2),
+    sr_return_tax decimal(7,2),
+    sr_return_amt_inc_tax decimal(7,2),
+    sr_fee decimal(7,2),
+    sr_return_ship_cost decimal(7,2),
+    sr_refunded_cash decimal(7,2),
+    sr_reversed_charge decimal(7,2),
+    sr_store_credit decimal(7,2),
+    sr_net_loss decimal(7,2)
 )
 DUPLICATE KEY(sr_item_sk, sr_ticket_number)
 PARTITION BY RANGE(sr_returned_date_sk)
@@ -1028,18 +1028,18 @@ CREATE TABLE IF NOT EXISTS store_sales (
     ss_store_sk bigint,
     ss_promo_sk bigint,
     ss_quantity integer,
-    ss_wholesale_cost decimalv3(7,2),
-    ss_list_price decimalv3(7,2),
-    ss_sales_price decimalv3(7,2),
-    ss_ext_discount_amt decimalv3(7,2),
-    ss_ext_sales_price decimalv3(7,2),
-    ss_ext_wholesale_cost decimalv3(7,2),
-    ss_ext_list_price decimalv3(7,2),
-    ss_ext_tax decimalv3(7,2),
-    ss_coupon_amt decimalv3(7,2),
-    ss_net_paid decimalv3(7,2),
-    ss_net_paid_inc_tax decimalv3(7,2),
-    ss_net_profit decimalv3(7,2)
+    ss_wholesale_cost decimal(7,2),
+    ss_list_price decimal(7,2),
+    ss_sales_price decimal(7,2),
+    ss_ext_discount_amt decimal(7,2),
+    ss_ext_sales_price decimal(7,2),
+    ss_ext_wholesale_cost decimal(7,2),
+    ss_ext_list_price decimal(7,2),
+    ss_ext_tax decimal(7,2),
+    ss_coupon_amt decimal(7,2),
+    ss_net_paid decimal(7,2),
+    ss_net_paid_inc_tax decimal(7,2),
+    ss_net_profit decimal(7,2)
 )
 DUPLICATE KEY(ss_item_sk, ss_ticket_number)
 PARTITION BY RANGE(ss_sold_date_sk)


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. move analyzing of the clickbench from running query to loading, just like other benchmarks
2. remove useless variables for Doris' master
3. change `datev2` to `date`, `decimalv3` to `decimal` as it's Doris' master's defaults.

