### PR TITLE
[improve](tablet_lock) do not hold tablet lock when clearing cache

### DIFF
--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -23,6 +23,7 @@
 #include "olap/segment_loader.h"
 #include "olap/tablet_schema.h"
 #include "util/time.h"
+#include "util/trace.h"
 
 namespace doris {
 
@@ -118,8 +119,14 @@ std::string Rowset::get_rowset_info_str() {
 }
 
 void Rowset::clear_cache() {
-    SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
-    clear_inverted_index_cache();
+    {
+        SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
+        SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+    }
+    {
+        SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
+        clear_inverted_index_cache();
+    }
 }
 
 Result<std::string> Rowset::segment_path(int64_t seg_id) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2649,7 +2649,7 @@ Status Tablet::ingest_binlog_metas(RowsetBinlogMetasPB* metas_pb) {
 }
 
 void Tablet::clear_cache() {
-    std::list<RowsetSharedPtr> rowsets;
+    std::vector<RowsetSharedPtr> rowsets;
     {
         std::shared_lock rlock(get_header_lock());
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);


### PR DESCRIPTION
We found that clearing cache sometimes consums a lot time, so do not hold lock when clearing cache and trace time-consuming cache clearing.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

