### PR TITLE
[fix](nereids) Fix add column syntax

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -237,7 +237,7 @@ addRollupClause
 
 alterTableClause
     : ADD COLUMN columnDef columnPosition? toRollup? properties=propertyClause?     #addColumnClause
-    | ADD COLUMN LEFT_PAREN columnDef (COMMA columnDef)? RIGHT_PAREN
+    | ADD COLUMN LEFT_PAREN columnDef (COMMA columnDef)* RIGHT_PAREN
         toRollup? properties=propertyClause?                                        #addColumnsClause
     | DROP COLUMN name=identifier fromRollup? properties=propertyClause?            #dropColumnClause
     | MODIFY COLUMN columnDef columnPosition? fromRollup?

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -237,7 +237,7 @@ addRollupClause
 
 alterTableClause
     : ADD COLUMN columnDef columnPosition? toRollup? properties=propertyClause?     #addColumnClause
-    | ADD COLUMN LEFT_PAREN columnDef (COMMA columnDef) RIGHT_PAREN
+    | ADD COLUMN LEFT_PAREN columnDef (COMMA columnDef)? RIGHT_PAREN
         toRollup? properties=propertyClause?                                        #addColumnsClause
     | DROP COLUMN name=identifier fromRollup? properties=propertyClause?            #dropColumnClause
     | MODIFY COLUMN columnDef columnPosition? fromRollup?

--- a/regression-test/suites/nereids_syntax_p0/ddl/add_column.groovy
+++ b/regression-test/suites/nereids_syntax_p0/ddl/add_column.groovy
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("add_column") {
+    def tableName ="test"
+
+    sql 'set enable_nereids_planner=true'
+    sql 'set enable_fallback_to_original_planner=false'
+
+    sql """
+    drop table if exists test
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS `test` (
+        `id` bigint(20) NOT NULL,
+        `count` bigint(20) NOT NULL,
+    ) ENGINE=OLAP
+    AGGREGATE KEY(`id`)
+    COMMENT 'OLAP'
+    DISTRIBUTED BY HASH(`id`) BUCKETS 5
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+    );
+    """
+
+    sql """
+    ALTER TABLE `test`
+    ADD COLUMN (`cost` VARCHAR(256) DEFAULT "add");
+    """
+}
+

--- a/regression-test/suites/nereids_syntax_p0/ddl/add_column.groovy
+++ b/regression-test/suites/nereids_syntax_p0/ddl/add_column.groovy
@@ -30,7 +30,7 @@ suite("add_column") {
         `id` bigint(20) NOT NULL,
         `count` bigint(20) NOT NULL,
     ) ENGINE=OLAP
-    AGGREGATE KEY(`id`)
+    UNIQUE KEY(`id`)
     COMMENT 'OLAP'
     DISTRIBUTED BY HASH(`id`) BUCKETS 5
     PROPERTIES (


### PR DESCRIPTION
The original parser allows the column_definition_list only to have one column_definition, this PR makes the nereids parser compatible with the legacy one.


