### PR TITLE
[feature-WIP](query cache) cache tablets aggregate result, FE part

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -30,6 +30,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.ToSqlContext;
+import org.apache.doris.planner.normalize.Normalizer;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
@@ -351,6 +352,17 @@ public class SlotRef extends Expr {
         msg.slot_ref = new TSlotRef(desc.getId().asInt(), desc.getParent().getId().asInt());
         msg.slot_ref.setColUniqueId(desc.getUniqueId());
         msg.setLabel(label);
+    }
+
+    @Override
+    protected void normalize(TExprNode msg, Normalizer normalizer) {
+        msg.node_type = TExprNodeType.SLOT_REF;
+        // we should eliminate the different tuple id to reuse query cache
+        msg.slot_ref = new TSlotRef(
+                normalizer.normalizeSlotId(desc.getId().asInt()),
+                0
+        );
+        msg.slot_ref.setColUniqueId(desc.getUniqueId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -155,6 +155,32 @@ public class FunctionSet<T> {
                     .put(Type.DECIMAL128, Type.DECIMAL128)
                     .build();
 
+    public static final Set<String> nonDeterministicFunctions =
+            ImmutableSet.<String>builder()
+                    .add("RAND")
+                    .add("RANDOM")
+                    .add("RANDOM_BYTES")
+                    .add("CONNECTION_ID")
+                    .add("DATABASE")
+                    .add("USER")
+                    .add("UUID")
+                    .add("CURRENT_USER")
+                    .add("UUID_NUMERIC")
+                    .build();
+
+    public static final Set<String> nonDeterministicTimeFunctions =
+            ImmutableSet.<String>builder()
+                    .add("NOW")
+                    .add("CURDATE")
+                    .add("CURRENT_DATE")
+                    .add("UTC_TIMESTAMP")
+                    .add("CURTIME")
+                    .add("CURRENT_TIMESTAMP")
+                    .add("CURRENT_TIME")
+                    .add("UNIX_TIMESTAMP")
+                    .add()
+                    .build();
+
     private static final Map<Type, String> STDDEV_UPDATE_SYMBOL =
             ImmutableMap.<Type, String>builder()
                 .put(Type.TINYINT,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Range;
 import java.io.DataInput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,21 @@ public class RangePartitionInfo extends PartitionInfo {
         if (exprs != null) {
             this.partitionExprs.addAll(exprs);
         }
+    }
+
+    public Map<Long, PartitionItem> getPartitionItems(Collection<Long> partitionIds) {
+        Map<Long, PartitionItem> columnRanges = Maps.newLinkedHashMapWithExpectedSize(partitionIds.size());
+        for (Long partitionId : partitionIds) {
+            PartitionItem partitionItem = idToItem.get(partitionId);
+            if (partitionItem == null) {
+                partitionItem = idToTempItem.get(partitionId);
+            }
+            if (partitionItem == null) {
+                throw new IllegalStateException("Can not found partition item: " + partitionId);
+            }
+            columnRanges.put(partitionId, partitionItem);
+        }
+        return columnRanges;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -327,6 +327,71 @@ public class Utils {
                 ).collect(ImmutableList.toImmutableList());
     }
 
+    /** getAllCombinations */
+    public static <T> List<List<T>> getAllCombinations(List<T> list, int itemNum) {
+        List<List<T>> result = Lists.newArrayList();
+        generateCombinations(list, itemNum, 0, Lists.newArrayList(), result);
+        return result;
+    }
+
+    private static <T> void generateCombinations(
+            List<T> list, int n, int start, List<T> current, List<List<T>> result) {
+        if (current.size() == n) {
+            result.add(new ArrayList<>(current));
+            return;
+        }
+
+        for (int i = start; i < list.size(); i++) {
+            current.add(list.get(i));
+            generateCombinations(list, n, i + 1, current, result);
+            current.remove(current.size() - 1);
+        }
+    }
+
+    public static <T> List<List<T>> allPermutations(List<T> list) {
+        List<List<T>> result = new ArrayList<>();
+        generatePermutations(new ArrayList<>(list), new ArrayList<>(), result);
+        return result;
+    }
+
+    private static <T> void generatePermutations(List<T> list, List<T> current, List<List<T>> result) {
+        if (!current.isEmpty()) {
+            result.add(new ArrayList<>(current));
+        }
+
+        for (int i = 0; i < list.size(); i++) {
+            T element = list.remove(i);
+            current.add(element);
+            generatePermutations(list, current, result);
+            current.remove(current.size() - 1);
+            list.add(i, element);
+        }
+    }
+
+    /** permutations */
+    public static <T> List<List<T>> permutations(List<T> list) {
+        list = new ArrayList<>(list);
+        List<List<T>> result = new ArrayList<>();
+        if (list.isEmpty()) {
+            result.add(new ArrayList<>());
+            return result;
+        }
+
+        T firstElement = list.get(0);
+        List<T> rest = list.subList(1, list.size());
+        List<List<T>> recursivePermutations = permutations(rest);
+
+        for (List<T> smallerPermutated : recursivePermutations) {
+            for (int index = 0; index <= smallerPermutated.size(); index++) {
+                List<T> temp = new ArrayList<>(smallerPermutated);
+                temp.add(index, firstElement);
+                result.add(temp);
+            }
+        }
+
+        return result;
+    }
+
     public static <T> List<T> copyRequiredList(List<T> list) {
         return ImmutableList.copyOf(Objects.requireNonNull(list, "non-null list is required"));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -33,11 +33,13 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TPartitionType;
 import org.apache.doris.thrift.TPlanFragment;
+import org.apache.doris.thrift.TQueryCacheParam;
 import org.apache.doris.thrift.TResultSinkType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -158,6 +160,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCAL;
 
     public Optional<NereidsSpecifyInstances<ScanSource>> specifyInstances = Optional.empty();
+
+    public TQueryCacheParam queryCacheParam;
 
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
@@ -350,6 +354,13 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         str.append("\n");
         str.append("  PARTITION: " + dataPartition.getExplainString(explainLevel) + "\n");
         str.append("  HAS_COLO_PLAN_NODE: " + hasColocatePlanNode + "\n");
+        if (queryCacheParam != null) {
+            str.append("\n");
+            str.append("  QUERY_CACHE:\n");
+            str.append("    CACHE_NODE_ID: " + queryCacheParam.getNodeId() + "\n");
+            str.append("    DIGEST: " + Hex.encodeHexString(queryCacheParam.getDigest()) + "\n");
+        }
+
         str.append("\n");
         if (sink != null) {
             str.append(sink.getExplainString("  ", explainLevel) + "\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/NormalizedPartitionPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/NormalizedPartitionPredicates.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner.normalize;
+
+import org.apache.doris.analysis.Expr;
+
+import java.util.List;
+import java.util.Map;
+
+/** NormalizedPartitionPredicates */
+public class NormalizedPartitionPredicates {
+    // the predicates which can not compute intersect range with the partitions
+    // case 1: no partition columns, say `non_partition_column = 1`
+    // case 2: partition column compute with non partition column, say `non_partition_column + partition_column = 1`
+    // case 3: the partition predicate contains some function which currently not supported convert to range,
+    //         say `date(partition_column) = '2024-08-14'`
+    public final List<Expr> remainedPredicates;
+
+    // the partitionId to partition range string,
+    // for example:
+    //   partitions is:
+    //     P1 values [('2024-08-01'), ('2024-08-10')), the partition id is 10001
+    //     P2 values [('2024-08-10'), ('2024-08-20')), the partition id is 10002
+    //
+    //   predicate is: part_column between '2024-08-08' and '2024-08-12'
+    //
+    //   the intersectPartitionRanges like is:
+    //   {
+    //     10001: "[('2024-08-08'), ('2024-08-10'))",
+    //     10002: "[('2024-08-10'), ('2024-08-13'))"
+    //   }
+    //
+    //   we should normalize the intersect range to closeOpened range to maintain the same format
+    public final Map<Long, String> intersectPartitionRanges;
+
+    public NormalizedPartitionPredicates(
+            List<Expr> remainedPredicates, Map<Long, String> intersectPartitionRanges) {
+        this.remainedPredicates = remainedPredicates;
+        this.intersectPartitionRanges = intersectPartitionRanges;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/Normalizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/Normalizer.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/apache/impala/blob/branch-2.9.0/fe/src/main/java/org/apache/impala/PlanFragment.java
+// and modified by Doris
+
+
+package org.apache.doris.planner.normalize;
+
+import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.planner.OlapScanNode;
+
+/** Normalizer */
+public interface Normalizer {
+    int normalizeSlotId(int slotId);
+
+    void setSlotIdToNormalizeId(int slotId, int normalizedId);
+
+    int normalizeTupleId(int tupleId);
+
+    int normalizePlanId(int planId);
+
+    DescriptorTable getDescriptorTable();
+
+    void setNormalizedPartitionPredicates(OlapScanNode olapScanNode, NormalizedPartitionPredicates predicates);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/PartitionRangePredicateNormalizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/PartitionRangePredicateNormalizer.java
@@ -1,0 +1,220 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/apache/impala/blob/branch-2.9.0/fe/src/main/java/org/apache/impala/PlanFragment.java
+// and modified by Doris
+
+package org.apache.doris.planner.normalize;
+
+import org.apache.doris.analysis.CompoundPredicate;
+import org.apache.doris.analysis.CompoundPredicate.Operator;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotId;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.RangePartitionInfo;
+import org.apache.doris.common.Pair;
+import org.apache.doris.planner.OlapScanNode;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** PartitionRangePredicateNormalizer */
+public class PartitionRangePredicateNormalizer {
+    private final Normalizer normalizer;
+    private final OlapScanNode olapScanNode;
+
+    public PartitionRangePredicateNormalizer(Normalizer normalizer, OlapScanNode olapScanNode) {
+        this.normalizer = Objects.requireNonNull(normalizer, "normalizer can not be null");
+        this.olapScanNode = Objects.requireNonNull(olapScanNode, "olapScanNode can not be null");
+    }
+
+    public List<Expr> normalize() {
+        NormalizedPartitionPredicates predicates = normalizePredicates();
+        normalizer.setNormalizedPartitionPredicates(olapScanNode, predicates);
+        return predicates.remainedPredicates;
+    }
+
+    private NormalizedPartitionPredicates normalizePredicates() {
+        OlapTable olapTable = olapScanNode.getOlapTable();
+        List<Column> partitionColumns = olapTable.getPartitionColumns();
+
+        if (partitionColumns.isEmpty()) {
+            return cannotIntersectPartitionRange();
+        }
+
+        if (partitionColumns.size() > 1) {
+            return cannotIntersectPartitionRange();
+        }
+
+        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        if (partitionInfo.getType() != PartitionType.RANGE) {
+            return cannotIntersectPartitionRange();
+        }
+
+        return normalizeSingleRangePartitionColumnPredicates(
+                partitionColumns.get(0), (RangePartitionInfo) partitionInfo);
+    }
+
+    private NormalizedPartitionPredicates normalizeSingleRangePartitionColumnPredicates(
+            Column partitionColumn, RangePartitionInfo rangePartitionInfo) {
+
+        List<Pair<Long, RangeSet<PartitionKey>>> partitionItemRanges
+                = rangePartitionInfo.getPartitionItems(olapScanNode.getSelectedPartitionIds())
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    RangeSet<PartitionKey> rangeSet = TreeRangeSet.create();
+                    rangeSet.add(entry.getValue().getItems());
+                    return Pair.of(entry.getKey(), rangeSet);
+                })
+                .collect(Collectors.toList());
+
+        List<Expr> conjuncts = extractConjuncts(olapScanNode.getConjuncts());
+
+        ToRangePredicatesExtractor extractor = ToRangePredicatesExtractor.extract(
+                conjuncts, olapScanNode, partitionColumn);
+
+        PredicateToRange predicateToRange = new PredicateToRange(partitionColumn);
+
+        for (Expr partitionPredicate : extractor.supportedToRangePredicates) {
+            RangeSet<PartitionKey> predicateRanges = predicateToRange.exprToRange(partitionPredicate);
+            partitionItemRanges = partitionItemRanges.stream()
+                    .map(kv -> {
+                        RangeSet<PartitionKey> partitionRangeSet = kv.second;
+                        RangeSet<PartitionKey> intersect = TreeRangeSet.create();
+                        for (Range<PartitionKey> predicateRange : predicateRanges.asRanges()) {
+                            intersect.addAll(partitionRangeSet.subRangeSet(predicateRange));
+                        }
+                        return Pair.of(kv.first, intersect);
+                    }).filter(kv -> !kv.second.isEmpty())
+                    .collect(Collectors.toList());
+        }
+
+        Map<Long, String> partitionToIntersectRange = partitionItemRanges.stream()
+                .map(pair -> Pair.of(pair.first, normalizeRangeSet(pair.second).toString()))
+                .collect(Collectors.toMap(Pair::key, Pair::value));
+
+        return new NormalizedPartitionPredicates(extractor.notSupportedToRangePredicates, partitionToIntersectRange);
+    }
+
+    private RangeSet<PartitionKey> normalizeRangeSet(RangeSet<PartitionKey> rangeSet) {
+        // normalize range to closeOpened range, the between predicate and less than predicate
+        // maybe reuse the same cache to save memory
+        RangeSet<PartitionKey> normalized = TreeRangeSet.create();
+        for (Range<PartitionKey> range : rangeSet.asRanges()) {
+            PartitionKey lowerEndpoint = range.lowerEndpoint();
+            PartitionKey upperEndpoint = range.upperEndpoint();
+
+            try {
+                if (!lowerEndpoint.isMinValue() && !range.contains(lowerEndpoint)) {
+                    lowerEndpoint = lowerEndpoint.successor();
+                }
+                if (!upperEndpoint.isMaxValue() && range.contains(upperEndpoint)) {
+                    upperEndpoint = upperEndpoint.successor();
+                }
+                normalized.add(Range.closedOpen(lowerEndpoint, upperEndpoint));
+            } catch (Throwable t) {
+                throw new IllegalStateException("Can not normalize range: " + t.getMessage(), t);
+            }
+        }
+        return normalized;
+    }
+
+    private NormalizedPartitionPredicates cannotIntersectPartitionRange() {
+        return new NormalizedPartitionPredicates(
+                // conjuncts will be used as the part of the digest
+                olapScanNode.getConjuncts(),
+                // can not compute intersect range
+                ImmutableMap.of(olapScanNode.getSelectedPartitionIds().iterator().next(), "")
+        );
+    }
+
+    private List<Expr> extractConjuncts(List<Expr> conjuncts) {
+        List<Expr> flattenedConjuncts = Lists.newArrayListWithCapacity(conjuncts.size());
+        for (Expr conjunct : conjuncts) {
+            boolean findChildren = true;
+            conjunct.foreachDown(expr -> {
+                if (expr instanceof CompoundPredicate && ((CompoundPredicate) expr).getOp() == Operator.AND) {
+                    return findChildren;
+                } else {
+                    flattenedConjuncts.add((Expr) expr);
+                    return !findChildren;
+                }
+            });
+        }
+        return flattenedConjuncts;
+    }
+
+    private static class ToRangePredicatesExtractor {
+        public final List<Expr> supportedToRangePredicates;
+        public final List<Expr> notSupportedToRangePredicates;
+
+        private ToRangePredicatesExtractor(
+                List<Expr> simplePartitionPredicates, List<Expr> notSupportedToRangePredicates) {
+            this.supportedToRangePredicates = simplePartitionPredicates;
+            this.notSupportedToRangePredicates = notSupportedToRangePredicates;
+        }
+
+        public static ToRangePredicatesExtractor extract(
+                List<Expr> conjuncts, OlapScanNode olapScanNode, Column partitionColumn) {
+            List<Expr> supportedPartitionPredicates = Lists.newArrayList();
+            List<Expr> otherPredicates = Lists.newArrayList();
+
+            Optional<SlotId> optPartitionId = findPartitionColumnSlotId(olapScanNode, partitionColumn);
+
+            for (Expr conjunct : conjuncts) {
+                if (optPartitionId.isPresent()
+                        && conjunct.isBound(optPartitionId.get())
+                        && PredicateToRange.supportedToRange(conjunct)) {
+                    supportedPartitionPredicates.add(conjunct);
+                } else {
+                    otherPredicates.add(conjunct);
+                }
+            }
+
+            return new ToRangePredicatesExtractor(supportedPartitionPredicates, otherPredicates);
+        }
+
+        private static Optional<SlotId> findPartitionColumnSlotId(OlapScanNode olapScanNode, Column partitionColumn) {
+            if (partitionColumn == null) {
+                return Optional.empty();
+            }
+
+            for (SlotDescriptor slot : olapScanNode.getTupleDesc().getSlots()) {
+                Column column = slot.getColumn();
+                if (column.getName().equalsIgnoreCase(partitionColumn.getName())) {
+                    return Optional.of(slot.getId());
+                }
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/PredicateToRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/PredicateToRange.java
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner.normalize;
+
+import org.apache.doris.analysis.BetweenPredicate;
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.BinaryPredicate.Operator;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.InPredicate;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.PartitionKey;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+
+/** PredicateToRange */
+public class PredicateToRange {
+    private final Column partitionColumn;
+    private final PartitionKey minKey;
+    private final PartitionKey maxKey;
+
+    public PredicateToRange(Column partitionColumn) {
+        this.partitionColumn = partitionColumn;
+
+        try {
+            minKey = PartitionKey.createInfinityPartitionKey(ImmutableList.of(partitionColumn), false);
+            maxKey = PartitionKey.createInfinityPartitionKey(ImmutableList.of(partitionColumn), true);
+        } catch (Throwable t) {
+            throw new IllegalStateException(
+                    "Can not create min/max partition key by the column: " + partitionColumn, t);
+        }
+    }
+
+    /** supportedPartitionPredicate */
+    public static boolean supportedToRange(Expr conjunct) {
+        if (conjunct instanceof BinaryPredicate) {
+            BinaryPredicate binaryPredicate = (BinaryPredicate) conjunct;
+            switch (binaryPredicate.getOp()) {
+                case EQ:
+                case LT:
+                case LE:
+                case GT:
+                case GE:
+                case NE:
+                    break;
+                default:
+                    return false;
+            }
+            return conjunct.getChild(0) instanceof SlotRef && conjunct.getChild(1) instanceof LiteralExpr;
+        } else if (conjunct instanceof BetweenPredicate) {
+            return conjunct.getChild(0) instanceof SlotRef
+                    && conjunct.getChild(1) instanceof LiteralExpr
+                    && conjunct.getChild(2) instanceof LiteralExpr;
+        } else if (conjunct instanceof InPredicate) {
+            if (!(conjunct.getChild(0) instanceof SlotRef)) {
+                return false;
+            }
+            for (int i = 1; i < conjunct.getChildren().size(); i++) {
+                if (!(conjunct.getChild(i) instanceof LiteralExpr)) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** exprToRange */
+    public RangeSet<PartitionKey> exprToRange(Expr predicate) {
+        if (predicate instanceof BinaryPredicate) {
+            return compareToRangeSet((BinaryPredicate) predicate);
+        } else if (predicate instanceof BetweenPredicate) {
+            return betweenToRange((BetweenPredicate) predicate);
+        } else if (predicate instanceof InPredicate) {
+            return inToRange((InPredicate) predicate);
+        } else {
+            throw new IllegalStateException("Unsupported to Range: " + predicate);
+        }
+    }
+
+    private RangeSet<PartitionKey> compareToRangeSet(BinaryPredicate predicate) {
+        Operator op = predicate.getOp();
+        Expr rightChild = predicate.getChild(1);
+        PartitionKey rightPartitionKey = toPartitionKey(rightChild);
+
+        TreeRangeSet<PartitionKey> rangeSet = TreeRangeSet.create();
+        switch (op) {
+            case EQ:
+                rangeSet.add(Range.closed(rightPartitionKey, rightPartitionKey));
+                break;
+            case NE:
+                rangeSet.add(Range.open(minKey, rightPartitionKey));
+                rangeSet.add(Range.open(rightPartitionKey, maxKey));
+                break;
+            case LT:
+                rangeSet.add(Range.open(minKey, rightPartitionKey));
+                break;
+            case LE:
+                rangeSet.add(Range.openClosed(minKey, rightPartitionKey));
+                break;
+            case GT:
+                rangeSet.add(Range.open(rightPartitionKey, maxKey));
+                break;
+            case GE:
+                rangeSet.add(Range.closedOpen(rightPartitionKey, maxKey));
+                break;
+            default:
+        }
+        return rangeSet;
+    }
+
+    private RangeSet<PartitionKey> betweenToRange(BetweenPredicate predicate) {
+        PartitionKey lowerBound = toPartitionKey(predicate.getChild(0));
+        PartitionKey upperBound = toPartitionKey(predicate.getChild(1));
+        TreeRangeSet<PartitionKey> rangeSet = TreeRangeSet.create();
+        if (predicate.isNotBetween()) {
+            rangeSet.add(Range.open(minKey, lowerBound));
+            rangeSet.add(Range.open(upperBound, maxKey));
+        } else {
+            rangeSet.add(Range.closed(lowerBound, upperBound));
+        }
+        return rangeSet;
+    }
+
+    private RangeSet<PartitionKey> inToRange(InPredicate predicate) {
+        boolean isNotIn = predicate.isNotIn();
+        RangeSet<PartitionKey> rangeSet = TreeRangeSet.create();
+        for (Expr item : predicate.getListChildren()) {
+            PartitionKey itemKey = toPartitionKey(item);
+            if (isNotIn) {
+                RangeSet<PartitionKey> completeRangeSet = TreeRangeSet.create();
+                completeRangeSet.add(Range.open(minKey, itemKey));
+                completeRangeSet.add(Range.open(itemKey, maxKey));
+
+                RangeSet<PartitionKey> intersect = TreeRangeSet.create();
+                for (Range<PartitionKey> completeRange : completeRangeSet.asRanges()) {
+                    intersect.addAll(rangeSet.subRangeSet(completeRange));
+                }
+                rangeSet = intersect;
+            } else {
+                rangeSet.add(Range.closed(itemKey, itemKey));
+            }
+        }
+
+        if (isNotIn) {
+            rangeSet = rangeSet.complement();
+        }
+        return rangeSet;
+    }
+
+    private PartitionKey toPartitionKey(Expr expr) {
+        // try to cast to literal, if wrong, query cache will be skipped
+        LiteralExpr literalExpr = (LiteralExpr) expr;
+        PartitionKey partitionKey = new PartitionKey();
+        partitionKey.pushColumn(literalExpr, partitionColumn.getDataType());
+        return partitionKey;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/QueryCacheNormalizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/QueryCacheNormalizer.java
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/apache/impala/blob/branch-2.9.0/fe/src/main/java/org/apache/impala/PlanFragment.java
+// and modified by Doris
+
+package org.apache.doris.planner.normalize;
+
+import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Tablet;
+import org.apache.doris.common.Pair;
+import org.apache.doris.planner.AggregationNode;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.planner.PlanNode;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.thrift.TNormalizedPlanNode;
+import org.apache.doris.thrift.TQueryCacheParam;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TCompactProtocol;
+
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/** QueryCacheNormalizer */
+public class QueryCacheNormalizer implements Normalizer {
+    private final PlanFragment fragment;
+    private final DescriptorTable descriptorTable;
+    private final NormalizedIdGenerator normalizedPlanIds =  new NormalizedIdGenerator();
+    private final NormalizedIdGenerator normalizedTupleIds =  new NormalizedIdGenerator();
+    private final NormalizedIdGenerator normalizedSlotIds =  new NormalizedIdGenerator();
+
+    // result
+    private final TQueryCacheParam queryCacheParam = new TQueryCacheParam();
+
+    public QueryCacheNormalizer(PlanFragment fragment, DescriptorTable descriptorTable) {
+        this.fragment = Objects.requireNonNull(fragment, "fragment can not be null");
+        this.descriptorTable = Objects.requireNonNull(descriptorTable, "descriptorTable can not be null");
+    }
+
+    public Optional<TQueryCacheParam> normalize(ConnectContext context) {
+        try {
+            Optional<CachePoint> cachePoint = computeCachePoint();
+            if (!cachePoint.isPresent()) {
+                return Optional.empty();
+            }
+            List<TNormalizedPlanNode> normalizedDigestPlans = normalizePlanTree(context, cachePoint.get());
+            byte[] digest = computeDigest(normalizedDigestPlans);
+            return setQueryCacheParam(cachePoint.get(), digest, context);
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    @VisibleForTesting
+    public List<TNormalizedPlanNode> normalizePlans(ConnectContext context) {
+        Optional<CachePoint> cachePoint = computeCachePoint();
+        if (!cachePoint.isPresent()) {
+            return ImmutableList.of();
+        }
+        return normalizePlanTree(context, cachePoint.get());
+    }
+
+    private Optional<TQueryCacheParam> setQueryCacheParam(
+            CachePoint cachePoint, byte[] digest, ConnectContext context) {
+        queryCacheParam.setNodeId(cachePoint.cacheRoot.getId().asInt());
+        queryCacheParam.setDigest(digest);
+        queryCacheParam.setForceRefreshQueryCache(context.getSessionVariable().isQueryCacheForceRefresh());
+        queryCacheParam.setEntryMaxBytes(context.getSessionVariable().getQueryCacheEntryMaxBytes());
+        queryCacheParam.setEntryMaxRows(context.getSessionVariable().getQueryCacheEntryMaxRows());
+
+        queryCacheParam.setOutputSlotMapping(
+                cachePoint.cacheRoot.getOutputTupleIds()
+                    .stream()
+                    .flatMap(tupleId -> descriptorTable.getTupleDesc(tupleId).getSlots().stream())
+                    .map(slot -> {
+                        int slotId = slot.getId().asInt();
+                        return Pair.of(slotId, normalizeSlotId(slotId));
+                    })
+                    .collect(Collectors.toMap(Pair::key, Pair::value))
+        );
+
+        return Optional.of(queryCacheParam);
+    }
+
+    private Optional<CachePoint> computeCachePoint() {
+        if (!fragment.getTargetRuntimeFilterIds().isEmpty()) {
+            return Optional.empty();
+        }
+        PlanNode planRoot = fragment.getPlanRoot();
+        return doComputeCachePoint(planRoot);
+    }
+
+    private Optional<CachePoint> doComputeCachePoint(PlanNode planRoot) {
+        if (planRoot instanceof AggregationNode) {
+            PlanNode child = planRoot.getChild(0);
+            if (child instanceof OlapScanNode) {
+                return Optional.of(new CachePoint(planRoot, planRoot));
+            } else if (child instanceof AggregationNode) {
+                Optional<CachePoint> childCachePoint = doComputeCachePoint(child);
+                if (childCachePoint.isPresent()) {
+                    return Optional.of(new CachePoint(planRoot, planRoot));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<TNormalizedPlanNode> normalizePlanTree(ConnectContext context, CachePoint cachePoint) {
+        List<TNormalizedPlanNode> normalizedPlans = new ArrayList<>();
+        doNormalizePlanTree(context, cachePoint.digestRoot, normalizedPlans);
+        return normalizedPlans;
+    }
+
+    private void doNormalizePlanTree(
+            ConnectContext context, PlanNode plan, List<TNormalizedPlanNode> normalizedPlans) {
+        for (PlanNode child : plan.getChildren()) {
+            doNormalizePlanTree(context, child, normalizedPlans);
+        }
+        normalizedPlans.add(plan.normalize(this));
+    }
+
+    public static byte[] computeDigest(List<TNormalizedPlanNode> normalizedDigestPlans) throws Exception {
+        TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+        for (TNormalizedPlanNode node : normalizedDigestPlans) {
+            digest.update(serializer.serialize(node));
+        }
+        return digest.digest();
+    }
+
+    @Override
+    public int normalizeSlotId(int slotId) {
+        return normalizedSlotIds.normalize(slotId);
+    }
+
+    @Override
+    public void setSlotIdToNormalizeId(int slotId, int normalizedId) {
+        normalizedSlotIds.set(slotId, normalizedId);
+    }
+
+    @Override
+    public int normalizeTupleId(int tupleId) {
+        return normalizedTupleIds.normalize(tupleId);
+    }
+
+    @Override
+    public int normalizePlanId(int planId) {
+        return normalizedPlanIds.normalize(planId);
+    }
+
+    @Override
+    public DescriptorTable getDescriptorTable() {
+        return descriptorTable;
+    }
+
+    @Override
+    public void setNormalizedPartitionPredicates(OlapScanNode olapScanNode, NormalizedPartitionPredicates predicates) {
+        OlapTable olapTable = olapScanNode.getOlapTable();
+        long selectIndexId = olapScanNode.getSelectedIndexId() == -1
+                ? olapTable.getBaseIndexId()
+                : olapScanNode.getSelectedIndexId();
+
+        Map<Long, String> tabletToRange = Maps.newLinkedHashMap();
+        for (Long partitionId : olapScanNode.getSelectedPartitionIds()) {
+            Set<Long> tabletIds = olapTable.getPartition(partitionId)
+                    .getIndex(selectIndexId)
+                    .getTablets()
+                    .stream()
+                    .map(Tablet::getId)
+                    .collect(Collectors.toSet());
+
+            String filterRange = predicates.intersectPartitionRanges.get(partitionId);
+            for (Long tabletId : tabletIds) {
+                tabletToRange.put(tabletId, filterRange);
+            }
+        }
+        queryCacheParam.setTabletToRange(tabletToRange);
+    }
+
+    private static class CachePoint {
+        PlanNode digestRoot;
+        PlanNode cacheRoot;
+
+        public CachePoint(PlanNode digestRoot, PlanNode cacheRoot) {
+            this.digestRoot = digestRoot;
+            this.cacheRoot = cacheRoot;
+        }
+    }
+
+    private static class NormalizedIdGenerator {
+        private final AtomicInteger idGenerator = new AtomicInteger(0);
+        private final Map<Integer, Integer> originIdToNormalizedId = Maps.newLinkedHashMap();
+
+        public Integer normalize(Integer originId) {
+            return originIdToNormalizedId.computeIfAbsent(originId, id -> idGenerator.getAndIncrement());
+        }
+
+        public void set(int originId, Integer normalizedId) {
+            originIdToNormalizedId.put(originId, normalizedId);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -150,6 +150,10 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_REWRITE_ELEMENT_AT_TO_SLOT = "enable_rewrite_element_at_to_slot";
     public static final String ENABLE_ODBC_TRANSCATION = "enable_odbc_transcation";
     public static final String ENABLE_SQL_CACHE = "enable_sql_cache";
+    public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
+    public static final String QUERY_CACHE_FORCE_REFRESH = "query_cache_force_refresh";
+    public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
+    public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
 
     public static final String ENABLE_COST_BASED_JOIN_REORDER = "enable_cost_based_join_reorder";
 
@@ -938,6 +942,18 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_SQL_CACHE)
     public boolean enableSqlCache = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_CACHE)
+    public boolean enableQueryCache = false;
+
+    @VarAttr(name = QUERY_CACHE_FORCE_REFRESH)
+    private boolean queryCacheForceRefresh = false;
+
+    @VarAttr(name = QUERY_CACHE_ENTRY_MAX_BYTES)
+    private long queryCacheEntryMaxBytes = 5242880;
+
+    @VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
+    private long queryCacheEntryMaxRows = 500000;
 
     @VariableMgr.VarAttr(name = FORWARD_TO_MASTER)
     public boolean forwardToMaster = true;
@@ -2796,6 +2812,38 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnableSqlCache(boolean enableSqlCache) {
         this.enableSqlCache = enableSqlCache;
+    }
+
+    public boolean getEnableQueryCache() {
+        return enableQueryCache;
+    }
+
+    public void setEnableQueryCache(boolean enableQueryCache) {
+        this.enableQueryCache = enableQueryCache;
+    }
+
+    public boolean isQueryCacheForceRefresh() {
+        return queryCacheForceRefresh;
+    }
+
+    public void setQueryCacheForceRefresh(boolean queryCacheForceRefresh) {
+        this.queryCacheForceRefresh = queryCacheForceRefresh;
+    }
+
+    public long getQueryCacheEntryMaxBytes() {
+        return queryCacheEntryMaxBytes;
+    }
+
+    public void setQueryCacheEntryMaxBytes(long queryCacheEntryMaxBytes) {
+        this.queryCacheEntryMaxBytes = queryCacheEntryMaxBytes;
+    }
+
+    public long getQueryCacheEntryMaxRows() {
+        return queryCacheEntryMaxRows;
+    }
+
+    public void setQueryCacheEntryMaxRows(long queryCacheEntryMaxRows) {
+        this.queryCacheEntryMaxRows = queryCacheEntryMaxRows;
     }
 
     public int getPartitionedHashJoinRowsThreshold() {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
@@ -1,0 +1,515 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.planner.normalize.QueryCacheNormalizer;
+import org.apache.doris.thrift.TNormalizedPlanNode;
+import org.apache.doris.thrift.TQueryCacheParam;
+import org.apache.doris.thrift.TRuntimeFilterMode;
+import org.apache.doris.thrift.TRuntimeFilterType;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class QueryCacheNormalizerTest extends TestWithFeService {
+    private static final Logger LOG = LogManager.getLogger(QueryCacheNormalizerTest.class);
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        connectContext.getSessionVariable().setEnableNereidsPlanner(true);
+
+        // Create database `db1`.
+        createDatabase("db1");
+
+        useDatabase("db1");
+
+        // Create tables.
+        String nonPart = "create table db1.non_part("
+                + "  k1 varchar(32),\n"
+                + "  k2 varchar(32),\n"
+                + "  k3 varchar(32),\n"
+                + "  v1 int,\n"
+                + "  v2 int)\n"
+                + "DUPLICATE KEY(k1, k2, k3)\n"
+                + "distributed by hash(k1) buckets 3\n"
+                + "properties('replication_num' = '1')";
+
+        String part1 = "create table db1.part1("
+                + "  dt date,\n"
+                + "  k1 varchar(32),\n"
+                + "  k2 varchar(32),\n"
+                + "  k3 varchar(32),\n"
+                + "  v1 int,\n"
+                + "  v2 int)\n"
+                + "DUPLICATE KEY(dt, k1, k2, k3)\n"
+                + "PARTITION BY RANGE(dt)\n"
+                + "(\n"
+                + "  PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),\n"
+                + "  PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01')),\n"
+                + "  PARTITION p202405 VALUES [('2024-05-01'), ('2024-06-01'))\n"
+                + ")\n"
+                + "distributed by hash(k1) buckets 3\n"
+                + "properties('replication_num' = '1')";
+
+        String part2 = "create table db1.part2("
+                + "  dt date,\n"
+                + "  k1 varchar(32),\n"
+                + "  k2 varchar(32),\n"
+                + "  k3 varchar(32),\n"
+                + "  v1 int,\n"
+                + "  v2 int)\n"
+                + "DUPLICATE KEY(dt, k1, k2, k3)\n"
+                + "PARTITION BY RANGE(dt)\n"
+                + "(\n"
+                + "  PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),\n"
+                + "  PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01')),\n"
+                + "  PARTITION p202405 VALUES [('2024-05-01'), ('2024-06-01'))\n"
+                + ")\n"
+                + "distributed by hash(k1) buckets 3\n"
+                + "properties('replication_num' = '1')";
+
+        String multiLeveParts = "create table db1.multi_level_parts("
+                + "  k1 int,\n"
+                + "  dt date,\n"
+                + "  hour int,\n"
+                + "  v1 int,\n"
+                + "  v2 int)\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "PARTITION BY RANGE(dt, hour)\n"
+                + "(\n"
+                + "  PARTITION p202403 VALUES [('2024-03-01', '0'), ('2024-03-01', '1')),\n"
+                + "  PARTITION p202404 VALUES [('2024-03-01', '1'), ('2024-03-01', '2')),\n"
+                + "  PARTITION p202405 VALUES [('2024-03-01', '2'), ('2024-03-01', '3'))\n"
+                + ")\n"
+                + "distributed by hash(k1) buckets 3\n"
+                + "properties('replication_num' = '1')";
+
+        createTables(nonPart, part1, part2, multiLeveParts);
+
+        connectContext.getSessionVariable().setEnableNereidsPlanner(true);
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+    }
+
+    @Test
+    public void testNormalize() throws Exception {
+        String digest1 = getDigest("select k1 as k, sum(v1) as v from db1.non_part group by 1");
+        String digest2 = getDigest("select sum(v1) as v1, k1 as k from db1.non_part group by 2");
+        Assertions.assertEquals(64, digest1.length());
+        Assertions.assertEquals(digest1, digest2);
+
+        String digest3 = getDigest("select k1 as k, sum(v1) as v from db1.non_part where v1 between 1 and 10 group by 1");
+        Assertions.assertNotEquals(digest1, digest3);
+
+        String digest4 = getDigest("select k1 as k, sum(v1) as v from db1.non_part where v1 >= 1 and v1 <= 10 group by 1");
+        Assertions.assertEquals(digest3, digest4);
+        Assertions.assertEquals(64, digest3.length());
+
+        String digest5 = getDigest("select k1 as k, sum(v1) as v from db1.non_part where v1 >= 1 and v1 < 11 group by 1");
+        Assertions.assertNotEquals(digest3, digest5);
+        Assertions.assertEquals(64, digest5.length());
+    }
+
+    @Test
+    public void testProjectOnOlapScan() throws Exception {
+        String digest1 = getDigest("select k1 + 1, k2, sum(v1), sum(v2) as v from db1.non_part group by 1, 2");
+        String digest2 = getDigest("select sum(v2), k2, sum(v1), k1 + 1 from db1.non_part group by 2, 4");
+        Assertions.assertEquals(digest1, digest2);
+        Assertions.assertEquals(64, digest1.length());
+
+        String digest3 = getDigest("select k1 + 1, k2, sum(v1 + 1), sum(v2) as v from db1.non_part group by 1, 2");
+        Assertions.assertNotEquals(digest1, digest3);
+        Assertions.assertEquals(64, digest3.length());
+    }
+
+    @Test
+    public void testProjectOnAggregate() throws Exception {
+        connectContext.getSessionVariable()
+                .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,TWO_PHASE_AGGREGATE_WITHOUT_DISTINCT");
+        try {
+            String digest1 = getDigest(
+                    "select k1 + 1, k2 + 2, sum(v1) + 3, sum(v2) + 4 as v from db1.non_part group by k1, k2"
+            );
+            String digest2 = getDigest(
+                    "select sum(v2) + 4, k2 + 2, sum(v1) + 3, k1 + 1 as v from db1.non_part group by k2, k1"
+            );
+            Assertions.assertEquals(digest1, digest2);
+            Assertions.assertEquals(64, digest1.length());
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    @Test
+    public void testPartitionTable() throws Throwable {
+        TQueryCacheParam queryCacheParam1 = getQueryCacheParam(
+                "select k1 as k, sum(v1) as v from db1.part1 group by 1");
+        TQueryCacheParam queryCacheParam2 = getQueryCacheParam(
+                "select k1 as k, sum(v1) as v from db1.part1 where dt < '2025-01-01' group by 1");
+        Assertions.assertEquals(queryCacheParam1.digest, queryCacheParam2.digest);
+        Assertions.assertEquals(32, queryCacheParam1.digest.remaining());
+        Assertions.assertEquals(queryCacheParam1.tablet_to_range, queryCacheParam2.tablet_to_range);
+
+        TQueryCacheParam queryCacheParam3 = getQueryCacheParam(
+                "select k1 as k, sum(v1) as v from db1.part1 where dt < '2024-05-20' group by 1");
+        Assertions.assertEquals(queryCacheParam1.digest, queryCacheParam3.digest);
+        Assertions.assertNotEquals(
+                Lists.newArrayList(queryCacheParam1.tablet_to_range.values()),
+                Lists.newArrayList(queryCacheParam3.tablet_to_range.values())
+        );
+        Assertions.assertEquals(32, queryCacheParam3.digest.remaining());
+
+        TQueryCacheParam queryCacheParam4 = getQueryCacheParam(
+                "select k1 as k, sum(v1) as v from db1.part1 where dt < '2024-04-20' group by 1");
+        Assertions.assertEquals(queryCacheParam1.digest, queryCacheParam4.digest);
+        Assertions.assertNotEquals(
+                Lists.newArrayList(queryCacheParam1.tablet_to_range.values()),
+                Lists.newArrayList(queryCacheParam4.tablet_to_range.values())
+        );
+        Assertions.assertEquals(32, queryCacheParam4.digest.remaining());
+    }
+
+    @Test
+    public void testMultiLevelPartitionTable() throws Throwable {
+        List<TQueryCacheParam> queryCacheParams = normalize(
+                "select k1, sum(v1) as v from db1.multi_level_parts group by 1");
+        Assertions.assertEquals(1, queryCacheParams.size());
+    }
+
+    @Test
+    public void testHaving() throws Throwable {
+        List<TNormalizedPlanNode> normalizedPlanNodes = onePhaseAggWithoutDistinct(() -> normalizePlans(
+                "select k1, sum(v1) as v from db1.part1 where dt='2024-05-01' group by 1 having v > 10"));
+        Assertions.assertEquals(2, normalizedPlanNodes.size());
+        Assertions.assertTrue(
+                normalizedPlanNodes.get(0).getOlapScanNode() != null
+                        && CollectionUtils.isEmpty(normalizedPlanNodes.get(0).getConjuncts())
+        );
+        Assertions.assertTrue(
+                normalizedPlanNodes.get(1).getAggregationNode() != null
+                && !CollectionUtils.isEmpty(normalizedPlanNodes.get(1).getConjuncts())
+        );
+    }
+
+    @Test
+    public void testRuntimeFilter() throws Throwable {
+        connectContext.getSessionVariable().setRuntimeFilterMode(TRuntimeFilterMode.GLOBAL.toString());
+        connectContext.getSessionVariable().setRuntimeFilterType(TRuntimeFilterType.IN_OR_BLOOM.getValue());
+        List<TQueryCacheParam> queryCacheParams = normalize(
+                "select * from (select k1, count(*) from db1.part1 where k1 < 15 group by k1)a\n"
+                        + "join (select k1, count(*) from db1.part1 where k1 < 10 group by k1)b\n"
+                        + "on a.k1 = b.k1");
+
+        // only non target side can use query cache
+        Assertions.assertEquals(1, queryCacheParams.size());
+    }
+
+    @Test
+    public void testSelectFromWhereNoGroupBy() throws Throwable {
+        List<TNormalizedPlanNode> plans1 = normalizePlans("select sum(v1) from db1.part1");
+        List<TNormalizedPlanNode> plans2 = normalizePlans("select sum(v1) as v from db1.part1");
+        Assertions.assertEquals(plans1, plans2);
+
+        List<TNormalizedPlanNode> plans3 = normalizePlans("select sum(v1) from db1.part1 where dt < '2025-01-01'");
+        Assertions.assertEquals(plans1, plans3);
+
+        List<TNormalizedPlanNode> plans4 = normalizePlans("select sum(v1) from db1.part1 where dt < '2024-05-01'");
+        Assertions.assertEquals(plans1, plans4);
+
+        TQueryCacheParam queryCacheParam1 = getQueryCacheParam("select sum(v1) from db1.part1");
+        TQueryCacheParam queryCacheParam2 = getQueryCacheParam("select sum(v1) from db1.part1 where dt <= '2024-04-20'");
+        Assertions.assertEquals(queryCacheParam1.digest, queryCacheParam2.digest);
+        Assertions.assertEquals(32, queryCacheParam1.digest.remaining());
+        Assertions.assertNotEquals(
+                Lists.newArrayList(queryCacheParam1.tablet_to_range.values()),
+                Lists.newArrayList(queryCacheParam2.tablet_to_range.values())
+        );
+
+        Assertions.assertEquals(
+                queryCacheParam1.tablet_to_range.values().stream().sorted().collect(Collectors.toList()),
+                ImmutableList.of(
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-05-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-05-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-05-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-05-01]; ..types: [DATEV2]; keys: [2024-06-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-05-01]; ..types: [DATEV2]; keys: [2024-06-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-05-01]; ..types: [DATEV2]; keys: [2024-06-01]; )]"
+                )
+        );
+
+        Assertions.assertEquals(
+                queryCacheParam2.tablet_to_range.values().stream().sorted().collect(Collectors.toList()),
+                ImmutableList.of(
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-03-01]; ..types: [DATEV2]; keys: [2024-04-01]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-04-21]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-04-21]; )]",
+                        "[[types: [DATEV2]; keys: [2024-04-01]; ..types: [DATEV2]; keys: [2024-04-21]; )]"
+                )
+        );
+
+        TQueryCacheParam queryCacheParam3 = getQueryCacheParam(
+                "select sum(v1), sum(v1 + 1), sum(v2), sum(v2 + 2) + 2 from db1.part1"
+        );
+        TQueryCacheParam queryCacheParam4 = getQueryCacheParam(
+                "select sum(v2 + 2) + 2, sum(v2), sum(v1 + 1), sum(v1) from db1.part1"
+        );
+        Assertions.assertEquals(queryCacheParam3.digest, queryCacheParam4.digest);
+        Assertions.assertEquals(32, queryCacheParam3.digest.remaining());
+        Assertions.assertEquals(queryCacheParam3.tablet_to_range, queryCacheParam4.tablet_to_range);
+
+        TQueryCacheParam queryCacheParam5 = getQueryCacheParam(
+                "select sum(v1) from db1.part1 where dt between '2024-04-15' and '2024-04-20' and k1 = 1"
+        );
+        TQueryCacheParam queryCacheParam6 = getQueryCacheParam(
+                "select sum(v1) from db1.part1 where dt between '2024-04-15' and '2024-04-20' and k1 = 2"
+        );
+        Assertions.assertNotEquals(queryCacheParam5.digest, queryCacheParam6.digest);
+        Assertions.assertEquals(32, queryCacheParam5.digest.remaining());
+        Assertions.assertEquals(32, queryCacheParam6.digest.remaining());
+        Assertions.assertEquals(queryCacheParam5.tablet_to_range, queryCacheParam6.tablet_to_range);
+    }
+
+    @Test
+    public void testSelectFromGroupBy() {
+        twoPhaseAggWithoutDistinct(() -> {
+            TQueryCacheParam queryCacheParam1 = getQueryCacheParam("select k1, sum(v1) from db1.part1 group by k1");
+            TQueryCacheParam queryCacheParam2 = getQueryCacheParam("select k1, sum(v1) from db1.part1 group by k1 limit 10");
+            Assertions.assertNotEquals(queryCacheParam1.digest, queryCacheParam2.digest);
+            Assertions.assertEquals(32, queryCacheParam1.digest.remaining());
+            Assertions.assertEquals(32, queryCacheParam2.digest.remaining());
+
+            TQueryCacheParam queryCacheParam3 = getQueryCacheParam("select sum(v1), k1 from db1.part1 group by k1");
+            Assertions.assertEquals(queryCacheParam1.digest, queryCacheParam3.digest);
+            Assertions.assertEquals(
+                    Lists.newArrayList(queryCacheParam1.tablet_to_range.values()),
+                    Lists.newArrayList(queryCacheParam3.tablet_to_range.values())
+            );
+
+            List<TNormalizedPlanNode> plans1 = normalizePlans("select k1, sum(v1) from db1.part1 group by k1");
+            List<TNormalizedPlanNode> plans2 = normalizePlans(
+                    "select sum(v1), k1 from db1.part1 where dt between '2024-04-10' and '2024-05-06' group by k1");
+            Assertions.assertEquals(plans1, plans2);
+        });
+    }
+
+    @Test
+    public void phasesAgg() {
+        List<TNormalizedPlanNode> onePhaseAggPlans = onePhaseAggWithoutDistinct(() -> normalizePlans(
+                "select sum(v1), k1 from db1.part1 where dt = '2024-04-10' group by k1"));
+        List<TNormalizedPlanNode> onePhaseAggPlans2 = onePhaseAggWithoutDistinct(() -> normalizePlans(
+                "select k1, sum(v1) from db1.part1 where dt = '2024-04-10' group by k1"));
+        Assertions.assertEquals(onePhaseAggPlans, onePhaseAggPlans2);
+
+        List<TNormalizedPlanNode> twoPhaseAggPlans = twoPhaseAggWithoutDistinct(() -> normalizePlans(
+                "select sum(v1), k1 from db1.part1 where dt = '2024-04-10' group by k1"));
+        Assertions.assertNotEquals(onePhaseAggPlans, twoPhaseAggPlans);
+    }
+
+    @Test
+    public void phasesDistinctAgg() {
+        List<TNormalizedPlanNode> noDistinctPlans = onePhaseAggWithoutDistinct(() -> normalizePlans(
+                "select k1 from db1.part1 where dt = '2024-04-10' group by k1"));
+        List<TNormalizedPlanNode> onePhaseAggPlans = onePhaseAggWithDistinct(() -> normalizePlans(
+                "select distinct k1 from db1.part1 where dt = '2024-04-10'"));
+        Assertions.assertEquals(noDistinctPlans, onePhaseAggPlans);
+        List<TNormalizedPlanNode> twoPhaseAggPlans = twoPhaseAggWithDistinct(() -> normalizePlans(
+                "select distinct k1 from db1.part1 where dt = '2024-04-10'"));
+        Assertions.assertEquals(onePhaseAggPlans, twoPhaseAggPlans);
+
+        List<TNormalizedPlanNode> threePhaseAggPlans = threePhaseAggWithDistinct(() -> normalizePlans(
+                "select sum(distinct v1), k1 from db1.part1 where dt = '2024-04-10' group by k1"));
+        List<TNormalizedPlanNode> fourPhaseAggPlans = fourPhaseAggWithDistinct(() -> normalizePlans(
+                "select sum(distinct v1), k1 from db1.part1 where dt = '2024-04-10' group by k1"));
+        Assertions.assertNotEquals(fourPhaseAggPlans, threePhaseAggPlans);
+    }
+
+    private String getDigest(String sql) throws Exception {
+        return Hex.encodeHexString(getQueryCacheParam(sql).digest);
+    }
+
+    private TQueryCacheParam getQueryCacheParam(String sql) throws Exception {
+        List<TQueryCacheParam> queryCaches = normalize(sql);
+        Assertions.assertEquals(1, queryCaches.size());
+        return queryCaches.get(0);
+    }
+
+    private List<TQueryCacheParam> normalize(String sql) throws Exception {
+        Planner planner = getSqlStmtExecutor(sql).planner();
+        DescriptorTable descTable = planner.getDescTable();
+        List<PlanFragment> fragments = planner.getFragments();
+        List<TQueryCacheParam> queryCacheParams = new ArrayList<>();
+        for (PlanFragment fragment : fragments) {
+            QueryCacheNormalizer normalizer = new QueryCacheNormalizer(fragment, descTable);
+            Optional<TQueryCacheParam> queryCacheParam = normalizer.normalize(connectContext);
+            if (queryCacheParam.isPresent()) {
+                queryCacheParams.add(queryCacheParam.get());
+            }
+        }
+        return queryCacheParams;
+    }
+
+    private List<TNormalizedPlanNode> normalizePlans(String sql) throws Exception {
+        Planner planner = getSqlStmtExecutor(sql).planner();
+        DescriptorTable descTable = planner.getDescTable();
+        List<PlanFragment> fragments = planner.getFragments();
+        List<TNormalizedPlanNode> normalizedPlans = new ArrayList<>();
+        for (PlanFragment fragment : fragments) {
+            QueryCacheNormalizer normalizer = new QueryCacheNormalizer(fragment, descTable);
+            normalizedPlans.addAll(normalizer.normalizePlans(connectContext));
+        }
+        return normalizedPlans;
+    }
+
+    private void onePhaseAggWithoutDistinct(Callback callback) {
+        onePhaseAggWithoutDistinct(() -> {
+            callback.run();
+            return null;
+        });
+    }
+
+    private <T> T onePhaseAggWithDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,"
+                            + "TWO_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "THREE_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT_WITH_FULL_DISTRIBUTE,"
+                            + "TWO_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    private <T> T twoPhaseAggWithDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,"
+                            + "THREE_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT_WITH_FULL_DISTRIBUTE,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    private <T> T threePhaseAggWithDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "FOUR_PHASE_AGGREGATE_WITH_DISTINCT_WITH_FULL_DISTRIBUTE,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,"
+                            + "TWO_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    private <T> T fourPhaseAggWithDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,"
+                            + "THREE_PHASE_AGGREGATE_WITH_DISTINCT,"
+                            + "ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,"
+                            + "TWO_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+
+    private <T> T onePhaseAggWithoutDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,TWO_PHASE_AGGREGATE_WITHOUT_DISTINCT");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    private void twoPhaseAggWithoutDistinct(Callback callback) {
+        twoPhaseAggWithoutDistinct(() -> {
+            callback.run();
+            return null;
+        });
+    }
+
+    private <T> T twoPhaseAggWithoutDistinct(ResultCallback<T> callback) {
+        try {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION,ONE_PHASE_AGGREGATE_WITHOUT_DISTINCT");
+            return callback.run();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            connectContext.getSessionVariable()
+                    .setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        }
+    }
+
+    private interface Callback {
+        void run() throws Throwable;
+    }
+
+    private interface ResultCallback<T> {
+        T run() throws Throwable;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -605,6 +605,7 @@ public abstract class TestWithFeService {
                 && connectContext.getState().getErrorCode() == null) {
             return stmtExecutor;
         } else {
+            // throw new IllegalStateException(connectContext.getState().getErrorMessage());
             return null;
         }
     }

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace java org.apache.doris.thrift
+
+include "Exprs.thrift"
+include "Types.thrift"
+include "Opcodes.thrift"
+include "Descriptors.thrift"
+include "Partitions.thrift"
+include "PlanNodes.thrift"
+
+struct TNormalizedOlapScanNode {
+  1: optional i64 table_id
+  2: optional i64 index_id
+  3: optional bool is_preaggregation
+  4: optional list<string> key_column_names
+  5: optional list<Types.TPrimitiveType> key_column_types
+  6: optional string rollup_name
+  7: optional string sort_column
+  8: optional list<string> select_columns
+}
+
+struct TNormalizedAggregateNode {
+  1: optional list<Exprs.TExpr> grouping_exprs
+  2: optional list<Exprs.TExpr> aggregate_functions
+  3: optional Types.TTupleId intermediate_tuple_id
+  4: optional Types.TTupleId output_tuple_id
+  5: optional bool is_finalize
+  6: optional bool use_streaming_preaggregation
+  7: optional list<Exprs.TExpr> projectToAggIntermediateTuple
+  8: optional list<Exprs.TExpr> projectToAggOutputTuple
+}
+
+struct TNormalizedPlanNode {
+  1: optional Types.TPlanNodeId node_id
+  2: optional PlanNodes.TPlanNodeType node_type
+  3: optional i32 num_children
+  5: optional set<Types.TTupleId> tuple_ids
+  6: optional set<Types.TTupleId> nullable_tuples
+  7: optional list<Exprs.TExpr> conjuncts
+  8: optional list<Exprs.TExpr> projects
+  9: optional i64 limit
+
+  10: optional TNormalizedOlapScanNode olap_scan_node
+  11: optional TNormalizedAggregateNode aggregation_node
+}

--- a/gensrc/thrift/Planner.thrift
+++ b/gensrc/thrift/Planner.thrift
@@ -23,6 +23,7 @@ include "Exprs.thrift"
 include "DataSinks.thrift"
 include "PlanNodes.thrift"
 include "Partitions.thrift"
+include "QueryCache.thrift"
 
 // TPlanFragment encapsulates info needed to execute a particular
 // plan fragment, including how to produce and how to partition its output.
@@ -61,6 +62,8 @@ struct TPlanFragment {
   // sink) in a single instance of this fragment. This is used for an optimization in
   // InitialReservation. Measured in bytes. required in V1
   8: optional i64 initial_reservation_total_claims
+
+  9: optional QueryCache.TQueryCacheParam query_cache_param
 }
 
 // location information for a single scan range

--- a/gensrc/thrift/QueryCache.thrift
+++ b/gensrc/thrift/QueryCache.thrift
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace cpp doris
+namespace java org.apache.doris.thrift
+
+struct TQueryCacheParam {
+  1: optional i32 node_id
+
+  2: optional binary digest
+
+  // the query slots order can different to the query cache slots order,
+  // so we should mapping current slot id in planNode to normalized slot id
+  // say:
+  //   SQL1: select id, count(*) cnt, sum(value) s from tbl group by id
+  //   SQL2: select sum(value) s, count(*) cnt, id from tbl group by id
+  //   the id always has normalized slot id 0,
+  //   the cnt always has normalized slot id 1
+  //   the s always has normalized slot id 2
+  //   but in SQL1, id, cnt, s can has slot id 5, 6, 7
+  //       in SQL2, s, cnt, id can has slot id 10, 11, 12
+  //   if generate plan cache in SQL1, we will make output_slot_mapping: {5: 0, 6: 1, 7: 2},
+  //   the SQL2 read plan cache and make output_slot_mapping: {10: 2, 11: 1, 12: 0},
+  //   even the select order is different, the normalized slot id is always equals:
+  //   the id always is 0, the cnt always is 1, the s always is 2.
+  //   then backend can mapping the current slots in the tuple to the query cached slots
+  3: optional map<i32, i32> output_slot_mapping
+
+  // mapping tablet to filter range,
+  // BE will use <digest, tablet id, filter range> as the key to search query cache.
+  // note that, BE not care what the filter range content is, just use as the part of the key.
+  4: optional map<i64, string> tablet_to_range
+
+  5: optional bool force_refresh_query_cache
+
+  6: optional i64 entry_max_bytes
+
+  7: optional i64 entry_max_rows
+}


### PR DESCRIPTION
# Proposed changes

support cache tablets aggregate result

for example

SQL 1:
```sql
select key, sum(value)
from tbl
where dt between '2024-08-01' and '2024-08-10'
group by key
```

SQL 2:
```sql
select key, sum(value)
from tbl
where dt between '2024-08-5' and '2024-08-15'
group by key
```

SQL 1 will update the tablets aggregate result which partition between '2024-08-01' and '2024-08-10'.
Then SQL 2 will reuse the tablets aggregate which partition between '2024-08-05' and '2024-08-10', and compute aggregate which partition between '2024-08-11' and '2024-08-15'

We only support simple aggregate which not contains join with runtime filter, at present.

# How to use

```sql
set enable_query_cache=true;
```

