### PR TITLE
[improvement](jdbc catalog) Force all resources to be closed in the close method

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -127,15 +127,14 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 try {
                     closeable.close();
                 } catch (Exception e) {
-                    LOG.warn("Cannot close resource");
+                    LOG.warn("Cannot close resource", e);
                 }
             }
         }
     }
 
-    protected boolean abortReadConnection(Connection connection, ResultSet resultSet)
+    protected void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException {
-        return false;
     }
 
     public void cleanDataSource() {

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -108,10 +108,10 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 }
             }
 
-            if (conn != null || resultSet != null) {
+            if (conn != null && resultSet != null) {
                 abortReadConnection(conn, resultSet);
-                closeResources(resultSet, stmt, conn);
             }
+            closeResources(resultSet, stmt, conn);
         } finally {
             if (config.getConnectionPoolMinSize() == 0 && hikariDataSource != null) {
                 hikariDataSource.close();

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -104,18 +104,12 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 try {
                     stmt.cancel();
                 } catch (SQLException e) {
-                    LOG.error("Error cancelling statement", e);
+                    LOG.warn("Cannot cancelling statement", e);
                 }
             }
 
-            boolean shouldAbort = conn != null && resultSet != null;
-            boolean aborted = false; // Used to record whether the abort operation is performed
-            if (shouldAbort) {
-                aborted = abortReadConnection(conn, resultSet);
-            }
-
-            // If no abort operation is performed, the resource needs to be closed manually
-            if (!aborted) {
+            if (conn != null || resultSet != null) {
+                abortReadConnection(conn, resultSet);
                 closeResources(resultSet, stmt, conn);
             }
         } finally {
@@ -131,15 +125,9 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
         for (AutoCloseable closeable : closeables) {
             if (closeable != null) {
                 try {
-                    if (closeable instanceof Connection) {
-                        if (!((Connection) closeable).isClosed()) {
-                            closeable.close();
-                        }
-                    } else {
-                        closeable.close();
-                    }
+                    closeable.close();
                 } catch (Exception e) {
-                    LOG.error("Cannot close resource: ", e);
+                    LOG.warn("Cannot close resource");
                 }
             }
         }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -104,7 +104,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 try {
                     stmt.cancel();
                 } catch (SQLException e) {
-                    LOG.warn("Cannot cancelling statement", e);
+                    LOG.warn("Cannot cancelling statement: ", e);
                 }
             }
 
@@ -127,7 +127,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 try {
                     closeable.close();
                 } catch (Exception e) {
-                    LOG.warn("Cannot close resource", e);
+                    LOG.warn("Cannot close resource: ", e);
                 }
             }
         }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/MySQLJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/MySQLJdbcExecutor.java
@@ -52,15 +52,13 @@ public class MySQLJdbcExecutor extends BaseJdbcExecutor {
     }
 
     @Override
-    protected boolean abortReadConnection(Connection connection, ResultSet resultSet)
+    protected void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException {
         if (!resultSet.isAfterLast()) {
             // Abort connection before closing. Without this, the MySQL driver
             // attempts to drain the connection by reading all the results.
             connection.abort(MoreExecutors.directExecutor());
-            return true;
         }
-        return false;
     }
 
     @Override

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SQLServerJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SQLServerJdbcExecutor.java
@@ -38,15 +38,13 @@ public class SQLServerJdbcExecutor extends BaseJdbcExecutor {
     }
 
     @Override
-    protected boolean abortReadConnection(Connection connection, ResultSet resultSet)
+    protected void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException {
         if (!resultSet.isAfterLast()) {
             // Abort connection before closing. Without this, the SQLServer driver
             // attempts to drain the connection by reading all the results.
             connection.abort(MoreExecutors.directExecutor());
-            return true;
         }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Force all resources to be closed in the close method. In the previous logic, query errors or query cancellation will not force the connection to be closed, which will cause abnormal Hikari connection counts. Although forced connection closure will generate some error logs in some cases, we should have this bottom-line guarantee and refine the closing logic later.