### PR TITLE
[fix](recvr) catch exception of transmit_block

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -156,7 +156,7 @@ Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_num
     {
         SCOPED_RAW_TIMER(&deserialize_time);
         block = Block::create_unique();
-        RETURN_IF_ERROR(block->deserialize(pblock));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(block->deserialize(pblock));
     }
 
     const auto rows = block->rows();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Receiver side of `transmit_block` may throw exception under some circumstances, catch exception to avoid BE coredump.
