### PR TITLE
[fix](util) Fix DorisOnce not accurate once when exception happend

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -119,12 +119,12 @@ public:
                                        std::unique_ptr<InvertedIndexIterator>* iter);
 
     const ShortKeyIndexDecoder* get_short_key_index() const {
-        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
+        DCHECK(_load_index_once.is_called() && _load_index_once.stored_result().ok());
         return _sk_index_decoder.get();
     }
 
     const PrimaryKeyIndexReader* get_primary_key_index() const {
-        DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());
+        DCHECK(_load_index_once.is_called() && _load_index_once.stored_result().ok());
         return _pk_index_reader.get();
     }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -605,7 +605,7 @@ inline CumulativeCompactionPolicy* Tablet::cumulative_compaction_policy() {
 }
 
 inline bool Tablet::init_succeeded() {
-    return _init_once.has_called() && _init_once.stored_result().ok();
+    return _init_once.is_called() && _init_once.stored_result().ok();
 }
 
 inline bool Tablet::is_used() {

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -51,7 +51,7 @@ namespace doris {
 template <typename ReturnType>
 class DorisCallOnce {
 public:
-    DorisCallOnce() : _once_flag(false) {}
+    DorisCallOnce() : _once_flag(false) = default;
 
     // this method is not exception safe, it will core when exception occurs in
     // callback method. I have tested the code https://en.cppreference.com/w/cpp/thread/call_once.

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -51,7 +51,7 @@ namespace doris {
 template <typename ReturnType>
 class DorisCallOnce {
 public:
-    DorisCallOnce() : _once_flag(false) = default;
+    DorisCallOnce() : _once_flag(false) {}
 
     // this method is not exception safe, it will core when exception occurs in
     // callback method. I have tested the code https://en.cppreference.com/w/cpp/thread/call_once.

--- a/be/test/util/doris_callonce_test.cpp
+++ b/be/test/util/doris_callonce_test.cpp
@@ -34,14 +34,14 @@ class DorisCallOnceTest : public ::testing::Test {};
 
 TEST_F(DorisCallOnceTest, TestNormal) {
     DorisCallOnce<Status> call1;
-    EXPECT_EQ(call1.has_called(), false);
+    EXPECT_EQ(call1.is_called(), false);
 
     Status st = call1.call([&]() -> Status { return Status::OK(); });
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
     EXPECT_EQ(call1.stored_result().code(), ErrorCode::OK);
 
     st = call1.call([&]() -> Status { return Status::InternalError(""); });
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
     // The error code should not changed
     EXPECT_EQ(call1.stored_result().code(), ErrorCode::OK);
 }
@@ -51,21 +51,21 @@ TEST_F(DorisCallOnceTest, TestNormal) {
 // array.
 TEST_F(DorisCallOnceTest, TestErrorHappens) {
     DorisCallOnce<Status> call1;
-    EXPECT_EQ(call1.has_called(), false);
+    EXPECT_EQ(call1.is_called(), false);
 
     Status st = call1.call([&]() -> Status { return Status::InternalError(""); });
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
     EXPECT_EQ(call1.stored_result().code(), ErrorCode::INTERNAL_ERROR);
 
     st = call1.call([&]() -> Status { return Status::OK(); });
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
     // The error code should not changed
     EXPECT_EQ(call1.stored_result().code(), ErrorCode::INTERNAL_ERROR);
 }
 
 TEST_F(DorisCallOnceTest, TestExceptionHappens) {
     DorisCallOnce<Status> call1;
-    EXPECT_EQ(call1.has_called(), false);
+    EXPECT_EQ(call1.is_called(), false);
     bool exception_occured = false;
     bool runtime_occured = false;
     try {
@@ -78,7 +78,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
         exception_occured = true;
     }
     EXPECT_EQ(exception_occured, true);
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
 
     // call again, should throw the same exception.
     exception_occured = false;
@@ -90,7 +90,7 @@ TEST_F(DorisCallOnceTest, TestExceptionHappens) {
         exception_occured = true;
     }
     EXPECT_EQ(exception_occured, true);
-    EXPECT_EQ(call1.has_called(), true);
+    EXPECT_EQ(call1.is_called(), true);
 
     // If call get result, should catch exception.
     exception_occured = false;


### PR DESCRIPTION
## Proposed changes

In cpp, exception catch relies on stack unwind and will destruct all stack variables before entering catch block.

In the original DorisOnce, if exception happended when `fn` called, the `_flag_lock` will be released before `_has_called` flag in set. The race condition may make it actually called twice.

This PR use std::once_falg and std::call_once to refactor the DorisOnce.

1. Support call once semantic and return result when `call()` is called. If an exception thrown, the exception will be rethrown whenever called the `call()`.
2. Supports to get is called status through function `is_called()`.
3. Support to get produced value through `stored_result()`. If exception throwed, will rethrow this exception. If it is not called, will throw an exception to indicate it.

