### PR TITLE
[fix](cooldown)No need to rdlock inside get_cooldown_tablets, there's enough rdlock inside tablet internal function calls.

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1620,7 +1620,6 @@ void TabletManager::get_cooldown_tablets(std::vector<TabletSharedPtr>* tablets,
         if (UNLIKELY(nullptr == tablet)) {
             return;
         }
-        std::shared_lock rdlock(tablet->get_header_lock());
         int64_t cooldown_timestamp = -1;
         size_t file_size = -1;
         if (!skip_tablet(tablet) &&


### PR DESCRIPTION
## Proposed changes
There's a recurse rdlock inside get_cooldown；when using libcxx，libcxx‘s shared_mutex dosen't support recursive lock, so causes hangs below:
#0  0x00007f788b101a35 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x00005636b8ff996f in std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) ()
#2  0x00005636b8ffad8b in std::__1::__shared_mutex_base::lock_shared() ()
#3  0x00005636addc524c in doris::Tablet::_has_data_to_cooldown() ()
#4  0x00005636addc353b in doris::Tablet::pick_cooldown_rowset() ()
#5  0x00005636addc56b9 in doris::Tablet::need_cooldown(long*, unsigned long*) ()
#6  0x00005636adde52f7 in doris::TabletManager::get_cooldown_tablets(std::__1::vector<std::__1::shared_ptr<doris::Tablet>, std::__1::allocator<std::__1::shared_ptr<doris::Tablet> > >*, std::__1::vector<std::__1::shared_ptr<doris::Rowset>, std::__1::allocator<std::__1::shared_ptr<doris::Rowset> > >*, std::__1::function<bool (std::__1::shared_ptr<doris::Tablet> const&)>) ()
#7  0x00005636adb0ed81 in doris::StorageEngine::_cooldown_tasks_producer_callback() ()
#8  0x00005636ae17a253 in doris::Thread::supervise_thread(void*) ()
#9  0x00007f788b0fdea5 in start_thread () from /lib64/libpthread.so.0
#10 0x00007f788b916b0d in clone () from /lib64/libc.so.6

review the code, there's no need a rdlock inside TabletManager::get_cooldown_tablets