### PR TITLE
[fix](nereids)prevent null pointer exception if datetime value overflows

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -346,9 +346,10 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
     private static Expression migrateToDateV2(DateTimeLiteral l, AdjustType type) {
         DateV2Literal d = new DateV2Literal(l.getYear(), l.getMonth(), l.getDay());
         if (type == AdjustType.UPPER && (l.getHour() != 0 || l.getMinute() != 0 || l.getSecond() != 0)) {
-            d = ((DateV2Literal) d.plusDays(1));
+            return d.plusDays(1);
+        } else {
+            return d;
         }
-        return d;
     }
 
     private static Expression migrateToDate(DateV2Literal l) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
@@ -104,22 +104,27 @@ public class TimeRoundSeries {
         if (getCeil) {
             step = step + (deltaInsidePeriod == 0 ? 0 : period);
         }
-        switch (tag) {
-            case YEAR:
-                return ((DateTimeLiteral) start.plusYears(step)).toJavaDateType();
-            case MONTH:
-                return ((DateTimeLiteral) start.plusMonths(step)).toJavaDateType();
-            case DAY:
-                return ((DateTimeLiteral) start.plusDays(step)).toJavaDateType();
-            case HOUR:
-                return ((DateTimeLiteral) start.plusHours(step)).toJavaDateType();
-            case MINUTE:
-                return ((DateTimeLiteral) start.plusMinutes(step)).toJavaDateType();
-            case SECOND:
-                return ((DateTimeLiteral) start.plusSeconds(step)).toJavaDateType();
-            default:
-                break;
+        try {
+            switch (tag) {
+                case YEAR:
+                    return ((DateTimeLiteral) start.plusYears(step)).toJavaDateType();
+                case MONTH:
+                    return ((DateTimeLiteral) start.plusMonths(step)).toJavaDateType();
+                case DAY:
+                    return ((DateTimeLiteral) start.plusDays(step)).toJavaDateType();
+                case HOUR:
+                    return ((DateTimeLiteral) start.plusHours(step)).toJavaDateType();
+                case MINUTE:
+                    return ((DateTimeLiteral) start.plusMinutes(step)).toJavaDateType();
+                case SECOND:
+                    return ((DateTimeLiteral) start.plusSeconds(step)).toJavaDateType();
+                default:
+                    break;
+            }
+        } catch (Exception ex) {
+            // do nothing
         }
+
         return null;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
@@ -104,28 +104,34 @@ public class TimeRoundSeries {
         if (getCeil) {
             step = step + (deltaInsidePeriod == 0 ? 0 : period);
         }
-        try {
-            switch (tag) {
-                case YEAR:
-                    return ((DateTimeLiteral) start.plusYears(step)).toJavaDateType();
-                case MONTH:
-                    return ((DateTimeLiteral) start.plusMonths(step)).toJavaDateType();
-                case DAY:
-                    return ((DateTimeLiteral) start.plusDays(step)).toJavaDateType();
-                case HOUR:
-                    return ((DateTimeLiteral) start.plusHours(step)).toJavaDateType();
-                case MINUTE:
-                    return ((DateTimeLiteral) start.plusMinutes(step)).toJavaDateType();
-                case SECOND:
-                    return ((DateTimeLiteral) start.plusSeconds(step)).toJavaDateType();
-                default:
-                    break;
-            }
-        } catch (Exception ex) {
-            // do nothing
+        Expression result = null;
+        switch (tag) {
+            case YEAR:
+                result = start.plusYears(step);
+                break;
+            case MONTH:
+                result = start.plusMonths(step);
+                break;
+            case DAY:
+                result = start.plusDays(step);
+                break;
+            case HOUR:
+                result = start.plusHours(step);
+                break;
+            case MINUTE:
+                result = start.plusMinutes(step);
+                break;
+            case SECOND:
+                result = start.plusSeconds(step);
+                break;
+            default:
+                break;
         }
-
-        return null;
+        if (result != null && result instanceof DateTimeLiteral) {
+            return ((DateTimeLiteral) result).toJavaDateType();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -336,7 +336,7 @@ public class DateLiteral extends Literal {
     }
 
     protected static boolean isDateOutOfRange(LocalDateTime dateTime) {
-        return dateTime.isBefore(START_OF_A_DAY) || dateTime.isAfter(END_OF_A_DAY);
+        return dateTime.isBefore(START_OF_A_DAY) || dateTime.isAfter(END_OF_A_DAY) || dateTime == null;
     }
 
     private boolean checkDatetime(TemporalAccessor dateTime) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -336,7 +336,7 @@ public class DateLiteral extends Literal {
     }
 
     protected static boolean isDateOutOfRange(LocalDateTime dateTime) {
-        return dateTime.isBefore(START_OF_A_DAY) || dateTime.isAfter(END_OF_A_DAY) || dateTime == null;
+        return dateTime == null || dateTime.isBefore(START_OF_A_DAY) || dateTime.isAfter(END_OF_A_DAY);
     }
 
     private boolean checkDatetime(TemporalAccessor dateTime) {

--- a/regression-test/suites/nereids_p0/datatype/test_datetime_overflow.groovy
+++ b/regression-test/suites/nereids_p0/datatype/test_datetime_overflow.groovy
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_datetime_overflow") {
+    sql 'set enable_nereids_planner=true'
+    sql 'set enable_fallback_to_original_planner=false'
+    sql """drop table if exists datetime_overflow_t"""
+    sql """CREATE TABLE datetime_overflow_t (
+            `id` bigint NULL,
+            `c` datetime NULL,
+            `d` date NULL,
+            INDEX idx_c (`c`) USING INVERTED
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`id`)
+            DISTRIBUTED BY RANDOM BUCKETS AUTO
+            PROPERTIES (
+            "replication_num" = "1"
+            );"""
+
+    sql """select * from datetime_overflow_t where d between "9999-12-31 00:00:01" and "9999-12-31 10:00:01";"""
+    sql """select * from datetime_overflow_t where d > "9999-12-31 00:00:01";"""
+}


### PR DESCRIPTION
date and datetime literal's plusXXX method( plusDays, plusWeeks, plusMonths) may return NullLiteral, So we should only convert the return value to date or datetime literal when it's not a NullLiteral

