### PR TITLE
[fix](local shuffle) Not channel_id causes a local merge infinite loop.

### DIFF
--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -856,13 +856,13 @@ public:
 
     void sub_mem_usage(int channel_id, size_t delta) { mem_trackers[channel_id]->release(delta); }
 
-    virtual void add_total_mem_usage(size_t delta, int channel_id = 0) {
+    virtual void add_total_mem_usage(size_t delta, int channel_id) {
         if (mem_usage.fetch_add(delta) + delta > config::local_exchange_buffer_mem_limit) {
             sink_deps.front()->block();
         }
     }
 
-    virtual void sub_total_mem_usage(size_t delta, int channel_id = 0) {
+    virtual void sub_total_mem_usage(size_t delta, int channel_id) {
         auto prev_usage = mem_usage.fetch_sub(delta);
         DCHECK_GE(prev_usage - delta, 0) << "prev_usage: " << prev_usage << " delta: " << delta
                                          << " channel_id: " << channel_id;

--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -54,9 +54,9 @@ void Exchanger<BlockType>::_enqueue_data_and_set_ready(int channel_id,
         // just unref the block.
         if constexpr (std::is_same_v<PartitionedBlock, BlockType> ||
                       std::is_same_v<BroadcastBlock, BlockType>) {
-            block.first->unref(local_state._shared_state, allocated_bytes);
+            block.first->unref(local_state._shared_state, allocated_bytes, channel_id);
         } else {
-            block->unref(local_state._shared_state, allocated_bytes);
+            block->unref(local_state._shared_state, allocated_bytes, channel_id);
             DCHECK_EQ(block->ref_value(), 0);
         }
     }
@@ -83,7 +83,7 @@ bool Exchanger<BlockType>::_dequeue_data(LocalExchangeSourceLocalState& local_st
             local_state._shared_state->sub_mem_usage(channel_id,
                                                      block->data_block.allocated_bytes());
             data_block->swap(block->data_block);
-            block->unref(local_state._shared_state, data_block->allocated_bytes());
+            block->unref(local_state._shared_state, data_block->allocated_bytes(), channel_id);
             DCHECK_EQ(block->ref_value(), 0);
         }
         return true;
@@ -100,7 +100,7 @@ bool Exchanger<BlockType>::_dequeue_data(LocalExchangeSourceLocalState& local_st
                 local_state._shared_state->sub_mem_usage(channel_id,
                                                          block->data_block.allocated_bytes());
                 data_block->swap(block->data_block);
-                block->unref(local_state._shared_state, data_block->allocated_bytes());
+                block->unref(local_state._shared_state, data_block->allocated_bytes(), channel_id);
                 DCHECK_EQ(block->ref_value(), 0);
             }
             return true;

--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -257,7 +257,7 @@ Status ShuffleExchanger::_split_rows(RuntimeState* state, const uint32_t* __rest
                 _enqueue_data_and_set_ready(it.second, local_state,
                                             {new_block_wrapper, {row_idx, start, size}});
             } else {
-                new_block_wrapper->unref(local_state._shared_state);
+                new_block_wrapper->unref(local_state._shared_state, local_state._channel_id);
             }
         }
     } else {

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -176,10 +176,10 @@ struct BlockWrapper {
     BlockWrapper(vectorized::Block&& data_block_) : data_block(std::move(data_block_)) {}
     ~BlockWrapper() { DCHECK_EQ(ref_count.load(), 0); }
     void ref(int delta) { ref_count += delta; }
-    void unref(LocalExchangeSharedState* shared_state, size_t allocated_bytes) {
+    void unref(LocalExchangeSharedState* shared_state, size_t allocated_bytes, int channel_id) {
         if (ref_count.fetch_sub(1) == 1) {
             DCHECK_GT(allocated_bytes, 0);
-            shared_state->sub_total_mem_usage(allocated_bytes);
+            shared_state->sub_total_mem_usage(allocated_bytes, channel_id);
             if (shared_state->exchanger->_free_block_limit == 0 ||
                 shared_state->exchanger->_free_blocks.size_approx() <
                         shared_state->exchanger->_free_block_limit *

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -189,8 +189,9 @@ struct BlockWrapper {
             }
         }
     }
-    void unref(LocalExchangeSharedState* shared_state) {
-        unref(shared_state, data_block.allocated_bytes());
+
+    void unref(LocalExchangeSharedState* shared_state, int channel_id) {
+        unref(shared_state, data_block.allocated_bytes(), channel_id);
     }
     int ref_value() const { return ref_count.load(); }
     std::atomic<int> ref_count = 0;


### PR DESCRIPTION
## Proposed changes

```
LOCAL_EXCHANGE_OPERATOR (LOCAL_MERGE_SORT): id=-4, parallel_tasks=24, _channel_id: 0, _num_partitions: 24, _num_senders: 24, _num_sources: 24, _running_sink_operators: 24, _running_source_operators: 1, mem_usage: 0, data queue info: Data Queue 0: [size approx = 1656, eos = false], MemTrackers: 0: 135659520, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0, 11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0, 21: 0, 22: 0, 23: 0, 
  DATA_STREAM_SINK_OPERATOR: id=3, Sink Buffer: (_should_stop = false, _busy_channels = 0, _is_finishing = false), _reach_limit: false
0.   this=0x7f9100dbca10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=false, _always_ready=false
0.   this=0x7f9100dbf910, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dc1910, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dc6c10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dc8810, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dc9d10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dd5e10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de0310, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de3210, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de3910, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de3b10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de3d10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de3f10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de5910, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100de9b10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100dea910, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
0.   this=0x7f9100debf10, LOCAL_MERGE_EXCHANGE_OPERATOR_DEPENDENCY: id=-4, block task = 0, ready=true, _always_ready=false
```

<!--Describe your changes.-->

