### PR TITLE
[Bug](runtime-filter) set inited to true on BloomFilterFuncBase::assign

### DIFF
--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -188,6 +188,7 @@ public:
         }
 
         _bloom_filter_alloced = data_size;
+        _inited = true;
         return _bloom_filter->init(data, data_size);
     }
 


### PR DESCRIPTION
## Proposed changes
set inited to true on BloomFilterFuncBase::assign
```cpp
*** SIGABRT unknown detail explain (@0x1ba2) received by PID 7074 (TID 9018 OR 0x7f4adf5df640) from PID 7074; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F525A7F6520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x0000560BDC6CE8DD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# 0x0000560BDC6C0F1A in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# doris::BloomFilterFuncBase::merge(doris::BloomFilterFuncBase*) at /home/zcp/repo_center/doris_master/doris/be/src/exprs/bloom_filter_func.h:159
11# doris::RuntimePredicateWrapper::merge(doris::RuntimePredicateWrapper const*) at /home/zcp/repo_center/doris_master/doris/be/src/exprs/runtime_filter.cpp:539
12# doris::IRuntimeFilter::merge_from(doris::RuntimePredicateWrapper const*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
13# doris::RuntimeFilterMergeControllerEntity::merge(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/runtime_filter_mgr.cpp:399
14# doris::FragmentMgr::merge_filter(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:1170
15# std::_Function_handler::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
16# doris::WorkThreadPool::work_thread(int) at /home/zcp/repo_center/doris_master/doris/be/src/util/work_thread_pool.hpp:159
17# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
18# start_thread at ./nptl/pthread_create.c:442
19# 0x00007F525A8DA850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
172.20.50.47 last coredump sql: 


```