### PR TITLE
[fix](Nereids) remove db readlock before get table from db (#38660)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -552,16 +552,13 @@ public class CascadesContext implements ScheduleContext {
         if (db == null) {
             throw new RuntimeException("Database [" + dbName + "] does not exist in catalog [" + ctlName + "].");
         }
-        db.readLock();
-        try {
-            TableIf table = db.getTableNullable(tableName);
-            if (table == null) {
-                throw new RuntimeException("Table [" + tableName + "] does not exist in database [" + dbName + "].");
-            }
-            return table;
-        } finally {
-            db.readUnlock();
+
+        TableIf table = db.getTableNullable(tableName);
+        if (table == null) {
+            throw new RuntimeException("Table [" + tableName + "] does not exist in database [" + dbName + "].");
         }
+        return table;
+
     }
 
     /**


### PR DESCRIPTION
pick from master #38660

insert will hold readlock of target table before planning. if nereids need db readlock after it, will lead to dead lock. because other statement need to hold db lock before get table lock

for example:

insert: target table read lock -> database read lock
drop table: database write lock -> target table write lock
