### PR TITLE
[fix](fs) Use full path as file cache key

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1757,8 +1757,8 @@ std::string BlockFileCache::clear_file_cache_directly() {
 std::map<size_t, FileBlockSPtr> BlockFileCache::get_blocks_by_key(const UInt128Wrapper& hash) {
     std::map<size_t, FileBlockSPtr> offset_to_block;
     std::lock_guard cache_lock(_mutex);
-    if (_files.contains(hash)) {
-        for (auto& [offset, cell] : _files[hash]) {
+    if (auto find_it = _files.find(hash); find_it != _files.end()) {
+        for (auto& [offset, cell] : find_it->second) {
             if (cell.file_block->state() == FileBlock::State::DOWNLOADED) {
                 offset_to_block.emplace(offset, cell.file_block);
                 use_cell(cell, nullptr,
@@ -1768,6 +1768,11 @@ std::map<size_t, FileBlockSPtr> BlockFileCache::get_blocks_by_key(const UInt128W
         }
     }
     return offset_to_block;
+}
+
+bool BlockFileCache::contains(const UInt128Wrapper& hash) {
+    std::lock_guard cache_lock(_mutex);
+    return _files.contains(hash);
 }
 
 void BlockFileCache::update_ttl_atime(const UInt128Wrapper& hash) {

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -103,7 +103,11 @@ public:
      */
     std::string reset_capacity(size_t new_capacity);
 
-    std::map<size_t, FileBlockSPtr> get_blocks_by_key(const UInt128Wrapper& hash);
+    std::map<size_t /* offset */, FileBlockSPtr> get_blocks_by_key(const UInt128Wrapper& hash);
+
+    // Return true if the cache contains the block with the given hash.
+    [[nodiscard]] bool contains(const UInt128Wrapper& hash);
+
     /// For debug.
     std::string dump_structure(const UInt128Wrapper& hash);
 


### PR DESCRIPTION
## Proposed changes

In path v1, the segment file path is "data/${shard_id}/${tablet_id}/${rowset_id}/${seg_id}.dat", which means that segment files of different rowsets can have the same file name (e.g. "0.dat"). However, the initial file cache key is based on the file name, which will lead to cache key collisions. Additionally, to maintain the generality of `CachedRemoteFileReader`, we should not assume that all files accessed by `CachedRemoteFileReader` have globally unique file names. Therefore, it is necessary to use the full path as the cache key.