### PR TITLE
[opt](set operation) INTERSECT should evaluated before others (#39095)

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -347,7 +347,8 @@ query
 
 queryTerm
     : queryPrimary                                                         #queryTermDefault
-    | left=queryTerm operator=(UNION | EXCEPT | MINUS | INTERSECT)
+    | left=queryTerm operator=INTERSECT setQuantifier? right=queryTerm     #setOperation
+    | left=queryTerm operator=(UNION | EXCEPT | MINUS)
       setQuantifier? right=queryTerm                                       #setOperation
     ;
 


### PR DESCRIPTION
pick from master #39095

this is a behaviour change PR.

set operation INTERSECT should evaluated before others. In Doris history, all set operators have same priority.

This PR change Nereids, let it be same with MySQL.

