### PR TITLE
[opt](arm)Remove negative optimizations of SSE2NEON on memcmp for ARM

### DIFF
--- a/be/src/vec/common/memcmp_small.h
+++ b/be/src/vec/common/memcmp_small.h
@@ -38,7 +38,7 @@ int cmp(T a, T b) {
 /// Results don't depend on the values inside uninitialized memory but Memory Sanitizer cannot see it.
 /// Disable optimized functions if compile with Memory Sanitizer.
 
-#if (defined(__SSE2__) || defined(__aarch64__)) && !defined(MEMORY_SANITIZER)
+#if (defined(__SSE2__) && !defined(__aarch64__)) && !defined(MEMORY_SANITIZER)
 #include "util/sse_util.hpp"
 
 /** All functions works under the following assumptions:


### PR DESCRIPTION



The main issue is that _mm_movemask_epi8 does not have a one-to-one corresponding instruction on ARM. Testing shows that it performs worse compared to using memcmp, which allows the compiler to generate the corresponding ARM instructions.
The following tests were conducted on ARM.
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
BM_memequal16_sse         3.77 ns         3.77 ns    743238946
BM_memequal16_orgin       2.11 ns         2.11 ns   1000000000
```



