### PR TITLE
[opt](assert_cast) Make assert cast do type check in release build by default

### DIFF
--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -36,6 +36,7 @@
 #include "util/crc32c.h"
 #include "util/debug_points.h"
 #include "util/doris_metrics.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/schema_util.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/jsonb/serialize.h"
@@ -1030,7 +1031,8 @@ Status BaseTablet::generate_new_block_for_partial_update(
                 if (rs_column.has_default_value()) {
                     mutable_column->insert_from(*mutable_default_value_columns[i].get(), 0);
                 } else if (rs_column.is_nullable()) {
-                    assert_cast<vectorized::ColumnNullable*>(mutable_column.get())
+                    assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                            mutable_column.get())
                             ->insert_null_elements(1);
                 } else {
                     mutable_column->insert_default();

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -1031,7 +1031,7 @@ Status BaseTablet::generate_new_block_for_partial_update(
                 if (rs_column.has_default_value()) {
                     mutable_column->insert_from(*mutable_default_value_columns[i].get(), 0);
                 } else if (rs_column.is_nullable()) {
-                    assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                    assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
                             mutable_column.get())
                             ->insert_null_elements(1);
                 } else {

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -1031,7 +1031,7 @@ Status BaseTablet::generate_new_block_for_partial_update(
                 if (rs_column.has_default_value()) {
                     mutable_column->insert_from(*mutable_default_value_columns[i].get(), 0);
                 } else if (rs_column.is_nullable()) {
-                    assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
+                    assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::DISABLE>(
                             mutable_column.get())
                             ->insert_null_elements(1);
                 } else {

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -25,6 +25,7 @@
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/predicate_column.h"
+#include "vec/common/assert_cast.h"
 #include "vec/exprs/vruntimefilter_wrapper.h"
 
 namespace doris {
@@ -69,13 +70,14 @@ private:
 
         uint16_t new_size = 0;
         if (column.is_column_dictionary()) {
-            const auto* dict_col = assert_cast<const vectorized::ColumnDictI32*>(&column);
+            const auto* dict_col =
+                    assert_cast<const vectorized::ColumnDictI32*, TypeCheck::Disable>(&column);
             new_size = _specific_filter->template find_dict_olap_engine<is_nullable>(
                     dict_col, null_map, sel, size);
         } else {
             const auto& data =
-                    assert_cast<const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*>(
-                            &column)
+                    assert_cast<const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*,
+                                TypeCheck::Disable>(&column)
                             ->get_data();
             new_size = _specific_filter->find_fixed_len_olap_engine((char*)data.data(), null_map,
                                                                     sel, size, data.size() != size);

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -70,15 +70,13 @@ private:
 
         uint16_t new_size = 0;
         if (column.is_column_dictionary()) {
-            const auto* dict_col =
-                    assert_cast<const vectorized::ColumnDictI32*, TypeCheckOnRelease::DISABLE>(
-                            &column);
+            const auto* dict_col = assert_cast<const vectorized::ColumnDictI32*>(&column);
             new_size = _specific_filter->template find_dict_olap_engine<is_nullable>(
                     dict_col, null_map, sel, size);
         } else {
             const auto& data =
-                    assert_cast<const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*,
-                                TypeCheckOnRelease::DISABLE>(&column)
+                    assert_cast<const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*>(
+                            &column)
                             ->get_data();
             new_size = _specific_filter->find_fixed_len_olap_engine((char*)data.data(), null_map,
                                                                     sel, size, data.size() != size);

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -71,13 +71,13 @@ private:
         uint16_t new_size = 0;
         if (column.is_column_dictionary()) {
             const auto* dict_col =
-                    assert_cast<const vectorized::ColumnDictI32*, TypeCheck::Disable>(&column);
+                    assert_cast<const vectorized::ColumnDictI32*, TypeCheckOnRelease::DISABLE>(&column);
             new_size = _specific_filter->template find_dict_olap_engine<is_nullable>(
                     dict_col, null_map, sel, size);
         } else {
             const auto& data =
                     assert_cast<const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*,
-                                TypeCheck::Disable>(&column)
+                                TypeCheckOnRelease::DISABLE>(&column)
                             ->get_data();
             new_size = _specific_filter->find_fixed_len_olap_engine((char*)data.data(), null_map,
                                                                     sel, size, data.size() != size);

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -71,7 +71,8 @@ private:
         uint16_t new_size = 0;
         if (column.is_column_dictionary()) {
             const auto* dict_col =
-                    assert_cast<const vectorized::ColumnDictI32*, TypeCheckOnRelease::DISABLE>(&column);
+                    assert_cast<const vectorized::ColumnDictI32*, TypeCheckOnRelease::DISABLE>(
+                            &column);
             new_size = _specific_filter->template find_dict_olap_engine<is_nullable>(
                     dict_col, null_map, sel, size);
         } else {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -360,8 +360,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             // not nullable to nullable
             if (new_col_nullable) {
                 auto* new_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::DISABLE>(
-                                new_col->assume_mutable().get());
+                        assert_cast<vectorized::ColumnNullable*>(new_col->assume_mutable().get());
 
                 new_nullable_col->change_nested_column(ref_col);
                 new_nullable_col->get_null_map_data().resize_fill(ref_col->size());
@@ -372,8 +371,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                 // the cast expr of schema change is `CastExpr(CAST String to Nullable(Int32))`,
                 // so need to handle nullable to not nullable here
                 auto* ref_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::DISABLE>(
-                                ref_col->assume_mutable().get());
+                        assert_cast<vectorized::ColumnNullable*>(ref_col->assume_mutable().get());
 
                 new_col = ref_nullable_col->get_nested_column_ptr();
             }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -360,7 +360,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             // not nullable to nullable
             if (new_col_nullable) {
                 auto* new_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
+                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::DISABLE>(
                                 new_col->assume_mutable().get());
 
                 new_nullable_col->change_nested_column(ref_col);
@@ -372,7 +372,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                 // the cast expr of schema change is `CastExpr(CAST String to Nullable(Int32))`,
                 // so need to handle nullable to not nullable here
                 auto* ref_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
+                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::DISABLE>(
                                 ref_col->assume_mutable().get());
 
                 new_col = ref_nullable_col->get_nested_column_ptr();

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -360,7 +360,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             // not nullable to nullable
             if (new_col_nullable) {
                 auto* new_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
                                 new_col->assume_mutable().get());
 
                 new_nullable_col->change_nested_column(ref_col);
@@ -372,7 +372,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                 // the cast expr of schema change is `CastExpr(CAST String to Nullable(Int32))`,
                 // so need to handle nullable to not nullable here
                 auto* ref_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                        assert_cast<vectorized::ColumnNullable*, TypeCheckOnRelease::Disable>(
                                 ref_col->assume_mutable().get());
 
                 new_col = ref_nullable_col->get_nested_column_ptr();

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -360,7 +360,8 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             // not nullable to nullable
             if (new_col_nullable) {
                 auto* new_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*>(new_col->assume_mutable().get());
+                        assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                                new_col->assume_mutable().get());
 
                 new_nullable_col->change_nested_column(ref_col);
                 new_nullable_col->get_null_map_data().resize_fill(ref_col->size());
@@ -371,7 +372,8 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                 // the cast expr of schema change is `CastExpr(CAST String to Nullable(Int32))`,
                 // so need to handle nullable to not nullable here
                 auto* ref_nullable_col =
-                        assert_cast<vectorized::ColumnNullable*>(ref_col->assume_mutable().get());
+                        assert_cast<vectorized::ColumnNullable*, TypeCheck::Disable>(
+                                ref_col->assume_mutable().get());
 
                 new_col = ref_nullable_col->get_nested_column_ptr();
             }

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -262,7 +262,7 @@ public:
                 }
                 auto iter = place_rows.begin();
                 while (iter != place_rows.end()) {
-                    assert_cast<const Derived*, TypeCheck::Disable>(this)->add_many(
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add_many(
                             iter->first, columns, iter->second, arena);
                     iter++;
                 }
@@ -271,7 +271,7 @@ public:
         }
 
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->add(places[i] + place_offset,
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(places[i] + place_offset,
                                                                        columns, i, arena);
         }
     }
@@ -280,7 +280,7 @@ public:
                             const IColumn** columns, Arena* arena) const override {
         for (size_t i = 0; i < batch_size; ++i) {
             if (places[i]) {
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->add(places[i] + place_offset,
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(places[i] + place_offset,
                                                                            columns, i, arena);
             }
         }
@@ -289,7 +289,7 @@ public:
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena* arena) const override {
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
         }
     }
     //now this is use for sum/count/avg/min/max win function, other win function should override this function in class
@@ -300,21 +300,21 @@ public:
         frame_start = std::max<int64_t>(frame_start, partition_start);
         frame_end = std::min<int64_t>(frame_end, partition_end);
         for (int64_t i = frame_start; i < frame_end; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
         }
     }
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena* arena, bool has_null) override {
         for (size_t i = batch_begin; i <= batch_end; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
         }
     }
 
     void insert_result_into_vec(const std::vector<AggregateDataPtr>& places, const size_t offset,
                                 IColumn& to, const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->insert_result_into(
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->insert_result_into(
                     places[i] + offset, to);
         }
     }
@@ -322,7 +322,7 @@ public:
     void serialize_vec(const std::vector<AggregateDataPtr>& places, size_t offset,
                        BufferWritable& buf, const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->serialize(places[i] + offset,
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(places[i] + offset,
                                                                              buf);
             buf.commit();
         }
@@ -338,11 +338,11 @@ public:
                                  const size_t num_rows, Arena* arena) const override {
         std::vector<char> place(size_of_data());
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->create(place.data());
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place.data());
             DEFER({ assert_cast<const Derived*>(this)->destroy(place.data()); });
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place.data(), columns, i,
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place.data(), columns, i,
                                                                        arena);
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->serialize(place.data(), buf);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(place.data(), buf);
             buf.commit();
         }
     }
@@ -367,13 +367,13 @@ public:
             try {
                 auto place = places + size_of_data * i;
                 VectorBufferReader buffer_reader(column->get_data_at(i));
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->create(place);
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->deserialize(
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(
                         place, buffer_reader, arena);
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = places + size_of_data * j;
-                    assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy(place);
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place);
                 }
                 throw;
             }
@@ -389,8 +389,8 @@ public:
             try {
                 auto rhs_place = rhs + size_of_data * i;
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->create(rhs_place);
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->deserialize_and_merge(
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
                         places[i] + offset, rhs_place, buffer_reader, arena);
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
@@ -400,7 +400,7 @@ public:
                 throw;
             }
         }
-        assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy_vec(rhs, num_rows);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy_vec(rhs, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
@@ -412,15 +412,15 @@ public:
             try {
                 auto rhs_place = rhs + size_of_data * i;
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->create(rhs_place);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
                 if (places[i]) {
-                    assert_cast<const Derived*, TypeCheck::Disable>(this)->deserialize_and_merge(
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
                             places[i] + offset, rhs_place, buffer_reader, arena);
                 }
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = rhs + size_of_data * j;
-                    assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy(place);
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place);
                 }
                 throw;
             }
@@ -437,7 +437,7 @@ public:
                    Arena* arena, const size_t num_rows) const override {
         const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->merge(
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(
                     places[i] + offset, rhs + size_of_data * i, arena);
         }
     }
@@ -448,7 +448,7 @@ public:
         const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
             if (places[i]) {
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->merge(
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(
                         places[i] + offset, rhs + size_of_data * i, arena);
             }
         }
@@ -463,12 +463,12 @@ public:
         auto* deserialized_place = (AggregateDataPtr)deserialized_data.data();
         for (size_t i = begin; i <= end; ++i) {
             VectorBufferReader buffer_reader(
-                    (assert_cast<const ColumnString&, TypeCheck::Disable>(column)).get_data_at(i));
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->create(deserialized_place);
+                    (assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column)).get_data_at(i));
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(deserialized_place);
             DEFER({
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy(deserialized_place);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(deserialized_place);
             });
-            assert_cast<const Derived*, TypeCheck::Disable>(this)->deserialize_and_merge(
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
                     place, deserialized_place, buffer_reader, arena);
         }
     }
@@ -483,8 +483,8 @@ public:
 
     void deserialize_and_merge(AggregateDataPtr __restrict place, AggregateDataPtr __restrict rhs,
                                BufferReadable& buf, Arena* arena) const override {
-        assert_cast<const Derived*, TypeCheck::Disable>(this)->deserialize(rhs, buf, arena);
-        assert_cast<const Derived*, TypeCheck::Disable>(this)->merge(place, rhs, arena);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(rhs, buf, arena);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(place, rhs, arena);
     }
 };
 

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -245,11 +245,12 @@ public:
 
     void add_batch(size_t batch_size, AggregateDataPtr* places, size_t place_offset,
                    const IColumn** columns, Arena* arena, bool agg_many) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
+
         if constexpr (std::is_same_v<Derived, AggregateFunctionBitmapCount<false, ColumnBitmap>> ||
                       std::is_same_v<Derived, AggregateFunctionBitmapCount<true, ColumnBitmap>> ||
                       std::is_same_v<Derived,
                                      AggregateFunctionBitmapOp<AggregateFunctionBitmapUnionOp>>) {
-            const Derived* derived = assert_cast<const Derived*>(this);
             if (agg_many) {
                 flat_hash_map<AggregateDataPtr, std::vector<int>> place_rows;
                 for (int i = 0; i < batch_size; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -271,8 +271,8 @@ public:
         }
 
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(places[i] + place_offset,
-                                                                       columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(
+                    places[i] + place_offset, columns, i, arena);
         }
     }
 
@@ -280,8 +280,8 @@ public:
                             const IColumn** columns, Arena* arena) const override {
         for (size_t i = 0; i < batch_size; ++i) {
             if (places[i]) {
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(places[i] + place_offset,
-                                                                           columns, i, arena);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(
+                        places[i] + place_offset, columns, i, arena);
             }
         }
     }
@@ -289,7 +289,8 @@ public:
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena* arena) const override {
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
+                                                                                arena);
         }
     }
     //now this is use for sum/count/avg/min/max win function, other win function should override this function in class
@@ -300,14 +301,16 @@ public:
         frame_start = std::max<int64_t>(frame_start, partition_start);
         frame_end = std::min<int64_t>(frame_end, partition_end);
         for (int64_t i = frame_start; i < frame_end; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
+                                                                                arena);
         }
     }
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena* arena, bool has_null) override {
         for (size_t i = batch_begin; i <= batch_end; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
+                                                                                arena);
         }
     }
 
@@ -322,8 +325,8 @@ public:
     void serialize_vec(const std::vector<AggregateDataPtr>& places, size_t offset,
                        BufferWritable& buf, const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(places[i] + offset,
-                                                                             buf);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(
+                    places[i] + offset, buf);
             buf.commit();
         }
     }
@@ -340,9 +343,10 @@ public:
         for (size_t i = 0; i != num_rows; ++i) {
             assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place.data());
             DEFER({ assert_cast<const Derived*>(this)->destroy(place.data()); });
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place.data(), columns, i,
-                                                                       arena);
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(place.data(), buf);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place.data(),
+                                                                                columns, i, arena);
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(place.data(),
+                                                                                      buf);
             buf.commit();
         }
     }
@@ -390,8 +394,9 @@ public:
                 auto rhs_place = rhs + size_of_data * i;
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
                 assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
-                        places[i] + offset, rhs_place, buffer_reader, arena);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)
+                        ->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader,
+                                                arena);
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = rhs + size_of_data * j;
@@ -414,8 +419,9 @@ public:
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
                 assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
                 if (places[i]) {
-                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
-                            places[i] + offset, rhs_place, buffer_reader, arena);
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)
+                            ->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader,
+                                                    arena);
                 }
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
@@ -463,10 +469,13 @@ public:
         auto* deserialized_place = (AggregateDataPtr)deserialized_data.data();
         for (size_t i = begin; i <= end; ++i) {
             VectorBufferReader buffer_reader(
-                    (assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column)).get_data_at(i));
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(deserialized_place);
+                    (assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column))
+                            .get_data_at(i));
+            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(
+                    deserialized_place);
             DEFER({
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(deserialized_place);
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(
+                        deserialized_place);
             });
             assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
                     place, deserialized_place, buffer_reader, arena);
@@ -483,7 +492,8 @@ public:
 
     void deserialize_and_merge(AggregateDataPtr __restrict place, AggregateDataPtr __restrict rhs,
                                BufferReadable& buf, Arena* arena) const override {
-        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(rhs, buf, arena);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(rhs, buf,
+                                                                                    arena);
         assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(place, rhs, arena);
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -237,8 +237,9 @@ public:
     void destroy_vec(AggregateDataPtr __restrict place,
                      const size_t num_rows) const noexcept override {
         const size_t size_of_data_ = size_of_data();
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*>(this)->destroy(place + size_of_data_ * i);
+            derived->destroy(place + size_of_data_ * i);
         }
     }
 
@@ -248,6 +249,7 @@ public:
                       std::is_same_v<Derived, AggregateFunctionBitmapCount<true, ColumnBitmap>> ||
                       std::is_same_v<Derived,
                                      AggregateFunctionBitmapOp<AggregateFunctionBitmapUnionOp>>) {
+            const Derived* derived = assert_cast<const Derived*>(this);
             if (agg_many) {
                 flat_hash_map<AggregateDataPtr, std::vector<int>> place_rows;
                 for (int i = 0; i < batch_size; ++i) {
@@ -262,8 +264,7 @@ public:
                 }
                 auto iter = place_rows.begin();
                 while (iter != place_rows.end()) {
-                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add_many(
-                            iter->first, columns, iter->second, arena);
+                    derived->add_many(iter->first, columns, iter->second, arena);
                     iter++;
                 }
                 return;
@@ -271,26 +272,25 @@ public:
         }
 
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(
-                    places[i] + place_offset, columns, i, arena);
+            derived->add(places[i] + place_offset, columns, i, arena);
         }
     }
 
     void add_batch_selected(size_t batch_size, AggregateDataPtr* places, size_t place_offset,
                             const IColumn** columns, Arena* arena) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i < batch_size; ++i) {
             if (places[i]) {
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(
-                        places[i] + place_offset, columns, i, arena);
+                derived->add(places[i] + place_offset, columns, i, arena);
             }
         }
     }
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena* arena) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i < batch_size; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
-                                                                                arena);
+            derived->add(place, columns, i, arena);
         }
     }
     //now this is use for sum/count/avg/min/max win function, other win function should override this function in class
@@ -298,35 +298,35 @@ public:
     void add_range_single_place(int64_t partition_start, int64_t partition_end, int64_t frame_start,
                                 int64_t frame_end, AggregateDataPtr place, const IColumn** columns,
                                 Arena* arena) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         frame_start = std::max<int64_t>(frame_start, partition_start);
         frame_end = std::min<int64_t>(frame_end, partition_end);
         for (int64_t i = frame_start; i < frame_end; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
-                                                                                arena);
+            derived->add(place, columns, i, arena);
         }
     }
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena* arena, bool has_null) override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = batch_begin; i <= batch_end; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
-                                                                                arena);
+            derived->add(place, columns, i, arena);
         }
     }
 
     void insert_result_into_vec(const std::vector<AggregateDataPtr>& places, const size_t offset,
                                 IColumn& to, const size_t num_rows) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->insert_result_into(
-                    places[i] + offset, to);
+            derived->insert_result_into(places[i] + offset, to);
         }
     }
 
     void serialize_vec(const std::vector<AggregateDataPtr>& places, size_t offset,
                        BufferWritable& buf, const size_t num_rows) const override {
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(
-                    places[i] + offset, buf);
+            derived->serialize(places[i] + offset, buf);
             buf.commit();
         }
     }
@@ -340,13 +340,12 @@ public:
     void streaming_agg_serialize(const IColumn** columns, BufferWritable& buf,
                                  const size_t num_rows, Arena* arena) const override {
         std::vector<char> place(size_of_data());
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place.data());
-            DEFER({ assert_cast<const Derived*>(this)->destroy(place.data()); });
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place.data(),
-                                                                                columns, i, arena);
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->serialize(place.data(),
-                                                                                      buf);
+            derived->create(place.data());
+            DEFER({ derived->destroy(place.data()); });
+            derived->add(place.data(), columns, i, arena);
+            derived->serialize(place.data(), buf);
             buf.commit();
         }
     }
@@ -366,18 +365,18 @@ public:
 
     void deserialize_vec(AggregateDataPtr places, const ColumnString* column, Arena* arena,
                          size_t num_rows) const override {
-        const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
+        const Derived* derived = assert_cast<const Derived*>(this);
+        const auto size_of_data = derived->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
             try {
                 auto place = places + size_of_data * i;
                 VectorBufferReader buffer_reader(column->get_data_at(i));
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place);
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(
-                        place, buffer_reader, arena);
+                derived->create(place);
+                derived->deserialize(place, buffer_reader, arena);
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = places + size_of_data * j;
-                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place);
+                    derived->destroy(place);
                 }
                 throw;
             }
@@ -387,51 +386,52 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena* arena,
                                    const size_t num_rows) const override {
-        const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
+        const Derived* derived = assert_cast<const Derived*>(this);
+        const auto size_of_data = derived->size_of_data();
         const auto* column_string = assert_cast<const ColumnString*>(column);
+
         for (size_t i = 0; i != num_rows; ++i) {
             try {
                 auto rhs_place = rhs + size_of_data * i;
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)
-                        ->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader,
-                                                arena);
+                derived->create(rhs_place);
+                derived->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader, arena);
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = rhs + size_of_data * j;
-                    assert_cast<const Derived*>(this)->destroy(place);
+                    derived->destroy(place);
                 }
                 throw;
             }
         }
-        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy_vec(rhs, num_rows);
+
+        derived->destroy_vec(rhs, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena* arena, const size_t num_rows) const override {
-        const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
+        const auto* derived = assert_cast<const Derived*>(this);
+        const auto size_of_data = derived->size_of_data();
         const auto* column_string = assert_cast<const ColumnString*>(column);
         for (size_t i = 0; i != num_rows; ++i) {
             try {
                 auto rhs_place = rhs + size_of_data * i;
                 VectorBufferReader buffer_reader(column_string->get_data_at(i));
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(rhs_place);
+                derived->create(rhs_place);
                 if (places[i]) {
-                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)
-                            ->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader,
-                                                    arena);
+                    derived->deserialize_and_merge(places[i] + offset, rhs_place, buffer_reader,
+                                                   arena);
                 }
             } catch (...) {
                 for (int j = 0; j < i; ++j) {
                     auto place = rhs + size_of_data * j;
-                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place);
+                    derived->destroy(place);
                 }
                 throw;
             }
         }
-        assert_cast<const Derived*>(this)->destroy_vec(rhs, num_rows);
+        derived->destroy_vec(rhs, num_rows);
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena* arena,
@@ -441,21 +441,21 @@ public:
 
     void merge_vec(const AggregateDataPtr* places, size_t offset, ConstAggregateDataPtr rhs,
                    Arena* arena, const size_t num_rows) const override {
-        const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
+        const auto* derived = assert_cast<const Derived*>(this);
+        const auto size_of_data = derived->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(
-                    places[i] + offset, rhs + size_of_data * i, arena);
+            derived->merge(places[i] + offset, rhs + size_of_data * i, arena);
         }
     }
 
     void merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                             ConstAggregateDataPtr rhs, Arena* arena,
                             const size_t num_rows) const override {
-        const auto size_of_data = assert_cast<const Derived*>(this)->size_of_data();
+        const auto* derived = assert_cast<const Derived*>(this);
+        const auto size_of_data = derived->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
             if (places[i]) {
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(
-                        places[i] + offset, rhs + size_of_data * i, arena);
+                derived->merge(places[i] + offset, rhs + size_of_data * i, arena);
             }
         }
     }
@@ -467,18 +467,15 @@ public:
                 << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
         std::vector<char> deserialized_data(size_of_data());
         auto* deserialized_place = (AggregateDataPtr)deserialized_data.data();
+        const ColumnString& column_string = assert_cast<const ColumnString&>(column);
+        const Derived* derived = assert_cast<const Derived*>(this);
         for (size_t i = begin; i <= end; ++i) {
-            VectorBufferReader buffer_reader(
-                    (assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column))
-                            .get_data_at(i));
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(
-                    deserialized_place);
-            DEFER({
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(
-                        deserialized_place);
-            });
-            assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize_and_merge(
-                    place, deserialized_place, buffer_reader, arena);
+            VectorBufferReader buffer_reader(column_string.get_data_at(i));
+            derived->create(deserialized_place);
+
+            DEFER({ derived->destroy(deserialized_place); });
+
+            derived->deserialize_and_merge(place, deserialized_place, buffer_reader, arena);
         }
     }
 
@@ -531,8 +528,9 @@ public:
 
     void deserialize_and_merge(AggregateDataPtr __restrict place, AggregateDataPtr __restrict rhs,
                                BufferReadable& buf, Arena* arena) const override {
-        assert_cast<const Derived*>(this)->deserialize(rhs, buf, arena);
-        assert_cast<const Derived*>(this)->merge(place, rhs, arena);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->deserialize(rhs, buf,
+                                                                                    arena);
+        assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->merge(place, rhs, arena);
     }
 };
 

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -100,12 +100,12 @@ public:
              Arena*) const override {
         if constexpr (IsFixLenColumnType<ColumnDataType>::value) {
             auto column =
-                    assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0]);
+                    assert_cast<const ColumnDataType*, TypeCheckOnRelease::DISABLE>(columns[0]);
             auto value = column->get_element(row_num);
             this->data(place).add(
                     HashUtil::murmur_hash64A((char*)&value, sizeof(value), HashUtil::MURMUR_SEED));
         } else {
-            auto value = assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0])
+            auto value = assert_cast<const ColumnDataType*, TypeCheckOnRelease::DISABLE>(columns[0])
                                  ->get_data_at(row_num);
             uint64_t hash_value =
                     HashUtil::murmur_hash64A(value.data, value.size, HashUtil::MURMUR_SEED);

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -99,7 +99,8 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         if constexpr (IsFixLenColumnType<ColumnDataType>::value) {
-            auto column = assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0]);
+            auto column =
+                    assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0]);
             auto value = column->get_element(row_num);
             this->data(place).add(
                     HashUtil::murmur_hash64A((char*)&value, sizeof(value), HashUtil::MURMUR_SEED));

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -31,6 +31,7 @@
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
@@ -98,12 +99,13 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         if constexpr (IsFixLenColumnType<ColumnDataType>::value) {
-            auto column = assert_cast<const ColumnDataType*>(columns[0]);
+            auto column = assert_cast<const ColumnDataType*, TypeCheck::Disable>(columns[0]);
             auto value = column->get_element(row_num);
             this->data(place).add(
                     HashUtil::murmur_hash64A((char*)&value, sizeof(value), HashUtil::MURMUR_SEED));
         } else {
-            auto value = assert_cast<const ColumnDataType*>(columns[0])->get_data_at(row_num);
+            auto value = assert_cast<const ColumnDataType*, TypeCheck::Disable>(columns[0])
+                                 ->get_data_at(row_num);
             uint64_t hash_value =
                     HashUtil::murmur_hash64A(value.data, value.size, HashUtil::MURMUR_SEED);
             this->data(place).add(hash_value);

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -99,12 +99,12 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         if constexpr (IsFixLenColumnType<ColumnDataType>::value) {
-            auto column = assert_cast<const ColumnDataType*, TypeCheck::Disable>(columns[0]);
+            auto column = assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0]);
             auto value = column->get_element(row_num);
             this->data(place).add(
                     HashUtil::murmur_hash64A((char*)&value, sizeof(value), HashUtil::MURMUR_SEED));
         } else {
-            auto value = assert_cast<const ColumnDataType*, TypeCheck::Disable>(columns[0])
+            auto value = assert_cast<const ColumnDataType*, TypeCheckOnRelease::Disable>(columns[0])
                                  ->get_data_at(row_num);
             uint64_t hash_value =
                     HashUtil::murmur_hash64A(value.data, value.size, HashUtil::MURMUR_SEED);

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -145,7 +145,8 @@ public:
 #ifdef __clang__
 #pragma clang fp reassociate(on)
 #endif
-        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         if constexpr (IsDecimalNumber<T>) {
             this->data(place).sum += column.get_data()[row_num].value;
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -145,7 +145,7 @@ public:
 #ifdef __clang__
 #pragma clang fp reassociate(on)
 #endif
-        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         if constexpr (IsDecimalNumber<T>) {
             this->data(place).sum += column.get_data()[row_num].value;
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -145,7 +145,7 @@ public:
 #ifdef __clang__
 #pragma clang fp reassociate(on)
 #endif
-        const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
         if constexpr (IsDecimalNumber<T>) {
             this->data(place).sum += column.get_data()[row_num].value;
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
@@ -108,8 +108,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
-        const auto& weight = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& weight = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         this->data(place).add(column.get_data()[row_num], weight.get_element(row_num));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
@@ -108,8 +108,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&>(*columns[0]);
-        const auto& weight = assert_cast<const ColumnFloat64&>(*columns[1]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& weight = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
         this->data(place).add(column.get_data()[row_num], weight.get_element(row_num));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
@@ -108,8 +108,10 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
-        const auto& weight = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+        const auto& column =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& weight =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         this->data(place).add(column.get_data()[row_num], weight.get_element(row_num));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.h
@@ -115,7 +115,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/common/assert_cast.h"
 #include "vec/core/types.h"
 #include "vec/io/io_helper.h"
 
@@ -114,7 +115,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColumnVector<T>&>(*columns[0]);
+        const auto& column = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.h
@@ -116,7 +116,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& column =
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.h
@@ -115,7 +115,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -167,9 +167,11 @@ public:
             auto* data = col.get_data().data();
             for (size_t i = 0; i != num_rows; ++i) {
                 assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place);
-                DEFER({ assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place); });
-                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
-                                                                           arena);
+                DEFER({
+                    assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place);
+                });
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns,
+                                                                                    i, arena);
                 data[i] = std::move(this->data(place).value);
             }
         } else {
@@ -305,7 +307,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 
@@ -373,7 +376,8 @@ public:
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -166,9 +166,10 @@ public:
             col.resize(num_rows);
             auto* data = col.get_data().data();
             for (size_t i = 0; i != num_rows; ++i) {
-                assert_cast<const Derived*>(this)->create(place);
-                DEFER({ assert_cast<const Derived*>(this)->destroy(place); });
-                assert_cast<const Derived*>(this)->add(place, columns, i, arena);
+                assert_cast<const Derived*, TypeCheck::Disable>(this)->create(place);
+                DEFER({ assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy(place); });
+                assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place, columns, i,
+                                                                           arena);
                 data[i] = std::move(this->data(place).value);
             }
         } else {
@@ -304,7 +305,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 
@@ -367,12 +368,12 @@ public:
         if constexpr (arg_is_nullable) {
             auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
-                const auto& column =
-                        assert_cast<const ColVecType&>(nullable_column.get_nested_column());
+                const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                        nullable_column.get_nested_column());
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -166,9 +166,9 @@ public:
             col.resize(num_rows);
             auto* data = col.get_data().data();
             for (size_t i = 0; i != num_rows; ++i) {
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->create(place);
-                DEFER({ assert_cast<const Derived*, TypeCheck::Disable>(this)->destroy(place); });
-                assert_cast<const Derived*, TypeCheck::Disable>(this)->add(place, columns, i,
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->create(place);
+                DEFER({ assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->destroy(place); });
+                assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)->add(place, columns, i,
                                                                            arena);
                 data[i] = std::move(this->data(place).value);
             }
@@ -305,7 +305,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(column.get_data()[row_num]);
     }
 
@@ -368,12 +368,12 @@ public:
         if constexpr (arg_is_nullable) {
             auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
-                const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         nullable_column.get_nested_column());
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
@@ -76,15 +76,15 @@ public:
         DCHECK_LT(row_num, columns[0]->size());
         if constexpr (arg_nullable) {
             auto& nullable_col =
-                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             auto& nullable_map = nullable_col.get_null_map_data();
             if (!nullable_map[row_num]) {
-                auto& col = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                auto& col = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         nullable_col.get_nested_column());
                 this->data(place).add(col.get_data()[row_num]);
             }
         } else {
-            auto& col = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+            auto& col = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             this->data(place).add(col.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
@@ -27,6 +27,7 @@
 
 #include "util/bitmap_value.h"
 #include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/common/assert_cast.h"
 #include "vec/data_types/data_type_bitmap.h"
 
 namespace doris {
@@ -74,14 +75,16 @@ public:
              Arena* arena) const override {
         DCHECK_LT(row_num, columns[0]->size());
         if constexpr (arg_nullable) {
-            auto& nullable_col = assert_cast<const ColumnNullable&>(*columns[0]);
+            auto& nullable_col =
+                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
             auto& nullable_map = nullable_col.get_null_map_data();
             if (!nullable_map[row_num]) {
-                auto& col = assert_cast<const ColVecType&>(nullable_col.get_nested_column());
+                auto& col = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                        nullable_col.get_nested_column());
                 this->data(place).add(col.get_data()[row_num]);
             }
         } else {
-            auto& col = assert_cast<const ColVecType&>(*columns[0]);
+            auto& col = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
             this->data(place).add(col.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -69,8 +69,8 @@ struct AggregateFunctionCollectSetData {
     size_t size() const { return data_set.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        data_set.insert(
-                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data()[row_num]);
+        data_set.insert(assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column)
+                                .get_data()[row_num]);
     }
 
     void merge(const SelfType& rhs) {
@@ -192,7 +192,8 @@ struct AggregateFunctionCollectListData {
     size_t size() const { return data.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& vec = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data();
+        const auto& vec =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data();
         data.push_back(vec[row_num]);
     }
 
@@ -432,8 +433,8 @@ struct AggregateFunctionArrayAggData<StringRef> {
 
     void add(const IColumn& column, size_t row_num) {
         const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(column);
-        const auto& vec =
-                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(col.get_nested_column());
+        const auto& vec = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
+                col.get_nested_column());
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->insert_from(vec, row_num);
         DCHECK(null_map->size() == nested_column->size());
@@ -567,7 +568,8 @@ public:
         if constexpr (HasLimit::value) {
             if (data.max_size == -1) {
                 data.max_size =
-                        (UInt64)assert_cast<const ColumnInt32*, TypeCheckOnRelease::Disable>(columns[1])
+                        (UInt64)assert_cast<const ColumnInt32*, TypeCheckOnRelease::Disable>(
+                                columns[1])
                                 ->get_element(row_num);
             }
             if (data.size() >= data.max_size) {
@@ -720,8 +722,9 @@ public:
                 if constexpr (std::is_same_v<StringRef, typename Data::ElementType>) {
                     auto& vec = assert_cast<ColumnString&, TypeCheckOnRelease::Disable>(
                             col_null->get_nested_column());
-                    const auto& vec_src = assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(
-                            col_src.get_nested_column());
+                    const auto& vec_src =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(
+                                    col_src.get_nested_column());
                     vec.insert_from(vec_src, i);
                 } else {
                     using ColVecType = ColumnVectorOrDecimal<typename Data::ElementType>;

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -70,7 +70,7 @@ struct AggregateFunctionCollectSetData {
 
     void add(const IColumn& column, size_t row_num) {
         data_set.insert(
-                assert_cast<const ColVecType&, TypeCheck::Disable>(column).get_data()[row_num]);
+                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data()[row_num]);
     }
 
     void merge(const SelfType& rhs) {
@@ -192,7 +192,7 @@ struct AggregateFunctionCollectListData {
     size_t size() const { return data.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& vec = assert_cast<const ColVecType&, TypeCheck::Disable>(column).get_data();
+        const auto& vec = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data();
         data.push_back(vec[row_num]);
     }
 
@@ -259,7 +259,7 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
 
             data->insert_range_from(
                     *rhs.data, 0,
-                    std::min(assert_cast<size_t, TypeCheck::Disable>(max_size - size()),
+                    std::min(assert_cast<size_t, TypeCheckOnRelease::Disable>(max_size - size()),
                              rhs.size()));
         } else {
             data->insert_range_from(*rhs.data, 0, rhs.size());
@@ -329,9 +329,9 @@ struct AggregateFunctionArrayAggData {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&, TypeCheck::Disable>(column);
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(column);
         const auto& vec =
-                assert_cast<const ColVecType&, TypeCheck::Disable>(col.get_nested_column())
+                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(col.get_nested_column())
                         .get_data();
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->get_data().push_back(vec[row_num]);
@@ -431,9 +431,9 @@ struct AggregateFunctionArrayAggData<StringRef> {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&, TypeCheck::Disable>(column);
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(column);
         const auto& vec =
-                assert_cast<const ColVecType&, TypeCheck::Disable>(col.get_nested_column());
+                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(col.get_nested_column());
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->insert_from(vec, row_num);
         DCHECK(null_map->size() == nested_column->size());
@@ -567,7 +567,7 @@ public:
         if constexpr (HasLimit::value) {
             if (data.max_size == -1) {
                 data.max_size =
-                        (UInt64)assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                        (UInt64)assert_cast<const ColumnInt32*, TypeCheckOnRelease::Disable>(columns[1])
                                 ->get_element(row_num);
             }
             if (data.size() >= data.max_size) {
@@ -718,17 +718,17 @@ public:
             for (size_t i = 0; i < num_rows; ++i) {
                 col_null->get_null_map_data().push_back(col_src.get_null_map_data()[i]);
                 if constexpr (std::is_same_v<StringRef, typename Data::ElementType>) {
-                    auto& vec = assert_cast<ColumnString&, TypeCheck::Disable>(
+                    auto& vec = assert_cast<ColumnString&, TypeCheckOnRelease::Disable>(
                             col_null->get_nested_column());
-                    const auto& vec_src = assert_cast<const ColumnString&, TypeCheck::Disable>(
+                    const auto& vec_src = assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(
                             col_src.get_nested_column());
                     vec.insert_from(vec_src, i);
                 } else {
                     using ColVecType = ColumnVectorOrDecimal<typename Data::ElementType>;
-                    auto& vec = assert_cast<ColVecType&, TypeCheck::Disable>(
+                    auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(
                                         col_null->get_nested_column())
                                         .get_data();
-                    auto& vec_src = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                    auto& vec_src = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
                                             col_src.get_nested_column())
                                             .get_data();
                     vec.push_back(vec_src[i]);

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -69,7 +69,7 @@ struct AggregateFunctionCollectSetData {
     size_t size() const { return data_set.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        data_set.insert(assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column)
+        data_set.insert(assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(column)
                                 .get_data()[row_num]);
     }
 
@@ -193,7 +193,7 @@ struct AggregateFunctionCollectListData {
 
     void add(const IColumn& column, size_t row_num) {
         const auto& vec =
-                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(column).get_data();
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(column).get_data();
         data.push_back(vec[row_num]);
     }
 
@@ -260,7 +260,7 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
 
             data->insert_range_from(
                     *rhs.data, 0,
-                    std::min(assert_cast<size_t, TypeCheckOnRelease::Disable>(max_size - size()),
+                    std::min(assert_cast<size_t, TypeCheckOnRelease::DISABLE>(max_size - size()),
                              rhs.size()));
         } else {
             data->insert_range_from(*rhs.data, 0, rhs.size());
@@ -330,9 +330,9 @@ struct AggregateFunctionArrayAggData {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(column);
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(column);
         const auto& vec =
-                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(col.get_nested_column())
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(col.get_nested_column())
                         .get_data();
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->get_data().push_back(vec[row_num]);
@@ -432,8 +432,8 @@ struct AggregateFunctionArrayAggData<StringRef> {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(column);
-        const auto& vec = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(column);
+        const auto& vec = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                 col.get_nested_column());
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->insert_from(vec, row_num);
@@ -568,7 +568,7 @@ public:
         if constexpr (HasLimit::value) {
             if (data.max_size == -1) {
                 data.max_size =
-                        (UInt64)assert_cast<const ColumnInt32*, TypeCheckOnRelease::Disable>(
+                        (UInt64)assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(
                                 columns[1])
                                 ->get_element(row_num);
             }
@@ -720,18 +720,18 @@ public:
             for (size_t i = 0; i < num_rows; ++i) {
                 col_null->get_null_map_data().push_back(col_src.get_null_map_data()[i]);
                 if constexpr (std::is_same_v<StringRef, typename Data::ElementType>) {
-                    auto& vec = assert_cast<ColumnString&, TypeCheckOnRelease::Disable>(
+                    auto& vec = assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(
                             col_null->get_nested_column());
                     const auto& vec_src =
-                            assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
                                     col_src.get_nested_column());
                     vec.insert_from(vec_src, i);
                 } else {
                     using ColVecType = ColumnVectorOrDecimal<typename Data::ElementType>;
-                    auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(
+                    auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(
                                         col_null->get_nested_column())
                                         .get_data();
-                    auto& vec_src = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
+                    auto& vec_src = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                                             col_src.get_nested_column())
                                             .get_data();
                     vec.push_back(vec_src[i]);

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -69,7 +69,8 @@ struct AggregateFunctionCollectSetData {
     size_t size() const { return data_set.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        data_set.insert(assert_cast<const ColVecType&>(column).get_data()[row_num]);
+        data_set.insert(
+                assert_cast<const ColVecType&, TypeCheck::Disable>(column).get_data()[row_num]);
     }
 
     void merge(const SelfType& rhs) {
@@ -191,7 +192,7 @@ struct AggregateFunctionCollectListData {
     size_t size() const { return data.size(); }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& vec = assert_cast<const ColVecType&>(column).get_data();
+        const auto& vec = assert_cast<const ColVecType&, TypeCheck::Disable>(column).get_data();
         data.push_back(vec[row_num]);
     }
 
@@ -256,8 +257,10 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
             }
             max_size = rhs.max_size;
 
-            data->insert_range_from(*rhs.data, 0,
-                                    std::min(assert_cast<size_t>(max_size - size()), rhs.size()));
+            data->insert_range_from(
+                    *rhs.data, 0,
+                    std::min(assert_cast<size_t, TypeCheck::Disable>(max_size - size()),
+                             rhs.size()));
         } else {
             data->insert_range_from(*rhs.data, 0, rhs.size());
         }
@@ -326,8 +329,10 @@ struct AggregateFunctionArrayAggData {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&>(column);
-        const auto& vec = assert_cast<const ColVecType&>(col.get_nested_column()).get_data();
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheck::Disable>(column);
+        const auto& vec =
+                assert_cast<const ColVecType&, TypeCheck::Disable>(col.get_nested_column())
+                        .get_data();
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->get_data().push_back(vec[row_num]);
         DCHECK(null_map->size() == nested_column->size());
@@ -426,8 +431,9 @@ struct AggregateFunctionArrayAggData<StringRef> {
     }
 
     void add(const IColumn& column, size_t row_num) {
-        const auto& col = assert_cast<const ColumnNullable&>(column);
-        const auto& vec = assert_cast<const ColVecType&>(col.get_nested_column());
+        const auto& col = assert_cast<const ColumnNullable&, TypeCheck::Disable>(column);
+        const auto& vec =
+                assert_cast<const ColVecType&, TypeCheck::Disable>(col.get_nested_column());
         null_map->push_back(col.get_null_map_data()[row_num]);
         nested_column->insert_from(vec, row_num);
         DCHECK(null_map->size() == nested_column->size());
@@ -561,7 +567,8 @@ public:
         if constexpr (HasLimit::value) {
             if (data.max_size == -1) {
                 data.max_size =
-                        (UInt64)assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num);
+                        (UInt64)assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                                ->get_element(row_num);
             }
             if (data.size() >= data.max_size) {
                 return;
@@ -711,15 +718,19 @@ public:
             for (size_t i = 0; i < num_rows; ++i) {
                 col_null->get_null_map_data().push_back(col_src.get_null_map_data()[i]);
                 if constexpr (std::is_same_v<StringRef, typename Data::ElementType>) {
-                    auto& vec = assert_cast<ColumnString&>(col_null->get_nested_column());
-                    const auto& vec_src =
-                            assert_cast<const ColumnString&>(col_src.get_nested_column());
+                    auto& vec = assert_cast<ColumnString&, TypeCheck::Disable>(
+                            col_null->get_nested_column());
+                    const auto& vec_src = assert_cast<const ColumnString&, TypeCheck::Disable>(
+                            col_src.get_nested_column());
                     vec.insert_from(vec_src, i);
                 } else {
                     using ColVecType = ColumnVectorOrDecimal<typename Data::ElementType>;
-                    auto& vec = assert_cast<ColVecType&>(col_null->get_nested_column()).get_data();
-                    auto& vec_src =
-                            assert_cast<const ColVecType&>(col_src.get_nested_column()).get_data();
+                    auto& vec = assert_cast<ColVecType&, TypeCheck::Disable>(
+                                        col_null->get_nested_column())
+                                        .get_data();
+                    auto& vec_src = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                                            col_src.get_nested_column())
+                                            .get_data();
                     vec.push_back(vec_src[i]);
                 }
                 to_arr.get_offsets().push_back(to_nested_col.size());

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -197,7 +197,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         data(place).count +=
-                !assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0])
+                !assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0])
                          .is_null_at(row_num);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -196,7 +196,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        data(place).count += !assert_cast<const ColumnNullable&>(*columns[0]).is_null_at(row_num);
+        data(place).count += !assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0])
+                                      .is_null_at(row_num);
     }
 
     void reset(AggregateDataPtr place) const override { data(place).count = 0; }

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -196,7 +196,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        data(place).count += !assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0])
+        data(place).count += !assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0])
                                       .is_null_at(row_num);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -196,8 +196,9 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        data(place).count += !assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0])
-                                      .is_null_at(row_num);
+        data(place).count +=
+                !assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0])
+                         .is_null_at(row_num);
     }
 
     void reset(AggregateDataPtr place) const override { data(place).count = 0; }

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -107,9 +107,9 @@ struct BaseData {
     }
 
     void add(const IColumn* column_x, const IColumn* column_y, size_t row_num) {
-        const auto& sources_x = assert_cast<const ColumnVector<T>&>(*column_x);
+        const auto& sources_x = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column_x);
         double source_data_x = sources_x.get_data()[row_num];
-        const auto& sources_y = assert_cast<const ColumnVector<T>&>(*column_y);
+        const auto& sources_y = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column_y);
         double source_data_y = sources_y.get_data()[row_num];
 
         sum_x += source_data_x;
@@ -186,7 +186,7 @@ struct BaseDatadecimal {
     }
 
     DecimalV2Value get_source_data(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnDecimal<T>&>(*column);
+        const auto& sources = assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(*column);
         Field field = sources[row_num];
         auto decimal_field = field.template get<DecimalField<T>>();
         int128_t value;

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -107,9 +107,11 @@ struct BaseData {
     }
 
     void add(const IColumn* column_x, const IColumn* column_y, size_t row_num) {
-        const auto& sources_x = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_x);
+        const auto& sources_x =
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_x);
         double source_data_x = sources_x.get_data()[row_num];
-        const auto& sources_y = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_y);
+        const auto& sources_y =
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_y);
         double source_data_y = sources_y.get_data()[row_num];
 
         sum_x += source_data_x;
@@ -186,7 +188,8 @@ struct BaseDatadecimal {
     }
 
     DecimalV2Value get_source_data(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(*column);
+        const auto& sources =
+                assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(*column);
         Field field = sources[row_num];
         auto decimal_field = field.template get<DecimalField<T>>();
         int128_t value;

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -107,9 +107,9 @@ struct BaseData {
     }
 
     void add(const IColumn* column_x, const IColumn* column_y, size_t row_num) {
-        const auto& sources_x = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column_x);
+        const auto& sources_x = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_x);
         double source_data_x = sources_x.get_data()[row_num];
-        const auto& sources_y = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column_y);
+        const auto& sources_y = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column_y);
         double source_data_y = sources_y.get_data()[row_num];
 
         sum_x += source_data_x;
@@ -186,7 +186,7 @@ struct BaseDatadecimal {
     }
 
     DecimalV2Value get_source_data(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(*column);
+        const auto& sources = assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(*column);
         Field field = sources[row_num];
         auto decimal_field = field.template get<DecimalField<T>>();
         int128_t value;

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -66,7 +66,7 @@ struct AggregateFunctionDistinctSingleNumericData {
 
     void add(const IColumn** columns, size_t /* columns_num */, size_t row_num, Arena*) {
         const auto& vec =
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0])
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*columns[0])
                         .get_data();
         if constexpr (stable) {
             data.emplace(vec[row_num], data.size());

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -66,7 +66,7 @@ struct AggregateFunctionDistinctSingleNumericData {
 
     void add(const IColumn** columns, size_t /* columns_num */, size_t row_num, Arena*) {
         const auto& vec =
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*columns[0]).get_data();
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]).get_data();
         if constexpr (stable) {
             data.emplace(vec[row_num], data.size());
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -66,7 +66,8 @@ struct AggregateFunctionDistinctSingleNumericData {
 
     void add(const IColumn** columns, size_t /* columns_num */, size_t row_num, Arena*) {
         const auto& vec =
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0]).get_data();
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*columns[0])
+                        .get_data();
         if constexpr (stable) {
             data.emplace(vec[row_num], data.size());
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -65,7 +65,8 @@ struct AggregateFunctionDistinctSingleNumericData {
     Container data;
 
     void add(const IColumn** columns, size_t /* columns_num */, size_t row_num, Arena*) {
-        const auto& vec = assert_cast<const ColumnVector<T>&>(*columns[0]).get_data();
+        const auto& vec =
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*columns[0]).get_data();
         if constexpr (stable) {
             data.emplace(vec[row_num], data.size());
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -229,11 +229,11 @@ public:
 
         for (size_t i = 0; i < num_arguments; ++i) {
             nested[i] =
-                    &assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[i]).get_data();
+                    &assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i]).get_data();
         }
 
         const auto& first_array_column =
-                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
+                assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[0]);
         const auto& offsets = first_array_column.get_offsets();
 
         size_t begin = offsets[row_num - 1];
@@ -242,7 +242,7 @@ public:
         /// Sanity check. NOTE We can implement specialization for a case with single argument, if the check will hurt performance.
         for (size_t i = 1; i < num_arguments; ++i) {
             const auto& ith_column =
-                    assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[i]);
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i]);
             const auto& ith_offsets = ith_column.get_offsets();
 
             if (ith_offsets[row_num] != end ||

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -228,8 +228,8 @@ public:
         std::vector<const IColumn*> nested(num_arguments);
 
         for (size_t i = 0; i < num_arguments; ++i) {
-            nested[i] =
-                    &assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i]).get_data();
+            nested[i] = &assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i])
+                                 .get_data();
         }
 
         const auto& first_array_column =

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -228,12 +228,12 @@ public:
         std::vector<const IColumn*> nested(num_arguments);
 
         for (size_t i = 0; i < num_arguments; ++i) {
-            nested[i] = &assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i])
+            nested[i] = &assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[i])
                                  .get_data();
         }
 
         const auto& first_array_column =
-                assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& offsets = first_array_column.get_offsets();
 
         size_t begin = offsets[row_num - 1];
@@ -242,7 +242,7 @@ public:
         /// Sanity check. NOTE We can implement specialization for a case with single argument, if the check will hurt performance.
         for (size_t i = 1; i < num_arguments; ++i) {
             const auto& ith_column =
-                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*columns[i]);
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[i]);
             const auto& ith_offsets = ith_column.get_offsets();
 
             if (ith_offsets[row_num] != end ||

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -228,10 +228,12 @@ public:
         std::vector<const IColumn*> nested(num_arguments);
 
         for (size_t i = 0; i < num_arguments; ++i) {
-            nested[i] = &assert_cast<const ColumnArray&>(*columns[i]).get_data();
+            nested[i] =
+                    &assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[i]).get_data();
         }
 
-        const auto& first_array_column = assert_cast<const ColumnArray&>(*columns[0]);
+        const auto& first_array_column =
+                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
         const auto& offsets = first_array_column.get_offsets();
 
         size_t begin = offsets[row_num - 1];
@@ -239,7 +241,8 @@ public:
 
         /// Sanity check. NOTE We can implement specialization for a case with single argument, if the check will hurt performance.
         for (size_t i = 1; i < num_arguments; ++i) {
-            const auto& ith_column = assert_cast<const ColumnArray&>(*columns[i]);
+            const auto& ith_column =
+                    assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[i]);
             const auto& ith_offsets = ith_column.get_offsets();
 
             if (ith_offsets[row_num] != end ||

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -102,7 +102,7 @@ struct AggregateFunctionGroupArrayIntersectData {
         if (is_column_data_nullable) {
             auto* const_col_data = const_cast<IColumn*>(&column_data);
             col_null = static_cast<ColumnNullable*>(const_col_data);
-            nested_column_data = &assert_cast<const ColVecType&, TypeCheck::Disable>(
+            nested_column_data = &assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                     col_null->get_nested_column());
         } else {
             nested_column_data = &static_cast<const ColVecType&>(column_data);
@@ -173,11 +173,11 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheck::Disable>(
-                                          assert_cast<const ColumnNullable&, TypeCheck::Disable>(
+                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+                                          assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
                                                   *columns[0])
                                                   .get_nested_column())
-                                : assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
+                                : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
 
         const auto& offsets = column.get_offsets();
         const auto offset = offsets[row_num - 1];
@@ -366,11 +366,11 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheck::Disable>(
-                                          assert_cast<const ColumnNullable&, TypeCheck::Disable>(
+                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+                                          assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
                                                   *columns[0])
                                                   .get_nested_column())
-                                : assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
+                                : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
 
         const auto nested_column_data = column.get_data_ptr();
         const auto& offsets = column.get_offsets();

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -102,7 +102,8 @@ struct AggregateFunctionGroupArrayIntersectData {
         if (is_column_data_nullable) {
             auto* const_col_data = const_cast<IColumn*>(&column_data);
             col_null = static_cast<ColumnNullable*>(const_col_data);
-            nested_column_data = &assert_cast<const ColVecType&>(col_null->get_nested_column());
+            nested_column_data = &assert_cast<const ColVecType&, TypeCheck::Disable>(
+                    col_null->get_nested_column());
         } else {
             nested_column_data = &static_cast<const ColVecType&>(column_data);
         }
@@ -172,10 +173,11 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&>(
-                                          assert_cast<const ColumnNullable&>(*columns[0])
+                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheck::Disable>(
+                                          assert_cast<const ColumnNullable&, TypeCheck::Disable>(
+                                                  *columns[0])
                                                   .get_nested_column())
-                                : assert_cast<const ColumnArray&>(*columns[0]);
+                                : assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
 
         const auto& offsets = column.get_offsets();
         const auto offset = offsets[row_num - 1];
@@ -364,10 +366,11 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&>(
-                                          assert_cast<const ColumnNullable&>(*columns[0])
+                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheck::Disable>(
+                                          assert_cast<const ColumnNullable&, TypeCheck::Disable>(
+                                                  *columns[0])
                                                   .get_nested_column())
-                                : assert_cast<const ColumnArray&>(*columns[0]);
+                                : assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[0]);
 
         const auto nested_column_data = column.get_data_ptr();
         const auto& offsets = column.get_offsets();

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -173,11 +173,12 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
-                                          assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
-                                                  *columns[0])
-                                                  .get_nested_column())
-                                : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+                col_is_nullable
+                        ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+                                  assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                          *columns[0])
+                                          .get_nested_column())
+                        : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
 
         const auto& offsets = column.get_offsets();
         const auto offset = offsets[row_num - 1];
@@ -366,11 +367,12 @@ public:
 
         const bool col_is_nullable = (*columns[0]).is_nullable();
         const ColumnArray& column =
-                col_is_nullable ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
-                                          assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
-                                                  *columns[0])
-                                                  .get_nested_column())
-                                : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+                col_is_nullable
+                        ? assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+                                  assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                          *columns[0])
+                                          .get_nested_column())
+                        : assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[0]);
 
         const auto nested_column_data = column.get_data_ptr();
         const auto& offsets = column.get_offsets();

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
@@ -99,7 +99,7 @@ struct AggregateFunctionGroupConcatImplStr {
     static const std::string separator;
     static void add(AggregateFunctionGroupConcatData& __restrict place, const IColumn** columns,
                     size_t row_num) {
-        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+        place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                           .get_data_at(row_num),
                   StringRef(separator.data(), separator.length()));
     }
@@ -108,9 +108,9 @@ struct AggregateFunctionGroupConcatImplStr {
 struct AggregateFunctionGroupConcatImplStrStr {
     static void add(AggregateFunctionGroupConcatData& __restrict place, const IColumn** columns,
                     size_t row_num) {
-        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+        place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                           .get_data_at(row_num),
-                  assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[1])
+                  assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[1])
                           .get_data_at(row_num));
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
@@ -25,6 +25,7 @@
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/columns/column_string.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_string.h"
@@ -98,7 +99,8 @@ struct AggregateFunctionGroupConcatImplStr {
     static const std::string separator;
     static void add(AggregateFunctionGroupConcatData& __restrict place, const IColumn** columns,
                     size_t row_num) {
-        place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num),
+        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                          .get_data_at(row_num),
                   StringRef(separator.data(), separator.length()));
     }
 };
@@ -106,8 +108,10 @@ struct AggregateFunctionGroupConcatImplStr {
 struct AggregateFunctionGroupConcatImplStrStr {
     static void add(AggregateFunctionGroupConcatData& __restrict place, const IColumn** columns,
                     size_t row_num) {
-        place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num),
-                  assert_cast<const ColumnString&>(*columns[1]).get_data_at(row_num));
+        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                          .get_data_at(row_num),
+                  assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[1])
+                          .get_data_at(row_num));
     }
 };
 

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.h
@@ -207,10 +207,10 @@ public:
         }
 
         if constexpr (std::is_same_v<T, std::string>) {
-            this->data(place).add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+            this->data(place).add(assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(*columns[0])
                                           .get_data_at(row_num));
         } else {
-            this->data(place).add(assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+            this->data(place).add(assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0])
                                           .get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.h
@@ -208,11 +208,11 @@ public:
 
         if constexpr (std::is_same_v<T, std::string>) {
             this->data(place).add(
-                    assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(*columns[0])
+                    assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                             .get_data_at(row_num));
         } else {
             this->data(place).add(
-                    assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0])
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0])
                             .get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.h
@@ -207,11 +207,13 @@ public:
         }
 
         if constexpr (std::is_same_v<T, std::string>) {
-            this->data(place).add(assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(*columns[0])
-                                          .get_data_at(row_num));
+            this->data(place).add(
+                    assert_cast<const ColumnString&, TypeCheckOnRelease::Disable>(*columns[0])
+                            .get_data_at(row_num));
         } else {
-            this->data(place).add(assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0])
-                                          .get_data()[row_num]);
+            this->data(place).add(
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0])
+                            .get_data()[row_num]);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.h
@@ -207,10 +207,11 @@ public:
         }
 
         if constexpr (std::is_same_v<T, std::string>) {
-            this->data(place).add(
-                    assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
+            this->data(place).add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                                          .get_data_at(row_num));
         } else {
-            this->data(place).add(assert_cast<const ColVecType&>(*columns[0]).get_data()[row_num]);
+            this->data(place).add(assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+                                          .get_data()[row_num]);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
@@ -76,7 +76,7 @@ struct AggregateFunctionHLLData {
     void reset() { dst_hll.clear(); }
 
     void add(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnHLL&, TypeCheck::Disable>(*column);
+        const auto& sources = assert_cast<const ColumnHLL&, TypeCheckOnRelease::DISABLE>(*column);
         dst_hll.merge(sources.get_element(row_num));
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
@@ -76,7 +76,7 @@ struct AggregateFunctionHLLData {
     void reset() { dst_hll.clear(); }
 
     void add(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnHLL&>(*column);
+        const auto& sources = assert_cast<const ColumnHLL&, TypeCheck::Disable>(*column);
         dst_hll.merge(sources.get_element(row_num));
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -147,7 +147,7 @@ struct AggregateFunctionMapAggData {
         write_binary(size, buf);
         for (size_t i = 0; i < size; i++) {
             write_binary(
-                    assert_cast<KeyColumnType&, TypeCheck::Disable>(*_key_column).get_data_at(i),
+                    assert_cast<KeyColumnType&, TypeCheckOnRelease::DISABLE>(*_key_column).get_data_at(i),
                     buf);
         }
         for (size_t i = 0; i < size; i++) {
@@ -165,7 +165,7 @@ struct AggregateFunctionMapAggData {
                 continue;
             }
             key.data = _arena.insert(key.data, key.size);
-            assert_cast<KeyColumnType&, TypeCheck::Disable>(*_key_column)
+            assert_cast<KeyColumnType&, TypeCheckOnRelease::DISABLE>(*_key_column)
                     .insert_data(key.data, key.size);
         }
         StringRef val;
@@ -209,21 +209,21 @@ public:
              Arena* arena) const override {
         if (columns[0]->is_nullable()) {
             auto& nullable_col =
-                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             auto& nullable_map = nullable_col.get_null_map_data();
             if (nullable_map[row_num]) {
                 return;
             }
             Field value;
             columns[1]->get(row_num, value);
-            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheck::Disable>(
+            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheckOnRelease::DISABLE>(
                                           nullable_col.get_nested_column())
                                           .get_data_at(row_num),
                                   value);
         } else {
             Field value;
             columns[1]->get(row_num, value);
-            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheck::Disable>(*columns[0])
+            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheckOnRelease::DISABLE>(*columns[0])
                                           .get_data_at(row_num),
                                   value);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -146,7 +146,9 @@ struct AggregateFunctionMapAggData {
         const size_t size = _key_column->size();
         write_binary(size, buf);
         for (size_t i = 0; i < size; i++) {
-            write_binary(assert_cast<KeyColumnType&>(*_key_column).get_data_at(i), buf);
+            write_binary(
+                    assert_cast<KeyColumnType&, TypeCheck::Disable>(*_key_column).get_data_at(i),
+                    buf);
         }
         for (size_t i = 0; i < size; i++) {
             write_binary(_value_column->get_data_at(i), buf);
@@ -163,7 +165,8 @@ struct AggregateFunctionMapAggData {
                 continue;
             }
             key.data = _arena.insert(key.data, key.size);
-            assert_cast<KeyColumnType&>(*_key_column).insert_data(key.data, key.size);
+            assert_cast<KeyColumnType&, TypeCheck::Disable>(*_key_column)
+                    .insert_data(key.data, key.size);
         }
         StringRef val;
         for (size_t i = 0; i < size; i++) {
@@ -205,22 +208,24 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena* arena) const override {
         if (columns[0]->is_nullable()) {
-            auto& nullable_col = assert_cast<const ColumnNullable&>(*columns[0]);
+            auto& nullable_col =
+                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
             auto& nullable_map = nullable_col.get_null_map_data();
             if (nullable_map[row_num]) {
                 return;
             }
             Field value;
             columns[1]->get(row_num, value);
-            this->data(place).add(
-                    assert_cast<const KeyColumnType&>(nullable_col.get_nested_column())
-                            .get_data_at(row_num),
-                    value);
+            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheck::Disable>(
+                                          nullable_col.get_nested_column())
+                                          .get_data_at(row_num),
+                                  value);
         } else {
             Field value;
             columns[1]->get(row_num, value);
-            this->data(place).add(
-                    assert_cast<const KeyColumnType&>(*columns[0]).get_data_at(row_num), value);
+            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheck::Disable>(*columns[0])
+                                          .get_data_at(row_num),
+                                  value);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -146,9 +146,9 @@ struct AggregateFunctionMapAggData {
         const size_t size = _key_column->size();
         write_binary(size, buf);
         for (size_t i = 0; i < size; i++) {
-            write_binary(
-                    assert_cast<KeyColumnType&, TypeCheckOnRelease::DISABLE>(*_key_column).get_data_at(i),
-                    buf);
+            write_binary(assert_cast<KeyColumnType&, TypeCheckOnRelease::DISABLE>(*_key_column)
+                                 .get_data_at(i),
+                         buf);
         }
         for (size_t i = 0; i < size; i++) {
             write_binary(_value_column->get_data_at(i), buf);
@@ -223,9 +223,10 @@ public:
         } else {
             Field value;
             columns[1]->get(row_num, value);
-            this->data(place).add(assert_cast<const KeyColumnType&, TypeCheckOnRelease::DISABLE>(*columns[0])
-                                          .get_data_at(row_num),
-                                  value);
+            this->data(place).add(
+                    assert_cast<const KeyColumnType&, TypeCheckOnRelease::DISABLE>(*columns[0])
+                            .get_data_at(row_num),
+                    value);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -73,10 +73,10 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+        value = less ? std::min(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
                                         .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+                     : std::max(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
                                         .get_data()[row_num],
                                 value);
     }
@@ -111,7 +111,7 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num];
+        value = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num];
     }
 
     /// Assuming to.has()
@@ -122,7 +122,7 @@ public:
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
         if (!has() ||
-            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num] <
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] <
                     value) {
             change(column, row_num, arena);
             return true;
@@ -142,7 +142,7 @@ public:
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
         if (!has() ||
-            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num] >
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] >
                     value) {
             change(column, row_num, arena);
             return true;
@@ -194,10 +194,10 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+        value = less ? std::min(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
                                         .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+                     : std::max(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
                                         .get_data()[row_num],
                                 value);
     }
@@ -232,7 +232,7 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+        value = assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
                         .get_data()[row_num];
     }
 
@@ -244,7 +244,7 @@ public:
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
         if (!has() ||
-            assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column).get_data()[row_num] <
+            assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] <
                     value) {
             change(column, row_num, arena);
             return true;
@@ -264,7 +264,7 @@ public:
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
         if (!has() ||
-            assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column).get_data()[row_num] >
+            assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] >
                     value) {
             change(column, row_num, arena);
             return true;
@@ -403,14 +403,14 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena* arena) {
         change_impl(
-                assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(row_num),
+                assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(row_num),
                 arena);
     }
 
     void change(const Self& to, Arena* arena) { change_impl(to.get_string_ref(), arena); }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(
+        if (!has() || assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
                               row_num) < get_string_ref()) {
             change(column, row_num, arena);
             return true;
@@ -420,7 +420,7 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(
+        if (!has() || assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
                               row_num) > get_string_ref()) {
             change(column, row_num, arena);
             return true;

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -73,10 +73,12 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
+        value = less ? std::min(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(
+                                        column)
                                         .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
+                     : std::max(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(
+                                        column)
                                         .get_data()[row_num],
                                 value);
     }
@@ -111,7 +113,8 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num];
+        value = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
+                        .get_data()[row_num];
     }
 
     /// Assuming to.has()
@@ -121,9 +124,8 @@ public:
     }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] <
-                    value) {
+        if (!has() || assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
+                                      .get_data()[row_num] < value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -141,9 +143,8 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] >
-                    value) {
+        if (!has() || assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
+                                      .get_data()[row_num] > value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -194,10 +195,12 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
+        value = less ? std::min(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(
+                                        column)
                                         .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
+                     : std::max(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(
+                                        column)
                                         .get_data()[row_num],
                                 value);
     }
@@ -243,9 +246,8 @@ public:
     }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] <
-                    value) {
+        if (!has() || assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
+                                      .get_data()[row_num] < value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -263,9 +265,8 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num] >
-                    value) {
+        if (!has() || assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
+                                      .get_data()[row_num] > value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -403,15 +404,17 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena* arena) {
         change_impl(
-                assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(row_num),
+                assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
+                        row_num),
                 arena);
     }
 
     void change(const Self& to, Arena* arena) { change_impl(to.get_string_ref(), arena); }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
-                              row_num) < get_string_ref()) {
+        if (!has() ||
+            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
+                    row_num) < get_string_ref()) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -420,8 +423,9 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
-                              row_num) > get_string_ref()) {
+        if (!has() ||
+            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
+                    row_num) > get_string_ref()) {
             change(column, row_num, arena);
             return true;
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -73,9 +73,11 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnVector<T>&>(column).get_data()[row_num],
+        value = less ? std::min(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+                                        .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnVector<T>&>(column).get_data()[row_num],
+                     : std::max(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+                                        .get_data()[row_num],
                                 value);
     }
 
@@ -109,7 +111,7 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnVector<T>&>(column).get_data()[row_num];
+        value = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num];
     }
 
     /// Assuming to.has()
@@ -119,7 +121,9 @@ public:
     }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnVector<T>&>(column).get_data()[row_num] < value) {
+        if (!has() ||
+            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num] <
+                    value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -137,7 +141,9 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnVector<T>&>(column).get_data()[row_num] > value) {
+        if (!has() ||
+            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column).get_data()[row_num] >
+                    value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -188,9 +194,11 @@ public:
 
     void change_if(const IColumn& column, size_t row_num, bool less) {
         has_value = true;
-        value = less ? std::min(assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num],
+        value = less ? std::min(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+                                        .get_data()[row_num],
                                 value)
-                     : std::max(assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num],
+                     : std::max(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+                                        .get_data()[row_num],
                                 value);
     }
 
@@ -224,7 +232,8 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num];
+        value = assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+                        .get_data()[row_num];
     }
 
     /// Assuming to.has()
@@ -234,7 +243,9 @@ public:
     }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num] < value) {
+        if (!has() ||
+            assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column).get_data()[row_num] <
+                    value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -252,7 +263,9 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() || assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num] > value) {
+        if (!has() ||
+            assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column).get_data()[row_num] >
+                    value) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -389,14 +402,16 @@ public:
     }
 
     void change(const IColumn& column, size_t row_num, Arena* arena) {
-        change_impl(assert_cast<const ColumnString&>(column).get_data_at(row_num), arena);
+        change_impl(
+                assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(row_num),
+                arena);
     }
 
     void change(const Self& to, Arena* arena) { change_impl(to.get_string_ref(), arena); }
 
     bool change_if_less(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnString&>(column).get_data_at(row_num) < get_string_ref()) {
+        if (!has() || assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(
+                              row_num) < get_string_ref()) {
             change(column, row_num, arena);
             return true;
         } else {
@@ -405,8 +420,8 @@ public:
     }
 
     bool change_if_greater(const IColumn& column, size_t row_num, Arena* arena) {
-        if (!has() ||
-            assert_cast<const ColumnString&>(column).get_data_at(row_num) > get_string_ref()) {
+        if (!has() || assert_cast<const ColumnString&, TypeCheck::Disable>(column).get_data_at(
+                              row_num) > get_string_ref()) {
             change(column, row_num, arena);
             return true;
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -73,7 +73,8 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num];
+        value = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(column)
+                        .get_data()[row_num];
     }
 
     void change(const Self& to, Arena*) {

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -73,7 +73,7 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(column).get_data()[row_num];
+        value = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(column).get_data()[row_num];
     }
 
     void change(const Self& to, Arena*) {

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -73,7 +73,7 @@ public:
 
     void change(const IColumn& column, size_t row_num, Arena*) {
         has_value = true;
-        value = assert_cast<const ColumnBitmap&>(column).get_data()[row_num];
+        value = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(column).get_data()[row_num];
     }
 
     void change(const Self& to, Arena*) {

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -201,7 +201,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena* arena) const override {
         const ColumnNullable* column =
-                assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         if (!column->is_null_at(row_num)) {
             this->set_flag(place);
             const IColumn* nested_column = &column->get_nested_column();
@@ -310,7 +310,7 @@ public:
         for (size_t i = 0; i < number_of_arguments; ++i) {
             if (is_nullable[i]) {
                 const auto& nullable_col =
-                        assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[i]);
+                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[i]);
                 if (nullable_col.is_null_at(row_num)) {
                     /// If at least one column has a null value in the current row,
                     /// we don't process this row.

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -200,7 +200,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena* arena) const override {
-        const ColumnNullable* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const ColumnNullable* column =
+                assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
         if (!column->is_null_at(row_num)) {
             this->set_flag(place);
             const IColumn* nested_column = &column->get_nested_column();
@@ -308,7 +309,8 @@ public:
 
         for (size_t i = 0; i < number_of_arguments; ++i) {
             if (is_nullable[i]) {
-                const auto& nullable_col = assert_cast<const ColumnNullable&>(*columns[i]);
+                const auto& nullable_col =
+                        assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[i]);
                 if (nullable_col.is_null_at(row_num)) {
                     /// If at least one column has a null value in the current row,
                     /// we don't process this row.

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -310,7 +310,8 @@ public:
         for (size_t i = 0; i < number_of_arguments; ++i) {
             if (is_nullable[i]) {
                 const auto& nullable_col =
-                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[i]);
+                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                *columns[i]);
                 if (nullable_col.is_null_at(row_num)) {
                     /// If at least one column has a null value in the current row,
                     /// we don't process this row.

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -54,9 +54,9 @@ public:
 
     void add(const IColumn** columns, size_t row_num) {
         const auto& bitmap_col =
-                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& data_col =
-                assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
+                assert_cast<const ColVecData&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
 
         if constexpr (IsNumber<T>) {
@@ -74,7 +74,7 @@ public:
             DCHECK(argument_size > 1);
             for (int idx = 2; idx < argument_size; ++idx) {
                 const auto& col =
-                        assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[idx]);
+                        assert_cast<const ColVecData&, TypeCheckOnRelease::DISABLE>(*columns[idx]);
                 if constexpr (IsNumber<T>) {
                     bitmap.add_key(col.get_element(row_num));
                 }
@@ -206,9 +206,9 @@ public:
 
     void add(const IColumn** columns, size_t row_num) {
         const auto& bitmap_col =
-                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& data_col =
-                assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
+                assert_cast<const ColVecData&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
         std::string update_key = data_col.get_data_at(row_num).to_string();
         bitmap_expr_cal.update(update_key, bitmap_value);
@@ -218,7 +218,7 @@ public:
         if (first_init) {
             DCHECK(argument_size > 1);
             const auto& col =
-                    assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[2]);
+                    assert_cast<const ColVecData&, TypeCheckOnRelease::DISABLE>(*columns[2]);
             std::string expr = col.get_data_at(row_num).to_string();
             bitmap_expr_cal.bitmap_calculation_init(expr);
             first_init = false;
@@ -313,7 +313,7 @@ struct OrthBitmapUnionCountData {
 
     void add(const IColumn** columns, size_t row_num) {
         const auto& column =
-                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         value |= column.get_data()[row_num];
     }
     void merge(const OrthBitmapUnionCountData& rhs) { result += rhs.result; }

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -53,8 +53,8 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&>(*columns[1]);
+        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
+        const auto& data_col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
 
         if constexpr (IsNumber<T>) {
@@ -71,7 +71,7 @@ public:
         if (first_init) {
             DCHECK(argument_size > 1);
             for (int idx = 2; idx < argument_size; ++idx) {
-                const auto& col = assert_cast<const ColVecData&>(*columns[idx]);
+                const auto& col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[idx]);
                 if constexpr (IsNumber<T>) {
                     bitmap.add_key(col.get_element(row_num));
                 }
@@ -202,8 +202,8 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&>(*columns[1]);
+        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
+        const auto& data_col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
         std::string update_key = data_col.get_data_at(row_num).to_string();
         bitmap_expr_cal.update(update_key, bitmap_value);
@@ -212,7 +212,7 @@ public:
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {
         if (first_init) {
             DCHECK(argument_size > 1);
-            const auto& col = assert_cast<const ColVecData&>(*columns[2]);
+            const auto& col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[2]);
             std::string expr = col.get_data_at(row_num).to_string();
             bitmap_expr_cal.bitmap_calculation_init(expr);
             first_init = false;
@@ -306,7 +306,7 @@ struct OrthBitmapUnionCountData {
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {}
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& column = assert_cast<const ColumnBitmap&>(*columns[0]);
+        const auto& column = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
         value |= column.get_data()[row_num];
     }
     void merge(const OrthBitmapUnionCountData& rhs) { result += rhs.result; }

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -53,8 +53,10 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
+        const auto& bitmap_col =
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& data_col =
+                assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
 
         if constexpr (IsNumber<T>) {
@@ -71,7 +73,8 @@ public:
         if (first_init) {
             DCHECK(argument_size > 1);
             for (int idx = 2; idx < argument_size; ++idx) {
-                const auto& col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[idx]);
+                const auto& col =
+                        assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[idx]);
                 if constexpr (IsNumber<T>) {
                     bitmap.add_key(col.get_element(row_num));
                 }
@@ -202,8 +205,10 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
+        const auto& bitmap_col =
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& data_col =
+                assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
         std::string update_key = data_col.get_data_at(row_num).to_string();
         bitmap_expr_cal.update(update_key, bitmap_value);
@@ -212,7 +217,8 @@ public:
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {
         if (first_init) {
             DCHECK(argument_size > 1);
-            const auto& col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[2]);
+            const auto& col =
+                    assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[2]);
             std::string expr = col.get_data_at(row_num).to_string();
             bitmap_expr_cal.bitmap_calculation_init(expr);
             first_init = false;
@@ -306,7 +312,8 @@ struct OrthBitmapUnionCountData {
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {}
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& column = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
         value |= column.get_data()[row_num];
     }
     void merge(const OrthBitmapUnionCountData& rhs) { result += rhs.result; }

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -53,8 +53,8 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[1]);
+        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& data_col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
 
         if constexpr (IsNumber<T>) {
@@ -71,7 +71,7 @@ public:
         if (first_init) {
             DCHECK(argument_size > 1);
             for (int idx = 2; idx < argument_size; ++idx) {
-                const auto& col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[idx]);
+                const auto& col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[idx]);
                 if constexpr (IsNumber<T>) {
                     bitmap.add_key(col.get_element(row_num));
                 }
@@ -202,8 +202,8 @@ public:
     using ColVecData = std::conditional_t<IsNumber<T>, ColumnVector<T>, ColumnString>;
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
-        const auto& data_col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[1]);
+        const auto& bitmap_col = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& data_col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[1]);
         const auto& bitmap_value = bitmap_col.get_element(row_num);
         std::string update_key = data_col.get_data_at(row_num).to_string();
         bitmap_expr_cal.update(update_key, bitmap_value);
@@ -212,7 +212,7 @@ public:
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {
         if (first_init) {
             DCHECK(argument_size > 1);
-            const auto& col = assert_cast<const ColVecData&, TypeCheck::Disable>(*columns[2]);
+            const auto& col = assert_cast<const ColVecData&, TypeCheckOnRelease::Disable>(*columns[2]);
             std::string expr = col.get_data_at(row_num).to_string();
             bitmap_expr_cal.bitmap_calculation_init(expr);
             first_init = false;
@@ -306,7 +306,7 @@ struct OrthBitmapUnionCountData {
     void init_add_key(const IColumn** columns, size_t row_num, int argument_size) {}
 
     void add(const IColumn** columns, size_t row_num) {
-        const auto& column = assert_cast<const ColumnBitmap&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColumnBitmap&, TypeCheckOnRelease::Disable>(*columns[0]);
         value |= column.get_data()[row_num];
     }
     void merge(const OrthBitmapUnionCountData& rhs) { result += rhs.result; }

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -223,11 +223,11 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[i]);
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(
+                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
                             nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
@@ -242,9 +242,9 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             const auto& quantile =
-                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+                    assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
 
             this->data(place).init();
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -258,8 +258,8 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         this->data(place).init();
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
     }
@@ -280,11 +280,11 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[i]);
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(
+                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
                             nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
@@ -299,11 +299,11 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             const auto& quantile =
-                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+                    assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
             const auto& compression =
-                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[2]);
+                    assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[2]);
 
             this->data(place).init(compression.get_element(row_num));
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -317,10 +317,10 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& compression =
-                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[2]);
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[2]);
 
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -343,13 +343,13 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                            assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
                                     *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
                     const auto& column =
-                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                            assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
                                     nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
@@ -363,11 +363,11 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             const auto& weight =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
             const auto& quantile =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
 
             this->data(place).init();
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -386,11 +386,11 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& sources =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& weight =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& quantile =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
 
         this->data(place).init();
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
@@ -413,13 +413,13 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                            assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
                                     *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
                     const auto& column =
-                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                            assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
                                     nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
@@ -434,13 +434,13 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             const auto& weight =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
             const auto& quantile =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
             const auto& compression =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[3]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[3]);
 
             this->data(place).init(compression.get_element(row_num));
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -458,13 +458,13 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& sources =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& weight =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& quantile =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
         const auto& compression =
-                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[3]);
+                assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[3]);
 
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
@@ -570,8 +570,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+        const auto& sources = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         AggregateFunctionPercentile::data(place).add(sources.get_data()[row_num],
                                                      quantile.get_data(), 1);
     }
@@ -618,15 +618,15 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& sources = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& quantile_array =
-                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[1]);
+                assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
         const auto& nested_column =
-                assert_cast<const ColumnNullable&, TypeCheck::Disable>(quantile_array.get_data())
+                assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(quantile_array.get_data())
                         .get_nested_column();
         const auto& nested_column_data =
-                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(nested_column);
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(nested_column);
 
         AggregateFunctionPercentileArray::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -222,12 +222,13 @@ public:
             for (int i = 0; i < 2; ++i) {
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnFloat64&>(*columns[i]);
+                    const auto& column =
+                            assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column =
-                            assert_cast<const ColumnFloat64&>(nullable_column->get_nested_column());
+                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(
+                            nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -240,8 +241,10 @@ public:
             this->data(place).add(column_data[0], column_data[1]);
 
         } else {
-            const auto& sources = assert_cast<const ColumnFloat64&>(*columns[0]);
-            const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
+            const auto& sources =
+                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+            const auto& quantile =
+                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
 
             this->data(place).init();
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -255,8 +258,8 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
+        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
         this->data(place).init();
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
     }
@@ -276,12 +279,13 @@ public:
             for (int i = 0; i < 3; ++i) {
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnFloat64&>(*columns[i]);
+                    const auto& column =
+                            assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column =
-                            assert_cast<const ColumnFloat64&>(nullable_column->get_nested_column());
+                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(
+                            nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -294,9 +298,12 @@ public:
             this->data(place).add(column_data[0], column_data[1]);
 
         } else {
-            const auto& sources = assert_cast<const ColumnFloat64&>(*columns[0]);
-            const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
-            const auto& compression = assert_cast<const ColumnFloat64&>(*columns[2]);
+            const auto& sources =
+                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+            const auto& quantile =
+                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+            const auto& compression =
+                    assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[2]);
 
             this->data(place).init(compression.get_element(row_num));
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -310,9 +317,10 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
-        const auto& compression = assert_cast<const ColumnFloat64&>(*columns[2]);
+        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+        const auto& compression =
+                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[2]);
 
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
@@ -334,12 +342,15 @@ public:
             for (int i = 0; i < 3; ++i) {
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
+                    const auto& column =
+                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                                    *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
-                            nullable_column->get_nested_column());
+                    const auto& column =
+                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                                    nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -351,9 +362,12 @@ public:
             this->data(place).add_with_weight(column_data[0], column_data[1], column_data[2]);
 
         } else {
-            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-            const auto& weight = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
+            const auto& sources =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+            const auto& weight =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+            const auto& quantile =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
 
             this->data(place).init();
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -371,9 +385,12 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-        const auto& weight = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-        const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
+        const auto& sources =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+        const auto& weight =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+        const auto& quantile =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
 
         this->data(place).init();
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
@@ -395,12 +412,15 @@ public:
             for (int i = 0; i < 4; ++i) {
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(*columns[i]);
+                    const auto& column =
+                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                                    *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnVector<Float64>&>(
-                            nullable_column->get_nested_column());
+                    const auto& column =
+                            assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(
+                                    nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -413,10 +433,14 @@ public:
             this->data(place).add_with_weight(column_data[0], column_data[1], column_data[2]);
 
         } else {
-            const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-            const auto& weight = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-            const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
-            const auto& compression = assert_cast<const ColumnVector<Float64>&>(*columns[3]);
+            const auto& sources =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+            const auto& weight =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+            const auto& quantile =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+            const auto& compression =
+                    assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[3]);
 
             this->data(place).init(compression.get_element(row_num));
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -433,10 +457,14 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnVector<Float64>&>(*columns[0]);
-        const auto& weight = assert_cast<const ColumnVector<Float64>&>(*columns[1]);
-        const auto& quantile = assert_cast<const ColumnVector<Float64>&>(*columns[2]);
-        const auto& compression = assert_cast<const ColumnVector<Float64>&>(*columns[3]);
+        const auto& sources =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[0]);
+        const auto& weight =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[1]);
+        const auto& quantile =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[2]);
+        const auto& compression =
+                assert_cast<const ColumnVector<Float64>&, TypeCheck::Disable>(*columns[3]);
 
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
@@ -542,8 +570,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
+        const auto& sources = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
         AggregateFunctionPercentile::data(place).add(sources.get_data()[row_num],
                                                      quantile.get_data(), 1);
     }
@@ -590,12 +618,15 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&>(*columns[0]);
-        const auto& quantile_array = assert_cast<const ColumnArray&>(*columns[1]);
+        const auto& sources = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile_array =
+                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
         const auto& nested_column =
-                assert_cast<const ColumnNullable&>(quantile_array.get_data()).get_nested_column();
-        const auto& nested_column_data = assert_cast<const ColumnFloat64&>(nested_column);
+                assert_cast<const ColumnNullable&, TypeCheck::Disable>(quantile_array.get_data())
+                        .get_nested_column();
+        const auto& nested_column_data =
+                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(nested_column);
 
         AggregateFunctionPercentileArray::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -223,12 +223,14 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[i]);
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
+                                    *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
-                            nullable_column->get_nested_column());
+                    const auto& column =
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
+                                    nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -258,8 +260,10 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+        const auto& sources =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         this->data(place).init();
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
     }
@@ -280,12 +284,14 @@ public:
                 const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
                 if (nullable_column == nullptr) { //Not Nullable column
                     const auto& column =
-                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[i]);
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
+                                    *columns[i]);
                     column_data[i] = column.get_element(row_num);
                 } else if (!nullable_column->is_null_at(
                                    row_num)) { // Nullable column && Not null data
-                    const auto& column = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
-                            nullable_column->get_nested_column());
+                    const auto& column =
+                            assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(
+                                    nullable_column->get_nested_column());
                     column_data[i] = column.get_element(row_num);
                 } else { // Nullable column && null data
                     if (i == 0) {
@@ -317,8 +323,10 @@ public:
             : AggregateFunctionPercentileApprox(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+        const auto& sources =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& compression =
                 assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[2]);
 
@@ -363,11 +371,14 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[0]);
             const auto& weight =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[1]);
             const auto& quantile =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[2]);
 
             this->data(place).init();
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -434,13 +445,17 @@ public:
 
         } else {
             const auto& sources =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[0]);
             const auto& weight =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[1]);
             const auto& quantile =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[2]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[2]);
             const auto& compression =
-                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(*columns[3]);
+                    assert_cast<const ColumnVector<Float64>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[3]);
 
             this->data(place).init(compression.get_element(row_num));
             this->data(place).add_with_weight(sources.get_element(row_num),
@@ -570,8 +585,10 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+        const auto& sources =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         AggregateFunctionPercentile::data(place).add(sources.get_data()[row_num],
                                                      quantile.get_data(), 1);
     }
@@ -618,13 +635,14 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& sources =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& quantile_array =
                 assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
-        const auto& nested_column =
-                assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(quantile_array.get_data())
-                        .get_nested_column();
+        const auto& nested_column = assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                            quantile_array.get_data())
+                                            .get_nested_column();
         const auto& nested_column_data =
                 assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(nested_column);
 

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -156,8 +156,9 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnVector<Int64>&>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&>(*columns[1]);
+        const auto& sources =
+                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
         AggregateFunctionPercentileOld::data(place).add(sources.get_int(row_num),
                                                         quantile.get_data(), 1);
     }
@@ -203,12 +204,16 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& sources = assert_cast<const ColumnVector<Int64>&>(*columns[0]);
-        const auto& quantile_array = assert_cast<const ColumnArray&>(*columns[1]);
+        const auto& sources =
+                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0]);
+        const auto& quantile_array =
+                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
         const auto& nested_column =
-                assert_cast<const ColumnNullable&>(quantile_array.get_data()).get_nested_column();
-        const auto& nested_column_data = assert_cast<const ColumnFloat64&>(nested_column);
+                assert_cast<const ColumnNullable&, TypeCheck::Disable>(quantile_array.get_data())
+                        .get_nested_column();
+        const auto& nested_column_data =
+                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(nested_column);
 
         AggregateFunctionPercentileArrayOld::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -157,8 +157,8 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& sources =
-                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheck::Disable>(*columns[1]);
+                assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         AggregateFunctionPercentileOld::data(place).add(sources.get_int(row_num),
                                                         quantile.get_data(), 1);
     }
@@ -205,15 +205,15 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& sources =
-                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0]);
+                assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         const auto& quantile_array =
-                assert_cast<const ColumnArray&, TypeCheck::Disable>(*columns[1]);
+                assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
         const auto& nested_column =
-                assert_cast<const ColumnNullable&, TypeCheck::Disable>(quantile_array.get_data())
+                assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(quantile_array.get_data())
                         .get_nested_column();
         const auto& nested_column_data =
-                assert_cast<const ColumnFloat64&, TypeCheck::Disable>(nested_column);
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(nested_column);
 
         AggregateFunctionPercentileArrayOld::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -158,7 +158,8 @@ public:
              Arena*) const override {
         const auto& sources =
                 assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[0]);
-        const auto& quantile = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
+        const auto& quantile =
+                assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         AggregateFunctionPercentileOld::data(place).add(sources.get_int(row_num),
                                                         quantile.get_data(), 1);
     }
@@ -209,9 +210,9 @@ public:
         const auto& quantile_array =
                 assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         const auto& offset_column_data = quantile_array.get_offsets();
-        const auto& nested_column =
-                assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(quantile_array.get_data())
-                        .get_nested_column();
+        const auto& nested_column = assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                            quantile_array.get_data())
+                                            .get_nested_column();
         const auto& nested_column_data =
                 assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(nested_column);
 

--- a/be/src/vec/aggregate_functions/aggregate_function_product.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_product.h
@@ -133,7 +133,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]), multiplier);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_product.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_product.h
@@ -133,7 +133,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]), multiplier);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_product.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_product.h
@@ -133,7 +133,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]), multiplier);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
@@ -114,14 +114,15 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         if constexpr (arg_is_nullable) {
-            auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+            auto& nullable_column =
+                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
-                const auto& column =
-                        assert_cast<const ColVecType&>(nullable_column.get_nested_column());
+                const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                        nullable_column.get_nested_column());
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
@@ -115,14 +115,14 @@ public:
              Arena*) const override {
         if constexpr (arg_is_nullable) {
             auto& nullable_column =
-                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*columns[0]);
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
-                const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
                         nullable_column.get_nested_column());
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
@@ -115,15 +115,15 @@ public:
              Arena*) const override {
         if constexpr (arg_is_nullable) {
             auto& nullable_column =
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*columns[0]);
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
-                const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
+                const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         nullable_column.get_nested_column());
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
             const auto& column =
-                    assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_quantile_state.h
@@ -122,7 +122,8 @@ public:
                 this->data(place).add(column.get_data()[row_num]);
             }
         } else {
-            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
             this->data(place).add(column.get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
@@ -43,8 +43,8 @@ public:
             return true;
         }
         if constexpr (arg_is_nullable) {
-            return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr)->is_null_at(
-                    _offset);
+            return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr)
+                    ->is_null_at(_offset);
         }
         return false;
     }
@@ -52,8 +52,8 @@ public:
     void insert_into(IColumn& to) const {
         if constexpr (arg_is_nullable) {
             auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr);
-            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(col->get_nested_column(),
-                                                                         _offset);
+            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(
+                    col->get_nested_column(), _offset);
         } else {
             assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(*_ptr, _offset);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
@@ -43,17 +43,19 @@ public:
             return true;
         }
         if constexpr (arg_is_nullable) {
-            return assert_cast<const ColumnNullable*>(_ptr)->is_null_at(_offset);
+            return assert_cast<const ColumnNullable*, TypeCheck::Disable>(_ptr)->is_null_at(
+                    _offset);
         }
         return false;
     }
 
     void insert_into(IColumn& to) const {
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*>(_ptr);
-            assert_cast<ColVecType&>(to).insert_from(col->get_nested_column(), _offset);
+            auto* col = assert_cast<const ColumnNullable*, TypeCheck::Disable>(_ptr);
+            assert_cast<ColVecType&, TypeCheck::Disable>(to).insert_from(col->get_nested_column(),
+                                                                         _offset);
         } else {
-            assert_cast<ColVecType&>(to).insert_from(*_ptr, _offset);
+            assert_cast<ColVecType&, TypeCheck::Disable>(to).insert_from(*_ptr, _offset);
         }
     }
 
@@ -75,7 +77,9 @@ protected:
 template <typename ColVecType, bool arg_is_nullable>
 struct CopiedValue : public Value<ColVecType, arg_is_nullable> {
 public:
-    void insert_into(IColumn& to) const { assert_cast<ColVecType&>(to).insert(_copied_value); }
+    void insert_into(IColumn& to) const {
+        assert_cast<ColVecType&, TypeCheck::Disable>(to).insert(_copied_value);
+    }
 
     bool is_null() const { return this->_ptr == nullptr; }
 
@@ -85,12 +89,13 @@ public:
         // because the address have meaningless, only need it to check is nullptr
         this->_ptr = (IColumn*)0x00000001;
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*>(column);
+            auto* col = assert_cast<const ColumnNullable*, TypeCheck::Disable>(column);
             if (col->is_null_at(row)) {
                 this->reset();
                 return;
             } else {
-                auto& nested_col = assert_cast<const ColVecType&>(col->get_nested_column());
+                auto& nested_col = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                        col->get_nested_column());
                 nested_col.get(row, _copied_value);
             }
         } else {
@@ -162,7 +167,8 @@ struct ReaderFunctionFirstNonNullData : Data {
             return;
         }
         if constexpr (Data::nullable) {
-            const auto* nullable_column = assert_cast<const ColumnNullable*>(columns[0]);
+            const auto* nullable_column =
+                    assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }
@@ -182,7 +188,8 @@ template <typename Data>
 struct ReaderFunctionLastNonNullData : Data {
     void add(int64_t row, const IColumn** columns) {
         if constexpr (Data::nullable) {
-            const auto* nullable_column = assert_cast<const ColumnNullable*>(columns[0]);
+            const auto* nullable_column =
+                    assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
@@ -43,7 +43,7 @@ public:
             return true;
         }
         if constexpr (arg_is_nullable) {
-            return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr)
+            return assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(_ptr)
                     ->is_null_at(_offset);
         }
         return false;
@@ -51,11 +51,11 @@ public:
 
     void insert_into(IColumn& to) const {
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr);
-            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(
+            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(_ptr);
+            assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).insert_from(
                     col->get_nested_column(), _offset);
         } else {
-            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(*_ptr, _offset);
+            assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).insert_from(*_ptr, _offset);
         }
     }
 
@@ -78,7 +78,7 @@ template <typename ColVecType, bool arg_is_nullable>
 struct CopiedValue : public Value<ColVecType, arg_is_nullable> {
 public:
     void insert_into(IColumn& to) const {
-        assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert(_copied_value);
+        assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).insert(_copied_value);
     }
 
     bool is_null() const { return this->_ptr == nullptr; }
@@ -89,12 +89,12 @@ public:
         // because the address have meaningless, only need it to check is nullptr
         this->_ptr = (IColumn*)0x00000001;
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column);
+            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(column);
             if (col->is_null_at(row)) {
                 this->reset();
                 return;
             } else {
-                auto& nested_col = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
+                auto& nested_col = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         col->get_nested_column());
                 nested_col.get(row, _copied_value);
             }
@@ -168,7 +168,7 @@ struct ReaderFunctionFirstNonNullData : Data {
         }
         if constexpr (Data::nullable) {
             const auto* nullable_column =
-                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0]);
+                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }
@@ -189,7 +189,7 @@ struct ReaderFunctionLastNonNullData : Data {
     void add(int64_t row, const IColumn** columns) {
         if constexpr (Data::nullable) {
             const auto* nullable_column =
-                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0]);
+                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader_first_last.h
@@ -43,7 +43,7 @@ public:
             return true;
         }
         if constexpr (arg_is_nullable) {
-            return assert_cast<const ColumnNullable*, TypeCheck::Disable>(_ptr)->is_null_at(
+            return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr)->is_null_at(
                     _offset);
         }
         return false;
@@ -51,11 +51,11 @@ public:
 
     void insert_into(IColumn& to) const {
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*, TypeCheck::Disable>(_ptr);
-            assert_cast<ColVecType&, TypeCheck::Disable>(to).insert_from(col->get_nested_column(),
+            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(_ptr);
+            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(col->get_nested_column(),
                                                                          _offset);
         } else {
-            assert_cast<ColVecType&, TypeCheck::Disable>(to).insert_from(*_ptr, _offset);
+            assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert_from(*_ptr, _offset);
         }
     }
 
@@ -78,7 +78,7 @@ template <typename ColVecType, bool arg_is_nullable>
 struct CopiedValue : public Value<ColVecType, arg_is_nullable> {
 public:
     void insert_into(IColumn& to) const {
-        assert_cast<ColVecType&, TypeCheck::Disable>(to).insert(_copied_value);
+        assert_cast<ColVecType&, TypeCheckOnRelease::Disable>(to).insert(_copied_value);
     }
 
     bool is_null() const { return this->_ptr == nullptr; }
@@ -89,12 +89,12 @@ public:
         // because the address have meaningless, only need it to check is nullptr
         this->_ptr = (IColumn*)0x00000001;
         if constexpr (arg_is_nullable) {
-            auto* col = assert_cast<const ColumnNullable*, TypeCheck::Disable>(column);
+            auto* col = assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column);
             if (col->is_null_at(row)) {
                 this->reset();
                 return;
             } else {
-                auto& nested_col = assert_cast<const ColVecType&, TypeCheck::Disable>(
+                auto& nested_col = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(
                         col->get_nested_column());
                 nested_col.get(row, _copied_value);
             }
@@ -168,7 +168,7 @@ struct ReaderFunctionFirstNonNullData : Data {
         }
         if constexpr (Data::nullable) {
             const auto* nullable_column =
-                    assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
+                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }
@@ -189,7 +189,7 @@ struct ReaderFunctionLastNonNullData : Data {
     void add(int64_t row, const IColumn** columns) {
         if constexpr (Data::nullable) {
             const auto* nullable_column =
-                    assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0]);
+                    assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0]);
             if (nullable_column->is_null_at(row)) {
                 return;
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -127,7 +127,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
         for (int i = 0; i < get_argument_types().size(); i++) {
-            auto event = assert_cast<const ColumnVector<UInt8>*, TypeCheck::Disable>(columns[i])
+            auto event = assert_cast<const ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(columns[i])
                                  ->get_data()[row_num];
             if (event) {
                 this->data(place).set(i);

--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -127,8 +127,9 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
         for (int i = 0; i < get_argument_types().size(); i++) {
-            auto event = assert_cast<const ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(columns[i])
-                                 ->get_data()[row_num];
+            auto event =
+                    assert_cast<const ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(columns[i])
+                            ->get_data()[row_num];
             if (event) {
                 this->data(place).set(i);
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -127,7 +127,8 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
         for (int i = 0; i < get_argument_types().size(); i++) {
-            auto event = assert_cast<const ColumnVector<UInt8>*>(columns[i])->get_data()[row_num];
+            auto event = assert_cast<const ColumnVector<UInt8>*, TypeCheck::Disable>(columns[i])
+                                 ->get_data()[row_num];
             if (event) {
                 this->data(place).set(i);
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -201,7 +201,7 @@ private:
 
     using PatternActions = PODArrayWithStackMemory<PatternAction, 64>;
 
-    Derived& derived() { return assert_cast<Derived&, TypeCheck::Disable>(*this); }
+    Derived& derived() { return assert_cast<Derived&, TypeCheckOnRelease::DISABLE>(*this); }
 
     void parse_pattern() {
         actions.clear();
@@ -601,19 +601,19 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
-        std::string pattern = assert_cast<const ColumnString*, TypeCheck::Disable>(columns[0])
+        std::string pattern = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(columns[0])
                                       ->get_data_at(0)
                                       .to_string();
         this->data(place).init(pattern, arg_count);
 
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&, TypeCheck::Disable>(*columns[1])
+                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(*columns[1])
                         .get_data()[row_num];
         typename AggregateFunctionSequenceMatchData<DateValueType, NativeType, Derived>::Events
                 events;
 
         for (auto i = 2; i < arg_count; i++) {
-            const auto event = assert_cast<const ColumnUInt8*, TypeCheck::Disable>(columns[i])
+            const auto event = assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(columns[i])
                                        ->get_data()[row_num];
             events.set(i - 2, event);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -601,20 +601,23 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
-        std::string pattern = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(columns[0])
-                                      ->get_data_at(0)
-                                      .to_string();
+        std::string pattern =
+                assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(columns[0])
+                        ->get_data_at(0)
+                        .to_string();
         this->data(place).init(pattern, arg_count);
 
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(*columns[1])
+                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(
+                        *columns[1])
                         .get_data()[row_num];
         typename AggregateFunctionSequenceMatchData<DateValueType, NativeType, Derived>::Events
                 events;
 
         for (auto i = 2; i < arg_count; i++) {
-            const auto event = assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(columns[i])
-                                       ->get_data()[row_num];
+            const auto event =
+                    assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(columns[i])
+                            ->get_data()[row_num];
             events.set(i - 2, event);
         }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -201,7 +201,7 @@ private:
 
     using PatternActions = PODArrayWithStackMemory<PatternAction, 64>;
 
-    Derived& derived() { return assert_cast<Derived&>(*this); }
+    Derived& derived() { return assert_cast<Derived&, TypeCheck::Disable>(*this); }
 
     void parse_pattern() {
         actions.clear();
@@ -601,17 +601,20 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, const ssize_t row_num,
              Arena*) const override {
-        std::string pattern =
-                assert_cast<const ColumnString*>(columns[0])->get_data_at(0).to_string();
+        std::string pattern = assert_cast<const ColumnString*, TypeCheck::Disable>(columns[0])
+                                      ->get_data_at(0)
+                                      .to_string();
         this->data(place).init(pattern, arg_count);
 
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&>(*columns[1]).get_data()[row_num];
+                assert_cast<const ColumnVector<NativeType>&, TypeCheck::Disable>(*columns[1])
+                        .get_data()[row_num];
         typename AggregateFunctionSequenceMatchData<DateValueType, NativeType, Derived>::Events
                 events;
 
         for (auto i = 2; i < arg_count; i++) {
-            const auto event = assert_cast<const ColumnUInt8*>(columns[i])->get_data()[row_num];
+            const auto event = assert_cast<const ColumnUInt8*, TypeCheck::Disable>(columns[i])
+                                       ->get_data()[row_num];
             events.set(i - 2, event);
         }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -105,7 +105,8 @@ struct BaseData {
     }
 
     void add(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column);
+        const auto& sources =
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column);
         double source_data = sources.get_data()[row_num];
 
         double delta = source_data - mean;

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -105,7 +105,7 @@ struct BaseData {
     }
 
     void add(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnVector<T>&>(*column);
+        const auto& sources = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column);
         double source_data = sources.get_data()[row_num];
 
         double delta = source_data - mean;

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -105,7 +105,7 @@ struct BaseData {
     }
 
     void add(const IColumn* column, size_t row_num) {
-        const auto& sources = assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*column);
+        const auto& sources = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*column);
         double source_data = sources.get_data()[row_num];
 
         double delta = source_data - mean;

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -100,7 +100,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
+        const auto& column =
+                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -100,7 +100,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -100,7 +100,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+        const auto& column = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -101,7 +101,7 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& column =
-                assert_cast<const ColVecType&, TypeCheckOnRelease::Disable>(*columns[0]);
+                assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
         this->data(place).add(TResult(column.get_data()[row_num]));
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.h
@@ -195,10 +195,10 @@ struct AggregateFunctionTopNData {
         for (int i = 0; i < std::min((int)counter_vector.size(), top_num); i++) {
             const auto& element = counter_vector[i];
             if constexpr (std::is_same_v<T, std::string>) {
-                assert_cast<ColumnString&, TypeCheck::Disable>(to).insert_data(
+                assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(
                         element.second.c_str(), element.second.length());
             } else {
-                assert_cast<ColVecType&, TypeCheck::Disable>(to).get_data().push_back(
+                assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
                         element.second);
             }
         }
@@ -214,9 +214,9 @@ struct AggregateFunctionTopNData {
 struct AggregateFunctionTopNImplInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
                                       ->get_element(row_num));
-        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+        place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                           .get_data_at(row_num));
     }
 };
@@ -224,9 +224,9 @@ struct AggregateFunctionTopNImplInt {
 struct AggregateFunctionTopNImplIntInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
                                       ->get_element(row_num),
-                              assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+                              assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
                                       ->get_element(row_num));
         place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
     }
@@ -239,20 +239,20 @@ struct AggregateFunctionTopNImplArray {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
                                           ->get_element(row_num),
-                                  assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+                                  assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
                                           ->get_element(row_num));
 
         } else {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
                                           ->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
-            place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+            place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                               .get_data_at(row_num));
         } else {
-            T val = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+            T val = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0])
                             .get_data()[row_num];
             place.add(val);
         }
@@ -266,9 +266,9 @@ struct AggregateFunctionTopNImplWeight {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
                                           ->get_element(row_num),
-                                  assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[3])
+                                  assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[3])
                                           ->get_element(row_num));
 
         } else {
@@ -276,15 +276,15 @@ struct AggregateFunctionTopNImplWeight {
                     assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
-            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[1])
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[1])
                                   .get_data()[row_num];
-            place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+            place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                               .get_data_at(row_num),
                       weight);
         } else {
-            T val = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+            T val = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0])
                             .get_data()[row_num];
-            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[1])
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[1])
                                   .get_data()[row_num];
             place.add(val, weight);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.h
@@ -214,8 +214,9 @@ struct AggregateFunctionTopNData {
 struct AggregateFunctionTopNImplInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
-                                      ->get_element(row_num));
+        place.set_paramenters(
+                assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
+                        ->get_element(row_num));
         place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                           .get_data_at(row_num));
     }
@@ -224,10 +225,11 @@ struct AggregateFunctionTopNImplInt {
 struct AggregateFunctionTopNImplIntInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
-                                      ->get_element(row_num),
-                              assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
-                                      ->get_element(row_num));
+        place.set_paramenters(
+                assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
+                        ->get_element(row_num),
+                assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
+                        ->get_element(row_num));
         place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
     }
 };
@@ -239,14 +241,16 @@ struct AggregateFunctionTopNImplArray {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
-                                          ->get_element(row_num),
-                                  assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
-                                          ->get_element(row_num));
+            place.set_paramenters(
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
+                            ->get_element(row_num),
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
+                            ->get_element(row_num));
 
         } else {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
-                                          ->get_element(row_num));
+            place.set_paramenters(
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
+                            ->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
             place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
@@ -266,17 +270,19 @@ struct AggregateFunctionTopNImplWeight {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
-                                          ->get_element(row_num),
-                                  assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[3])
-                                          ->get_element(row_num));
+            place.set_paramenters(
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
+                            ->get_element(row_num),
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[3])
+                            ->get_element(row_num));
 
         } else {
             place.set_paramenters(
                     assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
-            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[1])
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(
+                                  *columns[1])
                                   .get_data()[row_num];
             place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
                               .get_data_at(row_num),
@@ -284,7 +290,8 @@ struct AggregateFunctionTopNImplWeight {
         } else {
             T val = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0])
                             .get_data()[row_num];
-            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[1])
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(
+                                  *columns[1])
                                   .get_data()[row_num];
             place.add(val, weight);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.h
@@ -195,10 +195,11 @@ struct AggregateFunctionTopNData {
         for (int i = 0; i < std::min((int)counter_vector.size(), top_num); i++) {
             const auto& element = counter_vector[i];
             if constexpr (std::is_same_v<T, std::string>) {
-                assert_cast<ColumnString&>(to).insert_data(element.second.c_str(),
-                                                           element.second.length());
+                assert_cast<ColumnString&, TypeCheck::Disable>(to).insert_data(
+                        element.second.c_str(), element.second.length());
             } else {
-                assert_cast<ColVecType&>(to).get_data().push_back(element.second);
+                assert_cast<ColVecType&, TypeCheck::Disable>(to).get_data().push_back(
+                        element.second);
             }
         }
     }
@@ -213,16 +214,20 @@ struct AggregateFunctionTopNData {
 struct AggregateFunctionTopNImplInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num));
-        place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
+        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                                      ->get_element(row_num));
+        place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                          .get_data_at(row_num));
     }
 };
 
 struct AggregateFunctionTopNImplIntInt {
     static void add(AggregateFunctionTopNData<std::string>& __restrict place,
                     const IColumn** columns, size_t row_num) {
-        place.set_paramenters(assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num),
-                              assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
+        place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                                      ->get_element(row_num),
+                              assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+                                      ->get_element(row_num));
         place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
     }
 };
@@ -234,18 +239,21 @@ struct AggregateFunctionTopNImplArray {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(
-                    assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num),
-                    assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                                          ->get_element(row_num),
+                                  assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+                                          ->get_element(row_num));
 
         } else {
-            place.set_paramenters(
-                    assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num));
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[1])
+                                          ->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
-            place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
+            place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                              .get_data_at(row_num));
         } else {
-            T val = assert_cast<const ColVecType&>(*columns[0]).get_data()[row_num];
+            T val = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+                            .get_data()[row_num];
             place.add(val);
         }
     }
@@ -258,20 +266,26 @@ struct AggregateFunctionTopNImplWeight {
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
         if constexpr (has_default_param) {
-            place.set_paramenters(
-                    assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num),
-                    assert_cast<const ColumnInt32*>(columns[3])->get_element(row_num));
+            place.set_paramenters(assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[2])
+                                          ->get_element(row_num),
+                                  assert_cast<const ColumnInt32*, TypeCheck::Disable>(columns[3])
+                                          ->get_element(row_num));
 
         } else {
             place.set_paramenters(
                     assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
         }
         if constexpr (std::is_same_v<T, std::string>) {
-            auto weight = assert_cast<const ColumnVector<Int64>&>(*columns[1]).get_data()[row_num];
-            place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num), weight);
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[1])
+                                  .get_data()[row_num];
+            place.add(assert_cast<const ColumnString&, TypeCheck::Disable>(*columns[0])
+                              .get_data_at(row_num),
+                      weight);
         } else {
-            T val = assert_cast<const ColVecType&>(*columns[0]).get_data()[row_num];
-            auto weight = assert_cast<const ColumnVector<Int64>&>(*columns[1]).get_data()[row_num];
+            T val = assert_cast<const ColVecType&, TypeCheck::Disable>(*columns[0])
+                            .get_data()[row_num];
+            auto weight = assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[1])
+                                  .get_data()[row_num];
             place.add(val, weight);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -90,8 +90,9 @@ struct OneAdder {
             StringRef value = column.get_data_at(row_num);
             data.set.insert(Data::get_key(value));
         } else if constexpr (IsDecimalNumber<T>) {
-            data.set.insert(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
-                                    .get_data()[row_num]);
+            data.set.insert(
+                    assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
+                            .get_data()[row_num]);
         } else {
             data.set.insert(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
                                     .get_data()[row_num]);

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -90,10 +90,10 @@ struct OneAdder {
             StringRef value = column.get_data_at(row_num);
             data.set.insert(Data::get_key(value));
         } else if constexpr (IsDecimalNumber<T>) {
-            data.set.insert(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+            data.set.insert(assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column)
                                     .get_data()[row_num]);
         } else {
-            data.set.insert(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+            data.set.insert(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(column)
                                     .get_data()[row_num]);
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -90,9 +90,11 @@ struct OneAdder {
             StringRef value = column.get_data_at(row_num);
             data.set.insert(Data::get_key(value));
         } else if constexpr (IsDecimalNumber<T>) {
-            data.set.insert(assert_cast<const ColumnDecimal<T>&>(column).get_data()[row_num]);
+            data.set.insert(assert_cast<const ColumnDecimal<T>&, TypeCheck::Disable>(column)
+                                    .get_data()[row_num]);
         } else {
-            data.set.insert(assert_cast<const ColumnVector<T>&>(column).get_data()[row_num]);
+            data.set.insert(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(column)
+                                    .get_data()[row_num]);
         }
     }
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -387,7 +387,7 @@ public:
 
     void set_value(const IColumn** columns, size_t pos) {
         if constexpr (arg_is_nullable) {
-            if (assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0])
+            if (assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0])
                         ->is_null_at(pos)) {
                 // ptr == nullptr means nullable
                 _data_value.reset();
@@ -402,7 +402,7 @@ public:
         if (!_is_inited) {
             if (is_column_nullable(*column)) {
                 const auto* nullable_column =
-                        assert_cast<const ColumnNullable*, TypeCheck::Disable>(column);
+                        assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column);
                 if (nullable_column->is_null_at(0)) {
                     _default_value.reset();
                 } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -387,7 +387,8 @@ public:
 
     void set_value(const IColumn** columns, size_t pos) {
         if constexpr (arg_is_nullable) {
-            if (assert_cast<const ColumnNullable*>(columns[0])->is_null_at(pos)) {
+            if (assert_cast<const ColumnNullable*, TypeCheck::Disable>(columns[0])
+                        ->is_null_at(pos)) {
                 // ptr == nullptr means nullable
                 _data_value.reset();
                 return;
@@ -400,7 +401,8 @@ public:
     void check_default(const IColumn* column) {
         if (!_is_inited) {
             if (is_column_nullable(*column)) {
-                const auto* nullable_column = assert_cast<const ColumnNullable*>(column);
+                const auto* nullable_column =
+                        assert_cast<const ColumnNullable*, TypeCheck::Disable>(column);
                 if (nullable_column->is_null_at(0)) {
                     _default_value.reset();
                 } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -387,7 +387,7 @@ public:
 
     void set_value(const IColumn** columns, size_t pos) {
         if constexpr (arg_is_nullable) {
-            if (assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(columns[0])
+            if (assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0])
                         ->is_null_at(pos)) {
                 // ptr == nullptr means nullable
                 _data_value.reset();
@@ -402,7 +402,7 @@ public:
         if (!_is_inited) {
             if (is_column_nullable(*column)) {
                 const auto* nullable_column =
-                        assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column);
+                        assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(column);
                 if (nullable_column->is_null_at(0)) {
                     _default_value.reset();
                 } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -283,16 +283,16 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& window =
-                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0])
+                assert_cast<const ColumnVector<Int64>&, TypeCheckOnRelease::DISABLE>(*columns[0])
                         .get_data()[row_num];
         StringRef mode = columns[1]->get_data_at(row_num);
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&, TypeCheck::Disable>(*columns[2])
+                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(*columns[2])
                         .get_data()[row_num];
         const int NON_EVENT_NUM = 3;
         for (int i = NON_EVENT_NUM; i < IAggregateFunction::get_argument_types().size(); i++) {
             const auto& is_set =
-                    assert_cast<const ColumnVector<UInt8>&, TypeCheck::Disable>(*columns[i])
+                    assert_cast<const ColumnVector<UInt8>&, TypeCheckOnRelease::DISABLE>(*columns[i])
                             .get_data()[row_num];
             if (is_set) {
                 this->data(place).add(

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -283,14 +283,17 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
         const auto& window =
-                assert_cast<const ColumnVector<Int64>&>(*columns[0]).get_data()[row_num];
+                assert_cast<const ColumnVector<Int64>&, TypeCheck::Disable>(*columns[0])
+                        .get_data()[row_num];
         StringRef mode = columns[1]->get_data_at(row_num);
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&>(*columns[2]).get_data()[row_num];
+                assert_cast<const ColumnVector<NativeType>&, TypeCheck::Disable>(*columns[2])
+                        .get_data()[row_num];
         const int NON_EVENT_NUM = 3;
         for (int i = NON_EVENT_NUM; i < IAggregateFunction::get_argument_types().size(); i++) {
             const auto& is_set =
-                    assert_cast<const ColumnVector<UInt8>&>(*columns[i]).get_data()[row_num];
+                    assert_cast<const ColumnVector<UInt8>&, TypeCheck::Disable>(*columns[i])
+                            .get_data()[row_num];
             if (is_set) {
                 this->data(place).add(
                         binary_cast<NativeType, DateValueType>(timestamp), i - NON_EVENT_NUM,

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -287,12 +287,14 @@ public:
                         .get_data()[row_num];
         StringRef mode = columns[1]->get_data_at(row_num);
         const auto& timestamp =
-                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(*columns[2])
+                assert_cast<const ColumnVector<NativeType>&, TypeCheckOnRelease::DISABLE>(
+                        *columns[2])
                         .get_data()[row_num];
         const int NON_EVENT_NUM = 3;
         for (int i = NON_EVENT_NUM; i < IAggregateFunction::get_argument_types().size(); i++) {
             const auto& is_set =
-                    assert_cast<const ColumnVector<UInt8>&, TypeCheckOnRelease::DISABLE>(*columns[i])
+                    assert_cast<const ColumnVector<UInt8>&, TypeCheckOnRelease::DISABLE>(
+                            *columns[i])
                             .get_data()[row_num];
             if (is_set) {
                 this->data(place).add(

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -451,7 +451,8 @@ bool ColumnArray::has_equal_offsets(const ColumnArray& other) const {
 void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t length) {
     if (length == 0) return;
 
-    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
+    const ColumnArray& src_concrete =
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -484,7 +485,8 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
 
 void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
                                                     size_t length) {
-    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
+    const ColumnArray& src_concrete =
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -580,18 +582,21 @@ ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hin
 
     auto res = ColumnArray::create(data->clone_empty());
 
-    auto& res_elems = assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(res->get_data()).get_data();
+    auto& res_elems =
+            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(res->get_data()).get_data();
     auto& res_offsets = res->get_offsets();
 
-    filter_arrays_impl<T, Offset64>(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
-                                    get_offsets(), res_elems, res_offsets, filt, result_size_hint);
+    filter_arrays_impl<T, Offset64>(
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
+            get_offsets(), res_elems, res_offsets, filt, result_size_hint);
     return res;
 }
 
 template <typename T>
 size_t ColumnArray::filter_number(const Filter& filter) {
-    return filter_arrays_impl<T, Offset64>(assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
-                                           get_offsets(), filter);
+    return filter_arrays_impl<T, Offset64>(
+            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
+            get_offsets(), filter);
 }
 
 ColumnPtr ColumnArray::filter_string(const Filter& filt, ssize_t result_size_hint) const {
@@ -794,12 +799,14 @@ size_t ColumnArray::filter_generic(const Filter& filter) {
 ColumnPtr ColumnArray::filter_nullable(const Filter& filt, ssize_t result_size_hint) const {
     if (get_offsets().empty()) return ColumnArray::create(data);
 
-    const ColumnNullable& nullable_elems = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+    const ColumnNullable& nullable_elems =
+            assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
 
     auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
     auto filtered_array_of_nested_owner = array_of_nested->filter(filt, result_size_hint);
     const auto& filtered_array_of_nested =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*filtered_array_of_nested_owner);
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(
+                    *filtered_array_of_nested_owner);
     const auto& filtered_offsets = filtered_array_of_nested.get_offsets_ptr();
 
     auto res_null_map = ColumnUInt8::create();
@@ -817,7 +824,8 @@ size_t ColumnArray::filter_nullable(const Filter& filter) {
         return 0;
     }
 
-    ColumnNullable& nullable_elems = assert_cast<ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+    ColumnNullable& nullable_elems =
+            assert_cast<ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
     const auto result_size =
             filter_arrays_impl_only_data(nullable_elems.get_null_map_data(), get_offsets(), filter);
 
@@ -1037,7 +1045,8 @@ ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offse
 }
 
 ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offsets) const {
-    const ColumnNullable& nullable = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+    const ColumnNullable& nullable =
+            assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
 
     /// Make temporary arrays for each components of Nullable. Then replicate them independently and collect back to result.
     /// NOTE Offsets are calculated twice and it is redundant.
@@ -1051,9 +1060,12 @@ ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offs
 
     return ColumnArray::create(
             ColumnNullable::create(
-                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested).get_data_ptr(),
-                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_null_map).get_data_ptr()),
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested).get_offsets_ptr());
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested)
+                            .get_data_ptr(),
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_null_map)
+                            .get_data_ptr()),
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested)
+                    .get_offsets_ptr());
 }
 
 ColumnPtr ColumnArray::permute(const Permutation& perm, size_t limit) const {

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -382,7 +382,7 @@ void ColumnArray::insert(const Field& x) {
 
 void ColumnArray::insert_from(const IColumn& src_, size_t n) {
     DCHECK_LT(n, src_.size());
-    const ColumnArray& src = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src_);
+    const ColumnArray& src = assert_cast<const ColumnArray&>(src_);
     size_t size = src.size_at(n);
     size_t offset = src.offset_at(n);
 
@@ -451,8 +451,7 @@ bool ColumnArray::has_equal_offsets(const ColumnArray& other) const {
 void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t length) {
     if (length == 0) return;
 
-    const ColumnArray& src_concrete =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src);
+    const ColumnArray& src_concrete = assert_cast<const ColumnArray&>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -485,8 +484,7 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
 
 void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
                                                     size_t length) {
-    const ColumnArray& src_concrete =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src);
+    const ColumnArray& src_concrete = assert_cast<const ColumnArray&>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -582,8 +580,7 @@ ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hin
 
     auto res = ColumnArray::create(data->clone_empty());
 
-    auto& res_elems =
-            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(res->get_data()).get_data();
+    auto& res_elems = assert_cast<ColumnVector<T>&>(res->get_data()).get_data();
     auto& res_offsets = res->get_offsets();
 
     filter_arrays_impl<T, Offset64>(
@@ -805,8 +802,7 @@ ColumnPtr ColumnArray::filter_nullable(const Filter& filt, ssize_t result_size_h
     auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
     auto filtered_array_of_nested_owner = array_of_nested->filter(filt, result_size_hint);
     const auto& filtered_array_of_nested =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
-                    *filtered_array_of_nested_owner);
+            assert_cast<const ColumnArray&>(*filtered_array_of_nested_owner);
     const auto& filtered_offsets = filtered_array_of_nested.get_offsets_ptr();
 
     auto res_null_map = ColumnUInt8::create();

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -233,7 +233,7 @@ StringRef ColumnArray::serialize_value_into_arena(size_t n, Arena& arena,
 
 int ColumnArray::compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const {
     // since column type is complex, we can't use this function
-    const auto& rhs = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(rhs_);
+    const auto& rhs = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(rhs_);
 
     size_t lhs_size = size_at(n);
     size_t rhs_size = rhs.size_at(m);
@@ -382,7 +382,7 @@ void ColumnArray::insert(const Field& x) {
 
 void ColumnArray::insert_from(const IColumn& src_, size_t n) {
     DCHECK_LT(n, src_.size());
-    const ColumnArray& src = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src_);
+    const ColumnArray& src = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src_);
     size_t size = src.size_at(n);
     size_t offset = src.offset_at(n);
 
@@ -452,7 +452,7 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
     if (length == 0) return;
 
     const ColumnArray& src_concrete =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -486,7 +486,7 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
 void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
                                                     size_t length) {
     const ColumnArray& src_concrete =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -583,11 +583,11 @@ ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hin
     auto res = ColumnArray::create(data->clone_empty());
 
     auto& res_elems =
-            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(res->get_data()).get_data();
+            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(res->get_data()).get_data();
     auto& res_offsets = res->get_offsets();
 
     filter_arrays_impl<T, Offset64>(
-            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*data).get_data(),
             get_offsets(), res_elems, res_offsets, filt, result_size_hint);
     return res;
 }
@@ -595,7 +595,7 @@ ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hin
 template <typename T>
 size_t ColumnArray::filter_number(const Filter& filter) {
     return filter_arrays_impl<T, Offset64>(
-            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
+            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*data).get_data(),
             get_offsets(), filter);
 }
 
@@ -800,12 +800,12 @@ ColumnPtr ColumnArray::filter_nullable(const Filter& filt, ssize_t result_size_h
     if (get_offsets().empty()) return ColumnArray::create(data);
 
     const ColumnNullable& nullable_elems =
-            assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*data);
 
     auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
     auto filtered_array_of_nested_owner = array_of_nested->filter(filt, result_size_hint);
     const auto& filtered_array_of_nested =
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
                     *filtered_array_of_nested_owner);
     const auto& filtered_offsets = filtered_array_of_nested.get_offsets_ptr();
 
@@ -825,7 +825,7 @@ size_t ColumnArray::filter_nullable(const Filter& filter) {
     }
 
     ColumnNullable& nullable_elems =
-            assert_cast<ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+            assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(*data);
     const auto result_size =
             filter_arrays_impl_only_data(nullable_elems.get_null_map_data(), get_offsets(), filter);
 
@@ -924,7 +924,7 @@ ColumnPtr ColumnArray::replicate_string(const IColumn::Offsets& replicate_offset
 
     if (0 == col_size) return res;
 
-    ColumnArray& res_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::Disable>(*res);
+    ColumnArray& res_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(*res);
 
     const ColumnString& src_string = typeid_cast<const ColumnString&>(*data);
     const ColumnString::Chars& src_chars = src_string.get_chars();
@@ -1027,7 +1027,7 @@ ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offse
     column_match_offsets_size(col_size, replicate_offsets.size());
 
     MutableColumnPtr res = clone_empty();
-    ColumnArray& res_concrete = assert_cast<ColumnArray&, TypeCheckOnRelease::Disable>(*res);
+    ColumnArray& res_concrete = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(*res);
 
     if (0 == col_size) return res;
 
@@ -1046,7 +1046,7 @@ ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offse
 
 ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offsets) const {
     const ColumnNullable& nullable =
-            assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
+            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*data);
 
     /// Make temporary arrays for each components of Nullable. Then replicate them independently and collect back to result.
     /// NOTE Offsets are calculated twice and it is redundant.
@@ -1060,11 +1060,11 @@ ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offs
 
     return ColumnArray::create(
             ColumnNullable::create(
-                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested)
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*array_of_nested)
                             .get_data_ptr(),
-                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_null_map)
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*array_of_null_map)
                             .get_data_ptr()),
-            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested)
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*array_of_nested)
                     .get_offsets_ptr());
 }
 

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -233,7 +233,7 @@ StringRef ColumnArray::serialize_value_into_arena(size_t n, Arena& arena,
 
 int ColumnArray::compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const {
     // since column type is complex, we can't use this function
-    const auto& rhs = assert_cast<const ColumnArray&>(rhs_);
+    const auto& rhs = assert_cast<const ColumnArray&, TypeCheck::Disable>(rhs_);
 
     size_t lhs_size = size_at(n);
     size_t rhs_size = rhs.size_at(m);

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -233,7 +233,7 @@ StringRef ColumnArray::serialize_value_into_arena(size_t n, Arena& arena,
 
 int ColumnArray::compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const {
     // since column type is complex, we can't use this function
-    const auto& rhs = assert_cast<const ColumnArray&, TypeCheck::Disable>(rhs_);
+    const auto& rhs = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(rhs_);
 
     size_t lhs_size = size_at(n);
     size_t rhs_size = rhs.size_at(m);
@@ -382,7 +382,7 @@ void ColumnArray::insert(const Field& x) {
 
 void ColumnArray::insert_from(const IColumn& src_, size_t n) {
     DCHECK_LT(n, src_.size());
-    const ColumnArray& src = assert_cast<const ColumnArray&, TypeCheck::Disable>(src_);
+    const ColumnArray& src = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src_);
     size_t size = src.size_at(n);
     size_t offset = src.offset_at(n);
 
@@ -451,7 +451,7 @@ bool ColumnArray::has_equal_offsets(const ColumnArray& other) const {
 void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t length) {
     if (length == 0) return;
 
-    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheck::Disable>(src);
+    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -484,7 +484,7 @@ void ColumnArray::insert_range_from(const IColumn& src, size_t start, size_t len
 
 void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t start,
                                                     size_t length) {
-    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheck::Disable>(src);
+    const ColumnArray& src_concrete = assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(src);
 
     if (start + length > src_concrete.get_offsets().size()) {
         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
@@ -580,17 +580,17 @@ ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hin
 
     auto res = ColumnArray::create(data->clone_empty());
 
-    auto& res_elems = assert_cast<ColumnVector<T>&, TypeCheck::Disable>(res->get_data()).get_data();
+    auto& res_elems = assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(res->get_data()).get_data();
     auto& res_offsets = res->get_offsets();
 
-    filter_arrays_impl<T, Offset64>(assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*data).get_data(),
+    filter_arrays_impl<T, Offset64>(assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
                                     get_offsets(), res_elems, res_offsets, filt, result_size_hint);
     return res;
 }
 
 template <typename T>
 size_t ColumnArray::filter_number(const Filter& filter) {
-    return filter_arrays_impl<T, Offset64>(assert_cast<ColumnVector<T>&, TypeCheck::Disable>(*data).get_data(),
+    return filter_arrays_impl<T, Offset64>(assert_cast<ColumnVector<T>&, TypeCheckOnRelease::Disable>(*data).get_data(),
                                            get_offsets(), filter);
 }
 
@@ -794,12 +794,12 @@ size_t ColumnArray::filter_generic(const Filter& filter) {
 ColumnPtr ColumnArray::filter_nullable(const Filter& filt, ssize_t result_size_hint) const {
     if (get_offsets().empty()) return ColumnArray::create(data);
 
-    const ColumnNullable& nullable_elems = assert_cast<const ColumnNullable&, TypeCheck::Disable>(*data);
+    const ColumnNullable& nullable_elems = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
 
     auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
     auto filtered_array_of_nested_owner = array_of_nested->filter(filt, result_size_hint);
     const auto& filtered_array_of_nested =
-            assert_cast<const ColumnArray&, TypeCheck::Disable>(*filtered_array_of_nested_owner);
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*filtered_array_of_nested_owner);
     const auto& filtered_offsets = filtered_array_of_nested.get_offsets_ptr();
 
     auto res_null_map = ColumnUInt8::create();
@@ -817,7 +817,7 @@ size_t ColumnArray::filter_nullable(const Filter& filter) {
         return 0;
     }
 
-    ColumnNullable& nullable_elems = assert_cast<ColumnNullable&, TypeCheck::Disable>(*data);
+    ColumnNullable& nullable_elems = assert_cast<ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
     const auto result_size =
             filter_arrays_impl_only_data(nullable_elems.get_null_map_data(), get_offsets(), filter);
 
@@ -916,7 +916,7 @@ ColumnPtr ColumnArray::replicate_string(const IColumn::Offsets& replicate_offset
 
     if (0 == col_size) return res;
 
-    ColumnArray& res_arr = assert_cast<ColumnArray&, TypeCheck::Disable>(*res);
+    ColumnArray& res_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::Disable>(*res);
 
     const ColumnString& src_string = typeid_cast<const ColumnString&>(*data);
     const ColumnString::Chars& src_chars = src_string.get_chars();
@@ -1019,7 +1019,7 @@ ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offse
     column_match_offsets_size(col_size, replicate_offsets.size());
 
     MutableColumnPtr res = clone_empty();
-    ColumnArray& res_concrete = assert_cast<ColumnArray&, TypeCheck::Disable>(*res);
+    ColumnArray& res_concrete = assert_cast<ColumnArray&, TypeCheckOnRelease::Disable>(*res);
 
     if (0 == col_size) return res;
 
@@ -1037,7 +1037,7 @@ ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offse
 }
 
 ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offsets) const {
-    const ColumnNullable& nullable = assert_cast<const ColumnNullable&, TypeCheck::Disable>(*data);
+    const ColumnNullable& nullable = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*data);
 
     /// Make temporary arrays for each components of Nullable. Then replicate them independently and collect back to result.
     /// NOTE Offsets are calculated twice and it is redundant.
@@ -1051,9 +1051,9 @@ ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offs
 
     return ColumnArray::create(
             ColumnNullable::create(
-                    assert_cast<const ColumnArray&, TypeCheck::Disable>(*array_of_nested).get_data_ptr(),
-                    assert_cast<const ColumnArray&, TypeCheck::Disable>(*array_of_null_map).get_data_ptr()),
-            assert_cast<const ColumnArray&, TypeCheck::Disable>(*array_of_nested).get_offsets_ptr());
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested).get_data_ptr(),
+                    assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_null_map).get_data_ptr()),
+            assert_cast<const ColumnArray&, TypeCheckOnRelease::Disable>(*array_of_nested).get_offsets_ptr());
 }
 
 ColumnPtr ColumnArray::permute(const Permutation& perm, size_t limit) const {

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -171,11 +171,11 @@ public:
     const IColumn& get_offsets_column() const { return *offsets; }
 
     Offsets64& ALWAYS_INLINE get_offsets() {
-        return assert_cast<ColumnOffsets&>(*offsets).get_data();
+        return assert_cast<ColumnOffsets&, TypeCheck::Disable>(*offsets).get_data();
     }
 
     const Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const ColumnOffsets&>(*offsets).get_data();
+        return assert_cast<const ColumnOffsets&, TypeCheck::Disable>(*offsets).get_data();
     }
 
     bool has_equal_offsets(const ColumnArray& other) const;

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -171,11 +171,11 @@ public:
     const IColumn& get_offsets_column() const { return *offsets; }
 
     Offsets64& ALWAYS_INLINE get_offsets() {
-        return assert_cast<ColumnOffsets&, TypeCheck::Disable>(*offsets).get_data();
+        return assert_cast<ColumnOffsets&, TypeCheckOnRelease::Disable>(*offsets).get_data();
     }
 
     const Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const ColumnOffsets&, TypeCheck::Disable>(*offsets).get_data();
+        return assert_cast<const ColumnOffsets&, TypeCheckOnRelease::Disable>(*offsets).get_data();
     }
 
     bool has_equal_offsets(const ColumnArray& other) const;

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -171,11 +171,11 @@ public:
     const IColumn& get_offsets_column() const { return *offsets; }
 
     Offsets64& ALWAYS_INLINE get_offsets() {
-        return assert_cast<ColumnOffsets&, TypeCheckOnRelease::Disable>(*offsets).get_data();
+        return assert_cast<ColumnOffsets&, TypeCheckOnRelease::DISABLE>(*offsets).get_data();
     }
 
     const Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const ColumnOffsets&, TypeCheckOnRelease::Disable>(*offsets).get_data();
+        return assert_cast<const ColumnOffsets&, TypeCheckOnRelease::DISABLE>(*offsets).get_data();
     }
 
     bool has_equal_offsets(const ColumnArray& other) const;

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -58,7 +58,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(src).get_data()[n]);
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
@@ -236,7 +236,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(rhs).data[row];
     }
 
 private:

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -58,7 +58,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
@@ -236,7 +236,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
     }
 
 private:

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -228,7 +228,7 @@ public:
     size_t allocated_bytes() const override { return data->allocated_bytes() + sizeof(s); }
 
     int compare_at(size_t, size_t, const IColumn& rhs, int nan_direction_hint) const override {
-        auto rhs_const_column = assert_cast<const ColumnConst&, TypeCheck::Disable>(rhs);
+        auto rhs_const_column = assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(rhs);
 
         const auto* this_nullable = check_and_get_column<ColumnNullable>(data.get());
         const auto* rhs_nullable =

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -228,7 +228,7 @@ public:
     size_t allocated_bytes() const override { return data->allocated_bytes() + sizeof(s); }
 
     int compare_at(size_t, size_t, const IColumn& rhs, int nan_direction_hint) const override {
-        auto rhs_const_column = assert_cast<const ColumnConst&>(rhs);
+        auto rhs_const_column = assert_cast<const ColumnConst&, TypeCheck::Disable>(rhs);
 
         const auto* this_nullable = check_and_get_column<ColumnNullable>(data.get());
         const auto* rhs_nullable =

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -228,7 +228,7 @@ public:
     size_t allocated_bytes() const override { return data->allocated_bytes() + sizeof(s); }
 
     int compare_at(size_t, size_t, const IColumn& rhs, int nan_direction_hint) const override {
-        auto rhs_const_column = assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(rhs);
+        auto rhs_const_column = assert_cast<const ColumnConst&, TypeCheckOnRelease::DISABLE>(rhs);
 
         const auto* this_nullable = check_and_get_column<ColumnNullable>(data.get());
         const auto* rhs_nullable =

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -46,7 +46,7 @@ namespace doris::vectorized {
 
 template <typename T>
 int ColumnDecimal<T>::compare_at(size_t n, size_t m, const IColumn& rhs_, int) const {
-    auto& other = assert_cast<const Self&, TypeCheck::Disable>(rhs_);
+    auto& other = assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(rhs_);
     const T& a = data[n];
     const T& b = other.data[m];
 

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -46,7 +46,7 @@ namespace doris::vectorized {
 
 template <typename T>
 int ColumnDecimal<T>::compare_at(size_t n, size_t m, const IColumn& rhs_, int) const {
-    auto& other = assert_cast<const Self&>(rhs_);
+    auto& other = assert_cast<const Self&, TypeCheck::Disable>(rhs_);
     const T& a = data[n];
     const T& b = other.data[m];
 

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -116,7 +116,7 @@ public:
     void resize(size_t n) override { data.resize(n); }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(src).get_data()[n]);
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
@@ -241,7 +241,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(rhs).data[row];
     }
 
     void replace_column_null_data(const uint8_t* __restrict null_map) override;

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -116,7 +116,7 @@ public:
     void resize(size_t n) override { data.resize(n); }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
     }
 
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
@@ -241,7 +241,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
     }
 
     void replace_column_null_data(const uint8_t* __restrict null_map) override;

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -242,7 +242,7 @@ const char* ColumnMap::deserialize_and_insert_from_arena(const char* pos) {
 }
 
 int ColumnMap::compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const {
-    const auto& rhs = assert_cast<const ColumnMap&>(rhs_);
+    const auto& rhs = assert_cast<const ColumnMap&, TypeCheck::Disable>(rhs_);
 
     size_t lhs_size = size_at(n);
     size_t rhs_size = rhs.size_at(m);

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -242,7 +242,7 @@ const char* ColumnMap::deserialize_and_insert_from_arena(const char* pos) {
 }
 
 int ColumnMap::compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const {
-    const auto& rhs = assert_cast<const ColumnMap&, TypeCheck::Disable>(rhs_);
+    const auto& rhs = assert_cast<const ColumnMap&, TypeCheckOnRelease::DISABLE>(rhs_);
 
     size_t lhs_size = size_at(n);
     size_t rhs_size = rhs.size_at(m);

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -141,10 +141,10 @@ public:
     }
 
     ColumnArray::Offsets64& ALWAYS_INLINE get_offsets() {
-        return assert_cast<COffsets&, TypeCheck::Disable>(*offsets_column).get_data();
+        return assert_cast<COffsets&, TypeCheckOnRelease::DISABLE>(*offsets_column).get_data();
     }
     const ColumnArray::Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const COffsets&, TypeCheck::Disable>(*offsets_column).get_data();
+        return assert_cast<const COffsets&, TypeCheckOnRelease::DISABLE>(*offsets_column).get_data();
     }
     IColumn& get_offsets_column() { return *offsets_column; }
     const IColumn& get_offsets_column() const { return *offsets_column; }

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -141,10 +141,10 @@ public:
     }
 
     ColumnArray::Offsets64& ALWAYS_INLINE get_offsets() {
-        return assert_cast<COffsets&>(*offsets_column).get_data();
+        return assert_cast<COffsets&, TypeCheck::Disable>(*offsets_column).get_data();
     }
     const ColumnArray::Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const COffsets&>(*offsets_column).get_data();
+        return assert_cast<const COffsets&, TypeCheck::Disable>(*offsets_column).get_data();
     }
     IColumn& get_offsets_column() { return *offsets_column; }
     const IColumn& get_offsets_column() const { return *offsets_column; }

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -144,7 +144,8 @@ public:
         return assert_cast<COffsets&, TypeCheckOnRelease::DISABLE>(*offsets_column).get_data();
     }
     const ColumnArray::Offsets64& ALWAYS_INLINE get_offsets() const {
-        return assert_cast<const COffsets&, TypeCheckOnRelease::DISABLE>(*offsets_column).get_data();
+        return assert_cast<const COffsets&, TypeCheckOnRelease::DISABLE>(*offsets_column)
+                .get_data();
     }
     IColumn& get_offsets_column() { return *offsets_column; }
     const IColumn& get_offsets_column() const { return *offsets_column; }

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -626,14 +626,18 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {
     if (is_column_nullable(*column)) {
-        return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column.get())->get_nested_column_ptr();
+        return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column.get())
+                ->get_nested_column_ptr();
     }
 
     if (is_column_const(*column)) {
-        const auto& column_nested = assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(*column).get_data_column_ptr();
+        const auto& column_nested =
+                assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(*column)
+                        .get_data_column_ptr();
         if (is_column_nullable(*column_nested)) {
             return ColumnConst::create(
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*column_nested).get_nested_column_ptr(),
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*column_nested)
+                            .get_nested_column_ptr(),
                     column->size());
         }
     }

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -626,14 +626,14 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {
     if (is_column_nullable(*column)) {
-        return assert_cast<const ColumnNullable*, TypeCheck::Disable>(column.get())->get_nested_column_ptr();
+        return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column.get())->get_nested_column_ptr();
     }
 
     if (is_column_const(*column)) {
-        const auto& column_nested = assert_cast<const ColumnConst&, TypeCheck::Disable>(*column).get_data_column_ptr();
+        const auto& column_nested = assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(*column).get_data_column_ptr();
         if (is_column_nullable(*column_nested)) {
             return ColumnConst::create(
-                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*column_nested).get_nested_column_ptr(),
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*column_nested).get_nested_column_ptr(),
                     column->size());
         }
     }

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -626,17 +626,17 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {
     if (is_column_nullable(*column)) {
-        return assert_cast<const ColumnNullable*, TypeCheckOnRelease::Disable>(column.get())
+        return assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(column.get())
                 ->get_nested_column_ptr();
     }
 
     if (is_column_const(*column)) {
         const auto& column_nested =
-                assert_cast<const ColumnConst&, TypeCheckOnRelease::Disable>(*column)
+                assert_cast<const ColumnConst&, TypeCheckOnRelease::DISABLE>(*column)
                         .get_data_column_ptr();
         if (is_column_nullable(*column_nested)) {
             return ColumnConst::create(
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(*column_nested)
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*column_nested)
                             .get_nested_column_ptr(),
                     column->size());
         }

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -626,14 +626,14 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {
     if (is_column_nullable(*column)) {
-        return reinterpret_cast<const ColumnNullable*>(column.get())->get_nested_column_ptr();
+        return assert_cast<const ColumnNullable*, TypeCheck::Disable>(column.get())->get_nested_column_ptr();
     }
 
     if (is_column_const(*column)) {
-        const auto& column_nested = assert_cast<const ColumnConst&>(*column).get_data_column_ptr();
+        const auto& column_nested = assert_cast<const ColumnConst&, TypeCheck::Disable>(*column).get_data_column_ptr();
         if (is_column_nullable(*column_nested)) {
             return ColumnConst::create(
-                    assert_cast<const ColumnNullable&>(*column_nested).get_nested_column_ptr(),
+                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(*column_nested).get_nested_column_ptr(),
                     column->size());
         }
     }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -89,10 +89,10 @@ public:
     std::string get_name() const override { return "Nullable(" + nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override {
-        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map).size();
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map).size();
     }
     PURE bool is_null_at(size_t n) const override {
-        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map).get_data()[n] != 0;
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map).get_data()[n] != 0;
     }
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;
@@ -103,7 +103,7 @@ public:
     bool get_bool_inline(size_t n) const {
         return is_null_at(n)
                        ? false
-                       : assert_cast<const ColumnUInt8*, TypeCheck::Disable>(nested_column.get())
+                       : assert_cast<const ColumnUInt8*, TypeCheckOnRelease::Disable>(nested_column.get())
                                  ->get_bool(n);
     }
     StringRef get_data_at(size_t n) const override;
@@ -310,10 +310,10 @@ public:
 
     ColumnUInt8& get_null_map_column() {
         _need_update_has_null = true;
-        return assert_cast<ColumnUInt8&, TypeCheck::Disable>(*null_map);
+        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
     }
     const ColumnUInt8& get_null_map_column() const {
-        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map);
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
     }
 
     void clear() override {
@@ -349,7 +349,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        const auto& nullable_rhs = assert_cast<const ColumnNullable&, TypeCheck::Disable>(rhs);
+        const auto& nullable_rhs = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(rhs);
         null_map->replace_column_data(*nullable_rhs.null_map, row, self_row);
 
         if (!nullable_rhs.is_null_at(row)) {
@@ -413,7 +413,7 @@ public:
 private:
     // the two functions will not update `_need_update_has_null`
     ColumnUInt8& _get_null_map_column() {
-        return assert_cast<ColumnUInt8&, TypeCheck::Disable>(*null_map);
+        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
     }
     NullMap& _get_null_map_data() { return _get_null_map_column().get_data(); }
 

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -88,9 +88,11 @@ public:
     const char* get_family_name() const override { return "Nullable"; }
     std::string get_name() const override { return "Nullable(" + nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
-    size_t size() const override { return assert_cast<const ColumnUInt8&>(*null_map).size(); }
+    size_t size() const override {
+        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map).size();
+    }
     PURE bool is_null_at(size_t n) const override {
-        return assert_cast<const ColumnUInt8&>(*null_map).get_data()[n] != 0;
+        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map).get_data()[n] != 0;
     }
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;
@@ -99,8 +101,10 @@ public:
     }
     // column must be nullable(uint8)
     bool get_bool_inline(size_t n) const {
-        return is_null_at(n) ? false
-                             : assert_cast<const ColumnUInt8*>(nested_column.get())->get_bool(n);
+        return is_null_at(n)
+                       ? false
+                       : assert_cast<const ColumnUInt8*, TypeCheck::Disable>(nested_column.get())
+                                 ->get_bool(n);
     }
     StringRef get_data_at(size_t n) const override;
 
@@ -306,10 +310,10 @@ public:
 
     ColumnUInt8& get_null_map_column() {
         _need_update_has_null = true;
-        return assert_cast<ColumnUInt8&>(*null_map);
+        return assert_cast<ColumnUInt8&, TypeCheck::Disable>(*null_map);
     }
     const ColumnUInt8& get_null_map_column() const {
-        return assert_cast<const ColumnUInt8&>(*null_map);
+        return assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*null_map);
     }
 
     void clear() override {
@@ -345,7 +349,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        const auto& nullable_rhs = assert_cast<const ColumnNullable&>(rhs);
+        const auto& nullable_rhs = assert_cast<const ColumnNullable&, TypeCheck::Disable>(rhs);
         null_map->replace_column_data(*nullable_rhs.null_map, row, self_row);
 
         if (!nullable_rhs.is_null_at(row)) {
@@ -408,7 +412,9 @@ public:
 
 private:
     // the two functions will not update `_need_update_has_null`
-    ColumnUInt8& _get_null_map_column() { return assert_cast<ColumnUInt8&>(*null_map); }
+    ColumnUInt8& _get_null_map_column() {
+        return assert_cast<ColumnUInt8&, TypeCheck::Disable>(*null_map);
+    }
     NullMap& _get_null_map_data() { return _get_null_map_column().get_data(); }
 
     WrappedPtr nested_column;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -89,10 +89,10 @@ public:
     std::string get_name() const override { return "Nullable(" + nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map).size();
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(*null_map).size();
     }
     PURE bool is_null_at(size_t n) const override {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map)
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(*null_map)
                        .get_data()[n] != 0;
     }
     Field operator[](size_t n) const override;
@@ -103,7 +103,7 @@ public:
     // column must be nullable(uint8)
     bool get_bool_inline(size_t n) const {
         return is_null_at(n) ? false
-                             : assert_cast<const ColumnUInt8*, TypeCheckOnRelease::Disable>(
+                             : assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(
                                        nested_column.get())
                                        ->get_bool(n);
     }
@@ -311,10 +311,10 @@ public:
 
     ColumnUInt8& get_null_map_column() {
         _need_update_has_null = true;
-        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
+        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::DISABLE>(*null_map);
     }
     const ColumnUInt8& get_null_map_column() const {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(*null_map);
     }
 
     void clear() override {
@@ -351,7 +351,7 @@ public:
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
         const auto& nullable_rhs =
-                assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(rhs);
+                assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(rhs);
         null_map->replace_column_data(*nullable_rhs.null_map, row, self_row);
 
         if (!nullable_rhs.is_null_at(row)) {
@@ -415,7 +415,7 @@ public:
 private:
     // the two functions will not update `_need_update_has_null`
     ColumnUInt8& _get_null_map_column() {
-        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map);
+        return assert_cast<ColumnUInt8&, TypeCheckOnRelease::DISABLE>(*null_map);
     }
     NullMap& _get_null_map_data() { return _get_null_map_column().get_data(); }
 

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -92,7 +92,8 @@ public:
         return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map).size();
     }
     PURE bool is_null_at(size_t n) const override {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map).get_data()[n] != 0;
+        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*null_map)
+                       .get_data()[n] != 0;
     }
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;
@@ -101,10 +102,10 @@ public:
     }
     // column must be nullable(uint8)
     bool get_bool_inline(size_t n) const {
-        return is_null_at(n)
-                       ? false
-                       : assert_cast<const ColumnUInt8*, TypeCheckOnRelease::Disable>(nested_column.get())
-                                 ->get_bool(n);
+        return is_null_at(n) ? false
+                             : assert_cast<const ColumnUInt8*, TypeCheckOnRelease::Disable>(
+                                       nested_column.get())
+                                       ->get_bool(n);
     }
     StringRef get_data_at(size_t n) const override;
 
@@ -349,7 +350,8 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        const auto& nullable_rhs = assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(rhs);
+        const auto& nullable_rhs =
+                assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(rhs);
         null_map->replace_column_data(*nullable_rhs.null_map, row, self_row);
 
         if (!nullable_rhs.is_null_at(row)) {

--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -1333,7 +1333,8 @@ Status ColumnObject::merge_sparse_to_root_column() {
         Arena mem_pool;
         for (const auto& subcolumn : sparse_columns) {
             auto& column = subcolumn->data.get_finalized_column_ptr();
-            if (assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*column).is_null_at(i)) {
+            if (assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*column).is_null_at(
+                        i)) {
                 ++null_count;
                 continue;
             }

--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -768,7 +768,7 @@ void ColumnObject::insert_from(const IColumn& src, size_t n) {
     if (src_v != nullptr && src_v->is_scalar_variant() && is_scalar_variant() &&
         src_v->get_root_type()->equals(*get_root_type()) && src_v->is_finalized() &&
         is_finalized()) {
-        assert_cast<ColumnNullable&, TypeCheck::Disable>(*get_root())
+        assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(*get_root())
                 .insert_from(*src_v->get_root(), n);
         ++num_rows;
         return;
@@ -1333,7 +1333,7 @@ Status ColumnObject::merge_sparse_to_root_column() {
         Arena mem_pool;
         for (const auto& subcolumn : sparse_columns) {
             auto& column = subcolumn->data.get_finalized_column_ptr();
-            if (assert_cast<const ColumnNullable&, TypeCheck::Disable>(*column).is_null_at(i)) {
+            if (assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*column).is_null_at(i)) {
                 ++null_count;
                 continue;
             }

--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -768,7 +768,8 @@ void ColumnObject::insert_from(const IColumn& src, size_t n) {
     if (src_v != nullptr && src_v->is_scalar_variant() && is_scalar_variant() &&
         src_v->get_root_type()->equals(*get_root_type()) && src_v->is_finalized() &&
         is_finalized()) {
-        assert_cast<ColumnNullable&>(*get_root()).insert_from(*src_v->get_root(), n);
+        assert_cast<ColumnNullable&, TypeCheck::Disable>(*get_root())
+                .insert_from(*src_v->get_root(), n);
         ++num_rows;
         return;
     }
@@ -1332,7 +1333,7 @@ Status ColumnObject::merge_sparse_to_root_column() {
         Arena mem_pool;
         for (const auto& subcolumn : sparse_columns) {
             auto& column = subcolumn->data.get_finalized_column_ptr();
-            if (assert_cast<const ColumnNullable&>(*column).is_null_at(i)) {
+            if (assert_cast<const ColumnNullable&, TypeCheck::Disable>(*column).is_null_at(i)) {
                 ++null_count;
                 continue;
             }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -572,7 +572,7 @@ void ColumnStr<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs, int n
     auto sz = offsets.size();
     DCHECK(cmp_res.size() == sz);
     const auto& cmp_base =
-            assert_cast<const ColumnStr<T>&, TypeCheck::Disable>(rhs).get_data_at(rhs_row_id);
+            assert_cast<const ColumnStr<T>&, TypeCheckOnRelease::DISABLE>(rhs).get_data_at(rhs_row_id);
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -572,7 +572,8 @@ void ColumnStr<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs, int n
     auto sz = offsets.size();
     DCHECK(cmp_res.size() == sz);
     const auto& cmp_base =
-            assert_cast<const ColumnStr<T>&, TypeCheckOnRelease::DISABLE>(rhs).get_data_at(rhs_row_id);
+            assert_cast<const ColumnStr<T>&, TypeCheckOnRelease::DISABLE>(rhs).get_data_at(
+                    rhs_row_id);
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -571,7 +571,8 @@ void ColumnStr<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs, int n
                                     uint8* __restrict filter) const {
     auto sz = offsets.size();
     DCHECK(cmp_res.size() == sz);
-    const auto& cmp_base = assert_cast<const ColumnStr<T>&>(rhs).get_data_at(rhs_row_id);
+    const auto& cmp_base =
+            assert_cast<const ColumnStr<T>&, TypeCheck::Disable>(rhs).get_data_at(rhs_row_id);
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -187,7 +187,7 @@ const char* ColumnStruct::deserialize_and_insert_from_arena(const char* pos) {
 
 int ColumnStruct::compare_at(size_t n, size_t m, const IColumn& rhs_,
                              int nan_direction_hint) const {
-    const ColumnStruct& rhs = assert_cast<const ColumnStruct&, TypeCheck::Disable>(rhs_);
+    const ColumnStruct& rhs = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(rhs_);
 
     const size_t lhs_tuple_size = columns.size();
     const size_t rhs_tuple_size = rhs.tuple_size();
@@ -247,7 +247,7 @@ void ColumnStruct::insert_range_from(const IColumn& src, size_t start, size_t le
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
         columns[i]->insert_range_from(
-                *assert_cast<const ColumnStruct&, TypeCheck::Disable>(src).columns[i], start,
+                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i], start,
                 length);
     }
 }
@@ -257,7 +257,7 @@ void ColumnStruct::insert_range_from_ignore_overflow(const IColumn& src, size_t 
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
         columns[i]->insert_range_from_ignore_overflow(
-                *assert_cast<const ColumnStruct&, TypeCheck::Disable>(src).columns[i], start,
+                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i], start,
                 length);
     }
 }

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -247,8 +247,8 @@ void ColumnStruct::insert_range_from(const IColumn& src, size_t start, size_t le
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
         columns[i]->insert_range_from(
-                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i], start,
-                length);
+                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i],
+                start, length);
     }
 }
 
@@ -257,8 +257,8 @@ void ColumnStruct::insert_range_from_ignore_overflow(const IColumn& src, size_t 
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
         columns[i]->insert_range_from_ignore_overflow(
-                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i], start,
-                length);
+                *assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(src).columns[i],
+                start, length);
     }
 }
 

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -187,7 +187,7 @@ const char* ColumnStruct::deserialize_and_insert_from_arena(const char* pos) {
 
 int ColumnStruct::compare_at(size_t n, size_t m, const IColumn& rhs_,
                              int nan_direction_hint) const {
-    const ColumnStruct& rhs = assert_cast<const ColumnStruct&>(rhs_);
+    const ColumnStruct& rhs = assert_cast<const ColumnStruct&, TypeCheck::Disable>(rhs_);
 
     const size_t lhs_tuple_size = columns.size();
     const size_t rhs_tuple_size = rhs.tuple_size();
@@ -246,8 +246,9 @@ void ColumnStruct::insert_indices_from(const IColumn& src, const uint32_t* indic
 void ColumnStruct::insert_range_from(const IColumn& src, size_t start, size_t length) {
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
-        columns[i]->insert_range_from(*assert_cast<const ColumnStruct&>(src).columns[i], start,
-                                      length);
+        columns[i]->insert_range_from(
+                *assert_cast<const ColumnStruct&, TypeCheck::Disable>(src).columns[i], start,
+                length);
     }
 }
 
@@ -256,7 +257,8 @@ void ColumnStruct::insert_range_from_ignore_overflow(const IColumn& src, size_t 
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {
         columns[i]->insert_range_from_ignore_overflow(
-                *assert_cast<const ColumnStruct&>(src).columns[i], start, length);
+                *assert_cast<const ColumnStruct&, TypeCheck::Disable>(src).columns[i], start,
+                length);
     }
 }
 

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -163,7 +163,7 @@ void ColumnVector<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs,
     const auto sz = data.size();
     DCHECK(cmp_res.size() == sz);
     const auto& cmp_base =
-            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(rhs).get_data()[rhs_row_id];
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(rhs).get_data()[rhs_row_id];
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -162,7 +162,7 @@ void ColumnVector<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs,
                                        uint8* __restrict filter) const {
     const auto sz = data.size();
     DCHECK(cmp_res.size() == sz);
-    const auto& cmp_base = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(rhs)
+    const auto& cmp_base = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(rhs)
                                    .get_data()[rhs_row_id];
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -162,8 +162,8 @@ void ColumnVector<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs,
                                        uint8* __restrict filter) const {
     const auto sz = data.size();
     DCHECK(cmp_res.size() == sz);
-    const auto& cmp_base =
-            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(rhs).get_data()[rhs_row_id];
+    const auto& cmp_base = assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::Disable>(rhs)
+                                   .get_data()[rhs_row_id];
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -162,7 +162,8 @@ void ColumnVector<T>::compare_internal(size_t rhs_row_id, const IColumn& rhs,
                                        uint8* __restrict filter) const {
     const auto sz = data.size();
     DCHECK(cmp_res.size() == sz);
-    const auto& cmp_base = assert_cast<const ColumnVector<T>&>(rhs).get_data()[rhs_row_id];
+    const auto& cmp_base =
+            assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(rhs).get_data()[rhs_row_id];
     size_t begin = simd::find_zero(cmp_res, 0);
     while (begin < sz) {
         size_t end = simd::find_one(cmp_res, begin + 1);

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -161,7 +161,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheckOnRelease::Disable>(src).get_data()[n]);
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
@@ -325,7 +325,7 @@ public:
     /// This method implemented in header because it could be possibly devirtualized.
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override {
         return CompareHelper<T>::compare(data[n],
-                                         assert_cast<const Self&, TypeCheck::Disable>(rhs_).data[m],
+                                         assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs_).data[m],
                                          nan_direction_hint);
     }
 
@@ -402,7 +402,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs).data[row];
     }
 
     void replace_column_null_data(const uint8_t* __restrict null_map) override;

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -324,9 +324,9 @@ public:
 
     /// This method implemented in header because it could be possibly devirtualized.
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override {
-        return CompareHelper<T>::compare(data[n],
-                                         assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs_).data[m],
-                                         nan_direction_hint);
+        return CompareHelper<T>::compare(
+                data[n], assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs_).data[m],
+                nan_direction_hint);
     }
 
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -161,7 +161,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheck::Disable>(src).get_data()[n]);
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
@@ -324,7 +324,8 @@ public:
 
     /// This method implemented in header because it could be possibly devirtualized.
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override {
-        return CompareHelper<T>::compare(data[n], assert_cast<const Self&>(rhs_).data[m],
+        return CompareHelper<T>::compare(data[n],
+                                         assert_cast<const Self&, TypeCheck::Disable>(rhs_).data[m],
                                          nan_direction_hint);
     }
 
@@ -401,7 +402,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheck::Disable>(rhs).data[row];
     }
 
     void replace_column_null_data(const uint8_t* __restrict null_map) override;

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -161,7 +161,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        data.push_back(assert_cast<const Self&, TypeCheckOnRelease::Disable>(src).get_data()[n]);
+        data.push_back(assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(src).get_data()[n]);
     }
 
     void insert_data(const char* pos, size_t /*length*/) override {
@@ -325,7 +325,7 @@ public:
     /// This method implemented in header because it could be possibly devirtualized.
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override {
         return CompareHelper<T>::compare(
-                data[n], assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs_).data[m],
+                data[n], assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(rhs_).data[m],
                 nan_direction_hint);
     }
 
@@ -402,7 +402,7 @@ public:
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
-        data[self_row] = assert_cast<const Self&, TypeCheckOnRelease::Disable>(rhs).data[row];
+        data[self_row] = assert_cast<const Self&, TypeCheckOnRelease::DISABLE>(rhs).data[row];
     }
 
     void replace_column_null_data(const uint8_t* __restrict null_map) override;

--- a/be/src/vec/common/assert_cast.h
+++ b/be/src/vec/common/assert_cast.h
@@ -26,13 +26,13 @@
 #include "common/logging.h"
 #include "vec/common/demangle.h"
 
-enum class TypeCheck : bool { Enable = true, Disable = false };
+enum class TypeCheckOnRelease : bool { ENABLE = true, DISABLE = false };
 
 /** Perform static_cast in release build.
   * Checks type by comparing typeid and throw an exception in debug build.
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
   */
-template <typename To, TypeCheck check = TypeCheck::Enable, typename From>
+template <typename To, TypeCheckOnRelease check = TypeCheckOnRelease::ENABLE, typename From>
 PURE To assert_cast(From&& from) {
 #ifndef NDEBUG
     try {
@@ -61,7 +61,7 @@ PURE To assert_cast(From&& from) {
                               demangle(typeid(To).name()));
     __builtin_unreachable();
 #else
-    if constexpr (check == TypeCheck::Enable) {
+    if constexpr (check == TypeCheckOnRelease::ENABLE) {
         try {
             if constexpr (std::is_pointer_v<To>) {
                 if (typeid(*from) == typeid(std::remove_pointer_t<To>)) {

--- a/be/src/vec/common/assert_cast.h
+++ b/be/src/vec/common/assert_cast.h
@@ -28,8 +28,8 @@
 
 enum class TypeCheckOnRelease : bool { ENABLE = true, DISABLE = false };
 
-/** Perform static_cast in release build.
-  * Checks type by comparing typeid and throw an exception in debug build.
+/** Perform static_cast in release build when TypeCheckOnRelease is set to DISABLE.
+  * Checks type by comparing typeid and throw an exception in all the other situations.
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
   */
 template <typename To, TypeCheckOnRelease check = TypeCheckOnRelease::ENABLE, typename From>

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -408,7 +408,8 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 CHECK_EQ(sizeof(Fixed), key_sizes[j]);
                 if (!nullmap_columns.empty() && nullmap_columns[j]) {
                     const auto& nullmap =
-                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*nullmap_columns[j])
+                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(
+                                    *nullmap_columns[j])
                                     .get_data()
                                     .data();
                     for (size_t i = 0; i < row_numbers; ++i) {

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -408,10 +408,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 CHECK_EQ(sizeof(Fixed), key_sizes[j]);
                 if (!nullmap_columns.empty() && nullmap_columns[j]) {
                     const auto& nullmap =
-                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(
-                                    *nullmap_columns[j])
-                                    .get_data()
-                                    .data();
+                            assert_cast<const ColumnUInt8&>(*nullmap_columns[j]).get_data().data();
                     for (size_t i = 0; i < row_numbers; ++i) {
                         // make sure null cell is filled by 0x0
                         memcpy_fixed<Fixed, true>(

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -408,7 +408,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 CHECK_EQ(sizeof(Fixed), key_sizes[j]);
                 if (!nullmap_columns.empty() && nullmap_columns[j]) {
                     const auto& nullmap =
-                            assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*nullmap_columns[j])
+                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(*nullmap_columns[j])
                                     .get_data()
                                     .data();
                     for (size_t i = 0; i < row_numbers; ++i) {

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -408,7 +408,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 CHECK_EQ(sizeof(Fixed), key_sizes[j]);
                 if (!nullmap_columns.empty() && nullmap_columns[j]) {
                     const auto& nullmap =
-                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::Disable>(
+                            assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(
                                     *nullmap_columns[j])
                                     .get_data()
                                     .data();

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -408,7 +408,9 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 CHECK_EQ(sizeof(Fixed), key_sizes[j]);
                 if (!nullmap_columns.empty() && nullmap_columns[j]) {
                     const auto& nullmap =
-                            assert_cast<const ColumnUInt8&>(*nullmap_columns[j]).get_data().data();
+                            assert_cast<const ColumnUInt8&, TypeCheck::Disable>(*nullmap_columns[j])
+                                    .get_data()
+                                    .data();
                     for (size_t i = 0; i < row_numbers; ++i) {
                         // make sure null cell is filled by 0x0
                         memcpy_fixed<Fixed, true>(

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -518,7 +518,7 @@ std::string Block::dump_data(size_t begin, size_t row_limit, bool allow_null_mis
             if (data[i].column) {
                 if (data[i].type->is_nullable() && !data[i].column->is_nullable()) {
                     assert(allow_null_mismatch);
-                    s = assert_cast<const DataTypeNullable*>(data[i].type.get())
+                    s = assert_cast<const DataTypeNullable*, TypeCheck::Disable>(data[i].type.get())
                                 ->get_nested_type()
                                 ->to_string(*data[i].column, row_num);
                 } else {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -518,7 +518,7 @@ std::string Block::dump_data(size_t begin, size_t row_limit, bool allow_null_mis
             if (data[i].column) {
                 if (data[i].type->is_nullable() && !data[i].column->is_nullable()) {
                     assert(allow_null_mismatch);
-                    s = assert_cast<const DataTypeNullable*, TypeCheck::Disable>(data[i].type.get())
+                    s = assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(data[i].type.get())
                                 ->get_nested_type()
                                 ->to_string(*data[i].column, row_num);
                 } else {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -518,8 +518,7 @@ std::string Block::dump_data(size_t begin, size_t row_limit, bool allow_null_mis
             if (data[i].column) {
                 if (data[i].type->is_nullable() && !data[i].column->is_nullable()) {
                     assert(allow_null_mismatch);
-                    s = assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(
-                                data[i].type.get())
+                    s = assert_cast<const DataTypeNullable*>(data[i].type.get())
                                 ->get_nested_type()
                                 ->to_string(*data[i].column, row_num);
                 } else {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -518,7 +518,8 @@ std::string Block::dump_data(size_t begin, size_t row_limit, bool allow_null_mis
             if (data[i].column) {
                 if (data[i].type->is_nullable() && !data[i].column->is_nullable()) {
                     assert(allow_null_mismatch);
-                    s = assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(data[i].type.get())
+                    s = assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(
+                                data[i].type.get())
                                 ->get_nested_type()
                                 ->to_string(*data[i].column, row_num);
                 } else {

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -239,7 +239,7 @@ DataTypes make_nullable(const DataTypes& types) {
 
 DataTypePtr remove_nullable(const DataTypePtr& type) {
     if (type->is_nullable()) {
-        return assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
+        return assert_cast<const DataTypeNullable*, TypeCheck::Disable>(type.get())->get_nested_type();
     }
     return type;
 }

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -239,8 +239,7 @@ DataTypes make_nullable(const DataTypes& types) {
 
 DataTypePtr remove_nullable(const DataTypePtr& type) {
     if (type->is_nullable()) {
-        return assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(type.get())
-                ->get_nested_type();
+        return assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
     }
     return type;
 }

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -239,7 +239,8 @@ DataTypes make_nullable(const DataTypes& types) {
 
 DataTypePtr remove_nullable(const DataTypePtr& type) {
     if (type->is_nullable()) {
-        return assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(type.get())->get_nested_type();
+        return assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(type.get())
+                ->get_nested_type();
     }
     return type;
 }

--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -239,7 +239,7 @@ DataTypes make_nullable(const DataTypes& types) {
 
 DataTypePtr remove_nullable(const DataTypePtr& type) {
     if (type->is_nullable()) {
-        return assert_cast<const DataTypeNullable*, TypeCheck::Disable>(type.get())->get_nested_type();
+        return assert_cast<const DataTypeNullable*, TypeCheckOnRelease::DISABLE>(type.get())->get_nested_type();
     }
     return type;
 }

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -52,18 +52,21 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
 
     if constexpr (std::is_same<T, UInt128>::value) {
         std::string hex = int128_to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num));
         ostr.write(hex.data(), hex.size());
     } else if constexpr (std::is_same_v<T, float>) {
         // fmt::format_to maybe get inaccurate results at float type, so we use gutil implement.
         char buf[MAX_FLOAT_STR_LENGTH + 2];
         int len = FloatToBuffer(
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num),
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num),
                 MAX_FLOAT_STR_LENGTH + 2, buf);
         ostr.write(buf, len);
     } else if constexpr (std::is_integral<T>::value || std::numeric_limits<T>::is_iec559) {
         ostr.write_number(
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num));
     }
 }
 
@@ -165,15 +168,18 @@ std::string DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_n
     if constexpr (std::is_same<T, int128_t>::value || std::is_same<T, uint128_t>::value ||
                   std::is_same<T, UInt128>::value) {
         return int128_to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num));
     } else if constexpr (std::is_integral<T>::value) {
         return std::to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num));
     } else if constexpr (std::numeric_limits<T>::is_iec559) {
         fmt::memory_buffer buffer; // only use in size-predictable type.
         fmt::format_to(
                 buffer, "{}",
-                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                        row_num));
         return std::string(buffer.data(), buffer.size());
     }
 }

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -52,18 +52,18 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
 
     if constexpr (std::is_same<T, UInt128>::value) {
         std::string hex = int128_to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
         ostr.write(hex.data(), hex.size());
     } else if constexpr (std::is_same_v<T, float>) {
         // fmt::format_to maybe get inaccurate results at float type, so we use gutil implement.
         char buf[MAX_FLOAT_STR_LENGTH + 2];
         int len = FloatToBuffer(
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num),
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num),
                 MAX_FLOAT_STR_LENGTH + 2, buf);
         ostr.write(buf, len);
     } else if constexpr (std::is_integral<T>::value || std::numeric_limits<T>::is_iec559) {
         ostr.write_number(
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
     }
 }
 
@@ -165,15 +165,15 @@ std::string DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_n
     if constexpr (std::is_same<T, int128_t>::value || std::is_same<T, uint128_t>::value ||
                   std::is_same<T, UInt128>::value) {
         return int128_to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
     } else if constexpr (std::is_integral<T>::value) {
         return std::to_string(
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
     } else if constexpr (std::numeric_limits<T>::is_iec559) {
         fmt::memory_buffer buffer; // only use in size-predictable type.
         fmt::format_to(
                 buffer, "{}",
-                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
+                assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num));
         return std::string(buffer.data(), buffer.size());
     }
 }

--- a/be/src/vec/data_types/data_type_number_base.cpp
+++ b/be/src/vec/data_types/data_type_number_base.cpp
@@ -51,17 +51,19 @@ void DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_num,
     row_num = result.second;
 
     if constexpr (std::is_same<T, UInt128>::value) {
-        std::string hex =
-                int128_to_string(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
+        std::string hex = int128_to_string(
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
         ostr.write(hex.data(), hex.size());
     } else if constexpr (std::is_same_v<T, float>) {
         // fmt::format_to maybe get inaccurate results at float type, so we use gutil implement.
         char buf[MAX_FLOAT_STR_LENGTH + 2];
-        int len = FloatToBuffer(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num),
-                                MAX_FLOAT_STR_LENGTH + 2, buf);
+        int len = FloatToBuffer(
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num),
+                MAX_FLOAT_STR_LENGTH + 2, buf);
         ostr.write(buf, len);
     } else if constexpr (std::is_integral<T>::value || std::numeric_limits<T>::is_iec559) {
-        ostr.write_number(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
+        ostr.write_number(
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
     }
 }
 
@@ -162,13 +164,16 @@ std::string DataTypeNumberBase<T>::to_string(const IColumn& column, size_t row_n
 
     if constexpr (std::is_same<T, int128_t>::value || std::is_same<T, uint128_t>::value ||
                   std::is_same<T, UInt128>::value) {
-        return int128_to_string(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
+        return int128_to_string(
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
     } else if constexpr (std::is_integral<T>::value) {
-        return std::to_string(assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
+        return std::to_string(
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
     } else if constexpr (std::numeric_limits<T>::is_iec559) {
         fmt::memory_buffer buffer; // only use in size-predictable type.
-        fmt::format_to(buffer, "{}",
-                       assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num));
+        fmt::format_to(
+                buffer, "{}",
+                assert_cast<const ColumnVector<T>&, TypeCheck::Disable>(*ptr).get_element(row_num));
         return std::string(buffer.data(), buffer.size());
     }
 }

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
@@ -50,7 +50,8 @@ Status DataTypeDateTimeV2SerDe::serialize_one_cell_to_json(const IColumn& column
     row_num = result.second;
 
     UInt64 int_val =
-            assert_cast<const ColumnUInt64&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num);
+            assert_cast<const ColumnUInt64&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(
+                    row_num);
     DateV2Value<DateTimeV2ValueType> val =
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(int_val);
 

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
@@ -49,7 +49,8 @@ Status DataTypeDateTimeV2SerDe::serialize_one_cell_to_json(const IColumn& column
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    UInt64 int_val = assert_cast<const ColumnUInt64&>(*ptr).get_element(row_num);
+    UInt64 int_val =
+            assert_cast<const ColumnUInt64&, TypeCheck::Disable>(*ptr).get_element(row_num);
     DateV2Value<DateTimeV2ValueType> val =
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(int_val);
 
@@ -76,7 +77,7 @@ Status DataTypeDateTimeV2SerDe::deserialize_column_from_json_vector(
 }
 Status DataTypeDateTimeV2SerDe::deserialize_one_cell_from_json(IColumn& column, Slice& slice,
                                                                const FormatOptions& options) const {
-    auto& column_data = assert_cast<ColumnUInt64&>(column);
+    auto& column_data = assert_cast<ColumnUInt64&, TypeCheck::Disable>(column);
     UInt64 val = 0;
     if (options.date_olap_format) {
         DateV2Value<DateTimeV2ValueType> datetimev2_value;

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
@@ -50,7 +50,7 @@ Status DataTypeDateTimeV2SerDe::serialize_one_cell_to_json(const IColumn& column
     row_num = result.second;
 
     UInt64 int_val =
-            assert_cast<const ColumnUInt64&, TypeCheck::Disable>(*ptr).get_element(row_num);
+            assert_cast<const ColumnUInt64&, TypeCheckOnRelease::DISABLE>(*ptr).get_element(row_num);
     DateV2Value<DateTimeV2ValueType> val =
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(int_val);
 
@@ -77,7 +77,7 @@ Status DataTypeDateTimeV2SerDe::deserialize_column_from_json_vector(
 }
 Status DataTypeDateTimeV2SerDe::deserialize_one_cell_from_json(IColumn& column, Slice& slice,
                                                                const FormatOptions& options) const {
-    auto& column_data = assert_cast<ColumnUInt64&, TypeCheck::Disable>(column);
+    auto& column_data = assert_cast<ColumnUInt64&, TypeCheckOnRelease::DISABLE>(column);
     UInt64 val = 0;
     if (options.date_olap_format) {
         DateV2Value<DateTimeV2ValueType> datetimev2_value;

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -53,7 +53,8 @@ Status DataTypeStructSerDe::serialize_one_cell_to_json(const IColumn& column, in
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
+    const ColumnStruct& struct_column =
+            assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
     bw.write('{');
     for (int i = 0; i < struct_column.get_columns().size(); i++) {
         if (i != 0) {
@@ -279,7 +280,8 @@ void DataTypeStructSerDe::serialize_one_cell_to_hive_text(
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
+    const ColumnStruct& struct_column =
+            assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
 
     char collection_delimiter =
             options.get_collection_delimiter(hive_text_complex_type_delimiter_level);

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -53,7 +53,7 @@ Status DataTypeStructSerDe::serialize_one_cell_to_json(const IColumn& column, in
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheck::Disable>(*ptr);
+    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
     bw.write('{');
     for (int i = 0; i < struct_column.get_columns().size(); i++) {
         if (i != 0) {
@@ -73,7 +73,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
     if (slice.empty()) {
         return Status::InvalidArgument("slice is empty!");
     }
-    auto& struct_column = assert_cast<ColumnStruct&, TypeCheck::Disable>(column);
+    auto& struct_column = assert_cast<ColumnStruct&, TypeCheckOnRelease::DISABLE>(column);
 
     if (slice[0] != '{') {
         std::stringstream ss;
@@ -279,7 +279,7 @@ void DataTypeStructSerDe::serialize_one_cell_to_hive_text(
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheck::Disable>(*ptr);
+    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(*ptr);
 
     char collection_delimiter =
             options.get_collection_delimiter(hive_text_complex_type_delimiter_level);
@@ -335,7 +335,7 @@ Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
                                                    MysqlRowBuffer<is_binary_format>& result,
                                                    int row_idx, bool col_const,
                                                    const FormatOptions& options) const {
-    auto& col = assert_cast<const ColumnStruct&, TypeCheck::Disable>(column);
+    auto& col = assert_cast<const ColumnStruct&, TypeCheckOnRelease::DISABLE>(column);
     const auto col_index = index_check_const(row_idx, col_const);
     result.open_dynamic_mode();
     if (0 != result.push_string("{", 1)) {

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -53,7 +53,7 @@ Status DataTypeStructSerDe::serialize_one_cell_to_json(const IColumn& column, in
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&>(*ptr);
+    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheck::Disable>(*ptr);
     bw.write('{');
     for (int i = 0; i < struct_column.get_columns().size(); i++) {
         if (i != 0) {
@@ -73,7 +73,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
     if (slice.empty()) {
         return Status::InvalidArgument("slice is empty!");
     }
-    auto& struct_column = assert_cast<ColumnStruct&>(column);
+    auto& struct_column = assert_cast<ColumnStruct&, TypeCheck::Disable>(column);
 
     if (slice[0] != '{') {
         std::stringstream ss;
@@ -279,7 +279,7 @@ void DataTypeStructSerDe::serialize_one_cell_to_hive_text(
     ColumnPtr ptr = result.first;
     row_num = result.second;
 
-    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&>(*ptr);
+    const ColumnStruct& struct_column = assert_cast<const ColumnStruct&, TypeCheck::Disable>(*ptr);
 
     char collection_delimiter =
             options.get_collection_delimiter(hive_text_complex_type_delimiter_level);
@@ -335,7 +335,7 @@ Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
                                                    MysqlRowBuffer<is_binary_format>& result,
                                                    int row_idx, bool col_const,
                                                    const FormatOptions& options) const {
-    auto& col = assert_cast<const ColumnStruct&>(column);
+    auto& col = assert_cast<const ColumnStruct&, TypeCheck::Disable>(column);
     const auto col_index = index_check_const(row_idx, col_const);
     result.open_dynamic_mode();
     if (0 != result.push_string("{", 1)) {

--- a/be/src/vec/exec/format/table/transactional_hive_reader.cpp
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.cpp
@@ -156,13 +156,13 @@ Status TransactionalHiveReader::init_row_filters(const TFileRangeDesc& range) {
                 static int BUCKET_ID_INDEX = 1;
                 static int ROW_ID_INDEX = 2;
                 const ColumnInt64& original_transaction_column =
-                        assert_cast<const ColumnInt64&, TypeCheck::Disable>(
+                        assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(
                                 *block.get_by_position(ORIGINAL_TRANSACTION_INDEX).column);
                 const ColumnInt32& bucket_id_column =
-                        assert_cast<const ColumnInt32&, TypeCheck::Disable>(
+                        assert_cast<const ColumnInt32&, TypeCheckOnRelease::DISABLE>(
                                 *block.get_by_position(BUCKET_ID_INDEX).column);
                 const ColumnInt64& row_id_column =
-                        assert_cast<const ColumnInt64&, TypeCheck::Disable>(
+                        assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(
                                 *block.get_by_position(ROW_ID_INDEX).column);
 
                 DCHECK_EQ(original_transaction_column.size(), read_rows);

--- a/be/src/vec/exec/format/table/transactional_hive_reader.cpp
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.cpp
@@ -155,15 +155,12 @@ Status TransactionalHiveReader::init_row_filters(const TFileRangeDesc& range) {
                 static int ORIGINAL_TRANSACTION_INDEX = 0;
                 static int BUCKET_ID_INDEX = 1;
                 static int ROW_ID_INDEX = 2;
-                const ColumnInt64& original_transaction_column =
-                        assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(
-                                *block.get_by_position(ORIGINAL_TRANSACTION_INDEX).column);
-                const ColumnInt32& bucket_id_column =
-                        assert_cast<const ColumnInt32&, TypeCheckOnRelease::DISABLE>(
-                                *block.get_by_position(BUCKET_ID_INDEX).column);
-                const ColumnInt64& row_id_column =
-                        assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(
-                                *block.get_by_position(ROW_ID_INDEX).column);
+                const ColumnInt64& original_transaction_column = assert_cast<const ColumnInt64&>(
+                        *block.get_by_position(ORIGINAL_TRANSACTION_INDEX).column);
+                const ColumnInt32& bucket_id_column = assert_cast<const ColumnInt32&>(
+                        *block.get_by_position(BUCKET_ID_INDEX).column);
+                const ColumnInt64& row_id_column = assert_cast<const ColumnInt64&>(
+                        *block.get_by_position(ROW_ID_INDEX).column);
 
                 DCHECK_EQ(original_transaction_column.size(), read_rows);
                 DCHECK_EQ(bucket_id_column.size(), read_rows);

--- a/be/src/vec/exec/format/table/transactional_hive_reader.cpp
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.cpp
@@ -155,12 +155,15 @@ Status TransactionalHiveReader::init_row_filters(const TFileRangeDesc& range) {
                 static int ORIGINAL_TRANSACTION_INDEX = 0;
                 static int BUCKET_ID_INDEX = 1;
                 static int ROW_ID_INDEX = 2;
-                const ColumnInt64& original_transaction_column = assert_cast<const ColumnInt64&>(
-                        *block.get_by_position(ORIGINAL_TRANSACTION_INDEX).column);
-                const ColumnInt32& bucket_id_column = assert_cast<const ColumnInt32&>(
-                        *block.get_by_position(BUCKET_ID_INDEX).column);
-                const ColumnInt64& row_id_column = assert_cast<const ColumnInt64&>(
-                        *block.get_by_position(ROW_ID_INDEX).column);
+                const ColumnInt64& original_transaction_column =
+                        assert_cast<const ColumnInt64&, TypeCheck::Disable>(
+                                *block.get_by_position(ORIGINAL_TRANSACTION_INDEX).column);
+                const ColumnInt32& bucket_id_column =
+                        assert_cast<const ColumnInt32&, TypeCheck::Disable>(
+                                *block.get_by_position(BUCKET_ID_INDEX).column);
+                const ColumnInt64& row_id_column =
+                        assert_cast<const ColumnInt64&, TypeCheck::Disable>(
+                                *block.get_by_position(ROW_ID_INDEX).column);
 
                 DCHECK_EQ(original_transaction_column.size(), read_rows);
                 DCHECK_EQ(bucket_id_column.size(), read_rows);

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -335,7 +335,7 @@ private:
         ColumnPtr nested_column = nullptr;
         if (is_column_nullable(array_column.get_data())) {
             const auto& nested_null_column =
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
                             array_column.get_data());
             nested_null_map = nested_null_column.get_null_map_column().get_data().data();
             nested_column = nested_null_column.get_nested_column_ptr();

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -335,7 +335,8 @@ private:
         ColumnPtr nested_column = nullptr;
         if (is_column_nullable(array_column.get_data())) {
             const auto& nested_null_column =
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(array_column.get_data());
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(
+                            array_column.get_data());
             nested_null_map = nested_null_column.get_null_map_column().get_data().data();
             nested_column = nested_null_column.get_nested_column_ptr();
         } else {

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -335,7 +335,7 @@ private:
         ColumnPtr nested_column = nullptr;
         if (is_column_nullable(array_column.get_data())) {
             const auto& nested_null_column =
-                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(array_column.get_data());
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::Disable>(array_column.get_data());
             nested_null_map = nested_null_column.get_null_map_column().get_data().data();
             nested_column = nested_null_column.get_nested_column_ptr();
         } else {

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -328,15 +328,14 @@ private:
                                 const UInt8* src_null_map, UInt8* dst_null_map) const {
         // check array nested column type and get data
         auto left_column = arguments[0].column->convert_to_full_column_if_const();
-        const auto& array_column = assert_cast<const ColumnArray&>(*left_column);
+        const auto& array_column = reinterpret_cast<const ColumnArray&>(*left_column);
         const auto& offsets = array_column.get_offsets();
         DCHECK(offsets.size() == input_rows_count);
         const UInt8* nested_null_map = nullptr;
         ColumnPtr nested_column = nullptr;
         if (is_column_nullable(array_column.get_data())) {
             const auto& nested_null_column =
-                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
-                            array_column.get_data());
+                    reinterpret_cast<const ColumnNullable&>(array_column.get_data());
             nested_null_map = nested_null_column.get_null_map_column().get_data().data();
             nested_column = nested_null_column.get_nested_column_ptr();
         } else {

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -38,6 +38,7 @@
 #include "vec/columns/column_struct.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
 #include "vec/core/block.h"
 #include "vec/core/column_numbers.h"
 #include "vec/core/column_with_type_and_name.h"
@@ -327,14 +328,14 @@ private:
                                 const UInt8* src_null_map, UInt8* dst_null_map) const {
         // check array nested column type and get data
         auto left_column = arguments[0].column->convert_to_full_column_if_const();
-        const auto& array_column = reinterpret_cast<const ColumnArray&>(*left_column);
+        const auto& array_column = assert_cast<const ColumnArray&>(*left_column);
         const auto& offsets = array_column.get_offsets();
         DCHECK(offsets.size() == input_rows_count);
         const UInt8* nested_null_map = nullptr;
         ColumnPtr nested_column = nullptr;
         if (is_column_nullable(array_column.get_data())) {
             const auto& nested_null_column =
-                    reinterpret_cast<const ColumnNullable&>(array_column.get_data());
+                    assert_cast<const ColumnNullable&, TypeCheck::Disable>(array_column.get_data());
             nested_null_map = nested_null_column.get_null_map_column().get_data().data();
             nested_column = nested_null_column.get_nested_column_ptr();
         } else {

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -136,7 +136,8 @@ public:
 
         if (left_const) {
             left_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(col_left.column.get())
+                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
+                            col_left.column.get())
                             ->get_data_column_ptr());
         } else {
             left_column = check_and_get_column<const ColumnNullable>(col_left.column);
@@ -144,7 +145,8 @@ public:
 
         if (right_const) {
             right_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(col_right.column.get())
+                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
+                            col_right.column.get())
                             ->get_data_column_ptr());
         } else {
             right_column = check_and_get_column<const ColumnNullable>(col_right.column);

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -136,7 +136,7 @@ public:
 
         if (left_const) {
             left_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*, TypeCheck::Disable>(col_left.column.get())
+                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(col_left.column.get())
                             ->get_data_column_ptr());
         } else {
             left_column = check_and_get_column<const ColumnNullable>(col_left.column);
@@ -144,7 +144,7 @@ public:
 
         if (right_const) {
             right_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*, TypeCheck::Disable>(col_right.column.get())
+                    assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(col_right.column.get())
                             ->get_data_column_ptr());
         } else {
             right_column = check_and_get_column<const ColumnNullable>(col_right.column);

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -136,14 +136,16 @@ public:
 
         if (left_const) {
             left_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*>(col_left.column.get())->get_data_column_ptr());
+                    assert_cast<const ColumnConst*, TypeCheck::Disable>(col_left.column.get())
+                            ->get_data_column_ptr());
         } else {
             left_column = check_and_get_column<const ColumnNullable>(col_left.column);
         }
 
         if (right_const) {
             right_column = check_and_get_column<const ColumnNullable>(
-                    assert_cast<const ColumnConst*>(col_right.column.get())->get_data_column_ptr());
+                    assert_cast<const ColumnConst*, TypeCheck::Disable>(col_right.column.get())
+                            ->get_data_column_ptr());
         } else {
             right_column = check_and_get_column<const ColumnNullable>(col_right.column);
         }

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -414,10 +414,10 @@ public:
                                                      const ResultType& scale_diff_multiplier,
                                                      DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
         auto column_result = ColumnDecimal<ResultType>::create(
                 1,
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
                         .get_scale());
 
         if constexpr (check_overflow && !is_to_null_type &&
@@ -445,11 +445,11 @@ public:
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
         auto column_left_ptr = check_and_get_column<typename Traits::ColumnVectorA>(column_left);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_left->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
                         .get_scale());
         DCHECK(column_left_ptr != nullptr);
 
@@ -478,11 +478,11 @@ public:
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
         auto column_right_ptr = check_and_get_column<typename Traits::ColumnVectorB>(column_right);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_right->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
                         .get_scale());
         DCHECK(column_right_ptr != nullptr);
 

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -413,9 +413,12 @@ public:
                                                      const ResultType& max_result_number,
                                                      const ResultType& scale_diff_multiplier,
                                                      DataTypePtr res_data_type) {
-        auto type_result = assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type);
+        auto type_result =
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
         auto column_result = ColumnDecimal<ResultType>::create(
-                1, assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type).get_scale());
+                1,
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                        .get_scale());
 
         if constexpr (check_overflow && !is_to_null_type &&
                       ((!OpTraits::is_multiply && !OpTraits::is_plus_minus))) {
@@ -441,11 +444,13 @@ public:
                                                    const ResultType& max_result_number,
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
-        auto type_result = assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type);
+        auto type_result =
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
         auto column_left_ptr = check_and_get_column<typename Traits::ColumnVectorA>(column_left);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_left->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type).get_scale());
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                        .get_scale());
         DCHECK(column_left_ptr != nullptr);
 
         if constexpr (check_overflow && !is_to_null_type &&
@@ -472,11 +477,13 @@ public:
                                                    const ResultType& max_result_number,
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
-        auto type_result = assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type);
+        auto type_result =
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type);
         auto column_right_ptr = check_and_get_column<typename Traits::ColumnVectorB>(column_right);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_right->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type).get_scale());
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheck::Disable>(*res_data_type)
+                        .get_scale());
         DCHECK(column_right_ptr != nullptr);
 
         if constexpr (check_overflow && !is_to_null_type &&

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -414,11 +414,12 @@ public:
                                                      const ResultType& scale_diff_multiplier,
                                                      DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                        *res_data_type);
         auto column_result = ColumnDecimal<ResultType>::create(
-                1,
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
-                        .get_scale());
+                1, assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                           *res_data_type)
+                           .get_scale());
 
         if constexpr (check_overflow && !is_to_null_type &&
                       ((!OpTraits::is_multiply && !OpTraits::is_plus_minus))) {
@@ -445,11 +446,13 @@ public:
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                        *res_data_type);
         auto column_left_ptr = check_and_get_column<typename Traits::ColumnVectorA>(column_left);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_left->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                        *res_data_type)
                         .get_scale());
         DCHECK(column_left_ptr != nullptr);
 
@@ -478,11 +481,13 @@ public:
                                                    const ResultType& scale_diff_multiplier,
                                                    DataTypePtr res_data_type) {
         auto type_result =
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type);
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                        *res_data_type);
         auto column_right_ptr = check_and_get_column<typename Traits::ColumnVectorB>(column_right);
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_right->size(),
-                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(*res_data_type)
+                assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
+                        *res_data_type)
                         .get_scale());
         DCHECK(column_right_ptr != nullptr);
 

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -232,8 +232,7 @@ public:
                     }
                 } else {
                     const auto* __restrict cond_raw_data =
-                            assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(
-                                    when_column_ptr.get())
+                            assert_cast<const ColumnUInt8*>(when_column_ptr.get())
                                     ->get_data()
                                     .data();
 
@@ -336,7 +335,7 @@ public:
         // some types had simd automatically, but some not.
         for (uint8_t i = (has_else ? 0 : 1); i < column_holder.pair_count; i++) {
             auto* __restrict column_raw_data =
-                    assert_cast<ColumnType*, TypeCheckOnRelease::DISABLE>(
+                    assert_cast<ColumnType*>(
                             column_holder.then_ptrs[i].value()->assume_mutable().get())
                             ->get_data()
                             .data();

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -232,7 +232,7 @@ public:
                     }
                 } else {
                     const auto* __restrict cond_raw_data =
-                            assert_cast<const ColumnUInt8*, TypeCheck::Disable>(
+                            assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(
                                     when_column_ptr.get())
                                     ->get_data()
                                     .data();
@@ -303,11 +303,11 @@ public:
             }
             size_t target = is_consts[then_idx[row_idx]] ? 0 : row_idx;
             if constexpr (then_null) {
-                assert_cast<ColumnNullable*, TypeCheck::Disable>(result_column_ptr.get())
+                assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(result_column_ptr.get())
                         ->insert_from_with_type<ColumnType>(*raw_columns[then_idx[row_idx]],
                                                             target);
             } else {
-                assert_cast<ColumnType*, TypeCheck::Disable>(result_column_ptr.get())
+                assert_cast<ColumnType*, TypeCheckOnRelease::DISABLE>(result_column_ptr.get())
                         ->insert_from(*raw_columns[then_idx[row_idx]], target);
             }
         }
@@ -324,7 +324,7 @@ public:
         size_t rows_count = column_holder.rows_count;
         result_column_ptr->resize(rows_count);
         auto* __restrict result_raw_data =
-                assert_cast<ColumnType*, TypeCheck::Disable>(result_column_ptr.get())
+                assert_cast<ColumnType*, TypeCheckOnRelease::DISABLE>(result_column_ptr.get())
                         ->get_data()
                         .data();
 
@@ -336,7 +336,7 @@ public:
         // some types had simd automatically, but some not.
         for (uint8_t i = (has_else ? 0 : 1); i < column_holder.pair_count; i++) {
             auto* __restrict column_raw_data =
-                    assert_cast<ColumnType*, TypeCheck::Disable>(
+                    assert_cast<ColumnType*, TypeCheckOnRelease::DISABLE>(
                             column_holder.then_ptrs[i].value()->assume_mutable().get())
                             ->get_data()
                             .data();

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -232,7 +232,8 @@ public:
                     }
                 } else {
                     const auto* __restrict cond_raw_data =
-                            assert_cast<const ColumnUInt8*>(when_column_ptr.get())
+                            assert_cast<const ColumnUInt8*, TypeCheck::Disable>(
+                                    when_column_ptr.get())
                                     ->get_data()
                                     .data();
 
@@ -302,11 +303,11 @@ public:
             }
             size_t target = is_consts[then_idx[row_idx]] ? 0 : row_idx;
             if constexpr (then_null) {
-                assert_cast<ColumnNullable*>(result_column_ptr.get())
+                assert_cast<ColumnNullable*, TypeCheck::Disable>(result_column_ptr.get())
                         ->insert_from_with_type<ColumnType>(*raw_columns[then_idx[row_idx]],
                                                             target);
             } else {
-                assert_cast<ColumnType*>(result_column_ptr.get())
+                assert_cast<ColumnType*, TypeCheck::Disable>(result_column_ptr.get())
                         ->insert_from(*raw_columns[then_idx[row_idx]], target);
             }
         }
@@ -323,7 +324,9 @@ public:
         size_t rows_count = column_holder.rows_count;
         result_column_ptr->resize(rows_count);
         auto* __restrict result_raw_data =
-                assert_cast<ColumnType*>(result_column_ptr.get())->get_data().data();
+                assert_cast<ColumnType*, TypeCheck::Disable>(result_column_ptr.get())
+                        ->get_data()
+                        .data();
 
         // set default value
         for (int i = 0; i < rows_count; i++) {
@@ -333,7 +336,7 @@ public:
         // some types had simd automatically, but some not.
         for (uint8_t i = (has_else ? 0 : 1); i < column_holder.pair_count; i++) {
             auto* __restrict column_raw_data =
-                    assert_cast<ColumnType*>(
+                    assert_cast<ColumnType*, TypeCheck::Disable>(
                             column_holder.then_ptrs[i].value()->assume_mutable().get())
                             ->get_data()
                             .data();

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1525,7 +1525,7 @@ struct StringParsing {
         const ColumnString::Chars* chars = &col_from_string->get_chars();
         const IColumn::Offsets* offsets = &col_from_string->get_offsets();
 
-        [[maybe_unused]] const UInt32 scale = 0;
+        [[maybe_unused]] UInt32 scale = 0;
         if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
             const auto* type = assert_cast<const DataTypeDateTimeV2*>(
                     block.get_by_position(result).type.get());

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1525,10 +1525,11 @@ struct StringParsing {
         const ColumnString::Chars* chars = &col_from_string->get_chars();
         const IColumn::Offsets* offsets = &col_from_string->get_offsets();
 
+        [[maybe_unused]] const UInt32 scale = 0;
         if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
             const auto* type = assert_cast<const DataTypeDateTimeV2*>(
                     block.get_by_position(result).type.get());
-            const UInt32 scale = type->get_scale();
+            scale = type->get_scale();
         }
 
         size_t current_offset = 0;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1524,9 +1524,13 @@ struct StringParsing {
 
         const ColumnString::Chars* chars = &col_from_string->get_chars();
         const IColumn::Offsets* offsets = &col_from_string->get_offsets();
-        const auto* type =
-                assert_cast<const DataTypeDateTimeV2*>(block.get_by_position(result).type.get());
-        const UInt32 scale = type->get_scale();
+
+        if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
+            const auto* type = assert_cast<const DataTypeDateTimeV2*>(
+                    block.get_by_position(result).type.get());
+            const UInt32 scale = type->get_scale();
+        }
+
         size_t current_offset = 0;
 
         for (size_t i = 0; i < row; ++i) {

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1541,8 +1541,9 @@ struct StringParsing {
                           res == StringParser::PARSE_OVERFLOW ||
                           res == StringParser::PARSE_UNDERFLOW);
             } else if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
-                const auto* type = assert_cast<const DataTypeDateTimeV2*, TypeCheckOnRelease::DISABLE>(
-                        block.get_by_position(result).type.get());
+                const auto* type =
+                        assert_cast<const DataTypeDateTimeV2*, TypeCheckOnRelease::DISABLE>(
+                                block.get_by_position(result).type.get());
                 parsed = try_parse_impl<ToDataType>(vec_to[i], read_buffer, context,
                                                     type->get_scale());
             } else {

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -692,7 +692,6 @@ struct ConvertImplGenericFromJsonb {
             ColumnUInt8::Container* vec_null_map_to = &col_null_map_to->get_data();
             const bool is_complex = is_complex_type(data_type_to);
             const bool is_dst_string = is_string_or_fixed_string(data_type_to);
-            ColumnString& col_to_string = assert_cast<ColumnString&>(*col_to);
             for (size_t i = 0; i < size; ++i) {
                 const auto& val = col_from_string->get_data_at(i);
                 JsonbDocument* doc = JsonbDocument::createDocument(val.data, val.size);
@@ -721,7 +720,8 @@ struct ConvertImplGenericFromJsonb {
                 // add string to string column
                 if (context->jsonb_string_as_string() && is_dst_string && value->isString()) {
                     const auto* blob = static_cast<const JsonbBlobVal*>(value);
-                    col_to_string.insert_data(blob->getBlob(), blob->getBlobLen());
+                    assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(*col_to).insert_data(
+                            blob->getBlob(), blob->getBlobLen());
                     (*vec_null_map_to)[i] = 0;
                     continue;
                 }

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -692,6 +692,7 @@ struct ConvertImplGenericFromJsonb {
             ColumnUInt8::Container* vec_null_map_to = &col_null_map_to->get_data();
             const bool is_complex = is_complex_type(data_type_to);
             const bool is_dst_string = is_string_or_fixed_string(data_type_to);
+            ColumnString& col_to_string = assert_cast<ColumnString&>(*col_to);
             for (size_t i = 0; i < size; ++i) {
                 const auto& val = col_from_string->get_data_at(i);
                 JsonbDocument* doc = JsonbDocument::createDocument(val.data, val.size);
@@ -720,8 +721,7 @@ struct ConvertImplGenericFromJsonb {
                 // add string to string column
                 if (context->jsonb_string_as_string() && is_dst_string && value->isString()) {
                     const auto* blob = static_cast<const JsonbBlobVal*>(value);
-                    assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(*col_to).insert_data(
-                            blob->getBlob(), blob->getBlobLen());
+                    col_to_string.insert_data(blob->getBlob(), blob->getBlobLen());
                     (*vec_null_map_to)[i] = 0;
                     continue;
                 }

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -720,7 +720,7 @@ struct ConvertImplGenericFromJsonb {
                 // add string to string column
                 if (context->jsonb_string_as_string() && is_dst_string && value->isString()) {
                     const auto* blob = static_cast<const JsonbBlobVal*>(value);
-                    assert_cast<ColumnString&, TypeCheck::Disable>(*col_to).insert_data(
+                    assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(*col_to).insert_data(
                             blob->getBlob(), blob->getBlobLen());
                     (*vec_null_map_to)[i] = 0;
                     continue;
@@ -1541,7 +1541,7 @@ struct StringParsing {
                           res == StringParser::PARSE_OVERFLOW ||
                           res == StringParser::PARSE_UNDERFLOW);
             } else if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
-                const auto* type = assert_cast<const DataTypeDateTimeV2*, TypeCheck::Disable>(
+                const auto* type = assert_cast<const DataTypeDateTimeV2*, TypeCheckOnRelease::DISABLE>(
                         block.get_by_position(result).type.get());
                 parsed = try_parse_impl<ToDataType>(vec_to[i], read_buffer, context,
                                                     type->get_scale());

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -720,8 +720,8 @@ struct ConvertImplGenericFromJsonb {
                 // add string to string column
                 if (context->jsonb_string_as_string() && is_dst_string && value->isString()) {
                     const auto* blob = static_cast<const JsonbBlobVal*>(value);
-                    assert_cast<ColumnString&>(*col_to).insert_data(blob->getBlob(),
-                                                                    blob->getBlobLen());
+                    assert_cast<ColumnString&, TypeCheck::Disable>(*col_to).insert_data(
+                            blob->getBlob(), blob->getBlobLen());
                     (*vec_null_map_to)[i] = 0;
                     continue;
                 }
@@ -1541,7 +1541,7 @@ struct StringParsing {
                           res == StringParser::PARSE_OVERFLOW ||
                           res == StringParser::PARSE_UNDERFLOW);
             } else if constexpr (IsDataTypeDateTimeV2<ToDataType>) {
-                const auto* type = assert_cast<const DataTypeDateTimeV2*>(
+                const auto* type = assert_cast<const DataTypeDateTimeV2*, TypeCheck::Disable>(
                         block.get_by_position(result).type.get());
                 parsed = try_parse_impl<ToDataType>(vec_to[i], read_buffer, context,
                                                     type->get_scale());

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -163,8 +163,9 @@ public:
             auto res_column =
                     (*temporary_block.get_by_position(1).column->convert_to_full_column_if_const())
                             .mutate();
-            auto& res_map = assert_cast<ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(res_column.get())
-                                    ->get_data();
+            auto& res_map =
+                    assert_cast<ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(res_column.get())
+                            ->get_data();
             auto* __restrict res = res_map.data();
 
             // Here it's SIMD thought the compiler automatically

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -154,9 +154,6 @@ public:
                 ColumnsWithTypeAndName {block.get_by_position(filtered_args[0]),
                                         {nullptr, std::make_shared<DataTypeUInt8>(), ""}}};
 
-        auto& res_map = assert_cast<ColumnVector<UInt8>*>(res_column.get())->get_data();
-        auto* __restrict res = res_map.data();
-
         for (size_t i = 0; i < argument_size && remaining_rows; ++i) {
             temporary_block.get_by_position(0).column =
                     block.get_by_position(filtered_args[i]).column;
@@ -166,6 +163,10 @@ public:
             auto res_column =
                     (*temporary_block.get_by_position(1).column->convert_to_full_column_if_const())
                             .mutate();
+            auto& res_map =
+                    assert_cast<ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(res_column.get())
+                            ->get_data();
+            auto* __restrict res = res_map.data();
 
             // Here it's SIMD thought the compiler automatically
             // true: res[j]==1 && null_map_data[j]==1, false: others

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -163,7 +163,7 @@ public:
             auto res_column =
                     (*temporary_block.get_by_position(1).column->convert_to_full_column_if_const())
                             .mutate();
-            auto& res_map = assert_cast<ColumnVector<UInt8>*, TypeCheck::Disable>(res_column.get())
+            auto& res_map = assert_cast<ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(res_column.get())
                                     ->get_data();
             auto* __restrict res = res_map.data();
 

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -154,6 +154,9 @@ public:
                 ColumnsWithTypeAndName {block.get_by_position(filtered_args[0]),
                                         {nullptr, std::make_shared<DataTypeUInt8>(), ""}}};
 
+        auto& res_map = assert_cast<ColumnVector<UInt8>*>(res_column.get())->get_data();
+        auto* __restrict res = res_map.data();
+
         for (size_t i = 0; i < argument_size && remaining_rows; ++i) {
             temporary_block.get_by_position(0).column =
                     block.get_by_position(filtered_args[i]).column;
@@ -163,10 +166,6 @@ public:
             auto res_column =
                     (*temporary_block.get_by_position(1).column->convert_to_full_column_if_const())
                             .mutate();
-            auto& res_map =
-                    assert_cast<ColumnVector<UInt8>*, TypeCheckOnRelease::DISABLE>(res_column.get())
-                            ->get_data();
-            auto* __restrict res = res_map.data();
 
             // Here it's SIMD thought the compiler automatically
             // true: res[j]==1 && null_map_data[j]==1, false: others

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -163,7 +163,8 @@ public:
             auto res_column =
                     (*temporary_block.get_by_position(1).column->convert_to_full_column_if_const())
                             .mutate();
-            auto& res_map = assert_cast<ColumnVector<UInt8>*>(res_column.get())->get_data();
+            auto& res_map = assert_cast<ColumnVector<UInt8>*, TypeCheck::Disable>(res_column.get())
+                                    ->get_data();
             auto* __restrict res = res_map.data();
 
             // Here it's SIMD thought the compiler automatically

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -148,7 +148,7 @@ void validate_argument_type(const IFunction& func, const DataTypes& arguments,
 const ColumnConst* check_and_get_column_const_string_or_fixedstring(const IColumn* column) {
     if (!is_column_const(*column)) return {};
 
-    const ColumnConst* res = assert_cast<const ColumnConst*>(column);
+    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheck::Disable>(column);
 
     if (check_column<ColumnString>(&res->get_data_column())) return res;
 

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -148,7 +148,7 @@ void validate_argument_type(const IFunction& func, const DataTypes& arguments,
 const ColumnConst* check_and_get_column_const_string_or_fixedstring(const IColumn* column) {
     if (!is_column_const(*column)) return {};
 
-    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::Disable>(column);
+    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(column);
 
     if (check_column<ColumnString>(&res->get_data_column())) return res;
 

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -148,7 +148,7 @@ void validate_argument_type(const IFunction& func, const DataTypes& arguments,
 const ColumnConst* check_and_get_column_const_string_or_fixedstring(const IColumn* column) {
     if (!is_column_const(*column)) return {};
 
-    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheck::Disable>(column);
+    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::Disable>(column);
 
     if (check_column<ColumnString>(&res->get_data_column())) return res;
 

--- a/be/src/vec/functions/function_helpers.h
+++ b/be/src/vec/functions/function_helpers.h
@@ -55,7 +55,7 @@ template <typename Type>
 const ColumnConst* check_and_get_column_const(const IColumn* column) {
     if (!column || !is_column_const(*column)) return {};
 
-    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheck::Disable>(column);
+    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(column);
 
     if (!check_column<Type>(&res->get_data_column())) return {};
 

--- a/be/src/vec/functions/function_helpers.h
+++ b/be/src/vec/functions/function_helpers.h
@@ -55,7 +55,7 @@ template <typename Type>
 const ColumnConst* check_and_get_column_const(const IColumn* column) {
     if (!column || !is_column_const(*column)) return {};
 
-    const ColumnConst* res = assert_cast<const ColumnConst*>(column);
+    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheck::Disable>(column);
 
     if (!check_column<Type>(&res->get_data_column())) return {};
 

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -429,7 +429,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 (*vec_null_map_to)[i] = true;
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string = assert_cast<ColumnString*>(col_res.get());
+                auto* column_string = assert_cast<ColumnString*, TypeCheck::Disable>(col_res.get());
                 column_string->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             src_offset = src_next_offset;

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -402,6 +402,8 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
         offset_inc = IPV6_BINARY_LENGTH;
     }
 
+    auto* column_string = assert_cast<ColumnString*>(col_res.get());
+
     for (size_t out_offset = 0, i = 0; i < column_size; out_offset += offset_inc, ++i) {
         size_t src_next_offset = src_offset;
 
@@ -429,8 +431,6 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 (*vec_null_map_to)[i] = true;
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string =
-                        assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(col_res.get());
                 column_string->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             src_offset = src_next_offset;

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -398,12 +398,10 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
     std::string string_buffer;
 
     int offset_inc = 1;
+    ColumnString* column_string = nullptr;
     if constexpr (std::is_same_v<ToColumn, ColumnString>) {
         offset_inc = IPV6_BINARY_LENGTH;
-    }
-
-    if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-        auto* column_string = assert_cast<ColumnString*>(col_res.get());
+        column_string = assert_cast<ColumnString*>(col_res.get());
     }
 
     for (size_t out_offset = 0, i = 0; i < column_size; out_offset += offset_inc, ++i) {
@@ -433,6 +431,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 (*vec_null_map_to)[i] = true;
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
+                DCHECK(column_string != nullptr);
                 column_string->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             src_offset = src_next_offset;

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -429,7 +429,8 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 (*vec_null_map_to)[i] = true;
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string = assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(col_res.get());
+                auto* column_string =
+                        assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(col_res.get());
                 column_string->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             src_offset = src_next_offset;

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -429,7 +429,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 (*vec_null_map_to)[i] = true;
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string = assert_cast<ColumnString*, TypeCheck::Disable>(col_res.get());
+                auto* column_string = assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(col_res.get());
                 column_string->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             src_offset = src_next_offset;

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -402,7 +402,9 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
         offset_inc = IPV6_BINARY_LENGTH;
     }
 
-    auto* column_string = assert_cast<ColumnString*>(col_res.get());
+    if constexpr (std::is_same_v<ToColumn, ColumnString>) {
+        auto* column_string = assert_cast<ColumnString*>(col_res.get());
+    }
 
     for (size_t out_offset = 0, i = 0; i < column_size; out_offset += offset_inc, ++i) {
         size_t src_next_offset = src_offset;

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "runtime/string_search.hpp"
 #include "util/url_coding.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
 #include "vec/common/pod_array_fwd.h"
 #include "vec/common/string_ref.h"
@@ -576,8 +577,8 @@ struct Trim2Impl {
         const auto& rcol =
                 assert_cast<const ColumnConst*>(block.get_by_position(arguments[1]).column.get())
                         ->get_data_column_ptr();
-        if (const auto* col = assert_cast<const ColumnString*>(column.get())) {
-            if (const auto* col_right = assert_cast<const ColumnString*>(rcol.get())) {
+        if (const auto* col = check_and_get_column<const ColumnString>(column.get())) {
+            if (const auto* col_right = check_and_get_column<const ColumnString>(rcol.get())) {
                 auto col_res = ColumnString::create();
                 const auto* remove_str_raw = col_right->get_chars().data();
                 const ColumnString::Offset remove_str_size = col_right->get_offsets()[0];

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -577,8 +577,8 @@ struct Trim2Impl {
         const auto& rcol =
                 assert_cast<const ColumnConst*>(block.get_by_position(arguments[1]).column.get())
                         ->get_data_column_ptr();
-        if (const auto* col = check_and_get_column<const ColumnString>(column.get())) {
-            if (const auto* col_right = check_and_get_column<const ColumnString>(rcol.get())) {
+        if (const auto* col = assert_cast<const ColumnString*>(column.get())) {
+            if (const auto* col_right = assert_cast<const ColumnString*>(rcol.get())) {
                 auto col_res = ColumnString::create();
                 const auto* remove_str_raw = col_right->get_chars().data();
                 const ColumnString::Offset remove_str_size = col_right->get_offsets()[0];

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3157,10 +3157,12 @@ public:
             StringRef origin_str =
                     assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_origin.get())
                             ->get_data_at(i);
-            StringRef old_str = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_old.get())
-                                        ->get_data_at(i);
-            StringRef new_str = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_new.get())
-                                        ->get_data_at(i);
+            StringRef old_str =
+                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_old.get())
+                            ->get_data_at(i);
+            StringRef new_str =
+                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_new.get())
+                            ->get_data_at(i);
 
             std::string result = replace(origin_str.to_string(), old_str.to_string_view(),
                                          new_str.to_string_view());

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3155,9 +3155,12 @@ public:
 
         for (int i = 0; i < input_rows_count; ++i) {
             StringRef origin_str =
-                    assert_cast<const ColumnString*>(col_origin.get())->get_data_at(i);
-            StringRef old_str = assert_cast<const ColumnString*>(col_old.get())->get_data_at(i);
-            StringRef new_str = assert_cast<const ColumnString*>(col_new.get())->get_data_at(i);
+                    assert_cast<const ColumnString*, TypeCheck::Disable>(col_origin.get())
+                            ->get_data_at(i);
+            StringRef old_str = assert_cast<const ColumnString*, TypeCheck::Disable>(col_old.get())
+                                        ->get_data_at(i);
+            StringRef new_str = assert_cast<const ColumnString*, TypeCheck::Disable>(col_new.get())
+                                        ->get_data_at(i);
 
             std::string result = replace(origin_str.to_string(), old_str.to_string_view(),
                                          new_str.to_string_view());
@@ -3694,8 +3697,8 @@ public:
                     continue;
                 }
                 if (auto const_column = check_and_get_column<const ColumnConst>(*str_columns[j])) {
-                    auto str_column =
-                            assert_cast<const ColumnString*>(&(const_column->get_data_column()));
+                    auto str_column = assert_cast<const ColumnString*, TypeCheck::Disable>(
+                            &(const_column->get_data_column()));
                     auto data_item = str_column->get_data_at(0);
                     memcpy_small_allow_read_write_overflow15(
                             &res_data[res_offset[i - 1]] + current_length, data_item.data,

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3145,23 +3145,20 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         auto col_origin =
-                assert_cast<const ColumnString*>(block.get_by_position(arguments[0])
-                                                         .column->convert_to_full_column_if_const()
-                                                         .get());
+                block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
+        auto col_origin_str = assert_cast<const ColumnString*>(col_origin.get());
         auto col_old =
-                assert_cast<const ColumnString*>(block.get_by_position(arguments[1])
-                                                         .column->convert_to_full_column_if_const()
-                                                         .get());
+                block.get_by_position(arguments[1]).column->convert_to_full_column_if_const();
+        auto col_old_str = assert_cast<const ColumnString*>(col_old.get());
         auto col_new =
-                assert_cast<const ColumnString*>(block.get_by_position(arguments[2])
-                                                         .column->convert_to_full_column_if_const()
-                                                         .get());
+                block.get_by_position(arguments[2]).column->convert_to_full_column_if_const();
+        auto col_new_str = assert_cast<const ColumnString*>(col_new.get());
 
         ColumnString::MutablePtr col_res = ColumnString::create();
         for (int i = 0; i < input_rows_count; ++i) {
-            StringRef origin_str = col_origin->get_data_at(i);
-            StringRef old_str = col_old->get_data_at(i);
-            StringRef new_str = col_new->get_data_at(i);
+            StringRef origin_str = col_origin_str->get_data_at(i);
+            StringRef old_str = col_old_str->get_data_at(i);
+            StringRef new_str = col_new_str->get_data_at(i);
 
             std::string result = replace(origin_str.to_string(), old_str.to_string_view(),
                                          new_str.to_string_view());

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3155,11 +3155,11 @@ public:
 
         for (int i = 0; i < input_rows_count; ++i) {
             StringRef origin_str =
-                    assert_cast<const ColumnString*, TypeCheck::Disable>(col_origin.get())
+                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_origin.get())
                             ->get_data_at(i);
-            StringRef old_str = assert_cast<const ColumnString*, TypeCheck::Disable>(col_old.get())
+            StringRef old_str = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_old.get())
                                         ->get_data_at(i);
-            StringRef new_str = assert_cast<const ColumnString*, TypeCheck::Disable>(col_new.get())
+            StringRef new_str = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_new.get())
                                         ->get_data_at(i);
 
             std::string result = replace(origin_str.to_string(), old_str.to_string_view(),
@@ -3697,7 +3697,7 @@ public:
                     continue;
                 }
                 if (auto const_column = check_and_get_column<const ColumnConst>(*str_columns[j])) {
-                    auto str_column = assert_cast<const ColumnString*, TypeCheck::Disable>(
+                    auto str_column = assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(
                             &(const_column->get_data_column()));
                     auto data_item = str_column->get_data_at(0);
                     memcpy_small_allow_read_write_overflow15(

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3145,24 +3145,23 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         auto col_origin =
-                block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
+                assert_cast<const ColumnString*>(block.get_by_position(arguments[0])
+                                                         .column->convert_to_full_column_if_const()
+                                                         .get());
         auto col_old =
-                block.get_by_position(arguments[1]).column->convert_to_full_column_if_const();
+                assert_cast<const ColumnString*>(block.get_by_position(arguments[1])
+                                                         .column->convert_to_full_column_if_const()
+                                                         .get());
         auto col_new =
-                block.get_by_position(arguments[2]).column->convert_to_full_column_if_const();
+                assert_cast<const ColumnString*>(block.get_by_position(arguments[2])
+                                                         .column->convert_to_full_column_if_const()
+                                                         .get());
 
         ColumnString::MutablePtr col_res = ColumnString::create();
-
         for (int i = 0; i < input_rows_count; ++i) {
-            StringRef origin_str =
-                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_origin.get())
-                            ->get_data_at(i);
-            StringRef old_str =
-                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_old.get())
-                            ->get_data_at(i);
-            StringRef new_str =
-                    assert_cast<const ColumnString*, TypeCheckOnRelease::DISABLE>(col_new.get())
-                            ->get_data_at(i);
+            StringRef origin_str = col_origin->get_data_at(i);
+            StringRef old_str = col_old->get_data_at(i);
+            StringRef new_str = col_new->get_data_at(i);
 
             std::string result = replace(origin_str.to_string(), old_str.to_string_view(),
                                          new_str.to_string_view());

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3144,6 +3144,8 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
+        // We need a local variable to hold a reference to the converted column.
+        // So that the converted column will not be released before we use it.
         auto col_origin =
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
         auto col_origin_str = assert_cast<const ColumnString*>(col_origin.get());

--- a/be/src/vec/functions/function_variant_element.cpp
+++ b/be/src/vec/functions/function_variant_element.cpp
@@ -124,8 +124,9 @@ private:
             }
             JsonFunctions::parse_json_paths(field_name, &parsed_paths);
             for (size_t i = 0; i < docs.size(); ++i) {
-                if (!extract_from_document(parser, docs.get_data_at(i), parsed_paths,
-                                           assert_cast<ColumnString*>(result_column.get()))) {
+                if (!extract_from_document(
+                            parser, docs.get_data_at(i), parsed_paths,
+                            assert_cast<ColumnString*, TypeCheck::Disable>(result_column.get()))) {
                     VLOG_DEBUG << "failed to parse " << docs.get_data_at(i) << ", field "
                                << field_name;
                     result_column->insert_default();

--- a/be/src/vec/functions/function_variant_element.cpp
+++ b/be/src/vec/functions/function_variant_element.cpp
@@ -124,9 +124,9 @@ private:
             }
             JsonFunctions::parse_json_paths(field_name, &parsed_paths);
             for (size_t i = 0; i < docs.size(); ++i) {
-                if (!extract_from_document(
-                            parser, docs.get_data_at(i), parsed_paths,
-                            assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(result_column.get()))) {
+                if (!extract_from_document(parser, docs.get_data_at(i), parsed_paths,
+                                           assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(
+                                                   result_column.get()))) {
                     VLOG_DEBUG << "failed to parse " << docs.get_data_at(i) << ", field "
                                << field_name;
                     result_column->insert_default();

--- a/be/src/vec/functions/function_variant_element.cpp
+++ b/be/src/vec/functions/function_variant_element.cpp
@@ -123,10 +123,9 @@ private:
                 field_name = "$." + field_name;
             }
             JsonFunctions::parse_json_paths(field_name, &parsed_paths);
+            ColumnString* col_str = assert_cast<ColumnString*>(result_column.get());
             for (size_t i = 0; i < docs.size(); ++i) {
-                if (!extract_from_document(parser, docs.get_data_at(i), parsed_paths,
-                                           assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(
-                                                   result_column.get()))) {
+                if (!extract_from_document(parser, docs.get_data_at(i), parsed_paths, col_str)) {
                     VLOG_DEBUG << "failed to parse " << docs.get_data_at(i) << ", field "
                                << field_name;
                     result_column->insert_default();

--- a/be/src/vec/functions/function_variant_element.cpp
+++ b/be/src/vec/functions/function_variant_element.cpp
@@ -126,7 +126,7 @@ private:
             for (size_t i = 0; i < docs.size(); ++i) {
                 if (!extract_from_document(
                             parser, docs.get_data_at(i), parsed_paths,
-                            assert_cast<ColumnString*, TypeCheck::Disable>(result_column.get()))) {
+                            assert_cast<ColumnString*, TypeCheckOnRelease::DISABLE>(result_column.get()))) {
                     VLOG_DEBUG << "failed to parse " << docs.get_data_at(i) << ", field "
                                << field_name;
                     result_column->insert_default();

--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -382,9 +382,8 @@ Status VOrcTransformer::_resize_row_batch(const DataTypePtr& type, const IColumn
         for (auto* child : struct_batch->fields) {
             const IColumn& child_column = struct_col.get_column(idx);
             child->resize(child_column.size());
-            auto child_type =
-                    assert_cast<const vectorized::DataTypeStruct*>(real_type.get())
-                            ->get_element(idx);
+            auto child_type = assert_cast<const vectorized::DataTypeStruct*>(real_type.get())
+                                      ->get_element(idx);
             ++idx;
             RETURN_IF_ERROR(_resize_row_batch(child_type, child_column, child));
         }

--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -382,7 +382,7 @@ Status VOrcTransformer::_resize_row_batch(const DataTypePtr& type, const IColumn
         for (auto* child : struct_batch->fields) {
             const IColumn& child_column = struct_col.get_column(idx);
             child->resize(child_column.size());
-            auto child_type = assert_cast<const vectorized::DataTypeStruct*, TypeCheck::Disable>(
+            auto child_type = assert_cast<const vectorized::DataTypeStruct*, TypeCheckOnRelease::DISABLE>(
                                       real_type.get())
                                       ->get_element(idx);
             ++idx;

--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -382,7 +382,8 @@ Status VOrcTransformer::_resize_row_batch(const DataTypePtr& type, const IColumn
         for (auto* child : struct_batch->fields) {
             const IColumn& child_column = struct_col.get_column(idx);
             child->resize(child_column.size());
-            auto child_type = assert_cast<const vectorized::DataTypeStruct*>(real_type.get())
+            auto child_type = assert_cast<const vectorized::DataTypeStruct*, TypeCheck::Disable>(
+                                      real_type.get())
                                       ->get_element(idx);
             ++idx;
             RETURN_IF_ERROR(_resize_row_batch(child_type, child_column, child));

--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -383,8 +383,7 @@ Status VOrcTransformer::_resize_row_batch(const DataTypePtr& type, const IColumn
             const IColumn& child_column = struct_col.get_column(idx);
             child->resize(child_column.size());
             auto child_type =
-                    assert_cast<const vectorized::DataTypeStruct*, TypeCheckOnRelease::DISABLE>(
-                            real_type.get())
+                    assert_cast<const vectorized::DataTypeStruct*>(real_type.get())
                             ->get_element(idx);
             ++idx;
             RETURN_IF_ERROR(_resize_row_batch(child_type, child_column, child));

--- a/be/src/vec/runtime/vorc_transformer.cpp
+++ b/be/src/vec/runtime/vorc_transformer.cpp
@@ -382,9 +382,10 @@ Status VOrcTransformer::_resize_row_batch(const DataTypePtr& type, const IColumn
         for (auto* child : struct_batch->fields) {
             const IColumn& child_column = struct_col.get_column(idx);
             child->resize(child_column.size());
-            auto child_type = assert_cast<const vectorized::DataTypeStruct*, TypeCheckOnRelease::DISABLE>(
-                                      real_type.get())
-                                      ->get_element(idx);
+            auto child_type =
+                    assert_cast<const vectorized::DataTypeStruct*, TypeCheckOnRelease::DISABLE>(
+                            real_type.get())
+                            ->get_element(idx);
             ++idx;
             RETURN_IF_ERROR(_resize_row_batch(child_type, child_column, child));
         }


### PR DESCRIPTION
* Problem to solve

We encountered many issues that ultimately proved to be caused by memory insecurity. These issues are hard to solve, and the final crash log maybe not related to the root problem.

* Fix

We make `assert_cast` do type check in release build by default. And we can use a template arg `TypeCheckOnRelease::DISABLE` to disable type check in release build. 
`TypeCheckOnRelease::DISABLE` should be used when user agrees that this function will be called many many times (eg. add method of AggregatedData, which will be called by rows) or you think type safe has already been guaranteed (eg. `assert_cast<const Derived*, TypeCheckOnRelease::DISABLE>(this)`.
