### PR TITLE
[opt] change remote scan pool size

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -246,6 +246,13 @@ DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> b
 DEFINE_Int32(doris_scanner_min_thread_pool_thread_num, "8");
 DEFINE_Int32(remote_split_source_batch_size, "10240");
 DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
+DEFINE_Validator(doris_max_remote_scanner_thread_pool_thread_num, [](const int config) -> bool {
+    if (config == -1) {
+        CpuInfo::init();
+        doris_max_remote_scanner_thread_pool_thread_num = std::max(96, CpuInfo::num_cores() * 2);
+    }
+    return true;
+});
 // number of olap scanner thread pool queue size
 DEFINE_Int32(doris_scanner_thread_pool_queue_size, "102400");
 // default thrift client connect timeout(in seconds)

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -343,9 +343,7 @@ void ScannerScheduler::_deregister_metrics() {
 }
 
 int ScannerScheduler::get_remote_scan_thread_num() {
-    int remote_max_thread_num = config::doris_max_remote_scanner_thread_pool_thread_num != -1
-                                        ? config::doris_max_remote_scanner_thread_pool_thread_num
-                                        : std::max(512, CpuInfo::num_cores() * 10);
+    int remote_max_thread_num = config::doris_max_remote_scanner_thread_pool_thread_num;
     remote_max_thread_num =
             std::max(remote_max_thread_num, config::doris_scanner_thread_pool_thread_num);
     return remote_max_thread_num;


### PR DESCRIPTION
1. Use Config validator to init the scan pool size
2. The origin remote pool size is `max(512, core * 10)`, which is too large, change it to `max(96, core * 2)`