### PR TITLE
[fix](catalog) fix invalid getPartitionNames() methods

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -54,7 +54,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -597,14 +596,6 @@ public abstract class Table extends MetaObject implements Writable, TableIf, Gso
         table.put("Id", Long.toString(id));
         table.put("Name", name);
         return table;
-    }
-
-    public boolean isHasCompoundKey() {
-        return hasCompoundKey;
-    }
-
-    public Set<String> getPartitionNames() {
-        return Collections.EMPTY_SET;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
@@ -28,14 +28,11 @@ import org.apache.doris.thrift.TIcebergTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Table;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class IcebergExternalTable extends ExternalTable {
 
@@ -91,12 +88,5 @@ public class IcebergExternalTable extends ExternalTable {
 
     public Table getIcebergTable() {
         return IcebergUtils.getIcebergTable(getCatalog(), getDbName(), getName());
-    }
-
-    @Override
-    public Set<String> getPartitionNames() {
-        getIcebergTable();
-        return IcebergUtils.getIcebergTable(getCatalog(), getDbName(), getName())
-                .spec().fields().stream().map(PartitionField::name).collect(Collectors.toSet());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTable.java
@@ -51,7 +51,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -92,14 +91,6 @@ public class MaxComputeExternalTable extends ExternalTable {
                 .getRecordCount();
     }
 
-    @Override
-    public Set<String> getPartitionNames() {
-        makeSureInitialized();
-        Optional<SchemaCacheValue> schemaCacheValue = getSchemaCacheValue();
-        return schemaCacheValue.map(value -> ((MaxComputeSchemaCacheValue) value).getPartitionColNames())
-                .orElse(Collections.emptySet());
-    }
-
     public List<Column> getPartitionColumns() {
         makeSureInitialized();
         Optional<SchemaCacheValue> schemaCacheValue = getSchemaCacheValue();
@@ -129,7 +120,8 @@ public class MaxComputeExternalTable extends ExternalTable {
         TablePartitionValues partitionValues = new TablePartitionValues();
         partitionValues.addPartitions(partitionSpecs,
                 partitionSpecs.stream()
-                        .map(p -> parsePartitionValues(new ArrayList<>(getPartitionNames()), p))
+                        .map(p -> parsePartitionValues(getPartitionColumns().stream().map(c -> c.getName()).collect(
+                                Collectors.toList()), p))
                         .collect(Collectors.toList()),
                 partitionTypes);
         return partitionValues;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -110,7 +110,7 @@ public class MaxComputeScanNode extends FileQueryScanNode {
             return result;
         }
         try {
-            if (!table.getPartitionNames().isEmpty()) {
+            if (!table.getPartitionColumns().isEmpty()) {
                 if (conjuncts.isEmpty()) {
                     throw new IllegalArgumentException("Max Compute partition table need partition predicate.");
                 }


### PR DESCRIPTION
Some of `getPartitionNames()` is invalid can not used.
Remove these override methods to avoid unexpected behavior