### PR TITLE
[fix](cloud) Fix `TabletIndexPB` missing db_id

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -406,7 +406,7 @@ void MetaServiceImpl::batch_get_version(::google::protobuf::RpcController* contr
 void internal_create_tablet(MetaServiceCode& code, std::string& msg,
                             const doris::TabletMetaCloudPB& meta, std::shared_ptr<TxnKv> txn_kv,
                             const std::string& instance_id,
-                            std::set<std::pair<int64_t, int32_t>>& saved_schema) {
+                            std::set<std::pair<int64_t, int32_t>>& saved_schema, int64_t db_id) {
     doris::TabletMetaCloudPB tablet_meta(meta);
     bool has_first_rowset = tablet_meta.rs_metas_size() > 0;
 
@@ -496,7 +496,7 @@ void internal_create_tablet(MetaServiceCode& code, std::string& msg,
     MetaTabletIdxKeyInfo key_info1 {instance_id, tablet_id};
     meta_tablet_idx_key(key_info1, &key1);
     TabletIndexPB tablet_table;
-    // tablet_table.set_db_id(db_id);
+    tablet_table.set_db_id(db_id);
     tablet_table.set_table_id(table_id);
     tablet_table.set_index_id(index_id);
     tablet_table.set_partition_id(partition_id);
@@ -618,11 +618,13 @@ void MetaServiceImpl::create_tablets(::google::protobuf::RpcController* controll
         msg = fmt::format("failed to get vault id, vault name={}", name);
         return;
     }
+    DCHECK(request->has_db_id());
     // [index_id, schema_version]
     std::set<std::pair<int64_t, int32_t>> saved_schema;
     TEST_SYNC_POINT_RETURN_WITH_VOID("create_tablets");
     for (auto& tablet_meta : request->tablet_metas()) {
-        internal_create_tablet(code, msg, tablet_meta, txn_kv_, instance_id, saved_schema);
+        internal_create_tablet(code, msg, tablet_meta, txn_kv_, instance_id, saved_schema,
+                               request->db_id());
         if (code != MetaServiceCode::OK) {
             return;
         }

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2780,6 +2780,7 @@ int InstanceRecycler::repair_tablet_index() {
                                     .tag("idx_key", hex(idx_key));
                             return -1;
                         }
+                        LOG(INFO) << "xxx put idx_key=" << hex(idx_key);
                         txn->put(idx_key, idx_val);
                         need_commit = true;
                         ++num_tablet_repaired;

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -181,6 +181,9 @@ public:
 
     bool check_recycle_tasks();
 
+    // repaire TabletIndexPB missing db_id
+    int repair_tablet_index();
+
 private:
     // returns 0 for success otherwise error
     int init_obj_store_accessors();

--- a/cloud/test/fdb_injection_test.cpp
+++ b/cloud/test/fdb_injection_test.cpp
@@ -361,6 +361,7 @@ static int create_tablet(MetaService* meta_service, const std::string& instance_
     cloud::CreateTabletsRequest req;
     cloud::CreateTabletsResponse resp;
     req.set_cloud_unique_id(cloud_unique_id(instance_id));
+    req.set_db_id(1000);
     req.add_tablet_metas()->CopyFrom(add_tablet(table_id, index_id, partition_id, tablet_id));
     meta_service->create_tablets(&ctrl, &req, &resp, nullptr);
     if (ctrl.Failed()) {

--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -261,6 +261,7 @@ static void create_tablet(MetaService* meta_service, int64_t table_id, int64_t i
                           int64_t partition_id, int64_t tablet_id) {
     brpc::Controller cntl;
     CreateTabletsRequest req;
+    req.set_db_id(1000);
     CreateTabletsResponse res;
     add_tablet(req, table_id, index_id, partition_id, tablet_id);
     meta_service->create_tablets(&cntl, &req, &res, nullptr);

--- a/cloud/test/meta_service_job_test.cpp
+++ b/cloud/test/meta_service_job_test.cpp
@@ -168,6 +168,7 @@ void create_tablet(MetaService* meta_service, int64_t table_id, int64_t index_id
                    bool not_ready = false) {
     brpc::Controller cntl;
     CreateTabletsRequest req;
+    req.set_db_id(1000);
     CreateTabletsResponse res;
     auto tablet = req.add_tablet_metas();
     tablet->set_tablet_state(not_ready ? doris::TabletStatePB::PB_NOTREADY

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -129,6 +129,7 @@ static void create_tablet(MetaServiceProxy* meta_service, int64_t table_id, int6
                           int64_t partition_id, int64_t tablet_id) {
     brpc::Controller cntl;
     CreateTabletsRequest req;
+    req.set_db_id(1000);
     CreateTabletsResponse res;
     add_tablet(req, table_id, index_id, partition_id, tablet_id);
     meta_service->create_tablets(&cntl, &req, &res, nullptr);
@@ -7056,6 +7057,7 @@ TEST(MetaServiceTest, CreateTabletsVaultsTest) {
     {
         CreateTabletsRequest request;
         request.set_cloud_unique_id("test_cloud_unique_id");
+        request.set_db_id(1000);
 
         brpc::Controller cntl;
         CreateTabletsResponse response;
@@ -7069,6 +7071,7 @@ TEST(MetaServiceTest, CreateTabletsVaultsTest) {
     {
         CreateTabletsRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(1000);
         req.set_storage_vault_name("");
         req.add_tablet_metas();
 
@@ -7132,6 +7135,7 @@ TEST(MetaServiceTest, CreateTabletsVaultsTest) {
     {
         CreateTabletsRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(1000);
         req.set_storage_vault_name("");
         req.add_tablet_metas();
 
@@ -7155,6 +7159,7 @@ TEST(MetaServiceTest, CreateTabletsVaultsTest) {
     {
         CreateTabletsRequest req;
         req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(1000);
         req.set_storage_vault_name("non-existent");
         req.add_tablet_metas();
 

--- a/cloud/test/schema_kv_test.cpp
+++ b/cloud/test/schema_kv_test.cpp
@@ -63,6 +63,7 @@ static void create_tablet(MetaServiceProxy* meta_service, int64_t table_id, int6
                           int32_t schema_version) {
     brpc::Controller cntl;
     CreateTabletsRequest req;
+    req.set_db_id(1000);
     CreateTabletsResponse res;
     add_tablet(req, table_id, index_id, partition_id, tablet_id, rowset_id, schema_version);
     meta_service->create_tablets(&cntl, &req, &res, nullptr);
@@ -217,6 +218,7 @@ TEST(DetachSchemaKVTest, TabletTest) {
         config::write_schema_kv = true;
         brpc::Controller cntl;
         CreateTabletsRequest req;
+        req.set_db_id(1000);
         CreateTabletsResponse res;
         add_tablet(req, 10031, 10032, 10033, 100031, next_rowset_id(), 1);
         add_tablet(req, 10031, 10032, 10033, 100032, next_rowset_id(), 2);

--- a/cloud/test/schema_kv_test.cpp
+++ b/cloud/test/schema_kv_test.cpp
@@ -63,7 +63,6 @@ static void create_tablet(MetaServiceProxy* meta_service, int64_t table_id, int6
                           int32_t schema_version) {
     brpc::Controller cntl;
     CreateTabletsRequest req;
-    req.set_db_id(1000);
     CreateTabletsResponse res;
     add_tablet(req, table_id, index_id, partition_id, tablet_id, rowset_id, schema_version);
     meta_service->create_tablets(&cntl, &req, &res, nullptr);
@@ -218,7 +217,6 @@ TEST(DetachSchemaKVTest, TabletTest) {
         config::write_schema_kv = true;
         brpc::Controller cntl;
         CreateTabletsRequest req;
-        req.set_db_id(1000);
         CreateTabletsResponse res;
         add_tablet(req, 10031, 10032, 10033, 100031, next_rowset_id(), 1);
         add_tablet(req, 10031, 10032, 10033, 100032, next_rowset_id(), 2);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
@@ -214,6 +214,7 @@ public class CloudRollupJobV2 extends RollupJobV2 {
                                     tbl.rowStorePageSize());
                 requestBuilder.addTabletMetas(builder);
             } // end for rollupTablets
+            requestBuilder.setDbId(dbId);
             ((CloudInternalCatalog) Env.getCurrentInternalCatalog())
                     .sendCreateTabletsRpc(requestBuilder);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -235,6 +235,7 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
                                             tbl.rowStorePageSize());
                     requestBuilder.addTabletMetas(builder);
                 } // end for rollupTablets
+                requestBuilder.setDbId(dbId);
                 ((CloudInternalCatalog) Env.getCurrentInternalCatalog())
                         .sendCreateTabletsRpc(requestBuilder);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -180,6 +180,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             if (!storageVaultIdSet && ((CloudEnv) Env.getCurrentEnv()).getEnableStorageVault()) {
                 requestBuilder.setStorageVaultName(storageVaultName);
             }
+            requestBuilder.setDbId(dbId);
 
             LOG.info("create tablets, dbId: {}, tableId: {}, tableName: {}, partitionId: {}, partitionName: {}, "
                     + "indexId: {}, vault name {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -680,6 +680,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             sendCreateTabletsRpc(Cloud.CreateTabletsRequest.Builder requestBuilder) throws DdlException  {
         requestBuilder.setCloudUniqueId(Config.cloud_unique_id);
         Cloud.CreateTabletsRequest createTabletsReq = requestBuilder.build();
+        Preconditions.checkState(createTabletsReq.hasDbId(), "createTabletsReq must set dbId");
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("send create tablets rpc, createTabletsReq: {}", createTabletsReq);

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -895,6 +895,7 @@ message CreateTabletsRequest {
     optional string cloud_unique_id = 1; // For auth
     repeated doris.TabletMetaCloudPB tablet_metas = 2;
     optional string storage_vault_name = 3;
+    optional int64 db_id = 4;
 }
 
 message CreateTabletsResponse {


### PR DESCRIPTION
* In cloud mode, when creating tablet missing record `db_id` field in `TabletIndexPB`, so add a background task in recycler to fill `db_id` in `TabletIndexPB`

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

