### PR TITLE
[Enhancement]use awaitility  in partial update testcases

### DIFF
--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
@@ -15,6 +15,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
 
 suite("test_partial_update_insert_light_schema_change", "p0") {
 
@@ -56,16 +58,15 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             // schema change
             sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-            def try_times=100
-            while(true){
+            def try_times=12000
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
             
             // test insert data without new column
@@ -116,16 +117,14 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             // schema change
             sql " ALTER table ${tableName} DROP COLUMN c8 "
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
 
             // test insert data without delete column
@@ -194,16 +193,14 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             // schema change
             sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
 
             // test insert data with update column
@@ -234,42 +231,36 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             // schema change
             sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
 
             sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
 
             sql " ALTER table ${tableName} ADD COLUMN c3 int null "
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
 
             // test insert data with all key column, should fail because
@@ -315,16 +306,14 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
 
             
             sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-            try_times=100
-            while(true){
+            // if timeout awaitility will raise exception
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-                Thread.sleep(1200)
                 if(res[0][9].toString() == "FINISHED"){
-                    break;
+                    return true;
                 }
-                assert(try_times>0)
-                try_times--
-            }
+                return false;
+            });
             sql "sync"
             
             //test insert data with create index

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_schema_change.groovy
@@ -15,6 +15,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
 
 suite("test_partial_update_insert_schema_change", "p0") {
 
@@ -47,16 +49,15 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-    def try_times=100
-    while(true){
+    def try_times=12000
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
     
     // test insert data without new column
@@ -106,16 +107,14 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
 
     // test insert data without delete column
@@ -181,16 +180,14 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
 
     // test insert data with update column
@@ -219,42 +216,36 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     // schema change
     sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
 
     sql " ALTER table ${tableName} ADD COLUMN c3 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
 
     // test insert data with all key column, should fail because
@@ -300,16 +291,14 @@ suite("test_partial_update_insert_schema_change", "p0") {
 
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql "sync"
     
     //test insert data with create index

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
@@ -15,6 +15,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
 
 suite("test_partial_update_schema_change", "p0") {
 
@@ -70,16 +72,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-    def try_times=100
-    while(true){
+    def try_times=12000
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     
     // test load data without new column
     streamLoad {
@@ -192,16 +193,14 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data without delete column
     streamLoad {
@@ -314,16 +313,14 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with update column
     streamLoad {
@@ -398,28 +395,24 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with all key column, should fail because
     // it don't have any value columns
@@ -501,16 +494,14 @@ suite("test_partial_update_schema_change", "p0") {
     qt_sql10 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     //test load data with create index
     streamLoad {
@@ -674,17 +665,14 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
-    
+        return false;
+    });
     // test load data without new column
     streamLoad {
         table "${tableName}"
@@ -795,17 +783,14 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
-
+        return false;
+    });
     // test load data without delete column
     streamLoad {
         table "${tableName}"
@@ -912,17 +897,14 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
-
+        return false;
+    });
     // test load data with update column
     streamLoad {
         table "${tableName}"
@@ -995,27 +977,23 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with all key column
     streamLoad {
@@ -1092,16 +1070,14 @@ suite("test_partial_update_schema_change", "p0") {
     qt_sql23 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     //test load data with create index
     streamLoad {

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change_row_store.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change_row_store.groovy
@@ -15,6 +15,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
 
 suite("test_partial_update_row_store_schema_change", "p0") {
 
@@ -71,16 +73,16 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-    def try_times=100
-    while(true){
+    def try_times = 120000
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
+
     
     // test load data without new column
     streamLoad {
@@ -194,16 +196,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data without delete column
     streamLoad {
@@ -317,17 +317,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
-
+        return false;
+    });
     // test load data with update column
     streamLoad {
         table "${tableName}"
@@ -402,28 +399,24 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with all key column, should fail because
     // it don't have any value columns
@@ -506,16 +499,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     qt_sql10 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     //test load data with create index
     streamLoad {
@@ -681,16 +672,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     
     // test load data without new column
     streamLoad {
@@ -803,16 +792,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data without delete column
     streamLoad {
@@ -921,16 +908,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with update column
     streamLoad {
@@ -1005,27 +990,23 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     // test load data with all key column
     streamLoad {
@@ -1103,16 +1084,14 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     qt_sql23 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
-    try_times=100
-    while(true){
+    // if timeout awaitility will raise exception
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
-            break;
+            return true;
         }
-        assert(try_times>0)
-        try_times--
-    }
+        return false;
+    });
 
     //test load data with create index
     streamLoad {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
#37817

use awaitility  to replace thread.sleep in partial update regression testcases

