### PR TITLE
[Improvement](topn) set setHasRuntimePredicate for sort node and only set_detected_source…

### DIFF
--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -100,7 +100,7 @@ Status SortSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
 
     auto* query_ctx = state->get_query_ctx();
     // init runtime predicate
-    if (query_ctx->has_runtime_predicate(_node_id)) {
+    if (query_ctx->has_runtime_predicate(_node_id) && _algorithm == TSortAlgorithm::HEAP_SORT) {
         query_ctx->get_runtime_predicate(_node_id).set_detected_source();
     }
     return Status::OK();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -66,6 +66,7 @@ import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.planner.SchemaScanNode;
 import org.apache.doris.planner.SetOperationNode;
+import org.apache.doris.planner.SortNode;
 import org.apache.doris.planner.UnionNode;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.InternalService.PExecPlanFragmentResult;
@@ -3087,6 +3088,11 @@ public class Coordinator implements CoordInterface {
         }
 
         Map<TNetworkAddress, TPipelineFragmentParams> toThrift(int backendNum) {
+            Set<SortNode> topnSortNodes = scanNodes.stream()
+                    .filter(scanNode -> scanNode instanceof OlapScanNode)
+                    .flatMap(scanNode -> scanNode.getTopnFilterSortNodes().stream()).collect(Collectors.toSet());
+            topnSortNodes.forEach(SortNode::setHasRuntimePredicate);
+
             long memLimit = queryOptions.getMemLimit();
             // 2. update memory limit for colocate join
             if (colocateFragmentIds.contains(fragment.getFragmentId().asInt())) {


### PR DESCRIPTION
… when sort algorithm is heap sort

## Proposed changes
set setHasRuntimePredicate for sort node and only set_detected_source when sort algorithm is heap sort
