### PR TITLE
[fix](group commit) Fix group commit debug log and improve performance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -1242,9 +1242,9 @@ public class NativeInsertStmt extends InsertStmt {
                     for (Expr expr : row) {
                         if (!(expr instanceof LiteralExpr)) {
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("group commit is off for query_id: {}, table: {}, because not literal expr, "
-                                                + "expr: {}, row: {}", DebugUtil.printId(ctx.queryId()),
-                                        targetTable.getName(), expr, row);
+                                LOG.debug("group commit is off for query_id: {}, table: {}, "
+                                                + "because not literal expr: {}, row: {}",
+                                        DebugUtil.printId(ctx.queryId()), targetTable.getName(), expr, row);
                             }
                             return;
                         }
@@ -1253,8 +1253,9 @@ public class NativeInsertStmt extends InsertStmt {
                 // Does not support: insert into tbl values();
                 if (selectStmt.getValueList().getFirstRow().isEmpty() && CollectionUtils.isEmpty(targetColumnNames)) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("group commit is off for table: {}, because first row: {}, target columns: {}",
-                                targetTable.getName(), selectStmt.getValueList().getFirstRow(), targetColumnNames);
+                        LOG.debug("group commit is off for query_id: {}, table: {}, because first row: {}, "
+                                        + "target columns: {}", DebugUtil.printId(ctx.queryId()), targetTable.getName(),
+                                selectStmt.getValueList().getFirstRow(), targetColumnNames);
                     }
                     return;
                 }
@@ -1266,8 +1267,8 @@ public class NativeInsertStmt extends InsertStmt {
                         for (SelectListItem item : items) {
                             if (item.getExpr() != null && !(item.getExpr() instanceof LiteralExpr)) {
                                 if (LOG.isDebugEnabled()) {
-                                    LOG.debug("group commit is off for query_id: {}, for table: {}, "
-                                                    + "because not literal expr, expr: {}, row: {}",
+                                    LOG.debug("group commit is off for query_id: {}, table: {}, "
+                                                    + "because not literal expr: {}, row: {}",
                                             DebugUtil.printId(ctx.queryId()), targetTable.getName(), item.getExpr(),
                                             item);
                                 }
@@ -1282,7 +1283,7 @@ public class NativeInsertStmt extends InsertStmt {
             if (LOG.isDebugEnabled()) {
                 for (Pair<BooleanSupplier, Supplier<String>> pair : conditions) {
                     if (pair.first.getAsBoolean() == false) {
-                        LOG.debug("group commit is off for query_id: {}, for table: {}, because: {}",
+                        LOG.debug("group commit is off for query_id: {}, table: {}, because: {}",
                                 DebugUtil.printId(ctx.queryId()), targetTable.getName(), pair.second.get());
                         break;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -1242,8 +1242,9 @@ public class NativeInsertStmt extends InsertStmt {
                     for (Expr expr : row) {
                         if (!(expr instanceof LiteralExpr)) {
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("group commit is off for table: {}, because not literal expr, "
-                                        + "expr: {}, row: {}", targetTable.getName(), expr, row);
+                                LOG.debug("group commit is off for query_id: {}, table: {}, because not literal expr, "
+                                                + "expr: {}, row: {}", DebugUtil.printId(ctx.queryId()),
+                                        targetTable.getName(), expr, row);
                             }
                             return;
                         }
@@ -1265,8 +1266,10 @@ public class NativeInsertStmt extends InsertStmt {
                         for (SelectListItem item : items) {
                             if (item.getExpr() != null && !(item.getExpr() instanceof LiteralExpr)) {
                                 if (LOG.isDebugEnabled()) {
-                                    LOG.debug("group commit is off for table: {}, because not literal expr, "
-                                            + "expr: {}, row: {}", targetTable.getName(), item.getExpr(), item);
+                                    LOG.debug("group commit is off for query_id: {}, for table: {}, "
+                                                    + "because not literal expr, expr: {}, row: {}",
+                                            DebugUtil.printId(ctx.queryId()), targetTable.getName(), item.getExpr(),
+                                            item);
                                 }
                                 return;
                             }
@@ -1279,8 +1282,8 @@ public class NativeInsertStmt extends InsertStmt {
             if (LOG.isDebugEnabled()) {
                 for (Pair<BooleanSupplier, Supplier<String>> pair : conditions) {
                     if (pair.first.getAsBoolean() == false) {
-                        LOG.debug("group commit is off for table: {}, because: {}", targetTable.getName(),
-                                pair.second.get());
+                        LOG.debug("group commit is off for query_id: {}, for table: {}, because: {}",
+                                DebugUtil.printId(ctx.queryId()), targetTable.getName(), pair.second.get());
                         break;
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -97,7 +97,7 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
             if (!ctx.isGroupCommit() && LOG.isDebugEnabled()) {
                 for (Pair<BooleanSupplier, Supplier<String>> pair : conditions) {
                     if (pair.first.getAsBoolean() == false) {
-                        LOG.debug("group commit is off for query_id: {}, for table: {}, because: {}",
+                        LOG.debug("group commit is off for query_id: {}, table: {}, because: {}",
                                 DebugUtil.printId(ctx.queryId()), table.getName(), pair.second.get());
                         break;
                     }
@@ -105,9 +105,8 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
             }
         } else {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("group commit is off for query_id: {},  because for table: {}, because "
-                                + "logicalQuery class: {}", DebugUtil.printId(ctx.queryId()), table.getName(),
-                        logicalQuery.getClass().getName());
+                LOG.debug("group commit is off for query_id: {}, table: {}, because logicalQuery class: {}",
+                        DebugUtil.printId(ctx.queryId()), table.getName(), logicalQuery.getClass().getName());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -97,14 +97,16 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
             if (!ctx.isGroupCommit() && LOG.isDebugEnabled()) {
                 for (Pair<BooleanSupplier, Supplier<String>> pair : conditions) {
                     if (pair.first.getAsBoolean() == false) {
-                        LOG.debug("group commit is off for table: {}, because: {}", table.getName(), pair.second.get());
+                        LOG.debug("group commit is off for query_id: {}, for table: {}, because: {}",
+                                DebugUtil.printId(ctx.queryId()), table.getName(), pair.second.get());
                         break;
                     }
                 }
             }
         } else {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("group commit is off because for table: {}, because logicalQuery class: {}", table.getName(),
+                LOG.debug("group commit is off for query_id: {},  because for table: {}, because "
+                                + "logicalQuery class: {}", DebugUtil.printId(ctx.queryId()), table.getName(),
                         logicalQuery.getClass().getName());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -366,14 +366,14 @@ public class StmtExecutor {
             if (expr instanceof NullLiteral) {
                 row.addColBuilder().setValue(NULL_VALUE_FOR_LOAD);
             } else if (expr instanceof ArrayLiteral) {
-                row.addColBuilder().setValue(String.format("\"%s\"", expr.getStringValueForStreamLoad(options)));
+                row.addColBuilder().setValue("\"" + expr.getStringValueForStreamLoad(options) + "\"");
             } else {
                 String stringValue = expr.getStringValueForStreamLoad(options);
                 if (stringValue.equals(NULL_VALUE_FOR_LOAD) || stringValue.startsWith("\"") || stringValue.endsWith(
                         "\"")) {
-                    row.addColBuilder().setValue(String.format("\"%s\"", stringValue));
+                    row.addColBuilder().setValue("\"" + stringValue + "\"");
                 } else {
-                    row.addColBuilder().setValue(String.format("%s", stringValue));
+                    row.addColBuilder().setValue(stringValue);
                 }
             }
         }

--- a/regression-test/suites/insert_p0/txn_insert_concurrent_insert.groovy
+++ b/regression-test/suites/insert_p0/txn_insert_concurrent_insert.groovy
@@ -109,7 +109,7 @@ suite("txn_insert_concurrent_insert") {
         futures.add(future)
     }
     CompletableFuture<?>[] futuresArray = futures.toArray(new CompletableFuture[0])
-    CompletableFuture.allOf(futuresArray).get(3, TimeUnit.MINUTES)
+    CompletableFuture.allOf(futuresArray).get(10, TimeUnit.MINUTES)
     sql """ sync """
 
     def result = sql """ select count() from ${tableName}_0 """


### PR DESCRIPTION
## Proposed changes

1. show `query_id` in the debug log of when group commit insert does not work
2. remove string.format to improve performance
