### PR TITLE
[fix](Nereids) fix fold constant by be return type mismatched

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -176,7 +176,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             if (newChild != child) {
                 hasNewChildren = true;
             }
-            if (newChild.getDataType() != child.getDataType()) {
+            if (!newChild.getDataType().equals(child.getDataType())) {
                 newChildren.add(newChild.castTo(child.getDataType()));
             } else {
                 newChildren.add(newChild);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -176,7 +176,11 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             if (newChild != child) {
                 hasNewChildren = true;
             }
-            newChildren.add(newChild);
+            if (newChild.getDataType() != child.getDataType()) {
+                newChildren.add(newChild.castTo(child.getDataType()));
+            } else {
+                newChildren.add(newChild);
+            }
         }
         return hasNewChildren ? root.withChildren(newChildren) : root;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -177,7 +177,12 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
                 hasNewChildren = true;
             }
             if (!newChild.getDataType().equals(child.getDataType())) {
-                newChildren.add(newChild.castTo(child.getDataType()));
+                try {
+                    newChildren.add(newChild.castTo(child.getDataType()));
+                } catch (Exception e) {
+                    LOG.warn("expression of type {} cast to {} failed. ", newChild.getDataType(), child.getDataType());
+                    newChildren.add(newChild);
+                }
             } else {
                 newChildren.add(newChild);
             }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -53,4 +53,9 @@ suite("fold_constant_by_be") {
 
     sql 'set query_timeout=12;'
     qt_sql "select sleep(sign(1)*5);"
+    
+    explain {
+        sql("verbose select substring('123456', 1, 3)")
+        contains "varchar(3)"
+    }
 }


### PR DESCRIPTION
when using fold constant by be, the return type of substring('123456', 1, 3) would changed to be text, which we want it to be 3

