### PR TITLE
 [improvement](mtmv) Only Generate rewritten plan when generate mv plan for performance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -187,7 +187,7 @@ public class MTMV extends OlapTable {
                 this.relation = relation;
                 if (!Env.isCheckpointThread() && !Config.enable_check_compatibility_mode) {
                     try {
-                        this.cache = MTMVCache.from(this, MTMVPlanUtil.createMTMVContext(this));
+                        this.cache = MTMVCache.from(this, MTMVPlanUtil.createMTMVContext(this), true);
                     } catch (Throwable e) {
                         this.cache = null;
                         LOG.warn("generate cache failed", e);
@@ -274,7 +274,7 @@ public class MTMV extends OlapTable {
             writeMvLock();
             try {
                 if (cache == null) {
-                    this.cache = MTMVCache.from(this, connectionContext);
+                    this.cache = MTMVCache.from(this, connectionContext, true);
                 }
             } finally {
                 writeMvUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
@@ -89,7 +89,7 @@ public class MTMVCache {
         }
         // Can not convert to table sink, because use the same column from different table when self join
         // the out slot is wrong
-        planner.planWithLock(unboundMvPlan, PhysicalProperties.ANY, ExplainLevel.ALL_PLAN);
+        planner.planWithLock(unboundMvPlan, PhysicalProperties.ANY, ExplainLevel.REWRITTEN_PLAN);
         Plan originPlan = planner.getCascadesContext().getRewritePlan();
         // Eliminate result sink because sink operator is useless in query rewrite by materialized view
         // and the top sort can also be removed

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVCache.java
@@ -79,7 +79,7 @@ public class MTMVCache {
         return structInfo;
     }
 
-    public static MTMVCache from(MTMV mtmv, ConnectContext connectContext) {
+    public static MTMVCache from(MTMV mtmv, ConnectContext connectContext, boolean needCost) {
         LogicalPlan unboundMvPlan = new NereidsParser().parseSingle(mtmv.getQuerySql());
         StatementContext mvSqlStatementContext = new StatementContext(connectContext,
                 new OriginStatement(mtmv.getQuerySql(), 0));
@@ -89,7 +89,13 @@ public class MTMVCache {
         }
         // Can not convert to table sink, because use the same column from different table when self join
         // the out slot is wrong
-        planner.planWithLock(unboundMvPlan, PhysicalProperties.ANY, ExplainLevel.REWRITTEN_PLAN);
+        if (needCost) {
+            // Only in mv rewrite, we need plan with eliminated cost which is used for mv chosen
+            planner.planWithLock(unboundMvPlan, PhysicalProperties.ANY, ExplainLevel.ALL_PLAN);
+        } else {
+            // No need cost for performance
+            planner.planWithLock(unboundMvPlan, PhysicalProperties.ANY, ExplainLevel.REWRITTEN_PLAN);
+        }
         Plan originPlan = planner.getCascadesContext().getRewritePlan();
         // Eliminate result sink because sink operator is useless in query rewrite by materialized view
         // and the top sort can also be removed
@@ -111,7 +117,8 @@ public class MTMVCache {
         Optional<StructInfo> structInfoOptional = MaterializationContext.constructStructInfo(mvPlan, originPlan,
                 planner.getCascadesContext(),
                 new BitSet());
-        return new MTMVCache(mvPlan, originPlan, planner.getCascadesContext().getMemo().getRoot().getStatistics(),
+        return new MTMVCache(mvPlan, originPlan, needCost
+                ? planner.getCascadesContext().getMemo().getRoot().getStatistics() : null,
                 structInfoOptional.orElseGet(() -> null));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/TableCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/TableCollector.java
@@ -75,7 +75,7 @@ public class TableCollector extends DefaultPlanVisitor<Plan, TableCollectorConte
         }
         // Make sure use only one connection context when in query to avoid ConnectionContext.get() wrong
         MTMVCache expandedMv = MTMVCache.from(mtmv, context.getConnectContext() == null
-                ? MTMVPlanUtil.createMTMVContext(mtmv) : context.getConnectContext());
+                ? MTMVPlanUtil.createMTMVContext(mtmv) : context.getConnectContext(), false);
         expandedMv.getLogicalPlan().accept(this, context);
     }
 


### PR DESCRIPTION
## Proposed changes

Before query rewrite by materialized view, we collecet the table which query used by method `org.apache.doris.mtmv.MTMVCache#from`.

In `MTMVCache#from` we calcute the cost of plan which is useless for collecting table. 
So add `boolean needCost` param in method `MTMVCache#from` to identify that if need cost of plan or not for performance.
