### PR TITLE
[fix](Nereids) forbid sql cache when use nondeterministic function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -55,6 +55,8 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public class StatementContext {
 
+    public boolean hasUnsupportedSqlCacheExpression;
+
     private ConnectContext connectContext;
 
     private final Stopwatch stopwatch = Stopwatch.createUnstarted();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -90,7 +90,7 @@ public class SlotBinder extends SubExprAnalyzer {
     }
 
     public Expression bind(Expression expression) {
-        return expression.accept(this, null);
+        return expression.accept(this, getCascadesContext());
     }
 
     @Override
@@ -119,7 +119,7 @@ public class SlotBinder extends SubExprAnalyzer {
                 throw new AnalysisException(e.getMessage());
             }
         }
-        if (context != null) {
+        if (context != null && context.getStatementContext() != null) {
             context.getStatementContext().hasUnsupportedSqlCacheExpression = true;
         }
         return new Variable(unboundVariable.getName(), unboundVariable.getType(), literal);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -119,6 +119,7 @@ public class SlotBinder extends SubExprAnalyzer {
                 throw new AnalysisException(e.getMessage());
             }
         }
+        context.getStatementContext().hasUnsupportedSqlCacheExpression = true;
         return new Variable(unboundVariable.getName(), unboundVariable.getType(), literal);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -119,7 +119,9 @@ public class SlotBinder extends SubExprAnalyzer {
                 throw new AnalysisException(e.getMessage());
             }
         }
-        context.getStatementContext().hasUnsupportedSqlCacheExpression = true;
+        if (context != null) {
+            context.getStatementContext().hasUnsupportedSqlCacheExpression = true;
+        }
         return new Variable(unboundVariable.getName(), unboundVariable.getType(), literal);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -44,6 +44,7 @@ import org.apache.doris.nereids.trees.expressions.TimestampArithmetic;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
@@ -114,6 +115,7 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
         FunctionBuilder builder = functionRegistry.findFunctionBuilder(
                 unboundFunction.getDbName(), functionName, arguments);
         if (builder instanceof AliasUdfBuilder) {
+            context.cascadesContext.getStatementContext().hasUnsupportedSqlCacheExpression = true;
             // we do type coercion in build function in alias function, so it's ok to return directly.
             return builder.build(functionName, arguments);
         } else {
@@ -130,6 +132,9 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
                 // but COUNT function is always not nullable.
                 // so wrap COUNT with Nvl to ensure it's result is 0 instead of null to get the correct result
                 boundFunction = new Nvl(boundFunction, new BigIntLiteral(0));
+            }
+            if (boundFunction instanceof Nondeterministic) {
+                context.cascadesContext.getStatementContext().hasUnsupportedSqlCacheExpression = true;
             }
             return boundFunction;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -115,7 +115,9 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
         FunctionBuilder builder = functionRegistry.findFunctionBuilder(
                 unboundFunction.getDbName(), functionName, arguments);
         if (builder instanceof AliasUdfBuilder) {
-            context.cascadesContext.getStatementContext().hasUnsupportedSqlCacheExpression = true;
+            if (context != null) {
+                context.cascadesContext.getStatementContext().hasUnsupportedSqlCacheExpression = true;
+            }
             // we do type coercion in build function in alias function, so it's ok to return directly.
             return builder.build(functionName, arguments);
         } else {
@@ -133,7 +135,7 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
                 // so wrap COUNT with Nvl to ensure it's result is 0 instead of null to get the correct result
                 boundFunction = new Nvl(boundFunction, new BigIntLiteral(0));
             }
-            if (boundFunction instanceof Nondeterministic) {
+            if (context != null && boundFunction instanceof Nondeterministic) {
                 context.cascadesContext.getStatementContext().hasUnsupportedSqlCacheExpression = true;
             }
             return boundFunction;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ConnectionId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ConnectionId.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'ConnectionId'.
  */
 public class ConnectionId extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.StringType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'CurrentUser'.
  */
 public class CurrentUser extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(StringType.INSTANCE).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Database.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.VarcharType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'database'.
  */
 public class Database extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/User.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/User.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions.functions.scalar;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.VarcharType;
@@ -32,7 +33,7 @@ import java.util.List;
  * ScalarFunction 'User'.
  */
 public class User extends ScalarFunction
-        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable, Nondeterministic {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/TableValuedFunction.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.Properties;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
+import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
@@ -44,7 +45,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** TableValuedFunction */
-public abstract class TableValuedFunction extends BoundFunction implements UnaryExpression, CustomSignature {
+public abstract class TableValuedFunction extends BoundFunction
+        implements UnaryExpression, CustomSignature, Nondeterministic {
 
     protected final Supplier<TableValuedFunctionIf> catalogFunctionCache = Suppliers.memoize(this::toCatalogFunction);
     protected final Supplier<FunctionGenTable> tableCache = Suppliers.memoize(() -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -344,7 +344,7 @@ public class CacheAnalyzer {
             }
             return CacheMode.NoNeed;
         }
-        if (context.getStatementContext().hasUnsupportedSqlCacheExpression) {
+        if (context != null && context.getStatementContext().hasUnsupportedSqlCacheExpression) {
             return CacheMode.None;
         }
         if (!(parsedStmt instanceof LogicalPlanAdapter) || scanNodes.size() == 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -344,7 +344,8 @@ public class CacheAnalyzer {
             }
             return CacheMode.NoNeed;
         }
-        if (context != null && context.getStatementContext().hasUnsupportedSqlCacheExpression) {
+        if (context != null && context.getStatementContext() != null
+                && context.getStatementContext().hasUnsupportedSqlCacheExpression) {
             return CacheMode.None;
         }
         if (!(parsedStmt instanceof LogicalPlanAdapter) || scanNodes.size() == 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -344,6 +344,9 @@ public class CacheAnalyzer {
             }
             return CacheMode.NoNeed;
         }
+        if (context.getStatementContext().hasUnsupportedSqlCacheExpression) {
+            return CacheMode.None;
+        }
         if (!(parsedStmt instanceof LogicalPlanAdapter) || scanNodes.size() == 0) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("not a select stmt or no scan node. queryid {}", DebugUtil.printId(queryId));

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -212,6 +212,7 @@ suite("sql_cache") {
                 """
 
     def query_nondeterministics = {
+        sql "drop view if exists view_a"
         sql "CREATE VIEW view_a AS SELECT now() from $tableName"
 
         sql "set enable_sql_cache=true"

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -211,5 +211,18 @@ suite("sql_cache") {
                         k1;
                 """
 
+    def query_nondeterministics = {
+        sql "CREATE VIEW view_a AS SELECT now() from $tableName"
+
+        sql "set enable_sql_cache=true"
+        sql "admin set frontend config ('cache_last_version_interval_second'='0')"
+        def result1 = sql "select * from view_a"
+
+        sleep(3000)
+
+        def result2 = sql "select * from view_a"
+        assertNotEquals(result1, result2)
+    }()
+
     sql  "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '900')"
 }


### PR DESCRIPTION
## Proposed changes

The sql cache maybe return outdated cache because we cannot detect the the result of non-deterministric function changed, so I forbid sql cache when use nondeterministic function.

This problem not exists in the 2.1.3 because I refactor it
