### PR TITLE
[fix](recycler) Fix uninitialized num_entries when list a non-exist directory (#38782)

### DIFF
--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -285,8 +285,9 @@ public:
     }
 
 private:
+    // Return null if error occured, return emtpy DirEntries if dir is empty or doesn't exist.
     std::optional<DirEntries> list_directory(const char* dir_path) {
-        int num_entries;
+        int num_entries = 0;
         auto* file_infos = hdfsListDirectory(hdfs_.get(), dir_path, &num_entries);
         if (errno != 0 && errno != ENOENT) {
             LOG_WARNING("failed to list hdfs directory")

--- a/cloud/test/hdfs_accessor_test.cpp
+++ b/cloud/test/hdfs_accessor_test.cpp
@@ -181,6 +181,10 @@ TEST(HdfsAccessorTest, normal) {
     std::string to_delete_dir = "data/10001";
     ret = accessor.delete_directory(to_delete_dir);
     ASSERT_EQ(ret, 0);
+    ret = accessor.list_directory(to_delete_dir, &iter);
+    ASSERT_EQ(ret, 0);
+    ASSERT_FALSE(iter->has_next());
+
     files.erase(std::remove_if(files.begin(), files.end(),
                                [&](auto&& file) { return file.starts_with(to_delete_dir); }),
                 files.end());


### PR DESCRIPTION
## Proposed changes

`hdfsListDirectory` won't set `num_entries` when it returns nullptr
