### PR TITLE
[feature](file cache) Support in-memory filecache for no-disk/slow-disk system

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -983,12 +983,20 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 // format: {"path": "/path/to/file_cache", "total_size":53687091200, "normal_percent":85, "disposable_percent":10, "index_percent":5}
+// format: [{"path": "xxx", "total_size":53687091200, "storage": "memory"}]
+// Note1: storage is "disk" by default
+// Note2: when the storage is "memory", the path is ignored. So you can set xxx to anything you like
+// and doris will just reset the path to "memory" internally.
+// In a very wierd case when your storage is disk, and the directory, by accident, is named
+// "memory" for some reason, you should write the path as:
+//     {"path": "memory", "total_size":53687091200, "storage": "disk"}
+// or use the default storage value:
+//     {"path": "memory", "total_size":53687091200}
+// Both will use the directory "memory" on the disk instead of the real RAM.
 DEFINE_String(file_cache_path, "");
 DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
 
 DEFINE_Bool(clear_file_cache, "false");
-// cache segment files in memory instead of filesystem for no-disk/slow-disk system
-DEFINE_Bool(use_in_memory_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");
 DEFINE_mInt32(file_cache_enter_disk_resource_limit_mode_percent, "90");
 DEFINE_mInt32(file_cache_exit_disk_resource_limit_mode_percent, "80");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -987,6 +987,8 @@ DEFINE_String(file_cache_path, "");
 DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
 
 DEFINE_Bool(clear_file_cache, "false");
+// cache segment files in memory instead of filesystem for no-disk/slow-disk system
+DEFINE_Bool(use_in_memory_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");
 DEFINE_mInt32(file_cache_enter_disk_resource_limit_mode_percent, "90");
 DEFINE_mInt32(file_cache_exit_disk_resource_limit_mode_percent, "80");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1032,10 +1032,18 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
+// format: [{"path": "xxx", "total_size":53687091200, "storage": "memory"}]
+// Note1: storage is "disk" by default
+// Note2: when the storage is "memory", the path is ignored. So you can set xxx to anything you like
+// and doris will just reset the path to "memory" internally.
+// In a very wierd case when your storage is disk, and the directory, by accident, is named
+// "memory" for some reason, you should write the path as:
+//     {"path": "memory", "total_size":53687091200, "storage": "disk"}
+// or use the default storage value:
+//     {"path": "memory", "total_size":53687091200}
+// Both will use the directory "memory" on the disk instead of the real RAM.
 DECLARE_String(file_cache_path);
 DECLARE_Int64(file_cache_each_block_size);
-// cache segment files in memory instead of filesystem for no-disk/slow-disk system
-DECLARE_Bool(use_in_memory_file_cache);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
 DECLARE_Int32(file_cache_enter_disk_resource_limit_mode_percent);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1034,6 +1034,8 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
 DECLARE_Int64(file_cache_each_block_size);
+// cache segment files in memory instead of filesystem for no-disk/slow-disk system
+DECLARE_Bool(use_in_memory_file_cache);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
 DECLARE_Int32(file_cache_enter_disk_resource_limit_mode_percent);

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -99,7 +99,7 @@ BlockFileCache::BlockFileCache(const std::string& cache_base_path,
         _storage = std::make_unique<FSFileCacheStorage>();
     }
 
-    LOG(INFO) << "file cache path= " << _cache_base_path << cache_settings.to_string();
+    LOG(INFO) << "file cache path= " << _cache_base_path << " " << cache_settings.to_string();
 }
 
 UInt128Wrapper BlockFileCache::hash(const std::string& path) {
@@ -1512,8 +1512,8 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
 }
 
 void BlockFileCache::check_disk_resource_limit() {
-    if (_cache_base_path == "memory") {
-        return; // if storage is memory, skip the check
+    if (_storage->get_type() != FileCacheStorageType::DISK) {
+        return;
     }
     if (_capacity > _cur_cache_size) {
         _disk_resource_limit_mode = false;

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -51,37 +51,39 @@ BlockFileCache::BlockFileCache(const std::string& cache_base_path,
           _capacity(cache_settings.capacity),
           _max_file_block_size(cache_settings.max_file_block_size),
           _max_query_cache_size(cache_settings.max_query_cache_size) {
-    _cur_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(get_base_path().c_str(),
+    _is_in_memory = cache_base_path == "memory";
+
+    _cur_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(_cache_base_path.c_str(),
                                                                      "file_cache_cache_size", 0);
     _cur_ttl_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_ttl_cache_size", 0);
+            _cache_base_path.c_str(), "file_cache_ttl_cache_size", 0);
     _cur_normal_queue_element_count_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_normal_queue_element_count", 0);
+            _cache_base_path.c_str(), "file_cache_normal_queue_element_count", 0);
     _cur_ttl_cache_lru_queue_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_ttl_cache_lru_queue_size", 0);
+            _cache_base_path.c_str(), "file_cache_ttl_cache_lru_queue_size", 0);
     _cur_ttl_cache_lru_queue_element_count_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_ttl_cache_lru_queue_element_count", 0);
+            _cache_base_path.c_str(), "file_cache_ttl_cache_lru_queue_element_count", 0);
     _cur_normal_queue_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_normal_queue_cache_size", 0);
+            _cache_base_path.c_str(), "file_cache_normal_queue_cache_size", 0);
     _cur_index_queue_element_count_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_index_queue_element_count", 0);
+            _cache_base_path.c_str(), "file_cache_index_queue_element_count", 0);
     _cur_index_queue_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_index_queue_cache_size", 0);
+            _cache_base_path.c_str(), "file_cache_index_queue_cache_size", 0);
     _cur_disposable_queue_element_count_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_disposable_queue_element_count", 0);
+            _cache_base_path.c_str(), "file_cache_disposable_queue_element_count", 0);
     _cur_disposable_queue_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
-            get_base_path().c_str(), "file_cache_disposable_queue_cache_size", 0);
+            _cache_base_path.c_str(), "file_cache_disposable_queue_cache_size", 0);
 
     _queue_evict_size_metrics[0] = std::make_shared<bvar::Adder<size_t>>(
-            get_base_path().c_str(), "file_cache_index_queue_evict_size");
+            _cache_base_path.c_str(), "file_cache_index_queue_evict_size");
     _queue_evict_size_metrics[1] = std::make_shared<bvar::Adder<size_t>>(
-            get_base_path().c_str(), "file_cache_normal_queue_evict_size");
+            _cache_base_path.c_str(), "file_cache_normal_queue_evict_size");
     _queue_evict_size_metrics[2] = std::make_shared<bvar::Adder<size_t>>(
-            get_base_path().c_str(), "file_cache_disposable_queue_evict_size");
+            _cache_base_path.c_str(), "file_cache_disposable_queue_evict_size");
     _queue_evict_size_metrics[3] = std::make_shared<bvar::Adder<size_t>>(
-            get_base_path().c_str(), "file_cache_ttl_cache_evict_size");
+            _cache_base_path.c_str(), "file_cache_ttl_cache_evict_size");
     _total_evict_size_metrics = std::make_shared<bvar::Adder<size_t>>(
-            get_base_path().c_str(), "file_cache_total_evict_size");
+            _cache_base_path.c_str(), "file_cache_total_evict_size");
 
     _disposable_queue = LRUQueue(cache_settings.disposable_queue_size,
                                  cache_settings.disposable_queue_elements, 60 * 60);
@@ -92,14 +94,7 @@ BlockFileCache::BlockFileCache(const std::string& cache_base_path,
     _ttl_queue = LRUQueue(std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
                           std::numeric_limits<int>::max());
 
-    LOG(INFO) << fmt::format(
-            "file cache path={}, disposable queue size={} elements={}, index queue size={} "
-            "elements={}, query queue "
-            "size={} elements={}",
-            cache_base_path, cache_settings.disposable_queue_size,
-            cache_settings.disposable_queue_elements, cache_settings.index_queue_size,
-            cache_settings.index_queue_elements, cache_settings.query_queue_size,
-            cache_settings.query_queue_elements);
+    LOG(INFO) << "file cache path= " << _cache_base_path << cache_settings.to_string();
 }
 
 UInt128Wrapper BlockFileCache::hash(const std::string& path) {
@@ -207,7 +202,7 @@ Status BlockFileCache::initialize() {
 Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lock) {
     DCHECK(!_is_initialized);
     _is_initialized = true;
-    if (config::use_in_memory_file_cache) {
+    if (is_in_memory()) {
         _storage = std::make_unique<MemFileCacheStorage>();
     } else {
         _storage = std::make_unique<FSFileCacheStorage>();
@@ -414,7 +409,7 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
 }
 
 std::string BlockFileCache::clear_file_cache_async() {
-    LOG(INFO) << "start clear_file_cache_async, path=" << get_base_path();
+    LOG(INFO) << "start clear_file_cache_async, path=" << _cache_base_path;
     int64_t num_cells_all = 0;
     int64_t num_cells_to_delete = 0;
     int64_t num_files_all = 0;
@@ -435,7 +430,7 @@ std::string BlockFileCache::clear_file_cache_async() {
         }
     }
     std::stringstream ss;
-    ss << "finish clear_file_cache_async, path=" << get_base_path()
+    ss << "finish clear_file_cache_async, path=" << _cache_base_path
        << " num_files_all=" << num_files_all << " num_cells_all=" << num_cells_all
        << " num_cells_to_delete=" << num_cells_to_delete;
     auto msg = ss.str();
@@ -457,7 +452,7 @@ void BlockFileCache::recycle_deleted_blocks() {
     std::condition_variable cond;
     auto start_time = steady_clock::time_point();
     if (_async_clear_file_cache) {
-        LOG_INFO("Start clear file cache async").tag("path", get_base_path());
+        LOG_INFO("Start clear file cache async").tag("path", _cache_base_path);
         auto remove_file_block = [&cache_lock, this](FileBlockCell* cell) {
             std::lock_guard segment_lock(cell->file_block->_mutex);
             remove(cell->file_block, cache_lock, segment_lock);
@@ -535,7 +530,7 @@ void BlockFileCache::recycle_deleted_blocks() {
             _async_clear_file_cache = false;
             auto use_time = duration_cast<milliseconds>(steady_clock::time_point() - start_time);
             LOG_INFO("End clear file cache async")
-                    .tag("path", get_base_path())
+                    .tag("path", _cache_base_path)
                     .tag("use_time", static_cast<int64_t>(use_time.count()));
         }
     }
@@ -746,7 +741,7 @@ size_t BlockFileCache::try_release() {
         std::lock_guard lc(cell->file_block->_mutex);
         remove(file_block, l, lc);
     }
-    LOG(INFO) << "Released " << trash.size() << " blocks in file cache " << get_base_path();
+    LOG(INFO) << "Released " << trash.size() << " blocks in file cache " << _cache_base_path;
     return trash.size();
 }
 
@@ -1463,7 +1458,7 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
     int64_t space_released = 0;
     size_t old_capacity = 0;
     std::stringstream ss;
-    ss << "finish reset_capacity, path=" << get_base_path();
+    ss << "finish reset_capacity, path=" << _cache_base_path;
     auto start_time = steady_clock::time_point();
     {
         std::lock_guard cache_lock(_mutex);
@@ -1509,7 +1504,7 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
         _capacity = new_capacity;
     }
     auto use_time = duration_cast<milliseconds>(steady_clock::time_point() - start_time);
-    LOG(INFO) << "Finish tag deleted block. path=" << get_base_path()
+    LOG(INFO) << "Finish tag deleted block. path=" << _cache_base_path
               << " use_time=" << static_cast<int64_t>(use_time.count());
     ss << " old_capacity=" << old_capacity << " new_capacity=" << new_capacity;
     LOG(INFO) << ss.str();
@@ -1523,7 +1518,7 @@ void BlockFileCache::check_disk_resource_limit() {
     std::pair<int, int> percent;
     int ret = disk_used_percentage(_cache_base_path, &percent);
     if (ret != 0) {
-        LOG_ERROR("").tag("file cache path", get_base_path()).tag("error", strerror(errno));
+        LOG_ERROR("").tag("file cache path", _cache_base_path).tag("error", strerror(errno));
         return;
     }
     auto [capacity_percentage, inode_percentage] = percent;
@@ -1742,9 +1737,13 @@ std::string BlockFileCache::clear_file_cache_directly() {
     std::stringstream ss;
     auto start = steady_clock::now();
     std::lock_guard cache_lock(_mutex);
-    LOG_INFO("start clear_file_cache_directly").tag("path", get_base_path());
+    LOG_INFO("start clear_file_cache_directly").tag("path", _cache_base_path);
 
-    _storage->clear();
+    std::string clear_msg;
+    auto s = _storage->clear(clear_msg);
+    if (!s.ok()) {
+        return clear_msg;
+    }
 
     int64_t num_files = _files.size();
     int64_t cache_size = _cur_cache_size;
@@ -1762,7 +1761,7 @@ std::string BlockFileCache::clear_file_cache_directly() {
     _disposable_queue.clear(cache_lock);
     _ttl_queue.clear(cache_lock);
     ss << "finish clear_file_cache_directly"
-       << " path=" << get_base_path()
+       << " path=" << _cache_base_path
        << " time_elapsed=" << duration_cast<milliseconds>(steady_clock::now() - start).count()
        << " num_files=" << num_files << " cache_size=" << cache_size
        << " index_queue_size=" << index_queue_size << " normal_queue_size=" << normal_queue_size

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -40,6 +40,7 @@ class FSFileCacheStorage;
 // The current strategies are lru and ttl.
 class BlockFileCache {
     friend class FSFileCacheStorage;
+    friend class MemFileCacheStorage;
     friend class FileBlock;
     friend struct FileBlocksHolder;
 

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -68,8 +68,6 @@ public:
     /// Cache capacity in bytes.
     [[nodiscard]] size_t capacity() const { return _capacity; }
 
-    bool is_in_memory() const { return _is_in_memory; }
-
     // try to release all releasable block
     // it maybe hang the io/system
     size_t try_release();

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -444,8 +444,6 @@ private:
     LRUQueue _disposable_queue;
     LRUQueue _ttl_queue;
 
-    bool _is_in_memory = false;
-
     // metrics
     size_t _num_read_blocks = 0;
     size_t _num_hit_blocks = 0;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -72,7 +72,9 @@ public:
     // it maybe hang the io/system
     size_t try_release();
 
-    [[nodiscard]] const std::string& get_base_path() const { return _cache_base_path; }
+    [[nodiscard]] const std::string& get_base_path() const {
+        return (config::use_in_memory_file_cache ? "in-memory" : _cache_base_path);
+    }
 
     /**
          * Given an `offset` and `size` representing [offset, offset + size) bytes interval,

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -68,13 +68,13 @@ public:
     /// Cache capacity in bytes.
     [[nodiscard]] size_t capacity() const { return _capacity; }
 
+    bool is_in_memory() const { return _is_in_memory; }
+
     // try to release all releasable block
     // it maybe hang the io/system
     size_t try_release();
 
-    [[nodiscard]] const std::string& get_base_path() const {
-        return (config::use_in_memory_file_cache ? "in-memory" : _cache_base_path);
-    }
+    [[nodiscard]] const std::string& get_base_path() const { return _cache_base_path; }
 
     /**
          * Given an `offset` and `size` representing [offset, offset + size) bytes interval,
@@ -444,6 +444,8 @@ private:
     LRUQueue _normal_queue;
     LRUQueue _disposable_queue;
     LRUQueue _ttl_queue;
+
+    bool _is_in_memory = false;
 
     // metrics
     size_t _num_read_blocks = 0;

--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -26,6 +26,19 @@
 
 namespace doris::io {
 
+std::string FileCacheSettings::to_string() const {
+    std::stringstream ss;
+    ss << "capacity: " << capacity << ", max_file_block_size: " << max_file_block_size
+       << ", max_query_cache_size: " << max_query_cache_size
+       << ", disposable_queue_size: " << disposable_queue_size
+       << ", disposable_queue_elements: " << disposable_queue_elements
+       << ", index_queue_size: " << index_queue_size
+       << ", index_queue_elements: " << index_queue_elements
+       << ", query_queue_size: " << query_queue_size
+       << ", query_queue_elements: " << query_queue_elements;
+    return ss.str();
+}
+
 FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cache_size,
                                           size_t normal_percent, size_t disposable_percent,
                                           size_t index_percent) {

--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -35,13 +35,13 @@ std::string FileCacheSettings::to_string() const {
        << ", index_queue_size: " << index_queue_size
        << ", index_queue_elements: " << index_queue_elements
        << ", query_queue_size: " << query_queue_size
-       << ", query_queue_elements: " << query_queue_elements;
+       << ", query_queue_elements: " << query_queue_elements << ", storage: " << storage;
     return ss.str();
 }
 
 FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cache_size,
                                           size_t normal_percent, size_t disposable_percent,
-                                          size_t index_percent) {
+                                          size_t index_percent, const std::string& storage) {
     io::FileCacheSettings settings;
     if (capacity == 0) return settings;
     settings.capacity = capacity;
@@ -63,6 +63,7 @@ FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cach
     settings.query_queue_elements =
             std::max(settings.query_queue_size / settings.max_file_block_size,
                      REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS);
+    settings.storage = storage;
     return settings;
 }
 

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -95,6 +95,7 @@ struct FileCacheSettings {
     size_t query_queue_elements {0};
     size_t max_file_block_size {0};
     size_t max_query_cache_size {0};
+    std::string storage;
 
     // to string
     std::string to_string() const;
@@ -103,7 +104,8 @@ struct FileCacheSettings {
 FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cache_size,
                                           size_t normal_percent = DEFAULT_NORMAL_PERCENT,
                                           size_t disposable_percent = DEFAULT_DISPOSABLE_PERCENT,
-                                          size_t index_percent = DEFAULT_INDEX_PERCENT);
+                                          size_t index_percent = DEFAULT_INDEX_PERCENT,
+                                          const std::string& storage = "disk");
 
 struct CacheContext {
     CacheContext(const IOContext* io_context) {

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -95,6 +95,9 @@ struct FileCacheSettings {
     size_t query_queue_elements {0};
     size_t max_file_block_size {0};
     size_t max_query_cache_size {0};
+
+    // to string
+    std::string to_string() const;
 };
 
 FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cache_size,

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -26,6 +26,8 @@ class BlockFileCache;
 
 using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
 
+enum FileCacheStorageType { DISK = 0, MEMORY = 1 };
+
 struct FileWriterMapKeyHash {
     std::size_t operator()(const FileWriterMapKey& w) const {
         char* v1 = (char*)&w.first.value_;
@@ -60,7 +62,9 @@ public:
     // use when lazy load cache
     virtual void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                                std::lock_guard<std::mutex>& cache_lock) {}
+    // force clear all current data in the cache
     virtual Status clear(std::string& msg) = 0;
+    virtual FileCacheStorageType get_type() = 0;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -24,6 +24,20 @@ namespace doris::io {
 
 class BlockFileCache;
 
+using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
+
+struct FileWriterMapKeyHash {
+    std::size_t operator()(const FileWriterMapKey& w) const {
+        char* v1 = (char*)&w.first.value_;
+        char* v2 = (char*)&w.second;
+        char buf[24];
+        memcpy(buf, v1, 16);
+        memcpy(buf + 16, v2, 8);
+        std::string_view str(buf, 24);
+        return std::hash<std::string_view> {}(str);
+    }
+};
+
 // The interface is for organizing datas in disk
 class FileCacheStorage {
 public:
@@ -46,6 +60,7 @@ public:
     // use when lazy load cache
     virtual void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                                std::lock_guard<std::mutex>& cache_lock) {}
+    virtual void clear() = 0;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -60,7 +60,7 @@ public:
     // use when lazy load cache
     virtual void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                                std::lock_guard<std::mutex>& cache_lock) {}
-    virtual void clear() = 0;
+    virtual Status clear(std::string& msg) = 0;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -638,6 +638,24 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
     }
 }
 
+void FSFileCacheStorage::clear() {
+    std::stringstream ss;
+    auto st = global_local_filesystem()->delete_directory(_cache_base_path);
+    if (!st.ok()) {
+        ss << "failed to clear_file_cache_directly, path=" << _cache_base_path
+           << " delete dir failed: " << st;
+        LOG(WARNING) << ss.str();
+        return ss.str();
+    }
+    st = global_local_filesystem()->create_directory(_cache_base_path);
+    if (!st.ok()) {
+        ss << "failed to clear_file_cache_directly, path=" << _cache_base_path
+           << " create dir failed: " << st;
+        LOG(WARNING) << ss.str();
+        return ss.str();
+    }
+}
+
 FSFileCacheStorage::~FSFileCacheStorage() {
     if (_cache_background_load_thread.joinable()) {
         _cache_background_load_thread.join();

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -638,22 +638,25 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
     }
 }
 
-void FSFileCacheStorage::clear() {
+Status FSFileCacheStorage::clear(std::string& msg) {
     std::stringstream ss;
     auto st = global_local_filesystem()->delete_directory(_cache_base_path);
     if (!st.ok()) {
         ss << "failed to clear_file_cache_directly, path=" << _cache_base_path
            << " delete dir failed: " << st;
         LOG(WARNING) << ss.str();
-        return ss.str();
+        msg = ss.str();
+        return Status::InternalError(ss.str());
     }
     st = global_local_filesystem()->create_directory(_cache_base_path);
     if (!st.ok()) {
         ss << "failed to clear_file_cache_directly, path=" << _cache_base_path
            << " create dir failed: " << st;
         LOG(WARNING) << ss.str();
-        return ss.str();
+        msg = ss.str();
+        return Status::InternalError(ss.str());
     }
+    return Status::OK();
 }
 
 FSFileCacheStorage::~FSFileCacheStorage() {

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -69,6 +69,7 @@ public:
     Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
+    void clear() override;
 
     [[nodiscard]] static std::string get_path_in_local_cache(const std::string& dir, size_t offset,
                                                              FileCacheType type,
@@ -97,19 +98,6 @@ private:
     [[nodiscard]] std::string get_version_path() const;
 
     void load_cache_info_into_memory(BlockFileCache* _mgr) const;
-
-    using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
-    struct FileWriterMapKeyHash {
-        std::size_t operator()(const FileWriterMapKey& w) const {
-            char* v1 = (char*)&w.first.value_;
-            char* v2 = (char*)&w.second;
-            char buf[24];
-            memcpy(buf, v1, 16);
-            memcpy(buf + 16, v2, 8);
-            std::string_view str(buf, 24);
-            return std::hash<std::string_view> {}(str);
-        }
-    };
 
     std::string _cache_base_path;
     std::thread _cache_background_load_thread;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -83,6 +83,8 @@ public:
     [[nodiscard]] std::string get_path_in_local_cache(const UInt128Wrapper&,
                                                       uint64_t expiration_time) const;
 
+    FileCacheStorageType get_type() override { return DISK; }
+
 private:
     Status upgrade_cache_dir_if_necessary() const;
 

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -69,7 +69,7 @@ public:
     Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
-    void clear() override;
+    Status clear(std::string& msg) override;
 
     [[nodiscard]] static std::string get_path_in_local_cache(const std::string& dir, size_t offset,
                                                              FileCacheType type,

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "io/cache/mem_file_cache_storage.h"
+
+#include <filesystem>
+#include <mutex>
+#include <system_error>
+
+#include "common/logging.h"
+#include "io/cache/block_file_cache.h"
+#include "io/cache/file_block.h"
+#include "io/cache/file_cache_common.h"
+#include "runtime/exec_env.h"
+#include "vec/common/hex.h"
+
+namespace doris::io {
+
+MemFileCacheStorage::~MemFileCacheStorage() {}
+
+Status MemFileCacheStorage::init(BlockFileCache* _mgr) {
+    LOG_INFO("init in-memory file cache storage");
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
+    std::lock_guard<std::mutex> lock(_cache_map_mtx);
+
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter != _cache_map.end()) {
+        // despite the name append, it is indeed a put, so the key should not exist
+        DCHECK(false);
+        LOG_WARNING("key already exists in in-memory cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key already exists in in-memory cache map");
+    }
+    // TODO(zhengyu): allocate in mempool
+    auto mem_block =
+            MemBlock { std::shared_ptr<char>(new char[value.size], std::default_delete<char[]>()) };
+    DCHECK(mem_block.addr != nullptr);
+    _cache_map[map_key] = mem_block;
+    char* dst = mem_block.addr.get();
+    // TODO(zhengyu): zero copy!
+    memcpy(dst, value.data, value.size);
+
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::finalize(const FileCacheKey& key) {
+    // do nothing for in memory cache coz nothing to persist
+    // download state in FileBlock::finalize will inform the readers when finish
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
+    std::lock_guard<std::mutex> lock(_cache_map_mtx);
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter == _cache_map.end()) {
+            LOG_WARNING("key not found in cache map")
+                    .tag("hash", key.hash.to_string())
+                    .tag("offset", key.offset);
+            return Status::IOError("key not found in in-memory cache map when read");
+    }
+    auto mem_block = iter->second;
+    DCHECK(mem_block.addr != nullptr);
+    char* src = mem_block.addr.get();
+    char* dst = buffer.data;
+    size_t size = buffer.size;
+    memcpy(dst, src, size);
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::remove(const FileCacheKey& key) {
+    // find and clear the one in _cache_map
+    std::lock_guard<std::mutex> lock(_cache_map_mtx);
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter == _cache_map.end()) {
+        LOG_WARNING("key not found in cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key not found in in-memory cache map when remove");
+    }
+    _cache_map.erase(iter);
+    
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) {
+    // do nothing for in memory cache coz nothing to persist
+    return Status::OK();
+}
+
+void MemFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* _mgr,
+                                                        const FileCacheKey& key,
+                                                        std::lock_guard<std::mutex>& cache_lock) {
+    // load nothing for in memory cache coz nothing is persisted
+}
+
+void MemFileCacheStorage::clear() {
+    std::lock_guard<std::mutex> lock(_cache_map_mtx);
+    _cache_map.clear();
+}
+
+} // namespace doris::io

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -114,9 +114,10 @@ void MemFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* _mgr,
     // load nothing for in memory cache coz nothing is persisted
 }
 
-void MemFileCacheStorage::clear() {
+Status MemFileCacheStorage::clear(std::string& msg) {
     std::lock_guard<std::mutex> lock(_cache_map_mtx);
     _cache_map.clear();
+    return Status::OK();
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -53,7 +53,7 @@ Status MemFileCacheStorage::append(const FileCacheKey& key, const Slice& value) 
     }
     // TODO(zhengyu): allocate in mempool
     auto mem_block =
-            MemBlock {std::shared_ptr<char>(new char[value.size], std::default_delete<char[]>())};
+            MemBlock {std::shared_ptr<char[]>(new char[value.size], std::default_delete<char[]>())};
     DCHECK(mem_block.addr != nullptr);
     _cache_map[map_key] = mem_block;
     char* dst = mem_block.addr.get();

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -104,7 +104,14 @@ Status MemFileCacheStorage::remove(const FileCacheKey& key) {
     return Status::OK();
 }
 
-Status MemFileCacheStorage::change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) {
+Status MemFileCacheStorage::change_key_meta_type(const FileCacheKey& key,
+                                                 const FileCacheType type) {
+    // do nothing for in memory cache coz nothing to persist
+    return Status::OK();
+}
+
+Status MemFileCacheStorage::change_key_meta_expiration(const FileCacheKey& key,
+                                                       const uint64_t expiration) {
     // do nothing for in memory cache coz nothing to persist
     return Status::OK();
 }

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -34,6 +34,7 @@ MemFileCacheStorage::~MemFileCacheStorage() {}
 
 Status MemFileCacheStorage::init(BlockFileCache* _mgr) {
     LOG_INFO("init in-memory file cache storage");
+    _mgr->_lazy_open_done = true; // no data to load for memory storage
     return Status::OK();
 }
 

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -45,10 +45,10 @@ Status MemFileCacheStorage::append(const FileCacheKey& key, const Slice& value) 
     auto iter = _cache_map.find(map_key);
     if (iter != _cache_map.end()) {
         // despite the name append, it is indeed a put, so the key should not exist
-        DCHECK(false);
         LOG_WARNING("key already exists in in-memory cache map")
                 .tag("hash", key.hash.to_string())
                 .tag("offset", key.offset);
+        DCHECK(false);
         return Status::IOError("key already exists in in-memory cache map");
     }
     // TODO(zhengyu): allocate in mempool

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -34,7 +34,7 @@ MemFileCacheStorage::~MemFileCacheStorage() {}
 
 Status MemFileCacheStorage::init(BlockFileCache* _mgr) {
     LOG_INFO("init in-memory file cache storage");
-    _mgr->_lazy_open_done = true; // no data to load for memory storage
+    _mgr->_async_open_done = true; // no data to load for memory storage
     return Status::OK();
 }
 

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -52,7 +52,7 @@ Status MemFileCacheStorage::append(const FileCacheKey& key, const Slice& value) 
     }
     // TODO(zhengyu): allocate in mempool
     auto mem_block =
-            MemBlock { std::shared_ptr<char>(new char[value.size], std::default_delete<char[]>()) };
+            MemBlock {std::shared_ptr<char>(new char[value.size], std::default_delete<char[]>())};
     DCHECK(mem_block.addr != nullptr);
     _cache_map[map_key] = mem_block;
     char* dst = mem_block.addr.get();
@@ -73,10 +73,10 @@ Status MemFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, S
     auto map_key = std::make_pair(key.hash, key.offset);
     auto iter = _cache_map.find(map_key);
     if (iter == _cache_map.end()) {
-            LOG_WARNING("key not found in cache map")
-                    .tag("hash", key.hash.to_string())
-                    .tag("offset", key.offset);
-            return Status::IOError("key not found in in-memory cache map when read");
+        LOG_WARNING("key not found in cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key not found in in-memory cache map when read");
     }
     auto mem_block = iter->second;
     DCHECK(mem_block.addr != nullptr);
@@ -99,7 +99,7 @@ Status MemFileCacheStorage::remove(const FileCacheKey& key) {
         return Status::IOError("key not found in in-memory cache map when remove");
     }
     _cache_map.erase(iter);
-    
+
     return Status::OK();
 }
 

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -27,7 +27,7 @@
 namespace doris::io {
 
 struct MemBlock {
-    std::shared_ptr<char> addr;
+    std::shared_ptr<char[]> addr;
 };
 
 class MemFileCacheStorage : public FileCacheStorage {

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -39,7 +39,8 @@ public:
     Status finalize(const FileCacheKey& key) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
-    Status change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) override;
+    Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
+    Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
     Status clear(std::string& msg) override;

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -42,7 +42,7 @@ public:
     Status change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
-    void clear() override;
+    Status clear(std::string& msg) override;
 
 private:
     std::unordered_map<FileWriterMapKey, MemBlock, FileWriterMapKeyHash> _cache_map;

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -45,6 +45,8 @@ public:
                                        std::lock_guard<std::mutex>& cache_lock) override;
     Status clear(std::string& msg) override;
 
+    FileCacheStorageType get_type() override { return MEMORY; }
+
 private:
     std::unordered_map<FileWriterMapKey, MemBlock, FileWriterMapKeyHash> _cache_map;
     std::mutex _cache_map_mtx;

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+
+#include "io/cache/file_cache_common.h"
+#include "io/cache/file_cache_storage.h"
+
+namespace doris::io {
+
+struct MemBlock {
+    std::shared_ptr<char> addr;
+};
+
+class MemFileCacheStorage : public FileCacheStorage {
+public:
+    MemFileCacheStorage() = default;
+    ~MemFileCacheStorage() override;
+    Status init(BlockFileCache* _mgr) override;
+    Status append(const FileCacheKey& key, const Slice& value) override;
+    Status finalize(const FileCacheKey& key) override;
+    Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
+    Status remove(const FileCacheKey& key) override;
+    Status change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) override;
+    void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
+                                       std::lock_guard<std::mutex>& cache_lock) override;
+    void clear() override;
+
+private:
+    std::unordered_map<FileWriterMapKey, MemBlock, FileWriterMapKeyHash> _cache_map;
+    std::mutex _cache_map_mtx;
+};
+
+} // namespace doris::io

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -56,6 +56,9 @@ static std::string CACHE_QUERY_LIMIT_SIZE = "query_limit";
 static std::string CACHE_NORMAL_PERCENT = "normal_percent";
 static std::string CACHE_DISPOSABLE_PERCENT = "disposable_percent";
 static std::string CACHE_INDEX_PERCENT = "index_percent";
+static std::string CACHE_STORAGE = "storage";
+static std::string CACHE_STORAGE_DISK = "disk";
+static std::string CACHE_STORAGE_MEMORY = "memory";
 
 // TODO: should be a general util method
 // static std::string to_upper(const std::string& str) {
@@ -204,6 +207,7 @@ void parse_conf_broken_store_paths(const string& config_path, std::set<std::stri
  *    {"path": "storage1", "total_size":53687091200,"query_limit": "10737418240"},
  *    {"path": "storage2", "total_size":53687091200},
  *    {"path": "storage3", "total_size":53687091200, "normal_percent":85, "disposable_percent":10, "index_percent":5}
+ *    {"path": "xxx", "total_size":53687091200, "storage": "memory"}
  *  ]
  */
 Status parse_conf_cache_paths(const std::string& config_path, std::vector<CachePath>& paths) {
@@ -215,6 +219,18 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
         auto map = config.GetObject();
         DCHECK(map.HasMember(CACHE_PATH.c_str()));
         std::string path = map.FindMember(CACHE_PATH.c_str())->value.GetString();
+        std::string storage = CACHE_STORAGE_DISK; // disk storage by default
+        if (map.HasMember(CACHE_STORAGE.c_str())) {
+            std::string storage = map.FindMember(CACHE_STORAGE.c_str())->value.GetString();
+            if (storage != CACHE_STORAGE_DISK && storage != CACHE_STORAGE_MEMORY) [[unlikely]] {
+                return Status::InvalidArgument("invalid file cache storage type:" + storage);
+            }
+            if (storage == CACHE_STORAGE_MEMORY) {
+                // set path to "memory" for memory storage
+                // so that we can track it by path (use _path_to_cache map)
+                path = "memory";
+            }
+        }
         int64_t total_size = 0, query_limit_bytes = 0;
         if (map.HasMember(CACHE_TOTAL_SIZE.c_str())) {
             auto& value = map.FindMember(CACHE_TOTAL_SIZE.c_str())->value;
@@ -268,7 +284,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
         }
 
         paths.emplace_back(std::move(path), total_size, query_limit_bytes, normal_percent,
-                           disposable_percent, index_percent);
+                           disposable_percent, index_percent, storage);
     }
     if (paths.empty()) {
         return Status::InvalidArgument("fail to parse storage_root_path config. value={}",
@@ -279,7 +295,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
 
 io::FileCacheSettings CachePath::init_settings() const {
     return io::get_file_cache_settings(total_bytes, query_limit_bytes, normal_percent,
-                                       disposable_percent, index_percent);
+                                       disposable_percent, index_percent, storage);
 }
 
 } // end namespace doris

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -221,9 +221,9 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
         std::string path = map.FindMember(CACHE_PATH.c_str())->value.GetString();
         std::string storage = CACHE_STORAGE_DISK; // disk storage by default
         if (map.HasMember(CACHE_STORAGE.c_str())) {
-            std::string storage = map.FindMember(CACHE_STORAGE.c_str())->value.GetString();
+            storage = map.FindMember(CACHE_STORAGE.c_str())->value.GetString();
             if (storage != CACHE_STORAGE_DISK && storage != CACHE_STORAGE_MEMORY) [[unlikely]] {
-                return Status::InvalidArgument("invalid file cache storage type:" + storage);
+                return Status::InvalidArgument("invalid file cache storage type: " + storage);
             }
             if (storage == CACHE_STORAGE_MEMORY) {
                 // set path to "memory" for memory storage

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -228,7 +228,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
             if (storage == CACHE_STORAGE_MEMORY) {
                 // set path to "memory" for memory storage
                 // so that we can track it by path (use _path_to_cache map)
-                path = "memory";
+                path = CACHE_STORAGE_MEMORY;
             }
         }
         int64_t total_size = 0, query_limit_bytes = 0;

--- a/be/src/olap/options.h
+++ b/be/src/olap/options.h
@@ -53,13 +53,15 @@ struct CachePath {
     io::FileCacheSettings init_settings() const;
 
     CachePath(std::string path, int64_t total_bytes, int64_t query_limit_bytes,
-              size_t normal_percent, size_t disposable_percent, size_t index_percent)
+              size_t normal_percent, size_t disposable_percent, size_t index_percent,
+              std::string storage)
             : path(std::move(path)),
               total_bytes(total_bytes),
               query_limit_bytes(query_limit_bytes),
               normal_percent(normal_percent),
               disposable_percent(disposable_percent),
-              index_percent(index_percent) {}
+              index_percent(index_percent),
+              storage(storage) {}
 
     std::string path;
     int64_t total_bytes = 0;
@@ -67,6 +69,7 @@ struct CachePath {
     size_t normal_percent = io::DEFAULT_NORMAL_PERCENT;
     size_t disposable_percent = io::DEFAULT_DISPOSABLE_PERCENT;
     size_t index_percent = io::DEFAULT_INDEX_PERCENT;
+    std::string storage = "disk";
 };
 
 Status parse_conf_cache_paths(const std::string& config_path, std::vector<CachePath>& path);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -412,7 +412,7 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
         std::vector<std::thread> file_cache_init_threads;
 
         std::list<doris::Status> cache_status;
-        for (auto& cache_path : cache_paths) {
+        for (auto& cache_path : cache_paths) { //TODO(zhengyu): need refractor for in-memory cache
             if (cache_path_set.find(cache_path.path) != cache_path_set.end()) {
                 LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
                 continue;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -412,7 +412,7 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
         std::vector<std::thread> file_cache_init_threads;
 
         std::list<doris::Status> cache_status;
-        for (auto& cache_path : cache_paths) { //TODO(zhengyu): need refractor for in-memory cache
+        for (auto& cache_path : cache_paths) {
             if (cache_path_set.find(cache_path.path) != cache_path_set.end()) {
                 LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
                 continue;

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -1539,7 +1539,8 @@ TEST_F(BlockFileCacheTest, change_cache_type_memory_storage) {
         std::string data(size, '0');
         Slice result(data.data(), size);
         ASSERT_TRUE(blocks[0]->append(result).ok());
-        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
+        ASSERT_TRUE(
+                blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         ASSERT_TRUE(blocks[0]->finalize().ok());
     }
 }

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -1031,6 +1031,7 @@ void test_file_cache_memory_storage(io::FileCacheType cache_type) {
     //                   0          9  17   20       24  26 27   30 31
     {
         /// Test LRUCache::restore().
+        // storage will restore nothing
 
         io::BlockFileCache cache2(cache_base_path, settings);
         ASSERT_TRUE(cache2.initialize().ok());
@@ -1043,16 +1044,7 @@ void test_file_cache_memory_storage(io::FileCacheType cache_type) {
         auto holder1 = cache2.get_or_set(key, 2, 28, context); /// Get [2, 29]
 
         auto blocks1 = fromHolder(holder1);
-        ASSERT_EQ(blocks1.size(), 10);
-
-        assert_range(44, blocks1[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
-        assert_range(45, blocks1[1], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
-        assert_range(45, blocks1[2], io::FileBlock::Range(15, 16),
-                     io::FileBlock::State::DOWNLOADED);
-        assert_range(46, blocks1[3], io::FileBlock::Range(17, 20),
-                     io::FileBlock::State::DOWNLOADED);
-        assert_range(47, blocks1[4], io::FileBlock::Range(21, 21),
-                     io::FileBlock::State::DOWNLOADED);
+        ASSERT_EQ(blocks1.size(), 1);
     }
 }
 
@@ -1524,6 +1516,7 @@ TEST_F(BlockFileCacheTest, change_cache_type_memory_storage) {
     settings.max_file_block_size = 10;
     settings.max_query_cache_size = 15;
     settings.capacity = 30;
+    settings.storage = "memory";
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -697,7 +697,7 @@ void test_file_cache_memory_storage(io::FileCacheType cache_type) {
         ASSERT_TRUE(mgr.initialize().ok());
 
         for (int i = 0; i < 100; i++) {
-            if (mgr.get_lazy_open_success()) {
+            if (mgr.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1036,7 +1036,7 @@ void test_file_cache_memory_storage(io::FileCacheType cache_type) {
         io::BlockFileCache cache2(cache_base_path, settings);
         ASSERT_TRUE(cache2.initialize().ok());
         for (int i = 0; i < 100; i++) {
-            if (cache2.get_lazy_open_success()) {
+            if (cache2.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1175,12 +1175,12 @@ TEST_F(BlockFileCacheTest, max_ttl_size_memory_storage) {
     ASSERT_TRUE(cache.initialize());
     int i = 0;
     for (; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    ASSERT_TRUE(cache.get_lazy_open_success());
+    ASSERT_TRUE(cache.get_async_open_success());
     int64_t offset = 0;
     for (; offset < 100000000; offset += 100000) {
         auto holder = cache.get_or_set(key1, offset, 100000, context);
@@ -1520,7 +1520,7 @@ TEST_F(BlockFileCacheTest, change_cache_type_memory_storage) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1539,7 +1539,7 @@ TEST_F(BlockFileCacheTest, change_cache_type_memory_storage) {
         std::string data(size, '0');
         Slice result(data.data(), size);
         ASSERT_TRUE(blocks[0]->append(result).ok());
-        ASSERT_TRUE(blocks[0]->change_cache_type_self(io::FileCacheType::INDEX));
+        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         ASSERT_TRUE(blocks[0]->finalize().ok());
     }
 }
@@ -2253,7 +2253,7 @@ TEST_F(BlockFileCacheTest, ttl_modify_memory_storage) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2385,7 +2385,7 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal_memory_storage) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2501,7 +2501,7 @@ TEST_F(BlockFileCacheTest, ttl_change_expiration_time_memory_storage) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2605,12 +2605,12 @@ TEST_F(BlockFileCacheTest, ttl_reverse_memory_storage) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    ASSERT_TRUE(cache.get_lazy_open_success());
+    ASSERT_TRUE(cache.get_async_open_success());
     for (size_t offset = 0; offset < 30; offset += 6) {
         auto holder = cache.get_or_set(key2, offset, 6, context);
         auto blocks = fromHolder(holder);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -110,10 +110,28 @@ void download(io::FileBlockSPtr file_block, size_t size = 0) {
     ASSERT_TRUE(fs::exists(subdir));
 }
 
+void download_into_memory(io::FileBlockSPtr file_block, size_t size = 0) {
+    if (size == 0) {
+        size = file_block->range().size();
+    }
+
+    std::string data(size, '0');
+    Slice result(data.data(), size);
+    EXPECT_TRUE(file_block->append(result).ok());
+    EXPECT_TRUE(file_block->finalize().ok());
+}
+
 void complete(const io::FileBlocksHolder& holder) {
     for (const auto& file_block : holder.file_blocks) {
         ASSERT_TRUE(file_block->get_or_set_downloader() == io::FileBlock::get_caller_id());
         download(file_block);
+    }
+}
+
+void complete_into_memory(const io::FileBlocksHolder& holder) {
+    for (const auto& file_block : holder.file_blocks) {
+        ASSERT_TRUE(file_block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(file_block);
     }
 }
 
@@ -639,6 +657,405 @@ void test_file_cache(io::FileCacheType cache_type) {
     }
 }
 
+void test_file_cache_memory_storage(io::FileCacheType cache_type) {
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+
+    TUniqueId other_query_id;
+    other_query_id.hi = 2;
+    other_query_id.lo = 2;
+
+    io::FileCacheSettings settings;
+    switch (cache_type) {
+    case io::FileCacheType::INDEX:
+        settings.index_queue_elements = 5;
+        settings.index_queue_size = 30;
+        break;
+    case io::FileCacheType::NORMAL:
+        settings.query_queue_size = 30;
+        settings.query_queue_elements = 5;
+        break;
+    case io::FileCacheType::DISPOSABLE:
+        settings.disposable_queue_size = 30;
+        settings.disposable_queue_elements = 5;
+        break;
+    default:
+        break;
+    }
+    settings.capacity = 30;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context, other_context;
+    context.cache_type = other_context.cache_type = cache_type;
+    context.query_id = query_id;
+    other_context.query_id = other_query_id;
+    auto key = io::BlockFileCache::hash("key1");
+    {
+        io::BlockFileCache mgr(cache_base_path, settings);
+        ASSERT_TRUE(mgr.initialize().ok());
+
+        for (int i = 0; i < 100; i++) {
+            if (mgr.get_lazy_open_success()) {
+                break;
+            };
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        {
+            auto holder = mgr.get_or_set(key, 0, 10, context); /// Add range [0, 9]
+            auto blocks = fromHolder(holder);
+            /// Range was not present in mgr. It should be added in mgr as one while file block.
+            ASSERT_EQ(blocks.size(), 1);
+            assert_range(1, blocks[0], io::FileBlock::Range(0, 9), io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            assert_range(2, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADING);
+            download_into_memory(blocks[0]);
+            assert_range(3, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+        /// Current mgr:    [__________]
+        ///                   ^          ^
+        ///                   0          9
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 1);
+        ASSERT_EQ(mgr.get_used_cache_size(cache_type), 10);
+        {
+            /// Want range [5, 14], but [0, 9] already in mgr, so only [10, 14] will be put in mgr.
+            auto holder = mgr.get_or_set(key, 5, 10, context);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 2);
+
+            assert_range(4, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(5, blocks[1], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
+
+            ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(blocks[1]);
+            assert_range(6, blocks[1], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+
+        /// Current mgr:    [__________][_____]
+        ///                   ^          ^^     ^
+        ///                   0          910    14
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 2);
+        ASSERT_EQ(mgr.get_used_cache_size(cache_type), 15);
+
+        {
+            auto holder = mgr.get_or_set(key, 9, 1, context); /// Get [9, 9]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            assert_range(7, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+        {
+            auto holder = mgr.get_or_set(key, 9, 2, context); /// Get [9, 10]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 2);
+            assert_range(8, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(9, blocks[1], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+        {
+            auto holder = mgr.get_or_set(key, 10, 1, context); /// Get [10, 10]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            assert_range(10, blocks[0], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+        complete_into_memory(mgr.get_or_set(key, 17, 4, context)); /// Get [17, 20]
+        complete_into_memory(mgr.get_or_set(key, 24, 3, context)); /// Get [24, 26]
+
+        /// Current mgr:    [__________][_____]   [____]    [___]
+        ///                   ^          ^^     ^   ^    ^    ^   ^
+        ///                   0          910    14  17   20   24  26
+        ///
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 4);
+        ASSERT_EQ(mgr.get_used_cache_size(cache_type), 22);
+        {
+            auto holder = mgr.get_or_set(key, 0, 31, context); /// Get [0, 25]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 7);
+            assert_range(11, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(12, blocks[1], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::DOWNLOADED);
+            /// Missing [15, 16] should be added in mgr.
+            assert_range(13, blocks[2], io::FileBlock::Range(15, 16), io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[2]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(blocks[2]);
+
+            assert_range(14, blocks[3], io::FileBlock::Range(17, 20),
+                         io::FileBlock::State::DOWNLOADED);
+
+            assert_range(15, blocks[4], io::FileBlock::Range(21, 23), io::FileBlock::State::EMPTY);
+
+            assert_range(16, blocks[5], io::FileBlock::Range(24, 26),
+                         io::FileBlock::State::DOWNLOADED);
+
+            assert_range(16, blocks[6], io::FileBlock::Range(27, 30),
+                         io::FileBlock::State::SKIP_CACHE);
+            /// Current mgr:    [__________][_____][   ][____________]
+            ///                   ^                       ^            ^
+            ///                   0                        20          26
+            ///
+
+            /// Range [27, 30] must be evicted in previous getOrSet [0, 25].
+            /// Let's not invalidate pointers to returned blocks from range [0, 25] and
+            /// as max elements size is reached, next attempt to put something in mgr should fail.
+            /// This will also check that [27, 27] was indeed evicted.
+
+            auto holder1 = mgr.get_or_set(key, 27, 4, context);
+            auto blocks_1 = fromHolder(holder1); /// Get [27, 30]
+            ASSERT_EQ(blocks_1.size(), 1);
+            assert_range(17, blocks_1[0], io::FileBlock::Range(27, 30),
+                         io::FileBlock::State::SKIP_CACHE);
+        }
+        /// Current mgr:    [__________][_____][_][____]    [___]
+        ///                   ^          ^^     ^   ^    ^    ^   ^
+        ///                   0          910    14  17   20   24  26
+        ///
+        {
+            auto holder = mgr.get_or_set(key, 12, 10, context); /// Get [12, 21]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 4);
+
+            assert_range(18, blocks[0], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(19, blocks[1], io::FileBlock::Range(15, 16),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(20, blocks[2], io::FileBlock::Range(17, 20),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(21, blocks[3], io::FileBlock::Range(21, 21), io::FileBlock::State::EMPTY);
+
+            ASSERT_TRUE(blocks[3]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(blocks[3]);
+            ASSERT_TRUE(blocks[3]->state() == io::FileBlock::State::DOWNLOADED);
+        }
+        /// Current mgr:    [__________][_____][_][____][_]    [___]
+        ///                   ^          ^^     ^   ^    ^       ^   ^
+        ///                   0          910    14  17   20      24  26
+
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 6);
+        {
+            auto holder = mgr.get_or_set(key, 23, 5, context); /// Get [23, 28]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 3);
+
+            assert_range(22, blocks[0], io::FileBlock::Range(23, 23), io::FileBlock::State::EMPTY);
+            assert_range(23, blocks[1], io::FileBlock::Range(24, 26),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(24, blocks[2], io::FileBlock::Range(27, 27), io::FileBlock::State::EMPTY);
+
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            ASSERT_TRUE(blocks[2]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(blocks[0]);
+            download_into_memory(blocks[2]);
+        }
+        /// Current mgr:    [__________][_____][_][____][_]  [_][___][_]
+        ///                   ^          ^^     ^   ^    ^        ^   ^
+        ///                   0          910    14  17   20       24  26
+
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 8);
+        {
+            auto holder5 = mgr.get_or_set(key, 2, 3, context); /// Get [2, 4]
+            auto s5 = fromHolder(holder5);
+            ASSERT_EQ(s5.size(), 1);
+            assert_range(25, s5[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+
+            auto holder1 = mgr.get_or_set(key, 30, 2, context); /// Get [30, 31]
+            auto s1 = fromHolder(holder1);
+            ASSERT_EQ(s1.size(), 1);
+            assert_range(26, s1[0], io::FileBlock::Range(30, 31), io::FileBlock::State::EMPTY);
+
+            ASSERT_TRUE(s1[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(s1[0]);
+
+            /// Current mgr:    [__________][_____][_][____][_]  [_][___][_]    [__]
+            ///                   ^          ^^     ^   ^    ^        ^   ^  ^    ^  ^
+            ///                   0          910    14  17   20       24  26 27   30 31
+
+            auto holder2 = mgr.get_or_set(key, 23, 1, context); /// Get [23, 23]
+            auto s2 = fromHolder(holder2);
+            ASSERT_EQ(s2.size(), 1);
+
+            auto holder3 = mgr.get_or_set(key, 24, 3, context); /// Get [24, 26]
+            auto s3 = fromHolder(holder3);
+            ASSERT_EQ(s3.size(), 1);
+
+            auto holder4 = mgr.get_or_set(key, 27, 1, context); /// Get [27, 27]
+            auto s4 = fromHolder(holder4);
+            ASSERT_EQ(s4.size(), 1);
+
+            /// All mgr is now unreleasable because pointers are still hold
+            auto holder6 = mgr.get_or_set(key, 0, 40, context);
+            auto f = fromHolder(holder6);
+            ASSERT_EQ(f.size(), 12);
+
+            assert_range(29, f[9], io::FileBlock::Range(28, 29), io::FileBlock::State::SKIP_CACHE);
+            assert_range(30, f[11], io::FileBlock::Range(32, 39), io::FileBlock::State::SKIP_CACHE);
+        }
+        {
+            auto holder = mgr.get_or_set(key, 2, 3, context); /// Get [2, 4]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            assert_range(31, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+        }
+        // Current cache:    [__________][_____][_][____][_]  [_][___][_]    [__]
+        //                   ^          ^^     ^   ^    ^        ^   ^  ^    ^  ^
+        //                   0          910    14  17   20       24  26 27   30 31
+
+        {
+            auto holder = mgr.get_or_set(key, 25, 5, context); /// Get [25, 29]
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 3);
+
+            assert_range(32, blocks[0], io::FileBlock::Range(24, 26),
+                         io::FileBlock::State::DOWNLOADED);
+            assert_range(33, blocks[1], io::FileBlock::Range(27, 27),
+                         io::FileBlock::State::DOWNLOADED);
+
+            assert_range(34, blocks[2], io::FileBlock::Range(28, 29), io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[2]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            ASSERT_TRUE(blocks[2]->state() == io::FileBlock::State::DOWNLOADING);
+
+            bool lets_start_download = false;
+            std::mutex mutex;
+            std::condition_variable cv;
+
+            std::thread other_1([&] {
+                auto holder_2 =
+                        mgr.get_or_set(key, 25, 5, other_context); /// Get [25, 29] once again.
+                auto blocks_2 = fromHolder(holder_2);
+                ASSERT_EQ(blocks.size(), 3);
+
+                assert_range(35, blocks_2[0], io::FileBlock::Range(24, 26),
+                             io::FileBlock::State::DOWNLOADED);
+                assert_range(36, blocks_2[1], io::FileBlock::Range(27, 27),
+                             io::FileBlock::State::DOWNLOADED);
+                assert_range(37, blocks_2[2], io::FileBlock::Range(28, 29),
+                             io::FileBlock::State::DOWNLOADING);
+
+                ASSERT_TRUE(blocks[2]->get_or_set_downloader() != io::FileBlock::get_caller_id());
+                ASSERT_TRUE(blocks[2]->state() == io::FileBlock::State::DOWNLOADING);
+
+                {
+                    std::lock_guard lock(mutex);
+                    lets_start_download = true;
+                }
+                cv.notify_one();
+
+                while (blocks_2[2]->wait() == io::FileBlock::State::DOWNLOADING) {
+                }
+                ASSERT_TRUE(blocks_2[2]->state() == io::FileBlock::State::DOWNLOADED);
+            });
+
+            {
+                std::unique_lock lock(mutex);
+                cv.wait(lock, [&] { return lets_start_download; });
+            }
+
+            download_into_memory(blocks[2]);
+            ASSERT_TRUE(blocks[2]->state() == io::FileBlock::State::DOWNLOADED);
+
+            other_1.join();
+        }
+        ASSERT_EQ(mgr.get_file_blocks_num(cache_type), 9);
+        // Current cache:    [__________][_____][_][____][_]  [_][___][_]    [__]
+        //                   ^          ^^     ^   ^    ^        ^   ^  ^    ^  ^
+        //                   0          910    14  17   20       24  26 27   30 31
+
+        {
+            /// Now let's check the similar case but getting ERROR state after block->wait(), when
+            /// state is changed not manually via block->complete(state) but from destructor of holder
+            /// and notify_all() is also called from destructor of holder.
+
+            std::optional<io::FileBlocksHolder> holder;
+            holder.emplace(mgr.get_or_set(key, 3, 23, context)); /// Get [3, 25]
+
+            auto blocks = fromHolder(*holder);
+            ASSERT_EQ(blocks.size(), 8);
+
+            assert_range(38, blocks[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
+
+            assert_range(39, blocks[5], io::FileBlock::Range(22, 22), io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[5]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            ASSERT_TRUE(blocks[5]->state() == io::FileBlock::State::DOWNLOADING);
+
+            bool lets_start_download = false;
+            std::mutex mutex;
+            std::condition_variable cv;
+
+            std::thread other_1([&] {
+                auto holder_2 =
+                        mgr.get_or_set(key, 3, 23, other_context); /// Get [3, 25] once again
+                auto blocks_2 = fromHolder(*holder);
+                ASSERT_EQ(blocks_2.size(), 8);
+
+                assert_range(41, blocks_2[0], io::FileBlock::Range(0, 9),
+                             io::FileBlock::State::DOWNLOADED);
+                assert_range(42, blocks_2[5], io::FileBlock::Range(22, 22),
+                             io::FileBlock::State::DOWNLOADING);
+
+                ASSERT_TRUE(blocks_2[5]->get_downloader() != io::FileBlock::get_caller_id());
+                ASSERT_TRUE(blocks_2[5]->state() == io::FileBlock::State::DOWNLOADING);
+
+                {
+                    std::lock_guard lock(mutex);
+                    lets_start_download = true;
+                }
+                cv.notify_one();
+
+                while (blocks_2[5]->wait() == io::FileBlock::State::DOWNLOADING) {
+                }
+                ASSERT_TRUE(blocks_2[5]->state() == io::FileBlock::State::EMPTY);
+                ASSERT_TRUE(blocks_2[5]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+                download_into_memory(blocks_2[5]);
+            });
+
+            {
+                std::unique_lock lock(mutex);
+                cv.wait(lock, [&] { return lets_start_download; });
+            }
+            holder.reset();
+            other_1.join();
+            ASSERT_TRUE(blocks[5]->state() == io::FileBlock::State::DOWNLOADED);
+        }
+    }
+    // Current cache:    [__________][_][____][_]  [_][___][_]    [__]
+    //                   ^          ^   ^    ^        ^   ^  ^    ^  ^
+    //                   0          9  17   20       24  26 27   30 31
+    {
+        /// Test LRUCache::restore().
+
+        io::BlockFileCache cache2(cache_base_path, settings);
+        ASSERT_TRUE(cache2.initialize().ok());
+        for (int i = 0; i < 100; i++) {
+            if (cache2.get_lazy_open_success()) {
+                break;
+            };
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        auto holder1 = cache2.get_or_set(key, 2, 28, context); /// Get [2, 29]
+
+        auto blocks1 = fromHolder(holder1);
+        ASSERT_EQ(blocks1.size(), 10);
+
+        assert_range(44, blocks1[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+        assert_range(45, blocks1[1], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
+        assert_range(45, blocks1[2], io::FileBlock::Range(15, 16),
+                     io::FileBlock::State::DOWNLOADED);
+        assert_range(46, blocks1[3], io::FileBlock::Range(17, 20),
+                     io::FileBlock::State::DOWNLOADED);
+        assert_range(47, blocks1[4], io::FileBlock::Range(21, 21),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+}
+
 TEST_F(BlockFileCacheTest, normal) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -655,6 +1072,11 @@ TEST_F(BlockFileCacheTest, normal) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
     }
+}
+
+TEST_F(BlockFileCacheTest, normal_memory_storage) {
+    test_file_cache_memory_storage(io::FileCacheType::INDEX);
+    test_file_cache_memory_storage(io::FileCacheType::NORMAL);
 }
 
 TEST_F(BlockFileCacheTest, resize) {
@@ -737,6 +1159,53 @@ TEST_F(BlockFileCacheTest, max_ttl_size) {
     }
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, max_ttl_size_memory_storage) {
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 100000000;
+    settings.query_queue_elements = 100000;
+    settings.capacity = 100000000;
+    settings.max_file_block_size = 100000;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t cur_time = UnixSeconds();
+    context.expiration_time = cur_time + 120;
+    auto key1 = io::BlockFileCache::hash("key5");
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    int i = 0;
+    for (; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_lazy_open_success());
+    int64_t offset = 0;
+    for (; offset < 100000000; offset += 100000) {
+        auto holder = cache.get_or_set(key1, offset, 100000, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        if (offset < 90000000) {
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download_into_memory(blocks[0]);
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::DOWNLOADED);
+        } else {
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::SKIP_CACHE);
+        }
+        blocks.clear();
     }
 }
 
@@ -1040,6 +1509,45 @@ TEST_F(BlockFileCacheTest, change_cache_type) {
     }
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, change_cache_type_memory_storage) {
+    doris::config::enable_file_cache_query_limit = true;
+    io::FileCacheSettings settings;
+    settings.index_queue_elements = 5;
+    settings.index_queue_size = 15;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.query_queue_size = 15;
+    settings.query_queue_elements = 5;
+    settings.max_file_block_size = 10;
+    settings.max_query_cache_size = 15;
+    settings.capacity = 30;
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto key = io::BlockFileCache::hash("key1");
+    {
+        auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADING);
+        size_t size = blocks[0]->range().size();
+        std::string data(size, '0');
+        Slice result(data.data(), size);
+        ASSERT_TRUE(blocks[0]->append(result).ok());
+        ASSERT_TRUE(blocks[0]->change_cache_type_self(io::FileCacheType::INDEX));
+        ASSERT_TRUE(blocks[0]->finalize().ok());
     }
 }
 
@@ -1723,6 +2231,83 @@ TEST_F(BlockFileCacheTest, ttl_modify) {
     }
 }
 
+TEST_F(BlockFileCacheTest, ttl_modify_memory_storage) {
+    test_file_cache_memory_storage(io::FileCacheType::NORMAL);
+    auto sp = SyncPoint::get_instance();
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "BlockFileCache::set_sleep_time",
+            [](auto&& args) { *try_any_cast<int64_t*>(args[0]) = 1; }, &guard1);
+    sp->enable_processing();
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 30;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t cur_time = UnixSeconds();
+    context.expiration_time = cur_time + 120;
+    int64_t modify_time = cur_time + 5;
+    auto key1 = io::BlockFileCache::hash("key5");
+    auto key2 = io::BlockFileCache::hash("key6");
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    {
+        auto holder = cache.get_or_set(key1, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+    }
+    {
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+    }
+    cache.modify_expiration_time(key2, 0);
+    {
+        context.cache_type = io::FileCacheType::INDEX;
+        context.expiration_time = 0;
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        std::string buffer(10, '1');
+        EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    {
+        cache.modify_expiration_time(key2, modify_time);
+        context.expiration_time = modify_time;
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        EXPECT_EQ(blocks[0]->expiration_time(), modify_time);
+    }
+}
+
 TEST_F(BlockFileCacheTest, ttl_change_to_normal) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -1783,6 +2368,57 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal) {
     }
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, ttl_change_to_normal_memory_storage) {
+    test_file_cache_memory_storage(io::FileCacheType::NORMAL);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 30;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t cur_time = UnixSeconds();
+    context.expiration_time = cur_time + 180;
+    auto key2 = io::BlockFileCache::hash("key2");
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    {
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+    }
+    {
+        context.cache_type = io::FileCacheType::NORMAL;
+        context.expiration_time = 0;
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        std::string buffer(10, '1');
+        EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
     }
 }
 
@@ -1850,6 +2486,58 @@ TEST_F(BlockFileCacheTest, ttl_change_expiration_time) {
     }
 }
 
+TEST_F(BlockFileCacheTest, ttl_change_expiration_time_memory_storage) {
+    test_file_cache_memory_storage(io::FileCacheType::NORMAL);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 30;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t cur_time = UnixSeconds();
+    context.expiration_time = cur_time + 180;
+    int64_t change_time = cur_time + 120;
+    auto key2 = io::BlockFileCache::hash("key2");
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    {
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+    }
+    {
+        context.cache_type = io::FileCacheType::TTL;
+        context.expiration_time = change_time;
+        auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), change_time);
+        std::string buffer(10, '1');
+        EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+}
+
 TEST_F(BlockFileCacheTest, ttl_reverse) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -1900,6 +2588,52 @@ TEST_F(BlockFileCacheTest, ttl_reverse) {
 
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, ttl_reverse_memory_storage) {
+    test_file_cache_memory_storage(io::FileCacheType::NORMAL);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 36;
+    settings.query_queue_elements = 5;
+    settings.capacity = 36;
+    settings.max_file_block_size = 7;
+    settings.max_query_cache_size = 30;
+    settings.storage = "memory";
+    io::CacheContext context;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t cur_time = UnixSeconds();
+    context.expiration_time = cur_time + 180;
+    auto key2 = io::BlockFileCache::hash("key2");
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_lazy_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_lazy_open_success());
+    for (size_t offset = 0; offset < 30; offset += 6) {
+        auto holder = cache.get_or_set(key2, offset, 6, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key2, 50, 7, context); /// Add range [50, 57]
+        auto blocks = fromHolder(holder);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 56), io::FileBlock::State::SKIP_CACHE);
+    }
+    {
+        context.cache_type = io::FileCacheType::NORMAL;
+        auto holder = cache.get_or_set(key2, 50, 7, context); /// Add range [50, 57]
+        auto blocks = fromHolder(holder);
+        assert_range(1, blocks[0], io::FileBlock::Range(50, 56), io::FileBlock::State::SKIP_CACHE);
     }
 }
 
@@ -4740,6 +5474,28 @@ TEST_F(BlockFileCacheTest, test_load) {
         std::lock_guard block_lock(m2);
         cache.remove(blocks[0], cache_lock, block_lock);
         ASSERT_FALSE(fs::exists(dir / "20086"));
+    }
+}
+
+TEST_F(BlockFileCacheTest, file_cache_path_storage_parse) {
+    {
+        std::string file_cache_path =
+                "[{\"path\": \"xxx\", \"total_size\":102400, \"storage\": \"memory\"}]";
+        std::vector<doris::CachePath> cache_paths;
+        ASSERT_TRUE(parse_conf_cache_paths(file_cache_path, cache_paths).ok());
+        ASSERT_EQ(cache_paths.size(), 1);
+        ASSERT_TRUE(cache_paths[0].path == "memory");
+        ASSERT_TRUE(cache_paths[0].total_bytes == 102400);
+        ASSERT_TRUE(cache_paths[0].storage == "memory");
+    }
+    {
+        std::string file_cache_path = "[{\"path\": \"memory\", \"total_size\":102400}]";
+        std::vector<doris::CachePath> cache_paths;
+        ASSERT_TRUE(parse_conf_cache_paths(file_cache_path, cache_paths).ok());
+        ASSERT_EQ(cache_paths.size(), 1);
+        ASSERT_TRUE(cache_paths[0].path == "memory");
+        ASSERT_TRUE(cache_paths[0].total_bytes == 102400);
+        ASSERT_TRUE(cache_paths[0].storage == "disk");
     }
 }
 


### PR DESCRIPTION
User can set file_cache_path=[{..., "storage":"memory"}] to use RAM as file cache storage.