### PR TITLE
[Bug](compatibility) fix percentile function coredump when upgrade

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
@@ -33,8 +33,8 @@ AggregateFunctionPtr create_aggregate_function_percentile_approx_older(
     }
     if (argument_types.size() == 2) {
         return creator_without_type::create<
-                AggregateFunctionPercentileApproxTwoParams_OLDER<is_nullable>>((argument_types),
-                                                                               result_is_nullable);
+                AggregateFunctionPercentileApproxTwoParams_OLDER<is_nullable>>(
+                remove_nullable(argument_types), result_is_nullable);
     }
     if (argument_types.size() == 3) {
         return creator_without_type::create<

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -588,6 +588,9 @@ struct PercentileState {
 
     void write(BufferWritable& buf) const {
         write_binary(inited_flag, buf);
+        if (!inited_flag) {
+            return;
+        }
         int size_num = vec_quantile.size();
         write_binary(size_num, buf);
         for (const auto& quantile : vec_quantile) {
@@ -600,6 +603,9 @@ struct PercentileState {
 
     void read(BufferReadable& buf) {
         read_binary(inited_flag, buf);
+        if (!inited_flag) {
+            return;
+        }
         int size_num = 0;
         read_binary(size_num, buf);
         double data = 0.0;

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -583,7 +583,7 @@ public:
 template <typename T>
 struct PercentileState {
     mutable std::vector<Counts<T>> vec_counts;
-    std::vector<double> vec_quantile;
+    std::vector<double> vec_quantile {-1};
     bool inited_flag = false;
 
     void write(BufferWritable& buf) const {


### PR DESCRIPTION
## Proposed changes
if the inited_flag == false, should not write buf,
as the write function will write two std::vector, 
but in read function, use the size_num from vec_quantile vector,
if not have inited, the size of two vector maybe not equal.


<!--Describe your changes.-->

