### PR TITLE
[improve](cache) File cache async init

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -996,6 +996,9 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
+// thread will sleep 10ms per scan file num to limit IO
+DEFINE_Int64(scan_file_num_to_sleep, "1000");
+DEFINE_Int64(sleep_time_per_scan_file, "10");
 DEFINE_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
 // 4KB <= file_cache_max_file_segment_size <= 256MB
 DEFINE_Validator(file_cache_max_file_segment_size, [](const int64_t config) -> bool {

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -997,8 +997,8 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
 // thread will sleep 10ms per scan file num to limit IO
-DEFINE_Int64(scan_file_num_to_sleep, "1000");
-DEFINE_Int64(sleep_time_per_scan_file, "10");
+DEFINE_Int64(async_file_cache_init_file_num_interval, "1000");
+DEFINE_Int64(async_file_cache_init_sleep_interval_ms, "20");
 DEFINE_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
 // 4KB <= file_cache_max_file_segment_size <= 256MB
 DEFINE_Validator(file_cache_max_file_segment_size, [](const int64_t config) -> bool {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1047,6 +1047,8 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
+DECLARE_Int64(scan_file_num_to_sleep);
+DECLARE_Int64(sleep_time_per_scan_file);
 DECLARE_Int64(file_cache_min_file_segment_size);
 DECLARE_Int64(file_cache_max_file_segment_size);
 DECLARE_Bool(clear_file_cache);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1047,8 +1047,8 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240,"normal_percent":85, "disposable_percent":10, "index_percent":5}]
 DECLARE_String(file_cache_path);
-DECLARE_Int64(scan_file_num_to_sleep);
-DECLARE_Int64(sleep_time_per_scan_file);
+DECLARE_Int64(async_file_cache_init_file_num_interval);
+DECLARE_Int64(async_file_cache_init_sleep_interval_ms);
 DECLARE_Int64(file_cache_min_file_segment_size);
 DECLARE_Int64(file_cache_max_file_segment_size);
 DECLARE_Bool(clear_file_cache);

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -39,6 +39,7 @@
 #include <system_error>
 #include <utility>
 
+#include "common/logging.h"
 #include "common/status.h"
 #include "io/cache/block/block_file_cache.h"
 #include "io/cache/block/block_file_cache_fwd.h"
@@ -392,7 +393,7 @@ FileBlocksHolder LRUFileCache::get_or_set(const Key& key, size_t offset, size_t 
                                           const CacheContext& context) {
     if (!_lazy_open_done) {
         // Cache is not ready yet
-        LOG(WARNING) << std::format(
+        VLOG_NOTICE << std::format(
                 "Cache is not ready yet, skip cache for key: {}, offset: {}, size: {}.",
                 key.to_string(), offset, size);
         FileBlocks file_blocks = {std::make_shared<FileBlock>(

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -393,7 +393,7 @@ FileBlocksHolder LRUFileCache::get_or_set(const Key& key, size_t offset, size_t 
                                           const CacheContext& context) {
     if (!_lazy_open_done) {
         // Cache is not ready yet
-        VLOG_NOTICE << std::format(
+        VLOG_NOTICE << fmt::format(
                 "Cache is not ready yet, skip cache for key: {}, offset: {}, size: {}.",
                 key.to_string(), offset, size);
         FileBlocks file_blocks = {std::make_shared<FileBlock>(

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -159,7 +159,8 @@ Status LRUFileCache::initialize() {
     _is_initialized = true;
     _cache_background_thread = std::thread(&LRUFileCache::run_background_operation, this);
     int64_t cost = watch.elapsed_time() / 1000 / 1000;
-    LOG(INFO) << fmt::format("After initialize file cache path={}, init cost(ms)={}", cost);
+    LOG(INFO) << fmt::format("After initialize file cache path={}, init cost(ms)={}",
+                             _cache_base_path, cost);
     return Status::OK();
 }
 

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -914,9 +914,9 @@ Status LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& ca
                     need_to_check_if_empty_dir.push_back(key_it->path());
                 }
                 scan_file_num += 1;
-                if (scan_file_num % config::scan_file_num_to_sleep == 0) {
-                    std::this_thread::sleep_for(
-                            std::chrono::milliseconds(config::sleep_time_per_scan_file));
+                if (scan_file_num % config::async_file_cache_init_file_num_interval == 0) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(
+                            config::async_file_cache_init_sleep_interval_ms));
                 }
             }
         }

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -166,14 +166,7 @@ private:
 
     size_t get_available_cache_size(CacheType cache_type) const;
 
-    /**
-     * @brief Refact the cache directory as version 2.0 while the version of cache is 1.0
-     * 
-     * @return Status 
-     */
-    Status try_convert_cache_version() const;
-
-    void load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock);
+    Status load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock);
 
     Status write_file_cache_version() const;
 

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -173,7 +173,7 @@ private:
      */
     Status try_convert_cache_version() const;
 
-    void load_cache_info_into_memory();
+    void load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock);
 
     Status write_file_cache_version() const;
 


### PR DESCRIPTION
## Proposed changes

Do `load_cache_info_into_memory()` asynchronously in a background thread in `LRUFileCache::initialize()`.
When the cache is not ready, `LRUFileCache::get_or_set()` will return the FileBlock which state is SKIP_CACHE.

