### PR TITLE
[enhance](Cooldown) Add metric to trace cooldown task and unused remote files caused by failed upload and cold compaction

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -1006,6 +1006,7 @@ void DataDir::perform_remote_rowset_gc() {
         auto st = fs->batch_delete(seg_paths);
         if (st.ok()) {
             deleted_keys.push_back(std::move(key));
+            unused_remote_rowset_num << -1;
         } else {
             LOG(WARNING) << "failed to delete remote rowset. err=" << st;
         }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -148,6 +148,8 @@ namespace {
 bvar::Adder<uint64_t> exceed_version_limit_counter;
 bvar::Window<bvar::Adder<uint64_t>> exceed_version_limit_counter_minute(
         &exceed_version_limit_counter, 60);
+bvar::Adder<uint64_t> cooldown_pending_task("cooldown_pending_task");
+bvar::Adder<uint64_t> cooldown_processing_task("cooldown_processing_task");
 
 void set_last_failure_time(Tablet* tablet, const Compaction& compaction, int64_t ms) {
     switch (compaction.compaction_type()) {
@@ -230,8 +232,13 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
         VLOG_DEBUG << "tablet " << t->tablet_id() << " is not cooldown replica";
     };
 
-    _executors[_get_executor_pos(tablet_id)]->offer(
-            [task = std::move(async_write_task)]() { task(); });
+    cooldown_pending_task << 1;
+    _executors[_get_executor_pos(tablet_id)]->offer([task = std::move(async_write_task)]() {
+        cooldown_pending_task << -1;
+        cooldown_processing_task << 1;
+        task();
+        cooldown_processing_task << -1;
+    });
 }
 
 Tablet::Tablet(StorageEngine& engine, TabletMetaSharedPtr tablet_meta, DataDir* data_dir,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -170,6 +170,8 @@ void set_last_failure_time(Tablet* tablet, const Compaction& compaction, int64_t
 
 } // namespace
 
+bvar::Adder<uint64_t> unused_remote_rowset_num("unused_remote_rowset_num");
+
 WriteCooldownMetaExecutors::WriteCooldownMetaExecutors(size_t executor_nums)
         : _executor_nums(executor_nums) {
     for (size_t i = 0; i < _executor_nums; i++) {
@@ -2394,6 +2396,7 @@ void Tablet::record_unused_remote_rowset(const RowsetId& rowset_id, const std::s
         LOG(WARNING) << "failed to record unused remote rowset. tablet_id=" << tablet_id()
                      << " rowset_id=" << rowset_id << " resource_id=" << resource;
     }
+    unused_remote_rowset_num << 1;
 }
 
 Status Tablet::remove_all_remote_rowsets() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -51,6 +51,11 @@
 #include "util/once.h"
 #include "util/slice.h"
 
+namespace bvar {
+template <typename T>
+class Adder;
+}
+
 namespace doris {
 
 class Tablet;
@@ -77,6 +82,8 @@ enum KeysType : int;
 enum SortType : int;
 
 enum TabletStorageType { STORAGE_TYPE_LOCAL, STORAGE_TYPE_REMOTE, STORAGE_TYPE_REMOTE_AND_LOCAL };
+
+extern bvar::Adder<uint64_t> unused_remote_rowset_num;
 
 static inline constexpr auto TRACE_TABLET_LOCK_THRESHOLD = std::chrono::seconds(1);
 


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

Now user can see the procedure of the cooldown tasks through bvar along with the unused files generated by the failed compaction and upload.