### PR TITLE
Revert "[Opt](heartbeat) improve the tolerance of the cluster to occasional heartbeat failures"

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1923,12 +1923,12 @@ public class Config extends ConfigBase {
 
     /**
      * Maximum backend heartbeat failure tolerance count.
-     * Default is 3, which means if 3 heart failed, the backend will be marked as dead.
+     * Default is 1, which means if 1 heart failed, the backend will be marked as dead.
      * A larger value can improve the tolerance of the cluster to occasional heartbeat failures.
      * For example, when running regression tests, this value can be increased.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static long max_backend_heartbeat_failure_tolerance_count = 3;
+    public static long max_backend_heartbeat_failure_tolerance_count = 1;
 
     /**
      * Abort transaction time after lost heartbeat.

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/TabletHealthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/TabletHealthTest.java
@@ -61,7 +61,6 @@ public class TabletHealthTest extends TestWithFeService {
         Config.colocate_group_relocate_delay_second = -1000; // be dead will imm relocate
         Config.tablet_schedule_interval_ms = 7200_000L;  //disable schedule
         Config.tablet_checker_interval_ms = 7200_000L;  //disable checker
-        Config.max_backend_heartbeat_failure_tolerance_count = 1;
     }
 
     @Override


### PR DESCRIPTION
Reverts apache/doris#38896
This pr will cause performance regression test failed.