### PR TITLE
[improve](statistics)Clean expired TableStatsMeta.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4604,14 +4604,19 @@ show_param ::=
         RESULT = new ShowSyncJobStmt(dbName);
     :}
     /* show table stats */
-    | KW_TABLE opt_cached:cached KW_STATS table_name:tbl opt_partition_names:partitionNames opt_col_list:cols
+    | KW_TABLE KW_STATS table_name:tbl opt_partition_names:partitionNames opt_col_list:cols
     {:
-        RESULT = new ShowTableStatsStmt(tbl, cols, partitionNames, cached, null);
+        RESULT = new ShowTableStatsStmt(tbl, cols, partitionNames, null);
+    :}
+    /* show table id stats */
+    | KW_TABLE KW_STATS INTEGER_LITERAL:tableId
+    {:
+        RESULT = new ShowTableStatsStmt(tableId);
     :}
     /* show index stats */
     | KW_INDEX KW_STATS table_name:tbl ident:id
     {:
-        RESULT = new ShowTableStatsStmt(tbl, null, null, false, id);
+        RESULT = new ShowTableStatsStmt(tbl, null, null, id);
     :}
     /* show column stats */
     | KW_COLUMN opt_cached:cached KW_STATS table_name:tbl opt_col_list:cols opt_partition_names:partitionNames

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
@@ -89,18 +89,29 @@ public class ShowTableStatsStmt extends ShowStmt {
     private final TableName tableName;
     private final List<String> columnNames;
     private final PartitionNames partitionNames;
-    private final boolean cached;
     private final String indexName;
+    private final long tableId;
+    private final boolean useTableId;
 
     private TableIf table;
 
+    public ShowTableStatsStmt(long tableId) {
+        this.tableName = null;
+        this.columnNames = null;
+        this.partitionNames = null;
+        this.indexName = null;
+        this.tableId = tableId;
+        this.useTableId = true;
+    }
+
     public ShowTableStatsStmt(TableName tableName, List<String> columnNames,
-                              PartitionNames partitionNames, boolean cached, String indexName) {
+                              PartitionNames partitionNames, String indexName) {
         this.tableName = tableName;
         this.columnNames = columnNames;
         this.partitionNames = partitionNames;
-        this.cached = cached;
         this.indexName = indexName;
+        this.tableId = -1;
+        this.useTableId = false;
     }
 
     public TableName getTableName() {
@@ -110,6 +121,13 @@ public class ShowTableStatsStmt extends ShowStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
+        if (useTableId) {
+            if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.SHOW)) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "Permission denied",
+                        ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP());
+            }
+            return;
+        }
         tableName.analyze(analyzer);
         if (partitionNames != null) {
             partitionNames.analyze(analyzer);
@@ -171,6 +189,14 @@ public class ShowTableStatsStmt extends ShowStmt {
         return table;
     }
 
+    public boolean isUseTableId() {
+        return useTableId;
+    }
+
+    public long getTableId() {
+        return tableId;
+    }
+
     public ShowResultSet constructResultSet(TableStatsMeta tableStatistic) {
         if (indexName != null) {
             return constructIndexResultSet(tableStatistic);
@@ -183,6 +209,10 @@ public class ShowTableStatsStmt extends ShowStmt {
         } else {
             return constructColumnPartitionResultSet(tableStatistic);
         }
+    }
+
+    public ShowResultSet constructEmptyResultSet() {
+        return new ShowResultSet(getMetaData(), new ArrayList<>());
     }
 
     public ShowResultSet constructResultSet(long rowCount) {
@@ -312,9 +342,5 @@ public class ShowTableStatsStmt extends ShowStmt {
             }
         }
         return new ShowResultSet(getMetaData(), result);
-    }
-
-    public boolean isCached() {
-        return cached;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2712,6 +2712,17 @@ public class ShowExecutor {
     private void handleShowTableStats() {
         ShowTableStatsStmt showTableStatsStmt = (ShowTableStatsStmt) stmt;
         TableIf tableIf = showTableStatsStmt.getTable();
+        // Handle use table id to show table stats. Mainly for online debug.
+        if (showTableStatsStmt.isUseTableId()) {
+            long tableId = showTableStatsStmt.getTableId();
+            TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(tableId);
+            if (tableStats == null) {
+                resultSet = showTableStatsStmt.constructEmptyResultSet();
+            } else {
+                resultSet = showTableStatsStmt.constructResultSet(tableStats);
+            }
+            return;
+        }
         TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(tableIf.getId());
         /*
            tableStats == null means it's not analyzed, in this case show the estimated row count.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -1381,6 +1381,10 @@ public class AnalysisManager implements Writable {
         }
     }
 
+    public Set<Long> getIdToTblStatsKeys() {
+        return new HashSet<>(idToTblStats.keySet());
+    }
+
     public ColStatsMeta findColStatsMeta(long tblId, String indexName, String colName) {
         TableStatsMeta tableStats = findTableStatsStatus(tblId);
         if (tableStats == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -47,8 +47,23 @@ import java.util.stream.Collectors;
 
 public class TableStatsMeta implements Writable, GsonPostProcessable {
 
+    @SerializedName("ctlId")
+    public final long ctlId;
+
+    @SerializedName("ctln")
+    public final String ctlName;
+
+    @SerializedName("dbId")
+    public final long dbId;
+
+    @SerializedName("dbn")
+    public final String dbName;
+
     @SerializedName("tblId")
     public final long tblId;
+
+    @SerializedName("tbln")
+    public final String tblName;
 
     @SerializedName("idxId")
     public final long idxId;
@@ -93,14 +108,24 @@ public class TableStatsMeta implements Writable, GsonPostProcessable {
 
     @VisibleForTesting
     public TableStatsMeta() {
+        ctlId = 0;
+        ctlName = null;
+        dbId = 0;
+        dbName = null;
         tblId = 0;
+        tblName = null;
         idxId = 0;
     }
 
     // It's necessary to store these fields separately from AnalysisInfo, since the lifecycle between AnalysisInfo
     // and TableStats is quite different.
     public TableStatsMeta(long rowCount, AnalysisInfo analyzedJob, TableIf table) {
+        this.ctlId = table.getDatabase().getCatalog().getId();
+        this.ctlName = table.getDatabase().getCatalog().getName();
+        this.dbId = table.getDatabase().getId();
+        this.dbName = table.getDatabase().getFullName();
         this.tblId = table.getId();
+        this.tblName = table.getName();
         this.idxId = -1;
         this.rowCount = rowCount;
         update(analyzedJob, table);

--- a/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_drop_expired_table_stats", "p0,external,hive,external_docker,external_docker_hive") {
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable Hive test.")
+        return
+    }
+
+    for (String hivePrefix : ["hive2", "hive3"]) {
+        String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
+        String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String catalog_name = hivePrefix + "_test_drop_expired_table_stats"
+        sql """drop catalog if exists ${catalog_name};"""
+        sql """
+            create catalog if not exists ${catalog_name} properties (
+                'type'='hms',
+                'hadoop.username' = 'hadoop',
+                'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}'
+            );
+        """
+        logger.info("catalog " + catalog_name + " created")
+        sql """switch ${catalog_name};"""
+
+
+        sql """use stats_test"""
+        sql """analyze table employee_gz with sync"""
+        def result = sql """show table stats employee_gz"""
+        assertEquals(1, result.size())
+
+        def ctlId
+        def dbId
+        def tblId
+        result = sql """show catalogs"""
+
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == catalog_name) {
+                ctlId = result[i][0]
+            }
+        }
+        logger.info("catalog id is " + ctlId)
+        result = sql """show proc '/catalogs/$ctlId'"""
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == 'stats_test') {
+                dbId = result[i][0]
+            }
+        }
+        logger.info("db id is " + dbId)
+        result = sql """show proc '/catalogs/$ctlId/$dbId'"""
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == 'employee_gz') {
+                tblId = result[i][0]
+            }
+        }
+        logger.info("table id is " + tblId)
+        result = sql """show table stats $tblId"""
+        logger.info("Table stats " + result)
+        assertEquals(1, result.size())
+
+        sql """drop catalog ${catalog_name}"""
+        result = sql """show table stats $tblId"""
+        logger.info("Table stats " + result)
+        assertEquals(1, result.size())
+
+        try {
+            sql """drop expired stats"""
+        } catch (Exception e) {
+            logger.info("Drop expired stats exception. " + e.getMessage())
+        }
+        result = sql """show table stats $tblId"""
+        logger.info("Table stats " + result)
+        assertEquals(0, result.size())
+    }
+}
+


### PR DESCRIPTION
Drop catalog and older version of drop database (before https://github.com/apache/doris/pull/39685), will not remove table stats object in memory. Need a background thread to clean the garbage.