### PR TITLE
[fix](binlog) Fix NPE when recover binlogs (#39909)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropPartitionInfo.java
@@ -79,7 +79,9 @@ public class DropPartitionInfo implements Writable {
     }
 
     public Long getPartitionId() {
-        return partitionId;
+        // the field partition ID was added in PR: apache/doris#37196, the old version doesn't
+        // contain this field so it will be null.
+        return partitionId == null ? -1 : partitionId;
     }
 
     public String getPartitionName() {


### PR DESCRIPTION
Cherry-pick #39909 

The field partition ID of DropPartitionInfo was added in PR: apache/doris#37196, the old version doesn't contain this field so it will be null.

