### PR TITLE
[enhancement](Nereids) fast compute hash code of deep expression tree to reduce conflict

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/CommonSubExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/CommonSubExpressionCollector.java
@@ -37,8 +37,15 @@ public class CommonSubExpressionCollector extends ExpressionVisitor<Integer, Voi
         if (expr.children().isEmpty()) {
             return 0;
         }
-        return collectCommonExpressionByDepth(expr.children().stream().map(child ->
-                child.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1), expr);
+        return collectCommonExpressionByDepth(
+                expr.children()
+                        .stream()
+                        .map(child -> child.accept(this, context))
+                        .reduce(Math::max)
+                        .map(m -> m + 1)
+                        .orElse(1),
+                expr
+        );
     }
 
     private int collectCommonExpressionByDepth(int depth, Expression expr) {
@@ -53,7 +60,6 @@ public class CommonSubExpressionCollector extends ExpressionVisitor<Integer, Voi
 
     public static Set<Expression> getExpressionsFromDepthMap(
             int depth, Map<Integer, Set<Expression>> depthMap) {
-        depthMap.putIfAbsent(depth, new LinkedHashSet<>());
-        return depthMap.get(depth);
+        return depthMap.computeIfAbsent(depth, d -> new LinkedHashSet<>());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PredicatesSplitter.java
@@ -28,7 +28,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,9 +39,9 @@ import java.util.Set;
  */
 public class PredicatesSplitter {
 
-    private final Set<Expression> equalPredicates = new HashSet<>();
-    private final Set<Expression> rangePredicates = new HashSet<>();
-    private final Set<Expression> residualPredicates = new HashSet<>();
+    private final Set<Expression> equalPredicates = new LinkedHashSet<>();
+    private final Set<Expression> rangePredicates = new LinkedHashSet<>();
+    private final Set<Expression> residualPredicates = new LinkedHashSet<>();
     private final List<Expression> conjunctExpressions;
 
     public PredicatesSplitter(Expression target) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateNotNull.java
@@ -81,7 +81,7 @@ public class EliminateNotNull implements RewriteRuleFactory {
         // predicatesNotContainIsNotNull infer nonNullable slots: `id`
         // slotsFromIsNotNull: `id`, `name`
         // remove `name` (it's generated), remove `id` (because `id > 0` already contains it)
-        Set<Expression> predicatesNotContainIsNotNull = Sets.newHashSet();
+        Set<Expression> predicatesNotContainIsNotNull = Sets.newLinkedHashSet();
         List<Slot> slotsFromIsNotNull = Lists.newArrayList();
 
         for (Expression expr : exprs) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -148,11 +148,11 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
             case 2:
                 Expression left = children.get(0);
                 Expression right = children.get(1);
-                this.depth = Math.max(left.depth, right.depth) + 2;
+                this.depth = Math.max(left.depth, right.depth) + 1;
                 this.width = left.width + right.width;
                 this.compareWidthAndDepth =
                         left.compareWidthAndDepth && right.compareWidthAndDepth && supportCompareWidthAndDepth();
-                this.fastChildrenHashCode = left.fastChildrenHashCode() + right.fastChildrenHashCode();
+                this.fastChildrenHashCode = left.fastChildrenHashCode() + right.fastChildrenHashCode() + 2;
                 break;
             default:
                 int maxChildDepth = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -423,8 +423,10 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
             return false;
         }
         Expression that = (Expression) o;
-        if ((compareWidthAndDepth && (this.width != that.width || this.depth != that.depth
-                || this.fastChildrenHashCode != that.fastChildrenHashCode)) || arity() != that.arity() || !extraEquals(that)) {
+        if ((compareWidthAndDepth &&
+                (this.width != that.width || this.depth != that.depth
+                    || this.fastChildrenHashCode != that.fastChildrenHashCode))
+                || arity() != that.arity() || !extraEquals(that)) {
             return false;
         }
         return equalsChildren(that);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -423,8 +423,8 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
             return false;
         }
         Expression that = (Expression) o;
-        if ((compareWidthAndDepth &&
-                (this.width != that.width || this.depth != that.depth
+        if ((compareWidthAndDepth
+                && (this.width != that.width || this.depth != that.depth
                     || this.fastChildrenHashCode != that.fastChildrenHashCode))
                 || arity() != that.arity() || !extraEquals(that)) {
             return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -81,7 +81,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
                 this.depth = 1;
                 this.width = 1;
                 this.compareWidthAndDepth = supportCompareWidthAndDepth();
-                this.fastChildrenHashCode = 1;
+                this.fastChildrenHashCode = 0;
                 break;
             case 1:
                 Expression child = children[0];
@@ -136,7 +136,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
                 this.depth = 1;
                 this.width = 1;
                 this.compareWidthAndDepth = supportCompareWidthAndDepth();
-                this.fastChildrenHashCode = 1;
+                this.fastChildrenHashCode = 0;
                 break;
             case 1:
                 Expression child = children.get(0);
@@ -158,7 +158,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
                 int maxChildDepth = 0;
                 int sumChildWidth = 0;
                 boolean compareWidthAndDepth = true;
-                int fastChildrenhashCode = 1;
+                int fastChildrenhashCode = 0;
                 for (Expression expression : children) {
                     child = expression;
                     maxChildDepth = Math.max(child.depth, maxChildDepth);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Placeholder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Placeholder.java
@@ -61,8 +61,18 @@ public class Placeholder extends Expression implements LeafExpression {
     }
 
     @Override
+    public String toString() {
+        return "$" + placeholderId.asInt();
+    }
+
+    @Override
     public String toSql() {
         return "?";
+    }
+
+    @Override
+    public int fastChildrenHashCode() {
+        return placeholderId.asInt();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -238,6 +238,11 @@ public class SlotReference extends Slot {
     }
 
     @Override
+    public int fastChildrenHashCode() {
+        return exprId.asInt();
+    }
+
+    @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitSlotReference(this, context);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -366,6 +366,11 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
     }
 
     @Override
+    public int fastChildrenHashCode() {
+        return Objects.hashCode(getValue());
+    }
+
+    @Override
     public String toString() {
         return String.valueOf(getValue());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
@@ -167,7 +167,7 @@ public class PointQueryExecutor implements CoordInterface {
             } else if (binaryPredicate.getChild(1) instanceof LiteralExpr) {
                 binaryPredicate.setChild(1, conjunctVals.get(i));
             } else {
-                Preconditions.checkState(false, "Should conatains literal in " + binaryPredicate.toSqlImpl());
+                Preconditions.checkState(false, "Should contains literal in " + binaryPredicate.toSqlImpl());
             }
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/PredicatesSplitterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/PredicatesSplitterTest.java
@@ -61,7 +61,7 @@ public class PredicatesSplitterTest extends ExpressionRewriteTestHelper {
             String expectedRangeExpr,
             String expectedResidualExpr) {
 
-        Map<String, Slot> mem = Maps.newHashMap();
+        Map<String, Slot> mem = Maps.newLinkedHashMap();
         Expression targetExpr = replaceUnboundSlot(PARSER.parseExpression(expression), mem);
         SplitPredicate splitPredicate = Predicates.splitPredicates(targetExpr);
 


### PR DESCRIPTION
## Proposed changes

The Expression.hashCode default is getClass().hashCode(), just contains one level information, so the lots of expressions which is same type will return the same hash code and conflict, then compare deeply in the HashMap cause inefficient and hold table lock for long time.

This pr support fast compute hash code by the bottom literal and slot, reduce the compare expression time because of the conflict of hash code 

In my test case, the sql planner time can reduce from 20 minutes(not finished) to 35 seconds