### PR TITLE
[Fix](load) Fix the incorrect src value printed in the error log when strict mode is true

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -581,8 +581,11 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
                                                                          _num_of_columns_from_file);
                                 },
                                 [&]() -> std::string {
-                                    auto raw_value = _src_block_ptr->get_by_position(ctx_idx)
-                                                             .column->get_data_at(i);
+                                    auto raw_value =
+                                            _src_block_ptr
+                                                    ->get_by_position(_dest_slot_to_src_slot_index
+                                                                              [dest_index])
+                                                    .column->get_data_at(i);
                                     std::string raw_string = raw_value.to_string();
                                     fmt::memory_buffer error_msg;
                                     fmt::format_to(error_msg,


### PR DESCRIPTION
When there is a column order mapping, an incorrect src value will be printed because the wrong column was used.

