### PR TITLE
[fix](group commit) fix group commit core if be inject FragmentMgr.exec_plan_fragment.failed

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -2063,10 +2063,11 @@ void PInternalService::group_commit_insert(google::protobuf::RpcController* cont
                 st = Status::Error(ErrorCode::INTERNAL_ERROR,
                                    "_exec_plan_fragment_impl meet unknown error");
             }
+            closure_guard.release();
             if (!st.ok()) {
-                LOG(WARNING) << "exec plan fragment failed, errmsg=" << st;
+                LOG(WARNING) << "exec plan fragment failed, load_id=" << print_id(load_id)
+                             << ", errmsg=" << st;
             } else {
-                closure_guard.release();
                 for (int i = 0; i < request->data().size(); ++i) {
                     std::unique_ptr<PDataRow> row(new PDataRow());
                     row->CopyFrom(request->data(i));

--- a/regression-test/suites/insert_p0/group_commit/test_group_commit_error.groovy
+++ b/regression-test/suites/insert_p0/group_commit/test_group_commit_error.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_group_commit_error", "nonConcurrent") {
+    def tableName = "test_group_commit_error"
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `k` int ,
+            `v` int ,
+        ) engine=olap
+        DISTRIBUTED BY HASH(`k`) 
+        BUCKETS 5 
+        properties("replication_num" = "1", "group_commit_interval_ms"="2000")
+    """
+
+    GetDebugPoint().clearDebugPointsForAllBEs()
+    GetDebugPoint().clearDebugPointsForAllFEs()
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("FragmentMgr.exec_plan_fragment.failed")
+        sql """ set group_commit = async_mode """
+        sql """ insert into ${tableName} values (1, 1) """
+        assertTrue(false)
+    } catch (Exception e) {
+        logger.info("failed: " + e.getMessage())
+    } finally {
+        GetDebugPoint().clearDebugPointsForAllBEs()
+    }
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("FragmentMgr.exec_plan_fragment.failed")
+        sql """ set group_commit = async_mode """
+        sql """ set enable_nereids_planner = false """
+        sql """ insert into ${tableName} values (2, 2) """
+    } catch (Exception e) {
+        logger.info("failed: " + e.getMessage())
+    } finally {
+        GetDebugPoint().clearDebugPointsForAllBEs()
+    }
+}


### PR DESCRIPTION
```
*** SIGSEGV address not mapped to object (@0x0) received by PID 1898955 (TID 1900522 OR 0x7f4f94abc640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-3.0.2-tmp/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F5335001520 in /lib/x86_64-linux-gnu/libc.so.6
 4# brpc::Socket::Write(brpc::SocketMessagePtr<void>&, brpc::Socket::WriteOptions const*) in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 5# brpc::policy::HttpResponseSender::~HttpResponseSender() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 6# brpc::policy::HttpResponseSenderAsDone::~HttpResponseSenderAsDone() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 7# std::_Function_handler<void (), doris::PInternalService::group_commit_insert(google::protobuf::RpcController*, doris::PGroupCommitInsertRequest const*, doris::PGroupCommitInsertResponse*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 8# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_branch-3.0.2-tmp/doris/be/src/util/work_thread_pool.hpp:159
```