### PR TITLE
[fix](table-func) fix explode_map with alias 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -272,7 +272,8 @@ public class BindExpression implements AnalysisRuleFactory {
                 for (int idx = 0; idx < fields.size(); ++idx) {
                     expandAlias.add(new Alias(new StructElement(
                             boundSlot, new StringLiteral(fields.get(idx).getName())),
-                            generate.getExpandColumnAlias().get(i).get(idx)));
+                            generate.getExpandColumnAlias().get(i).get(idx),
+                            slot.getQualifier()));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -60,6 +60,10 @@ public class Alias extends NamedExpression implements UnaryExpression {
         this(exprId, ImmutableList.of(child), name, ImmutableList.of(), false);
     }
 
+    public Alias(Expression child, String name, List<String> qualifier) {
+        this(StatementScopeIdGenerator.newExprId(), ImmutableList.of(child), name, qualifier, false);
+    }
+
     public Alias(ExprId exprId, Expression child, String name, boolean nameFromChild) {
         this(exprId, ImmutableList.of(child), name, ImmutableList.of(), nameFromChild);
     }

--- a/regression-test/data/nereids_p0/sql_functions/table_function/explode_map.out
+++ b/regression-test/data/nereids_p0/sql_functions/table_function/explode_map.out
@@ -49,3 +49,46 @@ zhangsan	Math	60	Chinese	80
 zhangsan	Math	60	English	90
 zhangsan	Math	60	Math	60
 
+-- !explode_sql_alias --
+lisi	null	\N
+lisi2	\N	\N
+wangwu	Chinese	88
+wangwu	English	96
+wangwu	Math	90
+zhangsan	Chinese	80
+zhangsan	English	90
+zhangsan	Math	60
+
+-- !explode_outer_sql_alias --
+amory	\N	\N
+lisi	null	\N
+lisi2	\N	\N
+wangwu	Chinese	88
+wangwu	English	96
+wangwu	Math	90
+zhangsan	Chinese	80
+zhangsan	English	90
+zhangsan	Math	60
+
+-- !explode_sql_alias_multi --
+lisi	null	\N	null	\N
+lisi2	\N	\N	\N	\N
+wangwu	Chinese	88	Chinese	88
+wangwu	Chinese	88	English	96
+wangwu	Chinese	88	Math	90
+wangwu	English	96	Chinese	88
+wangwu	English	96	English	96
+wangwu	English	96	Math	90
+wangwu	Math	90	Chinese	88
+wangwu	Math	90	English	96
+wangwu	Math	90	Math	90
+zhangsan	Chinese	80	Chinese	80
+zhangsan	Chinese	80	English	90
+zhangsan	Chinese	80	Math	60
+zhangsan	English	90	Chinese	80
+zhangsan	English	90	English	90
+zhangsan	English	90	Math	60
+zhangsan	Math	60	Chinese	80
+zhangsan	Math	60	English	90
+zhangsan	Math	60	Math	60
+

--- a/regression-test/suites/nereids_p0/sql_functions/table_function/explode_map.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/table_function/explode_map.groovy
@@ -45,4 +45,10 @@ suite("explode_map") {
 
     // multi lateral view
     order_qt_explode_sql_multi """ select name, k,v,k1,v1 from sdu lateral view explode_map_outer(score) tmp as k,v lateral view explode_map(score) tmp2 as k1,v1 order by id;"""
+
+    // test with alias
+    order_qt_explode_sql_alias """ select name, tmp.k, tmp.v from sdu lateral view explode_map(score) tmp as k,v order by id;"""
+    order_qt_explode_outer_sql_alias """ select name, tmp.k, tmp.v from sdu lateral view explode_map_outer(score) tmp as k,v order by id; """
+
+    order_qt_explode_sql_alias_multi """ select name, tmp.k, tmp.v, tmp2.k, tmp2.v from sdu lateral view explode_map_outer(score) tmp as k,v lateral view explode_map(score) tmp2 as k,v order by id;"""
 }


### PR DESCRIPTION
## Proposed changes
when we use sql 
```
select 
    a.name,
    tmp.k,
    tmp.v
from (
    select 
        'zhangsan' name,
        map(1,20,2,30) score
)a lateral view explode_map(score)  tmp as k,v;

errCode = 2, detailMessage = Unknown table 'v'
```
after this pr:
```
mysql> select      a.name,     tmp.k,     tmp.v from (     select          'zhangsan' name,         map(1,20,2,30) score )a lateral view explode_map(score)  tmp as k,v;
+----------+------+------+
| name     | k    | v    |
+----------+------+------+
| zhangsan |    1 |   20 |
| zhangsan |    2 |   30 |
+----------+------+------+
2 rows in set (0.31 sec)
```
Issue Number: close #xxx

<!--Describe your changes.-->

