### PR TITLE
[fix](multi-catalog)fix max compute null parts table read

### DIFF
--- a/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
+++ b/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
@@ -170,6 +170,9 @@ public class MaxComputeJniScanner extends JniScanner {
                 // query columns required non-null, when query partition table
                 pushDownColumns.add(session.getSchema().getColumn(0));
             }
+            if (totalRows == 0) {
+                return;
+            }
             arrowAllocator = new RootAllocator(Integer.MAX_VALUE);
             curReader = session.openArrowRecordReader(start, totalRows, pushDownColumns, arrowAllocator);
             remainBatchRows = totalRows;


### PR DESCRIPTION
## Proposed changes

fix max compute null parts table read
if no any data in a part, we should make mc jni scanner return 0 rows



