### PR TITLE
[Bug](compatibility) fix window funnel function coredump when upgrade

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
@@ -59,9 +59,9 @@ private:
     AggregateFunctions aggregate_functions;
     AggregateFunctions nullable_aggregate_functions;
     std::unordered_map<std::string, std::string> function_alias;
-    /// @TEMPORARY: for be_exec_version=2
-    /// in order to solve agg of sum/count is not compatibility during the upgrade process
-    constexpr static int AGG_FUNCTION_NEW = 2;
+    /// @TEMPORARY: for be_exec_version=5
+    /// in order to solve agg function is not compatibility during the upgrade process
+    constexpr static int AGG_FUNCTION_NEW = 5;
     /// @TEMPORARY: for be_exec_version < AGG_FUNCTION_NEW. replace function to old version.
     std::unordered_map<std::string, std::string> function_to_replace;
 


### PR DESCRIPTION
## Proposed changes
this PR  https://github.com/apache/doris/pull/39270 have change the agg of window funnel
and max_be_exec_version is update to 5, in order to compatibility of the agg function when upgrade.

<!--Describe your changes.-->

