### PR TITLE
[fix](fe) Fix calc cloud qps metric incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricCalculator.java
@@ -130,7 +130,7 @@ public class MetricCalculator extends TimerTask {
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterRequestPerSecond(clusterId, rps,  metric.getLabels());
                 MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
-                clusterLastRequestCounter.replace(clusterId, metric.getValue());
+                clusterLastRequestCounter.put(clusterId, metric.getValue());
             });
         }
 
@@ -142,7 +142,7 @@ public class MetricCalculator extends TimerTask {
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterQueryPerSecond(clusterId, rps,  metric.getLabels());
                 MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
-                clusterLastQueryCounter.replace(clusterId, metric.getValue());
+                clusterLastQueryCounter.put(clusterId, metric.getValue());
             });
         }
 
@@ -154,7 +154,7 @@ public class MetricCalculator extends TimerTask {
                 rps = Double.max(rps, 0);
                 MetricRepo.updateClusterQueryErrRate(clusterId, rps, metric.getLabels());
                 MetricRepo.DORIS_METRIC_REGISTER.addMetrics(metric);
-                clusterLastQueryCounter.replace(clusterId, metric.getValue());
+                clusterLastQueryErrCounter.put(clusterId, metric.getValue());
             });
         }
     }


### PR DESCRIPTION
* When calculating qps, we should use `HashMap.put` instead of `HashMap.replace` to record last value

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

