### PR TITLE
[fix](stream load) do not throw exception but skip record when can not find database (#39360)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.MasterDaemon;
@@ -315,7 +314,8 @@ public class StreamLoadRecordMgr extends MasterDaemon {
                         if (Strings.isNullOrEmpty(streamLoadItem.getCluster())) {
                             dbName = streamLoadItem.getDb();
                         }
-                        throw new UserException("unknown database, database=" + dbName);
+                        LOG.warn("unknown database, database=" + dbName);
+                        continue;
                     }
                     long dbId = db.getId();
                     Env.getCurrentEnv().getStreamLoadRecordMgr()


### PR DESCRIPTION
pick (#39360)

When fetch stream load record from BE node, if can not find database, StreamLoadRecordMgr will throw exception and the remaining records will not be recorded in memory.

For example: Ten stream load records were pulled, and the database associated with the stream load of the first record was deleted by the user. Therefore, the pull will end, resulting in the remaining nine records not being consumed recorded in memory.

This pr do not throw exception but skip record when can not find database to solve this problem.

