### PR TITLE
[fix](nereids)filter estimation for slot=unknown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -345,7 +345,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 double val = statsForRight.maxValue;
                 if (val > statsForLeft.maxValue || val < statsForLeft.minValue) {
                     selectivity = 0.0;
-                } else if (ndv >= 1.0 ){
+                } else if (ndv >= 1.0 ) {
                     selectivity = StatsMathUtil.minNonNaN(1.0, 1.0 / ndv);
                 } else {
                     selectivity = DEFAULT_INEQUALITY_COEFFICIENT;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -345,7 +345,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 double val = statsForRight.maxValue;
                 if (val > statsForLeft.maxValue || val < statsForLeft.minValue) {
                     selectivity = 0.0;
-                } else if (ndv >= 1.0 ) {
+                } else if (ndv >= 1.0) {
                     selectivity = StatsMathUtil.minNonNaN(1.0, 1.0 / ndv);
                 } else {
                     selectivity = DEFAULT_INEQUALITY_COEFFICIENT;


### PR DESCRIPTION
## Proposed changes
detect new pattern: slot=unknown
suppose slot.ndv = 5, slot.row=100
expect filter result row is 20, but in master, the result is 0

Issue Number: close #xxx

<!--Describe your changes.-->

