### PR TITLE
[bugfix](iceberg)Restrictions on creating a database

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergGlueExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergGlueExternalCatalog.java
@@ -58,7 +58,7 @@ public class IcebergGlueExternalCatalog extends IcebergExternalCatalog {
                 catalogProperties.get(S3Properties.Env.ENDPOINT));
         catalogProperties.putIfAbsent(S3FileIOProperties.ENDPOINT, endpoint);
 
-        glueCatalog.initialize(icebergCatalogType, catalogProperties);
+        glueCatalog.initialize(getName(), catalogProperties);
         catalog = glueCatalog;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
@@ -44,7 +44,7 @@ public class IcebergHMSExternalCatalog extends IcebergExternalCatalog {
         Map<String, String> catalogProperties = catalogProperty.getProperties();
         String metastoreUris = catalogProperty.getOrDefault(HMSProperties.HIVE_METASTORE_URIS, "");
         catalogProperties.put(CatalogProperties.URI, metastoreUris);
-        hiveCatalog.initialize(icebergCatalogType, catalogProperties);
+        hiveCatalog.initialize(getName(), catalogProperties);
         catalog = hiveCatalog;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
@@ -60,7 +60,7 @@ public class IcebergHadoopExternalCatalog extends IcebergExternalCatalog {
         String warehouse = catalogProperty.getHadoopProperties().get(CatalogProperties.WAREHOUSE_LOCATION);
         hadoopCatalog.setConf(conf);
         catalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);
-        hadoopCatalog.initialize(icebergCatalogType, catalogProperties);
+        hadoopCatalog.initialize(getName(), catalogProperties);
         catalog = hadoopCatalog;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -107,6 +107,11 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
                 ErrorReport.reportDdlException(ErrorCode.ERR_DB_CREATE_EXISTS, dbName);
             }
         }
+        String icebergCatalogType = dorisCatalog.getIcebergCatalogType();
+        if (!IcebergExternalCatalog.ICEBERG_HMS.equals(icebergCatalogType)) {
+            throw new DdlException(
+                "Not supported: create database with properties for iceberg catalog type: " + icebergCatalogType);
+        }
         nsCatalog.createNamespace(Namespace.of(dbName), properties);
         dorisCatalog.onRefreshCache(true);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -108,7 +108,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
             }
         }
         String icebergCatalogType = dorisCatalog.getIcebergCatalogType();
-        if (!IcebergExternalCatalog.ICEBERG_HMS.equals(icebergCatalogType)) {
+        if (!properties.isEmpty() && !IcebergExternalCatalog.ICEBERG_HMS.equals(icebergCatalogType)) {
             throw new DdlException(
                 "Not supported: create database with properties for iceberg catalog type: " + icebergCatalogType);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergRestExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergRestExternalCatalog.java
@@ -47,7 +47,7 @@ public class IcebergRestExternalCatalog extends IcebergExternalCatalog {
 
         Configuration conf = replaceS3Properties(getConfiguration());
 
-        catalog = CatalogUtil.buildIcebergCatalog(icebergCatalogType,
+        catalog = CatalogUtil.buildIcebergCatalog(getName(),
                 convertToRestCatalogProperties(),
                 conf);
     }


### PR DESCRIPTION
## Proposed changes

1. Restrictions on creating a database. 
Currently, only attributes of the `hms` type of database can be added.
Like:
```
create database db properties ('a'='b');
```
2. Unify the catalog name of iceberg and doris to be the same.

