### PR TITLE
[fix](Nereids) fix insert into table with null literal default value (#39122)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -853,11 +853,15 @@ public class NativeInsertStmt extends InsertStmt {
             Column col = targetColumns.get(i);
 
             if (expr instanceof DefaultValueExpr) {
-                if (targetColumns.get(i).getDefaultValue() == null) {
+                if (targetColumns.get(i).getDefaultValue() == null && !targetColumns.get(i).isAllowNull()) {
                     throw new AnalysisException("Column has no default value, column="
                             + targetColumns.get(i).getName());
                 }
-                expr = new StringLiteral(targetColumns.get(i).getDefaultValue());
+                if (targetColumns.get(i).getDefaultValue() == null) {
+                    expr = new NullLiteral();
+                } else {
+                    expr = new StringLiteral(targetColumns.get(i).getDefaultValue());
+                }
             }
             if (expr instanceof Subquery) {
                 throw new AnalysisException("Insert values can not be query");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -450,6 +450,9 @@ public class Column implements Writable, GsonPostProcessable {
     }
 
     public Expr getDefaultValueExpr() throws AnalysisException {
+        if (defaultValue == null) {
+            return null;
+        }
         StringLiteral defaultValueLiteral = new StringLiteral(defaultValue);
         if (getDataType() == PrimitiveType.VARCHAR) {
             return defaultValueLiteral;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -217,6 +217,12 @@ public class BindSink implements AnalysisRuleFactory {
                                             // should not contain these unmentioned columns, so we just skip them.
                                             continue;
                                         } else if (column.getDefaultValue() == null) {
+                                            // throw exception if explicitly use Default value null when not nullable
+                                            // insert into table t values(DEFAULT)
+                                            if (!column.isAllowNull()) {
+                                                throw new AnalysisException("Column has no default value,"
+                                                    + " column=" + column.getName());
+                                            }
                                             // Otherwise, the unmentioned columns should be filled with default values
                                             // or null values
                                             columnToOutput.put(column.getName(), new Alias(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
@@ -109,7 +109,8 @@ public class ReadLockTest extends SSBTestBase {
 
     @Test
     public void testInsertInto() {
-        String sql = "INSERT INTO supplier(s_suppkey) SELECT lo_orderkey FROM lineorder";
+        String sql = "INSERT INTO supplier(s_suppkey, s_name, s_address, s_city, s_nation, s_region, s_phone) "
+                + "SELECT lo_orderkey, '', '', '', '', '', '' FROM lineorder";
         StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
         boolean originalDML = connectContext.getSessionVariable().enableNereidsDML;
         connectContext.getSessionVariable().enableNereidsDML = true;


### PR DESCRIPTION
cherry-pick: #39122

Problem:
when use insert with default value null, it can not be insert successfully
Solved:
when column is allow to be null, it can be null in create table with null default value

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

