### PR TITLE
[fix](delete) Incorrect status handling in CloudDeleteTask::execute()

### DIFF
--- a/be/src/cloud/cloud_delete_task.cpp
+++ b/be/src/cloud/cloud_delete_task.cpp
@@ -105,7 +105,7 @@ Status CloudDeleteTask::execute(CloudStorageEngine& engine, const TPushReq& requ
                 request.timeout, nullptr);
     }
 
-    return Status::OK();
+    return st;
 }
 
 } // namespace doris

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -329,6 +329,9 @@ Status retry_rpc(std::string_view op_name, const Request& req, Response* res,
             error_msg = cntl.ErrorText();
         } else if (res->status().code() == MetaServiceCode::OK) {
             return Status::OK();
+        } else if (res->status().code() == MetaServiceCode::INVALID_ARGUMENT) {
+            return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("failed to {}: {}", op_name,
+                                                                     res->status().msg());
         } else if (res->status().code() != MetaServiceCode::KV_TXN_CONFLICT) {
             return Status::Error<ErrorCode::INTERNAL_ERROR, false>("failed to {}: {}", op_name,
                                                                    res->status().msg());

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -124,9 +124,6 @@ inline MetaServiceCode cast_as(TxnErrorCode code) {
     case TxnErrorCode::TXN_TIMEOUT:
     case TxnErrorCode::TXN_INVALID_ARGUMENT:
     case TxnErrorCode::TXN_UNIDENTIFIED_ERROR:
-    case TxnErrorCode::TXN_KEY_TOO_LARGE:
-    case TxnErrorCode::TXN_VALUE_TOO_LARGE:
-    case TxnErrorCode::TXN_BYTES_TOO_LARGE:
         if constexpr (category == ErrCategory::READ) {
             return MetaServiceCode::KV_TXN_GET_ERR;
         } else if constexpr (category == ErrCategory::CREATE) {
@@ -134,6 +131,11 @@ inline MetaServiceCode cast_as(TxnErrorCode code) {
         } else {
             return MetaServiceCode::KV_TXN_COMMIT_ERR;
         }
+        [[fallthrough]];
+    case TxnErrorCode::TXN_KEY_TOO_LARGE:
+    case TxnErrorCode::TXN_VALUE_TOO_LARGE:
+    case TxnErrorCode::TXN_BYTES_TOO_LARGE:
+        return MetaServiceCode::INVALID_ARGUMENT;
     default:
         return MetaServiceCode::UNDEFINED_ERR;
     }


### PR DESCRIPTION
Previous impl. always returns OK to user when commit_rowset for the delete stmt. It may lead to missing delete predicate.

