### PR TITLE
[load](streamload) add streamload header skip_locations

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -61,6 +61,8 @@ public class BeSelectionPolicy {
 
     public List<String> preferredLocations = new ArrayList<>();
 
+    public List<String> skipLocations = new ArrayList<>();
+
     private BeSelectionPolicy() {
 
     }
@@ -122,6 +124,11 @@ public class BeSelectionPolicy {
             return this;
         }
 
+        public Builder addSkipLocations(List<String> skipLocations) {
+            policy.skipLocations.addAll(skipLocations);
+            return this;
+        }
+
         public Builder setEnableRoundRobin(boolean enableRoundRobin) {
             policy.enableRoundRobin = enableRoundRobin;
             return this;
@@ -176,13 +183,15 @@ public class BeSelectionPolicy {
     }
 
     public List<Backend> getCandidateBackends(Collection<Backend> backends) {
-        List<Backend> filterBackends = backends.stream().filter(this::isMatch).collect(Collectors.toList());
+        List<Backend> filterBackends = backends.stream().filter(this::isMatch)
+                .filter(item -> !skipLocations.contains(item.getHost())).collect(Collectors.toList());
         List<Backend> preLocationFilterBackends = filterBackends.stream()
                 .filter(iterm -> preferredLocations.contains(iterm.getHost())).collect(Collectors.toList());
         // If preLocations were chosen, use the preLocation backends. Otherwise we just ignore this filter.
         if (!preLocationFilterBackends.isEmpty()) {
             filterBackends = preLocationFilterBackends;
         }
+
         Collections.shuffle(filterBackends);
         int numComputeNode = filterBackends.stream().filter(Backend::isComputeNode).collect(Collectors.toList()).size();
         List<Backend> candidates = new ArrayList<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -376,6 +376,46 @@ public class SystemInfoServiceTest {
     }
 
     @Test
+    public void testSkipLocationsSelect() throws Exception {
+        Tag taga = Tag.create(Tag.TYPE_LOCATION, "taga");
+
+        // add more backends
+        addBackend(10002, "192.168.1.2", 9050);
+        Backend be2 = infoService.getBackend(10002);
+        be2.setAlive(true);
+        addBackend(10003, "192.168.1.3", 9050);
+        Backend be3 = infoService.getBackend(10003);
+        be3.setAlive(true);
+        addBackend(10004, "192.168.1.4", 9050);
+        Backend be4 = infoService.getBackend(10004);
+        be4.setAlive(true);
+        addBackend(10005, "192.168.1.5", 9050);
+        Backend be5 = infoService.getBackend(10005);
+        be5.setAlive(true);
+
+        List<String> skipLocations = new ArrayList<>();
+        skipLocations.add("192.168.1.2");
+        BeSelectionPolicy policy1 = new BeSelectionPolicy.Builder().addSkipLocations(skipLocations).build();
+        Assert.assertEquals(3, infoService.selectBackendIdsByPolicy(policy1, -1).size());
+        skipLocations.add("192.168.1.3");
+        BeSelectionPolicy policy2 = new BeSelectionPolicy.Builder().addSkipLocations(skipLocations).build();
+
+        Assert.assertEquals(2, infoService.selectBackendIdsByPolicy(policy2, -1).size());
+
+        skipLocations.clear();
+        BeSelectionPolicy policy3 = new BeSelectionPolicy.Builder().addSkipLocations(skipLocations).build();
+        Assert.assertEquals(4, infoService.selectBackendIdsByPolicy(policy3, -1).size());
+
+        skipLocations.add("192.168.1.2");
+        skipLocations.add("192.168.1.3");
+        skipLocations.add("192.168.1.4");
+        skipLocations.add("192.168.1.5");
+        BeSelectionPolicy policy4 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .addSkipLocations(skipLocations).preferComputeNode(true).assignExpectBeNum(1).build();
+        Assert.assertEquals(0, infoService.selectBackendIdsByPolicy(policy4, 1).size());
+    }
+
+    @Test
     public void testSelectBackendIdsForReplicaCreation() throws Exception {
         addBackend(10001, "192.168.1.1", 9050);
         Backend be1 = infoService.getBackend(10001);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Streamload is redirected to be. When the client and a be cannot be accessed (such as packet loss), an error will be reported to the client.
At this time, the client can skip the be by adding -H "skip_locations: 127.0.0.1,127.0.0.2" to ensure the normal operation of the client.