### PR TITLE
[fix](cloud-mow) FE should not request partition stats by snapshot read in calcDeleteBitmapForMow

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1960,7 +1960,7 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
         for (const auto& tablet_index : request->tablet_indexes()) {
             TabletIndexPB idx(tablet_index);
             TabletStatsPB tablet_stat;
-            internal_get_tablet_stats(code, msg, txn.get(), instance_id, idx, tablet_stat, true);
+            internal_get_tablet_stats(code, msg, txn.get(), instance_id, idx, tablet_stat, false);
             if (code != MetaServiceCode::OK) {
                 response->clear_base_compaction_cnts();
                 response->clear_cumulative_compaction_cnts();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

#37670 Let FE call get_delete_bitmap_update_lock in calcDeleteBitmapForMow to get the latest compaction stats of the corresponding partition at the same time, so that in the downstream calcDelete bitmap task, it can let BE determine if there is a concurrent compaction conflict.

However, this PR uses snapshot read when fetching the partition stats, which makes it possible for us to fetch outdated stats, thus allowing the BE to miss the conflict processing of concurrent compaction, and generating duplicate keys.

