### PR TITLE
[Enhancement](wal) modify wal api which hard to use

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckWalSizeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckWalSizeAction.java
@@ -69,13 +69,11 @@ public class CheckWalSizeAction extends RestBaseController {
                 return ResponseEntityBuilder.okWithCommonError(e.getMessage());
             }
         } else {
-            String[] hostPortArr;
-            List<HostInfo> hostInfos = new ArrayList<>();
-            hostPortArr = hostPorts.split(",");
+            String[] hostPortArr = hostPorts.split(",");
             if (hostPortArr.length == 0) {
                 return ResponseEntityBuilder.badRequest("No host:port specified");
             }
-            hostInfos = Lists.newArrayList();
+            List<HostInfo> hostInfos = new ArrayList<>();
             for (String hostPort : hostPortArr) {
                 try {
                     HostInfo hostInfo = SystemInfoService.getHostAndPort(hostPort);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -401,6 +401,10 @@ public class SystemInfoService {
                 .values().stream().filter(Backend::isComputeNode).collect(Collectors.toList());
     }
 
+    public List<Backend> getAllClusterBackends() {
+        return new ArrayList<>(getAllClusterBackendsNoException().values());
+    }
+
     // return num of backends that from different hosts
     public int getStorageBackendNumFromDiffHosts(boolean aliveOnly) {
         Set<String> hosts = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -401,10 +401,6 @@ public class SystemInfoService {
                 .values().stream().filter(Backend::isComputeNode).collect(Collectors.toList());
     }
 
-    public List<Backend> getAllClusterBackends() {
-        return new ArrayList<>(getAllClusterBackendsNoException().values());
-    }
-
     // return num of backends that from different hosts
     public int getStorageBackendNumFromDiffHosts(boolean aliveOnly) {
         Set<String> hosts = Sets.newHashSet();


### PR DESCRIPTION
## Proposed changes

Before this pr, this api needs backends' ip and port as param, which is hard to use. This pr modify it. If there is no param, doris will print all backends WAL info.

The acceptable usage are as follows 

```
curl -u root: "127.0.0.1:8038/api/get_wal_size?host_ports=127.0.0.1:9058"
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}%                                                                                             

curl -u root: "127.0.0.1:8038/api/get_wal_size?host_ports="         
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}%                                                                                                                                             

curl -u root: "127.0.0.1:8038/api/get_wal_size"            
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}% 
```

<!--Describe your changes.-->

