### PR TITLE
[fix](nereids) refine window child's local shuffle dist-expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -129,6 +129,13 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         return expression.accept(INSTANCE, context);
     }
 
+    public static Expr translateUseBackup(Expression expression, PlanTranslatorContext context) {
+        context.setTranslateUsingBackup(true);
+        Expr result = expression.accept(INSTANCE, context);
+        context.setTranslateUsingBackup(false);
+        return result;
+    }
+
     @Override
     public Expr visitAlias(Alias alias, PlanTranslatorContext context) {
         return alias.child().accept(this, context);
@@ -292,7 +299,9 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitSlotReference(SlotReference slotReference, PlanTranslatorContext context) {
-        return context.findSlotRef(slotReference.getExprId());
+        boolean translateUsingBackup = context.getTranslateUsingBackup();
+        return translateUsingBackup ? context.findBackupSlotRef(slotReference.getExprId())
+            : context.findSlotRef(slotReference.getExprId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -129,13 +129,6 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         return expression.accept(INSTANCE, context);
     }
 
-    public static Expr translateUseBackup(Expression expression, PlanTranslatorContext context) {
-        context.setTranslateUsingBackup(true);
-        Expr result = expression.accept(INSTANCE, context);
-        context.setTranslateUsingBackup(false);
-        return result;
-    }
-
     @Override
     public Expr visitAlias(Alias alias, PlanTranslatorContext context) {
         return alias.child().accept(this, context);
@@ -299,9 +292,8 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitSlotReference(SlotReference slotReference, PlanTranslatorContext context) {
-        boolean translateUsingBackup = context.getTranslateUsingBackup();
-        return translateUsingBackup ? context.findBackupSlotRef(slotReference.getExprId())
-            : context.findSlotRef(slotReference.getExprId());
+        return context.getCloneExprIdToSlot() == null ? context.findSlotRef(slotReference.getExprId())
+            : context.findCloneSlotRef(slotReference.getExprId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2326,8 +2326,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // to obtain better local shuffle distribution.
         List<List<Expr>> newChildDistributeExprLists = Lists.newArrayList();
         if (!partitionExprs.isEmpty() && inputPlanFragment.getPlanRoot() != null
-            && inputPlanFragment.getPlanRoot() instanceof SortNode
-            && !inputPlanFragment.getPlanRoot().getChildrenDistributeExprLists().isEmpty()) {
+                && inputPlanFragment.getPlanRoot() instanceof SortNode
+                && !inputPlanFragment.getPlanRoot().getChildrenDistributeExprLists().isEmpty()) {
             // safety consideration for those already has valid children distribute expr lists setting only
             // current op tree only has two patterns, one is the window with sort child, and another is two phase
             // global partition topn child, and the latter is no need to refresh its distribution expr list since

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2322,6 +2322,20 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // analytic window
         AnalyticWindow analyticWindow = physicalWindow.translateWindowFrame(windowFrame, context);
 
+        // refresh inputPlanFragment's distributeExprLists of window operator
+        // to obtain better local shuffle distribution.
+        List<List<Expr>> newChildDistributeExprLists = Lists.newArrayList();
+        if (!partitionExprs.isEmpty() && inputPlanFragment.getPlanRoot() != null
+            && inputPlanFragment.getPlanRoot() instanceof SortNode
+            && !inputPlanFragment.getPlanRoot().getChildrenDistributeExprLists().isEmpty()) {
+            // safety consideration for those already has valid children distribute expr lists setting only
+            // current op tree only has two patterns, one is the window with sort child, and another is two phase
+            // global partition topn child, and the latter is no need to refresh its distribution expr list since
+            // it's expected to be the same as window's, for the former pattern, it is the real candidate.
+            newChildDistributeExprLists.add(partitionExprs);
+            inputPlanFragment.getPlanRoot().setChildrenDistributeExprLists(newChildDistributeExprLists);
+        }
+
         // 2. get bufferedTupleDesc from SortNode and compute isNullableMatched
         Map<ExprId, SlotRef> bufferedSlotRefForWindow = getBufferedSlotRefForWindow(windowFrameGroup, context);
         TupleDescriptor bufferedTupleDesc = context.getBufferedTupleForWindow();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
@@ -81,7 +81,7 @@ public class PlanTranslatorContext {
 
     private final Map<Plan, Map<ExprId, SlotRef>> clonePlanToExprIdToSlotRefMap = Maps.newHashMap();
 
-    private Map<ExprId, SlotRef> cloneExprIdToSlot = Maps.newHashMap();
+    private Map<ExprId, SlotRef> cloneExprIdToSlot = null;
 
     /**
      * Inverted index from legacy slot to Nereids' slot.

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -1231,6 +1231,10 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         this.pushDownAggNoGroupingOp = pushDownAggNoGroupingOp;
     }
 
+    public List<List<Expr>> getChildrenDistributeExprLists() {
+        return this.childrenDistributeExprLists;
+    }
+
     public void setChildrenDistributeExprLists(List<List<Expr>> childrenDistributeExprLists) {
         this.childrenDistributeExprLists = childrenDistributeExprLists;
     }

--- a/regression-test/suites/nereids_syntax_p0/distribute/window_child_distribution_expr.groovy
+++ b/regression-test/suites/nereids_syntax_p0/distribute/window_child_distribution_expr.groovy
@@ -51,48 +51,48 @@ suite("window_child_distribution_expr") {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k1, t1.k2 order by t1.k3) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp;
 		"""
-    	        contains "distribute expr lists: k1[#17], k2[#18]"
+    	        contains "distribute expr lists: k1[#13], k2[#14]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k1, t1.k2 order by t1.k3) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp where rn <=1;
 		"""
-    	        contains "distribute expr lists: k1[#21], k2[#22]"
+    	        contains "distribute expr lists: k1[#17], k2[#18]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp;
 		"""
-    	        contains "distribute expr lists: k2[#18], k3[#19]"
+    	        contains "distribute expr lists: k2[#14], k3[#15]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp where rn <=1;
 		"""
-    	        contains "distribute expr lists: k2[#22], k3[#23]"
+    	        contains "distribute expr lists: k2[#18], k3[#19]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp;
 		"""
-    	        contains "distribute expr lists: k2[#15], k3[#16]"
+    	        contains "distribute expr lists: k2[#11], k3[#12]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp where rn <=1;
 		"""
-    	        contains "distribute expr lists: k2[#19], k3[#20]"
+    	        contains "distribute expr lists: k2[#15], k3[#16]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k1 order by t1.k3) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp;
 		"""
-    	        contains "distribute expr lists: k1[#15]"
+    	        contains "distribute expr lists: k1[#12]"
         }
 	explain {
                 sql """
                 select * from (select t2.k2, row_number() over (partition by t1.k1 order by t1.k3) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp where rn <=1;
 		"""
-    	        contains "distribute expr lists: k1[#18]"
+    	        contains "distribute expr lists: k1[#15]"
         }
 }

--- a/regression-test/suites/nereids_syntax_p0/distribute/window_child_distribution_expr.groovy
+++ b/regression-test/suites/nereids_syntax_p0/distribute/window_child_distribution_expr.groovy
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("window_child_distribution_expr") {
+        multi_sql """
+	    drop table if exists baseall;
+	    drop table if exists test;
+	    CREATE TABLE IF NOT EXISTS `baseall` (
+                `k1` tinyint(4) null comment "",
+	        `k2` smallint(6) null comment "",
+                `k3` int(11) null comment "",
+                `k4` bigint(20) null comment ""
+            ) engine=olap
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3 properties("replication_num" = "1");
+
+	    CREATE TABLE IF NOT EXISTS `test` (
+                `k1` tinyint(4) null comment "",
+                `k2` smallint(6) null comment "",
+                `k3` int(11) null comment ""
+            ) engine=olap
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3 properties("replication_num" = "1");
+	    
+	    insert into baseall values (1,1,1,1);
+	    insert into baseall values (2,2,2,2);
+	    insert into baseall values (3,3,3,3);
+	    insert into test values (1,1,1);
+	    insert into test values (2,2,2);
+	    insert into test values (3,3,3);
+
+            set enable_nereids_distribute_planner=true;
+            set enable_pipeline_x_engine=true;
+            set disable_join_reorder=true;
+            set enable_local_shuffle=true;
+            set force_to_local_shuffle=true;
+    	"""
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k1, t1.k2 order by t1.k3) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp;
+		"""
+    	        contains "distribute expr lists: k1[#17], k2[#18]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k1, t1.k2 order by t1.k3) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp where rn <=1;
+		"""
+    	        contains "distribute expr lists: k1[#21], k2[#22]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp;
+		"""
+    	        contains "distribute expr lists: k2[#18], k3[#19]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k1=t2.k1) tmp where rn <=1;
+		"""
+    	        contains "distribute expr lists: k2[#22], k3[#23]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp;
+		"""
+    	        contains "distribute expr lists: k2[#15], k3[#16]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k2, t1.k3 order by t1.k4) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp where rn <=1;
+		"""
+    	        contains "distribute expr lists: k2[#19], k3[#20]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k1 order by t1.k3) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp;
+		"""
+    	        contains "distribute expr lists: k1[#15]"
+        }
+	explain {
+                sql """
+                select * from (select t2.k2, row_number() over (partition by t1.k1 order by t1.k3) rn from baseall t1 join test t2 on t1.k2=t2.k2) tmp where rn <=1;
+		"""
+    	        contains "distribute expr lists: k1[#18]"
+        }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Refine window child's local shuffle dist-expr as the partition by keys, to avoid hash skew using original child's distribution exprs. Case's explain after this pr:

| 5:VANALYTIC(282) |
| | functions: [row_number()] |
| | partition by: k1[[#17](https://github.com/apache/doris/issues/17)], k2[[#18](https://github.com/apache/doris/issues/18)] |
| | order by: k3[[#19](https://github.com/apache/doris/issues/19)] ASC NULLS FIRST |
| | window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW |
| | final projections: k2[[#16](https://github.com/apache/doris/issues/16)], rn[[#20](https://github.com/apache/doris/pull/20)] |
| | final project output tuple id: 6 |
| | distribute expr lists: k1[[#17](https://github.com/apache/doris/issues/17)] |
| | |
| 4:VSORT(279) |
| | order by: k1[[#17](https://github.com/apache/doris/issues/17)] ASC, k2[[#18](https://github.com/apache/doris/issues/18)] ASC, k3[[#19](https://github.com/apache/doris/issues/19)] ASC |
| | algorithm: full sort |
| | offset: 0 |
| | distribute expr lists: k1[[#17](https://github.com/apache/doris/issues/17)], k2[[#18](https://github.com/apache/doris/issues/18)] |

