### PR TITLE
[fix](routine load) should update progress before handle transaction state transform

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -336,8 +336,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     @Override
     protected void updateProgress(RLTaskTxnCommitAttachment attachment) throws UserException {
-        super.updateProgress(attachment);
         updateProgressAndOffsetsCache(attachment);
+        super.updateProgress(attachment);
     }
 
     @Override


### PR DESCRIPTION
Update progress maybe throw exception, causing offset has been persisted on edit log or meta service, but the memory data has not been updated. It will cause repeated consumption. 

