### PR TITLE
[fix](mv) Fix test create table like test unstable (#39305)

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1242,6 +1242,39 @@ class Suite implements GroovyInterceptable {
         }
     }
 
+    def getMVJobState = { tableName, limit  ->
+        def jobStateResult = sql """  SHOW ALTER TABLE ROLLUP WHERE TableName='${tableName}' ORDER BY CreateTime DESC limit ${limit}"""
+        if (jobStateResult.size() != limit) {
+            logger.info("show alter table roll is empty" + jobStateResult)
+            return "NOT_READY"
+        }
+        for (int i = 0; i < jobStateResult.size(); i++) {
+            logger.info("getMVJobState is " + jobStateResult[i][8])
+            if (!jobStateResult[i][8].equals("FINISHED")) {
+                return "NOT_READY"
+            }
+        }
+        return "FINISHED";
+    }
+    def waitForRollUpJob =  (tbName, timeoutMillisecond, limit) -> {
+
+        long startTime = System.currentTimeMillis()
+        long timeoutTimestamp = startTime + timeoutMillisecond
+
+        String result
+        // time out or has run exceed 10 minute, then break
+        while (timeoutTimestamp > System.currentTimeMillis() && System.currentTimeMillis() - startTime < 600000){
+            result = getMVJobState(tbName, limit)
+            if (result == "FINISHED") {
+                sleep(200)
+                return
+            } else {
+                sleep(200)
+            }
+        }
+        Assert.assertEquals("FINISHED", result)
+    }
+
     String getJobName(String dbName, String mtmvName) {
         String showMTMV = "select JobName from mv_infos('database'='${dbName}') where Name = '${mtmvName}'";
 	    logger.info(showMTMV)

--- a/regression-test/suites/ddl_p0/test_create_table_like_nereids.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_like_nereids.groovy
@@ -48,6 +48,7 @@ suite("test_create_table_like_nereids") {
     // with all rollup
     sql "drop table if exists table_like_with_roll_up"
     sql "CREATE TABLE table_like_with_roll_up LIKE mal_test_create_table_like with rollup;"
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
     explain {
         sql ("select sum(a) from table_like_with_roll_up group by a")
         contains "ru1"
@@ -60,6 +61,7 @@ suite("test_create_table_like_nereids") {
     // with partial rollup
     sql "drop table if exists table_like_with_partial_roll_up;"
     sql "CREATE TABLE table_like_with_partial_roll_up LIKE mal_test_create_table_like with rollup (ru1);"
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
     sql "select * from table_like_with_partial_roll_up order by pk, a, b"
     explain {
         sql("select sum(a) from table_like_with_partial_roll_up group by a")
@@ -79,6 +81,7 @@ suite("test_create_table_like_nereids") {
     sql "drop table if exists table_like_with_partial_roll_up_exists"
     sql """CREATE TABLE if not exists table_like_with_partial_roll_up_exists
     LIKE mal_test_create_table_like with rollup (ru1);"""
+    waitForRollUpJob("mal_test_create_table_like", 5000, 2)
 
     sql "drop table if exists test_create_table_like_char_255"
     sql """


### PR DESCRIPTION
ddl_p0/test_create_table_like_nereids.groovy test result is unstable. Should wait util rollup join finished then we can compare the explain rollup result.

## Proposed changes

commitId: 3b7b29b8
pr: https://github.com/apache/doris/pull/39305