### PR TITLE
[ci](fix) adjust GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/comment-to-trigger-teamcity.yml
+++ b/.github/workflows/comment-to-trigger-teamcity.yml
@@ -21,6 +21,11 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   check-comment-if-need-to-trigger-teamcity:
 


### PR DESCRIPTION

when pr needs to skip the TeamCity build, an error occurs like below，
```
curl -L -X POST -H 'Accept: application/vnd.github+json' -H 'Authorization: ***' -H 'X-GitHub-Api-Version: 2022-11-28' https://api.github.com/repos/apache/doris/statuses/efa07c9ec476b4841bace614df58a98e62d22176 -d '{"state":"success","target_url":"","description":"Skip teamCity build","context":"FE UT (Doris FE UT)"}'
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/commits/statuses#create-a-commit-status",
  "status": "403"
}
```
it seems that GITHUB_TOKEN has changed the default permission.
According to the document https://docs.github.com/zh/actions/writing-workflows/workflow-syntax-for-github-actions#permissions, I try to set the required permission to fix this problem. 