### PR TITLE
[fix](nereids) fix partitionTopN choosing under multi winexprs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -285,8 +285,8 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
                     if (curPartitionLimit < chosenRowNumberPartitionLimit) {
                         chosenRowNumberPartitionLimit = curPartitionLimit;
                         chosenWindowFunc = windowFunc;
+                        hasRowNumber = true;
                     }
-                    hasRowNumber = true;
                 } else if (!hasRowNumber) {
                     // if no row_number, choose the one with minimal limit value
                     if (curPartitionLimit < chosenPartitionLimit) {

--- a/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
+++ b/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
@@ -63,6 +63,20 @@ suite("push_down_multi_filter_through_window") {
     }
 
     explain {
+        sql ("select * from (select rank() over(partition by c1 order by c3) as rk, row_number() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rk <= 1;")
+        contains "VPartitionTopN"
+        contains "functions: rank"
+        contains "partition limit: 1"
+    }
+
+    explain {
+        sql ("select * from (select rank() over(partition by c1 order by c3) as rk, row_number() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rn <= 10;")
+        contains "VPartitionTopN"
+        contains "functions: row_number"
+        contains "partition limit: 10"
+    }
+
+    explain {
         sql ("select * from (select rank() over(partition by c1 order by c3) as rk, rank() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 and rk <= 10;")
         contains "VPartitionTopN"
         contains "functions: rank"


### PR DESCRIPTION
intro by #38393

Fix the cases whose window function both contains row_number and other types but only the other types contains pushing down filter.