### PR TITLE
[enhance](Backup) Do connectivity check when creating repository (#38350)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -91,7 +91,6 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public static final int SIGNATURE_VERSION = 1;
     public static final Path BACKUP_ROOT_DIR = Paths.get(Config.tmp_dir, "backup").normalize();
     public static final Path RESTORE_ROOT_DIR = Paths.get(Config.tmp_dir, "restore").normalize();
-
     private RepositoryMgr repoMgr = new RepositoryMgr();
 
     // this lock is used for updating dbIdToBackupOrRestoreJobs
@@ -219,6 +218,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
         if (!st.ok()) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                                            "Failed to create repository: " + st.getErrMsg());
+        }
+        if (!repo.ping()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                    "Failed to create repository: failed to connect to the repo");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -368,6 +368,9 @@ public class Repository implements Writable {
     // Check if this repo is available.
     // If failed to connect this repo, set errMsg and return false.
     public boolean ping() {
+        if (FeConstants.runningUnitTest) {
+            return true;
+        }
         // for s3 sdk, the headObject() method does not support list "dir",
         // so we check FILE_REPO_INFO instead.
         String path = location + "/" + joinPrefix(PREFIX_REPO, name) + "/" + FILE_REPO_INFO;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -105,6 +105,7 @@ public class BackupHandlerTest {
         Config.tmp_dir = tmpPath;
         rootDir = new File(Config.tmp_dir);
         rootDir.mkdirs();
+        FeConstants.runningUnitTest = true;
 
         new Expectations() {
             {

--- a/regression-test/suites/backup_restore/test_backup_connectivity_failed.groovy
+++ b/regression-test/suites/backup_restore/test_backup_connectivity_failed.groovy
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_backup_restore", "connectivity_failed") {
+    def name = "test_name"
+    def bucket = "useless_bucket"
+    def prefix = "useless_prefix"
+    def endpoint = getS3Endpoint()
+    def region = getS3Region()
+    def ak = getS3AK()
+    def sk = getS3SK()
+    expectExceptionLike({
+        sql """
+            CREATE REPOSITORY `${name}`
+            WITH S3
+            ON LOCATION "s3://${bucket}/${prefix}/${name}"
+            PROPERTIES
+            (
+                "s3.endpoint" = "http://${endpoint}",
+                "s3.region" = "${region}",
+                "s3.access_key" = "${ak}",
+                "s3.secret_key" = "${sk}"
+            )
+            """
+    }, "Failed to create repository")
+}


### PR DESCRIPTION
Previously when creating repository, FE would not do connectivity check. It might result in confusing error when using backup restore.

pick #38350

