### PR TITLE
[improvement](external catalog)Optimize the process of refreshing catalog for 2.1 (#39205)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -76,7 +76,7 @@ public class RefreshManager {
     private void refreshCatalogInternal(CatalogIf catalog, boolean invalidCache) {
         String catalogName = catalog.getName();
         if (!catalogName.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
-            ((ExternalCatalog) catalog).onRefresh(invalidCache);
+            ((ExternalCatalog) catalog).onRefreshCache(invalidCache);
             LOG.info("refresh catalog {} with invalidCache {}", catalogName, invalidCache);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -388,6 +388,15 @@ public abstract class ExternalCatalog
         synchronized (this.propLock) {
             this.convertedProperties = null;
         }
+
+        refreshOnlyCatalogCache(invalidCache);
+    }
+
+    public void onRefreshCache(boolean invalidCache) {
+        refreshOnlyCatalogCache(invalidCache);
+    }
+
+    private void refreshOnlyCatalogCache(boolean invalidCache) {
         if (useMetaCache.isPresent()) {
             if (useMetaCache.get() && metaCache != null) {
                 metaCache.invalidateAll();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -126,7 +126,7 @@ public class HiveMetadataOps implements ExternalMetadataOps {
             catalogDatabase.setProperties(properties);
             catalogDatabase.setComment(properties.getOrDefault("comment", ""));
             client.createDatabase(catalogDatabase);
-            catalog.onRefresh(true);
+            catalog.onRefreshCache(true);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -146,7 +146,7 @@ public class HiveMetadataOps implements ExternalMetadataOps {
         }
         try {
             client.dropDatabase(dbName);
-            catalog.onRefresh(true);
+            catalog.onRefreshCache(true);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -107,7 +107,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
             }
         }
         nsCatalog.createNamespace(Namespace.of(dbName), properties);
-        dorisCatalog.onRefresh(true);
+        dorisCatalog.onRefreshCache(true);
     }
 
     @Override
@@ -123,7 +123,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
         }
         SupportsNamespaces nsCatalog = (SupportsNamespaces) catalog;
         nsCatalog.dropNamespace(Namespace.of(dbName));
-        dorisCatalog.onRefresh(true);
+        dorisCatalog.onRefreshCache(true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -123,10 +123,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     @Override
     public void onRefreshCache(boolean invalidCache) {
-        super.onRefreshCache(invalidCache);
-        if (jdbcClient != null) {
-            jdbcClient.closeClient();
-        }
+        onRefresh(invalidCache);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -122,6 +122,14 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     @Override
+    public void onRefreshCache(boolean invalidCache) {
+        super.onRefreshCache(invalidCache);
+        if (jdbcClient != null) {
+            jdbcClient.closeClient();
+        }
+    }
+
+    @Override
     public void onClose() {
         super.onClose();
         if (jdbcClient != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/RefreshCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/RefreshCatalogTest.java
@@ -155,18 +155,7 @@ public class RefreshCatalogTest extends TestWithFeService {
         } catch (Exception e) {
             // Do nothing
         }
-        Assertions.assertFalse(((ExternalCatalog) test2).isInitialized());
-        table.makeSureInitialized();
         Assertions.assertTrue(((ExternalCatalog) test2).isInitialized());
-        // table.makeSureInitialized() triggered init method
-        long l4 = test2.getLastUpdateTime();
-        Assertions.assertTrue(l4 > l3);
-        try {
-            DdlExecutor.execute(Env.getCurrentEnv(), refreshCatalogStmt);
-        } catch (Exception e) {
-            // Do nothing
-        }
-        Assertions.assertFalse(((ExternalCatalog) test2).isInitialized());
     }
 
     public static class RefreshCatalogProvider implements TestExternalCatalog.TestCatalogProvider {


### PR DESCRIPTION
## Proposed changes

bp: #39205

When the catalog attributes have not changed, refreshing the catalog only requires processing the cache, without rebuilding the entire catalog.