### PR TITLE
[fix](udf) Fix exception thrown when replayDropFunction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
@@ -93,7 +93,7 @@ public class GlobalFunctionMgr extends MetaObject {
 
     public synchronized void replayDropFunction(FunctionSearchDesc functionSearchDesc) {
         try {
-            FunctionUtil.dropFunctionImpl(functionSearchDesc, false, name2Function);
+            FunctionUtil.dropFunctionImpl(functionSearchDesc, true, name2Function);
             FunctionUtil.dropFromNereids(null, functionSearchDesc);
         } catch (UserException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
pick #39805 

This PR completes #25965 to fix uncaught runtime exception when calling
`org.apache.doris.catalog.GlobalFunctionMgr#replayDropFunction`

![img_v3_02e0_3889b1de-583e-48ba-8e7f-48e1d3ae799g](https://github.com/user-attachments/assets/b0dbfefb-16f3-4dbb-8a00-f4773978ba01)