### PR TITLE
[Performance](opt) opt the order by performance in permutation

### DIFF
--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <pdqsort.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
@@ -269,14 +270,22 @@ protected:
         for (U i = 0; i < s; ++i) res[i] = i;
 
         auto sort_end = res.end();
-        if (limit && limit < s) sort_end = res.begin() + limit;
-
-        if (reverse)
-            std::partial_sort(res.begin(), sort_end, res.end(),
-                              [this](size_t a, size_t b) { return data[a] > data[b]; });
-        else
-            std::partial_sort(res.begin(), sort_end, res.end(),
-                              [this](size_t a, size_t b) { return data[a] < data[b]; });
+        if (limit && limit < s / 8.0) {
+            sort_end = res.begin() + limit;
+            if (reverse)
+                std::partial_sort(res.begin(), sort_end, res.end(),
+                                  [this](size_t a, size_t b) { return data[a] > data[b]; });
+            else
+                std::partial_sort(res.begin(), sort_end, res.end(),
+                                  [this](size_t a, size_t b) { return data[a] < data[b]; });
+        } else {
+            if (reverse)
+                pdqsort(res.begin(), res.end(),
+                        [this](size_t a, size_t b) { return data[a] > data[b]; });
+            else
+                pdqsort(res.begin(), res.end(),
+                        [this](size_t a, size_t b) { return data[a] < data[b]; });
+        }
     }
 
     void ALWAYS_INLINE decimalv2_do_crc(size_t i, uint32_t& hash) const {

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -457,9 +457,8 @@ void ColumnStr<T>::get_permutation(bool reverse, size_t limit, int /*nan_directi
         res[i] = i;
     }
 
-    if (limit >= s) {
-        limit = 0;
-    }
+    // std::partial_sort need limit << s can get performance benefit
+    if (limit > (s / 8.0)) limit = 0;
 
     if (limit) {
         if (reverse) {
@@ -469,9 +468,9 @@ void ColumnStr<T>::get_permutation(bool reverse, size_t limit, int /*nan_directi
         }
     } else {
         if (reverse) {
-            std::sort(res.begin(), res.end(), less<false>(*this));
+            pdqsort(res.begin(), res.end(), less<false>(*this));
         } else {
-            std::sort(res.begin(), res.end(), less<true>(*this));
+            pdqsort(res.begin(), res.end(), less<true>(*this));
         }
     }
 }

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -236,7 +236,8 @@ void ColumnVector<T>::get_permutation(bool reverse, size_t limit, int nan_direct
 
     if (s == 0) return;
 
-    if (limit >= s) limit = 0;
+    // std::partial_sort need limit << s can get performance benefit
+    if (limit > (s / 8.0)) limit = 0;
 
     if (limit) {
         for (size_t i = 0; i < s; ++i) res[i] = i;


### PR DESCRIPTION
## Proposed changes

Before：
```
select l_quantity from lineitem order by l_quantity limit 10000020;
+--------------+
| ReturnedRows |
+--------------+
| 10000020     |
+--------------+
1 row in set (2 min 24.42 sec)

```

after:
```
mysql [tpch]>select l_quantity from lineitem order by l_quantity limit 10000020;
+--------------+
| ReturnedRows |
+--------------+
| 10000020     |
+--------------+
1 row in set (28.42 sec)
```

<!--Describe your changes.-->

