### PR TITLE
[fix](optimizer) Avoid Duplicate key exception when pull up predicates from child in aggretation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -99,20 +99,7 @@ public class PullUpPredicates extends PlanVisitor<ImmutableSet<Expression>, Void
         return cacheOrElse(aggregate, () -> {
             ImmutableSet<Expression> childPredicates = aggregate.child().accept(this, context);
             // TODO
-            Map<Expression, Slot> expressionSlotMap = aggregate.getOutputExpressions()
-                    .stream()
-                    .filter(this::hasAgg)
-                    .collect(Collectors.toMap(
-                            namedExpr -> {
-                                if (namedExpr instanceof Alias) {
-                                    return ((Alias) namedExpr).child();
-                                } else {
-                                    return namedExpr;
-                                }
-                            }, NamedExpression::toSlot)
-                    );
-            Expression expression = ExpressionUtils.replace(ExpressionUtils.and(Lists.newArrayList(childPredicates)),
-                    expressionSlotMap);
+            Expression expression = ExpressionUtils.and(Lists.newArrayList(childPredicates));
             List<Expression> predicates = ExpressionUtils.extractConjunction(expression);
             return getAvailableExpressions(predicates, aggregate);
         });

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -17,10 +17,7 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
-import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.NamedExpression;
-import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
@@ -72,6 +72,13 @@ class InferPredicatesTest extends TestWithFeService implements MemoPatternMatchS
                         + "distributed by hash(k2) buckets 1\n"
                         + "properties('replication_num' = '1');");
 
+        createTables("CREATE TABLE `test`.`test_tt` (\n"
+                + "`key` varchar(*) NOT NULL,\n"
+                + "  `value` varchar(*) NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "DISTRIBUTED BY HASH(`key`) BUCKETS 1\n"
+                + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1');");
+
         connectContext.setDatabase("default_cluster:test");
     }
 
@@ -626,5 +633,43 @@ class InferPredicatesTest extends TestWithFeService implements MemoPatternMatchS
                                 any()
                         ).when(join -> join.getJoinType() == JoinType.LEFT_OUTER_JOIN)
                 );
+    }
+
+    @Test
+    void testAggMultiAliasWithSameChild() {
+        String sql = "SELECT t.*\n"
+                + "FROM (\n"
+                + "        SELECT `key`, a , b \n"
+                + "        FROM (\n"
+                + "                SELECT `key`,\n"
+                + "                       any_value(value) AS a,\n"
+                + "                       any_value(CAST(value AS double)) AS b\n"
+                + "                FROM (\n"
+                + "                        SELECT `key`, CAST(value AS double) AS value\n"
+                + "                        FROM test_tt\n"
+                + "                        WHERE `key` = '1'\n"
+                + "                ) agg\n"
+                + "                GROUP BY `key`\n"
+                + "        ) proj\n"
+                + ") t\n"
+                + "LEFT JOIN\n"
+                + "( SELECT id, name FROM student) t2\n"
+                + "ON t.`key`=t2.`name`";
+        PlanChecker.from(connectContext).analyze(sql).rewrite().printlnTree();
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(
+                        logicalJoin(
+                                any(),
+                                logicalProject(
+                                    logicalFilter(
+                                            logicalOlapScan()
+                                    ).when(filter -> filter.getConjuncts().size() == 1
+                                            && filter.getPredicate().toSql().contains("name = '1'"))
+                                )
+                        ).when(join -> join.getJoinType() == JoinType.LEFT_OUTER_JOIN)
+                );
+
     }
 }


### PR DESCRIPTION
## Proposed changes
The agg expressions can not appears in child predicates.

Issue Number: close #38905

<!--Describe your changes.-->

