### PR TITLE
[fix](catalog) set timeout for split fetch

### DIFF
--- a/be/src/vec/exec/scan/split_source_connector.cpp
+++ b/be/src/vec/exec/scan/split_source_connector.cpp
@@ -58,7 +58,8 @@ Status RemoteSplitSourceConnector::get_next(bool* has_next, TFileRangeDesc* rang
         try {
             coord->fetchSplitBatch(result, request);
             if (result.__isset.status && result.status.status_code != TStatusCode::OK) {
-                return Status::IOError<false>("Failed to get batch of split source: {}", result.status.error_msgs[0]);
+                return Status::IOError<false>("Failed to get batch of split source: {}",
+                                              result.status.error_msgs[0]);
             }
         } catch (std::exception& e) {
             return Status::IOError<false>("Failed to get batch of split source: {}", e.what());

--- a/be/src/vec/exec/scan/split_source_connector.cpp
+++ b/be/src/vec/exec/scan/split_source_connector.cpp
@@ -47,6 +47,7 @@ Status RemoteSplitSourceConnector::get_next(bool* has_next, TFileRangeDesc* rang
     if (_scan_index == _scan_ranges.size() && !_last_batch) {
         SCOPED_TIMER(_get_split_timer);
         Status coord_status;
+        // No need to set timeout because on FE side, there is a max fetch time
         FrontendServiceConnection coord(_state->exec_env()->frontend_client_cache(),
                                         _state->get_query_ctx()->coord_addr, &coord_status);
         RETURN_IF_ERROR(coord_status);
@@ -56,6 +57,9 @@ Status RemoteSplitSourceConnector::get_next(bool* has_next, TFileRangeDesc* rang
         TFetchSplitBatchResult result;
         try {
             coord->fetchSplitBatch(result, request);
+            if (result.__isset.status && result.status.status_code != TStatusCode::OK) {
+                return Status::IOError<false>("Failed to get batch of split source: {}", result.status.error_msgs[0]);
+            }
         } catch (std::exception& e) {
             return Status::IOError<false>("Failed to get batch of split source: {}", e.what());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -985,10 +985,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         try {
             List<TScanRangeLocations> locations = splitSource.getNextBatch(request.getMaxNumSplits());
             result.setSplits(locations);
+            result.status = new TStatus(TStatusCode.OK);
             return result;
         } catch (Exception e) {
-            throw new TException("Failed to get split source " + request.getSplitSourceId(), e);
+            LOG.warn("failed to fetch split batch with source id {}", request.getSplitSourceId(), e);
+            result.status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            result.status.addToErrorMsgs(e.getMessage());
         }
+        return result;
     }
 
     @Override

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1558,6 +1558,7 @@ struct TFetchSplitBatchRequest {
 
 struct TFetchSplitBatchResult {
     1: optional list<Planner.TScanRangeLocations> splits
+    2: optional Status.TStatus status
 }
 
 service FrontendService {


### PR DESCRIPTION
When fetch splits in batch, BE will send rpc to FE to fetch batch of splits.
The FE may be blocked when listing file from hdfs, causing BE block too.
This PR add timeout on FE side to avoid BE block.