### PR TITLE
 [improvement](mtmv) Optimize the materialized view hint info when explain

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -535,9 +535,10 @@ public class NereidsPlanner extends Planner {
         String plan = "";
         String mvSummary = "";
         if (this.getPhysicalPlan() != null && cascadesContext != null) {
-            mvSummary = "\n\n========== MATERIALIZATIONS ==========\n"
-                    + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts(),
-                    this.getPhysicalPlan());
+            mvSummary = cascadesContext.getMaterializationContexts().isEmpty() ? "" :
+                    "\n\n========== MATERIALIZATIONS ==========\n"
+                            + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts(),
+                            this.getPhysicalPlan());
         }
         switch (explainLevel) {
             case PARSED_PLAN:

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -596,9 +596,10 @@ public class NereidsPlanner extends Planner {
             default:
                 plan = super.getExplainString(explainOptions);
                 plan += mvSummary;
+                plan += "\n\n========== STATISTICS ==========\n";
                 if (statementContext != null) {
                     if (statementContext.isHasUnknownColStats()) {
-                        plan += "\n\nStatistics\n planed with unknown column statistics\n";
+                        plan += "planed with unknown column statistics\n";
                     }
                 }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -596,7 +596,7 @@ public class NereidsPlanner extends Planner {
             default:
                 plan = super.getExplainString(explainOptions);
                 plan += mvSummary;
-                plan += "\n\n========== STATISTICS ==========\n";
+                plan += "\n\n\n========== STATISTICS ==========\n";
                 if (statementContext != null) {
                     if (statementContext.isHasUnknownColStats()) {
                         plan += "planed with unknown column statistics\n";

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -408,7 +408,7 @@ public abstract class MaterializationContext {
     }
 
     private static String generateIdentifierName(List<String> qualifiers) {
-        return String.join("#", qualifiers);
+        return String.join(".", qualifiers);
     }
 
     @Override

--- a/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
@@ -165,7 +165,7 @@ suite("sync_async_same_name") {
         check {result ->
             def splitResult = result.split("MaterializedViewRewriteFail")
             splitResult.length == 2 ? splitResult[0].contains(common_mv_name)
-                    && splitResult[0].contains("orders#${common_mv_name}") : false
+                    && splitResult[0].contains("orders.${common_mv_name}") : false
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Optimize the explain materialized view info, add double horizontal dividing line between `MATERIALIZATIONS` and
`STATISTICS`. Maybe think rewrite fail because` planed with unknown column statistics `, actually is rewrite successfully.
**Before:**
```text
| ========== MATERIALIZATIONS ==========                                                                                                                                                                                                                |
|                                                                                                                                                                                                                                                       |
| MaterializedView                                                                                                                                                                                                                                      |
| MaterializedViewRewriteSuccessAndChose:                                                                                                                                                                                                               |
|   internal#regression_test_nereids_rules_p0_mv_agg_with_roll_up#mv13_1 chose,                                                                                                                                                                         |
|                                                                                                                                                                                                                                                       |
| MaterializedViewRewriteSuccessButNotChose:                                                                                                                                                                                                            |
|   not chose: none,                                                                                                                                                                                                                                    |
|                                                                                                                                                                                                                                                       |
| MaterializedViewRewriteFail:                                                                                                                                                                                                                          |
|                                                                                                                                                                                                                                                       |
| Statistics                                                                                                                                                                                                                                            |
|  planed with unknown column statistics     
```

**After:**
```text
| ========== MATERIALIZATIONS ==========                                                                                                                                                                                                                |
|                                                                                                                                                                                                                                                       |
| MaterializedView                                                                                                                                                                                                                                      |
| MaterializedViewRewriteSuccessAndChose:                                                                                                                                                                                                               |
|   internal.regression_test_nereids_rules_p0_mv_agg_with_roll_up.mv13_1 chose,                                                                                                                                                                         |
|                                                                                                                                                                                                                                                       |
| MaterializedViewRewriteSuccessButNotChose:                                                                                                                                                                                                            |
|   not chose: none,                                                                                                                                                                                                                                    |
|                                                                                                                                                                                                                                                       |
| MaterializedViewRewriteFail:                                                                                                                                                                                                                          |
|                                                                                                                                                                                                                                                       |
|                                                                                                                                                                                                                                                       |
| ========== STATISTICS ==========                                                                                                                                                                                                                      |
| planed with unknown column statistics  
```


