### PR TITLE
[fix](cloud) overwrite job statistic without data quality check when update cloud progress

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -281,7 +281,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
 
         RLTaskTxnCommitAttachment commitAttach = new RLTaskTxnCommitAttachment(response.getCommitAttach());
-        updateProgress(commitAttach);
+        updateCloudProgress(commitAttach);
     }
 
     @Override
@@ -343,6 +343,12 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     protected void replayUpdateProgress(RLTaskTxnCommitAttachment attachment) {
         super.replayUpdateProgress(attachment);
+        updateProgressAndOffsetsCache(attachment);
+    }
+
+    @Override
+    protected void updateCloudProgress(RLTaskTxnCommitAttachment attachment) {
+        super.updateCloudProgress(attachment);
         updateProgressAndOffsetsCache(attachment);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -866,6 +866,18 @@ public abstract class RoutineLoadJob
                 attachment.getReceivedBytes(), false /* not replay */);
     }
 
+    protected void updateCloudProgress(RLTaskTxnCommitAttachment attachment) {
+        // In the cloud mode, the reason for needing to overwrite jobStatistic is that
+        // pulling the progress of meta service is equivalent to a replay operation of edit log,
+        // but this method will be called whenever scheduled by RoutineLoadScheduler,
+        // and accumulation will result in incorrect jobStatistic information.
+        this.jobStatistic.totalRows = attachment.getTotalRows();
+        this.jobStatistic.errorRows = attachment.getFilteredRows();
+        this.jobStatistic.unselectedRows = attachment.getUnselectedRows();
+        this.jobStatistic.receivedBytes = attachment.getReceivedBytes();
+        this.jobStatistic.totalTaskExcutionTimeMs = System.currentTimeMillis() - createTimestamp;
+    }
+
     private void updateNumOfData(long numOfTotalRows, long numOfErrorRows, long unselectedRows, long receivedBytes,
                                  boolean isReplay) throws UserException {
         this.jobStatistic.totalRows += numOfTotalRows;


### PR DESCRIPTION
`updateCloudProgress()` will be called when job need schedule, and then:
1. update job statistic by accumulation
2. do data quality check


Update job statistic by accumulation will cause job statistic incorrect, for job pause and resume will double the job statistic.

do data quality check is not need, for `updateCloudProgress()` is similar to the reply operation, 
```
if (this.jobStatistic.currentErrorRows > maxErrorNum
                || (this.jobStatistic.currentTotalRows > 0
                    && ((double) this.jobStatistic.currentErrorRows
                            / this.jobStatistic.currentTotalRows) > maxFilterRatio)) {
            LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
                    .add("current_total_rows", this.jobStatistic.currentTotalRows)
                    .add("current_error_rows", this.jobStatistic.currentErrorRows)
                    .add("max_error_num", maxErrorNum)
                    .add("max_filter_ratio", maxFilterRatio)
                    .add("msg", "current error rows is more than max_error_number "
                            + "or the max_filter_ratio is more than the max, begin to pause job")
                    .build());
            if (!isReplay) {
                // remove all of task in jobs and change job state to paused
                updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR,
                        "current error rows is more than max_error_number "
                            + "or the max_filter_ratio is more than the value set"), isReplay);
            }
            // reset currentTotalNum and currentErrorNum
            this.jobStatistic.currentErrorRows = 0;
            this.jobStatistic.currentTotalRows = 0;
        }
```
if quality checks are performed, it will result in the job not being able to `resume`.

