### PR TITLE
[enhance](C++) Prefer using make_unique_for_overwrite first when allocating buffer

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -743,7 +743,7 @@ Status InMemoryFileReader::read_at_impl(size_t offset, Slice result, size_t* byt
                                         const IOContext* io_ctx) {
     if (_data == nullptr) {
         _data = std::make_unique_for_overwrite<char[]>(_size);
-        
+
         size_t file_size = 0;
         RETURN_IF_ERROR(_reader->read_at(0, Slice(_data.get(), _size), &file_size, io_ctx));
         DCHECK_EQ(file_size, _size);

--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -742,7 +742,8 @@ Status InMemoryFileReader::_close_internal() {
 Status InMemoryFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                         const IOContext* io_ctx) {
     if (_data == nullptr) {
-        _data = std::make_unique<char[]>(_size);
+        _data = std::make_unique_for_overwrite<char[]>(_size);
+        
         size_t file_size = 0;
         RETURN_IF_ERROR(_reader->read_at(0, Slice(_data.get(), _size), &file_size, io_ctx));
         DCHECK_EQ(file_size, _size);

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -320,7 +320,7 @@ Status S3FileSystem::upload_impl(const Path& local_file, const Path& remote_file
     FileReaderSPtr local_reader;
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(local_file, &local_reader));
     size_t local_buffer_size = config::s3_file_system_local_upload_buffer_size;
-    std::unique_ptr<char[]> write_buffer = std::make_unique<char[]>(local_buffer_size);
+    std::unique_ptr<char[]> write_buffer = std::make_unique_for_overwrite<char[]>(local_buffer_size);
     size_t cur_read = 0;
     while (cur_read < local_reader->size()) {
         size_t bytes_read = 0;
@@ -361,7 +361,7 @@ Status S3FileSystem::batch_upload_impl(const std::vector<Path>& local_files,
         FileReaderSPtr local_reader;
         RETURN_IF_ERROR(io::global_local_filesystem()->open_file(local_file, &local_reader));
         size_t local_buffer_size = config::s3_file_system_local_upload_buffer_size;
-        std::unique_ptr<char[]> write_buffer = std::make_unique<char[]>(local_buffer_size);
+        std::unique_ptr<char[]> write_buffer = std::make_unique_for_overwrite<char[]>(local_buffer_size);
         size_t cur_read = 0;
         while (cur_read < local_reader->size()) {
             size_t bytes_read = 0;
@@ -402,7 +402,7 @@ Status S3FileSystem::download_impl(const Path& remote_file, const Path& local_fi
     auto key = DORIS_TRY(get_key(remote_file));
     int64_t size;
     RETURN_IF_ERROR(file_size(remote_file, &size));
-    std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
+    std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
     size_t bytes_read = 0;
     // clang-format off
     auto resp = client->get_object( {.bucket = _bucket, .key = key,},

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -320,7 +320,8 @@ Status S3FileSystem::upload_impl(const Path& local_file, const Path& remote_file
     FileReaderSPtr local_reader;
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(local_file, &local_reader));
     size_t local_buffer_size = config::s3_file_system_local_upload_buffer_size;
-    std::unique_ptr<char[]> write_buffer = std::make_unique_for_overwrite<char[]>(local_buffer_size);
+    std::unique_ptr<char[]> write_buffer =
+            std::make_unique_for_overwrite<char[]>(local_buffer_size);
     size_t cur_read = 0;
     while (cur_read < local_reader->size()) {
         size_t bytes_read = 0;
@@ -361,7 +362,8 @@ Status S3FileSystem::batch_upload_impl(const std::vector<Path>& local_files,
         FileReaderSPtr local_reader;
         RETURN_IF_ERROR(io::global_local_filesystem()->open_file(local_file, &local_reader));
         size_t local_buffer_size = config::s3_file_system_local_upload_buffer_size;
-        std::unique_ptr<char[]> write_buffer = std::make_unique_for_overwrite<char[]>(local_buffer_size);
+        std::unique_ptr<char[]> write_buffer =
+                std::make_unique_for_overwrite<char[]>(local_buffer_size);
         size_t cur_read = 0;
         while (cur_read < local_reader->size()) {
             size_t bytes_read = 0;

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
@@ -112,7 +112,7 @@ Status DataTypeBitMapSerDe::_write_column_to_mysql(const IColumn& column,
         const auto col_index = index_check_const(row_idx, col_const);
         BitmapValue bitmapValue = data_column.get_element(col_index);
         size_t size = bitmapValue.getSizeInBytes();
-        std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
         bitmapValue.write_to(buf.get());
         if (0 != result.push_string(buf.get(), size)) {
             return Status::InternalError("pack mysql buffer failed.");

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -65,7 +65,7 @@ Status DataTypeHLLSerDe::serialize_one_cell_to_json(const IColumn& column, int r
     ColumnPtr ptr = col_row.first;
     row_num = col_row.second;
     auto& data = const_cast<HyperLogLog&>(assert_cast<const ColumnHLL&>(*ptr).get_element(row_num));
-    std::unique_ptr<char[]> buf = std::make_unique<char[]>(data.max_serialized_size());
+    std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(data.max_serialized_size());
     size_t size = data.serialize((uint8*)buf.get());
     bw.write(buf.get(), size);
     return Status::OK();
@@ -162,7 +162,7 @@ Status DataTypeHLLSerDe::_write_column_to_mysql(const IColumn& column,
         const auto col_index = index_check_const(row_idx, col_const);
         HyperLogLog hyperLogLog = data_column.get_element(col_index);
         size_t size = hyperLogLog.max_serialized_size();
-        std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
         hyperLogLog.serialize((uint8*)buf.get());
         if (UNLIKELY(0 != result.push_string(buf.get(), size))) {
             return Status::InternalError("pack mysql buffer failed.");

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -65,7 +65,8 @@ Status DataTypeHLLSerDe::serialize_one_cell_to_json(const IColumn& column, int r
     ColumnPtr ptr = col_row.first;
     row_num = col_row.second;
     auto& data = const_cast<HyperLogLog&>(assert_cast<const ColumnHLL&>(*ptr).get_element(row_num));
-    std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(data.max_serialized_size());
+    std::unique_ptr<char[]> buf =
+            std::make_unique_for_overwrite<char[]>(data.max_serialized_size());
     size_t size = data.serialize((uint8*)buf.get());
     bw.write(buf.get(), size);
     return Status::OK();

--- a/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
+++ b/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
@@ -147,7 +147,7 @@ Status DataTypeQuantileStateSerDe::_write_column_to_mysql(const IColumn& column,
         const auto col_index = index_check_const(row_idx, col_const);
         auto& quantile_value = const_cast<QuantileState&>(data_column.get_element(col_index));
         size_t size = quantile_value.get_serialized_size();
-        std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
         quantile_value.serialize((uint8_t*)buf.get());
         if (0 != result.push_string(buf.get(), size)) {
             return Status::InternalError("pack mysql buffer failed.");

--- a/be/src/vec/functions/function_map.cpp
+++ b/be/src/vec/functions/function_map.cpp
@@ -103,7 +103,7 @@ public:
         auto& result_col_map_offsets = map_column->get_offsets();
         result_col_map_offsets.resize(input_rows_count);
 
-        std::unique_ptr<bool[]> col_const = std::make_unique<bool[]>(num_element);
+        std::unique_ptr<bool[]> col_const = std::make_unique_for_overwrite<bool[]>(num_element);
         for (size_t i = 0; i < num_element; ++i) {
             auto& col = block.get_by_position(arguments[i]).column;
             std::tie(col, col_const[i]) = unpack_if_const(col);

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -66,7 +66,7 @@ struct CompareMultiImpl {
         MutableColumnPtr result_column = data_type->create_column();
 
         Columns cols(arguments.size());
-        std::unique_ptr<bool[]> col_const = std::make_unique<bool[]>(arguments.size());
+        std::unique_ptr<bool[]> col_const = std::make_unique_for_overwrite<bool[]>(arguments.size());
         for (int i = 0; i < arguments.size(); ++i) {
             std::tie(cols[i], col_const[i]) =
                     unpack_if_const(block.get_by_position(arguments[i]).column);

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -66,7 +66,8 @@ struct CompareMultiImpl {
         MutableColumnPtr result_column = data_type->create_column();
 
         Columns cols(arguments.size());
-        std::unique_ptr<bool[]> col_const = std::make_unique_for_overwrite<bool[]>(arguments.size());
+        std::unique_ptr<bool[]> col_const =
+                std::make_unique_for_overwrite<bool[]>(arguments.size());
         for (int i = 0; i < arguments.size(); ++i) {
             std::tie(cols[i], col_const[i]) =
                     unpack_if_const(block.get_by_position(arguments[i]).column);


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

When allocating memory buffer using traditional `make_unique` function, it would try to do initialization when allocating the corresponding memory. For scenarios where the data is immediately overwritten, the initialization is wasted, so we could use `make_unique_for_overwrite` to prevent the useless initialization.