### PR TITLE
[test](injection) clean leaked load streams by idle timeout

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
@@ -98,7 +98,12 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
         // test segment num check when LoadStreamStub missed tail segments
         load_with_injection("LoadStreamStub.only_send_segment_0", "segment num mismatch")
         // test 1st stream to each backend failure
-        load_with_injection("VTabletWriterV2._open_streams_to_backend.one_stream_open_failure", "success")
+        try {
+            sql "set insert_timeout=120"
+            load_with_injection("VTabletWriterV2._open_streams_to_backend.one_stream_open_failure", "success")
+        } finally {
+            sql "set insert_timeout=14400"
+        }
         // test one backend open failure
         load_with_injection("VTabletWriterV2._open_streams.skip_one_backend", "success")
         sql """ set enable_memtable_on_sink_node=false """


### PR DESCRIPTION
## Proposed changes

Open stream failure fault injection caused load stream leak because `use_cnt` cannot drop to `0`.
This PR reduce the idle timeout for this injection case, which equals to load timeout.
On idle timeout, load streams are supposed to be closed.


