### PR TITLE
[fix](cancel) Fix wrong status when query failed

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -729,11 +729,11 @@ private:
     std::string _s3_error_log_file_path;
 };
 
-#define RETURN_IF_CANCELLED(state)                                                     \
-    do {                                                                              \
-        if (UNLIKELY((state)->is_cancelled())) {                                      \
-            return (state)->cancel_reason();                                    \
-        }                                                                             \
+#define RETURN_IF_CANCELLED(state)               \
+    do {                                         \
+        if (UNLIKELY((state)->is_cancelled())) { \
+            return (state)->cancel_reason();     \
+        }                                        \
     } while (false)
 
 } // namespace doris

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -729,9 +729,11 @@ private:
     std::string _s3_error_log_file_path;
 };
 
-#define RETURN_IF_CANCELLED(state)                                                    \
+#define RETURN_IF_CANCELLED(state)                                                     \
     do {                                                                              \
-        if (UNLIKELY((state)->is_cancelled())) return Status::Cancelled("Cancelled"); \
+        if (UNLIKELY((state)->is_cancelled())) {                                      \
+            return (state)->cancel_reason();                                    \
+        }                                                                             \
     } while (false)
 
 } // namespace doris


### PR DESCRIPTION
Pipeline task A failed with `Status A`, pipeline task B should also fail with same `Status A` instead of just returning a CANCELLED.