### PR TITLE
[fix](auditlog)Record return row count in audit log for internal query.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -3447,11 +3447,18 @@ public class StmtExecutor {
                         if (batch.getBatch() == null) {
                             continue;
                         }
-                        LOG.debug("Batch size for query {} is {}",
-                                DebugUtil.printId(queryId), batch.getBatch().rows.size());
+                        if (batch.getBatch().getRows() != null) {
+                            context.updateReturnRows(batch.getBatch().getRows().size());
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Batch size for query {} is {}",
+                                        DebugUtil.printId(queryId), batch.getBatch().rows.size());
+                            }
+                        }
                         resultRows.addAll(convertResultBatchToResultRows(batch.getBatch()));
-                        LOG.debug("Result size for query {} is currently {}",
-                                DebugUtil.printId(queryId), batch.getBatch().rows.size());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Result size for query {} is currently {}",
+                                    DebugUtil.printId(queryId), resultRows.size());
+                        }
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Record return row count in audit log for internal query. Before, the returned row count for internal select in audit log is always 0.