### PR TITLE
[Improvement](local exchange) optimize broadcast local exchanger

### DIFF
--- a/be/src/pipeline/local_exchange/local_exchange_source_operator.h
+++ b/be/src/pipeline/local_exchange/local_exchange_source_operator.h
@@ -57,6 +57,8 @@ private:
     int _channel_id;
     RuntimeProfile::Counter* _get_block_failed_counter = nullptr;
     RuntimeProfile::Counter* _copy_data_timer = nullptr;
+    std::vector<RuntimeProfile::Counter*> _deps_counter;
+    std::vector<DependencySPtr> _local_merge_deps;
 };
 
 class LocalExchangeSourceOperatorX final : public OperatorX<LocalExchangeSourceLocalState> {

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -94,6 +94,12 @@ struct PartitionedRowIdxs {
 
 using PartitionedBlock = std::pair<std::shared_ptr<BlockWrapper>, PartitionedRowIdxs>;
 
+struct RowRange {
+    uint32_t offset_start;
+    size_t length;
+};
+using BroadcastBlock = std::pair<std::shared_ptr<BlockWrapper>, RowRange>;
+
 template <typename BlockType>
 struct BlockQueue {
     std::atomic<bool> eos = false;
@@ -304,12 +310,11 @@ private:
     std::vector<std::atomic_int64_t> _queues_mem_usege;
 };
 
-class BroadcastExchanger final : public Exchanger<BlockWrapperSPtr> {
+class BroadcastExchanger final : public Exchanger<BroadcastBlock> {
 public:
     ENABLE_FACTORY_CREATOR(BroadcastExchanger);
     BroadcastExchanger(int running_sink_operators, int num_partitions, int free_block_limit)
-            : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions,
-                                          free_block_limit) {
+            : Exchanger<BroadcastBlock>(running_sink_operators, num_partitions, free_block_limit) {
         _data_queue.resize(num_partitions);
     }
     ~BroadcastExchanger() override = default;


### PR DESCRIPTION
## Proposed changes

Currently, data blocks are sinked in sink operators and copied to multiple downstream source operators in broadcast local exchanger. This PR change it to copy-when-pull mode, which means source operators get this data block when it could.

<!--Describe your changes.-->

