### PR TITLE
[fix](hudi) fix hudi count bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
@@ -63,6 +63,7 @@ import org.apache.doris.nereids.trees.plans.algebra.Project;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalHudiScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
@@ -761,9 +762,9 @@ public class AggregateStrategies implements ImplementationRuleFactory {
             }
 
         } else if (logicalScan instanceof LogicalFileScan) {
-            PhysicalFileScan physicalScan = (PhysicalFileScan) new LogicalFileScanToPhysicalFileScan()
-                    .build()
-                    .transform(logicalScan, cascadesContext)
+            Rule rule = (logicalScan instanceof LogicalHudiScan) ? new LogicalHudiScanToPhysicalHudiScan().build()
+                    : new LogicalFileScanToPhysicalFileScan().build();
+            PhysicalFileScan physicalScan = (PhysicalFileScan) rule.transform(logicalScan, cascadesContext)
                     .get(0);
             if (project != null) {
                 return aggregate.withChildren(ImmutableList.of(


### PR DESCRIPTION
## Proposed changes
bug:
```sql
SET enable_nereids_planner=true;
SET enable_fallback_to_original_planner=false;
explain select count(1) from hudi_table;
```
The new optimizer return the error message "do not support DLA type HUDI".
The reason for the bug is that the LogicalHudiScan is not considered in AggregateStrategies.

Related pr: https://github.com/apache/doris/pull/36187
<!--Describe your changes.-->

