### PR TITLE
[fix](mtmv) Add debug log decide for performance when query rewrite by materialized view (#39914)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -853,10 +853,12 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                         "View struct info is invalid", () -> String.format("view plan is %s",
                                 context.getStructInfo().getOriginalPlan().treeString()));
                 // tmp to location question
-                LOG.debug(String.format("View struct info is invalid, mv identifier is %s, query plan is %s,"
-                                + "view plan is %s",
-                        context.generateMaterializationIdentifier(), queryPlan.treeString(),
-                        context.getStructInfo().getTopPlan().treeString()));
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("View struct info is invalid, mv identifier is %s, query plan is %s,"
+                                    + "view plan is %s",
+                            context.generateMaterializationIdentifier(), queryPlan.treeString(),
+                            context.getStructInfo().getTopPlan().treeString()));
+                }
                 cascadesContext.getMemo().recordMaterializationCheckResult(this.getClass(), materializationId,
                         false);
                 return false;
@@ -868,20 +870,24 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
             context.recordFailReason(context.getStructInfo(),
                     "View struct info is invalid", () -> String.format("view plan is %s",
                             context.getStructInfo().getOriginalPlan().treeString()));
-            LOG.debug(String.format("View struct info is invalid, mv identifier is %s, query plan is %s,"
-                            + "view plan is %s",
-                    context.generateMaterializationIdentifier(), queryPlan.treeString(),
-                    context.getStructInfo().getTopPlan().treeString()));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("View struct info is invalid, mv identifier is %s, query plan is %s,"
+                                + "view plan is %s",
+                        context.generateMaterializationIdentifier(), queryPlan.treeString(),
+                        context.getStructInfo().getTopPlan().treeString()));
+            }
             return false;
         }
         if (!context.getStructInfo().isValid()) {
             context.recordFailReason(context.getStructInfo(),
                     "View original struct info is invalid", () -> String.format("view plan is %s",
                             context.getStructInfo().getOriginalPlan().treeString()));
-            LOG.debug(String.format("View struct info is invalid, mv identifier is %s,  query plan is %s,"
-                            + "view plan is %s",
-                    context.generateMaterializationIdentifier(), queryPlan.treeString(),
-                    context.getStructInfo().getTopPlan().treeString()));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("View struct info is invalid, mv identifier is %s,  query plan is %s,"
+                                + "view plan is %s",
+                        context.generateMaterializationIdentifier(), queryPlan.treeString(),
+                        context.getStructInfo().getTopPlan().treeString()));
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
## Proposed changes
In method `AbstractMaterializedViewRule#isMaterializationValid` Should add `LOG.isDebugEnabled()` before print debug log.  Because `Plan#treeString` in debug log is performance consume.

## Proposed changes

pr: https://github.com/apache/doris/pull/39914 
commitId: 45ddb8ce

