### PR TITLE
[fix](cancel) Fix buffer control block is not cancelled.

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -180,6 +180,10 @@ void PipelineXFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
             task->clear_blocking_state();
         }
     }
+
+    for (const auto& instance_id : _fragment_instance_ids) {
+        ExecEnv::GetInstance()->result_mgr()->cancel(instance_id);
+    }
 }
 
 Status PipelineXFragmentContext::prepare(const doris::TPipelineFragmentParams& request) {


### PR DESCRIPTION
When FE cancel the query before it is finished on BE, BufferControlBlock should also be cancelled.