### PR TITLE
[feature](profile)Enable merging of incomplete profiles.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -246,7 +246,11 @@ public class ExecutionProfile {
                     pipelineIdx++;
                 }
                 RuntimeProfile profileNode = new RuntimeProfile(name);
-                taskProfile.add(profileNode);
+                // The taskprofile is used to save the profile of the pipeline, without
+                // considering the FragmentLevel.
+                if (!(pipelineProfile.isSetIsFragmentLevel() && pipelineProfile.is_fragment_level)) {
+                    taskProfile.add(profileNode);
+                }
                 if (!pipelineProfile.isSetProfile()) {
                     LOG.warn("Profile is not set, {}", DebugUtil.printId(profile.getQueryId()));
                     return new Status(TStatusCode.INVALID_ARGUMENT, "Profile is not set");
@@ -294,7 +298,11 @@ public class ExecutionProfile {
                 pipelineIdx++;
             }
             RuntimeProfile profile = new RuntimeProfile(name);
-            taskProfile.add(profile);
+            // The taskprofile is used to save the profile of the pipeline, without
+            // considering the FragmentLevel.
+            if (!(param.isSetIsFragmentLevel() && param.is_fragment_level)) {
+                taskProfile.add(profile);
+            }
             if (param.isSetProfile()) {
                 profile.update(param.profile);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -117,23 +116,23 @@ public class ExecutionProfile {
             List<List<RuntimeProfile>> allPipelines = Lists.newArrayList();
             int pipelineSize = -1;
             for (TNetworkAddress beAddress : multiPipeline.keySet()) {
-                List<RuntimeProfile> ProfileSingleBE = multiPipeline.get(beAddress);
+                List<RuntimeProfile> profileSingleBE = multiPipeline.get(beAddress);
                 // Check that within the same fragment across all BEs, there should be the same
                 // number of pipelines.
                 if (pipelineSize == -1) {
-                    pipelineSize = ProfileSingleBE.size();
+                    pipelineSize = profileSingleBE.size();
                 } else {
-                    if (pipelineSize != ProfileSingleBE.size()) {
+                    if (pipelineSize != profileSingleBE.size()) {
                         LOG.warn("The profile sizes of the two BE are different, {} vs {}", pipelineSize,
-                                ProfileSingleBE.size());
-                        pipelineSize = Math.max(pipelineSize, ProfileSingleBE.size());
+                                profileSingleBE.size());
+                        pipelineSize = Math.max(pipelineSize, profileSingleBE.size());
                     }
                 }
             }
             for (int pipelineIdx = 0; pipelineIdx < pipelineSize; pipelineIdx++) {
                 List<RuntimeProfile> allPipelineTask = new ArrayList<RuntimeProfile>();
-                for (List<RuntimeProfile> ProfileSingleBE : multiPipeline.values()) {
-                    RuntimeProfile pipeline = ProfileSingleBE.get(pipelineIdx);
+                for (List<RuntimeProfile> profileSingleBE : multiPipeline.values()) {
+                    RuntimeProfile pipeline = profileSingleBE.get(pipelineIdx);
                     for (Pair<RuntimeProfile, Boolean> pipelineTaskProfile : pipeline.getChildList()) {
                         allPipelineTask.add(pipelineTaskProfile.first);
                     }


### PR DESCRIPTION
## Proposed changes

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
	at java.util.Objects.checkIndex(Objects.java:359) ~[?:?]
	at java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at org.apache.doris.common.profile.ExecutionProfile.getPipelineAggregatedProfile(ExecutionProfile.java:142) ~[doris-fe.jar:1.2-SNAPSHOT]
```

In the past, we needed to ensure that profiles were complete before merging. Now, this allows incomplete profiles to be merged, with missing profiles being marked in the merged profile.
```
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  0,  avg  0,  max  0,  min  0
                                -  WaitForDependency[SORT_OPERATOR_DEPENDENCY]Time:  avg  15min2sec,  max  15min2sec,  min  15min2sec
                  Pipeline  :  3(miss  profile):
                  Pipeline  :  4(instance_num=48):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (PASSTHROUGH)  (id=-14):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  29.410us,  max  43.336us,  min  
```
The reason for this issue is that there are currently multiple reporting paths for profiles. 
Some paths include an additional FragmentLevel profile, resulting in different profile structures.



<!--Describe your changes.-->

