### PR TITLE
[fix](cloud) Retry `commit_txn` should return ok except 2pc, consistent with local mode

### DIFF
--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -913,15 +913,18 @@ void commit_txn_immediately(
     }
 
     if (txn_info.status() == TxnStatusPB::TXN_STATUS_VISIBLE) {
-        code = MetaServiceCode::TXN_ALREADY_VISIBLE;
         if (request->has_is_2pc() && request->is_2pc()) {
+            code = MetaServiceCode::TXN_ALREADY_VISIBLE;
             ss << "transaction [" << txn_id << "] is already visible, not pre-committed.";
             msg = ss.str();
+            LOG(INFO) << msg;
             response->mutable_txn_info()->CopyFrom(txn_info);
             return;
         }
+        code = MetaServiceCode::OK;
         ss << "transaction is already visible: db_id=" << db_id << " txn_id=" << txn_id;
         msg = ss.str();
+        LOG(INFO) << msg;
         response->mutable_txn_info()->CopyFrom(txn_info);
         return;
     }
@@ -1482,9 +1485,10 @@ void commit_txn_with_sub_txn(const CommitTxnRequest* request, CommitTxnResponse*
     }
 
     if (txn_info.status() == TxnStatusPB::TXN_STATUS_VISIBLE) {
-        code = MetaServiceCode::TXN_ALREADY_VISIBLE;
+        code = MetaServiceCode::OK;
         ss << "transaction is already visible: db_id=" << db_id << " txn_id=" << txn_id;
         msg = ss.str();
+        LOG(INFO) << msg;
         response->mutable_txn_info()->CopyFrom(txn_info);
         return;
     }

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -1574,7 +1574,7 @@ TEST(MetaServiceTest, CommitTxnTest) {
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
-            ASSERT_EQ(res.status().code(), MetaServiceCode::TXN_ALREADY_VISIBLE);
+            ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
             auto found = res.status().msg().find(fmt::format(
                     "transaction is already visible: db_id={} txn_id={}", db_id, txn_id));
             ASSERT_TRUE(found != std::string::npos);
@@ -1813,7 +1813,7 @@ TEST(MetaServiceTest, CommitTxnWithSubTxnTest) {
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::TXN_ALREADY_VISIBLE);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         auto found = res.status().msg().find(
                 fmt::format("transaction is already visible: db_id={} txn_id={}", db_id, txn_id));
         ASSERT_TRUE(found != std::string::npos);


### PR DESCRIPTION
* sometimes, the network error between `meta-service` and fe/be make `commit_txn` timeout, the fe/be will retry to `commit_txn`, `meta-service` should return ok except 2pc

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

