### PR TITLE
[Fix](function) fix coredump because short of check on randoms arguments

### DIFF
--- a/be/src/vec/functions/random.cpp
+++ b/be/src/vec/functions/random.cpp
@@ -69,15 +69,19 @@ public:
             if (context->get_num_args() == 1) {
                 // This is a call to RandSeed, initialize the seed
                 if (!context->is_col_constant(0)) {
-                    return Status::InvalidArgument("Seed argument to rand() must be constant.");
+                    return Status::InvalidArgument("The param of rand function must be literal");
                 }
                 uint32_t seed = 0;
                 if (!context->get_constant_col(0)->column_ptr->is_null_at(0)) {
                     seed = (*context->get_constant_col(0)->column_ptr)[0].get<int64_t>();
                 }
                 generator->seed(seed);
-            } else {
-                // 0 or 2 args
+            } else if (context->get_num_args() == 2) {
+                if (!context->is_col_constant(0) || !context->is_col_constant(1)) {
+                    return Status::InvalidArgument("The param of rand function must be literal");
+                }
+                generator->seed(std::random_device()());
+            } else { // zero args
                 generator->seed(std::random_device()());
             }
         }
@@ -108,6 +112,7 @@ private:
                 context->get_function_state(FunctionContext::THREAD_LOCAL));
         DCHECK(generator != nullptr);
 
+        // checked in open()
         Int64 min = assert_cast<const ColumnInt64*>(
                             assert_cast<const ColumnConst*>(
                                     block.get_by_position(arguments[0]).column.get())

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Random.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Random.java
@@ -65,10 +65,17 @@ public class Random extends ScalarFunction
      */
     public Random(Expression lchild, Expression rchild) {
         super("random", lchild, rchild);
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
         // align with original planner behavior, refer to:
         // org/apache/doris/analysis/Expr.getBuiltinFunction()
-        Preconditions.checkState(lchild instanceof Literal && rchild instanceof Literal,
-                "The param of rand function must be literal");
+        for (Expression child : children()) {
+            if (!child.isLiteral()) {
+                throw new AnalysisException("The param of rand function must be literal ");
+            }
+        }
     }
 
     /**

--- a/regression-test/suites/nereids_p0/system/test_query_sys.groovy
+++ b/regression-test/suites/nereids_p0/system/test_query_sys.groovy
@@ -48,4 +48,25 @@ suite("test_query_sys", "query,p0") {
     sql "set enable_nereids_planner=true"
     def v2 = sql "select version()"
     assertEquals(v1, v2)
+
+    test {
+        sql "select random(random());"
+        exception "The param of rand function must be literal"
+    }
+
+    sql "set enable_nereids_planner=false"
+    sql """
+        CREATE TABLE IF NOT EXISTS `test_random` (
+        fcst_emp varchar(128) NOT NULL
+        ) ENGINE=OLAP
+        DISTRIBUTED BY HASH(`fcst_emp`)
+        PROPERTIES(
+        "replication_num" = "1",
+        "compression" = "LZ4" );
+    """
+    sql """ insert into test_random values('123,1233,4123,3131'); """
+    test {
+        sql "select random(1,array_size(split_by_string(fcst_emp,','))) from test_random;"
+        exception "The param of rand function must be literal"
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
crash or
```sql
mysql [test]>select random(1,array_size(split_by_string(fcst_emp,','))) from test_random;
+---------------------------------------------------------+
| random(1, array_size(split_by_string(`fcst_emp`, ','))) |
+---------------------------------------------------------+
|                                     7471044383762196303 |
+---------------------------------------------------------+
1 row in set (0.05 sec)
```

now:
both for nereids and legacy planner:
```sql
mysql [test]>select random(1,array_size(split_by_string(fcst_emp,','))) from test_random;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[INVALID_ARGUMENT]The param of rand function must be literal
```

doc pr: https://github.com/apache/doris-website/pull/992