### PR TITLE
[chore](backup) limit the involved tablets in a backup job

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1533,6 +1533,15 @@ public class Config extends ConfigBase {
     public static int max_backup_restore_job_num_per_db = 10;
 
     /**
+     * Control the max num of tablets per backup job involved.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "用于控制每次 backup job 允许备份的 tablet 上限，以避免 OOM",
+        "Control the max num of tablets per backup job involved, to avoid OOM"
+    })
+    public static int max_backup_tablets_per_job = 300000;
+
+    /**
      * whether to ignore table that not support type when backup, and not report exception.
      */
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -525,8 +525,9 @@ public class BackupJob extends AbstractJob {
 
         // Limit the max num of tablets involved in a backup job, to avoid OOM.
         if (unfinishedTaskIds.size() > Config.max_backup_tablets_per_job) {
-            String msg = String.format("the num involved tablets %d exceeds the limit %d"
-                    + "change config `max_backup_tablets_per_job` to change this limitation",
+            String msg = String.format("the num involved tablets %d exceeds the limit %d, "
+                    + "which might cause the FE OOM, change config `max_backup_tablets_per_job` "
+                    + "to change this limitation",
                     unfinishedTaskIds.size(), Config.max_backup_tablets_per_job);
             LOG.warn(msg);
             status = new Status(ErrCode.COMMON_ERROR, msg);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -523,6 +523,16 @@ public class BackupJob extends AbstractJob {
             }
         }
 
+        // Limit the max num of tablets involved in a backup job, to avoid OOM.
+        if (unfinishedTaskIds.size() > Config.max_backup_tablets_per_job) {
+            String msg = String.format("the num involved tablets %d exceeds the limit %d"
+                    + "change config `max_backup_tablets_per_job` to change this limitation",
+                    unfinishedTaskIds.size(), Config.max_backup_tablets_per_job);
+            LOG.warn(msg);
+            status = new Status(ErrCode.COMMON_ERROR, msg);
+            return;
+        }
+
         backupMeta = new BackupMeta(copiedTables, copiedResources);
 
         // send tasks


### PR DESCRIPTION
and to avoid FE OOM caused by saving too much metadata.

Assuming the average tablet size is 50MB, the default value of 300000 can support 14TB of data per backup job.

The docs PR: https://github.com/apache/doris-website/pull/1056
