### PR TITLE
[fix](function) fix aes_encrypt/decrypt has wrong results in view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -548,12 +548,7 @@ public class FunctionCallExpr extends Expr {
                 || fnName.getFunction().equalsIgnoreCase("json_object")) {
             len = len - 1;
         }
-        if (fnName.getFunction().equalsIgnoreCase("aes_decrypt")
-                || fnName.getFunction().equalsIgnoreCase("aes_encrypt")
-                || fnName.getFunction().equalsIgnoreCase("sm4_decrypt")
-                || fnName.getFunction().equalsIgnoreCase("sm4_encrypt")) {
-            len = len - 1;
-        }
+
         for (int i = 0; i < len; ++i) {
             if (i != 0) {
                 if (fnName.getFunction().equalsIgnoreCase("group_concat")
@@ -563,11 +558,13 @@ public class FunctionCallExpr extends Expr {
                     sb.append(", ");
                 }
             }
-            if (i == 1 && (fnName.getFunction().equalsIgnoreCase("aes_decrypt")
+            if (ConnectContext.get() != null && ConnectContext.get().getState().isQuery() && i == 1
+                    && (fnName.getFunction().equalsIgnoreCase("aes_decrypt")
                 || fnName.getFunction().equalsIgnoreCase("aes_encrypt")
                 || fnName.getFunction().equalsIgnoreCase("sm4_decrypt")
                 || fnName.getFunction().equalsIgnoreCase("sm4_encrypt"))) {
                 sb.append("\'***\'");
+                continue;
             } else if (orderByElements.size() > 0 && i == len - orderByElements.size()) {
                 sb.append("ORDER BY");
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DorisAssert.java
@@ -169,6 +169,7 @@ public class DorisAssert {
 
         public QueryAssert(ConnectContext connectContext, String sql) {
             this.connectContext = connectContext;
+            this.connectContext.getState().setIsQuery(true);
             this.sql = sql;
         }
 


### PR DESCRIPTION
## Proposed changes

This commit fix 3 problems:

**Before:**

case 1: No matching function  in view.

```
MySQL [test]> create view test_view as select 1,to_base64(AES_ENCRYPT('doris','doris'));
Query OK, 0 rows affected (0.01 sec)

MySQL [test]> select * from test_view;
ERROR 1105 (HY000): errCode = 2, detailMessage = No matching function with signature: aes_encrypt(varchar(-1)).
MySQL [test]> show create table test_view;
```

case 2: The secret key is being shown beside '***' in result header

```
MySQL [test]> SELECT aes_decrypt(   from_base64("EXp7k7M9Zv1mIwPpno28Hg=="),   '17IMZrGdwWf2Piy8',   'II2HLtihr5TQpQgR'  , 'AES_128_CBC');
+---------------------------------------------------------------------------------------------------+
| aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***''17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR') |
+---------------------------------------------------------------------------------------------------+
| 17777208882                                                                                       |
+---------------------------------------------------------------------------------------------------+
1 row in set (0.03 sec)
```

case 3:  Wrong result in view

```
MySQL [test]> set block_encryption_mode='AES_128_CBC';
Query OK, 0 rows affected (0.01 sec)

MySQL [test]> CREATE VIEW client_user_test AS SELECT aes_decrypt(   from_base64('EXp7k7M9Zv1mIwPpno28Hg=='),   '17IMZrGdwWf2Piy8',   'II2HLtihr5TQpQgR'  );
Query OK, 0 rows affected (0.04 sec)

MySQL [test]> show create view client_user_test;
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
| View             | Create View                                                                                                                                                                                                                                                       | character_set_client | collation_connection |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
| client_user_test | CREATE VIEW `client_user_test` COMMENT 'VIEW' AS SELECT aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***''17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR') AS `aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***''17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR')`; | utf8                 | utf8_general_ci      |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
1 row in set (0.01 sec)

MySQL [test]> select * from client_user_test;
+---------------------------------------------------------------------------------------------------+
| aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***''17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR') |
+---------------------------------------------------------------------------------------------------+
| NULL                                                                                              |
+---------------------------------------------------------------------------------------------------+
1 row in set (0.95 sec)
```


**After:**

case 1:

```
MySQL [test]> create view test_view as select 1,to_base64(AES_ENCRYPT('doris','doris'));
Query OK, 0 rows affected (0.01 sec)

MySQL [test]> select * from test_view;
+------+------------------------------------------+
| 1    | to_base64(aes_encrypt('doris', 'doris')) |
+------+------------------------------------------+
|    1 | 4x0fdjDNBZAJxCD7qm/EHg==                 |
+------+------------------------------------------+
1 row in set (0.04 sec)
```

case 2:

```
MySQL [test]> SELECT aes_decrypt(   from_base64("EXp7k7M9Zv1mIwPpno28Hg=="),   '17IMZrGdwWf2Piy8',   'II2HLtihr5TQpQgR'  , 'AES_128_CBC');
+------------------------------------------------------------------------------------------------+
| aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***', 'II2HLtihr5TQpQgR', 'AES_128_CBC') |
+------------------------------------------------------------------------------------------------+
| 17777208882                                                                                    |
+------------------------------------------------------------------------------------------------+
1 row in set (0.04 sec)
```

case 3:

```
MySQL [test]> set block_encryption_mode='AES_128_CBC';Query OK, 0 rows affected (0.01 sec)

MySQL [test]> CREATE VIEW client_user_test AS SELECT aes_decrypt(   from_base64('EXp7k7M9Zv1mIwPpno28Hg=='),   '17IMZrGdwWf2Piy8',   'II2HLtihr5TQpQgR'  );
Query OK, 0 rows affected (0.00 sec)

MySQL [test]> show create view client_user_test;
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
| View             | Create View                                                                                                                                                                                                                                                                           | character_set_client | collation_connection |
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
| client_user_test | CREATE VIEW `client_user_test` COMMENT 'VIEW' AS SELECT aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC') AS `aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC')`; | utf8                 | utf8_general_ci      |
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+----------------------+
1 row in set (0.00 sec)

MySQL [test]> select * from client_user_test;
+-------------------------------------------------------------------------------------------------------------+
| aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC') |
+-------------------------------------------------------------------------------------------------------------+
| 17777208882                                                                                                 |
+-------------------------------------------------------------------------------------------------------------+
1 row in set (0.04 sec)
```

<!--Describe your changes.-->

