### PR TITLE
[feature](statistics)Use workload group to limit statistics io.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2407,9 +2407,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static boolean allow_analyze_statistics_info_polluting_file_cache = true;
 
-    @ConfField
-    public static int cpu_resource_limit_per_analyze_task = 1;
-
     @ConfField(mutable = true)
     public static boolean force_sample_analyze = false; // avoid full analyze for performance reason
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateWorkloadGroupStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateWorkloadGroupStmt.java
@@ -36,11 +36,21 @@ public class CreateWorkloadGroupStmt extends DdlStmt implements NotFallbackInPar
 
     private final String workloadGroupName;
     private final Map<String, String> properties;
+    private final boolean isInternal;
 
     public CreateWorkloadGroupStmt(boolean ifNotExists, String workloadGroupName, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.workloadGroupName = workloadGroupName;
         this.properties = properties;
+        this.isInternal = false;
+    }
+
+    public CreateWorkloadGroupStmt(boolean ifNotExists, String workloadGroupName,
+                                   Map<String, String> properties, boolean isInternal) {
+        this.ifNotExists = ifNotExists;
+        this.workloadGroupName = workloadGroupName;
+        this.properties = properties;
+        this.isInternal = isInternal;
     }
 
     public boolean isIfNotExists() {
@@ -53,6 +63,10 @@ public class CreateWorkloadGroupStmt extends DdlStmt implements NotFallbackInPar
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public boolean isInternal() {
+        return isInternal;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -68,6 +68,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPostProcessable {
 
     public static final String DEFAULT_GROUP_NAME = "normal";
+    public static final String INTERNAL_GROUP_PREFIX = "__internal_wlg_";
 
     public static final Long DEFAULT_GROUP_ID = 1L;
 
@@ -336,7 +337,12 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
                 }
                 throw new DdlException("workload group " + workloadGroupName + " already exist");
             }
-            if (idToWorkloadGroup.size() >= Config.workload_group_max_num) {
+            if (!stmt.isInternal() && workloadGroupName.startsWith(INTERNAL_GROUP_PREFIX)) {
+                throw new DdlException("workload group " + workloadGroupName
+                        + " is preserved for internal use, try another name.");
+            }
+            if (idToWorkloadGroup.size() >= Config.workload_group_max_num
+                    && !workloadGroupName.startsWith(INTERNAL_GROUP_PREFIX)) {
                 throw new DdlException(
                         "workload group number can not be exceed " + Config.workload_group_max_num);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +35,7 @@ public class StatisticConstants {
     public static final String TABLE_STATISTIC_TBL_NAME = "column_statistics";
     public static final String PARTITION_STATISTIC_TBL_NAME = "partition_statistics";
     public static final String HISTOGRAM_TBL_NAME = "histogram_statistics";
+    public static final String STATISTICS_WORKLOAD_GROUP_NAME = WorkloadGroupMgr.INTERNAL_GROUP_PREFIX + "statistics";
 
     public static final int MAX_NAME_LEN = 64;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -205,7 +205,7 @@ public class StatisticsUtil {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         sessionVariable.internalSession = true;
         sessionVariable.setMaxExecMemByte(Config.statistics_sql_mem_limit_in_bytes);
-        sessionVariable.cpuResourceLimit = Config.cpu_resource_limit_per_analyze_task;
+        sessionVariable.setWorkloadGroup(StatisticConstants.STATISTICS_WORKLOAD_GROUP_NAME);
         sessionVariable.setEnableInsertStrict(true);
         sessionVariable.setInsertMaxFilterRatio(1.0);
         sessionVariable.enablePageCache = false;

--- a/regression-test/suites/statistics/test_statistics_workload_group.groovy
+++ b/regression-test/suites/statistics/test_statistics_workload_group.groovy
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_statistics_workload_group") {
+
+    def result = sql """show workload groups like '__internal_wlg_statistics'"""
+    for (int i = 0; i < 300; i++) {
+        if (result.size() == 1) {
+            break;
+        }
+        if (result.size() > 1) {
+            throw new RuntimeException("Found more than 1 __internal_wlg_statistics.")
+        }
+        result = sql """show workload groups like '__internal_wlg_statistics'"""
+    }
+    assertEquals(result.size(), 1)
+    assertEquals(result[0][15], "100000000")
+
+    sql """alter workload group __internal_wlg_statistics properties ("read_bytes_per_second"="1222");"""
+    result = sql """show workload groups like '__internal_wlg_statistics'"""
+    assertEquals(result.size(), 1)
+    assertEquals(result[0][15], "1222")
+
+    sql """alter workload group __internal_wlg_statistics properties ("read_bytes_per_second"="100000000");"""
+    result = sql """show workload groups like '__internal_wlg_statistics'"""
+    assertEquals(result.size(), 1)
+    assertEquals(result[0][15], "100000000")
+
+}
+


### PR DESCRIPTION
Use workload group to limit statistics io. This is mainly for partition stats collection, avoid using too much IO resource.