### PR TITLE
[feature](pipeline) check nullable in SET operator

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -401,4 +401,16 @@ Status AggSharedState::_destroy_agg_status(vectorized::AggregateDataPtr data) {
 
 LocalExchangeSharedState::~LocalExchangeSharedState() = default;
 
+Status SetSharedState::update_build_not_ignore_null(const vectorized::VExprContextSPtrs& ctxs) {
+    if (ctxs.size() > build_not_ignore_null.size()) {
+        return Status::InternalError("build_not_ignore_null not initialized");
+    }
+
+    for (int i = 0; i < ctxs.size(); ++i) {
+        build_not_ignore_null[i] = build_not_ignore_null[i] || ctxs[i]->root()->is_nullable();
+    }
+
+    return Status::OK();
+}
+
 } // namespace doris::pipeline

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -684,6 +684,10 @@ public:
     std::unique_ptr<SetHashTableVariants> hash_table_variants = nullptr; // the real data HERE.
     std::vector<bool> build_not_ignore_null;
 
+    // The SET operator's child might have different nullable attributes.
+    // If a calculation involves both nullable and non-nullable columns, the final output should be a nullable column
+    Status update_build_not_ignore_null(const vectorized::VExprContextSPtrs& ctxs);
+
     /// init in both upstream side.
     //The i-th result expr list refers to the i-th child.
     std::vector<vectorized::VExprContextSPtrs> child_exprs_lists;

--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -114,6 +114,9 @@ Status SetProbeSinkLocalState<is_intersect>::init(RuntimeState* state, LocalSink
     }
     auto& child_exprs_lists = _shared_state->child_exprs_lists;
     child_exprs_lists[parent._cur_child_id] = _child_exprs;
+
+    RETURN_IF_ERROR(_shared_state->update_build_not_ignore_null(_child_exprs));
+
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/set_source_operator.cpp
+++ b/be/src/pipeline/exec/set_source_operator.cpp
@@ -51,6 +51,12 @@ Status SetSourceLocalState<is_intersect>::open(RuntimeState* state) {
     vector<bool> nullable_flags(column_nums, false);
     for (int i = 0; i < column_nums; ++i) {
         nullable_flags[i] = output_data_types[i]->is_nullable();
+        if (nullable_flags[i] != _shared_state->build_not_ignore_null[i]) {
+            return Status::InternalError(
+                    "SET operator expects a nullalbe : {} column in column {}, but the computed "
+                    "output is a nullable : {} column",
+                    nullable_flags[i], i, _shared_state->build_not_ignore_null[i]);
+        }
     }
 
     _left_table_data_types.clear();


### PR DESCRIPTION
## Proposed changes

There are some issues where planning problems lead to discrepancies between the nullable attribute of the computed column and the expected output column.

```
[INTERNAL_ERROR]SET operator expects a nullalbe : true column in column 0, but the computed output is a nullable : false column
```

<!--Describe your changes.-->

