### PR TITLE
[optimize](table stat) Reduce lock when get table statistics

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -151,13 +151,8 @@ public class ShowDataStmt extends ShowStmt {
                     OlapTable olapTable = (OlapTable) table;
                     long tableSize = 0;
                     long replicaCount = 0;
-                    olapTable.readLock();
-                    try {
-                        tableSize = olapTable.getDataSize();
-                        replicaCount = olapTable.getReplicaCount();
-                    } finally {
-                        olapTable.readUnlock();
-                    }
+                    tableSize = olapTable.getDataSize();
+                    replicaCount = olapTable.getReplicaCount();
                     //|TableName|Size|ReplicaCount|
                     List<Object> row = Arrays.asList(table.getName(), tableSize, replicaCount);
                     totalRowsObject.add(row);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -231,48 +231,42 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
 
     public long getUsedDataQuotaWithLock() {
         long usedDataQuota = 0;
+        List<Table> tables = new ArrayList<>();
         readLock();
         try {
-            for (Table table : this.idToTable.values()) {
-                if (table.getType() != TableType.OLAP) {
-                    continue;
-                }
-
-                OlapTable olapTable = (OlapTable) table;
-                olapTable.readLock();
-                try {
-                    usedDataQuota = usedDataQuota + olapTable.getDataSize();
-                } finally {
-                    olapTable.readUnlock();
-                }
-            }
-            return usedDataQuota;
+            tables.addAll(this.idToTable.values());
         } finally {
             readUnlock();
         }
+        for (Table table : tables) {
+            if (table.getType() != TableType.OLAP) {
+                continue;
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            usedDataQuota = usedDataQuota + olapTable.getDataSize();
+        }
+        return usedDataQuota;
     }
 
     public long getReplicaCountWithLock() {
+        long usedReplicaCount = 0;
+        List<Table> tables = new ArrayList<>();
         readLock();
         try {
-            long usedReplicaCount = 0;
-            for (Table table : this.idToTable.values()) {
-                if (table.getType() != TableType.OLAP) {
-                    continue;
-                }
-
-                OlapTable olapTable = (OlapTable) table;
-                olapTable.readLock();
-                try {
-                    usedReplicaCount = usedReplicaCount + olapTable.getReplicaCount();
-                } finally {
-                    olapTable.readUnlock();
-                }
-            }
-            return usedReplicaCount;
+            tables.addAll(this.idToTable.values());
         } finally {
             readUnlock();
         }
+        for (Table table : tables) {
+            if (table.getType() != TableType.OLAP) {
+                continue;
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            usedReplicaCount = usedReplicaCount + olapTable.getReplicaCount();
+        }
+        return usedReplicaCount;
     }
 
     public long getReplicaQuotaLeftWithLock() {


### PR DESCRIPTION
## Proposed changes

Issue Number: this pr will pick part of #35457 to reduce the potential of dead lock with following example:

时间点 | create table线程1 | create table线程2 | table stat线程 | truncate线程
-- | -- | -- | -- | --
t1 | add table1 read lock |   |   |  
t2 |   | add table2 read lock |   |  
t3 |   |   | try add table1 write lock，blocked |  
t4 |   |   |   | try add table2 write lock，blocked
t5 | try add table2 read lock，Due to a thread attempting to add the table2 write lock earlier, it was forced to queue up |   |   |  
t6 |   | try add table1 read lock，Due to a thread attempting to add the table1 write lock earlier, it was forced to queue up |   |  

This deadlock situation usually occurs when it is a fair lock. So we should optimize the read lock.

This PR places the updates of table statistics(such as data size/replica count) in the Table Stats Thread to be done on a scheduled basis, so that there is no need to add a read lock when obtaining table statistics.

<!--Describe your changes.-->

