### PR TITLE
[fix](mv) Fix test create table like test unstable

### DIFF
--- a/regression-test/suites/ddl_p0/test_create_table_like_nereids.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_like_nereids.groovy
@@ -46,6 +46,7 @@ suite("test_create_table_like_nereids") {
     // with all rollup
     sql "drop table if exists table_like_with_roll_up"
     sql "CREATE TABLE table_like_with_roll_up LIKE mal_test_create_table_like with rollup;"
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
     explain {
         sql ("select sum(a) from table_like_with_roll_up group by a")
         contains "ru1"
@@ -58,6 +59,7 @@ suite("test_create_table_like_nereids") {
     // with partial rollup
     sql "drop table if exists table_like_with_partial_roll_up;"
     sql "CREATE TABLE table_like_with_partial_roll_up LIKE mal_test_create_table_like with rollup (ru1);"
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
     sql "select * from table_like_with_partial_roll_up order by pk, a, b"
     explain {
         sql("select sum(a) from table_like_with_partial_roll_up group by a")
@@ -76,6 +78,7 @@ suite("test_create_table_like_nereids") {
     sql "drop table if exists table_like_with_partial_roll_up_exists"
     sql """CREATE TABLE if not exists table_like_with_partial_roll_up_exists
     LIKE mal_test_create_table_like with rollup (ru1);"""
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
 
     sql "drop table if exists test_create_table_like_char_255"
     sql """


### PR DESCRIPTION
## Proposed changes

ddl_p0/test_create_table_like_nereids.groovy test result is unstable.
Should wait util rollup join finished then we can compare the explain rollup result.

