### PR TITLE
[Fix](Planner) fix delete from using does not attach partition information (#39020)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -169,6 +169,7 @@ public class DeleteStmt extends DdlStmt {
         }
 
         FromClause fromUsedInInsert;
+        targetTableRef.setPartitionNames(partitionNames);
         if (fromClause == null) {
             fromUsedInInsert = new FromClause(Lists.newArrayList(targetTableRef));
         } else {

--- a/regression-test/data/delete_p0/test_delete_from_partition.out
+++ b/regression-test/data/delete_p0/test_delete_from_partition.out
@@ -94,3 +94,10 @@ i	i	9	9
 -- !sql --
 i	i	9	9
 
+-- !sql --
+1	2	test1
+2	2	test
+
+-- !sql --
+2	2	test
+


### PR DESCRIPTION
cherry-pick: #39020
Problem:
when use delete from using clause and assign partition information, it would delete more data from other partition
Solved:
add partition information when transfer delete clause into insert into select clause

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

