### PR TITLE
[fix](memory) Fix OwnedSlice free memory

### DIFF
--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -85,7 +85,8 @@ public:
     OwnedSlice build() {
         uint8_t* ret = data_;
         if (ret == initial_data_) {
-            ret = reinterpret_cast<uint8_t*>(Allocator::alloc(len_));
+            ret = reinterpret_cast<uint8_t*>(Allocator::alloc(capacity_));
+            DCHECK(len_ <= capacity_);
             memcpy(ret, data_, len_);
         }
         OwnedSlice result(ret, len_, capacity_);

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -362,7 +362,12 @@ public:
     OwnedSlice(const OwnedSlice&) = delete;
     void operator=(const OwnedSlice&) = delete;
 
-    ~OwnedSlice() { Allocator::free(_slice.data, _capacity); }
+    ~OwnedSlice() {
+        if (_slice.data != nullptr) {
+            DCHECK(_capacity != 0);
+            Allocator::free(_slice.data, _capacity);
+        }
+    }
 
     const Slice& slice() const { return _slice; }
 


### PR DESCRIPTION
```
I20240828 11:41:58.529152 20190 mem_tracker_limiter.cpp:193] [Address Sanitizer] memory buf not exist, mem tracker label: Load#Id=ac42f13dd1430d2c-bd60f5a4829d0792, consumption: 13054587, peak consumption: 13054587, buf: 0, size: 0, stack_trace:
        0#  doris::OwnedSlice::~OwnedSlice()
        1#  doris::segment_v2::ScalarColumnWriter::finish_current_page()
        2#  doris::segment_v2::ScalarColumnWriter::finish()
        3#  doris::segment_v2::VerticalSegmentWriter::write_batch()
        4#  doris::SegmentFlusher::_add_rows(std::unique_ptr<doris::segment_v2::VerticalSegmentWriter, std::default_delete<doris::segment_v2::VerticalSegmentWriter> >&, doris::vectorized::Block const*, unsigned long, unsigned long)
        5#  doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*)
        6#  doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*)
        7#  doris::BaseBetaRowsetWriter::flush_memtable(doris::vectorized::Block*, int, long*)
        8#  doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*)
        9#  doris::FlushToken::_flush_memtable(std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >, int, long)
        10# doris::MemtableFlushTask::run()
        11# doris::ThreadPool::dispatch_thread()
        12# doris::Thread::supervise_thread(void*)
        13# ?
        14# clone
```
```
I20240828 11:41:58.613629 20183 mem_tracker_limiter.cpp:182] [Address Sanitizer] free memory buf size inaccurate, mem tracker label: Load#Id=433657e8b3834e94-ac178bb7ab8ff661, consumption: 3239536, peak consumption: 6385184, buf: 0x6030015390a0, size: 32, old buf: 0x6030015390a0, old size: 20, new stack_trace:
	0#  doris::OwnedSlice::~OwnedSlice()
	1#  doris::segment_v2::IndexedColumnWriter::_finish_current_data_page(unsigned long&)
	2#  doris::segment_v2::IndexedColumnWriter::finish(doris::segment_v2::IndexedColumnMetaPB*)
	3#  doris::PrimaryKeyIndexBuilder::finalize(doris::segment_v2::PrimaryKeyIndexMetaPB*)
	4#  doris::segment_v2::VerticalSegmentWriter::_write_primary_key_index()
	5#  doris::segment_v2::VerticalSegmentWriter::finalize_columns_index(unsigned long*)
	6#  doris::segment_v2::VerticalSegmentWriter::finalize(unsigned long*, unsigned long*)
	7#  doris::SegmentFlusher::_flush_segment_writer(std::unique_ptr<doris::segment_v2::VerticalSegmentWriter, std::default_delete<doris::segment_v2::VerticalSegmentWriter> >&, std::shared_ptr<doris::TabletSchema>, long*)
	8#  doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*)
	9#  doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*)
	10# doris::BetaRowsetWriterV2::flush_memtable(doris::vectorized::Block*, int, long*)
	11# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*)
	12# doris::FlushToken::_flush_memtable(std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >, int, long)
	13# doris::MemtableFlushTask::run()
	14# doris::ThreadPool::dispatch_thread()
	15# doris::Thread::supervise_thread(void*)
	16# ?
	17# clone
, old stack_trace:
	0#  Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long)
	1#  doris::faststring::build()
	2#  doris::segment_v2::BinaryPrefixPageBuilder::finish(doris::OwnedSlice*)
	3#  doris::segment_v2::IndexedColumnWriter::_finish_current_data_page(unsigned long&)
	4#  doris::segment_v2::IndexedColumnWriter::finish(doris::segment_v2::IndexedColumnMetaPB*)
	5#  doris::PrimaryKeyIndexBuilder::finalize(doris::segment_v2::PrimaryKeyIndexMetaPB*)
	6#  doris::segment_v2::VerticalSegmentWriter::_write_primary_key_index()
	7#  doris::segment_v2::VerticalSegmentWriter::finalize_columns_index(unsigned long*)
	8#  doris::segment_v2::VerticalSegmentWriter::finalize(unsigned long*, unsigned long*)
	9#  doris::SegmentFlusher::_flush_segment_writer(std::unique_ptr<doris::segment_v2::VerticalSegmentWriter, std::default_delete<doris::segment_v2::VerticalSegmentWriter> >&, std::shared_ptr<doris::TabletSchema>, long*)
	10# doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*)
	11# doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*)
	12# doris::BetaRowsetWriterV2::flush_memtable(doris::vectorized::Block*, int, long*)
	13# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*)
	14# doris::FlushToken::_flush_memtable(std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >, int, long)
	15# doris::MemtableFlushTask::run()
	16# doris::ThreadPool::dispatch_thread()
	17# doris::Thread::supervise_thread(void*)
	18# ?
	19# clon
```