### PR TITLE
[fix](memory) Fix Allocator release memory to correct MemTracker after TLS attach task ends

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -139,7 +139,7 @@ DEFINE_mBool(enable_stacktrace, "true");
 
 DEFINE_mInt64(stacktrace_in_alloc_large_memory_bytes, "2147483648");
 
-DEFINE_mBool(enable_memory_orphan_check, "false");
+DEFINE_mBool(enable_memory_orphan_check, "true");
 
 // The maximum time a thread waits for full GC. Currently only query will wait for full gc.
 DEFINE_mInt32(thread_wait_gc_max_milliseconds, "1000");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -192,7 +192,9 @@ DECLARE_mBool(enable_stacktrace);
 // if is -1, disable print stacktrace when alloc large memory.
 DECLARE_mInt64(stacktrace_in_alloc_large_memory_bytes);
 
-// default is true. if any memory tracking in Orphan mem tracker will report error.
+// default is true. if alloc memory tracking in Orphan mem tracker will report error.
+// allocator free memory not need to check, because when the thread memory tracker label is Orphan,
+// use the tracker saved in Allocator.
 DECLARE_mBool(enable_memory_orphan_check);
 
 // The maximum time a thread waits for a full GC. Currently only query will wait for full gc.

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -26,7 +26,10 @@
 namespace doris {
 template <typename TAllocator>
 PageBase<TAllocator>::PageBase(size_t b, bool use_cache, segment_v2::PageTypePB page_type)
-        : LRUCacheValueBase(), _size(b), _capacity(b) {
+        : TAllocator(use_cache ? StoragePageCache::instance()->mem_tracker(page_type) : nullptr),
+          LRUCacheValueBase(),
+          _size(b),
+          _capacity(b) {
     if (use_cache) {
         _mem_tracker_by_allocator = StoragePageCache::instance()->mem_tracker(page_type);
     } else {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -220,9 +220,9 @@ public:
         ss << std::this_thread::get_id();
         return ss.str();
     }
-    // After thread_mem_tracker_mgr is initialized, the current thread Hook starts to
-    // consume/release mem_tracker.
-    // Note that the use of shared_ptr will cause a crash. The guess is that there is an
+    // Note that if set global Memory Hook, After thread_mem_tracker_mgr is initialized,
+    // the current thread Hook starts to consume/release mem_tracker.
+    // the use of shared_ptr will cause a crash. The guess is that there is an
     // intermediate state during the copy construction of shared_ptr. Shared_ptr is not equal
     // to nullptr, but the object it points to is not initialized. At this time, when the memory
     // is released somewhere, the hook is triggered to cause the crash.

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -310,7 +310,7 @@ public:
                 // The brpc server should respond as quickly as possible.
                 bthread_context->thread_mem_tracker_mgr->disable_wait_gc();
                 // set the data so that next time bthread_getspecific in the thread returns the data.
-                CHECK(0 == bthread_setspecific(btls_key, bthread_context) || k_doris_exit);
+                CHECK(0 == bthread_setspecific(btls_key, bthread_context) || doris::k_doris_exit);
             }
             DCHECK(bthread_context != nullptr);
             bthread_context->thread_local_handle_count++;

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -352,7 +352,7 @@ static ThreadContext* thread_context(bool allow_return_null = false) {
         // in bthread
         // bthread switching pthread may be very frequent, remember not to use lock or other time-consuming operations.
         auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
-        DCHECK(bthread_context != nullptr);
+        DCHECK(bthread_context != nullptr && bthread_context->thread_local_handle_count > 0);
         return bthread_context;
     }
     if (allow_return_null) {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -215,7 +215,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume_memory(
         size_t size) {
-    DCHECK(tracker->label() == doris::thread_context()->thread_mem_tracker()->label())
+    DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
             << ", thread mem tracker label: "
             << doris::thread_context()->thread_mem_tracker()->label()
             << ", allocator tracker label: " << tracker->label();
@@ -227,7 +227,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release
         size_t size) const {
     doris::ThreadContext* thread_context = doris::thread_context(true);
     if (thread_context && thread_context->thread_mem_tracker()->label() != "Orphan") {
-        DCHECK(tracker->label() == thread_context->thread_mem_tracker()->label())
+        DCHECK(thread_context->thread_mem_tracker()->label() == tracker->label())
                 << ", thread mem tracker label: " << thread_context->thread_mem_tracker()->label()
                 << ", allocator tracker label: " << tracker->label();
         RELEASE_THREAD_MEM_TRACKER(size);

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -217,10 +217,11 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume
         size_t size) {
     // `alloc` requires that the current thread_mem_tracker label is not `Orphan`
     // and is the same as the thread_mem_tracker label when Allocator is constructed.
-    DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
-            << ", thread mem tracker label: "
-            << doris::thread_context()->thread_mem_tracker()->label()
-            << ", allocator tracker label: " << tracker->label();
+    // TODO, need to be 0 when the load or other memory tracker ends.
+    // DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
+    //         << ", thread mem tracker label: "
+    //         << doris::thread_context()->thread_mem_tracker()->label()
+    //         << ", allocator tracker label: " << tracker->label();
     CONSUME_THREAD_MEM_TRACKER(size);
 }
 
@@ -235,9 +236,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release
     // such as modifying reserved memory.
     doris::ThreadContext* thread_context = doris::thread_context(true);
     if (thread_context && thread_context->thread_mem_tracker()->label() != "Orphan") {
-        DCHECK(thread_context->thread_mem_tracker()->label() == tracker->label())
-                << ", thread mem tracker label: " << thread_context->thread_mem_tracker()->label()
-                << ", allocator tracker label: " << tracker->label();
+        // TODO, need to be 0 when the load or other memory tracker ends.
+        // DCHECK(thread_context->thread_mem_tracker()->label() == tracker->label())
+        //         << ", thread mem tracker label: " << thread_context->thread_mem_tracker()->label()
+        //         << ", allocator tracker label: " << tracker->label();
         RELEASE_THREAD_MEM_TRACKER(size);
     } else {
         tracker->release(size);

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -220,8 +220,8 @@ template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename Memory
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release_memory(
         size_t size) const {
     doris::ThreadContext* thread_context = doris::thread_context(true);
-    DCHECK(_tracker);
-    if (thread_context && thread_context->thread_mem_tracker()->label() == _tracker->label()) {
+    if (thread_context) {
+        DCHECK(!_tracker || thread_context->thread_mem_tracker()->label() == _tracker->label());
         RELEASE_THREAD_MEM_TRACKER(size);
     } else {
         _tracker->release(size);

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -226,10 +226,9 @@ template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename Memory
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release_memory(
         size_t size) const {
     doris::ThreadContext* thread_context = doris::thread_context(true);
-    if (thread_context) {
-        DCHECK(tracker->label() == doris::thread_context()->thread_mem_tracker()->label())
-                << ", thread mem tracker label: "
-                << doris::thread_context()->thread_mem_tracker()->label()
+    if (thread_context && thread_context->thread_mem_tracker()->label() != "Orphan") {
+        DCHECK(tracker->label() == thread_context->thread_mem_tracker()->label())
+                << ", thread mem tracker label: " << thread_context->thread_mem_tracker()->label()
                 << ", allocator tracker label: " << tracker->label();
         RELEASE_THREAD_MEM_TRACKER(size);
     } else {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -215,12 +215,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume_memory(
         size_t size) {
-    // `alloc` requires that the current thread_mem_tracker label is not `Orphan`
-    // and is the same as the thread_mem_tracker label when Allocator is constructed.
-    DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
-            << ", thread mem tracker label: "
-            << doris::thread_context()->thread_mem_tracker()->label()
-            << ", allocator tracker label: " << tracker->label();
     CONSUME_THREAD_MEM_TRACKER(size);
 }
 
@@ -235,10 +229,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release
     // such as modifying reserved memory.
     doris::ThreadContext* thread_context = doris::thread_context(true);
     if (thread_context && thread_context->thread_mem_tracker()->label() != "Orphan") {
-        // TODO, need to be 0 when the load or other memory tracker ends.
-        // DCHECK(thread_context->thread_mem_tracker()->label() == tracker->label())
-        //         << ", thread mem tracker label: " << thread_context->thread_mem_tracker()->label()
-        //         << ", allocator tracker label: " << tracker->label();
         RELEASE_THREAD_MEM_TRACKER(size);
     } else {
         tracker->release(size);

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -221,6 +221,8 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release
         size_t size) const {
     doris::ThreadContext* thread_context = doris::thread_context(true);
     if (thread_context) {
+        // phmap FlatHashSetPolicy may release memory not allocated by Allocator,
+        // and consume_memory may not be called before release_memory is called, in which case _tracker is nullptr.
         DCHECK(!_tracker || thread_context->thread_mem_tracker()->label() == _tracker->label());
         RELEASE_THREAD_MEM_TRACKER(size);
     } else {

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -217,11 +217,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume
         size_t size) {
     // `alloc` requires that the current thread_mem_tracker label is not `Orphan`
     // and is the same as the thread_mem_tracker label when Allocator is constructed.
-    // TODO, need to be 0 when the load or other memory tracker ends.
-    // DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
-    //         << ", thread mem tracker label: "
-    //         << doris::thread_context()->thread_mem_tracker()->label()
-    //         << ", allocator tracker label: " << tracker->label();
+    DCHECK(doris::thread_context()->thread_mem_tracker()->label() == tracker->label())
+            << ", thread mem tracker label: "
+            << doris::thread_context()->thread_mem_tracker()->label()
+            << ", allocator tracker label: " << tracker->label();
     CONSUME_THREAD_MEM_TRACKER(size);
 }
 

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -227,11 +227,6 @@ template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename Memory
 class Allocator {
 public:
     Allocator();
-    Allocator(const Allocator& that) { tracker = that.tracker; }
-    Allocator& operator=(const Allocator& that) {
-        tracker = that.tracker;
-        return *this;
-    }
 
     void sys_memory_check(size_t size) const;
     void memory_tracker_check(size_t size) const;

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -226,6 +226,13 @@ class MemTrackerLimiter;
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 class Allocator {
 public:
+    Allocator();
+    Allocator(const Allocator& that) { tracker = that.tracker; }
+    Allocator& operator=(const Allocator& that) {
+        tracker = that.tracker;
+        return *this;
+    }
+
     void sys_memory_check(size_t size) const;
     void memory_tracker_check(size_t size) const;
     // If sys memory or tracker exceeds the limit, but there is no external catch bad_alloc,
@@ -399,6 +406,8 @@ public:
         return buf;
     }
 
+    std::shared_ptr<doris::MemTrackerLimiter> tracker {nullptr};
+
 protected:
     static constexpr size_t get_stack_threshold() { return 0; }
 
@@ -416,8 +425,6 @@ protected:
                                       | (mmap_populate ? MAP_POPULATE : 0)
 #endif
             ;
-
-    std::shared_ptr<doris::MemTrackerLimiter> _tracker {nullptr};
 };
 
 /** Allocator with optimization to place small memory ranges in automatic memory.

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -209,6 +209,10 @@ private:
     static std::mutex _mutex;
 };
 
+namespace doris {
+class MemTrackerLimiter;
+}
+
 /** Responsible for allocating / freeing memory. Used, for example, in PODArray, Arena.
   * Also used in hash tables.
   * The interface is different from std::allocator
@@ -228,7 +232,7 @@ public:
     // alloc will continue to execute, so the consume memtracker is forced.
     void memory_check(size_t size) const;
     // Increases consumption of this tracker by 'bytes'.
-    void consume_memory(size_t size) const;
+    void consume_memory(size_t size);
     void release_memory(size_t size) const;
     void throw_bad_alloc(const std::string& err) const;
 #ifndef NDEBUG
@@ -412,6 +416,8 @@ protected:
                                       | (mmap_populate ? MAP_POPULATE : 0)
 #endif
             ;
+
+    std::shared_ptr<doris::MemTrackerLimiter> _tracker {nullptr};
 };
 
 /** Allocator with optimization to place small memory ranges in automatic memory.

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -226,7 +226,7 @@ class MemTrackerLimiter;
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 class Allocator {
 public:
-    Allocator();
+    Allocator(const std::shared_ptr<doris::MemTrackerLimiter>& tracker = nullptr);
 
     void sys_memory_check(size_t size) const;
     void memory_tracker_check(size_t size) const;
@@ -401,7 +401,7 @@ public:
         return buf;
     }
 
-    std::shared_ptr<doris::MemTrackerLimiter> tracker {nullptr};
+    std::shared_ptr<doris::MemTrackerLimiter> mem_tracker {nullptr};
 
 protected:
     static constexpr size_t get_stack_threshold() { return 0; }

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 /// `Allocator_` implements several interfaces of `std::allocator`
 /// which `phmap::flat_hash_map` will use.
 template <typename T>
-class Allocator_ : private Allocator<true, false, false, DefaultMemoryAllocator> {
+class Allocator_ : public Allocator<true, false, false, DefaultMemoryAllocator> {
 public:
     using value_type = T;
     using pointer = T*;
@@ -34,7 +34,14 @@ public:
     Allocator_() = default;
 
     template <typename T_>
-    Allocator_(const Allocator_<T_>&) {};
+    Allocator_(const Allocator_<T_>& that)
+            : Allocator<true, false, false, DefaultMemoryAllocator>(that) {};
+
+    template <typename T_>
+    Allocator_<T_>& operator=(const Allocator_<T_>& that) {
+        Allocator<true, false, false, DefaultMemoryAllocator>::operator=(that);
+        return *this;
+    }
 
     constexpr T* allocate(size_t n) { return static_cast<T*>(Allocator::alloc(n * sizeof(T))); }
 

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 /// `Allocator_` implements several interfaces of `std::allocator`
 /// which `phmap::flat_hash_map` will use.
 template <typename T>
-class Allocator_ : public Allocator<true, false, false, DefaultMemoryAllocator> {
+class Allocator_ : private Allocator<true, false, false, DefaultMemoryAllocator> {
 public:
     using value_type = T;
     using pointer = T*;

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -34,14 +34,7 @@ public:
     Allocator_() = default;
 
     template <typename T_>
-    Allocator_(const Allocator_<T_>& that)
-            : Allocator<true, false, false, DefaultMemoryAllocator>(that) {};
-
-    template <typename T_>
-    Allocator_<T_>& operator=(const Allocator_<T_>& that) {
-        Allocator<true, false, false, DefaultMemoryAllocator>::operator=(that);
-        return *this;
-    }
+    Allocator_(const Allocator_<T_>&) {};
 
     constexpr T* allocate(size_t n) { return static_cast<T*>(Allocator::alloc(n * sizeof(T))); }
 


### PR DESCRIPTION
Allocator save TLS MemTracker during first alloc, which is used to release memory after TLS attach task ends.
