### PR TITLE
[Improve](Legacy planner)forbidden mvrewrite when there is no mv index in legacy planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -309,7 +309,9 @@ public class BinaryPredicate extends Predicate implements Writable {
         Preconditions.checkState(match.getReturnType().getPrimitiveType() == PrimitiveType.BOOLEAN);
         //todo(dhc): should add oppCode
         //this.vectorOpcode = match.opcode;
-        LOG.debug(debugString() + " opcode: " + vectorOpcode);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(debugString() + " opcode: " + vectorOpcode);
+        }
     }
 
     private boolean canCompareDate(PrimitiveType t1, PrimitiveType t2) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionSet;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
@@ -512,7 +513,13 @@ public class SelectStmt extends QueryStmt {
                 }
                 OlapTable olapTable = (OlapTable) tbl.getTable();
                 if (olapTable.getIndexIds().size() != 1) {
-                    haveMv = true;
+                    for (MaterializedIndexMeta meta : olapTable.getIndexIdToMeta().values()) {
+                        List<Column> idxColumns = meta.getSchema();
+                        // check the index is a mv index
+                        if (!idxColumns.isEmpty() && null != idxColumns.get(0).getDefineExpr()) {
+                            haveMv = true;
+                        }
+                    }
                 }
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -199,7 +199,9 @@ public class SlotRef extends Expr {
     @Override
     public void computeOutputColumn(Analyzer analyzer) {
         outputColumn = desc.getSlotOffset();
-        LOG.debug("SlotRef: " + debugString() + " outputColumn: " + outputColumn);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("SlotRef: " + debugString() + " outputColumn: " + outputColumn);
+        }
     }
 
     @Override


### PR DESCRIPTION
Problem:
In legacy planner mode, when do select request from a table with rollup index; It will do mv rewrite operation, this will invoker too much Expr.toSql that will cause cpu consumption。
Solution:
when do mv rewrite judgement，add mv index check when the tables index number > 1；if there is no mv index, do not do mv rewrite.
