### PR TITLE
[chore](compile)Enable the shorten-64-to-32 compilation option in Exprs

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -293,15 +293,13 @@ if (COMPILER_CLANG)
                         -Wunused-volatile-lvalue
                         -Wunused-template
                         -Wunused-member-function
-                        -Wunused-macros
-                        -Wconversion)
+                        -Wunused-macros)
     add_compile_options( -Wno-gnu-statement-expression
                         -Wno-implicit-float-conversion
                         -Wno-implicit-int-conversion
                         -Wno-sign-conversion
                         -Wno-missing-field-initializers
-                        -Wno-unused-const-variable
-                        -Wno-shorten-64-to-32)
+                        -Wno-unused-const-variable)
     if (USE_LIBCPP)
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)
         add_definitions(-DUSE_LIBCPP)
@@ -415,6 +413,9 @@ elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN_UT")
 else()
     message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif()
+
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=shorten-64-to-32")
+
 
 # Add flags that are common across build types
 set(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")

--- a/be/src/common/cast_set.h
+++ b/be/src/common/cast_set.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <type_traits>
+namespace doris {
+
+template <typename T, typename U>
+    requires std::is_integral_v<T> && std::is_integral_v<U>
+void cast_set(T& a, U b) {
+    a = static_cast<T>(b);
+}
+
+template <typename T, typename U>
+    requires std::is_integral_v<T> && std::is_integral_v<U>
+T cast_set(U b) {
+    return static_cast<T>(b);
+}
+
+} // namespace doris

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -1191,9 +1191,9 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<primitive_type>& range,
         } // 3.1.2 produces the Cartesian product of ScanKey and fixed_value
         else {
             auto fixed_value_set = range.get_fixed_value_set();
-            int original_key_range_size = _begin_scan_keys.size();
+            int64_t original_key_range_size = _begin_scan_keys.size();
 
-            for (int i = 0; i < original_key_range_size; ++i) {
+            for (int64_t i = 0; i < original_key_range_size; ++i) {
                 OlapTuple start_base_key_range = _begin_scan_keys[i];
                 OlapTuple end_base_key_range = _end_scan_keys[i];
 

--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -25,3 +25,6 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS *.cpp *.cc)
 add_library(Exprs STATIC ${SRC_FILES})
 
 pch_reuse(Exprs)
+if (COMPILER_CLANG)
+    target_compile_options(Exprs PRIVATE -Wshorten-64-to-32)
+endif ()

--- a/be/src/exprs/block_bloom_filter.hpp
+++ b/be/src/exprs/block_bloom_filter.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "common/cast_set.h"
 #include "vec/common/string_ref.h"
 #ifdef __AVX2__
 #include <immintrin.h>
@@ -75,7 +76,7 @@ public:
     // Same as above with convenience of hashing the key.
     void insert(const StringRef& key) noexcept {
         if (key.data) {
-            insert(HashUtil::crc_hash(key.data, key.size, _hash_seed));
+            insert(HashUtil::crc_hash(key.data, cast_set<int32_t>(key.size), _hash_seed));
         }
     }
 
@@ -119,7 +120,7 @@ public:
     // Same as above with convenience of hashing the key.
     bool find(const StringRef& key) const noexcept {
         if (key.data) {
-            return find(HashUtil::crc_hash(key.data, key.size, _hash_seed));
+            return find(HashUtil::crc_hash(key.data, cast_set<int32_t>(key.size), _hash_seed));
         }
         return false;
     }

--- a/be/src/exprs/block_bloom_filter_impl.cc
+++ b/be/src/exprs/block_bloom_filter_impl.cc
@@ -66,7 +66,7 @@ Status BlockBloomFilter::init_internal(const int log_space_bytes, uint32_t hash_
     }
     // Don't use _log_num_buckets if it will lead to undefined behavior by a shift
     // that is too large.
-    _directory_mask = (1ULL << _log_num_buckets) - 1;
+    _directory_mask = (1U << _log_num_buckets) - 1;
 
     const size_t alloc_size = directory_size();
     close(); // Ensure that any previously allocated memory for directory_ is released.

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -143,9 +143,9 @@ public:
         }
         DCHECK(bloom_filter_length >= 0);
         DCHECK_EQ((bloom_filter_length & (bloom_filter_length - 1)), 0);
-        _bloom_filter_alloced = bloom_filter_length;
+        cast_set(_bloom_filter_alloced, bloom_filter_length);
         _bloom_filter.reset(BloomFilterAdaptor::create(_null_aware));
-        RETURN_IF_ERROR(_bloom_filter->init(bloom_filter_length));
+        RETURN_IF_ERROR(_bloom_filter->init(cast_set<int>(bloom_filter_length)));
         _inited = true;
         return Status::OK();
     }
@@ -187,14 +187,14 @@ public:
             _bloom_filter->set_contain_null();
         }
 
-        _bloom_filter_alloced = data_size;
+        _bloom_filter_alloced = cast_set<int32_t>(data_size);
         _inited = true;
         return _bloom_filter->init(data, data_size);
     }
 
     void get_data(char** data, int* len) {
         *data = _bloom_filter->data();
-        *len = _bloom_filter->size();
+        *len = cast_set<int>(_bloom_filter->size());
     }
 
     bool contain_null() const {

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -215,7 +215,7 @@ public:
         _contains_null |= set->_contains_null;
     }
 
-    virtual int size() = 0;
+    virtual size_t size() = 0;
     virtual bool find(const void* data) const = 0;
     // use in vectorize execute engine
     virtual bool find(const void* data, size_t) const = 0;
@@ -330,7 +330,7 @@ public:
         }
     }
 
-    int size() override { return _set.size(); }
+    size_t size() override { return _set.size(); }
 
     bool find(const void* data) const override {
         if (data == nullptr) {
@@ -484,7 +484,7 @@ public:
         }
     }
 
-    int size() override { return _set.size(); }
+    size_t size() override { return _set.size(); }
 
     bool find(const void* data) const override {
         if (data == nullptr) {
@@ -651,7 +651,7 @@ public:
         }
     }
 
-    int size() override { return _set.size(); }
+    size_t size() override { return _set.size(); }
 
     bool find(const void* data) const override {
         if (data == nullptr) {

--- a/be/src/gutil/bits.cc
+++ b/be/src/gutil/bits.cc
@@ -20,10 +20,10 @@ const char Bits::num_bits[] = {
         5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 3, 4, 4, 5, 4, 5, 5, 6,
         4, 5, 5, 6, 5, 6, 6, 7, 4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8};
 
-int Bits::Count(const void* m, int num_bytes) {
+int Bits::Count(const void* m, int64_t num_bytes) {
     int nbits = 0;
     const uint8* s = (const uint8*)m;
-    for (int i = 0; i < num_bytes; i++) nbits += num_bits[*s++];
+    for (int64_t i = 0; i < num_bytes; i++) nbits += num_bits[*s++];
     return nbits;
 }
 

--- a/be/src/gutil/bits.h
+++ b/be/src/gutil/bits.h
@@ -5,6 +5,7 @@
 #pragma once
 
 
+#include "common/cast_set.h"
 #include "gutil/integral_types.h"
 // IWYU pragma: no_include <butil/macros.h>
 #include "gutil/macros.h" // IWYU pragma: keep
@@ -38,7 +39,7 @@ public:
 #if defined(__x86_64__) && defined __GNUC__
         int64 count = 0;
         asm("popcnt %1,%0" : "=r"(count) : "rm"(n) : "cc");
-        return count;
+        return doris::cast_set<int>(count);
 #else
         return CountOnes64(n);
 #endif
@@ -50,7 +51,7 @@ public:
     static uint64 ReverseBits64(uint64 n);
 
     // Return the number of one bits in the byte sequence.
-    static int Count(const void* m, int num_bytes);
+    static int Count(const void* m, int64_t num_bytes);
 
     // Return the number of different bits in the given byte sequences.
     // (i.e., the Hamming distance)

--- a/be/src/gutil/endian.h
+++ b/be/src/gutil/endian.h
@@ -67,7 +67,7 @@ inline wide::UInt256 gbswap_256(wide::UInt256 host_int) {
 
 // Swap bytes of a 24-bit value.
 inline uint32_t bswap_24(uint32_t x) {
-    return ((x & 0x0000ffULL) << 16) | ((x & 0x00ff00ULL)) | ((x & 0xff0000ULL) >> 16);
+    return ((x & 0x0000ffU) << 16) | ((x & 0x00ff00U)) | ((x & 0xff0000U) >> 16);
 }
 
 #ifdef IS_LITTLE_ENDIAN

--- a/be/src/gutil/strings/numbers.cc
+++ b/be/src/gutil/strings/numbers.cc
@@ -10,12 +10,13 @@
 #include <ctype.h>
 #include <errno.h>
 #include <float.h> // for DBL_DIG and FLT_DIG
-#include <math.h>  // for HUGE_VAL
+#include <inttypes.h>
+#include <math.h> // for HUGE_VAL
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <sys/types.h>
+
 #include <limits>
 #include <ostream>
 
@@ -28,7 +29,6 @@ using std::string;
 #include <fmt/format.h>
 
 #include "common/logging.h"
-
 #include "gutil/gscoped_ptr.h"
 #include "gutil/integral_types.h"
 #include "gutil/stringprintf.h"
@@ -702,12 +702,16 @@ size_t u64tostr_base36(uint64 number, size_t buf_size, char* buffer) {
 }
 
 // Generate functions that wrap safe_strtoXXX_base.
-#define GEN_SAFE_STRTO(name, type)                                                  \
-    bool name##_base(const string& str, type* value, int base) {                    \
-        return name##_base(str.c_str(), value, base);                               \
-    }                                                                               \
-    bool name(const char* str, type* value) { return name##_base(str, value, 10); } \
-    bool name(const string& str, type* value) { return name##_base(str.c_str(), value, 10); }
+#define GEN_SAFE_STRTO(name, type)                               \
+    bool name##_base(const string& str, type* value, int base) { \
+        return name##_base(str.c_str(), value, base);            \
+    }                                                            \
+    bool name(const char* str, type* value) {                    \
+        return name##_base(str, value, 10);                      \
+    }                                                            \
+    bool name(const string& str, type* value) {                  \
+        return name##_base(str.c_str(), value, 10);              \
+    }
 GEN_SAFE_STRTO(safe_strto32, int32);
 GEN_SAFE_STRTO(safe_strtou32, uint32);
 GEN_SAFE_STRTO(safe_strto64, int64);
@@ -1042,7 +1046,7 @@ int HexDigitsPrefix(const char* buf, int num_digits) {
 //    strict mode, but "01" == "1" otherwise.
 // ----------------------------------------------------------------------
 
-int AutoDigitStrCmp(const char* a, int alen, const char* b, int blen, bool strict) {
+int AutoDigitStrCmp(const char* a, size_t alen, const char* b, size_t blen, bool strict) {
     int aindex = 0;
     int bindex = 0;
     while ((aindex < alen) && (bindex < blen)) {
@@ -1115,11 +1119,11 @@ int AutoDigitStrCmp(const char* a, int alen, const char* b, int blen, bool stric
     }
 }
 
-bool AutoDigitLessThan(const char* a, int alen, const char* b, int blen) {
+bool AutoDigitLessThan(const char* a, size_t alen, const char* b, size_t blen) {
     return AutoDigitStrCmp(a, alen, b, blen, false) < 0;
 }
 
-bool StrictAutoDigitLessThan(const char* a, int alen, const char* b, int blen) {
+bool StrictAutoDigitLessThan(const char* a, size_t alen, const char* b, size_t blen) {
     return AutoDigitStrCmp(a, alen, b, blen, true) < 0;
 }
 

--- a/be/src/gutil/strings/numbers.h
+++ b/be/src/gutil/strings/numbers.h
@@ -6,8 +6,9 @@
 #pragma once
 
 #include <stddef.h>
-#include <time.h>
 #include <stdint.h>
+#include <time.h>
+
 #include <functional>
 
 using std::less;
@@ -321,11 +322,11 @@ inline bool ParseLeadingBoolValue(const string& str, bool deflt) {
 //    strict mode, but "01" == "1" otherwise.
 // ----------------------------------------------------------------------
 
-int AutoDigitStrCmp(const char* a, int alen, const char* b, int blen, bool strict);
+int AutoDigitStrCmp(const char* a, size_t alen, const char* b, size_t blen, bool strict);
 
-bool AutoDigitLessThan(const char* a, int alen, const char* b, int blen);
+bool AutoDigitLessThan(const char* a, size_t alen, const char* b, size_t blen);
 
-bool StrictAutoDigitLessThan(const char* a, int alen, const char* b, int blen);
+bool StrictAutoDigitLessThan(const char* a, size_t alen, const char* b, size_t blen);
 
 struct autodigit_less {
     bool operator()(const string& a, const string& b) const {

--- a/be/src/gutil/strings/split_internal.h
+++ b/be/src/gutil/strings/split_internal.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <iterator>
+
+#include "common/cast_set.h"
 using std::back_insert_iterator;
 using std::iterator_traits;
 #include <map>
@@ -106,8 +108,9 @@ public:
             // found_delimiter is allowed to be empty.
             // Sets curr_piece_ to all text up to but excluding the delimiter itself.
             // Sets text_ to remaining data after the delimiter.
-            curr_piece_.set(text_.begin(), found_delimiter.begin() - text_.begin());
-            text_.remove_prefix(found_delimiter.end() - text_.begin());
+            curr_piece_.set(text_.begin(),
+                            doris::cast_set<int>(found_delimiter.begin() - text_.begin()));
+            text_.remove_prefix(doris::cast_set<int>(found_delimiter.end() - text_.begin()));
         } while (!predicate_(curr_piece_));
         return *this;
     }
@@ -187,7 +190,7 @@ using small_ = char;
 struct big_ {
     char dummy[2];
 };
-}
+} // namespace base
 
 // This class implements the behavior of the split API by giving callers access
 // to the underlying split substrings in various convenient ways, such as

--- a/be/src/gutil/strings/substitute.h
+++ b/be/src/gutil/strings/substitute.h
@@ -2,14 +2,20 @@
 
 #pragma once
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
+
 #include <string.h>
+
 #include <string>
 
 using std::string;
 
+#include "gutil/stringprintf.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/stringpiece.h"
-#include "gutil/stringprintf.h"
 
 namespace strings {
 
@@ -178,3 +184,7 @@ inline string Substitute(StringPiece format,
 }
 
 } // namespace strings
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/be/src/olap/decimal12.h
+++ b/be/src/olap/decimal12.h
@@ -115,7 +115,7 @@ struct decimal12_t {
             integer = i;
             fraction = f;
 
-            int32_t frac_len = (nullptr != sepr) ? MAX_FRAC_DIGITS_NUM - strlen(sepr + 1)
+            int64_t frac_len = (nullptr != sepr) ? MAX_FRAC_DIGITS_NUM - strlen(sepr + 1)
                                                  : MAX_FRAC_DIGITS_NUM;
             frac_len = frac_len > 0 ? frac_len : 0;
             fraction *= g_power_table[frac_len];

--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -56,7 +56,7 @@ public:
     virtual ~Field() = default;
 
     size_t size() const { return _type_info->size(); }
-    int32_t length() const { return _length; }
+    size_t length() const { return _length; }
     size_t field_size() const { return size() + 1; }
     size_t index_size() const { return _index_size; }
     int32_t unique_id() const { return _unique_id; }
@@ -202,7 +202,7 @@ public:
     void add_sub_field(std::unique_ptr<Field> sub_field) {
         _sub_fields.emplace_back(std::move(sub_field));
     }
-    Field* get_sub_field(int i) const { return _sub_fields[i].get(); }
+    Field* get_sub_field(size_t i) const { return _sub_fields[i].get(); }
     size_t get_sub_field_count() const { return _sub_fields.size(); }
 
     void set_precision(int32_t precision) { _precision = precision; }
@@ -219,7 +219,7 @@ protected:
     // Note that, the struct type itself has fixed length, but due to
     // its number of subfields is a variable, so the actual length of
     // a struct field is not fixed.
-    uint32_t _length;
+    size_t _length;
     // Since the length of the STRING type cannot be determined,
     // only dynamic memory can be used. Arena cannot realize realloc.
     // The schema information is shared globally. Therefore,
@@ -342,7 +342,7 @@ public:
 
     void set_to_zone_map_max(char* ch) const override {
         auto slice = reinterpret_cast<Slice*>(ch);
-        int length = _length < MAX_ZONE_MAP_INDEX_SIZE ? _length : MAX_ZONE_MAP_INDEX_SIZE;
+        auto length = _length < MAX_ZONE_MAP_INDEX_SIZE ? _length : MAX_ZONE_MAP_INDEX_SIZE;
         slice->size = length;
         memset(slice->data, 0xFF, slice->size);
     }
@@ -393,7 +393,7 @@ public:
     }
     void set_to_zone_map_max(char* ch) const override {
         auto slice = reinterpret_cast<Slice*>(ch);
-        int length = _length < MAX_ZONE_MAP_INDEX_SIZE ? _length : MAX_ZONE_MAP_INDEX_SIZE;
+        auto length = _length < MAX_ZONE_MAP_INDEX_SIZE ? _length : MAX_ZONE_MAP_INDEX_SIZE;
 
         slice->size = length - OLAP_VARCHAR_MAX_BYTES;
         memset(slice->data, 0xFF, slice->size);

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -95,7 +95,7 @@ public:
     int32_t tablet_schema_hash() const { return _rowset_meta_pb.tablet_schema_hash(); }
 
     void set_tablet_schema_hash(int64_t tablet_schema_hash) {
-        _rowset_meta_pb.set_tablet_schema_hash(tablet_schema_hash);
+        _rowset_meta_pb.set_tablet_schema_hash(cast_set<int32_t>(tablet_schema_hash));
     }
 
     RowsetTypePB rowset_type() const { return _rowset_meta_pb.rowset_type(); }
@@ -269,7 +269,7 @@ public:
         if (!is_segments_overlapping()) {
             score = 1;
         } else {
-            score = num_segments();
+            cast_set(score, num_segments());
             CHECK(score > 0);
         }
         return score;
@@ -284,7 +284,7 @@ public:
                 way_num = 1;
             }
         } else {
-            way_num = num_segments();
+            cast_set(way_num, num_segments());
             CHECK(way_num > 0);
         }
         return way_num;

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
@@ -107,7 +107,7 @@ public:
     // Read and union all bitmaps in range [from, to) into `result`
     Status read_union_bitmap(rowid_t from, rowid_t to, roaring::Roaring* result);
 
-    rowid_t bitmap_nums() const { return _reader->bitmap_nums(); }
+    rowid_t bitmap_nums() const { return cast_set<rowid_t>(_reader->bitmap_nums()); }
 
     rowid_t current_ordinal() const { return _current_rowid; }
 

--- a/be/src/olap/rowset/segment_v2/bloom_filter.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 
+#include "common/cast_set.h"
 #include "common/status.h"
 #include "gutil/integral_types.h"
 #include "util/murmur_hash3.h"
@@ -114,7 +115,7 @@ public:
         } else {
             return Status::InvalidArgument("invalid strategy:{}", strategy);
         }
-        _num_bytes = filter_size;
+        cast_set(_num_bytes, filter_size);
         DCHECK((_num_bytes & (_num_bytes - 1)) == 0);
         _size = _num_bytes + 1;
         // reserve last byte for null flag

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/cast_set.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h" // for Status
@@ -584,7 +585,7 @@ public:
     }
 
     Status seek_to_ordinal(ordinal_t ord_idx) override {
-        _current_rowid = ord_idx;
+        cast_set(_current_rowid, ord_idx);
         return Status::OK();
     }
 
@@ -595,7 +596,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override {
         for (size_t i = 0; i < *n; ++i) {
-            rowid_t row_id = _current_rowid + i;
+            auto row_id = cast_set<rowid_t>(_current_rowid + i);
             GlobalRowLoacation location(_tablet_id, _rowset_id, _segment_id, row_id);
             dst->insert_data(reinterpret_cast<const char*>(&location), sizeof(GlobalRowLoacation));
         }

--- a/be/src/olap/rowset/segment_v2/index_page.h
+++ b/be/src/olap/rowset/segment_v2/index_page.h
@@ -95,13 +95,13 @@ public:
         return _footer.type() == IndexPageFooterPB::LEAF;
     }
 
-    const Slice& get_key(int idx) const {
+    const Slice& get_key(int64_t idx) const {
         DCHECK(_parsed);
         DCHECK(idx >= 0 && idx < _footer.num_entries());
         return _keys[idx];
     }
 
-    const PagePointer& get_value(int idx) const {
+    const PagePointer& get_value(int64_t idx) const {
         DCHECK(_parsed);
         DCHECK(idx >= 0 && idx < _footer.num_entries());
         return _values[idx];

--- a/be/src/olap/rowset/segment_v2/row_ranges.h
+++ b/be/src/olap/rowset/segment_v2/row_ranges.h
@@ -198,10 +198,10 @@ public:
     bool contain(rowid_t from, rowid_t to) {
         // binary search
         RowRange tmp_range = RowRange(from, to);
-        int32_t start = 0;
-        int32_t end = _ranges.size();
+        int64_t start = 0;
+        int64_t end = _ranges.size();
         while (start <= end) {
-            int32_t mid = (start + end) / 2;
+            int64_t mid = (start + end) / 2;
             if (_ranges[mid].is_before(tmp_range)) {
                 start = mid;
             } else if (_ranges[mid].is_after(tmp_range)) {
@@ -247,7 +247,7 @@ public:
             return;
         }
         RowRange range_to_add = range;
-        for (int i = _ranges.size() - 1; i >= 0; --i) {
+        for (int64_t i = _ranges.size() - 1; i >= 0; --i) {
             const RowRange last = _ranges[i];
             DCHECK(!last.is_after(range));
             RowRange u;

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -87,7 +87,7 @@ public:
     Schema(const std::vector<TabletColumnPtr>& columns, const std::vector<ColumnId>& col_ids) {
         size_t num_key_columns = 0;
         _unique_ids.resize(columns.size());
-        for (size_t i = 0; i < columns.size(); ++i) {
+        for (int i = 0; i < columns.size(); ++i) {
             if (columns[i]->is_key()) {
                 ++num_key_columns;
             }

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -80,7 +80,7 @@ public:
         segment_v2::SegmentSharedPtr segment;
     };
 
-    SegmentCache(size_t memory_bytes_limit, size_t segment_num_limit)
+    SegmentCache(size_t memory_bytes_limit, uint32_t segment_num_limit)
             : LRUCachePolicyTrackingManual(CachePolicy::CacheType::SEGMENT_CACHE,
                                            memory_bytes_limit, LRUCacheType::SIZE,
                                            config::tablet_rowset_stale_sweep_time_sec,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -673,7 +673,7 @@ inline size_t Tablet::num_rows() {
 
 inline int Tablet::version_count() const {
     std::shared_lock rdlock(_meta_lock);
-    return _tablet_meta->version_count();
+    return cast_set<int>(_tablet_meta->version_count());
 }
 
 inline Version Tablet::max_version() const {

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -211,8 +211,8 @@ private:
     int32_t _precision = -1;
     int32_t _frac = -1;
 
-    int32_t _length = -1;
-    int32_t _index_length = -1;
+    int64_t _length = -1;
+    int64_t _index_length = -1;
 
     bool _is_bf_column = false;
 

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -443,7 +443,7 @@ public:
         auto r_value = reinterpret_cast<const StructValue*>(right);
         uint32_t l_size = l_value->size();
         uint32_t r_size = r_value->size();
-        size_t cur = 0;
+        uint32_t cur = 0;
 
         if (!l_value->has_null() && !r_value->has_null()) {
             while (cur < l_size && cur < r_size) {
@@ -496,7 +496,7 @@ public:
 
         size_t allocate_size = src_value->size() * sizeof(*src_value->values());
         // allocate memory for children value
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             if (src_value->is_null_at(i)) continue;
             allocate_size += _type_infos[i]->size();
         }
@@ -505,7 +505,7 @@ public:
         auto ptr = reinterpret_cast<uint8_t*>(dest_value->mutable_values());
         ptr += dest_value->size() * sizeof(*dest_value->values());
 
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             dest_value->set_child_value(nullptr, i);
             if (src_value->is_null_at(i)) continue;
             dest_value->set_child_value(ptr, i);
@@ -513,7 +513,7 @@ public:
         }
 
         // copy children value
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             if (src_value->is_null_at(i)) continue;
             _type_infos[i]->deep_copy(dest_value->mutable_child_value(i), src_value->child_value(i),
                                       arena);
@@ -534,14 +534,14 @@ public:
         dest_value->set_has_null(src_value->has_null());
         *base += src_value->size() * sizeof(*src_value->values());
 
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             dest_value->set_child_value(nullptr, i);
             if (src_value->is_null_at(i)) continue;
             dest_value->set_child_value(*base, i);
             *base += _type_infos[i]->size();
         }
 
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             if (dest_value->is_null_at(i)) {
                 continue;
             }
@@ -578,7 +578,7 @@ public:
         auto src_value = reinterpret_cast<const StructValue*>(src);
         std::string result = "{";
 
-        for (size_t i = 0; i < src_value->size(); ++i) {
+        for (uint32_t i = 0; i < src_value->size(); ++i) {
             std::string field_value = _type_infos[i]->to_string(src_value->child_value(i));
             result += field_value;
             if (i < src_value->size() - 1) {

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -512,8 +512,8 @@ struct SpillSortSharedState : public BasicSharedState,
         auto rows = block->rows();
         if (rows > 0 && 0 == avg_row_bytes) {
             avg_row_bytes = std::max((std::size_t)1, block->bytes() / rows);
-            spill_block_batch_row_count =
-                    (SORT_BLOCK_SPILL_BATCH_BYTES + avg_row_bytes - 1) / avg_row_bytes;
+            spill_block_batch_row_count = cast_set<int>(
+                    (SORT_BLOCK_SPILL_BATCH_BYTES + avg_row_bytes - 1) / avg_row_bytes);
             LOG(INFO) << "spill sort block batch row count: " << spill_block_batch_row_count;
         }
     }

--- a/be/src/pipeline/exec/join/join_op.h
+++ b/be/src/pipeline/exec/join/join_op.h
@@ -43,7 +43,7 @@ namespace doris::pipeline {
  *  RowRefListWithFlags is a list of many RowRefWithFlags. This means each row will have different visited flags. It's used for join operation which has `other_conjuncts`.
  */
 struct RowRef {
-    uint32_t row_num = 0;
+    size_t row_num = 0;
 
     RowRef() = default;
     RowRef(size_t row_num_count) : row_num(row_num_count) {}

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -353,7 +353,7 @@ DecimalV2Value DecimalV2Value::sqrt(const DecimalV2Value& v) {
     return DecimalV2Value(ret);
 }
 
-int DecimalV2Value::parse_from_str(const char* decimal_str, int32_t length) {
+int DecimalV2Value::parse_from_str(const char* decimal_str, int64_t length) {
     int32_t error = E_DEC_OK;
     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
 

--- a/be/src/runtime/decimalv2_value.h
+++ b/be/src/runtime/decimalv2_value.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <string_view>
 
+#include "common/cast_set.h"
 #include "util/hash_util.hpp"
 #include "vec/core/wide_integer.h"
 
@@ -175,7 +176,7 @@ public:
     // NOTE: return a negative value if decimal is negative.
     // ATTN: the max length of fraction part in OLAP is 9, so the 'big digits' except the first one
     // will be truncated.
-    int32_t frac_value() const { return static_cast<int64_t>(_value % ONE_BILLION); }
+    int32_t frac_value() const { return cast_set<int32_t>(_value % ONE_BILLION); }
 
     bool operator==(const DecimalV2Value& other) const { return _value == other.value(); }
 
@@ -211,7 +212,7 @@ public:
     // (to make error handling easier)
     //
     // e.g. "1.2"  ".2"  "1.2e-3"  "1.2e3"
-    int parse_from_str(const char* decimal_str, int32_t length);
+    int parse_from_str(const char* decimal_str, int64_t length);
 
     std::string get_debug_info() const { return to_string(); }
 

--- a/be/src/runtime/jsonb_value.h
+++ b/be/src/runtime/jsonb_value.h
@@ -47,7 +47,7 @@ struct JsonBinaryValue {
         static_cast<void>(from_json_string(const_cast<const char*>(ptr), len));
     }
     JsonBinaryValue(const std::string& s) {
-        static_cast<void>(from_json_string(s.c_str(), s.length()));
+        static_cast<void>(from_json_string(s.c_str(), cast_set<int>(s.length())));
     }
     JsonBinaryValue(const char* ptr, int len) { static_cast<void>(from_json_string(ptr, len)); }
 
@@ -121,14 +121,14 @@ struct JsonBinaryValue {
 
     struct HashOfJsonBinaryValue {
         size_t operator()(const JsonBinaryValue& v) const {
-            return HashUtil::hash(v.ptr, v.len, 0);
+            return HashUtil::hash(v.ptr, cast_set<int32_t>(v.len), 0);
         }
     };
 };
 
 // This function must be called 'hash_value' to be picked up by boost.
 inline std::size_t hash_value(const JsonBinaryValue& v) {
-    return HashUtil::hash(v.ptr, v.len, 0);
+    return HashUtil::hash(v.ptr, cast_set<int32_t>(v.len), 0);
 }
 
 std::ostream& operator<<(std::ostream& os, const JsonBinaryValue& json_value);

--- a/be/src/runtime/large_int_value.h
+++ b/be/src/runtime/large_int_value.h
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <string>
 
+#include "common/cast_set.h"
+
 namespace doris {
 
 inline const __int128 MAX_INT128 = ~((__int128)0x01 << 127);
@@ -32,7 +34,7 @@ inline const __int128 MIN_INT128 = ((__int128)0x01 << 127);
 class LargeIntValue {
 public:
     static int32_t to_buffer(__int128 value, char* buffer) {
-        return fmt::format_to(buffer, FMT_COMPILE("{}"), value) - buffer;
+        return cast_set<int32_t>(fmt::format_to(buffer, FMT_COMPILE("{}"), value) - buffer);
     }
 
     static std::string to_string(__int128 value) { return fmt::format(FMT_COMPILE("{}"), value); }

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <string>
+#include <type_traits>
 
 #include "olap/decimal12.h"
 #include "runtime/define_primitive_type.h"
@@ -326,9 +327,9 @@ template <>
 struct PrimitiveTypeConvertor<TYPE_DATE> {
     using CppType = typename PrimitiveTypeTraits<TYPE_DATE>::CppType;
     using StorageFieldType = typename PrimitiveTypeTraits<TYPE_DATE>::StorageFieldType;
-
+    static_assert(std::is_same_v<uint24_t, StorageFieldType>);
     static inline StorageFieldType to_storage_field_type(const CppType& value) {
-        return value.to_olap_date();
+        return uint24_t {cast_set<uint32_t>(value.to_olap_date())};
     }
 };
 

--- a/be/src/runtime/string_search.hpp
+++ b/be/src/runtime/string_search.hpp
@@ -42,7 +42,7 @@ public:
     // search for this pattern in str.
     //   Returns the offset into str if the pattern exists
     //   Returns -1 if the pattern is not found
-    int search(const StringRef* str) const {
+    int64_t search(const StringRef* str) const {
         auto it = search(str->data, str->size);
         if (it == str->data + str->size) {
             return -1;
@@ -51,7 +51,7 @@ public:
         }
     }
 
-    int search(const StringRef& str) const {
+    int64_t search(const StringRef& str) const {
         auto it = search(str.data, str.size);
         if (it == str.data + str.size) {
             return -1;

--- a/be/src/runtime/workload_group/workload_group.h
+++ b/be/src/runtime/workload_group/workload_group.h
@@ -167,7 +167,7 @@ public:
         return _is_shutdown && _query_ctxs.empty();
     }
 
-    int query_num() {
+    int64_t query_num() {
         std::shared_lock<std::shared_mutex> r_lock(_mutex);
         return _query_ctxs.size();
     }

--- a/be/src/util/bit_packing.inline.h
+++ b/be/src/util/bit_packing.inline.h
@@ -237,7 +237,7 @@ const uint8_t* BitPacking::Unpack32Values(const uint8_t* __restrict__ in, int64_
     static_assert(BIT_WIDTH >= 0, "BIT_WIDTH too low");
     static_assert(BIT_WIDTH <= MAX_BITWIDTH, "BIT_WIDTH too high");
     DCHECK_LE(BIT_WIDTH, sizeof(OutType) * CHAR_BIT) << "BIT_WIDTH too high for output";
-    constexpr int BYTES_TO_READ = BitUtil::RoundUpNumBytes(32 * BIT_WIDTH);
+    constexpr auto BYTES_TO_READ = BitUtil::RoundUpNumBytes(32 * BIT_WIDTH);
     DCHECK_GE(in_bytes, BYTES_TO_READ);
 
     // Call UnpackValue for 0 <= i < 32.
@@ -275,7 +275,7 @@ const uint8_t* BitPacking::UnpackAndDecode32Values(const uint8_t* __restrict__ i
                                                    bool* __restrict__ decode_error) {
     static_assert(BIT_WIDTH >= 0, "BIT_WIDTH too low");
     static_assert(BIT_WIDTH <= MAX_BITWIDTH, "BIT_WIDTH too high");
-    constexpr int BYTES_TO_READ = BitUtil::RoundUpNumBytes(32 * BIT_WIDTH);
+    constexpr auto BYTES_TO_READ = BitUtil::RoundUpNumBytes(32 * BIT_WIDTH);
     DCHECK_GE(in_bytes, BYTES_TO_READ);
     // TODO: this could be optimised further by using SIMD instructions.
     // https://lemire.me/blog/2016/08/25/faster-dictionary-decoding-with-simd-instructions/
@@ -303,7 +303,7 @@ const uint8_t* BitPacking::UnpackUpTo31Values(const uint8_t* __restrict__ in, in
     static_assert(BIT_WIDTH <= MAX_BITWIDTH, "BIT_WIDTH too high");
     DCHECK_LE(BIT_WIDTH, sizeof(OutType) * CHAR_BIT) << "BIT_WIDTH too high for output";
     constexpr int MAX_BATCH_SIZE = 31;
-    const int BYTES_TO_READ = BitUtil::RoundUpNumBytes(num_values * BIT_WIDTH);
+    const auto BYTES_TO_READ = BitUtil::RoundUpNumBytes(num_values * BIT_WIDTH);
     DCHECK_GE(in_bytes, BYTES_TO_READ);
     DCHECK_LE(num_values, MAX_BATCH_SIZE);
 
@@ -347,7 +347,7 @@ const uint8_t* BitPacking::UnpackAndDecodeUpTo31Values(const uint8_t* __restrict
     static_assert(BIT_WIDTH >= 0, "BIT_WIDTH too low");
     static_assert(BIT_WIDTH <= MAX_BITWIDTH, "BIT_WIDTH too high");
     constexpr int MAX_BATCH_SIZE = 31;
-    const int BYTES_TO_READ = BitUtil::RoundUpNumBytes(num_values * BIT_WIDTH);
+    const auto BYTES_TO_READ = BitUtil::RoundUpNumBytes(num_values * BIT_WIDTH);
     DCHECK_GE(in_bytes, BYTES_TO_READ);
     DCHECK_LE(num_values, MAX_BATCH_SIZE);
 

--- a/be/src/util/bit_stream_utils.h
+++ b/be/src/util/bit_stream_utils.h
@@ -240,7 +240,7 @@ public:
     bool GetZigZagInteger(INT_T* v);
 
     /// Returns the number of bytes left in the stream.
-    int bytes_left() { return buffer_end_ - buffer_pos_; }
+    int64_t bytes_left() { return buffer_end_ - buffer_pos_; }
 
     /// Maximum byte length of a vlq encoded integer of type T.
     template <typename T>

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -279,7 +279,7 @@ inline bool BatchedBitReader::SkipBatch(int bit_width, int num_values_to_skip) {
     DCHECK_LE(bit_width, MAX_BITWIDTH);
     DCHECK_GE(num_values_to_skip, 0);
 
-    int skip_bytes = BitUtil::RoundUpNumBytes(bit_width * num_values_to_skip);
+    auto skip_bytes = BitUtil::RoundUpNumBytes(bit_width * num_values_to_skip);
     if (skip_bytes > buffer_end_ - buffer_pos_) {
         return false;
     }

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -280,7 +280,7 @@ public:
     }
 
     // Returns the rounded up to 64 multiple. Used for conversions of bits to i64.
-    static inline uint32_t round_up_numi_64(uint32_t bits) { return (bits + 63) >> 6; }
+    static inline uint64_t round_up_numi_64(uint64_t bits) { return (bits + 63) >> 6; }
 
     constexpr static inline int64_t Ceil(int64_t value, int64_t divisor) {
         return value / divisor + (value % divisor != 0);
@@ -295,7 +295,7 @@ public:
     /// Specialized round up and down functions for frequently used factors,
     /// like 8 (bits->bytes), 32 (bits->i32), and 64 (bits->i64)
     /// Returns the rounded up number of bytes that fit the number of bits.
-    constexpr static inline uint32_t RoundUpNumBytes(uint32_t bits) { return (bits + 7) >> 3; }
+    constexpr static inline uint64_t RoundUpNumBytes(uint64_t bits) { return (bits + 7) >> 3; }
 
     /// Non hw accelerated pop count.
     /// TODO: we don't use this in any perf sensitive code paths currently.  There

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -19,6 +19,10 @@
 // and modified by Doris
 
 #pragma once
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 #include <gen_cpp/Types_types.h>
 #include <xxh3.h>
@@ -401,3 +405,6 @@ struct std::hash<std::pair<First, Second>> {
         return util_hash::HashLen16(h1, h2);
     }
 };
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -177,7 +177,7 @@ public:
     static JsonbDocument* makeDocument(char* pb, uint32_t size, const JsonbValue* rval);
 
     // create an JsonbDocument object from JSONB packed bytes
-    static JsonbDocument* createDocument(const char* pb, uint32_t size);
+    static JsonbDocument* createDocument(const char* pb, uint64_t size);
 
     // create an JsonbValue from JSONB packed bytes
     static JsonbValue* createValue(const char* pb, uint32_t size);
@@ -1109,7 +1109,7 @@ inline JsonbDocument* JsonbDocument::makeDocument(char* pb, uint32_t size, const
     return doc;
 }
 
-inline JsonbDocument* JsonbDocument::createDocument(const char* pb, uint32_t size) {
+inline JsonbDocument* JsonbDocument::createDocument(const char* pb, uint64_t size) {
     if (!pb || size < sizeof(JsonbHeader) + sizeof(JsonbValue)) {
         return nullptr;
     }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -380,7 +380,7 @@ public:
     void get_all_children(std::vector<RuntimeProfile*>* children);
 
     // Returns the number of counters in this profile
-    int num_counters() const { return _counter_map.size(); }
+    int64_t num_counters() const { return _counter_map.size(); }
 
     // Returns name of this profile
     const std::string& name() const { return _name; }

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -291,7 +291,7 @@ inline bool operator!=(const Slice& x, const Slice& y) {
 }
 
 inline int Slice::compare(const Slice& b) const {
-    const int min_len = (size < b.size) ? size : b.size;
+    const auto min_len = (size < b.size) ? size : b.size;
     int r = mem_compare(data, b.data, min_len);
     if (r == 0) {
         if (size < b.size)

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -102,7 +102,7 @@ public:
     // In the case of overflow, the max/min value for the data type will be returned.
     // Assumes s represents a decimal number.
     template <typename T>
-    static inline T string_to_int(const char* __restrict s, int len, ParseResult* result) {
+    static inline T string_to_int(const char* __restrict s, int64_t len, ParseResult* result) {
         T ans = string_to_int_internal<T>(s, len, result);
         if (LIKELY(*result == PARSE_SUCCESS)) {
             return ans;
@@ -116,7 +116,8 @@ public:
     // In the case of overflow, the max/min value for the data type will be returned.
     // Assumes s represents a decimal number.
     template <typename T>
-    static inline T string_to_unsigned_int(const char* __restrict s, int len, ParseResult* result) {
+    static inline T string_to_unsigned_int(const char* __restrict s, int64_t len,
+                                           ParseResult* result) {
         T ans = string_to_unsigned_int_internal<T>(s, len, result);
         if (LIKELY(*result == PARSE_SUCCESS)) {
             return ans;
@@ -128,7 +129,7 @@ public:
 
     // Convert a string s representing a number in given base into a decimal number.
     template <typename T>
-    static inline T string_to_int(const char* __restrict s, int len, int base,
+    static inline T string_to_int(const char* __restrict s, int64_t len, int base,
                                   ParseResult* result) {
         T ans = string_to_int_internal<T>(s, len, base, result);
         if (LIKELY(*result == PARSE_SUCCESS)) {
@@ -140,12 +141,12 @@ public:
     }
 
     template <typename T>
-    static inline T string_to_float(const char* __restrict s, int len, ParseResult* result) {
+    static inline T string_to_float(const char* __restrict s, int64_t len, ParseResult* result) {
         return string_to_float_internal<T>(s, len, result);
     }
 
     // Parses a string for 'true' or 'false', case insensitive.
-    static inline bool string_to_bool(const char* __restrict s, int len, ParseResult* result) {
+    static inline bool string_to_bool(const char* __restrict s, int64_t len, ParseResult* result) {
         bool ans = string_to_bool_internal(s, len, result);
         if (LIKELY(*result == PARSE_SUCCESS)) {
             return ans;
@@ -157,7 +158,7 @@ public:
 
     template <PrimitiveType P, typename T = PrimitiveTypeTraits<P>::CppType::NativeType,
               typename DecimalType = PrimitiveTypeTraits<P>::ColumnType::value_type>
-    static inline T string_to_decimal(const char* __restrict s, int len, int type_precision,
+    static inline T string_to_decimal(const char* __restrict s, int64_t len, int type_precision,
                                       int type_scale, ParseResult* result);
 
     template <typename T>
@@ -175,7 +176,7 @@ public:
                 break;
             }
             if ((val_end = base.find(element_separator, val_pos)) == std::string::npos) {
-                val_end = base.size();
+                val_end = static_cast<int>(base.size());
             }
             result->insert(std::make_pair(base.substr(key_pos, key_end - key_pos),
                                           base.substr(val_pos, val_end - val_pos)));
@@ -194,27 +195,28 @@ private:
     // Assumes s represents a decimal number.
     // Return PARSE_FAILURE on leading whitespace. Trailing whitespace is allowed.
     template <typename T>
-    static inline T string_to_int_internal(const char* __restrict s, int len, ParseResult* result);
+    static inline T string_to_int_internal(const char* __restrict s, int64_t len,
+                                           ParseResult* result);
 
     // This is considerably faster than glibc's implementation.
     // In the case of overflow, the max/min value for the data type will be returned.
     // Assumes s represents a decimal number.
     // Return PARSE_FAILURE on leading whitespace. Trailing whitespace is allowed.
     template <typename T>
-    static inline T string_to_unsigned_int_internal(const char* __restrict s, int len,
+    static inline T string_to_unsigned_int_internal(const char* __restrict s, int64_t len,
                                                     ParseResult* result);
 
     // Convert a string s representing a number in given base into a decimal number.
     // Return PARSE_FAILURE on leading whitespace. Trailing whitespace is allowed.
     template <typename T>
-    static inline T string_to_int_internal(const char* __restrict s, int len, int base,
+    static inline T string_to_int_internal(const char* __restrict s, int64_t len, int base,
                                            ParseResult* result);
 
     // Converts an ascii string to an integer of type T assuming it cannot overflow
     // and the number is positive.
     // Leading whitespace is not allowed. Trailing whitespace will be skipped.
     template <typename T>
-    static inline T string_to_int_no_overflow(const char* __restrict s, int len,
+    static inline T string_to_int_no_overflow(const char* __restrict s, int64_t len,
                                               ParseResult* result);
 
     // This is considerably faster than glibc's implementation (>100x why???)
@@ -225,16 +227,16 @@ private:
     // Return PARSE_FAILURE on leading whitespace. Trailing whitespace is allowed.
     // TODO: Investigate using intrinsics to speed up the slow strtod path.
     template <typename T>
-    static inline T string_to_float_internal(const char* __restrict s, int len,
+    static inline T string_to_float_internal(const char* __restrict s, int64_t len,
                                              ParseResult* result);
 
     // parses a string for 'true' or 'false', case insensitive
     // Return PARSE_FAILURE on leading whitespace. Trailing whitespace is allowed.
-    static inline bool string_to_bool_internal(const char* __restrict s, int len,
+    static inline bool string_to_bool_internal(const char* __restrict s, int64_t len,
                                                ParseResult* result);
 
     // Returns true if s only contains whitespace.
-    static inline bool is_all_whitespace(const char* __restrict s, int len) {
+    static inline bool is_all_whitespace(const char* __restrict s, int64_t len) {
         for (int i = 0; i < len; ++i) {
             if (!LIKELY(is_whitespace(s[i]))) {
                 return false;
@@ -244,12 +246,12 @@ private:
     }
 
     // For strings like "3.0", "3.123", and "3.", can parse them as 3.
-    static inline bool is_float_suffix(const char* __restrict s, int len) {
+    static inline bool is_float_suffix(const char* __restrict s, int64_t len) {
         return (s[0] == '.' && is_all_digit(s + 1, len - 1));
     }
 
-    static inline bool is_all_digit(const char* __restrict s, int len) {
-        for (int i = 0; i < len; ++i) {
+    static inline bool is_all_digit(const char* __restrict s, int64_t len) {
+        for (int64_t i = 0; i < len; ++i) {
             if (!LIKELY(s[i] >= '0' && s[i] <= '9')) {
                 return false;
             }
@@ -258,7 +260,7 @@ private:
     }
 
     // Returns the position of the first non-whitespace character in s.
-    static inline int skip_leading_whitespace(const char* __restrict s, int len) {
+    static inline int skip_leading_whitespace(const char* __restrict s, int64_t len) {
         int i = 0;
         while (i < len && is_whitespace(s[i])) {
             ++i;
@@ -275,7 +277,7 @@ private:
 }; // end of class StringParser
 
 template <typename T>
-T StringParser::string_to_int_internal(const char* __restrict s, int len, ParseResult* result) {
+T StringParser::string_to_int_internal(const char* __restrict s, int64_t len, ParseResult* result) {
     if (UNLIKELY(len <= 0)) {
         *result = PARSE_FAILURE;
         return 0;
@@ -337,7 +339,7 @@ T StringParser::string_to_int_internal(const char* __restrict s, int len, ParseR
 }
 
 template <typename T>
-T StringParser::string_to_unsigned_int_internal(const char* __restrict s, int len,
+T StringParser::string_to_unsigned_int_internal(const char* __restrict s, int64_t len,
                                                 ParseResult* result) {
     if (UNLIKELY(len <= 0)) {
         *result = PARSE_FAILURE;
@@ -385,7 +387,7 @@ T StringParser::string_to_unsigned_int_internal(const char* __restrict s, int le
 }
 
 template <typename T>
-T StringParser::string_to_int_internal(const char* __restrict s, int len, int base,
+T StringParser::string_to_int_internal(const char* __restrict s, int64_t len, int base,
                                        ParseResult* result) {
     typedef typename std::make_unsigned<T>::type UnsignedT;
     UnsignedT val = 0;
@@ -445,7 +447,8 @@ T StringParser::string_to_int_internal(const char* __restrict s, int len, int ba
 }
 
 template <typename T>
-T StringParser::string_to_int_no_overflow(const char* __restrict s, int len, ParseResult* result) {
+T StringParser::string_to_int_no_overflow(const char* __restrict s, int64_t len,
+                                          ParseResult* result) {
     T val = 0;
     if (UNLIKELY(len == 0)) {
         *result = PARSE_SUCCESS;
@@ -477,8 +480,9 @@ T StringParser::string_to_int_no_overflow(const char* __restrict s, int len, Par
 }
 
 template <typename T>
-T StringParser::string_to_float_internal(const char* __restrict s, int len, ParseResult* result) {
-    int i = 0;
+T StringParser::string_to_float_internal(const char* __restrict s, int64_t len,
+                                         ParseResult* result) {
+    int64_t i = 0;
     // skip leading spaces
     for (; i < len; ++i) {
         if (!is_whitespace(s[i])) {
@@ -487,7 +491,7 @@ T StringParser::string_to_float_internal(const char* __restrict s, int len, Pars
     }
 
     // skip back spaces
-    int j = len - 1;
+    int64_t j = len - 1;
     for (; j >= i; j--) {
         if (!is_whitespace(s[j])) {
             break;
@@ -510,7 +514,7 @@ T StringParser::string_to_float_internal(const char* __restrict s, int len, Pars
     if (res.ec == std::errc() && res.ptr == s + j + 1) {
         if (abs(val) == std::numeric_limits<T>::infinity()) {
             auto contain_inf = false;
-            for (int k = i; k < j + 1; k++) {
+            for (int64_t k = i; k < j + 1; k++) {
                 if (s[k] == 'i' || s[k] == 'I') {
                     contain_inf = true;
                     break;
@@ -528,7 +532,7 @@ T StringParser::string_to_float_internal(const char* __restrict s, int len, Pars
     return 0;
 }
 
-inline bool StringParser::string_to_bool_internal(const char* __restrict s, int len,
+inline bool StringParser::string_to_bool_internal(const char* __restrict s, int64_t len,
                                                   ParseResult* result) {
     *result = PARSE_SUCCESS;
 
@@ -551,7 +555,7 @@ inline bool StringParser::string_to_bool_internal(const char* __restrict s, int 
 }
 
 template <PrimitiveType P, typename T, typename DecimalType>
-T StringParser::string_to_decimal(const char* __restrict s, int len, int type_precision,
+T StringParser::string_to_decimal(const char* __restrict s, int64_t len, int type_precision,
                                   int type_scale, ParseResult* result) {
     static_assert(std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t> ||
                           std::is_same_v<T, __int128> || std::is_same_v<T, wide::Int256>,

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -283,9 +283,9 @@ public:
         }
     }
 
-    int32_t find_code(const StringRef& value) const { return _dict.find_code(value); }
+    int64_t find_code(const StringRef& value) const { return _dict.find_code(value); }
 
-    int32_t find_code_by_bound(const StringRef& value, bool greater, bool eq) const {
+    int64_t find_code_by_bound(const StringRef& value, bool greater, bool eq) const {
         return _dict.find_code_by_bound(value, greater, eq);
     }
 
@@ -364,7 +364,7 @@ public:
             _total_str_len += value.size;
         }
 
-        int32_t find_code(const StringRef& value) const {
+        int64_t find_code(const StringRef& value) const {
             for (size_t i = 0; i < _dict_data->size(); i++) {
                 if ((*_dict_data)[i] == value) {
                     return i;
@@ -402,11 +402,11 @@ public:
 
                 // For dictionary data of char type, sv.size is the schema length,
                 // so use strnlen to remove the 0 at the end to get the actual length.
-                int32_t len = sv.size;
+                int64_t len = sv.size;
                 if (type == FieldType::OLAP_FIELD_TYPE_CHAR) {
                     len = strnlen(sv.data, sv.size);
                 }
-                uint32_t hash_val = HashUtil::crc_hash(sv.data, len, 0);
+                uint32_t hash_val = HashUtil::crc_hash(sv.data, cast_set<int32_t>(len), 0);
                 _hash_values[code] = hash_val;
                 _compute_hash_value_flags[code] = 1;
                 return _hash_values[code];
@@ -430,7 +430,7 @@ public:
         //  so upper_bound is the code 0 of b, then evaluate code < 0 and returns empty
         // If the predicate is col <= 'a' and upper_bound-1 is -1,
         //  then evaluate code <= -1 and returns empty
-        int32_t find_code_by_bound(const StringRef& value, bool greater, bool eq) const {
+        int64_t find_code_by_bound(const StringRef& value, bool greater, bool eq) const {
             auto code = find_code(value);
             if (code >= 0) {
                 return code;

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -216,7 +216,7 @@ public:
 
         const char* ptr = strings[0].data;
         for (size_t i = 0; i != num; i++) {
-            uint32_t len = strings[i].size;
+            auto len = strings[i].size;
             length += len;
             offset += len;
             offsets.push_back(offset);
@@ -301,7 +301,7 @@ public:
         Char* data = chars.data();
         size_t offset = old_size;
         for (size_t i = 0; i < num; i++) {
-            uint32_t len = strings[i].size;
+            auto len = strings[i].size;
             if (len) {
                 memcpy(data + offset, strings[i].data, len);
                 offset += len;
@@ -324,7 +324,7 @@ public:
         Char* data = chars.data();
         size_t offset = old_size;
         for (size_t i = 0; i < num; i++) {
-            uint32_t len = strings[i].size;
+            auto len = strings[i].size;
             if (len) {
                 memcpy(data + offset, strings[i].data, copy_length);
                 offset += len;
@@ -361,7 +361,7 @@ public:
         for (size_t i = 0; i < num; i++) {
             int32_t codeword = data_array[i + start_index];
             new_size += dict[codeword].size;
-            offsets[offset_size + i] = new_size;
+            offsets[offset_size + i] = cast_set<T>(new_size);
         }
 
         check_chars_length(new_size, offsets.size());
@@ -425,13 +425,15 @@ public:
             for (size_t i = start; i < end; ++i) {
                 if (null_data[i] == 0) {
                     auto data_ref = get_data_at(i);
-                    hash = HashUtil::zlib_crc_hash(data_ref.data, data_ref.size, hash);
+                    hash = HashUtil::zlib_crc_hash(data_ref.data, cast_set<int32_t>(data_ref.size),
+                                                   hash);
                 }
             }
         } else {
             for (size_t i = start; i < end; ++i) {
                 auto data_ref = get_data_at(i);
-                hash = HashUtil::zlib_crc_hash(data_ref.data, data_ref.size, hash);
+                hash = HashUtil::zlib_crc_hash(data_ref.data, cast_set<int32_t>(data_ref.size),
+                                               hash);
             }
         }
     }
@@ -492,7 +494,7 @@ public:
     void insert_default() override { offsets.push_back(chars.size()); }
 
     void insert_many_defaults(size_t length) override {
-        offsets.resize_fill(offsets.size() + length, chars.size());
+        offsets.resize_fill(offsets.size() + length, cast_set<T>(chars.size()));
     }
 
     int compare_at(size_t n, size_t m, const IColumn& rhs_,

--- a/be/src/vec/common/hash_table/hash.h
+++ b/be/src/vec/common/hash_table/hash.h
@@ -188,7 +188,7 @@ struct HashCRC32<doris::vectorized::UInt136> {
     size_t operator()(const doris::vectorized::UInt136& x) const {
 #if defined(__SSE4_2__) || defined(__aarch64__)
         doris::vectorized::UInt64 crc = -1ULL;
-        crc = _mm_crc32_u8(crc, x.a);
+        crc = _mm_crc32_u8(doris::cast_set<uint32_t>(crc), x.a);
         crc = _mm_crc32_u64(crc, x.b);
         crc = _mm_crc32_u64(crc, x.c);
         return crc;

--- a/be/src/vec/common/hash_table/hash_map_context.h
+++ b/be/src/vec/common/hash_table/hash_map_context.h
@@ -74,21 +74,21 @@ struct MethodBaseInner {
 
     virtual size_t serialized_keys_size(bool is_build) const { return 0; }
 
-    void init_join_bucket_num(uint32_t num_rows, uint32_t bucket_size, const uint8_t* null_map) {
+    void init_join_bucket_num(uint64_t num_rows, uint32_t bucket_size, const uint8_t* null_map) {
         bucket_nums.resize(num_rows);
 
         if (null_map == nullptr) {
             init_join_bucket_num(num_rows, bucket_size);
             return;
         }
-        for (uint32_t k = 0; k < num_rows; ++k) {
+        for (uint64_t k = 0; k < num_rows; ++k) {
             bucket_nums[k] =
                     null_map[k] ? bucket_size : hash_table->hash(keys[k]) & (bucket_size - 1);
         }
     }
 
-    void init_join_bucket_num(uint32_t num_rows, uint32_t bucket_size) {
-        for (uint32_t k = 0; k < num_rows; ++k) {
+    void init_join_bucket_num(uint64_t num_rows, uint32_t bucket_size) {
+        for (uint64_t k = 0; k < num_rows; ++k) {
             bucket_nums[k] = hash_table->hash(keys[k]) & (bucket_size - 1);
         }
     }

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -19,7 +19,10 @@
 // and modified by Doris
 
 #pragma once
-
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
 #include <common/compiler_util.h>
 #include <stdint.h>
 #include <string.h>
@@ -687,3 +690,6 @@ void swap(PODArray<T, initial_bytes, TAllocator, pad_right_, pad_left_>& lhs,
 }
 
 } // namespace doris::vectorized
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/be/src/vec/common/sort/partition_sorter.h
+++ b/be/src/vec/common/sort/partition_sorter.h
@@ -66,7 +66,7 @@ public:
         }
         return true;
     }
-    int row = 0;
+    int64_t row = 0;
     std::shared_ptr<MergeSortCursorImpl> impl = nullptr;
 };
 

--- a/be/src/vec/common/string_buffer.hpp
+++ b/be/src/vec/common/string_buffer.hpp
@@ -76,7 +76,7 @@ public:
         return ref;
     }
 
-    void read(char* data, int len) {
+    void read(char* data, size_t len) {
         memcpy(data, _data, len);
         _data += len;
     }

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -147,8 +147,8 @@ inline bool memequalSSE2Wide(const char* p1, const char* p2, size_t size) {
 //   - s1/n1: ptr/len for the first string
 //   - s2/n2: ptr/len for the second string
 //   - len: min(n1, n2) - this can be more cheaply passed in by the caller
-PURE inline int string_compare(const char* s1, int64_t n1, const char* s2, int64_t n2,
-                               int64_t len) {
+PURE inline int64_t string_compare(const char* s1, int64_t n1, const char* s2, int64_t n2,
+                                   int64_t len) {
     DCHECK_EQ(len, std::min(n1, n2));
 #if defined(__SSE4_2__) || defined(__aarch64__)
     while (len >= sse_util::CHARS_PER_128_BIT_REGISTER) {
@@ -206,11 +206,11 @@ struct StringRef {
     explicit operator std::string() const { return to_string(); }
     operator std::string_view() const { return std::string_view {data, size}; }
 
-    StringRef substring(int start_pos, int new_len) const {
+    StringRef substring(size_t start_pos, int64_t new_len) const {
         return {data + start_pos, (new_len < 0) ? (size - start_pos) : new_len};
     }
 
-    StringRef substring(int start_pos) const { return substring(start_pos, size - start_pos); }
+    StringRef substring(size_t start_pos) const { return substring(start_pos, size - start_pos); }
 
     const char* begin() const { return data; }
     const char* end() const { return data + size; }
@@ -239,8 +239,8 @@ struct StringRef {
     // this < other: -1
     // this == other: 0
     // this > other: 1
-    int compare(const StringRef& other) const {
-        int l = std::min(size, other.size);
+    int64_t compare(const StringRef& other) const {
+        auto l = std::min(size, other.size);
 
         if (l == 0) {
             if (size == other.size) {
@@ -254,7 +254,7 @@ struct StringRef {
         }
 
         // string_compare doesn't have sign result
-        int cmp_result = string_compare(this->data, this->size, other.data, other.size, l);
+        auto cmp_result = string_compare(this->data, this->size, other.data, other.size, l);
         return (cmp_result > 0) - (cmp_result < 0);
     }
 
@@ -300,7 +300,7 @@ struct StringRef {
 
 // This function must be called 'hash_value' to be picked up by boost.
 inline std::size_t hash_value(const StringRef& v) {
-    return HashUtil::hash(v.data, v.size, 0);
+    return HashUtil::hash(v.data, cast_set<int32_t>(v.size), 0);
 }
 
 using StringRefs = std::vector<StringRef>;
@@ -336,7 +336,7 @@ inline size_t hash_less_than8(const char* data, size_t size) {
         uint8_t b = data[size >> 1];
         uint8_t c = data[size - 1];
         uint32_t y = static_cast<uint32_t>(a) + (static_cast<uint32_t>(b) << 8);
-        uint32_t z = size + (static_cast<uint32_t>(c) << 2);
+        uint32_t z = cast_set<uint32_t>(size + (static_cast<uint32_t>(c) << 2));
         return shift_mix(y * k2 ^ z * k3) * k2;
     }
 
@@ -347,7 +347,7 @@ inline size_t hash_less_than16(const char* data, size_t size) {
     if (size > 8) {
         auto a = unaligned_load<doris::vectorized::UInt64>(data);
         auto b = unaligned_load<doris::vectorized::UInt64>(data + size - 8);
-        return hash_len16(a, rotate_by_at_least1(b + size, size)) ^ b;
+        return hash_len16(a, rotate_by_at_least1(b + size, cast_set<int>(size))) ^ b;
     }
 
     return hash_less_than8(data, size);

--- a/be/src/vec/common/string_searcher.h
+++ b/be/src/vec/common/string_searcher.h
@@ -47,7 +47,7 @@ public:
 #if defined(__SSE2__) || defined(__aarch64__)
 protected:
     static constexpr auto n = sizeof(__m128i);
-    const int page_size = sysconf(_SC_PAGESIZE); //::getPageSize();
+    const long page_size = sysconf(_SC_PAGESIZE); //::getPageSize();
 
     bool page_safe(const void* const ptr) const {
         return ((page_size - 1) & reinterpret_cast<std::uintptr_t>(ptr)) <= page_size - n;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -814,7 +814,7 @@ void Block::filter_block_internal(Block* block, const std::vector<uint32_t>& col
 }
 
 void Block::filter_block_internal(Block* block, const IColumn::Filter& filter,
-                                  uint32_t column_to_keep) {
+                                  uint64_t column_to_keep) {
     std::vector<uint32_t> columns_to_filter;
     columns_to_filter.resize(column_to_keep);
     for (uint32_t i = 0; i < column_to_keep; ++i) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -289,7 +289,7 @@ public:
                                       const IColumn::Filter& filter);
     // need exception safety
     static void filter_block_internal(Block* block, const IColumn::Filter& filter,
-                                      uint32_t column_to_keep);
+                                      uint64_t column_to_keep);
     // need exception safety
     static void filter_block_internal(Block* block, const IColumn::Filter& filter);
 

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -165,7 +165,7 @@ class JsonbField {
 public:
     JsonbField() = default;
 
-    JsonbField(const char* ptr, uint32_t len) : size(len) {
+    JsonbField(const char* ptr, uint64_t len) : size(len) {
         data = new char[size];
         if (!data) {
             LOG(FATAL) << "new data buffer failed, size: " << size;
@@ -213,7 +213,7 @@ public:
     }
 
     const char* get_value() const { return data; }
-    uint32_t get_size() const { return size; }
+    uint64_t get_size() const { return size; }
 
     bool operator<(const JsonbField& r) const {
         LOG(FATAL) << "comparing between JsonbField is not supported";
@@ -252,7 +252,7 @@ public:
 
 private:
     char* data = nullptr;
-    uint32_t size = 0;
+    uint64_t size = 0;
 };
 
 template <typename T>

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -281,7 +281,7 @@ struct MergeSortBlockCursor {
     MergeSortCursorImpl* operator->() const { return impl.get(); }
 
     /// The specified row of this cursor is greater than the specified row of another cursor.
-    int8_t less_at(const MergeSortBlockCursor& rhs, int rows) const {
+    int8_t less_at(const MergeSortBlockCursor& rhs, int64_t rows) const {
         for (size_t i = 0; i < impl->sort_columns_size; ++i) {
             int direction = impl->desc[i].direction;
             int nulls_direction = impl->desc[i].nulls_direction;

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -388,7 +388,7 @@ std::string decimal_to_string(const T& value, UInt32 scale) {
     std::string str = std::string(max_result_length, '0');
 
     T abs_value = value;
-    int pos = 0;
+    size_t pos = 0;
 
     if (is_nagetive) {
         abs_value = -value;
@@ -445,7 +445,7 @@ size_t decimal_to_string(const T& value, char* dst, UInt32 scale, const T& scale
 
     bool is_negative = value < 0;
     T abs_value = value;
-    int pos = 0;
+    size_t pos = 0;
 
     if (is_negative) {
         abs_value = -value;

--- a/be/src/vec/data_types/data_type_jsonb.h
+++ b/be/src/vec/data_types/data_type_jsonb.h
@@ -69,7 +69,7 @@ public:
 
     virtual Field get_default() const override {
         std::string default_json = "{}";
-        JsonBinaryValue binary_val(default_json.c_str(), default_json.size());
+        JsonBinaryValue binary_val(default_json.c_str(), cast_set<int>(default_json.size()));
         return JsonbField(binary_val.value(), binary_val.size());
     }
 

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -188,7 +188,7 @@ protected:
         for (int row_num = 0; row_num < size; row_num++) {
             auto num = is_const ? col_vec.get_element(0) : col_vec.get_element(row_num);
             static_cast<const Derived*>(this)->push_number(chars, num);
-            offsets[row_num] = chars.size();
+            cast_set(offsets[row_num], chars.size());
         }
     }
 

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -48,7 +48,7 @@ struct ColumnVectorBatch;
 } // namespace orc
 
 #define SERIALIZE_COLUMN_TO_JSON()                                            \
-    for (size_t i = start_idx; i < end_idx; ++i) {                            \
+    for (int i = start_idx; i < end_idx; ++i) {                               \
         if (i != start_idx) {                                                 \
             bw.write(options.field_delim.data(), options.field_delim.size()); \
         }                                                                     \

--- a/be/src/vec/data_types/serde/data_type_string_serde.h
+++ b/be/src/vec/data_types/serde/data_type_string_serde.h
@@ -72,7 +72,7 @@ public:
                                       FormatOptions& options) const override {
         auto result = check_column_const_set_readability(column, row_num);
         ColumnPtr ptr = result.first;
-        row_num = result.second;
+        cast_set(row_num, result.second);
         const auto& value = assert_cast<const ColumnType&>(*ptr).get_data_at(row_num);
 
         if (_nesting_level > 1) {
@@ -210,7 +210,8 @@ public:
         result.writeKey(col_id);
         const auto& data_ref = column.get_data_at(row_num);
         result.writeStartBinary();
-        result.writeBinary(reinterpret_cast<const char*>(data_ref.data), data_ref.size);
+        result.writeBinary(reinterpret_cast<const char*>(data_ref.data),
+                           cast_set<uint32_t>(data_ref.size));
         result.writeEndBinary();
     }
 
@@ -232,8 +233,8 @@ public:
                 continue;
             }
             auto string_ref = string_column.get_data_at(string_i);
-            checkArrowStatus(builder.Append(string_ref.data, string_ref.size), column.get_name(),
-                             array_builder->type()->name());
+            checkArrowStatus(builder.Append(string_ref.data, cast_set<int>(string_ref.size)),
+                             column.get_name(), array_builder->type()->name());
         }
     }
     void read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int start,
@@ -300,7 +301,7 @@ public:
                                   int row_num) const override {
         const auto& col = assert_cast<const ColumnType&>(column);
         const auto& data_ref = col.get_data_at(row_num);
-        result.SetString(data_ref.data, data_ref.size);
+        result.SetString(data_ref.data, cast_set<uint32_t>(data_ref.size));
         return Status::OK();
     }
     Status read_one_cell_from_json(IColumn& column, const rapidjson::Value& result) const override {

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -71,7 +71,7 @@ private:
             arguments[i] = column_id;
         }
 
-        size_t num_columns_without_result = block->columns();
+        auto num_columns_without_result = cast_set<int32_t>(block->columns());
         auto res_data_column = ColumnVector<UInt8>::create(block->rows());
         ColumnPtr argument_column =
                 block->get_by_position(arguments[0]).column->convert_to_full_column_if_const();

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -153,7 +153,7 @@ public:
 
     void add_child(const VExprSPtr& expr) { _children.push_back(expr); }
     VExprSPtr get_child(int i) const { return _children[i]; }
-    int get_num_children() const { return _children.size(); }
+    size_t get_num_children() const { return _children.size(); }
 
     virtual bool need_judge_selectivity() {
         return std::ranges::any_of(_children.begin(), _children.end(),

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -440,7 +440,7 @@ bool try_read_int_text(T& x, ReadBuffer& buf) {
 
 template <typename T>
 const char* try_read_first_int_text(T& x, const char* pos, const char* end) {
-    const int len = end - pos;
+    const auto len = end - pos;
     int i = 0;
     while (i < len) {
         if (pos[i] >= '0' && pos[i] <= '9') {

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -92,16 +92,16 @@ bool VecDateTimeValue::check_date(uint32_t year, uint32_t month, uint32_t day) {
 // The interval format is that with no delimiters
 // YYYY-MM-DD HH-MM-DD.FFFFFF AM in default format
 // 0    1  2  3  4  5  6      7
-bool VecDateTimeValue::from_date_str(const char* date_str, int len) {
+bool VecDateTimeValue::from_date_str(const char* date_str, int64_t len) {
     return from_date_str_base(date_str, len, nullptr);
 }
 //parse timezone to get offset
-bool VecDateTimeValue::from_date_str(const char* date_str, int len,
+bool VecDateTimeValue::from_date_str(const char* date_str, int64_t len,
                                      const cctz::time_zone& local_time_zone) {
     return from_date_str_base(date_str, len, &local_time_zone);
 }
 
-bool VecDateTimeValue::from_date_str_base(const char* date_str, int len,
+bool VecDateTimeValue::from_date_str_base(const char* date_str, size_t len,
                                           const cctz::time_zone* local_time_zone) {
     const char* ptr = date_str;
     const char* end = date_str + len;
@@ -683,7 +683,7 @@ char* write_four_digits_to_string(int number, char* dst) {
     return dst + 4;
 }
 
-bool VecDateTimeValue::to_format_string_conservative(const char* format, int len, char* to,
+bool VecDateTimeValue::to_format_string_conservative(const char* format, size_t len, char* to,
                                                      int max_valid_length) const {
     if (check_range(_year, _month, _day, _hour, _minute, _second, _type)) {
         return false;
@@ -1203,8 +1203,9 @@ static int check_word(const char* lib[], const char* str, const char* end, const
 
 // this method is exactly same as fromDateFormatStr() in DateLiteral.java in FE
 // change this method should also change that.
-bool VecDateTimeValue::from_date_format_str(const char* format, int format_len, const char* value,
-                                            int value_len, const char** sub_val_end) {
+bool VecDateTimeValue::from_date_format_str(const char* format, size_t format_len,
+                                            const char* value, size_t value_len,
+                                            const char** sub_val_end) {
     if (value_len <= 0) [[unlikely]] {
         return false;
     }
@@ -2253,8 +2254,8 @@ void DateV2Value<T>::set_zero() {
 // this method is exactly same as fromDateFormatStr() in DateLiteral.java in FE
 // change this method should also change that.
 template <typename T>
-bool DateV2Value<T>::from_date_format_str(const char* format, int format_len, const char* value,
-                                          int value_len, const char** sub_val_end) {
+bool DateV2Value<T>::from_date_format_str(const char* format, size_t format_len, const char* value,
+                                          size_t value_len, const char** sub_val_end) {
     if (value_len <= 0) [[unlikely]] {
         return false;
     }
@@ -3449,7 +3450,7 @@ void DateV2Value<T>::set_microsecond(uint32_t microsecond) {
 }
 
 template <typename T>
-bool DateV2Value<T>::to_format_string_conservative(const char* format, int len, char* to,
+bool DateV2Value<T>::to_format_string_conservative(const char* format, size_t len, char* to,
                                                    int max_valid_length) const {
     if (is_invalid(year(), month(), day(), hour(), minute(), second(), microsecond())) {
         return false;


### PR DESCRIPTION
## Proposed changes

Since there are quite a few, I'll modify each module one by one here.

```
 /mnt/disk2/yanxuecheng/doris/be/src/vec/common/hash_table/hash_map_context.h:344:40: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
  344 |             Base::init_join_bucket_num(num_rows, bucket_size, null_map);
      |                   ~~~~~~~~~~~~~~~~~~~~ ^~~~~~~~
```

<!--Describe your changes.-->

