### PR TITLE
[fix](auth) Fix ResourceTypeEnum Compatibility Upgrade

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
@@ -134,5 +134,9 @@ public class ResourcePattern implements Writable, GsonPostProcessable {
         if ("*".equals(resourceName)) {
             resourceName = "%";
         }
+        // 2.x -> 3.0 compatibility logic
+        if (resourceType == null) {
+            resourceType = ResourceTypeEnum.GENERAL;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
@@ -71,7 +71,7 @@ public class ResourcePattern implements Writable, GsonPostProcessable {
             resourceName = "%";
         }
         this.resourceName = Strings.isNullOrEmpty(resourceName) ? "%" : resourceName;
-        resourceType = type == null ? ResourceTypeEnum.GENERAL : type;
+        resourceType = type;
     }
 
     public void setResourceType(ResourceTypeEnum type) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ResourcePattern.java
@@ -71,7 +71,7 @@ public class ResourcePattern implements Writable, GsonPostProcessable {
             resourceName = "%";
         }
         this.resourceName = Strings.isNullOrEmpty(resourceName) ? "%" : resourceName;
-        resourceType = type;
+        resourceType = type == null ? ResourceTypeEnum.GENERAL : type;
     }
 
     public void setResourceType(ResourceTypeEnum type) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -836,6 +836,11 @@ public class Role implements Writable, GsonPostProcessable {
     public void revokePrivs(ResourcePattern resourcePattern, PrivBitSet privs, boolean errOnNonExist)
             throws DdlException {
         PrivBitSet existingPriv;
+        // 2.x -> 3.0 compatibility logic
+        if (resourcePattern.getResourceType() == null) {
+            // 2.x not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
+            resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
+        }
         switch (resourcePattern.getResourceType()) {
             case GENERAL:
                 existingPriv = resourcePatternToPrivs.get(resourcePattern);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -152,6 +152,14 @@ public class Role implements Writable, GsonPostProcessable {
     public Role(String roleName, ResourcePattern resourcePattern, PrivBitSet privs) throws DdlException {
         this.roleName = roleName;
         // grant has trans privs
+        // 2.1 -> 3.0 compatibility logic
+        int version = Env.getCurrentEnvJournalVersion();
+        LOG.info("current version {}", version);
+        if (version >= FeMetaVersion.VERSION_129
+                && resourcePattern.getResourceType() == null) {
+            // 2.1 not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
+            resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
+        }
         switch (resourcePattern.getResourceType()) {
             case GENERAL:
                 this.resourcePatternToPrivs.put(resourcePattern, privs);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -152,11 +152,6 @@ public class Role implements Writable, GsonPostProcessable {
     public Role(String roleName, ResourcePattern resourcePattern, PrivBitSet privs) throws DdlException {
         this.roleName = roleName;
         // grant has trans privs
-        // 2.x -> 3.0 compatibility logic
-        if (resourcePattern.getResourceType() == null) {
-            // 2.x not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
-            resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
-        }
         switch (resourcePattern.getResourceType()) {
             case GENERAL:
                 this.resourcePatternToPrivs.put(resourcePattern, privs);
@@ -836,11 +831,6 @@ public class Role implements Writable, GsonPostProcessable {
     public void revokePrivs(ResourcePattern resourcePattern, PrivBitSet privs, boolean errOnNonExist)
             throws DdlException {
         PrivBitSet existingPriv;
-        // 2.x -> 3.0 compatibility logic
-        if (resourcePattern.getResourceType() == null) {
-            // 2.x not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
-            resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
-        }
         switch (resourcePattern.getResourceType()) {
             case GENERAL:
                 existingPriv = resourcePatternToPrivs.get(resourcePattern);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -153,10 +153,7 @@ public class Role implements Writable, GsonPostProcessable {
         this.roleName = roleName;
         // grant has trans privs
         // 2.1 -> 3.0 compatibility logic
-        int version = Env.getCurrentEnvJournalVersion();
-        LOG.info("current version {}", version);
-        if (version >= FeMetaVersion.VERSION_129
-                && resourcePattern.getResourceType() == null) {
+        if (resourcePattern.getResourceType() == null) {
             // 2.1 not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
             resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -152,9 +152,9 @@ public class Role implements Writable, GsonPostProcessable {
     public Role(String roleName, ResourcePattern resourcePattern, PrivBitSet privs) throws DdlException {
         this.roleName = roleName;
         // grant has trans privs
-        // 2.1 -> 3.0 compatibility logic
+        // 2.x -> 3.0 compatibility logic
         if (resourcePattern.getResourceType() == null) {
-            // 2.1 not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
+            // 2.x not have cloud auth, so just transfer to ResourceTypeEnum.GENERAL
             resourcePattern.setResourceType(ResourceTypeEnum.GENERAL);
         }
         switch (resourcePattern.getResourceType()) {


### PR DESCRIPTION
```
RuntimeLogger 2024-08-12 22:47:37,850 ERROR (replayer|88) [EditLog.loadJournal():1244] replay Operation Type 64, log id: 13752
java.lang.NullPointerException: Cannot invoke "org.apache.doris.analysis.ResourceTypeEnum.ordinal()" because the return value of "org.apache.doris.analysis.ResourcePattern.getResourceType()" is null
	at org.apache.doris.mysql.privilege.Role.<init>(Role.java:155) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.privilege.Auth.grantInternal(Auth.java:706) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.privilege.Auth.replayGrant(Auth.java:657) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:466) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.replayJournal(Env.java:2913) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env$4.runOneCycle(Env.java:2675) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

