### PR TITLE
[Fix](compile) Fix compilation failure on gcc

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -953,7 +953,7 @@ public:
             if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
                 output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), out_buf.pos);
             }
-        } catch (std::exception e) {
+        } catch (std::exception& e) {
             return Status::InternalError("Fail to do ZSTD compress due to exception {}", e.what());
         } catch (...) {
             // Do not set compress_failed to release context


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
FAILED: src/util/CMakeFiles/Util.dir/block_compression.cpp.o
ccache /var/local/ldb-toolchain/bin/g++ -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -DBRPC_ENABLE_CPU_PROFILER -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DLIBJVM -DS2_USE_GFLAGS -DS2_USE_GLOG -DUSE_AZURE -DUSE_HADOOP_HDFS -DUSE_JEMALLOC -DUSE_MEM_TRACKER -DUSE_UNWIND -D__STDC_FORMAT_MACROS -I/root/doris/be/src/apache-orc/c++/include -I/root/doris/be/build_release/src/apache-orc/c++/include -I/root/doris/be/build_release/src/clucene/src/shared -I/root/doris/be/src/clucene/src/core -I/root/doris/be/src/clucene/src/shared -I/root/doris/be/src/clucene/src/contribs-lib -I/root/doris/be/src -I/root/doris/be/test -I/usr/lib/jvm/jdk-17.0.2/include -I/usr/lib/jvm/jdk-17.0.2/include/linux -isystem /root/doris/be/../common -isystem /root/doris/be/../gensrc/build -isystem /var/local/thirdparty/installed/include -isystem /var/local/thirdparty/installed/gperftools/include -O3 -DNDEBUG -O3 -O3 -DNDEBUG   -D OS_LINUX -g -Wall -Wextra -Werror -pthread -fstrict-aliasing -fno-omit-frame-pointer -Wnon-virtual-dtor -Wno-unused-parameter -Wno-sign-compare -fdiagnostics-color=always -Wno-nonnull -Wno-stringop-overread -Wno-stringop-overflow -Wno-array-bounds -msse4.2 -mavx2 -std=gnu++20 -MD -MT src/util/CMakeFiles/Util.dir/block_compression.cpp.o -MF src/util/CMakeFiles/Util.dir/block_compression.cpp.o.d -o src/util/CMakeFiles/Util.dir/block_compression.cpp.o -c /root/doris/be/src/util/block_compression.cpp
/root/doris/be/src/util/block_compression.cpp: In member function 'virtual doris::Status doris::ZstdBlockCompression::compress(const std::vector<doris::Slice>&, size_t, doris::faststring*)':
/root/doris/be/src/util/block_compression.cpp:956:33: error: catching polymorphic type 'class std::exception' by value [-Werror=catch-value=]
956 |         } catch (std::exception e) {
    |                                 ^
cc1plus: all warnings being treated as errors
```

introduced by https://github.com/apache/doris/pull/39433
