### PR TITLE
[fix](protocol) CLIENT_MULTI_STATEMENTS not used actually

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -81,6 +81,9 @@ public class MysqlChannel implements BytesChannel {
     // mysql flag CLIENT_DEPRECATE_EOF
     private boolean clientDeprecatedEOF;
 
+    // mysql flag CLIENT_MULTI_STATEMENTS
+    private boolean clientMultiStatements;
+
     private ConnectContext context;
 
     protected MysqlChannel() {
@@ -93,6 +96,14 @@ public class MysqlChannel implements BytesChannel {
 
     public boolean clientDeprecatedEOF() {
         return clientDeprecatedEOF;
+    }
+
+    public void setClientMultiStatements() {
+        clientMultiStatements = true;
+    }
+
+    public boolean clientMultiStatements() {
+        return clientMultiStatements;
     }
 
     public MysqlChannel(StreamConnection connection, ConnectContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -168,6 +168,12 @@ public class MysqlProto {
         if (capability.isDeprecatedEOF()) {
             context.getMysqlChannel().setClientDeprecatedEOF();
         }
+
+        // we do not save client capability to context, so here we save CLIENT_MULTI_STATEMENTS to MysqlChannel
+        if (capability.isClientMultiStatements()) {
+            context.getMysqlChannel().setClientMultiStatements();
+        }
+
         MysqlAuthPacket authPacket = new MysqlAuthPacket();
         if (!authPacket.readFrom(handshakeResponse)) {
             ErrorReport.report(ErrorCode.ERR_NOT_SUPPORTED_AUTH_MODE);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -391,7 +391,7 @@ public abstract class ConnectProcessor {
                                 // when client not request CLIENT_MULTI_STATEMENTS, mysql treat all query as
                                 // single statement. Doris treat it with multi statement, but only return
                                 // the last statement result.
-                                if (getConnectContext().getCapability().isClientMultiStatements()) {
+                                if (getConnectContext().getMysqlChannel().clientMultiStatements()) {
                                     finalizeCommand();
                                 }
                             }


### PR DESCRIPTION
in pr https://github.com/apache/doris/pull/36759, we try to output result depend CLIENT_MULTI_STATEMENTS,

but in `MysqlProto::negotiate` function, we call `context.setCapability(context.getServerCapability())` function set capability in context use server default flags instead of client flags.

So here, we save  CLIENT_MULTI_STATEMENTS flag in MysqlChannel like flag CLIENT_DEPRECATE_EOF