### PR TITLE
[Bug] test suite test_table_options may cause NPE in FE #39457

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -1135,6 +1135,15 @@ public class MetadataGenerator {
         String clg = params.getCatalog();
         CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(clg);
         DatabaseIf database = catalog.getDbNullable(dbId);
+        if (database == null) {
+            // BE gets the database id list from FE and then invokes this interface
+            // per database. there is a chance that in between database can be dropped.
+            // so need to handle database not exist case and return ok so that BE continue the
+            // loop with next database.
+            result.setDataBatch(dataBatch);
+            result.setStatus(new TStatus(TStatusCode.OK));
+            return result;
+        }
         List<TableIf> tables = database.getTables();
         if (catalog instanceof InternalCatalog) {
             tableOptionsForInternalCatalog(currentUserIdentity, catalog, database, tables, dataBatch);
@@ -1222,6 +1231,15 @@ public class MetadataGenerator {
         CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(clg);
         List<TRow> dataBatch = Lists.newArrayList();
         DatabaseIf database = catalog.getDbNullable(dbId);
+        if (database == null) {
+            // BE gets the database id list from FE and then invokes this interface
+            // per database. there is a chance that in between database can be dropped.
+            // so need to handle database not exist case and return ok so that BE continue the
+            // loop with next database.
+            result.setDataBatch(dataBatch);
+            result.setStatus(new TStatus(TStatusCode.OK));
+            return result;
+        }
         List<TableIf> tables = database.getTables();
         if (catalog instanceof InternalCatalog) {
             tablePropertiesForInternalCatalog(currentUserIdentity, catalog, database, tables, dataBatch);


### PR DESCRIPTION
## Proposed changes

Issue Number: close  #39457

If database is delete then FE should    check and return OK with empty set to BE, so that BE can continue the scan other database id 

Unit testing:
stubbed BE to add a invalid database id in the begin of the dbresult.dbids and reproduced this issue.
mysql> select * from information_schema.table_options;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]TStatus: Cannot invoke "org.apache.doris.catalog.DatabaseIf.getTables()" because "database" is null
mysql> select * from information_schema.table_properties;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]TStatus: Cannot invoke "org.apache.doris.catalog.DatabaseIf.getTables()" because "database" is null
mysql> 
After fix in FE both table query success with invalid dbid from BE.
*************************** 776. row ***************************
  TABLE_CATALOG: internal
   TABLE_SCHEMA: regression_test_tpch_unique_sql_zstd_bucket1_p0
     TABLE_NAME: partsupp
    TABLE_MODEL: UNI
TABLE_MODEL_KEY: PS_PARTKEY,PS_SUPPKEY
 DISTRIBUTE_KEY: PS_PARTKEY
DISTRIBUTE_TYPE: HASH
    BUCKETS_NUM: 1
  PARTITION_NUM: 1
776 rows in set (0.11 sec)

mysql> 

Both table can query even if in the begining there is a invalid dbid in BE list.


