### PR TITLE
[Fix](cloud) CloudStorageEngine should wait compaction task done when stoping it

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -228,6 +228,14 @@ void CloudStorageEngine::stop() {
             t->join();
         }
     }
+
+    if (_base_compaction_thread_pool) {
+        _base_compaction_thread_pool->shutdown();
+    }
+    if (_cumu_compaction_thread_pool) {
+        _cumu_compaction_thread_pool->shutdown();
+    }
+    LOG(INFO) << "Cloud storage engine is stopped.";
 }
 
 bool CloudStorageEngine::stopped() {


### PR DESCRIPTION
When stoping doris, CloudStorageEngine should wait compaction task done, like StorageEngine does, if we don't wait, the compaction task run in background may core beacause these task will access CloudStorageEngine to get _txn_delete_bitmap_cache
