### PR TITLE
[fix](be) Prevent RocksDB from generating many large log files

### DIFF
--- a/be/src/olap/olap_meta.cpp
+++ b/be/src/olap/olap_meta.cpp
@@ -69,7 +69,7 @@ Status OlapMeta::init() {
     // set log file's size, num and level
     options.max_log_file_size = 10485760;
     options.keep_log_file_num = 10;
-    options.info_log_level = rocksdb::WARN_LEVEL;
+    options.info_log_level = rocksdb::InfoLogLevel::WARN_LEVEL;
 
     std::string db_path = _root_path + META_POSTFIX;
     std::vector<ColumnFamilyDescriptor> column_families;

--- a/be/src/olap/olap_meta.cpp
+++ b/be/src/olap/olap_meta.cpp
@@ -65,6 +65,12 @@ Status OlapMeta::init() {
     options.IncreaseParallelism();
     options.create_if_missing = true;
     options.create_missing_column_families = true;
+
+    // set log file's size, num and level
+    options.max_log_file_size = 10485760;
+    options.keep_log_file_num = 10;
+    options.info_log_level = rocksdb::WARN_LEVEL;
+
     std::string db_path = _root_path + META_POSTFIX;
     std::vector<ColumnFamilyDescriptor> column_families;
     // default column family is required


### PR DESCRIPTION
## Proposed changes

Prevent RocksDB from generating many large log files.
We have a cluster with doris 1.2.4, in be meta dir, it generated more than 150G LOG file as following:

[root@9 meta]# ls -lht
total 157G
-rw-r--r-- 1 doris doris 4.0M Aug 27 22:48 107324255.sst
-rw-r--r-- 1 doris doris 4.3G Aug 27 22:48 LOG
-rw-r--r-- 1 doris doris 292M Aug 27 22:48 MANIFEST-104377434
-rw-r--r-- 1 doris doris 2.0M Aug 27 22:48 107324254.sst
-rw-r--r-- 1 doris doris 8.4M Aug 27 22:48 107324253.log
-rw-r--r-- 1 doris doris 2.1M Aug 27 22:48 107324252.sst
-rw-r--r-- 1 doris doris 1.7M Aug 27 22:48 107324250.sst
-rw-r--r-- 1 doris doris 1.8M Aug 27 22:48 107324248.sst
-rw-r--r-- 1 doris doris 6.9M Aug 27 22:48 107324246.sst
-rw-r--r-- 1 doris doris 9.5K Aug 14 09:32 OPTIONS-104377438
-rw-r--r-- 1 doris doris   19 Aug 14 09:32 CURRENT
-rw-r--r-- 1 doris doris 152G Aug 14 09:30 LOG.old.1723599084129852
-rw-r--r-- 1 doris doris 9.5K May 15  2023 OPTIONS-000010
-rw-r--r-- 1 doris doris   37 May 15  2023 IDENTITY
-rw-r--r-- 1 doris doris    0 May 15  2023 LOCK

Issue Number: close #xxx

<!--Describe your changes.-->

