### PR TITLE
[enhance](server) add metrics to show thread cpu usage

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -67,9 +67,9 @@
 #include "util/network_util.h"
 #include "util/perf_counters.h"
 #include "util/system_metrics.h"
+#include "util/thread.h"
 #include "util/thrift_util.h"
 #include "util/time.h"
-#include "util/thread.h"
 
 namespace doris {
 namespace {

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -69,6 +69,7 @@
 #include "util/system_metrics.h"
 #include "util/thrift_util.h"
 #include "util/time.h"
+#include "util/thread.h"
 
 namespace doris {
 namespace {
@@ -366,6 +367,8 @@ void Daemon::calculate_metrics_thread() {
                         &lst_net_send_bytes, &lst_net_receive_bytes);
             }
             update_rowsets_and_segments_num_metrics();
+
+            ThreadMgr::instance()->update_threads_metrics();
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(15)));
 }

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -299,6 +299,9 @@ public:
 #define INT_COUNTER_METRIC_REGISTER(entity, metric) \
     metric = (IntCounter*)(entity->register_metric<IntCounter>(&METRIC_##metric))
 
+#define DOUBLE_COUNTER_METRIC_REGISTER(entity, metric) \
+    metric = (DoubleCounter*)(entity->register_metric<DoubleCounter>(&METRIC_##metric))
+
 #define INT_GAUGE_METRIC_REGISTER(entity, metric) \
     metric = (IntGauge*)(entity->register_metric<IntGauge>(&METRIC_##metric))
 

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -61,19 +61,18 @@
 #include "http/web_page_handler.h"
 #include "runtime/thread_context.h"
 #include "util/debug/sanitizer_scopes.h"
+#include "util/doris_metrics.h"
 #include "util/easy_json.h"
+#include "util/metrics.h"
 #include "util/os_util.h"
 #include "util/scoped_cleanup.h"
 #include "util/url_coding.h"
-#include "util/metrics.h"
-#include "util/doris_metrics.h"
 
 namespace doris {
 
 __thread Thread* Thread::_tls = nullptr;
 
-
-// Singleton instance of ThreadMgr. Only visible in this file, used only by Thread.
+// Singleton instance of ThreadMgr.
 // // The Thread class adds a reference to thread_manager while it is supervising a thread so
 // // that a race between the end of the process's main thread (and therefore the destruction
 // // of thread_manager) and the end of a thread that tries to remove itself from the
@@ -89,13 +88,13 @@ static void init_threadmgr() {
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(thread_cpu_total, MetricUnit::NOUNIT);
 
-void ThreadMgr::ThreadDescriptor::register_metric(){
+void ThreadMgr::ThreadDescriptor::register_metric() {
     _metric_entity = DorisMetrics::instance()->metric_registry()->register_entity(
-        std::string("thread.") + _name, {{"name", _name}});
+            std::string("thread.") + _name, {{"name", _name}});
     DOUBLE_COUNTER_METRIC_REGISTER(_metric_entity, thread_cpu_total);
 }
 
-void ThreadMgr::ThreadDescriptor::deregister_metric(){
+void ThreadMgr::ThreadDescriptor::deregister_metric() {
     DorisMetrics::instance()->metric_registry()->deregister_entity(_metric_entity);
 }
 
@@ -255,7 +254,7 @@ void ThreadMgr::display_thread_callback(const WebPageHandler::ArgumentMap& args,
     }
 }
 
-void ThreadMgr::update_threads_metrics(){
+void ThreadMgr::update_threads_metrics() {
     std::vector<ThreadDescriptor> descriptors_to_update;
     {
         std::unique_lock<std::mutex> l(_lock);

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -293,7 +293,6 @@ private:
 // Registers /threadz with the debug webserver.
 void register_thread_display_page(WebPageHandler* web_page_handler);
 
-
 // A singleton class that tracks all live threads, and groups them together for easy
 // auditing. Used only by Thread.
 class ThreadMgr {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -29,10 +29,10 @@
 
 #include "common/status.h"
 #include "gutil/ref_counted.h"
-#include "util/countdown_latch.h"
 #include "http/web_page_handler.h"
-#include "util/metrics.h"
+#include "util/countdown_latch.h"
 #include "util/doris_metrics.h"
+#include "util/metrics.h"
 
 namespace doris {
 


### PR DESCRIPTION
## Proposed changes

Add a metric `thread_cpu_total` to show cpu usage by each thread, which improves observability.

Before, when a instance costs too much CPU, user does not know which task consumes it. User needs to run `top -H` on the machine to see the cpu usage details. Now, user just needs a simple check of the metrics.

Major implementation changes
1. add `ThreadMgr::instance` static method and `ThreadMgr::update_threads_metrics` method
2. add three methods for `ThreadMgr::ThreadDescriptor` class: `register_metric`, `update_metric`, `deregister_metric`
3. call `update_threads_metrics` to update threads metrics periodically `calculate_metrics_thread `

## Usage example

User can query thread pool usage by the following promql
![image](https://github.com/user-attachments/assets/7220d54c-25f9-4b1d-94f9-9f146e2952c8)

For example, check the cpu usage of `CumuCompaction` thread pool 
![image](https://github.com/user-attachments/assets/ad7b4884-2748-496f-a9b4-94adb929f628)



<!--Describe your changes.-->

