### PR TITLE
[fix](ctas) fix NPE when ctas with old planner and varchar issue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1371,8 +1371,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                     if (resultExpr.getSrcSlotRef() != null
                             && resultExpr.getSrcSlotRef().getTable() != null
                             && !resultExpr.getSrcSlotRef().getTable().isManagedTable()) {
-                        if (createTableStmt.getPartitionDesc().inIdentifierPartitions(
-                                resultExpr.getSrcSlotRef().getColumnName())
+                        if ((createTableStmt.getPartitionDesc() != null
+                                && createTableStmt.getPartitionDesc().inIdentifierPartitions(
+                                resultExpr.getSrcSlotRef().getColumnName()))
                                 || (createTableStmt.getDistributionDesc() != null
                                 && createTableStmt.getDistributionDesc().inDistributionColumns(
                                         resultExpr.getSrcSlotRef().getColumnName()))) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
@@ -121,6 +121,8 @@ public class CreateTableCommand extends Command implements ForwardWithSync {
             Slot s = slots.get(i);
             DataType dataType = s.getDataType().conversion();
             if (i == 0 && dataType.isStringType()) {
+                // first column of olap table can not be string type.
+                // So change it to varchar type.
                 dataType = VarcharType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
             } else {
                 dataType = TypeCoercionUtils.replaceSpecifiedType(dataType,
@@ -133,13 +135,21 @@ public class CreateTableCommand extends Command implements ForwardWithSync {
                         if (createTableInfo.getPartitionTableInfo().inIdentifierPartitions(s.getName())
                                 || (createTableInfo.getDistribution() != null
                                 && createTableInfo.getDistribution().inDistributionColumns(s.getName()))) {
-                            // String type can not be used in partition/distributed column
+                            // String type can not be used in partition/distributed column,
                             // so we replace it to varchar
                             dataType = TypeCoercionUtils.replaceSpecifiedType(dataType,
                                     CharacterType.class, VarcharType.MAX_VARCHAR_TYPE);
                         } else {
-                            dataType = TypeCoercionUtils.replaceSpecifiedType(dataType,
-                                    CharacterType.class, StringType.INSTANCE);
+                            if (i == 0) {
+                                // first column of olap table can not be string type.
+                                // So change it to varchar type.
+                                dataType = TypeCoercionUtils.replaceSpecifiedType(dataType,
+                                        CharacterType.class, VarcharType.MAX_VARCHAR_TYPE);
+                            } else {
+                                // change varchar/char column from external table to string type
+                                dataType = TypeCoercionUtils.replaceSpecifiedType(dataType,
+                                        CharacterType.class, StringType.INSTANCE);
+                            }
                         }
                     }
                 } else {
@@ -215,3 +225,4 @@ public class CreateTableCommand extends Command implements ForwardWithSync {
         return StmtType.CREATE;
     }
 }
+

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
@@ -468,3 +468,13 @@ doris
 
 -- !sql --
 
+-- !sql --
+int_u	bigint	Yes	true	\N	
+text	varchar(65533)	Yes	true	\N	
+t2	text	Yes	false	\N	NONE
+
+-- !sql --
+int_u	bigint	Yes	true	\N	
+text	varchar(65533)	Yes	true	\N	
+t2	varchar(65533)	Yes	false	\N	NONE
+

--- a/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_mysql_jdbc_catalog.out
@@ -474,7 +474,15 @@ text	varchar(65533)	Yes	true	\N
 t2	text	Yes	false	\N	NONE
 
 -- !sql --
+varchar	varchar(65533)	Yes	true	\N	
+int_u	bigint	Yes	false	\N	NONE
+
+-- !sql --
 int_u	bigint	Yes	true	\N	
 text	varchar(65533)	Yes	true	\N	
 t2	varchar(65533)	Yes	false	\N	NONE
+
+-- !sql --
+varchar	varchar(65533)	Yes	true	\N	
+int_u	bigint	Yes	false	\N	NONE
 

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -612,6 +612,20 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
 
         order_qt_sql """select * from mysql_conjuncts.doris_test.text_push where pk <=7;"""
 
+        // test create table as select
+        sql """use internal.${internal_db_name}"""
+        sql """drop table if exists ctas_partition_text_1"""
+        sql """drop table if exists ctas_partition_text_2"""
+        sql """set enable_nereids_planner=true"""
+        sql """create table ctas_partition_text_1 distributed by hash(text) buckets 1 properties("replication_num" = "1") as select int_u, text, text as t2 from mysql_conjuncts.doris_test.all_types;"""
+        qt_sql """desc ctas_partition_text_1"""
+        // ctas logic is different between new and old planner.
+        // so need to test both.
+        // the old planner's test can be removed once the old planner is removed.
+        sql """set enable_nereids_planner=false"""
+        sql """create table ctas_partition_text_2 distributed by hash(text) buckets 1 properties("replication_num" = "1") as select int_u, text, text as t2 from mysql_conjuncts.doris_test.all_types;"""
+        qt_sql """desc ctas_partition_text_2"""
+
         sql """drop catalog if exists mysql_conjuncts;"""
     }
 }

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -23,6 +23,7 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-java-8.0.25.jar"
+    // String driver_url = "mysql-connector-java-8.0.25.jar"
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String user = "test_jdbc_user";
         String pwd = '123456';
@@ -616,15 +617,25 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
         sql """use internal.${internal_db_name}"""
         sql """drop table if exists ctas_partition_text_1"""
         sql """drop table if exists ctas_partition_text_2"""
+        sql """drop table if exists ctas_partition_text_3"""
+        sql """drop table if exists ctas_partition_text_4"""
         sql """set enable_nereids_planner=true"""
+        // 1. test text type column as distribution col
         sql """create table ctas_partition_text_1 distributed by hash(text) buckets 1 properties("replication_num" = "1") as select int_u, text, text as t2 from mysql_conjuncts.doris_test.all_types;"""
         qt_sql """desc ctas_partition_text_1"""
+        // 2. test varchar type column as first col
+        sql """create table ctas_partition_text_2 distributed by hash(int_u) buckets 1 properties("replication_num" = "1") as select varchar, int_u from mysql_conjuncts.doris_test.all_types;"""
+        qt_sql """desc ctas_partition_text_2"""
         // ctas logic is different between new and old planner.
         // so need to test both.
         // the old planner's test can be removed once the old planner is removed.
         sql """set enable_nereids_planner=false"""
-        sql """create table ctas_partition_text_2 distributed by hash(text) buckets 1 properties("replication_num" = "1") as select int_u, text, text as t2 from mysql_conjuncts.doris_test.all_types;"""
-        qt_sql """desc ctas_partition_text_2"""
+        // 1. test text type column as distribution col
+        sql """create table ctas_partition_text_3 distributed by hash(text) buckets 1 properties("replication_num" = "1") as select int_u, text, text as t2 from mysql_conjuncts.doris_test.all_types;"""
+        qt_sql """desc ctas_partition_text_3"""
+        // 2. test varchar type column as first col
+        sql """create table ctas_partition_text_4 distributed by hash(int_u) buckets 1 properties("replication_num" = "1") as select varchar, int_u from mysql_conjuncts.doris_test.all_types;"""
+        qt_sql """desc ctas_partition_text_4"""
 
         sql """drop catalog if exists mysql_conjuncts;"""
     }


### PR DESCRIPTION
Fix 2 bugs:
1. 
introduced from #35489
When the target table is unpartitioned with text type column from external table,
NPE will be thrown.
Only happen when using old planner.
The new planner works well.

2.
If first column is varchar type, the new planner will change it to string type
and then failed because first column can not be string type.