### PR TITLE
[fix](build index)Only get file size for inverted index

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -103,6 +103,10 @@ Status BetaRowset::get_inverted_index_size(size_t* index_size) {
     if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
         auto indices = _schema->indexes();
         for (auto& index : indices) {
+            // only get file_size for inverted index
+            if (index.index_type() != IndexType::INVERTED) {
+                continue;
+            }
             for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
                 auto seg_path = segment_file_path(seg_id);
                 int64_t file_size = 0;


### PR DESCRIPTION
## Proposed changes

Fix `NOT FOUND` index file error message in logs.
bp #39965

