### PR TITLE
[fix](catalog) hide some properties in show create catalog stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateCatalogStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateCatalogStmt.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
@@ -41,7 +42,6 @@ import java.util.Map;
  * Statement for create a new catalog.
  */
 public class CreateCatalogStmt extends DdlStmt implements NotFallbackInParser {
-    public static final String CREATE_TIME_PROP = "create_time";
     private final boolean ifNotExists;
     private final String catalogName;
     private final String resource;
@@ -101,7 +101,7 @@ public class CreateCatalogStmt extends DdlStmt implements NotFallbackInParser {
         }
 
         String currentDateTime = LocalDateTime.now(ZoneId.systemDefault()).toString().replace("T", " ");
-        properties.put(CREATE_TIME_PROP, currentDateTime);
+        properties.put(ExternalCatalog.CREATE_TIME, currentDateTime);
         PropertyAnalyzer.checkCatalogProperties(properties, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PrintableMap.java
@@ -43,6 +43,7 @@ public class PrintableMap<K, V> {
     private boolean wrap;
     private boolean hidePassword;
     private String entryDelimiter = ",";
+    private Set<String> additionalHiddenKeys = Sets.newHashSet();
 
     public static final Set<String> SENSITIVE_KEY;
     public static final Set<String> HIDDEN_KEY;
@@ -98,6 +99,10 @@ public class PrintableMap<K, V> {
         this.hidePassword = hidePassword;
     }
 
+    public void setAdditionalHiddenKeys(Set<String> additionalHiddenKeys) {
+        this.additionalHiddenKeys = additionalHiddenKeys;
+    }
+
     @Override
     public String toString() {
         if (map == null) {
@@ -119,7 +124,7 @@ public class PrintableMap<K, V> {
         List<Map.Entry<K, V>> entries = new ArrayList<>();
         while (iter.hasNext()) {
             Map.Entry<K, V> entry = iter.next();
-            if (!HIDDEN_KEY.contains(entry.getKey())) {
+            if (!HIDDEN_KEY.contains(entry.getKey()) && !additionalHiddenKeys.contains(entry.getKey())) {
                 entries.add(entry);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -36,6 +36,7 @@ import org.apache.doris.common.CaseSensibility;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.PatternMatcherWrapper;
 import org.apache.doris.common.UserException;
@@ -87,8 +88,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     public static final String ACCESS_CONTROLLER_PROPERTY_PREFIX_PROP = "access_controller.properties.";
     public static final String METADATA_REFRESH_INTERVAL_SEC = "metadata_refresh_interval_sec";
     public static final String CATALOG_TYPE_PROP = "type";
-
-    private static final String YES = "yes";
 
     private final MonitoredReentrantReadWriteLock lock = new MonitoredReentrantReadWriteLock(true);
 
@@ -384,12 +383,12 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                         row.add(name);
                         row.add(catalog.getType());
                         if (name.equals(currentCtlg)) {
-                            row.add(YES);
+                            row.add("Yes");
                         } else {
-                            row.add("");
+                            row.add("No");
                         }
                         Map<String, String> props = catalog.getProperties();
-                        String createTime = props.getOrDefault(CreateCatalogStmt.CREATE_TIME_PROP, "UNRECORDED");
+                        String createTime = props.getOrDefault(ExternalCatalog.CREATE_TIME, FeConstants.null_string);
                         row.add(createTime);
                         row.add(TimeUtils.longToTimeString(catalog.getLastUpdateTime()));
                         row.add(catalog.getComment());
@@ -450,7 +449,10 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             }
             if (catalog.getProperties().size() > 0) {
                 sb.append(" PROPERTIES (\n");
-                sb.append(new PrintableMap<>(catalog.getProperties(), "=", true, true, true, true));
+                PrintableMap<String, String> printableMap = new PrintableMap<>(catalog.getProperties(), "=", true, true,
+                        true, true);
+                printableMap.setAdditionalHiddenKeys(ExternalCatalog.HIDDEN_PROPERTIES);
+                sb.append(printableMap);
                 sb.append("\n);");
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -101,7 +101,13 @@ public abstract class ExternalCatalog
     public static final String DORIS_VERSION = "doris.version";
     public static final String DORIS_VERSION_VALUE = Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH;
     public static final String USE_META_CACHE = "use_meta_cache";
+    public static final String CREATE_TIME = "create_time";
     public static final boolean DEFAULT_USE_META_CACHE = true;
+
+    // Properties that should not be shown in the `show create catalog` result
+    public static final Set<String> HIDDEN_PROPERTIES = Sets.newHashSet(
+            CREATE_TIME,
+            USE_META_CACHE);
 
     // Unique id of this catalog, will be assigned after catalog is loaded.
     @SerializedName(value = "id")

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -269,6 +269,8 @@ public class CatalogMgrTest extends TestWithFeService {
         List<String> result = showResultSet.getResultRows().get(0);
         Assertions.assertEquals("my_catalog", result.get(0));
         Assertions.assertTrue(result.get(1).startsWith("\nCREATE CATALOG `my_catalog`\nCOMMENT \"hms comment\"\n PROPERTIES ("));
+        Assertions.assertTrue(!result.get(1).contains(ExternalCatalog.CREATE_TIME));
+        Assertions.assertTrue(!result.get(1).contains(ExternalCatalog.USE_META_CACHE));
 
         testCatalogMgrPersist();
 
@@ -355,7 +357,8 @@ public class CatalogMgrTest extends TestWithFeService {
         String showCatalogSql = "SHOW CATALOGS";
         ShowCatalogStmt showStmt = (ShowCatalogStmt) parseAndAnalyzeStmt(showCatalogSql);
         ShowResultSet showResultSet = mgr.showCatalogs(showStmt, user2Ctx.getCurrentCatalog().getName());
-        Assertions.assertEquals("yes", showResultSet.getResultRows().get(1).get(3));
+        Assertions.assertEquals("Yes", showResultSet.getResultRows().get(1).get(3));
+        Assertions.assertEquals("No", showResultSet.getResultRows().get(0).get(3));
 
         // user2 can switch to hive
         SwitchStmt switchHive = (SwitchStmt) parseAndAnalyzeStmt("switch hive;", user2Ctx);
@@ -365,7 +368,7 @@ public class CatalogMgrTest extends TestWithFeService {
         showCatalogSql = "SHOW CATALOGS";
         showStmt = (ShowCatalogStmt) parseAndAnalyzeStmt(showCatalogSql);
         showResultSet = mgr.showCatalogs(showStmt, user2Ctx.getCurrentCatalog().getName());
-        Assertions.assertEquals("yes", showResultSet.getResultRows().get(0).get(3));
+        Assertions.assertEquals("Yes", showResultSet.getResultRows().get(0).get(3));
     }
 
     @Test


### PR DESCRIPTION
the `use_meta_cache` and `create_time` property should not be visible in
show create catalog stmt.
These properties are not for user.
But you can still see them in `show catalog xxx` stmt