### PR TITLE
[improve](cloud-mow) splitting large rowset meta into multiple KVs

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1159,7 +1159,7 @@ void MetaServiceImpl::commit_rowset(::google::protobuf::RpcController* controlle
     DCHECK_GT(rowset_meta.txn_expiration(), 0);
     auto tmp_rs_val = rowset_meta.SerializeAsString();
     // splitting large values (>90*1000) into multiple KVs
-    selectdb::put(txn.get(), tmp_rs_key, tmp_rs_val, 0);
+    cloud::put(txn.get(), tmp_rs_key, tmp_rs_val, 0);
     LOG(INFO) << "put tmp_rs_key " << hex(tmp_rs_key) << " delete recycle_rs_key "
               << hex(recycle_rs_key) << " value_size " << tmp_rs_val.size() << " txn_id "
               << request->txn_id();
@@ -1260,7 +1260,7 @@ void MetaServiceImpl::update_tmp_rowset(::google::protobuf::RpcController* contr
     }
 
     // splitting large values (>90*1000) into multiple KVs
-    selectdb::put(txn.get(), update_key, update_val, 0);
+    cloud::put(txn.get(), update_key, update_val, 0);
     LOG(INFO) << "xxx put "
               << "update_rowset_key " << hex(update_key) << " value_size " << update_val.size();
     err = txn->commit();
@@ -1310,7 +1310,7 @@ void internal_get_rowset(Transaction* txn, int64_t start, int64_t end,
             if (k != last_key) {
                 last_key = k;
                 ValueBuf buf;
-                err = selectdb::get(txn, k, &buf);
+                err = cloud::get(txn, k, &buf);
                 if (err != TxnErrorCode::TXN_OK) {
                     ss << "failed to get tmp rowset key"
                        << (err == TxnErrorCode::TXN_KEY_NOT_FOUND ? " (not found)" : "");

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -882,7 +882,7 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
     auto tmp_rowset_key = meta_rowset_tmp_key({instance_id, txn_id, tablet_id});
     std::string tmp_rowset_val;
     ValueBuf buf;
-    auto err = selectdb::get(txn.get(), tmp_rowset_key, &buf);
+    auto err = cloud::get(txn.get(), tmp_rowset_key, &buf);
     if (err != TxnErrorCode::TXN_OK) {
         SS << "failed to get tmp rowset key"
            << (err == TxnErrorCode::TXN_KEY_NOT_FOUND ? " (not found)" : "")
@@ -923,7 +923,7 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
     int64_t version = compaction.output_versions(0);
     auto rowset_key = meta_rowset_key({instance_id, tablet_id, version});
     // splitting large values (>90*1000) into multiple KVs
-    selectdb::put(txn.get(), rowset_key, tmp_rowset_val, 0);
+    cloud::put(txn.get(), rowset_key, tmp_rowset_val, 0);
     INSTANCE_LOG(INFO) << "put rowset meta, tablet_id=" << tablet_id
                        << " rowset_key=" << hex(rowset_key);
 
@@ -1228,7 +1228,7 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
         std::string tmp_rowset_val;
         // FIXME: async get
         ValueBuf buf;
-        auto err = selectdb::get(txn.get(), tmp_rowset_key, &buf);
+        auto err = cloud::get(txn.get(), tmp_rowset_key, &buf);
         if (err != TxnErrorCode::TXN_OK) {
             SS << "failed to get tmp rowset key"
                << (err == TxnErrorCode::TXN_KEY_NOT_FOUND ? " (not found)" : "")
@@ -1252,7 +1252,7 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
         auto rowset_key = meta_rowset_key(
                 {instance_id, new_tablet_id, schema_change.output_versions().at(i)});
         // splitting large values (>90*1000) into multiple KVs
-        selectdb::put(txn.get(), rowset_key, tmp_rowset_val, 0);
+        cloud::put(txn.get(), rowset_key, tmp_rowset_val, 0);
         txn->remove(tmp_rowset_key);
     }
 

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -838,7 +838,7 @@ void scan_tmp_rowset(
             LOG(INFO) << "range_get rowset_tmp_key=" << hex(k) << " txn_id=" << txn_id;
             tmp_rowsets_meta->emplace_back();
             ValueBuf buf;
-            auto err = selectdb::get(txn.get(), k, &buf);
+            auto err = cloud::get(txn.get(), k, &buf);
             if (err != TxnErrorCode::TXN_OK) {
                 ss << "failed to get tmp rowset key"
                    << (err == TxnErrorCode::TXN_KEY_NOT_FOUND ? " (not found)" : "");
@@ -849,14 +849,14 @@ void scan_tmp_rowset(
                                                               : cast_as<ErrCategory::READ>(err);
                 return;
             }
-            doris::RowsetMetaPB rs_meta;
+            doris::RowsetMetaCloudPB rs_meta;
             if (!buf.to_pb(&rs_meta)) {
                 code = MetaServiceCode::PROTOBUF_PARSE_ERR;
                 msg = "malformed rowset meta, unable to deserialize";
                 LOG(WARNING) << msg << " key=" << hex(k);
                 return;
             }
-            tmp_rowsets_meta.back().second = rs_meta;
+            tmp_rowsets_meta->back().second = rs_meta;
             // Save keys that will be removed later
             tmp_rowsets_meta->back().first = std::string(k.data(), k.size());
             ++num_rowsets;
@@ -1231,7 +1231,7 @@ void commit_txn_immediately(
         for (auto& i : rowsets) {
             size_t rowset_size = i.first.size() + i.second.size();
             // splitting large values (>90*1000) into multiple KVs
-            selectdb::put(txn.get(), i.first, i.second, 0);
+            cloud::put(txn.get(), i.first, i.second, 0);
             LOG(INFO) << "xxx put rowset_key=" << hex(i.first) << " txn_id=" << txn_id
                       << " rowset_size=" << rowset_size;
         }


### PR DESCRIPTION
now large rowset meta save to fdb will fail, it will report error `failed to commit rowset: failed to save rowset meta, err=Value length exceeds limit`, rowset meta  need to split into multiple KVs when value is bigger than 90kb.
