### PR TITLE
[Chore](runtime-filter) avoid dcheck fail when rf merge failed

### DIFF
--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -396,12 +396,7 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
         RuntimeFilterWrapperHolder holder;
         RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(&params, holder.getHandle()));
 
-        auto st = cnt_val->filter->merge_from(holder.getHandle()->get());
-        if (!st) {
-            // prevent error ignored
-            DCHECK(false) << st.msg();
-            return st;
-        }
+        RETURN_IF_ERROR(cnt_val->filter->merge_from(holder.getHandle()->get()));
 
         cnt_val->arrive_id.insert(UniqueId(request->fragment_instance_id()));
         merged_size = cnt_val->arrive_id.size();


### PR DESCRIPTION
## Proposed changes
 avoid dcheck fail when rf merge failed
there is a difference in the logic of calculating bf size between 2.1 and 3.0, so the merge will fail
this pr is to prevent core dump caused by dcheck failure during rolling upgrade.