### PR TITLE
[Fix](multi-catalog) Fix not throw error when call close() in hive/iceberg writer.

### DIFF
--- a/be/src/vec/sink/writer/vhive_partition_writer.cpp
+++ b/be/src/vec/sink/writer/vhive_partition_writer.cpp
@@ -117,24 +117,26 @@ Status VHivePartitionWriter::open(RuntimeState* state, RuntimeProfile* profile) 
 }
 
 Status VHivePartitionWriter::close(const Status& status) {
+    Status result_status;
     if (_file_format_transformer != nullptr) {
-        Status st = _file_format_transformer->close();
-        if (!st.ok()) {
+        result_status = _file_format_transformer->close();
+        if (!result_status.ok()) {
             LOG(WARNING) << fmt::format("_file_format_transformer close failed, reason: {}",
-                                        st.to_string());
+                                        result_status.to_string());
         }
     }
-    if (!status.ok() && _fs != nullptr) {
+    bool status_ok = result_status.ok() && status.ok();
+    if (!status_ok && _fs != nullptr) {
         auto path = fmt::format("{}/{}", _write_info.write_path, _file_name);
         Status st = _fs->delete_file(path);
         if (!st.ok()) {
             LOG(WARNING) << fmt::format("Delete file {} failed, reason: {}", path, st.to_string());
         }
     }
-    if (status.ok()) {
+    if (status_ok) {
         _state->hive_partition_updates().emplace_back(_build_partition_update());
     }
-    return Status::OK();
+    return result_status;
 }
 
 Status VHivePartitionWriter::write(vectorized::Block& block) {

--- a/be/src/vec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/vec/sink/writer/vhive_table_writer.cpp
@@ -242,15 +242,19 @@ Status VHiveTableWriter::_filter_block(doris::vectorized::Block& block,
 }
 
 Status VHiveTableWriter::close(Status status) {
+    Status result_status;
     int64_t partitions_to_writers_size = _partitions_to_writers.size();
     {
         SCOPED_RAW_TIMER(&_close_ns);
         for (const auto& pair : _partitions_to_writers) {
             Status st = pair.second->close(status);
-            if (st != Status::OK()) {
+            if (!st.ok()) {
                 LOG(WARNING) << fmt::format("partition writer close failed for partition {}",
                                             st.to_string());
-                continue;
+                if (result_status.ok()) {
+                    result_status = st;
+                    continue;
+                }
             }
         }
         _partitions_to_writers.clear();
@@ -266,7 +270,7 @@ Status VHiveTableWriter::close(Status status) {
         COUNTER_SET(_close_timer, _close_ns);
         COUNTER_SET(_write_file_counter, _write_file_count);
     }
-    return Status::OK();
+    return result_status;
 }
 
 std::shared_ptr<VHivePartitionWriter> VHiveTableWriter::_create_partition_writer(


### PR DESCRIPTION
## Proposed changes

[Fix] (multi-catalog) Fix not throw error when call close() in hive/iceberg writer.

When the file writer closes(), it will sync buffer to commit. Therefore, sometimes data is written only when close() is called, which can expose some errors. For example, hdfs_file_writer. Therefore, this error needs to be captured in the entire close process.

