### PR TITLE
[Improvement](top-n) adjust the strategy for selecting the sort algorithm

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -352,7 +352,7 @@ public class SortNode extends PlanNode {
                 algorithm = TSortAlgorithm.FULL_SORT;
             }
         } else {
-            if (limit == 0) {
+            if (limit <= 0) {
                 algorithm = TSortAlgorithm.FULL_SORT;
             } else if (hasRuntimePredicate || useTwoPhaseReadOpt) {
                 algorithm = TSortAlgorithm.HEAP_SORT;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -340,8 +340,6 @@ public class SortNode extends PlanNode {
         msg.sort_node.setIsAnalyticSort(isAnalyticSort);
         msg.sort_node.setIsColocate(isColocate);
 
-        boolean isFixedLength = info.getOrderingExprs().stream()
-                .allMatch(e -> !e.getType().isStringType() && !e.getType().isCollectionType());
         ConnectContext connectContext = ConnectContext.get();
         TSortAlgorithm algorithm;
         if (connectContext != null && !connectContext.getSessionVariable().forceSortAlgorithm.isEmpty()) {
@@ -354,12 +352,18 @@ public class SortNode extends PlanNode {
                 algorithm = TSortAlgorithm.FULL_SORT;
             }
         } else {
-            if (limit > 0 && limit + offset < 1024 && (useTwoPhaseReadOpt || hasRuntimePredicate || isFixedLength)) {
-                algorithm = TSortAlgorithm.HEAP_SORT;
-            } else if (limit > 0 && !isFixedLength && limit + offset < 256) {
-                algorithm = TSortAlgorithm.TOPN_SORT;
-            } else {
+            if (limit == 0) {
                 algorithm = TSortAlgorithm.FULL_SORT;
+            } else if (hasRuntimePredicate || useTwoPhaseReadOpt) {
+                algorithm = TSortAlgorithm.HEAP_SORT;
+            } else {
+                if (limit + offset < 5000000) {
+                    algorithm = TSortAlgorithm.HEAP_SORT;
+                } else if (limit + offset < 20000000) {
+                    algorithm = TSortAlgorithm.FULL_SORT;
+                } else {
+                    algorithm = TSortAlgorithm.TOPN_SORT;
+                }
             }
         }
         msg.sort_node.setAlgorithm(algorithm);


### PR DESCRIPTION
## Proposed changes
1. heap和topn filter应该是绑定关系, 有topn filter时直接走heap
2. 把topn filter阈值设置为heap+topn比topn/full慢的边界
3. 按limit分为小->中->大,
有topn filter时选用算法应该是 heap+topn filter[0,10000000) -> full[10000000,20000000) -> topn[20000000,)
否则选用算法应该是 heap[0,5000000) -> full[5000000,20000000) -> topn -> topn[20000000,)

select * from lineorder order by lo_orderpriority limit 100000;
heap:3.33s
full:18.3s

select * from lineorder order by lo_orderpriority limit 1000000;
heap:5.3s
np:8s
full:39s
topn:30s

select * from lineorder order by lo_orderpriority limit 5000000;
heap:17.57 sec
np:21.02 sec
full:41.85 sec
topn:32.20 sec

select * from lineorder order by lo_orderpriority limit 10000000;
heap:35s
np: 39s
full:47s
topn:40s

select * from lineorder order by lo_orderpriority limit 20000000;
heap:1 min 9.16 sec
full:48.09 sec
topn: 44.97 sec
