### PR TITLE
[fix](regression) fix test_group_commit_timeout failed due to different error message

### DIFF
--- a/regression-test/suites/insert_p0/test_group_commit_timeout.groovy
+++ b/regression-test/suites/insert_p0/test_group_commit_timeout.groovy
@@ -46,7 +46,7 @@ suite("test_group_commit_timeout", "nonConcurrent") {
     } catch (Exception e) {
         long end = System.currentTimeMillis()
         logger.info("failed " + e.getMessage())
-        assertTrue(e.getMessage().contains("FragmentMgr cancel worker going to cancel timeout instance") || e.getMessage().contains("Execute timeout"))
+        assertTrue(e.getMessage().contains("FragmentMgr cancel worker going to cancel timeout instance") || e.getMessage().contains("Execute timeout") || e.getMessage().contains("timeout"))
         assertTrue(end - start <= 60000)
     } finally {
         sql "SET global query_timeout = ${query_timeout[0][1]}"


### PR DESCRIPTION
the case is failed:
```
(test_group_commit_timeout.groovy:48) - failed errCode = 2, detailMessage = query is timeout, killed by timeout checker
```