### PR TITLE
[fix](json) fix parsing fails when json key string is empty.

### DIFF
--- a/be/src/util/jsonb_parser.h
+++ b/be/src/util/jsonb_parser.h
@@ -370,7 +370,7 @@ private:
             }
         }
 
-        if (!in.good() || in.peek() != '"' || key_len == 0) {
+        if (!in.good() || in.peek() != '"') {
             if (key_len == JsonbKeyValue::sMaxKeyLen)
                 err_ = JsonbErrType::E_INVALID_KEY_LENGTH;
             else

--- a/be/src/util/jsonb_parser.h
+++ b/be/src/util/jsonb_parser.h
@@ -369,7 +369,7 @@ private:
                 key[key_len++] = ch;
             }
         }
-
+        // The JSON key can be an empty string.
         if (!in.good() || in.peek() != '"') {
             if (key_len == JsonbKeyValue::sMaxKeyLen)
                 err_ = JsonbErrType::E_INVALID_KEY_LENGTH;


### PR DESCRIPTION
## Proposed changes

This is a very subtle bug that can only be reproduced in a non-AVX2 environment.
```
// USE_AVX2 = false
mysql [(none)]>mysql [(none)]>select cast('{"":1, " ":"v1"}' as json);
+----------------------------------+
| cast('{"":1, " ":"v1"}' as JSON) |
+----------------------------------+
| NULL                             |
+----------------------------------+

//USE_AVX2 = true
mysql [(none)]>select cast('{"":1, " ":"v1"}' as json);
+----------------------------------+
| cast('{"":1, " ":"v1"}' as JSON) |
+----------------------------------+
| {"":1," ":"v1"}                  |
+----------------------------------+
```

<!--Describe your changes.-->

