### PR TITLE
[opt](Nereids) support parse sql with semicolon at beginning

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -26,11 +26,11 @@ options { tokenVocab = DorisLexer; }
 }
 
 multiStatements
-    : statement (SEMICOLON+ statement)* SEMICOLON* EOF
+    : SEMICOLON* statement (SEMICOLON+ statement)* SEMICOLON* EOF
     ;
 
 singleStatement
-    : statement SEMICOLON* EOF
+    : SEMICOLON* statement SEMICOLON* EOF
     ;
 
 statement

--- a/regression-test/suites/nereids_syntax_p0/test_semicolon_at_begin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_semicolon_at_begin.groovy
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_semicolon_at_begin") {
+    sql ";;;select 1"
+}


### PR DESCRIPTION
For statement with semicolon at beginning like: ;SELECT 1; MySQL could not parse it, but legacy planner could
