### PR TITLE
[Fix](Exception) throw exception in defer may result std::terminate

### DIFF
--- a/be/src/vec/functions/function_variant_element.cpp
+++ b/be/src/vec/functions/function_variant_element.cpp
@@ -103,11 +103,11 @@ private:
     static Status get_element_column(const ColumnObject& src, const ColumnPtr& index_column,
                                      ColumnPtr* result) {
         std::string field_name = index_column->get_data_at(0).to_string();
-        Defer finalize([&]() { (*result)->assume_mutable()->finalize(); });
         if (src.empty()) {
             *result = ColumnObject::create(true);
             // src subcolumns empty but src row count may not be 0
             (*result)->assume_mutable()->insert_many_defaults(src.size());
+            (*result)->assume_mutable()->finalize();
             return Status::OK();
         }
         if (src.is_scalar_variant() &&
@@ -132,6 +132,7 @@ private:
                 }
             }
             *result = ColumnObject::create(true, type, std::move(result_column));
+            (*result)->assume_mutable()->finalize();
             return Status::OK();
         } else {
             auto mutable_src = src.clone_finalized();
@@ -173,6 +174,7 @@ private:
                 result_col->insert_many_defaults(src.size());
             }
             *result = result_col->get_ptr();
+            (*result)->assume_mutable()->finalize();
             VLOG_DEBUG << "dump new object "
                        << static_cast<const ColumnObject*>(result_col.get())->debug_string()
                        << ", path " << path.get_path();


### PR DESCRIPTION
```
1  __pthread_kill_internal (signo=6, threadid=140314099000896) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140314099000896, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fa1e2e8e476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fa1e2e747f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x000055f77d0e71ea in __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#6  0x000055f77d0e5956 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
#7  0x000055f77d0e59c1 in std::terminate () at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:58
#8  0x000055f76ffc5fbe in __clang_call_terminate ()
#9  0x000055f77667ef44 in doris::Defer<doris::vectorized::FunctionVariantElement::get_element_column(doris::vectorized::ColumnObject const&, COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn> const&, COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>*)::{lambda()#1}>::~Defer() (this=0x7f9d6c06a900) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/defer_op.h:37
```