### PR TITLE
[fix](Nereids) fix explain plan with sql cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -182,7 +182,7 @@ public class NereidsPlanner extends Planner {
             if (plan instanceof LogicalSqlCache) {
                 rewrittenPlan = analyzedPlan = plan;
                 LogicalSqlCache logicalSqlCache = (LogicalSqlCache) plan;
-                physicalPlan = new PhysicalSqlCache(
+                optimizedPlan = physicalPlan = new PhysicalSqlCache(
                         logicalSqlCache.getQueryId(),
                         logicalSqlCache.getColumnLabels(), logicalSqlCache.getFieldInfos(),
                         logicalSqlCache.getResultExprs(), logicalSqlCache.getResultSetInFe(),

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -771,6 +771,11 @@ suite("parse_sql_from_sql_cache") {
             assertNoCache "select * from test_use_plan_cache21"
             def result2 = sql "select * from test_use_plan_cache21"
             assertTrue(result2.size() == 1)
+        }),
+        extraThread("test_explain_sql_cache", {
+            sql "set enable_sql_cache=true"
+            sql "select 100"
+            sql "explain plan select 100"
         })
     ).get()
 }

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -771,11 +771,6 @@ suite("parse_sql_from_sql_cache") {
             assertNoCache "select * from test_use_plan_cache21"
             def result2 = sql "select * from test_use_plan_cache21"
             assertTrue(result2.size() == 1)
-        }),
-        extraThread("test_explain_sql_cache", {
-            sql "set enable_sql_cache=true"
-            sql "select 100"
-            sql "explain plan select 100"
         })
     ).get()
 }

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -244,4 +244,11 @@ suite("sql_cache") {
     }
 
     sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
+
+    // explain plan with sql cache
+    connect {
+        sql "set enable_sql_cache=true"
+        sql "select 100"
+        sql "explain plan select 100"
+    }
 }


### PR DESCRIPTION
## Proposed changes

introduced by #38950, explain plan with sql cache will throw an exception
```
errCode = 2, detailMessage = Cannot invoke "org.apache.doris.nereids.trees.plans.Plan.treeString()" because "this.optimizedPlan" is null
```