### PR TITLE
[fix](doris compose) fix docker py exception

### DIFF
--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -29,14 +29,6 @@ ARG JDK_IMAGE=openjdk:17-jdk-slim
 
 FROM ${JDK_IMAGE}
 
-RUN <<EOF
-    if [ -d "/usr/local/openjdk-17" ]; then
-        ln -s /usr/local/openjdk-17  /usr/local/openjdk
-    else \
-        ln -s /usr/local/openjdk-8  /usr/local/openjdk
-    fi
-EOF
-
 # set environment variables
 ENV JAVA_HOME="/usr/local/openjdk"
 ENV JACOCO_VERSION 0.8.8
@@ -58,12 +50,10 @@ RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/${JACOCO_VERSION}/j
 
 # cloud
 COPY cloud/CMakeLists.txt cloud/output* output/ms* /opt/apache-doris/cloud/
-RUN <<EOF
-    mkdir /opt/apache-doris/fdb
-    if [ -d /opt/apache-doris/cloud/bin ]; then
-        sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/cloud/bin/start.sh
+RUN mkdir /opt/apache-doris/fdb
+RUN if [ -d /opt/apache-doris/cloud/bin ]; then                           \
+        sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/cloud/bin/start.sh  \
     fi
-EOF
 
 # fe and be
 COPY output /opt/apache-doris/

--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -51,8 +51,8 @@ RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/${JACOCO_VERSION}/j
 # cloud
 COPY cloud/CMakeLists.txt cloud/output* output/ms* /opt/apache-doris/cloud/
 RUN mkdir /opt/apache-doris/fdb
-RUN if [ -d /opt/apache-doris/cloud/bin ]; then                           \
-        sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/cloud/bin/start.sh  \
+RUN if [ -d /opt/apache-doris/cloud/bin ]; then                            \
+        sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/cloud/bin/start.sh ; \
     fi
 
 # fe and be

--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -30,7 +30,6 @@ ARG JDK_IMAGE=openjdk:17-jdk-slim
 FROM ${JDK_IMAGE}
 
 # set environment variables
-ENV JAVA_HOME="/usr/local/openjdk"
 ENV JACOCO_VERSION 0.8.8
 
 RUN mkdir -p /opt/apache-doris/coverage

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -363,7 +363,7 @@ class Node(object):
                     "ipv4_address": self.get_ip(),
                 }
             },
-            "extra_hosts": extra_hosts(),
+            "extra_hosts": extra_hosts,
             "ports": self.docker_ports(),
             "ulimits": {
                 "core": -1

--- a/docker/runtime/doris-compose/doris-compose.py
+++ b/docker/runtime/doris-compose/doris-compose.py
@@ -20,7 +20,6 @@ import command
 import sys
 import traceback
 import utils
-import warnings
 
 
 def parse_args():
@@ -49,7 +48,6 @@ if __name__ == '__main__':
     disable_log = getattr(args, "output_json", False)
     if disable_log:
         utils.set_enable_log(False)
-        warnings.filterwarnings("ignore")
 
     code = None
     try:

--- a/docker/runtime/doris-compose/doris-compose.py
+++ b/docker/runtime/doris-compose/doris-compose.py
@@ -20,6 +20,7 @@ import command
 import sys
 import traceback
 import utils
+import warnings
 
 
 def parse_args():
@@ -48,6 +49,7 @@ if __name__ == '__main__':
     disable_log = getattr(args, "output_json", False)
     if disable_log:
         utils.set_enable_log(False)
+        warnings.filterwarnings("ignore")
 
     code = None
     try:

--- a/docker/runtime/doris-compose/requirements.txt
+++ b/docker/runtime/doris-compose/requirements.txt
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-docker>=7.1.0
+docker
 docker-compose
 filelock
 jsonpickle
 prettytable
 pymysql
 python-dateutil
-#requests=2.31.0
+requests<=2.31.0

--- a/docker/runtime/doris-compose/requirements.txt
+++ b/docker/runtime/doris-compose/requirements.txt
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-docker
+docker>=7.1.0
 docker-compose
 filelock
 jsonpickle
 prettytable
 pymysql
 python-dateutil
-requests=2.31.0
+#requests=2.31.0

--- a/docker/runtime/doris-compose/requirements.txt
+++ b/docker/runtime/doris-compose/requirements.txt
@@ -22,3 +22,4 @@ jsonpickle
 prettytable
 pymysql
 python-dateutil
+requests=2.31.0

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -453,6 +453,9 @@ class RegressionTest {
             log.warn("install doris compose requirements failed: code=${proc.exitValue()}, "
                     + "output: ${sout.toString()}, error: ${serr.toString()}")
         }
+
+        def pipList = 'pip list'.execute().text
+        log.info("python library: ${pipList}")
     }
 
     static void printPassed() {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -587,7 +587,7 @@ class SuiteCluster {
     }
 
     private Object runCmd(String cmd, int timeoutSecond = 60) throws Exception {
-        def fullCmd = String.format('python %s %s --output-json', config.dorisComposePath, cmd)
+        def fullCmd = String.format('python -W ignore %s %s --output-json', config.dorisComposePath, cmd)
         logger.info('Run doris compose cmd: {}', fullCmd)
         def proc = fullCmd.execute()
         def outBuf = new StringBuilder()


### PR DESCRIPTION
```
Exception:
java.lang.Exception: Exit value: 1 != 0, stdout: {
    "code": 1,
    "err": "Traceback (most recent call last):\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/command.py\", line 336, in run\n    cluster = CLUSTER.Cluster.load(args.NAME)\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/cluster.py\", line 656, in load\n    raise Exception(\nException: Failed to load cluster, its directory /tmp/doris/test_coordidator_be_restart not exists.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.10/dist-packages/requests/adapters.py\", line 633, in send\n    conn = self.get_connection_with_tls_context(\n  File \"/usr/local/lib/python3.10/dist-packages/requests/adapters.py\", line 489, in get_connection_with_tls_context\n    conn = self.poolmanager.connection_from_host(\n  File \"/usr/lib/python3/dist-packages/urllib3/poolmanager.py\", line 245, in connection_from_host\n    return self.connection_from_context(request_context)\n  File \"/usr/lib/python3/dist-packages/urllib3/poolmanager.py\", line 257, in connection_from_context\n    raise URLSchemeUnknown(scheme)\nurllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/lib/python3/dist-packages/docker/api/client.py\", line 214, in _retrieve_server_version\n    return self.version(api_version=False)[\"ApiVersion\"]\n  File \"/usr/lib/python3/dist-packages/docker/api/daemon.py\", line 181, in version\n    return self._result(self._get(url), json=True)\n  File \"/usr/lib/python3/dist-packages/docker/utils/decorators.py\", line 46, in inner\n    return f(self, *args, **kwargs)\n  File \"/usr/lib/python3/dist-packages/docker/api/client.py\", line 237, in _get\n    return self.get(url, **self._set_request_timeout(kwargs))\n  File \"/usr/local/lib/python3.10/dist-packages/requests/sessions.py\", line 602, in get\n    return self.request(\"GET\", url, **kwargs)\n  File \"/usr/local/lib/python3.10/dist-packages/requests/sessions.py\", line 589, in request\n    resp = self.send(prep, **send_kwargs)\n  File \"/usr/local/lib/python3.10/dist-packages/requests/sessions.py\", line 703, in send\n    r = adapter.send(request, **kwargs)\n  File \"/usr/local/lib/python3.10/dist-packages/requests/adapters.py\", line 637, in send\n    raise InvalidURL(e, request=request)\nrequests.exceptions.InvalidURL: Not supported URL scheme http+docker\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/doris-compose.py\", line 54, in <module>\n    data = run(args, disable_log, help)\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/doris-compose.py\", line 38, in run\n    result = cmd.run(args)\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/command.py\", line 386, in run\n    cluster = CLUSTER.Cluster.new(args.NAME, args.IMAGE, args.cloud,\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/cluster.py\", line 640, in new\n    subnet = gen_subnet_prefix16()\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/cluster.py\", line 87, in gen_subnet_prefix16\n    used_subnet = utils.get_docker_subnets_prefix16()\n  File \"/home/ubuntu/regression-test/doris_master/NEREIDS_ASAN/p0/docker/runtime/doris-compose/utils.py\", line 226, in get_docker_subnets_prefix16\n    client = docker.from_env()\n  File \"/usr/lib/python3/dist-packages/docker/client.py\", line 96, in from_env\n    return cls(\n  File \"/usr/lib/python3/dist-packages/docker/client.py\", line 45, in __init__\n    self.api = APIClient(*args, **kwargs)\n  File \"/usr/lib/python3/dist-packages/docker/api/client.py\", line 197, in __init__\n    self._version = self._retrieve_server_version()\n  File \"/usr/lib/python3/dist-packages/docker/api/client.py\", line 221, in _retrieve_server_version\n    raise DockerException(\ndocker.errors.DockerException: Error while fetching server API version: Not supported URL scheme http+docker\n"
}
, stderr: /usr/local/lib/python3.10/dist-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/usr/local/lib/python3.10/dist-packages/paramiko/transport.py:258: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
  at org.apache.doris.regression.suite.SuiteCluster.runCmd(SuiteCluster.groovy:603)
```

