### PR TITLE
[fix](inverted index) Fix Session Variable Compatibility

### DIFF
--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -317,11 +317,10 @@ struct TQueryOptions {
 
   118: optional TSerdeDialect serde_dialect = TSerdeDialect.DORIS;
 
-  119: optional bool enable_match_without_inverted_index = true;
+  119: optional bool keep_carriage_return = false; // \n,\r\n split line in CSV.
 
-  120: optional bool enable_fallback_on_missing_inverted_index = true;
-
-  121: optional bool keep_carriage_return = false; // \n,\r\n split line in CSV.
+  120: optional bool enable_match_without_inverted_index = true;
+  121: optional bool enable_fallback_on_missing_inverted_index = true;
 
   122: optional i32 runtime_bloom_filter_min_size = 1048576;
 


### PR DESCRIPTION
## Proposed changes

1. Modify the conflict changes caused by https://github.com/apache/doris/pull/38077, adjusting the correct order to:
    119: optional bool keep_carriage_return = false; // \n,\r\n split line in CSV.
    120: optional bool enable_match_without_inverted_index = true;
    121: optional bool enable_fallback_on_missing_inverted_index = true;

<!--Describe your changes.-->

