### PR TITLE
[fix](function) Hide secret key for aes_decrypt/encrypt in result header

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -651,6 +651,7 @@ public class FunctionCallExpr extends Expr {
                             || fnName.getFunction().equalsIgnoreCase("sm4_decrypt_v2")
                             || fnName.getFunction().equalsIgnoreCase("sm4_encrypt_v2"))) {
                 sb.append("\'***\'");
+                continue;
             } else if (orderByElements.size() > 0 && i == len - orderByElements.size()) {
                 sb.append("ORDER BY ");
             }

--- a/regression-test/data/view_p0/view_p0.out
+++ b/regression-test/data/view_p0/view_p0.out
@@ -18,3 +18,9 @@
 -- !sql2 --
 
 
+-- !select_aes --
+17777208882
+
+-- !show_aes --
+test_view_aes	CREATE VIEW `test_view_aes` AS SELECT aes_decrypt(from_base64("EXp7k7M9Zv1mIwPpno28Hg=="), '17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC');	utf8mb4	utf8mb4_0900_bin
+

--- a/regression-test/suites/view_p0/view_p0.groovy
+++ b/regression-test/suites/view_p0/view_p0.groovy
@@ -135,7 +135,16 @@ suite("view_p0") {
 
     sql """CREATE VIEW IF NOT EXISTS `test_view_abc`(`a`) AS WITH T1 AS (SELECT 1 AS 'a'), T2 AS (SELECT 2 AS 'a') SELECT T1.a FROM T1 UNION ALL SELECT T2.a FROM T2;"""
 
-    sql "drop view if exists test_view_abc;" 
+    sql "drop view if exists test_view_abc;"
+
+    sql "drop view if exists test_view_aes;"
+    sql """CREATE VIEW IF NOT EXISTS `test_view_aes`
+           AS
+           SELECT aes_decrypt(from_base64("EXp7k7M9Zv1mIwPpno28Hg=="), '17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC');
+    """
+    qt_select_aes "SELECT * FROM test_view_aes;"
+    qt_show_aes "SHOW CREATE VIEW test_view_aes;"
+    sql "drop view if exists test_view_aes;"
 
     sql """DROP TABLE IF EXISTS test_view_table2"""
     


### PR DESCRIPTION
## Proposed changes

Fix the case: The secret key is being shown beside '***' in result header

```
MySQL [lambxu]> set experimental_enable_nereids_planner = false;
Query OK, 0 rows affected (0.01 sec)

MySQL [lambxu]> SELECT aes_decrypt(   from_base64("EXp7k7M9Zv1mIwPpno28Hg=="),   '17IMZrGdwWf2Piy8',   'II2HLtihr5TQpQgR'  , 'AES_128_CBC');
+------------------------------------------------------------------------------------------------------------------+
| aes_decrypt(from_base64('EXp7k7M9Zv1mIwPpno28Hg=='), '***''17IMZrGdwWf2Piy8', 'II2HLtihr5TQpQgR', 'AES_128_CBC') |
+------------------------------------------------------------------------------------------------------------------+
| 17777208882                                                                                                      |
+------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

<!--Describe your changes.-->

