### PR TITLE
[opt](nereids) Join related cost calculation formula works well at least 3be num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -271,14 +271,14 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         Statistics childStatistics = context.getChildStatistics(0);
         double intputRowCount = childStatistics.getRowCount();
         DistributionSpec spec = distribute.getDistributionSpec();
-
+        int beNumForDist = Math.max(3, beNumber);
         // shuffle
         if (spec instanceof DistributionSpecHash) {
             return CostV1.of(context.getSessionVariable(),
-                    intputRowCount / beNumber,
+                    intputRowCount / beNumForDist,
                     0,
                     intputRowCount * childStatistics.dataSizeFactor(
-                            distribute.child().getOutput()) / beNumber
+                            distribute.child().getOutput()) / beNumForDist
                     );
         }
 
@@ -301,7 +301,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     0,
                     0,
                     intputRowCount * childStatistics.dataSizeFactor(
-                            distribute.child().getOutput()) / beNumber);
+                            distribute.child().getOutput()) / beNumForDist);
         }
 
         // any
@@ -310,7 +310,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                 0,
                 0,
                 intputRowCount * childStatistics.dataSizeFactor(distribute.child().getOutput())
-                        * RANDOM_SHUFFLE_TO_HASH_SHUFFLE_FACTOR / beNumber);
+                        * RANDOM_SHUFFLE_TO_HASH_SHUFFLE_FACTOR / beNumForDist);
     }
 
     private double expressionTreeCost(List<? extends Expression> expressions) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -271,6 +271,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         Statistics childStatistics = context.getChildStatistics(0);
         double intputRowCount = childStatistics.getRowCount();
         DistributionSpec spec = distribute.getDistributionSpec();
+        // cost model is trained by clusters with more than 3 BE.
         int beNumForDist = Math.max(3, beNumber);
         // shuffle
         if (spec instanceof DistributionSpecHash) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -422,7 +422,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             //                    on the output rows, taken on outputRowCount()
             double probeSideFactor = 1.0;
             double buildSideFactor = context.getSessionVariable().getBroadcastRightTableScaleFactor();
-            int totalInstanceNumber = parallelInstance * beNumber;
+            int totalInstanceNumber = parallelInstance * Math.max(3, beNumber);
             if (buildSideFactor <= 1.0) {
                 if (buildStats.computeSize(physicalHashJoin.right().getOutput()) < 1024 * 1024) {
                     // no penalty to broadcast if build side is small


### PR DESCRIPTION
## Proposed changes

In previouse #37823, we adjust the shuffle and join cost. However the new cost model is not good to single BE.
the  new cost model count BE number at least 3

Issue Number: close #xxx

<!--Describe your changes.-->

