### PR TITLE
[fix](function) avoid calculating sqrt of negative in agg function CORR

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_corr.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_corr.cpp
@@ -68,7 +68,8 @@ struct CorrMoment {
     }
 
     T get() const {
-        if ((m0 * x2 - x1 * x1) * (m0 * y2 - y1 * y1) == 0) [[unlikely]] {
+        // avoid float error(silent nan) when x or y is constant
+        if (m0 * x2 <= x1 * x1 || m0 * y2 <= y1 * y1) [[unlikely]] {
             return 0;
         }
         return (m0 * xy - x1 * y1) / sqrt((m0 * x2 - x1 * x1) * (m0 * y2 - y1 * y1));

--- a/regression-test/data/nereids_function_p0/agg_function/test_corr.out
+++ b/regression-test/data/nereids_function_p0/agg_function/test_corr.out
@@ -14,3 +14,21 @@
 -- !sql --
 0.8944271909999159
 
+-- !sql_const1 --
+0.0
+
+-- !sql_const2 --
+0.0
+
+-- !sql_const3 --
+0.0
+
+-- !sql_const4 --
+0.0
+
+-- !sql_const5 --
+0.0
+
+-- !sql_const6 --
+0.0
+

--- a/regression-test/suites/nereids_function_p0/agg_function/test_corr.groovy
+++ b/regression-test/suites/nereids_function_p0/agg_function/test_corr.groovy
@@ -82,5 +82,11 @@ suite("test_corr") {
     qt_sql "select corr(x,y) from test_corr"
 
     qt_sql "select corr(cast(x as float),cast(y as float)) from test_corr"
-    sql """ DROP TABLE IF EXISTS test_corr """
+
+    qt_sql_const1 "select corr(x,1) from test_corr"
+    qt_sql_const2 "select corr(x,1e100) from test_corr"
+    qt_sql_const3 "select corr(x,1e-100) from test_corr"
+    qt_sql_const4 "select corr(1,y) from test_corr"
+    qt_sql_const5 "select corr(1e100,y) from test_corr"
+    qt_sql_const6 "select corr(1e-100,y) from test_corr"
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
```sql
mysql [sqlfunctest]>SELECT CORR(data, 89.999999) FROM DOUBLEDATA_NOT_EMPTY_NULLABLE;
+---------------------------------------+
| corr(data, cast(89.999999 as DOUBLE)) |
+---------------------------------------+
|                                  NULL |
+---------------------------------------+
1 row in set (0.53 sec)
```
--- actually here's a silent nan by float exception. now sure in all platform.

after:
```sql
mysql [sqlfunctest]>SELECT CORR(data, 89.999999) FROM DOUBLEDATA_NOT_EMPTY_NULLABLE;
+---------------------------------------+
| corr(data, cast(89.999999 as DOUBLE)) |
+---------------------------------------+
|                                     0 |
+---------------------------------------+
1 row in set (0.13 sec)
```
--- is stable

