### PR TITLE
[fix](Nereids) cast to boolean wrong when constant folding by be

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -348,7 +348,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
         } else if (type.isBooleanType()) {
             int num = resultContent.getUint32ValueCount();
             for (int i = 0; i < num; ++i) {
-                Literal literal = BooleanLiteral.of(resultContent.getUint32Value(i) == 1);
+                Literal literal = BooleanLiteral.of(resultContent.getUint32Value(i) != 0);
                 res.add(literal);
             }
         } else if (type.isTinyIntType()) {


### PR DESCRIPTION
not add case because be return wrong answer for this

select cast(2.0 as boolean); -- should return 1 not 2

