### PR TITLE
[fix](statistics)Use utf-8 charset for internal query result.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQueryBuffer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQueryBuffer.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics.util;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Parse the MySQL protocol result data returned by BE,
@@ -127,7 +128,7 @@ public class InternalQueryBuffer {
     public String readStringWithLength() {
         byte[] bytes = readBytesWithLength();
         if (bytes != null) {
-            return new String(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
         }
         return null;
     }


### PR DESCRIPTION
Use utf-8 charset for internal query result.
User's environment may set default java file encode to some other character set, which may cause internal query get Garbled Characters. Use utf-8 to decode string bytes from BE.