### PR TITLE
[enhance](Hdfs) Add bvar latencyrecorder for HDFS operation in Recycler

### DIFF
--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -34,9 +34,11 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "common/stopwatch.h"
 #include "cpp/s3_rate_limiter.h"
 #include "cpp/sync_point.h"
 #include "recycler/s3_accessor.h"
+#include "recycler/util.h"
 
 using namespace Azure::Storage::Blobs;
 

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -17,7 +17,10 @@
 
 #include "recycler/hdfs_accessor.h"
 
+#include <bvar/latency_recorder.h>
 #include <gen_cpp/cloud.pb.h>
+
+#include "recycler/s3_accessor.h"
 #ifdef USE_HADOOP_HDFS
 #include <hadoop_hdfs/hdfs.h> // IWYU pragma: export
 #else
@@ -44,6 +47,12 @@ std::string hdfs_error() {
     return fmt::format("({}): {}", std::strerror(errno), err_msg ? err_msg : "");
 }
 
+bvar::LatencyRecorder hdfs_write_latency("hdfs_write");
+bvar::LatencyRecorder hdfs_open_latency("hdfs_open");
+bvar::LatencyRecorder hdfs_close_latency("hdfs_close");
+bvar::LatencyRecorder hdfs_list_dir("hdfs_list_dir");
+bvar::LatencyRecorder hdfs_exist_latency("hdfs_exist");
+bvar::LatencyRecorder hdfs_delete_latency("hdfs_delete");
 } // namespace
 
 class HDFSBuilder {
@@ -292,6 +301,7 @@ private:
     // Return null if error occured, return emtpy DirEntries if dir is empty or doesn't exist.
     std::optional<DirEntries> list_directory(const char* dir_path) {
         int num_entries = 0;
+        SCOPED_BVAR_LATENCY(hdfs_list_dir);
         auto* file_infos = hdfsListDirectory(hdfs_.get(), dir_path, &num_entries);
         if (errno != 0 && errno != ENOENT) {
             LOG_WARNING("failed to list hdfs directory")
@@ -430,6 +440,7 @@ int HdfsAccessor::delete_file(const std::string& relative_path) {
     // Path exists
     auto path = to_fs_path(relative_path);
     LOG_INFO("delete object").tag("uri", to_uri(relative_path)); // Audit log
+    SCOPED_BVAR_LATENCY(hdfs_delete_latency);
     ret = hdfsDelete(fs_.get(), path.c_str(), 0);
     if (ret != 0) {
         LOG_WARNING("failed to delete object")
@@ -443,7 +454,11 @@ int HdfsAccessor::delete_file(const std::string& relative_path) {
 
 int HdfsAccessor::put_file(const std::string& relative_path, const std::string& content) {
     auto path = to_fs_path(relative_path);
-    auto* file = hdfsOpenFile(fs_.get(), path.c_str(), O_WRONLY, 0, 0, 0);
+    hdfsFile file;
+    {
+        SCOPED_BVAR_LATENCY(hdfs_open_latency);
+        file = hdfsOpenFile(fs_.get(), path.c_str(), O_WRONLY, 0, 0, 0);
+    }
     if (!file) {
         LOG_WARNING("failed to create file")
                 .tag("uri", to_uri(relative_path))
@@ -453,11 +468,16 @@ int HdfsAccessor::put_file(const std::string& relative_path, const std::string& 
 
     std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [&](int*) {
         if (file) {
+            SCOPED_BVAR_LATENCY(hdfs_close_latency);
             hdfsCloseFile(fs_.get(), file);
         }
     });
 
-    int64_t written_bytes = hdfsWrite(fs_.get(), file, content.data(), content.size());
+    int64_t written_bytes = 0;
+    {
+        SCOPED_BVAR_LATENCY(hdfs_write_latency);
+        written_bytes = hdfsWrite(fs_.get(), file, content.data(), content.size());
+    }
     if (written_bytes < content.size()) {
         LOG_WARNING("failed to write file")
                 .tag("uri", to_uri(relative_path))
@@ -465,7 +485,11 @@ int HdfsAccessor::put_file(const std::string& relative_path, const std::string& 
         return -1;
     }
 
-    int ret = hdfsCloseFile(fs_.get(), file);
+    int ret = 0;
+    {
+        SCOPED_BVAR_LATENCY(hdfs_close_latency);
+        ret = hdfsCloseFile(fs_.get(), file);
+    }
     file = nullptr;
     if (ret != 0) {
         LOG_WARNING("failed to close file")
@@ -496,6 +520,7 @@ int HdfsAccessor::list_all(std::unique_ptr<ListIterator>* res) {
 
 int HdfsAccessor::exists(const std::string& relative_path) {
     auto path = to_fs_path(relative_path);
+    SCOPED_BVAR_LATENCY(hdfs_exist_latency);
     int ret = hdfsExists(fs_.get(), path.c_str());
 #ifdef USE_HADOOP_HDFS
     // when calling hdfsExists() and return non-zero code,

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -20,7 +20,9 @@
 #include <bvar/latency_recorder.h>
 #include <gen_cpp/cloud.pb.h>
 
-#include "recycler/s3_accessor.h"
+#include "common/stopwatch.h"
+#include "recycler/util.h"
+
 #ifdef USE_HADOOP_HDFS
 #include <hadoop_hdfs/hdfs.h> // IWYU pragma: export
 #else

--- a/cloud/src/recycler/s3_accessor.h
+++ b/cloud/src/recycler/s3_accessor.h
@@ -23,8 +23,7 @@
 #include <cstdint>
 #include <memory>
 
-#include "common/stopwatch.h"
-#include "recycler/s3_obj_client.h"
+#include "recycler/obj_storage_client.h"
 #include "recycler/storage_vault_accessor.h"
 
 namespace Aws::S3 {
@@ -51,12 +50,6 @@ extern bvar::LatencyRecorder s3_list_object_versions_latency;
 extern bvar::LatencyRecorder s3_get_bucket_version_latency;
 extern bvar::LatencyRecorder s3_copy_object_latency;
 }; // namespace s3_bvar
-
-// The time unit is the same with BE: us
-#define SCOPED_BVAR_LATENCY(bvar_item)                     \
-    StopWatch sw;                                          \
-    std::unique_ptr<int, std::function<void(int*)>> defer( \
-            (int*)0x01, [&](int*) { bvar_item << sw.elapsed_us(); });
 
 struct AccessorRateLimiter {
 public:

--- a/cloud/src/recycler/s3_obj_client.cpp
+++ b/cloud/src/recycler/s3_obj_client.cpp
@@ -30,9 +30,11 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "common/stopwatch.h"
 #include "cpp/s3_rate_limiter.h"
 #include "cpp/sync_point.h"
 #include "recycler/s3_accessor.h"
+#include "recycler/util.h"
 
 namespace doris::cloud {
 

--- a/cloud/src/recycler/util.h
+++ b/cloud/src/recycler/util.h
@@ -25,6 +25,12 @@
 
 namespace doris::cloud {
 
+// The time unit is the same with BE: us
+#define SCOPED_BVAR_LATENCY(bvar_item)                     \
+    StopWatch sw;                                          \
+    std::unique_ptr<int, std::function<void(int*)>> defer( \
+            (int*)0x01, [&](int*) { bvar_item << sw.elapsed_us(); });
+
 class TxnKv;
 
 /**


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

This pr adds several bvar for HDFS operation in Recycler.
The bvars are as follows:
```C++
bvar::LatencyRecorder hdfs_write_latency("hdfs_write");
bvar::LatencyRecorder hdfs_open_latency("hdfs_open");
bvar::LatencyRecorder hdfs_close_latency("hdfs_close");
bvar::LatencyRecorder hdfs_list_dir("hdfs_list_dir");
bvar::LatencyRecorder hdfs_exist_latency("hdfs_exist");
bvar::LatencyRecorder hdfs_delete_latency("hdfs_delete");
```