### PR TITLE
[Chore](aggregation) remove useless code for aggregation function Covar

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_covar.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.cpp
@@ -46,15 +46,6 @@ AggregateFunctionPtr create_function_single_value(const String& name,
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
 
-#define DISPATCH(TYPE)                                                              \
-    if (which.idx == TypeIndex::TYPE)                                               \
-        return creator_without_type::create<AggregateFunctionTemplate<              \
-                NameData<Data<TYPE, BaseDatadecimal<TYPE>>>, is_nullable>>(         \
-                custom_nullable ? remove_nullable(argument_types) : argument_types, \
-                result_is_nullable);
-    FOR_DECIMAL_TYPES(DISPATCH)
-#undef DISPATCH
-
     LOG(WARNING) << fmt::format("create_function_single_value with unknowed type {}",
                                 argument_types[0]->get_name());
     return nullptr;


### PR DESCRIPTION
## Proposed changes

Issue Number: #30983

<!--Describe your changes.-->

In the fe function signature of a Covar function, passing in a decimal type will force it to be converted to a double without special handling.
