### PR TITLE
[improvement](fe) When checkpoint generates image file, it is flushed to disk in batches to avoid full disk IO due to forced flushing of too large image files at once

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/DataOutputBuffer.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/DataOutputBuffer.java
@@ -68,18 +68,18 @@ public class DataOutputBuffer extends DataOutputStream {
         }
 
         public void write(DataInput in, int len) throws IOException {
-            int newcount = count + len;
-            if (newcount > buf.length) {
-                byte[] newbuf = new byte[Math.max(buf.length << 1, newcount)];
-                System.arraycopy(buf, 0, newbuf, 0, count);
-                buf = newbuf;
+            int newCount = count + len;
+            if (newCount > buf.length) {
+                byte[] newBuf = new byte[Math.max(buf.length << 1, newCount)];
+                System.arraycopy(buf, 0, newBuf, 0, count);
+                buf = newBuf;
             }
             in.readFully(buf, count, len);
-            count = newcount;
+            count = newCount;
         }
     }
 
-    private Buffer buffer;
+    private final Buffer buffer;
 
     /** Constructs a new empty buffer. */
     public DataOutputBuffer() {

--- a/fe/fe-common/src/test/java/org/apache/doris/common/io/CountingDataOutputStreamTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/io/CountingDataOutputStreamTest.java
@@ -1,0 +1,24 @@
+package org.apache.doris.common.io;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class CountingDataOutputStreamTest {
+    private static final Logger LOG = LogManager.getLogger(CountingDataOutputStreamTest.class);
+
+    @Test
+    public void testWrite() {
+        File file = new File("/Users/hantongyang/data/meta_test.txt");
+        try (CountingDataOutputStream out = new CountingDataOutputStream(Files.newOutputStream(file.toPath()))) {
+            byte[] data = String.valueOf('a').getBytes(StandardCharsets.UTF_8);
+            out.write(data, 0, data.length);
+        } catch (Exception e) {
+            LOG.error(e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
@@ -79,14 +79,14 @@ public class MetaWriter {
 
     private Delegate delegate;
 
-    public void setDelegate(CountingDataOutputStream dos, List<MetaIndex> indices) {
+    private void setDelegate(CountingDataOutputStream dos, List<MetaIndex> indices) {
         this.delegate = (name, method) -> {
             indices.add(new MetaIndex(name, dos.getCount()));
             return method.write();
         };
     }
 
-    public long doWork(String name, WriteMethod method) throws IOException {
+    private long doWork(String name, WriteMethod method) throws IOException {
         if (delegate == null) {
             return method.write();
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/meta/MetaWriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/meta/MetaWriterTest.java
@@ -1,0 +1,17 @@
+package org.apache.doris.persist.meta;
+
+import org.apache.doris.catalog.Env;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class MetaWriterTest {
+
+    @Test
+    public void testWrite() throws IOException {
+        File file = new File("");
+        MetaWriter.write(file, Env.getCurrentEnv());
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

