### PR TITLE
[fix](window_funnel) fix upgrading problem caused by behaviour change of window_funnel

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
@@ -61,7 +61,7 @@ private:
     std::unordered_map<std::string, std::string> function_alias;
     /// @TEMPORARY: for be_exec_version=2
     /// in order to solve agg of sum/count is not compatibility during the upgrade process
-    constexpr static int AGG_FUNCTION_NEW = 2;
+    constexpr static int AGG_FUNCTION_NEW = 5;
     /// @TEMPORARY: for be_exec_version < AGG_FUNCTION_NEW. replace function to old version.
     std::unordered_map<std::string, std::string> function_to_replace;
 

--- a/regression-test/suites/nereids_p0/aggregate/window_funnel.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/window_funnel.groovy
@@ -595,7 +595,7 @@ suite("window_funnel") {
             event_timestamp datetime,
             phone_brand varchar(64),
             tab_num int
-        ) distributed by hash(user_id) buckets 3 properties("replication_num"="1");
+        ) distributed by hash(event_timestamp) buckets 3 properties("replication_num"="1");
     """
     sql """
         INSERT INTO windowfunnel_test VALUES


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

For the latest published 2.1 version `2.1.5`:
```
max_be_exec_version=4;
AGG_FUNCTION_NEW=2;
```
and `branch-2.1`:
```
max_be_exec_version=5;
AGG_FUNCTION_NEW=2;
```
It will cause problem when upgrading.
This PR fix the problem, set `AGG_FUNCTION_NEW` to `5`.

