### PR TITLE
[fix](Nereids) fix insert into table with null literal default value (#39122)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -920,11 +920,15 @@ public class NativeInsertStmt extends InsertStmt {
             Column col = targetColumns.get(i);
 
             if (expr instanceof DefaultValueExpr) {
-                if (targetColumns.get(i).getDefaultValue() == null) {
+                if (targetColumns.get(i).getDefaultValue() == null && !targetColumns.get(i).isAllowNull()) {
                     throw new AnalysisException("Column has no default value, column="
                             + targetColumns.get(i).getName());
                 }
-                expr = new StringLiteral(targetColumns.get(i).getDefaultValue());
+                if (targetColumns.get(i).getDefaultValue() == null) {
+                    expr = new NullLiteral();
+                } else {
+                    expr = new StringLiteral(targetColumns.get(i).getDefaultValue());
+                }
             }
             if (expr instanceof Subquery) {
                 throw new AnalysisException("Insert values can not be query");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -498,6 +498,9 @@ public class Column implements Writable, GsonPostProcessable {
     }
 
     public Expr getDefaultValueExpr() throws AnalysisException {
+        if (defaultValue == null) {
+            return null;
+        }
         StringLiteral defaultValueLiteral = new StringLiteral(defaultValue);
         if (getDataType() == PrimitiveType.VARCHAR) {
             return defaultValueLiteral;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -344,7 +344,7 @@ public class BindSink implements AnalysisRuleFactory {
                 } else if (column.getDefaultValue() == null) {
                     // throw exception if explicitly use Default value but no default value present
                     // insert into table t values(DEFAULT)
-                    if (columnToChildOutput.get(column) instanceof DefaultValueSlot) {
+                    if (columnToChildOutput.get(column) instanceof DefaultValueSlot && !column.isAllowNull()) {
                         throw new AnalysisException("Column has no default value,"
                                 + " column=" + column.getName());
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -397,7 +397,9 @@ public class InsertUtils {
     private static NamedExpression generateDefaultExpression(Column column) {
         try {
             if (column.getDefaultValue() == null) {
-                throw new AnalysisException("Column has no default value, column=" + column.getName());
+                if (!column.isAllowNull()) {
+                    throw new AnalysisException("Column has no default value, column=" + column.getName());
+                }
             }
             if (column.getDefaultValueExpr() != null) {
                 Expression defualtValueExpression = new NereidsParser().parseExpression(


### PR DESCRIPTION
cherry-pick: #39122

Problem:
when use insert with default value null, it can not be insert successfully
Solved:
when column is allow to be null, it can be null in create table with null default value

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

