### PR TITLE
[fix](thrift) fix wrong order of field 27 and 28 in TCreateTabletReq thrift

### DIFF
--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -163,8 +163,8 @@ struct TCreateTabletReq {
     24: optional i64 time_series_compaction_file_count_threshold = 2000
     25: optional i64 time_series_compaction_time_threshold_seconds = 3600
     26: optional i64 time_series_compaction_empty_rowsets_threshold = 5
-    27: optional TInvertedIndexStorageFormat inverted_index_storage_format = TInvertedIndexStorageFormat.V1
-    28: optional i64 time_series_compaction_level_threshold = 1
+    27: optional i64 time_series_compaction_level_threshold = 1
+    28: optional TInvertedIndexStorageFormat inverted_index_storage_format = TInvertedIndexStorageFormat.V1
 }
 
 struct TDropTabletReq {


### PR DESCRIPTION
## Proposed changes

fix wrong order of field 27 and 28 in `TCreateTabletReq` thrift introduced by  #32418 and 0cde0cbf19011bc8d421add4734d7cd57308973f.

`TCreateTabletReq` is used for creating tablet, so this PR will fix problem creating tablet when upgrading 2.0.x -> 2.1.4/2.1.5 or 2.1.4/2.1.5 -> 3.0.x, BUT will cause problem creating tablet when upgrading 2.1.4/2.1.5 -> 2.1.6+.

master and branch-2.0 
```
    27: optional i64 time_series_compaction_level_threshold = 1
    28: optional TInvertedIndexStorageFormat inverted_index_storage_format = TInvertedIndexStorageFormat.V1
```

branch-2.1 (affects 2.1.4 and 2.1.5)
```
    27: optional TInvertedIndexStorageFormat inverted_index_storage_format = TInvertedIndexStorageFormat.V1
    28: optional i64 time_series_compaction_level_threshold = 1
```