### PR TITLE
[fix asan core](memoryleak) should deconstruct filter entity in scope of query context

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1148,8 +1148,6 @@ Status FragmentMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
 Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
                                  butil::IOBufAsZeroCopyInputStream* attach_data) {
     UniqueId queryid = request->query_id();
-    std::shared_ptr<RuntimeFilterMergeControllerEntity> filter_controller;
-    RETURN_IF_ERROR(_runtimefilter_controller.acquire(queryid, &filter_controller));
 
     std::shared_ptr<QueryContext> query_ctx;
     {
@@ -1165,6 +1163,8 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
         }
     }
     SCOPED_ATTACH_TASK(query_ctx.get());
+    std::shared_ptr<RuntimeFilterMergeControllerEntity> filter_controller;
+    RETURN_IF_ERROR(_runtimefilter_controller.acquire(queryid, &filter_controller));
     auto merge_status = filter_controller->merge(request, attach_data);
     return merge_status;
 }


### PR DESCRIPTION
## Proposed changes

Merge controller operation may create new memory and save in controller's object pool. So that should deconstruct the shared ptr in scope of query context to avoid asan check core.
<!--Describe your changes.-->

