### PR TITLE
[fix](be) be core dump caused by an invalid pointer

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -229,6 +229,8 @@ Status Segment::load_index() {
 }
 
 Status Segment::_create_column_readers() {
+    std::unordered_map<uint32_t, uint32_t> _column_id_to_footer_ordinal;
+
     for (uint32_t ordinal = 0; ordinal < _footer.columns().size(); ++ordinal) {
         auto& column_pb = _footer.columns(ordinal);
         _column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -133,11 +133,6 @@ private:
     int64_t _meta_mem_usage;
     SegmentFooterPB _footer;
 
-    // Map from column unique id to column ordinal in footer's ColumnMetaPB
-    // If we can't find unique id from it, it means this segment is created
-    // with an old schema.
-    std::unordered_map<uint32_t, uint32_t> _column_id_to_footer_ordinal;
-
     // map column unique id ---> column reader
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,
     // This means that this segment has no data for that column, which may be added


### PR DESCRIPTION
## Proposed changes

`Be core dump caused by an invalid pointer`

1. stack
```
(gdb) bt
#0  std::less<int>::operator() (__y=<error reading variable>, __x=@0x559e596f70a0: 5, this=0x559d9c05f998) at /var/local/ldb-toolchain/include/c++/11/bits/stl_function.h:385
#1  std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_get_insert_unique_pos (__k=@0x559e596f70a0: 5, this=0x559d9c05f998)
    at /var/local/ldb-toolchain/include/c++/11/bits/stl_tree.h:2069
#2  std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_emplace_unique<int, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > (this=0x559d9c05f998) at /var/local/ldb-toolchain/include/c++/11/bits/stl_tree.h:2387
#3  std::map<int, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::emplace<int, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > (this=0x559d9c05f998) at /var/local/ldb-toolchain/include/c++/11/bits/stl_map.h:577
#4  doris::segment_v2::Segment::_create_column_readers (this=this@entry=0x559d9c05f880) at /data/TCHouse-D-1.2/be/src/olap/rowset/segment_v2/segment.cpp:249
#5  0x0000559ac958a51a in doris::segment_v2::Segment::_open (this=0x559d9c05f880) at /data/TCHouse-D-1.2/be/src/olap/rowset/segment_v2/segment.cpp:90
#6  doris::segment_v2::Segment::open (fs=..., path=..., cache_path=..., segment_id=segment_id@entry=63, rowset_id=..., tablet_schema=..., output=0x7ff262c331c0)
    at /data/TCHouse-D-1.2/be/src/olap/rowset/segment_v2/segment.cpp:70
#7  0x0000559ac987ec13 in doris::BetaRowset::load_segments (this=0x559de684dbc0, segments=segments@entry=0x7ff262c33330)
    at /var/local/ldb-toolchain/include/c++/11/ext/atomicity.h:109
#8  0x0000559ac9852594 in doris::SegmentLoader::load_segments (this=0x559ad18f3a08 <doris::SegmentLoader::create_global_instance(unsigned long)::instance>, rowset=..., 
    cache_handle=cache_handle@entry=0x559f7d4ae1c8, use_cache=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1290
#9  0x0000559ac9885d26 in doris::BetaRowsetReader::get_segment_iterators (this=0x559f7d4ae000, read_context=0x559fce254a58, out_iters=0x7ff262c337c0, use_cache=<optimized out>)
    at /data/TCHouse-D-1.2/be/src/olap/segment_loader.h:79
#10 0x0000559ac9883cf7 in doris::BetaRowsetReader::init (this=0x559f7d4ae000, read_context=0x559fce254a58) at /data/TCHouse-D-1.2/be/src/olap/rowset/beta_rowset_reader.cpp:201
#11 0x0000559ace701bf5 in doris::vectorized::BlockReader::_init_collect_iter (this=this@entry=0x559fce254a00, read_params=..., 
    valid_rs_readers=valid_rs_readers@entry=0x7ff262c339e0) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1290
#12 0x0000559ace7020f1 in doris::vectorized::BlockReader::init (this=0x559fce254a00, read_params=...) at /data/TCHouse-D-1.2/be/src/vec/olap/block_reader.cpp:156
#13 0x0000559ace90cae7 in doris::vectorized::NewOlapScanner::open (this=0x559df7883800, state=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/unique_ptr.h:421
#14 0x0000559ace8eb533 in doris::vectorized::ScannerScheduler::_scanner_scan (this=<optimized out>, scheduler=<optimized out>, ctx=0x559da179c1e0, scanner=0x559df7883800)
    at /data/TCHouse-D-1.2/be/src/util/stopwatch.hpp:67
#15 0x0000559ac98d9333 in std::function<void ()>::operator()() const (this=0x7ff262c34008) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556
#16 doris::PriorityWorkStealingThreadPool::work_thread (this=0x559adb26ee00, thread_id=<optimized out>)
    at /data/TCHouse-D-1.2/be/src/util/priority_work_stealing_thread_pool.hpp:134
#17 0x0000559ad1528b00 in std::execute_native_thread_routine (__p=0x559adac31530) at ../../../../../libstdc++-v3/src/c++11/thread.cc:82
#18 0x00007ff36057dea5 in __pthread_mutex_unlock_full () from /lib64/libpthread.so.0
#19 0x0000000000000000 in ?? ()
```
3. debug
```
(gdb) p _column_id_to_footer_ordinal._M_h._M_buckets[5]                                                                                                                      
$136 = (std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, unsigned int>, false> > >::__node_base_ptr) 0x559df368b880

(gdb) p *(std::pair<const unsigned int, unsigned int>*)((std::__detail::_Hash_node<std::pair<const unsigned int, unsigned int>, false> *)0x559df368b880)->_M_storage
Cannot access memory at address 0x600000006
```
<!--Describe your changes.-->

