### PR TITLE
[Fature](commit) Support batch commit transactions for stream load 2PC by transaction ids

### DIFF
--- a/be/src/http/action/stream_load_2pc.cpp
+++ b/be/src/http/action/stream_load_2pc.cpp
@@ -59,7 +59,18 @@ void StreamLoad2PCAction::handle(HttpRequest* req) {
         std::string req_txn_id = req->header(HTTP_TXN_ID_KEY);
         msg.append("transaction [" + req_txn_id + "] ");
         try {
-            ctx->txn_id = std::stoull(req_txn_id);
+            std::stringstream ss(req_txn_id);
+            std::string token;
+            std::set<int64_t> txn_id_set;
+            while (std::getline(ss, token, ',')) {
+                txn_id_set.insert(std::stoi(token));
+            }
+            if (txn_id_set.size() > 1) {
+                std::vector txn_ids(txn_id_set.begin(), txn_id_set.end());
+                ctx->txn_ids = txn_ids;
+            } else {
+                ctx->txn_id = std::stoull(req_txn_id);
+            }
         } catch (const std::exception& e) {
             status = Status::InternalError("convert txn_id [{}] failed, reason={}", req_txn_id,
                                            e.what());

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -167,6 +167,7 @@ public:
     bool is_chunked_transfer = false;
 
     int64_t txn_id = default_txn_id;
+    std::vector<int64_t> txn_ids;
 
     // http stream
     bool is_read_schema = true;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -262,6 +262,10 @@ Status StreamLoadExecutor::operate_txn_2pc(StreamLoadContext* ctx) {
         request.__set_txnId(ctx->txn_id);
     }
 
+    if (ctx->txn_ids.size() > 1) {
+        request.__set_txnIds(ctx->txn_ids);
+    }
+
     TNetworkAddress master_addr = _exec_env->master_info()->network_address;
     TLoadTxn2PCResult result;
     int64_t duration_ns = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -950,6 +950,12 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
     }
 
     @Override
+    public void batchCommitTransaction2PC(Database db, List<Table> tableList, List<Long> txnIds, long timeoutMillis)
+            throws UserException {
+        throw new UserException(NOT_SUPPORTED_MSG);
+    }
+
+    @Override
     public void abortTransaction(Long dbId, Long transactionId, String reason) throws UserException {
         cleanSubTransactions(transactionId);
         abortTransaction(dbId, transactionId, reason, null, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
@@ -100,6 +100,9 @@ public interface GlobalTransactionMgrIface extends Writable {
     public void commitTransaction2PC(Database db, List<Table> tableList, long transactionId, long timeoutMillis)
             throws UserException;
 
+    public void batchCommitTransaction2PC(Database db, List<Table> tableList, List<Long> txnIds, long timeoutMillis)
+            throws UserException;
+
     public void abortTransaction(Long dbId, Long transactionId, String reason) throws UserException;
 
     public void abortTransaction(Long dbId, Long txnId, String reason,

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
@@ -32,6 +32,7 @@ import mockit.Mock;
 import mockit.MockUp;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FakeEditLog extends MockUp<EditLog> {
@@ -48,6 +49,15 @@ public class FakeEditLog extends MockUp<EditLog> {
         // do nothing
         System.out.println("insert transaction manager is called");
         allTransactionState.put(transactionState.getTransactionId(), transactionState);
+    }
+
+    @Mock
+    public void logBatchInsertTransactionState(List<TransactionState> transactionStates) {
+        // do nothing
+        System.out.println("insert transaction manager is called");
+        for (TransactionState transactionState : transactionStates) {
+            allTransactionState.put(transactionState.getTransactionId(), transactionState);
+        }
     }
 
     @Mock

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -858,6 +858,7 @@ struct TLoadTxn2PCRequest {
     9: optional string token
     10: optional i64 thrift_rpc_timeout_ms
     11: optional string label
+    12: optional list<i64> txnIds;
 
     // For cloud
     1000: optional string auth_code_uuid

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_batch_commit.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_2pc_batch_commit.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_stream_load_2pc_batch_commit", "p0") {
+    def tableName = "test_txn_batch_commit"
+    InetSocketAddress address = context.config.feHttpInetSocketAddress
+    String user = context.config.feHttpUser
+    String password = context.config.feHttpPassword
+    String db = context.config.getDbNameByFile(context.file)
+
+    def do_stream_load_2pc = {
+        def label = UUID.randomUUID().toString().replaceAll("-", "")
+        def txnId;
+        streamLoad {
+            table "${tableName}"
+
+            set 'label', "${label}"
+            set 'column_separator', '|'
+            set 'columns', 'k1, k2, v1, v2, v3'
+            set 'two_phase_commit', 'true'
+
+            file 'test_two_phase_commit.csv'
+
+            check { result, exception, startTime, endTime ->
+                if (exception != null) {
+                    throw exception
+                }
+                log.info("Stream load result: ${result}".toString())
+                def json = parseJson(result)
+                assertEquals("success", json.Status.toLowerCase())
+                assertEquals(2, json.NumberTotalRows)
+                assertEquals(0, json.NumberFilteredRows)
+                assertEquals(0, json.NumberUnselectedRows)
+                txnId = json.TxnId
+            }
+        }
+        return txnId
+    }
+
+    def do_streamload_2pc_batch_commit = { txnId ->
+        def command = "curl -X PUT --location-trusted -u ${context.config.feHttpUser}:${context.config.feHttpPassword}" +
+                " -H txn_id:${txnId}" +
+                " -H txn_operation:commit" +
+                " http://${context.config.feHttpAddress}/api/${db}/${tableName}/_stream_load_2pc"
+        log.info("http_stream execute 2pc: ${command}")
+
+        def process = command.execute()
+        code = process.waitFor()
+        out = process.text
+        log.info("http_stream 2pc result: ${out}".toString())
+        def json2pc = parseJson(out)
+        return json2pc
+    }
+
+    try {
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """
+            CREATE TABLE IF NOT EXISTS ${tableName} (
+                `k1` bigint(20) NULL DEFAULT "1",
+                `k2` bigint(20) NULL ,
+                `v1` tinyint(4) NULL,
+                `v2` tinyint(4) NULL,
+                `v3` tinyint(4) NULL
+            ) ENGINE=OLAP
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+        """
+
+        txnId1 = do_stream_load_2pc.call()
+        txnId2 = do_stream_load_2pc.call()
+        txnId3 = do_stream_load_2pc.call()
+        txnIds = txnId1 + "," + txnId2 + "," + txnId3
+
+        result = do_streamload_2pc_batch_commit.call(txnIds)
+        assertEquals("success", result.status.toLowerCase())
+
+        Thread.sleep(5000) // wait for publish version
+        sql_res = sql "select count(*) from ${tableName}"
+        assertEquals(6, sql_res[0][0])
+    } finally {
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+    }
+}


### PR DESCRIPTION
## Proposed changes

 
The current implementation of Doris only allows to commit  a single stream 2PC transaction per TLoadTxn2PCRequest. This can lead to performance issues in high concurrency scenarios, such as with the flink-doris-connector:
Each 2PC commit request acquires a write lock on the table and the database. With multiple concurrent write requests using stream load 2PC to a single table, Doris sequentially locks and unlocks the table and database multiple times during the commit phase. If these transactions were batched into a single request, Doris could process them collectively, requiring only one lock on the table and database. Additionally, Doris can write the edit log in a batch mode, which could further enhance performance.

In my test case, I tested 1000 commit requests: 100 tables and 10 concurrent writes per table.
commit cost:
- **1.533s** in original commit model
- **0.038s** in batch commit model

