### PR TITLE
[fix](Nereids) should push project through limit after eliminate union node (#39640)

### DIFF
--- a/regression-test/suites/nereids_p0/union/push_limit_with_eliminate_union.groovy
+++ b/regression-test/suites/nereids_p0/union/push_limit_with_eliminate_union.groovy
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("push_limit_with_eliminate_union") {
+    // this should not failed for [INTERNAL_ERROR]VSlotRef  have invalid slot id
+    sql """(select 1 limit 0 union all select count() + 1) limit 1;"""
+}


### PR DESCRIPTION
pick from master #39640

otherwise:

push limit through union could generate plan:

limit
+-- union
    |-- limit
    |   +-- empty relation
    +-- limit
        +-- project

and then eliminate union will generate plan:

+-- limit
    +-  project
        +-- limit
            +-- project

it could not be processed by tranlator correctly

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

