### PR TITLE
[Bug](partition-topn) fix partition-topn calculate partition input rows have error

### DIFF
--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -224,7 +224,7 @@ private:
     // Expressions and parameters used for build _sort_description
     vectorized::VSortExecExprs _vsort_exec_exprs;
     vectorized::VExprContextSPtrs _partition_expr_ctxs;
-    int64_t child_input_rows = 0;
+    int64_t _sorted_partition_input_rows = 0;
     std::vector<PartitionDataPtr> _value_places;
     int _num_partition = 0;
     std::vector<const vectorized::IColumn*> _partition_columns;
@@ -238,6 +238,7 @@ private:
     RuntimeProfile::Counter* _selector_block_timer = nullptr;
     RuntimeProfile::Counter* _hash_table_size_counter = nullptr;
     RuntimeProfile::Counter* _passthrough_rows_counter = nullptr;
+    RuntimeProfile::Counter* _sorted_partition_input_rows_counter = nullptr;
     Status _init_hash_method();
 };
 

--- a/be/src/pipeline/exec/partition_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_source_operator.cpp
@@ -29,6 +29,8 @@ Status PartitionSortSourceLocalState::init(RuntimeState* state, LocalStateInfo& 
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_open_timer);
     _get_sorted_timer = ADD_TIMER(profile(), "GetSortedTime");
+    _sorted_partition_output_rows_counter =
+            ADD_COUNTER(profile(), "SortedPartitionOutputRows", TUnit::UNIT);
     return Status::OK();
 }
 
@@ -57,7 +59,7 @@ Status PartitionSortSourceOperatorX::get_block(RuntimeState* state, vectorized::
             }
             if (!output_block->empty()) {
                 COUNTER_UPDATE(local_state.blocks_returned_counter(), 1);
-                COUNTER_UPDATE(local_state.rows_returned_counter(), output_block->rows());
+                local_state._num_rows_returned += output_block->rows();
             }
             return Status::OK();
         }
@@ -79,7 +81,7 @@ Status PartitionSortSourceOperatorX::get_block(RuntimeState* state, vectorized::
     }
     if (!output_block->empty()) {
         COUNTER_UPDATE(local_state.blocks_returned_counter(), 1);
-        COUNTER_UPDATE(local_state.rows_returned_counter(), output_block->rows());
+        local_state._num_rows_returned += output_block->rows();
     }
     return Status::OK();
 }
@@ -98,7 +100,7 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
         //current sort have eos, so get next idx
         auto rows = local_state._shared_state->partition_sorts[local_state._sort_idx]
                             ->get_output_rows();
-        local_state._num_rows_returned += rows;
+        COUNTER_UPDATE(local_state._sorted_partition_output_rows_counter, rows);
         local_state._shared_state->partition_sorts[local_state._sort_idx].reset(nullptr);
         local_state._sort_idx++;
     }

--- a/be/src/pipeline/exec/partition_sort_source_operator.h
+++ b/be/src/pipeline/exec/partition_sort_source_operator.h
@@ -34,14 +34,14 @@ public:
     ENABLE_FACTORY_CREATOR(PartitionSortSourceLocalState);
     using Base = PipelineXLocalState<PartitionSortNodeSharedState>;
     PartitionSortSourceLocalState(RuntimeState* state, OperatorXBase* parent)
-            : PipelineXLocalState<PartitionSortNodeSharedState>(state, parent),
-              _get_sorted_timer(nullptr) {}
+            : PipelineXLocalState<PartitionSortNodeSharedState>(state, parent) {}
 
     Status init(RuntimeState* state, LocalStateInfo& info) override;
 
 private:
     friend class PartitionSortSourceOperatorX;
-    RuntimeProfile::Counter* _get_sorted_timer;
+    RuntimeProfile::Counter* _get_sorted_timer = nullptr;
+    RuntimeProfile::Counter* _sorted_partition_output_rows_counter = nullptr;
     std::atomic<int> _sort_idx = 0;
 };
 


### PR DESCRIPTION
## Proposed changes
1. fix the _sorted_partition_input_rows calculate have error, it's should only update the rows which have been emplace into hash table, not include the rows which is pass through.

2. add some counter in profile could get some info of about input/output rows have been do partition-topn.

<!--Describe your changes.-->

