### PR TITLE
[Fix](Schema Change ) fix schema change fail as  internal sorting will no change to run

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -271,6 +271,11 @@ DEFINE_mInt64(column_dictionary_key_size_threshold, "0");
 DEFINE_mInt64(memory_limitation_per_thread_for_schema_change_bytes, "2147483648");
 DEFINE_mInt64(memory_limitation_per_thread_for_storage_migration_bytes, "100000000");
 
+// memory_limitation_per_thread_for_schema_change_internal_sorting_bytes unit bytes
+DEFINE_mInt64(memory_limitation_per_thread_for_schema_change_internal_sorting_bytes, "2147483648");
+// schema change internal sorting memory limit as a fraction of soft memory limit
+DEFINE_Double(schema_change_internal_sorting_mem_limit_frac_per_thread, "0.5");
+
 // the clean interval of file descriptor cache and segment cache
 DEFINE_mInt32(cache_clean_interval, "10");
 // the clean interval of tablet lookup cache

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -316,6 +316,9 @@ DECLARE_mInt64(column_dictionary_key_size_threshold);
 DECLARE_mInt64(memory_limitation_per_thread_for_schema_change_bytes);
 DECLARE_mInt64(memory_limitation_per_thread_for_storage_migration_bytes);
 
+DECLARE_mInt64(memory_limitation_per_thread_for_schema_change_internal_sorting_bytes);
+DECLARE_Double(schema_change_internal_sorting_mem_limit_frac_per_thread);
+
 // the clean interval of file descriptor cache and segment cache
 DECLARE_mInt32(cache_clean_interval);
 // the clean interval of tablet lookup cache

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -239,9 +239,10 @@ public:
                                                           bool sc_sorting, bool sc_directly) {
         if (sc_sorting) {
             return std::make_unique<VSchemaChangeWithSorting>(
-                    changer, ExecEnv::GetInstance()
-                                     ->storage_engine()
-                                     ->memory_limitation_bytes_per_thread_for_schema_change());
+                    changer,
+                    ExecEnv::GetInstance()
+                            ->storage_engine()
+                            ->memory_limitation_bytes_per_thread_for_schema_change_internal_sorting());
         }
 
         if (sc_directly) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -178,6 +178,14 @@ int64_t StorageEngine::memory_limitation_bytes_per_thread_for_schema_change() co
                     config::memory_limitation_per_thread_for_schema_change_bytes);
 }
 
+int64_t StorageEngine::memory_limitation_bytes_per_thread_for_schema_change_internal_sorting()
+        const {
+    return std::min(
+            static_cast<int64_t>(memory_limitation_bytes_per_thread_for_schema_change() *
+                                 config::schema_change_internal_sorting_mem_limit_frac_per_thread),
+            config::memory_limitation_per_thread_for_schema_change_internal_sorting_bytes);
+}
+
 Status StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
     std::vector<std::thread> threads;
     std::vector<Status> results(data_dirs.size());

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -235,6 +235,8 @@ public:
 
     int64_t memory_limitation_bytes_per_thread_for_schema_change() const;
 
+    int64_t memory_limitation_bytes_per_thread_for_schema_change_internal_sorting() const;
+
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.


### PR DESCRIPTION
## Proposed changes

when doing sorting schema change,  the memory limit for changer and internal sorting now is memory limit of schema change task, witch will case the internal sorting no chance to run, and the schema change failed. 

this pr try to limit the  changer and internal sorting to std::min(0.5*memory_limit_of_schema_change_per_thread, memory_limitation_per_thread_for_schema_change_internal_sorting_bytes) to let the internal sorting and changer have enough memory to run.

<!--Describe your changes.-->

