### PR TITLE
[enhancement](Nereids) support reuse sql cache between different comment

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
@@ -344,6 +344,13 @@ public class NereidsParser {
         return tree;
     }
 
+    /**
+     * removeCommentAndTrimBlank
+     *
+     * for example: select   \/*+SET_VAR(key=value)*\/ \/* trace_id: 1234 *\/ *,   a, \n b from table
+     *
+     * will be normalized to: select \/*+SET_VAR(key=value)*\/ * , a, b from table
+     */
     public static String removeCommentAndTrimBlank(String sql) {
         DorisLexer lexer = new DorisLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);

--- a/regression-test/plugins/test_helper.groovy
+++ b/regression-test/plugins/test_helper.groovy
@@ -57,6 +57,8 @@ Suite.metaClass.createTestTable = { String tableName, boolean uniqueTable = fals
                (4, 1), (4, 2),
                (5, 1), (5, 2)
         """
+
+    sql "sync"
 }
 
 

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -722,10 +722,7 @@ suite("parse_sql_from_sql_cache") {
             def result2 = sql "select * from (select $randomInt as id)a"
             assertTrue(result2.size() == 1)
 
-            assertNoCache "select * from test_use_plan_cache20 limit 0"
-            def result3 = sql "select * from test_use_plan_cache20 limit 0"
-            assertTrue(result3.isEmpty())
-
+            sql "select * from test_use_plan_cache20 limit 0"
             assertHasCache "select * from test_use_plan_cache20 limit 0"
             def result4 = sql "select * from test_use_plan_cache20 limit 0"
             assertTrue(result4.isEmpty())
@@ -771,6 +768,21 @@ suite("parse_sql_from_sql_cache") {
             assertNoCache "select * from test_use_plan_cache21"
             def result2 = sql "select * from test_use_plan_cache21"
             assertTrue(result2.size() == 1)
+        }),
+        extraThread("remove_comment", {
+            createTestTable "test_use_plan_cache22"
+
+            // after partition changed 10s, the sql cache can be used
+            sleep(10000)
+
+            sql "set enable_nereids_planner=true"
+            sql "set enable_fallback_to_original_planner=false"
+            sql "set enable_sql_cache=true"
+
+            assertNoCache "select /*+SET_VAR(disable_nereids_rules='')*/ /*comment2*/ * from test_use_plan_cache22 order by 1, 2"
+            sql "select /*+SET_VAR(disable_nereids_rules='')*/ /*comment1*/ * from test_use_plan_cache22 order by 1, 2"
+
+            assertHasCache "select /*+SET_VAR(disable_nereids_rules='')*/ /*comment2*/ * from test_use_plan_cache22 order by 1, 2"
         })
     ).get()
 }


### PR DESCRIPTION
## Proposed changes

support reuse sql cache between different comment like this:

SQL 1:
```sql
select /* trace_id: 100001 */ from tbl;
```

SQL 2:
```sql
select /* trace_id: 100002 */ from tbl;
```