### PR TITLE
[opt](set operation) INTERSECT should evaluated before others

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -385,7 +385,8 @@ query
 
 queryTerm
     : queryPrimary                                                         #queryTermDefault
-    | left=queryTerm operator=(UNION | EXCEPT | MINUS | INTERSECT)
+    | left=queryTerm operator=INTERSECT setQuantifier? right=queryTerm     #setOperation
+    | left=queryTerm operator=(UNION | EXCEPT | MINUS)
       setQuantifier? right=queryTerm                                       #setOperation
     ;
 

--- a/regression-test/suites/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.groovy
@@ -110,7 +110,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_mixed_set_operators """
-        explain shape plan select * from t1 union select * from t2 except select * from t3 intersect select * from t4;
+        explain shape plan (select * from t1 union select * from t2 except select * from t3) intersect select * from t4;
     """
 
     qt_join_with_union """
@@ -202,7 +202,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_with_hint_mixed_set_operators """
-        explain shape plan select /*+ USE_CBO_RULE(INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 except select * from t3 intersect select * from t4;
+        explain shape plan (select /*+ USE_CBO_RULE(INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 except select * from t3) intersect select * from t4;
     """
 
     qt_with_hint_join_with_union """
@@ -294,7 +294,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_with_hint_no_mixed_set_operators """
-        explain shape plan select /*+ USE_CBO_RULE(NO_INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 except select * from t3 intersect select * from t4;
+        explain shape plan (select /*+ USE_CBO_RULE(NO_INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 except select * from t3) intersect select * from t4;
     """
 
     qt_with_hint_no_join_with_union """


### PR DESCRIPTION
this is a behaviour change PR.

set operation INTERSECT should evaluated before others. In Doris history, all set operators have same priority.

This PR change Nereids, let it be same with MySQL.

