### PR TITLE
[fix](jdbc catalog) Fix Memory Leak by Enabling Weak References in HikariCP

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -94,6 +94,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 .setConnectionPoolMaxLifeTime(request.connection_pool_max_life_time)
                 .setConnectionPoolKeepAlive(request.connection_pool_keep_alive);
         JdbcDataSource.getDataSource().setCleanupInterval(request.connection_pool_cache_clear_time);
+        System.setProperty("com.zaxxer.hikari.useWeakReferences", "true");
         init(config, request.statement);
         this.jdbcDriverVersion = getJdbcDriverVersion();
     }
@@ -309,7 +310,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                             ds.setKeepaliveTime(config.getConnectionPoolMaxLifeTime() / 5L); // default 6 min
                         }
                         hikariDataSource = ds;
-                        JdbcDataSource.getDataSource().putSource(hikariDataSourceKey, ds);
+                        JdbcDataSource.getDataSource().putSource(hikariDataSourceKey, hikariDataSource);
                         LOG.info("JdbcClient set"
                                 + " ConnectionPoolMinSize = " + config.getConnectionPoolMinSize()
                                 + ", ConnectionPoolMaxSize = " + config.getConnectionPoolMaxSize()

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcDataSource.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcDataSource.java
@@ -59,8 +59,10 @@ public class JdbcDataSource {
     }
 
     public void setCleanupInterval(long interval) {
-        this.cleanupInterval = interval * 1000L;
-        restartCleanupTask();
+        if (this.cleanupInterval != interval * 1000L) {
+            this.cleanupInterval = interval * 1000L;
+            restartCleanupTask();
+        }
     }
 
     private synchronized void restartCleanupTask() {


### PR DESCRIPTION
This PR addresses a memory leak issue caused by FastList objects in HikariCP being retained by ThreadLocal variables, which are not easily garbage collected in long-running JNI threads. To mitigate this, a system property com.zaxxer.hikari.useWeakReferences is set to true, ensuring that WeakReference is used for ThreadLocal objects, allowing the garbage collector to reclaim memory more effectively.
Even though setting this will affect some performance, solving resource leaks is relatively more important
Performance difference before and after setting
Before setting:
10 concurrency 0.02-0.05
100 concurrency 0.18-0.4
After setting:
10 concurrency 0.02-0.07
100 concurrency 0.18-0.7
