### PR TITLE
[enhancment](limit) make offset be reserverd keyword to support 'offset integer limit integer' grammar to be compatible with presto

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -534,6 +534,7 @@ limitClause
     : (LIMIT limit=INTEGER_VALUE)
     | (LIMIT limit=INTEGER_VALUE OFFSET offset=INTEGER_VALUE)
     | (LIMIT offset=INTEGER_VALUE COMMA limit=INTEGER_VALUE)
+    | (OFFSET offset=INTEGER_VALUE LIMIT limit=INTEGER_VALUE)
     ;
 
 partitionClause
@@ -1259,7 +1260,6 @@ nonReserved
     | NON_NULLABLE
     | NULLS
     | OF
-    | OFFSET
     | ONLY
     | OPEN
     | OPTIMIZED

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -6804,6 +6804,8 @@ limit_clause ::=
   {: RESULT = new LimitElement(offset.longValue(), limit.longValue()); :}
   | KW_LIMIT INTEGER_LITERAL:limit KW_OFFSET INTEGER_LITERAL:offset
   {: RESULT = new LimitElement(offset.longValue(), limit.longValue()); :}
+  | KW_OFFSET INTEGER_LITERAL:offset KW_LIMIT INTEGER_LITERAL:limit
+  {: RESULT = new LimitElement(offset.longValue(), limit.longValue()); :}
   ;
 
 type ::=
@@ -8257,8 +8259,6 @@ keyword ::=
     | KW_NULLS:id
     {: RESULT = id; :}
     | KW_OF:id
-    {: RESULT = id; :}
-    | KW_OFFSET:id
     {: RESULT = id; :}
     | KW_ONLY:id
     {: RESULT = id; :}

--- a/regression-test/suites/nereids_syntax_p0/test_limit.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_limit.groovy
@@ -36,4 +36,16 @@ suite("test_limit") {
         sql "select * from test1 limit 2 offset 1"
         result([[1]])
     }
+
+    test {
+        sql "select * from test1 offset 1 limit 2"
+        result([[1]])
+    }
+
+    test {
+        sql "select * from test1 limit 1,2"
+        result([[1]])
+    }
+
+
 }


### PR DESCRIPTION
offset is reserved keyword in mysql, presto, here make  make offset be reserverd keyword to be compatible with presto to support 'offset integer limit integer' grammar

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

