### PR TITLE
[enhancement](user) Support limit user connection by ip

### DIFF
--- a/be/src/exec/schema_scanner/schema_user_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_user_scanner.cpp
@@ -52,6 +52,7 @@ std::vector<SchemaScanner::ColumnDesc> SchemaUserScanner::_s_user_columns = {
         {"max_updates", TYPE_BIGINT, sizeof(int64_t), false},
         {"max_connections", TYPE_BIGINT, sizeof(int64_t), false},
         {"max_user_connections", TYPE_BIGINT, sizeof(int64_t), false},
+        {"max_user_ip_connections", TYPE_BIGINT, sizeof(int64_t), false},
         {"plugin", TYPE_CHAR, sizeof(StringRef), false},
         {"authentication_string", TYPE_VARCHAR, sizeof(StringRef), false},
         {"password_policy.expiration_seconds", TYPE_VARCHAR, sizeof(StringRef), false},

--- a/be/src/exec/schema_scanner/schema_user_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_user_scanner.cpp
@@ -52,7 +52,6 @@ std::vector<SchemaScanner::ColumnDesc> SchemaUserScanner::_s_user_columns = {
         {"max_updates", TYPE_BIGINT, sizeof(int64_t), false},
         {"max_connections", TYPE_BIGINT, sizeof(int64_t), false},
         {"max_user_connections", TYPE_BIGINT, sizeof(int64_t), false},
-        {"max_user_ip_connections", TYPE_BIGINT, sizeof(int64_t), false},
         {"plugin", TYPE_CHAR, sizeof(StringRef), false},
         {"authentication_string", TYPE_VARCHAR, sizeof(StringRef), false},
         {"password_policy.expiration_seconds", TYPE_VARCHAR, sizeof(StringRef), false},

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -2167,11 +2167,10 @@ public class Auth implements Writable {
 
                         // Set password policy info
                         userInfo.set(21, String.valueOf(getMaxConn(userIdent.getQualifiedUser())));
-                        userInfo.set(22, String.valueOf(getMaxIpConn(userIdent.getQualifiedUser())));
                         List<List<String>> passWordPolicyInfo = getPasswdPolicyInfo(userIdent);
                         if (passWordPolicyInfo.size() == 8) {
                             for (int i = 0; i < passWordPolicyInfo.size(); i++) {
-                                userInfo.set(25 + i, passWordPolicyInfo.get(i).get(1));
+                                userInfo.set(24 + i, passWordPolicyInfo.get(i).get(1));
                             }
                         }
                         userInfos.add(userInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -2099,7 +2099,7 @@ public class Auth implements Writable {
             for (List<User> users : nameToUsers.values()) {
                 for (User user : users) {
                     if (!user.isSetByDomainResolver()) {
-                        List<String> userInfo = Lists.newArrayList(Collections.nCopies(33, ""));
+                        List<String> userInfo = Lists.newArrayList(Collections.nCopies(32, ""));
                         UserIdentity userIdent = user.getUserIdentity();
                         userInfo.set(0, userIdent.getHost());
                         userInfo.set(1, userIdent.getQualifiedUser());

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -1138,6 +1138,15 @@ public class Auth implements Writable {
         }
     }
 
+    public long getMaxIpConn(String qualifiedUser) {
+        readLock();
+        try {
+            return propertyMgr.getMaxIpConn(qualifiedUser);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public int getQueryTimeout(String qualifiedUser) {
         readLock();
         try {
@@ -2090,7 +2099,7 @@ public class Auth implements Writable {
             for (List<User> users : nameToUsers.values()) {
                 for (User user : users) {
                     if (!user.isSetByDomainResolver()) {
-                        List<String> userInfo = Lists.newArrayList(Collections.nCopies(32, ""));
+                        List<String> userInfo = Lists.newArrayList(Collections.nCopies(33, ""));
                         UserIdentity userIdent = user.getUserIdentity();
                         userInfo.set(0, userIdent.getHost());
                         userInfo.set(1, userIdent.getQualifiedUser());
@@ -2158,10 +2167,11 @@ public class Auth implements Writable {
 
                         // Set password policy info
                         userInfo.set(21, String.valueOf(getMaxConn(userIdent.getQualifiedUser())));
+                        userInfo.set(22, String.valueOf(getMaxIpConn(userIdent.getQualifiedUser())));
                         List<List<String>> passWordPolicyInfo = getPasswdPolicyInfo(userIdent);
                         if (passWordPolicyInfo.size() == 8) {
                             for (int i = 0; i < passWordPolicyInfo.size(); i++) {
-                                userInfo.set(24 + i, passWordPolicyInfo.get(i).get(1));
+                                userInfo.set(25 + i, passWordPolicyInfo.get(i).get(1));
                             }
                         }
                         userInfos.add(userInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CommonUserProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CommonUserProperties.java
@@ -44,6 +44,9 @@ public class CommonUserProperties implements Writable, GsonPostProcessable {
     // The max connections allowed for a user on one FE
     @SerializedName(value = "mc", alternate = {"maxConn"})
     private long maxConn = 100;
+    // The max connections allowed for a user and ip on one FE
+    @SerializedName(value = "mic", alternate = {"maxIpConn"})
+    private long maxIpConn = 100;
     // The maximum total number of query instances that the user is allowed to send from this FE
     @SerializedName(value = "mqi", alternate = {"maxQueryInstances"})
     private long maxQueryInstances = -1;
@@ -75,6 +78,10 @@ public class CommonUserProperties implements Writable, GsonPostProcessable {
         return maxConn;
     }
 
+    long getMaxIpConn() {
+        return maxIpConn;
+    }
+
     long getMaxQueryInstances() {
         return maxQueryInstances;
     }
@@ -94,6 +101,11 @@ public class CommonUserProperties implements Writable, GsonPostProcessable {
     void setMaxConn(long maxConn) {
         this.maxConn = maxConn;
     }
+
+    void setMaxIpConn(long maxIpConn) {
+        this.maxIpConn = maxIpConn;
+    }
+
 
     void setMaxQueryInstances(long maxQueryInstances) {
         this.maxQueryInstances = maxQueryInstances;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -118,6 +118,15 @@ public class UserPropertyMgr implements Writable {
         return existProperty.getMaxConn();
     }
 
+    public long getMaxIpConn(String qualifiedUser) {
+        UserProperty existProperty = propertyMap.get(qualifiedUser);
+        existProperty = getLdapPropertyIfNull(qualifiedUser, existProperty);
+        if (existProperty == null) {
+            return 0;
+        }
+        return existProperty.getMaxIpConn();
+    }
+
     public long getMaxQueryInstances(String qualifiedUser) {
         UserProperty existProperty = propertyMap.get(qualifiedUser);
         existProperty = getLdapPropertyIfNull(qualifiedUser, existProperty);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -112,6 +112,7 @@ public class UserPropertyTest {
         UserProperty userProperty = new UserProperty();
         userProperty.update(properties);
         Assert.assertEquals(100, userProperty.getMaxConn());
+        Assert.assertEquals(100, userProperty.getMaxIpConn());
         Assert.assertEquals("/user/palo2", userProperty.getLoadClusterInfo("dpp-cluster").second.getPaloPath());
         Assert.assertEquals("dpp-cluster", userProperty.getDefaultLoadCluster());
         Assert.assertEquals(3000, userProperty.getMaxQueryInstances());
@@ -128,6 +129,8 @@ public class UserPropertyTest {
             String value = row.get(1);
 
             if (key.equalsIgnoreCase("max_user_connections")) {
+                Assert.assertEquals("100", value);
+            } else if (key.equalsIgnoreCase("max_user_ip_connections")) {
                 Assert.assertEquals("100", value);
             } else if (key.equalsIgnoreCase("load_cluster.dpp-cluster.hadoop_palo_path")) {
                 Assert.assertEquals("/user/palo2", value);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -123,6 +123,15 @@ public class UserPropertyTest {
         Assert.assertEquals(500, userProperty.getQueryTimeout());
         Assert.assertEquals(Sets.newHashSet(), userProperty.getCopiedResourceTags());
 
+        properties.add(Pair.of("max_user_ip_connections", "120"));
+        try {
+            userProperty.update(properties);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("max_user_ip_connections should not be larger than max_user_connections"));
+        }
+
+
         // fetch property
         List<List<String>> rows = userProperty.fetchProperty();
         for (List<String> row : rows) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -101,6 +101,7 @@ public class UserPropertyTest {
     public void testUpdate() throws UserException {
         List<Pair<String, String>> properties = Lists.newArrayList();
         properties.add(Pair.of("MAX_USER_CONNECTIONS", "100"));
+        properties.add(Pair.of("max_user_ip_connections", "20"));
         properties.add(Pair.of("load_cluster.dpp-cluster.hadoop_palo_path", "/user/palo2"));
         properties.add(Pair.of("default_load_cluster", "dpp-cluster"));
         properties.add(Pair.of("max_qUERY_instances", "3000"));
@@ -112,7 +113,7 @@ public class UserPropertyTest {
         UserProperty userProperty = new UserProperty();
         userProperty.update(properties);
         Assert.assertEquals(100, userProperty.getMaxConn());
-        Assert.assertEquals(100, userProperty.getMaxIpConn());
+        Assert.assertEquals(20, userProperty.getMaxIpConn());
         Assert.assertEquals("/user/palo2", userProperty.getLoadClusterInfo("dpp-cluster").second.getPaloPath());
         Assert.assertEquals("dpp-cluster", userProperty.getDefaultLoadCluster());
         Assert.assertEquals(3000, userProperty.getMaxQueryInstances());
@@ -131,7 +132,7 @@ public class UserPropertyTest {
             if (key.equalsIgnoreCase("max_user_connections")) {
                 Assert.assertEquals("100", value);
             } else if (key.equalsIgnoreCase("max_user_ip_connections")) {
-                Assert.assertEquals("100", value);
+                Assert.assertEquals("20", value);
             } else if (key.equalsIgnoreCase("load_cluster.dpp-cluster.hadoop_palo_path")) {
                 Assert.assertEquals("/user/palo2", value);
             } else if (key.equalsIgnoreCase("default_load_cluster")) {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/UserPropertyTest.java
@@ -43,6 +43,7 @@ public class UserPropertyTest {
 
         List<Pair<String, String>> properties = Lists.newArrayList();
         properties.add(Pair.of(UserProperty.PROP_MAX_USER_CONNECTIONS, "100"));
+        properties.add(Pair.of(UserProperty.PROP_MAX_USER_IP_CONNECTIONS, "100"));
         properties.add(Pair.of(UserProperty.PROP_MAX_QUERY_INSTANCES, "2"));
         properties.add(Pair.of(UserProperty.PROP_PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, "8"));
         properties.add(Pair.of(UserProperty.PROP_SQL_BLOCK_RULES, "r1,r2"));

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/UserPropertyTest.java
@@ -60,6 +60,7 @@ public class UserPropertyTest {
         UserProperty prop2 = UserProperty.read(in);
 
         Assert.assertEquals(100, prop2.getMaxConn());
+        Assert.assertEquals(100, prop2.getMaxIpConn());
         Assert.assertEquals(2, prop2.getMaxQueryInstances());
         Assert.assertEquals(8, prop2.getParallelFragmentExecInstanceNum());
         Assert.assertEquals(Lists.newArrayList("r1", "r2"),

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
@@ -280,7 +280,7 @@ public class ResourceTagQueryTest {
         Assert.assertEquals(1000000, execMemLimit);
 
         List<List<String>> userProps = Env.getCurrentEnv().getAuth().getUserProperties(Auth.ROOT_USER);
-        Assert.assertEquals(12, userProps.size());
+        Assert.assertEquals(13, userProps.size());
 
         // now :
         // be1 be2 be3 ==>tag1;

--- a/regression-test/suites/account_p0/test_auth_compatibility.groovy
+++ b/regression-test/suites/account_p0/test_auth_compatibility.groovy
@@ -97,7 +97,10 @@ suite("test_auth_compatibility", "account") {
     connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
     try {
         connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
+        assertTrue(false. "should not be able to login")
     } catch (Exception e) {
         assertTrue(e.getMessage().contains("Reach limit of connections"), e.getMessage())
     }
+    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '100'"""
+
 }

--- a/regression-test/suites/account_p0/test_auth_compatibility.groovy
+++ b/regression-test/suites/account_p0/test_auth_compatibility.groovy
@@ -74,7 +74,7 @@ suite("test_auth_compatibility", "account") {
 
     sql """SET PROPERTY FOR '${user}' 'max_user_connections'= '2048'"""
 
-    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '2'"""
+    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '100'"""
 
     sql """SET PROPERTY FOR '${user}'
     'load_cluster.cluster1.hadoop_palo_path' = '/user/doris/doris_path',
@@ -86,21 +86,11 @@ suite("test_auth_compatibility", "account") {
     assertEquals(result.Value as String, "2048" as String)
 
     result = getProperty("max_user_ip_connections", "${user}")
-    assertEquals(result.Value as String, "2" as String)
+    assertEquals(result.Value as String, "100" as String)
 
     result = getProperty("default_load_cluster", "${user}")
     assertEquals(result.Value as String, "cluster1" as String)
 
     result = getProperty("load_cluster.cluster1.hadoop_palo_path", "${user}")
     assertEquals(result.Value as String, "/user/doris/doris_path" as String)
-
-    connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
-    try {
-        connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
-        assertTrue(false. "should not be able to login")
-    } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Reach limit of connections"), e.getMessage())
-    }
-    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '100'"""
-
 }

--- a/regression-test/suites/account_p0/test_auth_compatibility.groovy
+++ b/regression-test/suites/account_p0/test_auth_compatibility.groovy
@@ -74,6 +74,8 @@ suite("test_auth_compatibility", "account") {
 
     sql """SET PROPERTY FOR '${user}' 'max_user_connections'= '2048'"""
 
+    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '10'"""
+
     sql """SET PROPERTY FOR '${user}'
     'load_cluster.cluster1.hadoop_palo_path' = '/user/doris/doris_path',
     'load_cluster.cluster1.hadoop_configs' = 'fs.default.name=hdfs://dpp.cluster.com:port;mapred.job.tracker=dpp.cluster.com:port;hadoop.job.ugi=user,password;mapred.job.queue.name=job_queue_name_in_hadoop;mapred.job.priority=HIGH;';
@@ -82,6 +84,9 @@ suite("test_auth_compatibility", "account") {
 
     def result = getProperty("max_user_connections", "${user}")
     assertEquals(result.Value as String, "2048" as String)
+
+    result = getProperty("max_user_ip_connections", "${user}")
+    assertEquals(result.Value as String, "10" as String)
 
     result = getProperty("default_load_cluster", "${user}")
     assertEquals(result.Value as String, "cluster1" as String)

--- a/regression-test/suites/account_p0/test_auth_compatibility.groovy
+++ b/regression-test/suites/account_p0/test_auth_compatibility.groovy
@@ -74,7 +74,7 @@ suite("test_auth_compatibility", "account") {
 
     sql """SET PROPERTY FOR '${user}' 'max_user_connections'= '2048'"""
 
-    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '10'"""
+    sql """SET PROPERTY FOR '${user}' 'max_user_ip_connections'= '2'"""
 
     sql """SET PROPERTY FOR '${user}'
     'load_cluster.cluster1.hadoop_palo_path' = '/user/doris/doris_path',
@@ -86,11 +86,18 @@ suite("test_auth_compatibility", "account") {
     assertEquals(result.Value as String, "2048" as String)
 
     result = getProperty("max_user_ip_connections", "${user}")
-    assertEquals(result.Value as String, "10" as String)
+    assertEquals(result.Value as String, "2" as String)
 
     result = getProperty("default_load_cluster", "${user}")
     assertEquals(result.Value as String, "cluster1" as String)
 
     result = getProperty("load_cluster.cluster1.hadoop_palo_path", "${user}")
     assertEquals(result.Value as String, "/user/doris/doris_path" as String)
+
+    connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
+    try {
+        connect(user = user, password = pwd, url = context.config.jdbcUrl) {}
+    } catch (Exception e) {
+        assertTrue(e.getMessage().contains("Reach limit of connections"), e.getMessage())
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In some cases, multiple services may use a common account, but the service may not be able to control the number of connections well, and we need to restrict it in the doris.

Such as prod and stage environment use common user, but stage database connection use too many due to user connection too many.

This parameter can be used to refine user connection limits.

The use way as follow
```
SET PROPERTY FOR 'root' 'max_user_ip_connections' = '50';
```
You can use it control server connect number per ip(such as podIp in k8s) and control it concurrent.


