### PR TITLE
[fix](gson) Fix Expr deserialize compatibility

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -579,6 +579,11 @@ public class GsonUtils {
 
     // the builder of GSON instance.
     // Add any other adapters if necessary.
+    //
+    // ATTN:
+    // Since GsonBuilder.create() adds all registered factories to GSON in reverse order, if you
+    // need to ensure the search order of two RuntimeTypeAdapterFactory instances, be sure to
+    // register them in reverse priority order.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .addSerializationExclusionStrategy(
@@ -589,8 +594,8 @@ public class GsonUtils {
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
             .registerTypeAdapterFactory(new PreProcessTypeAdapterFactory())
-            .registerTypeAdapterFactory(new ExprAdapterFactory())
             .registerTypeAdapterFactory(exprAdapterFactory)
+            .registerTypeAdapterFactory(new ExprAdapterFactory())
             .registerTypeAdapterFactory(columnTypeAdapterFactory)
             .registerTypeAdapterFactory(distributionInfoTypeAdapterFactory)
             .registerTypeAdapterFactory(resourceTypeAdapterFactory)
@@ -775,6 +780,11 @@ public class GsonUtils {
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
             final Class<T> rawType = (Class<T>) type.getRawType();
             final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+
+            if (!Expr.class.isAssignableFrom(rawType)) {
+                // reduce the stack depth.
+                return null;
+            }
 
             return new TypeAdapter<T>() {
                 public void write(JsonWriter out, T value) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils134.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils134.java
@@ -473,6 +473,11 @@ public class GsonUtils134 {
 
     // the builder of GSON instance.
     // Add any other adapters if necessary.
+    //
+    // ATTN:
+    // Since GsonBuilder.create() adds all registered factories to GSON in reverse order, if you
+    // need to ensure the search order of two RuntimeTypeAdapterFactory instances, be sure to
+    // register them in reverse priority order.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder().addSerializationExclusionStrategy(
                     new HiddenAnnotationExclusionStrategy()).enableComplexMapKeySerialization()
             .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
@@ -480,8 +485,8 @@ public class GsonUtils134 {
             // .registerTypeHierarchyAdapter(Expr.class, new ExprAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
-            .registerTypeAdapterFactory(new ExprAdapterFactory())
             .registerTypeAdapterFactory(exprAdapterFactory)
+            .registerTypeAdapterFactory(new ExprAdapterFactory())
             .registerTypeAdapterFactory(columnTypeAdapterFactory)
             .registerTypeAdapterFactory(distributionInfoTypeAdapterFactory)
             .registerTypeAdapterFactory(resourceTypeAdapterFactory)
@@ -659,6 +664,11 @@ public class GsonUtils134 {
 
             final Class<T> rawType = (Class<T>) type.getRawType();
             final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+
+            if (!Expr.class.isAssignableFrom(rawType)) {
+                // reduce the stack depth.
+                return null;
+            }
 
             return new TypeAdapter<T>() {
                 public void write(JsonWriter out, T value) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/ExprTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/ExprTest.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.meta.MetaContext;
+import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.persist.gson.GsonUtils134;
+
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+public class ExprTest {
+    private static final Logger LOG = LogManager.getLogger(ExprTest.class);
+
+    private static class ExprWrapper {
+        @SerializedName("expr")
+        private Expr expr;
+    }
+
+    @Test
+    public void testExprDeserializeCompatibility() {
+        LOG.info("run testDeserializeExprWithMetaVersion134 test");
+
+        String serializedString = "{\"expr\":{\"expr\": \"AAAADAAAAAAKZGF0ZV90cnVuYwAAAQAAAAIAAAABAAAAAANkYXkAAAAIAAAABW1vbnRoAAA\\u003d\"}}";
+
+        MetaContext ctx = new MetaContext();
+        ctx.setMetaVersion(FeMetaVersion.VERSION_129);
+        ctx.setThreadLocalInfo();
+        GsonUtils134.GSON.fromJson(serializedString, ExprWrapper.class);
+        GsonUtils.GSON.fromJson(serializedString, ExprWrapper.class);
+        MetaContext.remove();
+    }
+}


### PR DESCRIPTION
Since GsonBuilder.create() adds all registered factories to GSON in reverse order, and ExprAdapterFactory is registered before the RuntimeTypeAdapterFactory for Expr, ExprAdapterFactory will not be executed.

This PR adjusts their registration order. Now, it will first check-in ExprAdapterFactory whether to use the pre-134 deserialize method and then attempt to use the RuntimeTypeAdapterFactory for Expr.class.


