### PR TITLE
[fix](index) fix inverted index compound file entry size int32 overflow

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.h
@@ -40,7 +40,7 @@ using InvertedIndexDirectoryMap =
 class FileInfo {
 public:
     std::string filename;
-    int32_t filesize;
+    int64_t filesize;
 };
 
 class InvertedIndexFileWriter {


### PR DESCRIPTION
change FileInfo::filesize from int32_t to int64_t to avoid overflow