### PR TITLE
[fix](mtmv)Fix cancelled tasks with running status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
@@ -137,8 +137,8 @@ public abstract class AbstractTask implements Task {
     @Override
     public void cancel() throws JobException {
         try {
-            executeCancelLogic();
             status = TaskStatus.CANCELED;
+            executeCancelLogic();
         } catch (Exception e) {
             log.warn("cancel task failed, job id is {}, task id is {}", jobId, taskId, e);
             throw new JobException(e);


### PR DESCRIPTION
The state of writing the log first and changing it later resulted in the memory state being cancelled and the state after restarting being running

