### PR TITLE
[Cherry-pick](branch-2.1) Pick "[Enhancement](wal) modify wal api which hard to use (#38895)"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckWalSizeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CheckWalSizeAction.java
@@ -63,11 +63,7 @@ public class CheckWalSizeAction extends RestBaseController {
         String hostPorts = request.getParameter(HOST_PORTS);
         List<Backend> backends = new ArrayList<>();
         if (Strings.isNullOrEmpty(hostPorts)) {
-            try {
-                backends = Env.getCurrentSystemInfo().getAllBackendsByAllCluster().values().asList();
-            } catch (AnalysisException e) {
-                return ResponseEntityBuilder.okWithCommonError(e.getMessage());
-            }
+            backends = Env.getCurrentSystemInfo().getAllBackends();
         } else {
             String[] hostPortArr = hostPorts.split(",");
             if (hostPortArr.length == 0) {


### PR DESCRIPTION
## Proposed changes

Pick #38895

Before this pr, this api needs backends' ip and port as param, which is hard to use. This pr modify it. If there is no param, doris will print all backends WAL info.

The acceptable usage are as follows 

```
curl -u root: "127.0.0.1:8038/api/get_wal_size?host_ports=127.0.0.1:9058"
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}%                                                                                             

curl -u root: "127.0.0.1:8038/api/get_wal_size?host_ports="         
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}%                                                                                                                                             

curl -u root: "127.0.0.1:8038/api/get_wal_size"            
{"msg":"success","code":0,"data":["127.0.0.1:9058:0"],"count":0}% 
```

<!--Describe your changes.-->

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

