### PR TITLE
[Fix](Nerieds) insert into table with default not null but not included in insert schema

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -923,7 +923,8 @@ public class NativeInsertStmt extends InsertStmt {
             Column col = targetColumns.get(i);
 
             if (expr instanceof DefaultValueExpr) {
-                if (targetColumns.get(i).getDefaultValue() == null && !targetColumns.get(i).isAllowNull()) {
+                if (targetColumns.get(i).getDefaultValue() == null && !targetColumns.get(i).isAllowNull()
+                        && !targetColumns.get(i).isAutoInc()) {
                     throw new AnalysisException("Column has no default value, column="
                             + targetColumns.get(i).getName());
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -337,7 +337,7 @@ public class BindSink implements AnalysisRuleFactory {
                 } else if (column.getDefaultValue() == null) {
                     // throw exception if explicitly use Default value but no default value present
                     // insert into table t values(DEFAULT)
-                    if (columnToChildOutput.get(column) instanceof DefaultValueSlot && !column.isAllowNull()) {
+                    if (!column.isAllowNull()) {
                         throw new AnalysisException("Column has no default value,"
                                 + " column=" + column.getName());
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -337,7 +337,7 @@ public class BindSink implements AnalysisRuleFactory {
                 } else if (column.getDefaultValue() == null) {
                     // throw exception if explicitly use Default value but no default value present
                     // insert into table t values(DEFAULT)
-                    if (!column.isAllowNull()) {
+                    if (!column.isAllowNull() && !column.isAutoInc()) {
                         throw new AnalysisException("Column has no default value,"
                                 + " column=" + column.getName());
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -427,7 +427,7 @@ public class InsertUtils {
                 return new Alias(new NullLiteral(DataType.fromCatalogType(column.getType())), column.getName());
             }
             if (column.getDefaultValue() == null) {
-                if (!column.isAllowNull()) {
+                if (!column.isAllowNull() && !column.isAutoInc()) {
                     throw new AnalysisException("Column has no default value, column=" + column.getName());
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
@@ -109,7 +109,8 @@ public class ReadLockTest extends SSBTestBase {
 
     @Test
     public void testInserInto() {
-        String sql = "INSERT INTO supplier(s_suppkey) SELECT lo_orderkey FROM lineorder";
+        String sql = "INSERT INTO supplier(s_suppkey, s_name, s_address, s_city, s_nation, s_region, s_phone) "
+                + "SELECT lo_orderkey, '', '', '', '', '', '' FROM lineorder";
         StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
         InsertIntoTableCommand insertIntoTableCommand = (InsertIntoTableCommand) parser.parseSingle(sql);
         NereidsPlanner planner = new NereidsPlanner(statementContext);


### PR DESCRIPTION
example:
create table t(k1 int not null, k2 int not null);
insert into t (k1) values (101);
it should be failed because we don't know what value should k2 be

