### PR TITLE
[Bug](compatibility) fix percentile_approx function coredump when upgrade

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
@@ -33,8 +33,8 @@ AggregateFunctionPtr create_aggregate_function_percentile_approx_older(
     }
     if (argument_types.size() == 2) {
         return creator_without_type::create<
-                AggregateFunctionPercentileApproxTwoParams_OLDER<is_nullable>>((argument_types),
-                                                                               result_is_nullable);
+                AggregateFunctionPercentileApproxTwoParams_OLDER<is_nullable>>(
+                remove_nullable(argument_types), result_is_nullable);
     }
     if (argument_types.size() == 3) {
         return creator_without_type::create<


### PR DESCRIPTION
## Proposed changes

this pr https://github.com/apache/doris/pull/37330 have change the nullable of agg function,
But it's shouldn't change the old percentile_approx  function.
this could cause it's core dump when upgrade.

<!--Describe your changes.-->

