### PR TITLE
[Fix](local merge) Fix local exchange dependencies acquired by local merge

### DIFF
--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -452,10 +452,7 @@ Status PipelineXLocalState<SharedStateArg>::init(RuntimeState* state, LocalState
             DCHECK(info.le_state_map.find(_parent->operator_id()) != info.le_state_map.end());
             _shared_state = info.le_state_map.at(_parent->operator_id()).first.get();
 
-            auto deps = _shared_state->get_dep_by_channel_id(info.task_idx);
-            if (deps.size() == 1) {
-                _dependency = deps.front().get();
-            }
+            _dependency = _shared_state->get_dep_by_channel_id(info.task_idx).front().get();
             _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
                     _runtime_profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
         } else if (info.shared_state) {
@@ -541,7 +538,7 @@ Status PipelineXSinkLocalState<SharedState>::init(RuntimeState* state, LocalSink
         if constexpr (std::is_same_v<LocalExchangeSharedState, SharedState>) {
             DCHECK(info.le_state_map.find(_parent->dests_id().front()) != info.le_state_map.end());
             _dependency = info.le_state_map.at(_parent->dests_id().front()).second.get();
-            _shared_state = (SharedState*)_dependency->shared_state();
+            _shared_state = _dependency->shared_state()->template cast<SharedState>();
         } else {
             _shared_state = info.shared_state->template cast<SharedState>();
             _dependency = _shared_state->create_sink_dependency(

--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.cpp
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.cpp
@@ -63,15 +63,24 @@ Status LocalExchangeSourceLocalState::close(RuntimeState* state) {
 }
 
 std::vector<Dependency*> LocalExchangeSourceLocalState::dependencies() const {
-    auto deps = Base::dependencies();
-    auto le_deps = _shared_state->get_dep_by_channel_id(_channel_id);
-    if (le_deps.size() > 1) {
+    if (_exchanger->get_type() == ExchangeType::LOCAL_MERGE_SORT && _channel_id == 0) {
+        // If this is a local merge exchange, source operator is runnable only if all sink operators
+        // set dependencies ready
+        std::vector<Dependency*> deps;
+        auto le_deps = _shared_state->get_dep_by_channel_id(_channel_id);
+        DCHECK_GT(le_deps.size(), 1);
         // If this is a local merge exchange, we should use all dependencies here.
         for (auto& dep : le_deps) {
             deps.push_back(dep.get());
         }
+        return deps;
+    } else if (_exchanger->get_type() == ExchangeType::LOCAL_MERGE_SORT && _channel_id != 0) {
+        // If this is a local merge exchange and is not the first task, source operators always
+        // return empty result so no dependencies here.
+        return {};
+    } else {
+        return Base::dependencies();
     }
-    return deps;
 }
 
 std::string LocalExchangeSourceLocalState::debug_string(int indentation_level) const {

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -800,7 +800,7 @@ Status PipelineFragmentContext::_add_local_exchange_impl(
     }
     operator_xs.insert(operator_xs.begin(), source_op);
 
-    shared_state->create_dependencies(source_op->operator_id(), source_op->node_id());
+    shared_state->create_dependencies(local_exchange_id);
 
     // 5. Set children for two pipelines separately.
     std::vector<std::shared_ptr<Pipeline>> new_children;


### PR DESCRIPTION
## Proposed changes

LocalMergeExchangeSharedState is not used correctly and its dependencies are not used by source operators.

<!--Describe your changes.-->

