### PR TITLE
[fix](inverted index) fix error handling in fast_execute

### DIFF
--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -210,6 +210,7 @@ Status VExpr::prepare(RuntimeState* state, const RowDescriptor& row_desc, VExprC
         RETURN_IF_ERROR(i->prepare(state, row_desc, context));
     }
     --context->_depth_num;
+    _enable_inverted_index_query = state->query_options().enable_inverted_index_query;
     return Status::OK();
 }
 
@@ -603,6 +604,10 @@ Status VExpr::get_result_from_const(vectorized::Block* block, const std::string&
 
 bool VExpr::fast_execute(Block& block, const ColumnNumbers& arguments, size_t result,
                          size_t input_rows_count, const std::string& function_name) {
+    if (!_enable_inverted_index_query) {
+        return false;
+    }
+
     std::string result_column_name = gen_predicate_result_sign(block, arguments, function_name);
     if (!block.has(result_column_name)) {
         DBUG_EXECUTE_IF("segment_iterator.fast_execute", {
@@ -651,11 +656,19 @@ std::string VExpr::gen_predicate_result_sign(Block& block, const ColumnNumbers& 
             std::set<std::string> values;
             for (size_t i = 1; i < arguments.size(); i++) {
                 const auto& entry = block.get_by_position(arguments[i]);
+                if (!is_column_const(*entry.column)) {
+                    return pred_result_sign;
+                }
                 values.insert(entry.type->to_string(*entry.column, 0));
             }
             pred_result_sign += boost::join(values, ",");
+        } else if (function_name == "collection_in" || function_name == "collection_not_in") {
+            return pred_result_sign;
         } else {
             const auto& entry = block.get_by_position(arguments[1]);
+            if (!is_column_const(*entry.column)) {
+                return pred_result_sign;
+            }
             pred_result_sign += entry.type->to_string(*entry.column, 0);
         }
     }

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -328,6 +328,7 @@ protected:
     // ensuring uniqueness during index traversal
     uint32_t _index_unique_id = 0;
     bool _can_fast_execute = false;
+    bool _enable_inverted_index_query = true;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
## Proposed changes

1. fix error handling in fast_execute
2. Fixed the issue where fast_execute was still being executed when set enable_inverted_index_query = false.

<!--Describe your changes.-->

